### PR TITLE
Add missing Dockerfile in terraform provisioner

### DIFF
--- a/mithril-infra/aggregator.tf
+++ b/mithril-infra/aggregator.tf
@@ -18,6 +18,11 @@ resource "null_resource" "mithril-aggregator" {
     destination = "/home/curry/docker-compose.yaml"
   }
 
+  provisioner "file" {
+    source      = "Dockerfile.cardano"
+    destination = "/home/curry/Dockerfile.cardano"
+  }
+
   # logs shipment to grafana cloud
   provisioner "file" {
     source      = "promtail-config.yml"


### PR DESCRIPTION
The new `Dockerfile.cardano` file is not found when terraform configuration is applied.
This PR fixes the issue.

Relates to #273