### PR TITLE
Remove rand dependency

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -562,7 +562,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "proptest",
- "rand",
  "rand_chacha",
  "rand_core",
  "rayon",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,7 +17,6 @@ digest      = { version = "0.9.0", features=["alloc"] }
 num-bigint  = "0.4.0"
 num-traits  = "0.2.14"
 typenum     = "1.14.0"
-rand        = "0.8"
 rand_core   = "0.6.3"
 blake2      = "0.9.2"
 generic-array = "0.14"

--- a/rust/src/key_reg.rs
+++ b/rust/src/key_reg.rs
@@ -174,7 +174,8 @@ mod tests {
     use ark_bls12_377::Bls12_377;
     use proptest::collection::vec;
     use proptest::prelude::*;
-    use rand::{rngs::StdRng, SeedableRng};
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
 
     fn arb_participants(min: usize, max: usize) -> impl Strategy<Value = Vec<(PartyId, Stake)>> {
         vec(any::<Stake>(), min..=max).prop_map(|v| v.into_iter().enumerate().collect())
@@ -186,7 +187,7 @@ mod tests {
                        nkeys in 2..10_usize,
                        stop in 2..10_usize,
                        seed in any::<[u8;32]>()) {
-            let mut rng = StdRng::from_seed(seed);
+            let mut rng = ChaCha20Rng::from_seed(seed);
             let mut kr = KeyReg::new(&ps);
 
             let gen_keys = (1..nkeys).map(|i| {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -58,7 +58,7 @@ mod c_api {
         stm::*,
         PartyId, Stake,
     };
-    use rand::rngs::OsRng;
+    use rand_core::OsRng;
     use std::ffi::CStr;
     use std::os::raw::c_char;
 

--- a/rust/src/msp.rs
+++ b/rust/src/msp.rs
@@ -7,7 +7,7 @@ use ark_ec::{AffineCurve, PairingEngine};
 use ark_ff::{bytes::ToBytes, ToConstraintField, UniformRand};
 use blake2::VarBlake2b;
 use digest::{Update, VariableOutput};
-use rand::Rng;
+use rand_core::{CryptoRng, RngCore};
 use std::cmp::Ordering;
 use std::hash::Hash;
 use std::marker::PhantomData;
@@ -65,7 +65,7 @@ const M: &[u8] = b"M";
 impl<PE: PairingEngine> Msp<PE> {
     pub fn gen<R>(rng: &mut R) -> (MspSk<PE>, MspPk<PE>)
     where
-        R: Rng + rand::CryptoRng + ?Sized,
+        R: RngCore + CryptoRng,
     {
         // sk=x <- Zq
         // mvk <- g2^x
@@ -168,7 +168,9 @@ mod tests {
     use super::*;
     use ark_bls12_377::{Bls12_377, Fr, G1Affine, G2Affine};
     use proptest::prelude::*;
-    use rand::thread_rng;
+
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::{OsRng, SeedableRng};
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(1000))]
@@ -185,27 +187,34 @@ mod tests {
         }
 
         #[test]
-        fn test_sig(msg in prop::collection::vec(any::<u8>(), 1..128)) {
-            let (sk, pk) = Msp::<Bls12_377>::gen(&mut thread_rng());
+        fn test_sig(
+            msg in prop::collection::vec(any::<u8>(), 1..128),
+            seed in any::<[u8;32]>(),
+        ) {
+            let (sk, pk) = Msp::<Bls12_377>::gen(&mut ChaCha20Rng::from_seed(seed));
             let sig = Msp::sig(&sk, &msg);
             assert!(Msp::ver(&msg, &pk.mvk, &sig));
         }
 
         #[test]
         fn test_invalid_sig(msg in prop::collection::vec(any::<u8>(), 1..128),
-                            r in any::<u64>()) {
-            let (sk, pk) = Msp::<Bls12_377>::gen(&mut thread_rng());
+                            r in any::<u64>(),
+                            seed in any::<[u8;32]>(),
+        ) {
+            let (sk, pk) = Msp::<Bls12_377>::gen(&mut ChaCha20Rng::from_seed(seed));
             let x = MspSig(G1Affine::prime_subgroup_generator().mul(Fr::from(r)));
             assert!(!Msp::ver(&msg, &pk.mvk, &x));
         }
 
         #[test]
         fn test_aggregate_sig(msg in prop::collection::vec(any::<u8>(), 1..128),
-                              num_sigs in 1..16) {
+                              num_sigs in 1..16,
+                              seed in any::<[u8;32]>(),
+        ) {
             let mut mvks = Vec::new();
             let mut sigs = Vec::new();
             for _ in 0..num_sigs {
-                let (sk, pk) = Msp::<Bls12_377>::gen(&mut thread_rng());
+                let (sk, pk) = Msp::<Bls12_377>::gen(&mut ChaCha20Rng::from_seed(seed));
                 let sig = Msp::sig(&sk, &msg);
                 assert!(Msp::ver(&msg, &pk.mvk, &sig));
                 sigs.push(sig);
@@ -228,7 +237,7 @@ mod tests {
     #[test]
     fn test_gen() {
         for _ in 0..128 {
-            let (_sk, pk) = Msp::<Bls12_377>::gen(&mut thread_rng());
+            let (_sk, pk) = Msp::<Bls12_377>::gen(&mut OsRng);
             assert!(Msp::check(&pk));
         }
     }


### PR DESCRIPTION
Got messed up with local and upstream version of main in #23 . This covers those changes. 

* Using rand_core and rand_chacha is sufficient
* changed the bound of `rand::Rng + rand_core::CryptoRng + ?Sized` by `RngCore + CryptoRng` from rand_core.