### PR TITLE
use StoreError in stores

### DIFF
--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -20,9 +20,8 @@ pub use snapshot_uploaders::{
 };
 pub use snapshotter::{DumbSnapshotter, GzipSnapshotter, SnapshotError, Snapshotter};
 pub use store::{
-    CertificatePendingStore, CertificateStore, ProtocolParametersStore,
-    ProtocolParametersStoreError, ProtocolParametersStorer, SingleSignatureStore,
-    VerificationKeyStore, VerificationKeyStoreError, VerificationKeyStorer,
+    CertificatePendingStore, CertificateStore, ProtocolParametersStore, ProtocolParametersStorer,
+    SingleSignatureStore, VerificationKeyStore, VerificationKeyStorer,
 };
 
 #[cfg(test)]

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -13,7 +13,7 @@ use mithril_common::crypto_helper::{
     PROTOCOL_VERSION,
 };
 use mithril_common::entities::{self, SignerWithStake};
-use mithril_common::store::{StakeStoreError, StakeStorer};
+use mithril_common::store::{StakeStorer, StoreError};
 use mithril_common::{
     NEXT_SIGNER_EPOCH_RETRIEVAL_OFFSET, SIGNER_EPOCH_RECORDING_OFFSET,
     SIGNER_EPOCH_RETRIEVAL_OFFSET,
@@ -23,11 +23,8 @@ use crate::dependency::{
     ProtocolParametersStoreWrapper, SingleSignatureStoreWrapper, StakeStoreWrapper,
     VerificationKeyStoreWrapper,
 };
-use crate::store::{
-    SingleSignatureStoreError, SingleSignatureStorer, VerificationKeyStoreError,
-    VerificationKeyStorer,
-};
-use crate::{ProtocolParametersStoreError, ProtocolParametersStorer};
+use crate::store::{SingleSignatureStorer, VerificationKeyStorer};
+use crate::ProtocolParametersStorer;
 
 #[cfg(test)]
 use mockall::automock;
@@ -58,17 +55,8 @@ pub enum ProtocolError {
     #[error("no beacon available")]
     UnavailableBeacon(),
 
-    #[error("verification key store error: '{0}'")]
-    VerificationKeyStore(#[from] VerificationKeyStoreError),
-
-    #[error("stake store error: '{0}'")]
-    StakeStore(#[from] StakeStoreError),
-
-    #[error("single signature store error: '{0}'")]
-    SingleSignatureStore(#[from] SingleSignatureStoreError),
-
-    #[error("protocol parameters store error: '{0}'")]
-    ProtocolParametersStore(#[from] ProtocolParametersStoreError),
+    #[error("store error: {0}")]
+    StoreError(#[from] StoreError),
 
     #[error("beacon error: '{0}'")]
     Beacon(#[from] entities::EpochError),

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -1,11 +1,10 @@
 use crate::snapshot_stores::SnapshotStoreError;
-use crate::store::StoreError;
-use crate::{ProtocolError, ProtocolParametersStoreError, SnapshotError};
+use crate::{ProtocolError, SnapshotError};
 
 use mithril_common::chain_observer::ChainObserverError;
 use mithril_common::digesters::{ImmutableDigesterError, ImmutableFileListingError};
 use mithril_common::entities::Epoch;
-use mithril_common::store::StakeStoreError;
+use mithril_common::store::StoreError;
 use mithril_common::BeaconProviderError;
 use std::error::Error as StdError;
 use std::io;
@@ -21,15 +20,6 @@ pub enum RuntimeError {
 
     #[error("digester error: {0}")]
     Digester(#[from] ImmutableDigesterError),
-
-    #[error("snapshot store error: {0}")]
-    SnapshotStore(#[from] SnapshotStoreError),
-
-    #[error("stake store error: {0}")]
-    StakeStore(#[from] StakeStoreError),
-
-    #[error("protocol parameters store error: {0}")]
-    ProtocolParametersStore(#[from] ProtocolParametersStoreError),
 
     #[error("store error: {0}")]
     StoreError(#[from] StoreError),
@@ -51,6 +41,9 @@ pub enum RuntimeError {
 
     #[error("certificate chain gap error: {0} vs {1}")]
     CertificateChainEpochGap(Epoch, Epoch),
+
+    #[error("snapshot store error: {0}")]
+    SnapshotStore(#[from] SnapshotStoreError),
 
     #[error("general error: {0}")]
     General(Box<dyn StdError + Sync + Send>),

--- a/mithril-aggregator/src/store/certificate_store.rs
+++ b/mithril-aggregator/src/store/certificate_store.rs
@@ -1,8 +1,7 @@
-use super::StoreError;
 use tokio::sync::RwLock;
 
 use mithril_common::entities::{Beacon, Certificate};
-use mithril_common::store::adapter::StoreAdapter;
+use mithril_common::store::{adapter::StoreAdapter, StoreError};
 
 type Adapter = Box<dyn StoreAdapter<Key = String, Record = Certificate>>;
 

--- a/mithril-aggregator/src/store/error.rs
+++ b/mithril-aggregator/src/store/error.rs
@@ -1,8 +1,0 @@
-use mithril_common::store::adapter::AdapterError;
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum StoreError {
-    #[error("physical adapter returned an error: {0}")]
-    AdapterError(#[from] AdapterError),
-}

--- a/mithril-aggregator/src/store/mod.rs
+++ b/mithril-aggregator/src/store/mod.rs
@@ -1,19 +1,11 @@
 mod certificate_store;
-mod error;
 mod pending_certificate_store;
 mod protocol_parameters_store;
 mod single_signature_store;
 mod verification_key_store;
 
 pub use certificate_store::CertificateStore;
-pub use error::StoreError;
 pub use pending_certificate_store::CertificatePendingStore;
-pub use protocol_parameters_store::{
-    ProtocolParametersStore, ProtocolParametersStoreError, ProtocolParametersStorer,
-};
-pub use single_signature_store::{
-    SingleSignatureStore, SingleSignatureStoreError, SingleSignatureStorer,
-};
-pub use verification_key_store::{
-    VerificationKeyStore, VerificationKeyStoreError, VerificationKeyStorer,
-};
+pub use protocol_parameters_store::{ProtocolParametersStore, ProtocolParametersStorer};
+pub use single_signature_store::{SingleSignatureStore, SingleSignatureStorer};
+pub use verification_key_store::{VerificationKeyStore, VerificationKeyStorer};

--- a/mithril-aggregator/src/store/pending_certificate_store.rs
+++ b/mithril-aggregator/src/store/pending_certificate_store.rs
@@ -1,8 +1,7 @@
-use super::StoreError;
 use tokio::sync::RwLock;
 
 use mithril_common::entities::CertificatePending;
-use mithril_common::store::adapter::StoreAdapter;
+use mithril_common::store::{adapter::StoreAdapter, StoreError};
 
 type Adapter = Box<dyn StoreAdapter<Key = String, Record = CertificatePending>>;
 

--- a/mithril-common/src/store/error.rs
+++ b/mithril-common/src/store/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+use super::adapter::AdapterError;
+
+/// Generic error type for stores.
+#[derive(Error, Debug)]
+pub enum StoreError {
+    /// Error raised when the underlying [adapter][StoreAdapter] raise an error.
+    #[error("Store adapter raised an error: {0}")]
+    AdapterError(#[from] AdapterError),
+}

--- a/mithril-common/src/store/mod.rs
+++ b/mithril-common/src/store/mod.rs
@@ -2,6 +2,8 @@
 //! to store stakes.
 
 pub mod adapter;
+mod error;
 mod stake_store;
 
-pub use stake_store::{StakeStore, StakeStoreError, StakeStorer};
+pub use error::StoreError;
+pub use stake_store::{StakeStore, StakeStorer};


### PR DESCRIPTION
Each stores tended to use their own specific error type, all of them
having only one value: AdapterError. This is now done within one type in
mithril-common::StoreError.