### PR TITLE
Update Aggregator startup command on GCP

### DIFF
--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -10,7 +10,7 @@ use mithril_common::entities::{
 };
 use mithril_common::{store::stake_store::StakeStorer, CardanoNetwork};
 
-use slog_scope::{debug, error, info, trace, warn};
+use slog_scope::{debug, error, info, trace};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -262,7 +262,6 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .await;
 
         debug!("creating certificate pending using multisigner");
-        warn!("pending certificate's previous hash is fake");
         let pending_certificate = CertificatePending::new(
             beacon,
             multi_signer

--- a/mithril-infra/docker-compose.yaml
+++ b/mithril-infra/docker-compose.yaml
@@ -63,6 +63,16 @@ services:
       - ./ipc:/ipc
     ports:
       - "80:8080"
+    command:
+      [
+        "--db-directory",
+        "/db",
+        "--snapshot-directory",
+        "/mithril-aggregator/snapshots",
+        "--server-port",
+        "8080",
+        "-vvv"
+      ]
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
The default configuration for `snapshot_directory` (i.e. `.`)  was used and is not writable as it is the `/app/bin` directory of the container. This PR fixes the issue by adding a `command` to the `mithril-aggregator` node configuration.

Also removed unwanted warning about pending certificate previous hash.

Relates to #273 