### PR TITLE
Use a deterministic RNG for Verification Keys in Signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2083,6 +2083,7 @@ dependencies = [
  "mithril",
  "mithril-common",
  "mockall",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.3",
  "reqwest",
  "serde",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -15,6 +15,7 @@ flate2 = "1.0.23"
 hex = "0.4.3"
 mithril = { path = "../mithril-core" }
 mithril-common = { path = "../mithril-common" }
+rand_chacha = "0.3.1"
 rand_core   = "0.6.3"
 reqwest = { version = "0.11", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -121,7 +121,18 @@ impl SingleSigner for MithrilSingleSigner {
                     .iter()
                     .find(|s| s.party_id == self.party_id)
                     .ok_or(SingleSignerError::UnregisteredPartyId())?;
-                let mut rng = rand_core::OsRng;
+
+                // TODO: Uncomment next line and remove the 4 following lines with deterministic random generator when the protocol initializer store is created
+                //let mut rng = rand_core::OsRng;
+                use rand_chacha::ChaCha20Rng;
+                use rand_core::SeedableRng;
+                let seed: [u8; 32] = self.party_id.as_bytes()[..32].try_into().map_err(|_| {
+                    SingleSignerError::ProtocolSignerCreationFailure(
+                        "impossible to generate a seed".to_string(),
+                    )
+                })?;
+                let mut rng = ChaCha20Rng::from_seed(seed);
+                //
                 ProtocolInitializer::setup(
                     protocol_parameters.to_owned().into(),
                     current_signer_with_stake.stake,


### PR DESCRIPTION
This is a short term fix: it will allow the deterministic generation of `Verifications Keys` by the Signer
It will help us in handling epoch offset until the `Protocol Initializer Store` is implemented in the Signer

:warning:  This modification will be rolled back to a non deterministic RNG once issue #362 is completed

Relates to #361 