### PR TITLE
Remove common test utils from release build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,8 +111,18 @@ jobs:
         if: ${{ matrix.skip_tests != true }}
         shell: bash
         run: |
-          set -o pipefail && \
-          cargo test --release --features portable -p $CARGO_PROJECT_NAME --no-fail-fast \
+          set -o pipefail
+          get_features() {
+            local features='portable'
+          
+            if [[ "${{ matrix.project }}" == "mithril-common" ]]; then
+              features="$features test-utils"
+            fi
+          
+            echo $features
+          }
+          
+          cargo test --release --features "$(get_features)" -p $CARGO_PROJECT_NAME --no-fail-fast \
               -- -Z unstable-options --format json --report-time \
               | tee >(cargo2junit > test-results-${{ env.ARTIFACTS_PATTERN }}.xml)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
  "getrandom 0.2.7",
  "once_cell",
+ "serde",
  "version_check",
 ]
 
@@ -30,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7ed72e1635e121ca3e79420540282af22da58be50de153d36f81ddc6b83aa9e"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
@@ -45,6 +46,12 @@ checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
 
 [[package]]
 name = "arc-swap"
@@ -98,9 +105,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5262ed948da60dd8956c6c5aca4d4163593dddb7b32d73267c93dab7b2e98940"
+checksum = "0da5b41ee986eed3f524c380e6d64965aea573882a8907682ad100f7859305ca"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -108,16 +115,16 @@ dependencies = [
  "async-lock",
  "blocking",
  "futures-lite",
- "num_cpus",
  "once_cell",
 ]
 
 [[package]]
 name = "async-io"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5e18f61464ae81cde0a23e713ae8fd299580c54d697a35820cfd0625b8b0e07"
+checksum = "0ab006897723d9352f63e2b13047177c3982d8d79709d713ce7747a8f19fd1b0"
 dependencies = [
+ "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
@@ -151,11 +158,12 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2c06e30a24e8c78a3987d07f0930edf76ef35e027e7bdb063fccafdad1f60c"
+checksum = "02111fd8655a613c25069ea89fc8d9bb89331fa77486eb3bc059ee757cfa481c"
 dependencies = [
  "async-io",
+ "autocfg",
  "blocking",
  "cfg-if",
  "event-listener",
@@ -372,9 +380,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "bytecount"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
@@ -457,9 +471,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.17"
+version = "3.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e724a68d9319343bb3328c9cc2dfde263f4b3142ee1059a9980580171c954b"
+checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
 dependencies = [
  "atty",
  "bitflags",
@@ -474,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.17"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13547f7012c01ab4a0e8f8967730ada8f9fdf419e8b6c792788f39cf4e46eefa"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -586,9 +600,9 @@ checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -844,9 +858,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "ena"
@@ -874,9 +888,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fancy-regex"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6b8560a05112eb52f04b00e5d3790c0dd75d9d980eb8a122fb23b92a623ccf"
+checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
 dependencies = [
  "bit-set",
  "regex",
@@ -905,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "fixed"
-version = "1.17.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff8fc11090cf4e92c9f9052e778d3dc869d0fb943cdc5568df3d3b559a58787"
+checksum = "e0371cd413fb63f8ec1b9eb4dff47fa2c88b21abc681771234c84808b9920991"
 dependencies = [
  "az",
  "bytemuck",
@@ -973,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d24d088325f939faaf806483fbfac0548e43018606bfe7a44abc83f6dc75ea"
+checksum = "6bb65943183b6b3cbf00f64c181e8178217e30194381b150e4f87ec59864c803"
 dependencies = [
  "lazy_static",
  "num",
@@ -989,9 +1003,9 @@ checksum = "85dcb89d2b10c5f6133de2efd8c11959ce9dbb46a2f7a4cab208c4eeda6ce1ab"
 
 [[package]]
 name = "futures"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab30e97ab6aacfe635fad58f22c2bb06c8b685f7421eb1e064a729e2a5f481fa"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1004,9 +1018,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bfc52cbddcfd745bf1740338492bb0bd83d76c67b445f91c5fb29fae29ecaa1"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1014,15 +1028,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2acedae88d38235936c3922476b10fced7b2b68136f5e3c03c2d5be348a1115"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d11aa21b5b587a64682c0094c2bdd4df0076c5324961a40cc3abd7f37930528"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1031,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a66fc6d035a26a3ae255a6d2bca35eda63ae4c5512bef54449113f7a1228e5"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -1052,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0db9cce532b0eae2ccf2766ab246f114b56b9cf6d445e00c2549fbc100ca045d"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1063,21 +1077,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0bae1fe9752cf7fd9b0064c674ae63f97b37bc714d745cbde0afb7ec4e6765"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "842fc63b931f4056a24d59de13fb1272134ce261816e063e634ad0c15cdc5306"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.23"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0828a5471e340229c11c77ca80017937ce3c58cb788a17e5f1c2d5c485a9577"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1284,9 +1298,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
@@ -1361,13 +1375,14 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.45"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5528d9c2817db4e10cc78f8d4c8228906e5854f389ff6b076cee3572a09d35"
+checksum = "4c495f162af0bf17656d0014a0eded5f3cd2f365fdd204548c2869db89359dc7"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1436,6 +1451,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iso8601"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5b94fbeb759754d87e1daea745bc8efd3037cd16980331fe1d1524c9a79ce96"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1478,25 +1502,31 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.12.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f866fd6aaffb6be509b844f988b8c8cef3194418a08f9223294c4c676f2b497f"
+checksum = "4ebd40599e7f1230ce296f73b88c022b98ed66689f97eaa54bbeadc337a2ffa6"
 dependencies = [
  "ahash",
+ "anyhow",
  "base64 0.13.0",
+ "bytecount",
  "fancy-regex",
  "fraction",
- "itoa 0.4.8",
+ "iso8601",
+ "itoa 1.0.3",
  "lazy_static",
+ "memchr",
  "num-cmp",
  "parking_lot",
  "percent-encoding",
  "regex",
  "reqwest",
+ "serde",
  "serde_json",
  "structopt",
- "time 0.3.13",
+ "time 0.3.14",
  "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1602,9 +1632,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1721,7 +1751,7 @@ dependencies = [
  "async-trait",
  "blake2",
  "chrono",
- "clap 3.2.17",
+ "clap 3.2.19",
  "cloud-storage",
  "config",
  "flate2",
@@ -1753,7 +1783,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "blake2",
- "clap 3.2.17",
+ "clap 3.2.19",
  "cli-table",
  "config",
  "flate2",
@@ -1793,7 +1823,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "sha2 0.10.2",
+ "sha2 0.10.3",
  "slog",
  "slog-scope",
  "sqlite",
@@ -1808,7 +1838,7 @@ name = "mithril-end-to-end"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "clap 3.2.17",
+ "clap 3.2.19",
  "glob",
  "hex",
  "mithril-common",
@@ -1831,7 +1861,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "blake2",
- "clap 3.2.17",
+ "clap 3.2.19",
  "config",
  "hex",
  "httpmock",
@@ -1857,7 +1887,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.0",
  "blake2",
- "clap 3.2.17",
+ "clap 3.2.19",
  "hex",
  "log",
  "mithril-common",
@@ -2210,9 +2240,9 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pest"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69486e2b8c2d2aeb9762db7b4e00b0331156393555cff467f4163ff06821eef8"
+checksum = "4b0560d531d1febc25a3c9398a62a71256c0178f2e3443baedd9ad4bb8c9deb4"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -2220,9 +2250,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13570633aff33c6d22ce47dd566b10a3b9122c2fe9d8e7501895905be532b91"
+checksum = "905708f7f674518498c1f8d644481440f476d39ca6ecae83319bba7c6c12da91"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2230,9 +2260,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c567e5702efdc79fb18859ea74c3eb36e14c43da7b8c1f098a4ed6514ec7a0"
+checksum = "5803d8284a629cc999094ecd630f55e91b561a1d1ba75e233b00ae13b91a69ad"
 dependencies = [
  "pest",
  "pest_meta",
@@ -2243,9 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb32be5ee3bbdafa8c7a18b0a8a8d962b66cfa2ceee4037f49267a50ee821fe"
+checksum = "1538eb784f07615c6d9a8ab061089c6c54a344c5b4301db51990ca1c241e8c04"
 dependencies = [
  "once_cell",
  "pest",
@@ -2317,9 +2347,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
+checksum = "716b4eeb6c4a1d3ecc956f75b43ec2e8e8ba80026413e70a3f41fd3313d3492b"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2336,19 +2366,20 @@ checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
 
 [[package]]
 name = "polling"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685404d509889fade3e86fe3a5803bca2ec09b0c0778d5ada6ec8bf7a8de5259"
+checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "libc",
  "log",
@@ -2776,9 +2807,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -2799,9 +2830,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -2818,9 +2849,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2829,9 +2860,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
@@ -2862,14 +2893,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.26"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
 dependencies = [
  "indexmap",
+ "itoa 1.0.3",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2911,9 +2943,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+checksum = "899bf02746a2c92bf1053d9327dadb252b01af1f81f90cdb902411f518bc7215"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2998,7 +3030,7 @@ dependencies = [
  "hostname",
  "slog",
  "slog-json",
- "time 0.3.13",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -3010,7 +3042,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.13",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -3034,7 +3066,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.13",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -3056,9 +3088,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
 dependencies = [
  "libc",
  "winapi",
@@ -3252,18 +3284,18 @@ checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3301,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa 1.0.3",
  "libc",
@@ -3598,6 +3630,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931179334a56395bcf64ba5e0ff56781381c1a5832178280c7d7f91d1679aeb0"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3620,6 +3658,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "value-bag"
@@ -3820,13 +3864,13 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "4.2.5"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
 dependencies = [
  "either",
- "lazy_static",
  "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/demo/protocol-demo/Makefile
+++ b/demo/protocol-demo/Makefile
@@ -25,6 +25,7 @@ test:
 check:
 	${CARGO} check --release --all-features --all-targets
 	${CARGO} clippy --release --all-features
+	${CARGO} fmt --check
 
 clean:
 	${CARGO} clean

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -19,7 +19,7 @@ mithril-common = { path = "../mithril-common" }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.8"
+serde_yaml = "0.9.10"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = "2.7.0"
 slog-bunyan = "2.4.0"

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -32,6 +32,7 @@ warp = "0.3"
 
 [dev-dependencies]
 httpmock = "0.6.6"
+mithril-common = { path = "../mithril-common", features = ["test-utils"] }
 mockall = "0.11.0"
 slog-term = "2.9.0"
 tempfile = "3.3.0"

--- a/mithril-aggregator/Makefile
+++ b/mithril-aggregator/Makefile
@@ -20,6 +20,7 @@ test:
 check:
 	${CARGO} check --release --all-features --all-targets
 	${CARGO} clippy --release --all-features
+	${CARGO} fmt --check
 
 help:
 	@${CARGO} run -- -h

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -28,6 +28,7 @@ tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 httpmock = "0.6.6"
+mithril-common = { path = "../mithril-common", features = ["test-utils"] }
 mockall = "0.11.0"
 
 [features]

--- a/mithril-client/Makefile
+++ b/mithril-client/Makefile
@@ -25,6 +25,7 @@ test:
 check:
 	${CARGO} check --release --all-features --all-targets
 	${CARGO} clippy --release --all-features
+	${CARGO} fmt --check
 
 clean:
 	${CARGO} clean

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -13,26 +13,25 @@ blake2 = "0.9.2"
 fixed = "1.15.0"
 glob = "0.3"
 hex = "0.4.3"
-http = "0.2.6"
-jsonschema = "0.12.2"
+http = { version = "0.2.6", optional = true }
+jsonschema = { version = "0.12.2", optional = true }
 mithril = { path = "../mithril-core" }
 mockall = "0.11.0"
 nom = "7.1"
-rand_chacha = "0.3.1"
+rand_chacha = { version = "0.3.1", optional = true }
 rand_core   = "0.6.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.8"
+serde_yaml = { version = "0.8", optional = true }
 sha2 = "0.10.2"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
+slog-scope = { version = "4.4.0", optional = true }
 sqlite = "0.27.0"
 thiserror = "1.0.31"
 tokio = { version = "1.17.0", features = ["full"] }
 walkdir = "2"
-warp = "0.3"
-
-[dev-dependencies]
-slog-scope = "4.4.0"
+warp = { version = "0.3", optional = true }
 
 [features]
 portable = ["mithril/portable"]
+test-utils= ["http", "jsonschema", "rand_chacha", "serde_yaml", "slog-scope", "warp"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -14,7 +14,7 @@ fixed = "1.15.0"
 glob = "0.3"
 hex = "0.4.3"
 http = { version = "0.2.6", optional = true }
-jsonschema = { version = "0.12.2", optional = true }
+jsonschema = { version = "0.16.0", optional = true }
 mithril = { path = "../mithril-core" }
 mockall = "0.11.0"
 nom = "7.1"
@@ -22,7 +22,7 @@ rand_chacha = { version = "0.3.1", optional = true }
 rand_core   = "0.6.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = { version = "0.8", optional = true }
+serde_yaml = { version = "0.9.10", optional = true }
 sha2 = "0.10.2"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
 slog-scope = { version = "4.4.0", optional = true }

--- a/mithril-common/Makefile
+++ b/mithril-common/Makefile
@@ -8,7 +8,7 @@ build:
 	${CARGO} build --release
 
 test:
-	${CARGO} test
+	${CARGO} test --features test-utils
 
 check:
 	${CARGO} check --release --all-features --all-targets

--- a/mithril-common/Makefile
+++ b/mithril-common/Makefile
@@ -13,6 +13,7 @@ test:
 check:
 	${CARGO} check --release --all-features --all-targets
 	${CARGO} clippy --release --all-features
+	${CARGO} fmt --check
 
 doc:
 	${CARGO} doc --no-deps --open

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -242,7 +242,7 @@ impl CertificateVerifier for MithrilCertificateVerifier {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-utils"))]
 mod tests {
     use async_trait::async_trait;
     use mockall::mock;

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -1,9 +1,11 @@
 //! Tools to request metadata, like the current epoch or the stake distribution, from the Cardano
 
 mod cli_observer;
+#[cfg(feature = "test-utils")]
 mod fake_observer;
 mod interface;
 
 pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
+#[cfg(feature = "test-utils")]
 pub use fake_observer::FakeObserver;
 pub use interface::{ChainObserver, ChainObserverError};

--- a/mithril-common/src/crypto_helper/codec.rs
+++ b/mithril-common/src/crypto_helper/codec.rs
@@ -21,7 +21,7 @@ where
     serde_json::from_slice(from_vec.as_slice()).map_err(|e| format!("can't deserialize: {}", e))
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-utils"))]
 pub mod tests {
     use super::super::tests_setup::*;
     use super::super::types::*;

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -2,6 +2,7 @@
 
 mod codec;
 mod conversions;
+#[cfg(feature = "test-utils")]
 pub mod tests_setup;
 mod types;
 

--- a/mithril-common/src/entities/certificate_pending.rs
+++ b/mithril-common/src/entities/certificate_pending.rs
@@ -49,7 +49,7 @@ impl CertificatePending {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-utils"))]
 mod tests {
     use crate::fake_data;
 

--- a/mithril-common/src/entities/single_signatures.rs
+++ b/mithril-common/src/entities/single_signatures.rs
@@ -45,7 +45,7 @@ impl SingleSignatures {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "test-utils"))]
 mod tests {
     use super::*;
     use crate::crypto_helper::key_encode_hex;

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -12,6 +12,7 @@
 //! - useful test utilities including stubs, [fake data][fake_data] builders, a tool validate
 //! conformity to an open api specification ([apispec]).
 
+#[cfg(feature = "test-utils")]
 pub mod apispec;
 mod beacon_provider;
 pub mod certificate_chain;
@@ -19,6 +20,7 @@ pub mod chain_observer;
 pub mod crypto_helper;
 pub mod digesters;
 pub mod entities;
+#[cfg(feature = "test-utils")]
 pub mod fake_data;
 pub mod store;
 

--- a/mithril-common/src/store/adapter/mod.rs
+++ b/mithril-common/src/store/adapter/mod.rs
@@ -13,7 +13,11 @@ pub use memory_adapter::MemoryAdapter;
 pub use sqlite_adapter::{SQLiteAdapter, SQLiteResultIterator};
 pub use store_adapter::*;
 
+#[cfg(feature = "test-utils")]
 mod dumb_adapter;
+#[cfg(feature = "test-utils")]
 pub use dumb_adapter::DumbStoreAdapter;
+#[cfg(feature = "test-utils")]
 mod fail_adapter;
+#[cfg(feature = "test-utils")]
 pub use fail_adapter::FailStoreAdapter;

--- a/mithril-core/Makefile
+++ b/mithril-core/Makefile
@@ -21,6 +21,7 @@ test:
 check:
 	${CARGO} check --release --all-features --all-targets
 	${CARGO} clippy --release --all-features
+	${CARGO} fmt --check
 
 clean:
 	${CARGO} clean

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1.17.0", features = ["full"] }
 
 [dev-dependencies]
 httpmock = "0.6.6"
+mithril-common = { path = "../mithril-common", features = ["test-utils"] }
 mockall = "0.11.0"
 slog-term = "2.9.0"
 

--- a/mithril-signer/Makefile
+++ b/mithril-signer/Makefile
@@ -20,6 +20,7 @@ test:
 check:
 	${CARGO} check --release --all-features --all-targets
 	${CARGO} clippy --release --all-features
+	${CARGO} fmt --check
 
 help:
 	@${CARGO} run -- -h

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -13,7 +13,7 @@ mithril-common = { path = "../../mithril-common", features = ["test-utils"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-serde_yaml = "0.8"
+serde_yaml = "0.9.10"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_trace"] }
 slog-async = "2.7.0"
 slog-scope = "4.4.0"

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1.52"
 clap = { version = "3.1.6", features = ["derive"] }
 glob = "0.3"
 hex = "0.4.3"
-mithril-common = { path = "../../mithril-common" }
+mithril-common = { path = "../../mithril-common", features = ["test-utils"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/mithril-test-lab/mithril-end-to-end/Makefile
+++ b/mithril-test-lab/mithril-end-to-end/Makefile
@@ -19,6 +19,7 @@ test:
 check:
 	${CARGO} check --release --all-features --all-targets
 	${CARGO} clippy --release --all-features
+	${CARGO} fmt --check
 
 clean:
 	${CARGO} clean


### PR DESCRIPTION
This will prevent us from using common test utilities in production code (since now we don't have to use the fake data anymore).
Hopefully this should also reduce the aggregator compilation time. 