### PR TITLE
Remove trigger CI on PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,7 @@
 name: CI
 
 # do not run workflow twice on PRs
-on:
-  push:
-  pull_request:
-    types: [opened, reopened]
+on: [push]
 
 jobs:
   build-mithril-core:


### PR DESCRIPTION
We don't need anymore to trigger a CI run when a PR is created

Closes #121 