### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/root/manual/getting-started/bootstrap-cardano-node.md
@@ -14,9 +14,9 @@ Thanks to a **Mithril Client** connected to a **Mithril Aggregator**, you will r
 
 The Mithril test networks are:
 
-* `preview`: Test network with magic id `2`, implemented on the IOG hosted Mitril Aggregator
+* `preview`: Test network with magic id `2`, implemented on the IOG hosted Mithril Aggregator
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
-* `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mitril Aggregator, now deprecated
+* `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
 In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
@@ -189,7 +189,7 @@ Verify the Certificate of the snapshot and unpack its content in order to feed t
 NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client restore $SNAPSHOT_DIGEST
 ```
 
-You will see that the snapshot archive is unpacked and that the associcated certificate is valid
+You will see that the snapshot archive is unpacked and that the associated certificate is valid
 
 ```bash
 Unpacking snapshot...

--- a/docs/root/manual/getting-started/run-mithril-devnet.md
+++ b/docs/root/manual/getting-started/run-mithril-devnet.md
@@ -477,7 +477,7 @@ Verify the Certificate of the snapshot and unpack its content in order to feed t
 NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client restore $SNAPSHOT_DIGEST
 ```
 
-You will see that the snapshot archive is unpacked and that the associcated certificate is valid
+You will see that the snapshot archive is unpacked and that the associated certificate is valid
 
 ```bash
 Unpacking snapshot...

--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -14,9 +14,9 @@ In this guide, you will learn how to setup a **Mithril Signer** on top of a **Ca
 
 The Mithril test networks are:
 
-* `preview`: Test network with magic id `2`, implemented on the IOG hosted Mitril Aggregator
+* `preview`: Test network with magic id `2`, implemented on the IOG hosted Mithril Aggregator
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
-* `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mitril Aggregator, now deprecated
+* `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
 In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
@@ -136,7 +136,7 @@ sudo mv mithril-signer /opt/mithril
 :::caution
 
 * `User=cardano`:
-Replace this value with the correct user. We assume that the user used to run the **Cardano Node** is `cardano`. The **Mitril Signer** must imperatively run with the same user.
+Replace this value with the correct user. We assume that the user used to run the **Cardano Node** is `cardano`. The **Mithril Signer** must imperatively run with the same user.
 
 * in the `/opt/mithril/mithril-signer/service.env` env file:
   * `PARTY_ID=YOUR_POOL_ID_BECH32`: replace `YOUR_POOL_ID_BECH32` with your BECH32 `Pool Id`

--- a/docs/root/mithril/mithril-network/aggregator.md
+++ b/docs/root/mithril/mithril-network/aggregator.md
@@ -98,7 +98,7 @@ In its first version, the **Mithril Aggregator** is composed of two main compone
 
 :::tip
 
-The documentation of the REST API of the **Mitril Aggregator** is available [here](/aggregator-api).
+The documentation of the REST API of the **Mithril Aggregator** is available [here](/aggregator-api).
 
 :::
 

--- a/mithril-common/src/entities/cardano_network.rs
+++ b/mithril-common/src/entities/cardano_network.rs
@@ -79,3 +79,49 @@ impl Display for CardanoNetwork {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cardano_network_from_code() {
+        assert_eq!(
+            CardanoNetwork::from_code("mainnet".to_string(), None).unwrap(),
+            CardanoNetwork::MainNet
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("mainnet".to_string(), Some(123)).unwrap(),
+            CardanoNetwork::MainNet
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("preview".to_string(), None).unwrap(),
+            CardanoNetwork::TestNet(PREVIEW_MAGIC_ID)
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("preview".to_string(), Some(123)).unwrap(),
+            CardanoNetwork::TestNet(PREVIEW_MAGIC_ID)
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("preprod".to_string(), None).unwrap(),
+            CardanoNetwork::TestNet(PREPROD_MAGIC_ID)
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("preprod".to_string(), Some(123)).unwrap(),
+            CardanoNetwork::TestNet(PREPROD_MAGIC_ID)
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("testnet".to_string(), None).unwrap(),
+            CardanoNetwork::TestNet(TESTNET_MAGIC_ID)
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("testnet".to_string(), Some(123)).unwrap(),
+            CardanoNetwork::TestNet(TESTNET_MAGIC_ID)
+        );
+        assert_eq!(
+            CardanoNetwork::from_code("private".to_string(), Some(123)).unwrap(),
+            CardanoNetwork::TestNet(123)
+        );
+        assert!(CardanoNetwork::from_code("private".to_string(), None).is_err());
+    }
+}

--- a/mithril-test-lab/mithril-devnet/README.md
+++ b/mithril-test-lab/mithril-devnet/README.md
@@ -25,7 +25,7 @@ This cli is inspired by this [script](https://github.com/input-output-hk/cardano
 git clone https://github.com/input-output-hk/mithril
 
 # Go to sources directory
-cd mithril-test-lab/mitril-devnet
+cd mithril-test-lab/mithril-devnet
 
 # Chmod scripts
 chmod u+x *.sh


### PR DESCRIPTION
This PR:
* Fixes few typos in the documentation 
* Adds a test on the `code to Cardano Network` conversion