### PR TITLE
Make fake Beacon static

### DIFF
--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -10,7 +10,7 @@ async fn create_certificate() {
     let mut tester = RuntimeTester::build().await;
 
     comment!("create signers & declare stake distribution");
-    let signers = tests_setup::setup_signers(2);
+    let signers = tests_setup::setup_signers(10);
     let signers_with_stake: Vec<SignerWithStake> =
         signers.clone().into_iter().map(|s| s.into()).collect();
     tester

--- a/mithril-common/src/fake_data.rs
+++ b/mithril-common/src/fake_data.rs
@@ -1,7 +1,5 @@
 //! Fake data builders for testing.
 
-use std::time::{SystemTime, UNIX_EPOCH};
-
 use crate::entities::{
     CertificateMetadata, LotteryIndex, ProtocolMessage, ProtocolMessagePartKey, SingleSignatures,
 };
@@ -10,13 +8,8 @@ use crate::{crypto_helper, entities};
 /// Fake Beacon
 pub fn beacon() -> entities::Beacon {
     let network = "testnet".to_string();
-    let seconds_since_unix_epoch = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    let immutable_file_number = (seconds_since_unix_epoch / (20)) as u64; // 1 immutable_file_number every 20s
-    let epoch = (immutable_file_number / 9) as u64; // 1 epoch every 9 immutable_file_number
-
+    let immutable_file_number = 100;
+    let epoch = 10;
     entities::Beacon::new(network, epoch, immutable_file_number)
 }
 


### PR DESCRIPTION
This was a source of flakiness in some integration tests and a static fake beacon is now enough