### PR TITLE
Add 'latest' tag to Docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,8 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags:
+          tags: |
+            latest
             type=raw,value={{branch}}-{{sha}}
 
       - name: Download ${{ matrix.project }} executable


### PR DESCRIPTION
This PR adds the `latest` tag to the Docker images when they are produced by the CI and stored in the registry.

Relates to #92