### PR TITLE
New features org

### DIFF
--- a/mithril-core/src/error.rs
+++ b/mithril-core/src/error.rs
@@ -6,7 +6,7 @@ use crate::multi_sig_zcash::{Signature, VerificationKey, VerificationKeyPoP};
 use digest::{Digest, FixedOutput};
 #[cfg(feature = "blast")]
 use {
-    crate::multi_sig::{Signature, VerificationKey, VerificationKeyPoP},
+    crate::multi_sig_blast::{Signature, VerificationKey, VerificationKeyPoP},
     blst::BLST_ERROR,
 };
 
@@ -170,9 +170,9 @@ pub(crate) fn blst_err_to_atms(
         BLST_ERROR::BLST_SUCCESS => Ok(()),
         BLST_ERROR::BLST_VERIFY_FAIL => {
             if let Some(s) = sig {
-                return Err(MultiSignatureError::SignatureInvalid(s));
+                Err(MultiSignatureError::SignatureInvalid(s))
             } else {
-                return Err(MultiSignatureError::AggregateSignatureInvalid);
+                Err(MultiSignatureError::AggregateSignatureInvalid)
             }
         }
         _ => Err(MultiSignatureError::SerializationError),

--- a/mithril-core/src/key_reg.rs
+++ b/mithril-core/src/key_reg.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 #[cfg(feature = "blast")]
-use crate::multi_sig::{VerificationKey, VerificationKeyPoP};
+use crate::multi_sig_blast::{VerificationKey, VerificationKeyPoP};
 #[cfg(not(feature = "blast"))]
 use crate::multi_sig_zcash::{VerificationKey, VerificationKeyPoP};
 

--- a/mithril-core/src/lib.rs
+++ b/mithril-core/src/lib.rs
@@ -9,7 +9,7 @@ mod merkle_tree;
 pub mod stm;
 
 #[cfg(feature = "blast")]
-mod multi_sig;
+mod multi_sig_blast;
 #[cfg(not(feature = "blast"))]
 mod multi_sig_zcash;
 

--- a/mithril-core/src/merkle_tree.rs
+++ b/mithril-core/src/merkle_tree.rs
@@ -1,7 +1,7 @@
 //! Creation and verification of Merkle Trees
 use crate::error::MerkleTreeError;
 #[cfg(feature = "blast")]
-use crate::multi_sig::VerificationKey;
+use crate::multi_sig_blast::VerificationKey;
 #[cfg(not(feature = "blast"))]
 use crate::multi_sig_zcash::VerificationKey;
 use crate::stm::Stake;

--- a/mithril-core/src/multi_sig_blast.rs
+++ b/mithril-core/src/multi_sig_blast.rs
@@ -426,9 +426,7 @@ impl Signature {
             hasher.update(&index.to_be_bytes());
             signatures.push(&sig.0);
             scalar_bytes[..16].copy_from_slice(&hasher.finalize().as_slice()[..16]);
-            scalars.push(blst_scalar {
-                b: scalar_bytes.clone(),
-            });
+            scalars.push(blst_scalar { b: scalar_bytes });
             messages.push(msg); // todo: can we do this for the same message??
         }
 

--- a/mithril-core/src/multi_sig_zcash.rs
+++ b/mithril-core/src/multi_sig_zcash.rs
@@ -16,9 +16,9 @@ use group::Curve;
 
 use rand_core::{CryptoRng, RngCore};
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
-use std::fmt::{Display, Formatter};
 use std::{
     cmp::Ordering,
+    fmt::{Display, Formatter},
     hash::{Hash, Hasher},
     iter::Sum,
 };

--- a/mithril-core/src/stm.rs
+++ b/mithril-core/src/stm.rs
@@ -110,7 +110,7 @@ use crate::error::{AggregationError, RegisterError, StmSignatureError};
 use crate::key_reg::ClosedKeyReg;
 use crate::merkle_tree::{MTLeaf, MerkleTreeCommitment, Path};
 #[cfg(feature = "blast")]
-use crate::multi_sig::{Signature, SigningKey, VerificationKey, VerificationKeyPoP};
+use crate::multi_sig_blast::{Signature, SigningKey, VerificationKey, VerificationKeyPoP};
 #[cfg(not(feature = "blast"))]
 use crate::multi_sig_zcash::{Signature, SigningKey, VerificationKey, VerificationKeyPoP};
 use digest::{Digest, FixedOutput};


### PR DESCRIPTION
This PR closes #421 and #414:
1. Handled the missing unwraps in `mithril-core`, by properly handling the errors of `zkcrypto`'s backend.
2. Re-adapted the features, such that the default feature is zkcrypto, and the optional is blast. Before if blast was used, we still had the zkcrypto backend, becase the conditional compilation happened when zkcrypto was _not_ enabled, so having both didn't change anything. In this way, the code is checked for both backends in the pipeline.

While doing this, I've also revisited the error files. I removed the SingleSignatureError, and merged everything into the SignatureError, as I believe that is sufficient.