### PR TITLE
Move GCP Aggregator to 'preview' network

### DIFF
--- a/docs/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/root/manual/getting-started/bootstrap-cardano-node.md
@@ -10,6 +10,18 @@ Thanks to a **Mithril Client** connected to a **Mithril Aggregator**, you will r
 
 :::
 
+:::tip
+
+The Mithril test networks are:
+
+* `preview`: Test network with magic id `2`, implemented on the IOG hosted Mitril Aggregator
+* `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
+* `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mitril Aggregator, now deprecated
+
+In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+
+:::
+
 ## Download source
 
 Download from Github (HTTPS)

--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -10,6 +10,18 @@ In this guide, you will learn how to setup a **Mithril Signer** on top of a **Ca
 
 :::
 
+:::tip
+
+The Mithril test networks are:
+
+* `preview`: Test network with magic id `2`, implemented on the IOG hosted Mitril Aggregator
+* `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
+* `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mitril Aggregator, now deprecated
+
+In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+
+:::
+
 :::danger
 
 This guide is working only on a Linux machine.
@@ -141,7 +153,6 @@ First create an env file that will be used by the service
 sudo cat > /opt/mithril/mithril-signer.env << EOF
 PARTY_ID=YOUR_POOL_ID_BECH32
 NETWORK=testnet
-NETWORK_MAGIC=1097911063
 AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator
 RUN_INTERVAL=60000 DB_DIRECTORY=/cardano/db
 CARDANO_NODE_SOCKET_PATH=/cardano/ipc/node.socket

--- a/mithril-aggregator/config/preview.json
+++ b/mithril-aggregator/config/preview.json
@@ -1,14 +1,14 @@
 {
     "cardano_cli_path": "cardano-cli",
     "cardano_cli_socket_path": "/tmp/cardano.sock",
-    "network": "testnet",
+    "network": "preview",
     "run_interval": 60000,
     "protocol_parameters": {
         "k": 5,
         "m": 100,
         "phi_f": 0.65
     },
-    "url_snapshot_manifest": "https://storage.googleapis.com/cardano-testnet/snapshots.json",
+    "url_snapshot_manifest": "https://storage.googleapis.com/cardano-preview/snapshots.json",
     "snapshot_store_type": "local",
     "snapshot_uploader_type": "gcp",
     "stores_directory": "./mithril-aggregator/stores"

--- a/mithril-aggregator/src/entities.rs
+++ b/mithril-aggregator/src/entities.rs
@@ -104,30 +104,7 @@ impl Config {
     }
 
     pub fn get_network(&self) -> Result<CardanoNetwork, ConfigError> {
-        match self.network.to_lowercase().as_str() {
-            "mainnet" => Ok(CardanoNetwork::MainNet),
-            "testnet" => {
-                if let Some(magic) = self.network_magic {
-                    Ok(CardanoNetwork::TestNet(magic))
-                } else {
-                    Err(ConfigError::Message(
-                        "no NETWORK MAGIC number given for testnet network".to_string(),
-                    ))
-                }
-            }
-            "devnet" => {
-                if let Some(magic) = self.network_magic {
-                    Ok(CardanoNetwork::DevNet(magic))
-                } else {
-                    Err(ConfigError::Message(
-                        "no NETWORK MAGIC number given for devnet network".to_string(),
-                    ))
-                }
-            }
-            what => Err(ConfigError::Message(format!(
-                "could not parse network '{}', the only recognized networks are: mainnet, devnet, testnet",
-                what
-            ))),
-        }
+        CardanoNetwork::from_code(self.network.clone(), self.network_magic)
+            .map_err(|e| ConfigError::Message(e.to_string()))
     }
 }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -484,7 +484,7 @@ pub mod tests {
 
         // old beacon means the current beacon is newer
         let beacon = Beacon {
-            network: "testnet".to_string(),
+            network: "private".to_string(),
             epoch: Epoch(0),
             immutable_file_number: 0,
         };

--- a/mithril-client/config/preview.json
+++ b/mithril-client/config/preview.json
@@ -1,0 +1,4 @@
+{
+    "network": "preview",
+    "aggregator_endpoint": "https://aggregator.api.mithril.network/aggregator"
+}

--- a/mithril-client/src/main.rs
+++ b/mithril-client/src/main.rs
@@ -154,10 +154,13 @@ to {}
 
 Restore a Cardano Node with:
 
-docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="{}",target=/data/db/ -e NETWORK=testnet inputoutput/cardano-node
+docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="{}",target=/data/db/ -e NETWORK={} inputoutput/cardano-node
 
 "###,
-                    digest, to, to
+                    digest,
+                    to,
+                    to,
+                    config.network.clone()
                 );
                 Ok(())
             }

--- a/mithril-common/src/entities/cardano_network.rs
+++ b/mithril-common/src/entities/cardano_network.rs
@@ -1,19 +1,68 @@
-use crate::MagicId;
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
+use thiserror::Error;
+
+use crate::MagicId;
+
+const TESTNET_MAGIC_ID: MagicId = 1097911063;
+const PREPROD_MAGIC_ID: MagicId = 1;
+const PREVIEW_MAGIC_ID: MagicId = 2;
+
+#[derive(Error, Debug)]
+pub enum CardanoNetworkError {
+    #[error("parse from code error: '{0}'")]
+    ParseFromCode(String),
+}
 
 /// The Cardano Network that is being targeted
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize, Hash, Eq, PartialOrd)]
 pub enum CardanoNetwork {
-    /// The Cardano mainnet
+    /// The Cardano mainnet network
     MainNet,
 
-    /// The Cardano testnet
+    /// A Cardano test network (testnet, preview, or preprod)
     TestNet(MagicId),
 
     /// A Cardano private devnet
     DevNet(MagicId),
+}
+
+impl CardanoNetwork {
+    /// Instantiates a CardanoNetwork from its code and magic id
+    pub fn from_code(
+        network_code: String,
+        network_magic: Option<u64>,
+    ) -> Result<CardanoNetwork, CardanoNetworkError> {
+        match network_code.to_lowercase().as_str() {
+            "mainnet" => Ok(CardanoNetwork::MainNet),
+            "testnet" => Ok(CardanoNetwork::TestNet(TESTNET_MAGIC_ID)),
+            "preview" => Ok(CardanoNetwork::TestNet(PREVIEW_MAGIC_ID)),
+            "preprod" => Ok(CardanoNetwork::TestNet(PREPROD_MAGIC_ID)),
+            "private" => {
+                if let Some(magic) = network_magic {
+                    Ok(CardanoNetwork::TestNet(magic))
+                } else {
+                    Err(CardanoNetworkError::ParseFromCode(
+                        "no NETWORK MAGIC number given for test network".to_string(),
+                    ))
+                }
+            }
+            "devnet" => {
+                if let Some(magic) = network_magic {
+                    Ok(CardanoNetwork::DevNet(magic))
+                } else {
+                    Err(CardanoNetworkError::ParseFromCode(
+                        "no NETWORK MAGIC number given for devnet network".to_string(),
+                    ))
+                }
+            }
+            what => Err(CardanoNetworkError::ParseFromCode(format!(
+                "could not parse network '{}', the only recognized networks are: mainnet, devnet, testnet, preview, preprod and private",
+                what
+            ))),
+        }
+    }
 }
 
 impl Display for CardanoNetwork {
@@ -21,7 +70,12 @@ impl Display for CardanoNetwork {
         match *self {
             CardanoNetwork::MainNet => write!(f, "mainnet"),
             CardanoNetwork::DevNet(_) => write!(f, "devnet"),
-            CardanoNetwork::TestNet(_) => write!(f, "testnet"),
+            CardanoNetwork::TestNet(magic_id) => match magic_id {
+                TESTNET_MAGIC_ID => write!(f, "testnet"),
+                PREVIEW_MAGIC_ID => write!(f, "preview"),
+                PREPROD_MAGIC_ID => write!(f, "preprod"),
+                _ => write!(f, "private"),
+            },
         }
     }
 }

--- a/mithril-infra/Dockerfile.cardano
+++ b/mithril-infra/Dockerfile.cardano
@@ -1,4 +1,4 @@
-FROM inputoutput/cardano-node:1.35.2
+FROM inputoutput/cardano-node:1.35.3
 
 # Fix env file rights
 # In order to be able to interact with the Cardano node trough its 'node.socket'

--- a/mithril-infra/aggregator.tf
+++ b/mithril-infra/aggregator.tf
@@ -54,7 +54,7 @@ resource "null_resource" "mithril-aggregator" {
 
   provisioner "remote-exec" {
     inline = [
-      "IMAGE_ID=${var.image_id} GOOGLE_APPLICATION_CREDENTIALS_JSON='${var.google_application_credentials_json}' CURRENT_UID=$(id -u) DOCKER_GID=$(getent group docker | cut -d: -f3)  docker-compose -f /home/curry/docker-compose.yaml --profile all up -d"
+      "NETWORK=preview IMAGE_ID=${var.image_id} GOOGLE_APPLICATION_CREDENTIALS_JSON='${var.google_application_credentials_json}' CURRENT_UID=$(id -u) DOCKER_GID=$(getent group docker | cut -d: -f3)  docker-compose -f /home/curry/docker-compose.yaml --profile all up -d"
     ]
   }
 }

--- a/mithril-infra/docker-compose.yaml
+++ b/mithril-infra/docker-compose.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node:
-    image: cardano-node/1.35.2-modified
+    image: cardano-node/1.35.3-modified
     build:
       context: .
       dockerfile: Dockerfile.cardano

--- a/mithril-infra/docker-compose.yaml
+++ b/mithril-infra/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
         max-size: "100m"
         max-file: "5"
     volumes:
-      - ./cardano-configurations/network/testnet:/config
-      - ./testnet/node.db:/db
+      - ./cardano-configurations/network/${NETWORK}:/config
+      - ./${NETWORK}/node.db:/db
       - ./ipc:/ipc
     environment:
       - CARDANO_SOCKET_PATH=/ipc/node.socket # used by cardano-node
@@ -56,22 +56,21 @@ services:
       - all
     environment:
       - RUST_BACKTRACE=1
-      - NETWORK_MAGIC=1097911063
       - GOOGLE_APPLICATION_CREDENTIALS_JSON=${GOOGLE_APPLICATION_CREDENTIALS_JSON}
-      - NETWORK=${NETWORK:-testnet}
+      - NETWORK=${NETWORK}
       - PROTOCOL_PARAMETERS__K=5
       - PROTOCOL_PARAMETERS__M=100
       - PROTOCOL_PARAMETERS__PHI_F=0.65
       - RUN_INTERVAL=60000
-      - URL_SNAPSHOT_MANIFEST=https://storage.googleapis.com/cardano-${NETWORK:-testnet}/snapshots.json
+      - URL_SNAPSHOT_MANIFEST=https://storage.googleapis.com/cardano-${NETWORK}/snapshots.json
       - SNAPSHOT_STORE_TYPE=local
       - SNAPSHOT_UPLOADER_TYPE=gcp
       - DATA_STORES_DIRECTORY=/mithril-aggregator
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
     volumes:
-      - ./testnet/mithril-aggregator:/mithril-aggregator
-      - ./testnet/node.db:/db
+      - ./${NETWORK}/mithril-aggregator:/mithril-aggregator
+      - ./${NETWORK}/node.db:/db
       - ./ipc:/ipc
     ports:
       - "8080:8080"
@@ -106,17 +105,16 @@ services:
     environment:
       - RUST_BACKTRACE=1
       - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
-      - NETWORK=testnet
-      - NETWORK_MAGIC=1097911063
-      - PARTY_ID=pool1frevxe70aqw2ce58c0muyesnahl88nfjjsp25h85jwakzgd2g2l # IOG1 / https://testnet.cardanoscan.io/pool/48f2c367cfe81cac6687c3f7c26613edfe73cd329402aa5cf493bb61
+      - NETWORK=${NETWORK}
+      - PARTY_ID=pool10g0tvpyc3phkym8r6hamdulyzd6shzjldpahyvdkljl7ur2adfe # ADA Capital / https://preview.cexplorer.io/pool/pool10g0tvpyc3phkym8r6hamdulyzd6shzjldpahyvdkljl7ur2adfe
       - RUN_INTERVAL=60000
       - DB_DIRECTORY=/db
       - DATA_STORES_DIRECTORY=/mithril-signer-0
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
     volumes:
-      - ./testnet/mithril-signer-0:/mithril-signer-0
-      - ./testnet/node.db:/db
+      - ./${NETWORK}/mithril-signer-0:/mithril-signer-0
+      - ./${NETWORK}/node.db:/db
       - ./ipc:/ipc
     logging:
       driver: "json-file"
@@ -134,73 +132,16 @@ services:
     environment:
       - RUST_BACKTRACE=1
       - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
-      - NETWORK=testnet
-      - NETWORK_MAGIC=1097911063
-      - PARTY_ID=pool1987uhrx7pt5rea26sqsdrlenfclm2wxafd4rpspvz3qyqshnuyy # IOG2 / https://testnet.cardanoscan.io/pool/29fdcb8cde0ae83cf55a8020d1ff334e3fb538dd4b6a30c02c144040
+      - NETWORK=${NETWORK}
+      - PARTY_ID=pool1t2zfh44yjhgxxrmt563k0wjw9v7vc7jn29vpyyz4vrq4yk8k4m6 # APEX / https://preview.cexplorer.io/pool/pool1t2zfh44yjhgxxrmt563k0wjw9v7vc7jn29vpyyz4vrq4yk8k4m6
       - RUN_INTERVAL=60000
       - DB_DIRECTORY=/db
       - DATA_STORES_DIRECTORY=/mithril-signer-1
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
     volumes:
-      - ./testnet/mithril-signer-1:/mithril-signer-1
-      - ./testnet/node.db:/db
-      - ./ipc:/ipc
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "100m"
-        max-file: "5"
-
-  mithril-signer-2:
-    image: ghcr.io/input-output-hk/mithril-signer:${IMAGE_ID:-latest}
-    restart: always
-    user: ${CURRENT_UID}
-    profiles:
-      - mithril
-      - all
-    environment:
-      - RUST_BACKTRACE=1
-      - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
-      - NETWORK=testnet
-      - NETWORK_MAGIC=1097911063
-      - PARTY_ID=pool12luf5ysaxajd0g8dvtpuyxdchln363dhed8637psyx2eqzatmcv # Random unnamed pool / https://testnet.cardanoscan.io/pool/57f89a121d3764d7a0ed62c3c219b8bfe71d45b7cb4fa8f830219590
-      - RUN_INTERVAL=60000
-      - DB_DIRECTORY=/db
-      - DATA_STORES_DIRECTORY=/mithril-signer-2
-      - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
-      - CARDANO_CLI_PATH=/app/bin/cardano-cli
-    volumes:
-      - ./testnet/mithril-signer-2:/mithril-signer-2
-      - ./testnet/node.db:/db
-      - ./ipc:/ipc
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "100m"
-        max-file: "5"
-
-  mithril-signer-3:
-    image: ghcr.io/input-output-hk/mithril-signer:${IMAGE_ID:-latest}
-    restart: always
-    user: ${CURRENT_UID}
-    profiles:
-      - mithril
-      - all
-    environment:
-      - RUST_BACKTRACE=1
-      - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
-      - NETWORK=testnet
-      - NETWORK_MAGIC=1097911063
-      - PARTY_ID=pool17vmenrzf2ylr92t390wwhk3jn0ursx00sy92cfa807s3whyknrc # PIPE / https://testnet.cardanoscan.io/pool/f337998c49513e32a9712bdcebda329bf83819ef810aac27a77fa117
-      - RUN_INTERVAL=60000
-      - DB_DIRECTORY=/db
-      - DATA_STORES_DIRECTORY=/mithril-signer-3
-      - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
-      - CARDANO_CLI_PATH=/app/bin/cardano-cli
-    volumes:
-      - ./testnet/mithril-signer-3:/mithril-signer-3
-      - ./testnet/node.db:/db
+      - ./${NETWORK}/mithril-signer-1:/mithril-signer-1
+      - ./${NETWORK}/node.db:/db
       - ./ipc:/ipc
     logging:
       driver: "json-file"

--- a/mithril-infra/scripts/configure-testnet.sh
+++ b/mithril-infra/scripts/configure-testnet.sh
@@ -7,17 +7,6 @@ set -e
 # accept github.com key
 ssh-keyscan github.com >> ~/.ssh/known_hosts
 
-# download gpg key signing testnet dump
-curl https://api.github.com/users/abailly-iohk/gpg_keys | jq -r '.[] | .raw_key' | gpg --import
-
-# download & verify testnet archive
-# TODO: use mithril client!
-curl -o testnet.tar.gz https://storage.googleapis.com/cardano-testnet/testnet.tar.gz
-curl -o testnet.tar.gz.asc https://storage.googleapis.com/cardano-testnet/testnet.tar.gz.asc
-gpg --verify testnet.tar.gz.asc
-
-tar xzf testnet.tar.gz
-
 # get cardano network configuration
 git clone https://github.com/input-output-hk/cardano-configurations
 

--- a/mithril-signer/config/preview.json
+++ b/mithril-signer/config/preview.json
@@ -1,0 +1,8 @@
+{
+    "network": "preview",
+    "aggregator_endpoint": "https://aggregator.api.mithril.network/aggregator",
+    "party_id": 0,
+    "run_interval": 20000,
+    "db_directory": "/db",
+    "data_stores_directory": "./mithril-signer/stores"
+}

--- a/mithril-signer/src/entities.rs
+++ b/mithril-signer/src/entities.rs
@@ -40,30 +40,7 @@ pub struct Config {
 impl Config {
     /// Return the CardanoNetwork value from the configuration.
     pub fn get_network(&self) -> Result<CardanoNetwork, ConfigError> {
-        match self.network.to_lowercase().as_str() {
-            "mainnet" => Ok(CardanoNetwork::MainNet),
-            "testnet" => {
-                if let Some(magic) = self.network_magic {
-                    Ok(CardanoNetwork::TestNet(magic))
-                } else {
-                    Err(ConfigError::Message(
-                        "no NETWORK MAGIC number given for testnet network".to_string(),
-                    ))
-                }
-            }
-            "devnet" => {
-                if let Some(magic) = self.network_magic {
-                    Ok(CardanoNetwork::DevNet(magic))
-                } else {
-                    Err(ConfigError::Message(
-                        "no NETWORK MAGIC number given for devnet network".to_string(),
-                    ))
-                }
-            }
-            what => Err(ConfigError::Message(format!(
-                "could not parse network '{}', the only recognized networks are: mainnet, devnet, testnet",
-                what
-            ))),
-        }
+        CardanoNetwork::from_code(self.network.clone(), self.network_magic)
+            .map_err(|e| ConfigError::Message(e.to_string()))
     }
 }


### PR DESCRIPTION
This PR upgrades the Aggregator hosted on GCP cloud so that it uses the `preview` Cardano network instead of the legacy `testnet`:

- [x] Upgrade Cardano node to `1.35.3`
- [x] Parametrize the `docker-compose.yaml` file so that it can be used with different network
- [x] Update the `poolIds` of the Signer nodes (which `poolIds` are selected among the SPOs on the `preview` network) and reduce their number to `2`
- [x] Use `preview` network with `NETWORK=preview` in the `aggregator.tf` file
- [x] Update documentation

After merge, manually duplicate stores data so that we don't need to wait 2 epochs before signing

Relates to #457 