### PR TITLE
Fix attempt 'Permission Denied' in devnet

### DIFF
--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -783,7 +783,7 @@ cat >> docker-compose.yaml <<EOF
     profiles:
       - cardano
     volumes:
-    - ./${NODE}:/data
+    - ./${NODE}:/data:z
     environment:
     - CARDANO_NODE_SOCKET_PATH=/data/ipc/node.sock
     networks:
@@ -832,7 +832,7 @@ cat >> docker-compose.yaml <<EOF
     profiles:
       - cardano
     volumes:
-    - ./${NODE}:/data
+    - ./${NODE}:/data:z
     environment:
     - CARDANO_NODE_SOCKET_PATH=/data/ipc/node.sock
     networks:
@@ -876,7 +876,7 @@ cat >> docker-compose.yaml <<EOF
     profiles:
       - mithril
     volumes:
-      - ./${NODE}:/data
+      - ./${NODE}:/data:z
     networks:
     - mithril_network
     ports:
@@ -922,7 +922,7 @@ cat >> docker-compose.yaml <<EOF
     profiles:
       - mithril
     volumes:
-      - ./${NODE}:/data
+      - ./${NODE}:/data:z
     networks:
     - mithril_network
     env_file:


### PR DESCRIPTION
This PR adds a `:z` option on volumes in the `devnet` `docker-compose.yaml` generated file so that we avoid `Permission denied` errors

Relates with #459