### PR TITLE
Update 'cardano-node' to version 1.35.0

### DIFF
--- a/mithril-aggregator/Dockerfile
+++ b/mithril-aggregator/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR /app/
 RUN chown -R appuser /app/
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.34.1-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.35.0-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN rm -f cardano-bin.tar.gz
 

--- a/mithril-aggregator/Dockerfile.ci
+++ b/mithril-aggregator/Dockerfile.ci
@@ -14,7 +14,7 @@ COPY mithril-aggregator/mithril-aggregator /app/bin/mithril-aggregator
 COPY mithril-aggregator/config /app/config
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.34.1-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.35.0-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN rm -f cardano-bin.tar.gz
 

--- a/mithril-infra/Dockerfile.cardano
+++ b/mithril-infra/Dockerfile.cardano
@@ -1,4 +1,4 @@
-FROM inputoutput/cardano-node:latest
+FROM inputoutput/cardano-node:1.35.0
 
 # Fix env file rights
 # In order to be able to interact with the Cardano node trough its 'node.socket'

--- a/mithril-infra/docker-compose.yaml
+++ b/mithril-infra/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: cardano-node/latest-modified
+    image: cardano-node/1.35.0-modified
     build:
       context: .
       dockerfile: Dockerfile.cardano

--- a/mithril-signer/Dockerfile
+++ b/mithril-signer/Dockerfile
@@ -50,7 +50,7 @@ COPY --from=rustbuilder /app/config /app/config
 WORKDIR /app/
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.34.1-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.35.0-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN rm -f cardano-bin.tar.gz
 

--- a/mithril-signer/Dockerfile.ci
+++ b/mithril-signer/Dockerfile.ci
@@ -14,7 +14,7 @@ COPY mithril-signer/mithril-signer /app/bin/mithril-signer
 COPY mithril-signer/config /app/config
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.34.1-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.35.0-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN rm -f cardano-bin.tar.gz
 

--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -45,7 +45,7 @@ NETWORK_MAGIC=42
 SECURITY_PARAM=2
 NODE_ADDR_PREFIX="172.16.238"
 NODE_ADDR_INCREMENT=10
-CARDANO_BINARY_URL="https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.34.1-linux.tar.gz"
+CARDANO_BINARY_URL="https://hydra.iohk.io/build/13065769/download/1/cardano-node-1.35.0-linux.tar.gz"
 
 BFT_NODES=()
 BFT_NODES_N=()


### PR DESCRIPTION
This upgrade to version `1.35.0` is mandatory to resume receiving new blocks from the Cardano `testnet` following `Vasil` hard fork

Relates to #273 