### PR TITLE
Clean wrappers

### DIFF
--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -7,10 +7,12 @@ use std::sync::Arc;
 
 use mithril_common::{store::adapter::JsonFileStoreAdapter, CardanoNetwork};
 
-use crate::dependency::{SnapshotStoreWrapper, SnapshotUploaderWrapper};
 use crate::snapshot_stores::LocalSnapshotStore;
 use crate::tools::GcpFileUploader;
-use crate::{LocalSnapshotUploader, RemoteSnapshotStore, RemoteSnapshotUploader};
+use crate::{
+    LocalSnapshotUploader, RemoteSnapshotStore, RemoteSnapshotUploader, SnapshotStore,
+    SnapshotUploader,
+};
 
 // TODO: 'LIST_SNAPSHOTS_MAX_ITEMS' keep as const or in config, or add a parameter to `list_snapshots`?
 const LIST_SNAPSHOTS_MAX_ITEMS: usize = 20;
@@ -88,7 +90,7 @@ pub enum SnapshotUploaderType {
 
 impl Configuration {
     /// Create a snapshot store from the configuration settings.
-    pub fn build_snapshot_store(&self) -> Result<SnapshotStoreWrapper, Box<dyn Error>> {
+    pub fn build_snapshot_store(&self) -> Result<Arc<dyn SnapshotStore>, Box<dyn Error>> {
         match self.snapshot_store_type {
             SnapshotStoreType::Gcp => Ok(Arc::new(RemoteSnapshotStore::new(
                 Box::new(GcpFileUploader::default()),
@@ -104,7 +106,7 @@ impl Configuration {
     }
 
     /// Create a snapshot uploader from configuration settings.
-    pub fn build_snapshot_uploader(&self) -> SnapshotUploaderWrapper {
+    pub fn build_snapshot_uploader(&self) -> Arc<dyn SnapshotUploader> {
         match self.snapshot_uploader_type {
             SnapshotUploaderType::Gcp => Arc::new(RemoteSnapshotUploader::new(Box::new(
                 GcpFileUploader::default(),

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -20,53 +20,8 @@ use crate::{
     SingleSignatureStore, Snapshotter, VerificationKeyStore, VerificationKeyStorer,
 };
 
-///  SnapshotStoreWrapper wraps a SnapshotStore
-pub type SnapshotStoreWrapper = Arc<dyn SnapshotStore>;
-
-///  SnapshotUploaderWrapper wraps a SnapshotUploader
-pub type SnapshotUploaderWrapper = Arc<dyn SnapshotUploader>;
-
 /// MultiSignerWrapper wraps a MultiSigner
 pub type MultiSignerWrapper = Arc<RwLock<dyn MultiSigner>>;
-
-/// CertificatePendingStoreWrapper wraps a CertificatePendingStore
-pub type CertificatePendingStoreWrapper = Arc<CertificatePendingStore>;
-
-///  CertificateStoreWrapper wraps a CertificateStore
-pub type CertificateStoreWrapper = Arc<CertificateStore>;
-
-///  VerificationKeyStoreWrapper wraps a VerificationKeyStore
-pub type VerificationKeyStoreWrapper = Arc<VerificationKeyStore>;
-
-///  StakeStoreWrapper wraps a StakeStore
-pub type StakeStoreWrapper = Arc<StakeStore>;
-
-///  SingleSignatureStoreWrapper wraps a SingleSignatureStore
-pub type SingleSignatureStoreWrapper = Arc<SingleSignatureStore>;
-
-///  ProtocolParametersStoreWrapper wraps ProtocolParameters
-pub type ProtocolParametersStoreWrapper = Arc<ProtocolParametersStore>;
-
-///  ChainObserverWrapper wraps a ChainObserver
-pub type ChainObserverWrapper = Arc<dyn ChainObserver>;
-
-/// BeaconProviderWrapper wraps a BeaconProvider
-pub type BeaconProviderWrapper = Arc<dyn BeaconProvider>;
-
-/// BeaconProviderWrapper wraps a BeaconProvider
-pub type ImmutableFileObserverWrapper = Arc<dyn ImmutableFileObserver>;
-
-/// DigesterWrapper wraps a Digester
-pub type DigesterWrapper = Arc<dyn ImmutableDigester>;
-
-/// SnapshotterWrapper wraps a Snapshotter
-pub type SnapshotterWrapper = Arc<dyn Snapshotter>;
-
-/// CertificateVerifierWrapper wraps a CertificateVerifier
-pub type CertificateVerifierWrapper = Arc<dyn CertificateVerifier>;
-
-/// ProtocolGenesisVerifierWrapper wraps a ProtocolGenesisVerifier
-pub type ProtocolGenesisVerifierWrapper = Arc<ProtocolGenesisVerifier>;
 
 /// DependencyManager handles the dependencies
 pub struct DependencyManager {
@@ -74,52 +29,52 @@ pub struct DependencyManager {
     pub config: Configuration,
 
     /// Snapshot store.
-    pub snapshot_store: SnapshotStoreWrapper,
+    pub snapshot_store: Arc<dyn SnapshotStore>,
 
     /// Snapshot uploader service.
-    pub snapshot_uploader: SnapshotUploaderWrapper,
+    pub snapshot_uploader: Arc<dyn SnapshotUploader>,
 
     /// Multisigner service.
     pub multi_signer: MultiSignerWrapper,
 
     /// Certificate pending store.
-    pub certificate_pending_store: CertificatePendingStoreWrapper,
+    pub certificate_pending_store: Arc<CertificatePendingStore>,
 
     /// Certificate store.
-    pub certificate_store: CertificateStoreWrapper,
+    pub certificate_store: Arc<CertificateStore>,
 
     /// Verification key store.
-    pub verification_key_store: VerificationKeyStoreWrapper,
+    pub verification_key_store: Arc<VerificationKeyStore>,
 
     /// Stake store.
-    pub stake_store: StakeStoreWrapper,
+    pub stake_store: Arc<StakeStore>,
 
     /// Signer single signature store.
-    pub single_signature_store: SingleSignatureStoreWrapper,
+    pub single_signature_store: Arc<SingleSignatureStore>,
 
     /// Protocol parameter store.
-    pub protocol_parameters_store: ProtocolParametersStoreWrapper,
+    pub protocol_parameters_store: Arc<ProtocolParametersStore>,
 
     /// Chain observer service.
-    pub chain_observer: ChainObserverWrapper,
+    pub chain_observer: Arc<dyn ChainObserver>,
 
     /// Beacon provider service.
-    pub beacon_provider: BeaconProviderWrapper,
+    pub beacon_provider: Arc<dyn BeaconProvider>,
 
     /// Immutable file observer service.
-    pub immutable_file_observer: ImmutableFileObserverWrapper,
+    pub immutable_file_observer: Arc<dyn ImmutableFileObserver>,
 
     /// Digester service.
-    pub digester: DigesterWrapper,
+    pub digester: Arc<dyn ImmutableDigester>,
 
     /// Snapshotter service.
-    pub snapshotter: SnapshotterWrapper,
+    pub snapshotter: Arc<dyn Snapshotter>,
 
     /// Certificate verifier service.
-    pub certificate_verifier: CertificateVerifierWrapper,
+    pub certificate_verifier: Arc<dyn CertificateVerifier>,
 
     /// Genesis signature verifier service.
-    pub genesis_verifier: ProtocolGenesisVerifierWrapper,
+    pub genesis_verifier: Arc<ProtocolGenesisVerifier>,
 }
 
 #[doc(hidden)]

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -33,15 +33,16 @@ fn certificate_certificate_hash(
 }
 
 mod handlers {
-    use crate::dependency::{CertificatePendingStoreWrapper, CertificateStoreWrapper};
     use crate::http_server::routes::reply;
+    use crate::{CertificatePendingStore, CertificateStore};
     use slog_scope::{debug, warn};
     use std::convert::Infallible;
+    use std::sync::Arc;
     use warp::http::StatusCode;
 
     /// Certificate Pending
     pub async fn certificate_pending(
-        certificate_pending_store: CertificatePendingStoreWrapper,
+        certificate_pending_store: Arc<CertificatePendingStore>,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("certificate_pending");
 
@@ -58,7 +59,7 @@ mod handlers {
     /// Certificate by certificate hash
     pub async fn certificate_certificate_hash(
         certificate_hash: String,
-        certificate_store: CertificateStoreWrapper,
+        certificate_store: Arc<CertificateStore>,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("certificate_certificate_hash/{}", certificate_hash);
 

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -23,17 +23,18 @@ fn epoch_settings(
 }
 
 mod handlers {
-    use crate::dependency::{MultiSignerWrapper, ProtocolParametersStoreWrapper};
+    use crate::dependency::MultiSignerWrapper;
     use crate::http_server::routes::reply;
-    use crate::ProtocolParametersStorer;
+    use crate::{ProtocolParametersStore, ProtocolParametersStorer};
     use mithril_common::entities::EpochSettings;
     use slog_scope::{debug, warn};
     use std::convert::Infallible;
+    use std::sync::Arc;
     use warp::http::StatusCode;
 
     /// Epoch Settings
     pub async fn epoch_settings(
-        protocol_parameters_store: ProtocolParametersStoreWrapper,
+        protocol_parameters_store: Arc<ProtocolParametersStore>,
         multi_signer: MultiSignerWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("epoch_settings");

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -1,8 +1,8 @@
-use crate::dependency::{
-    CertificatePendingStoreWrapper, CertificateStoreWrapper, MultiSignerWrapper,
-    ProtocolParametersStoreWrapper, SnapshotStoreWrapper,
+use crate::dependency::MultiSignerWrapper;
+use crate::{
+    CertificatePendingStore, CertificateStore, Configuration, DependencyManager,
+    ProtocolParametersStore, SnapshotStore,
 };
-use crate::{Configuration, DependencyManager};
 use std::convert::Infallible;
 use std::sync::Arc;
 use warp::Filter;
@@ -10,28 +10,28 @@ use warp::Filter;
 /// With snapshot store middleware
 pub fn with_snapshot_store(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = (SnapshotStoreWrapper,), Error = Infallible> + Clone {
+) -> impl Filter<Extract = (Arc<dyn SnapshotStore>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.snapshot_store.clone())
 }
 
 /// With certificate store middleware
 pub fn with_certificate_store(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = (CertificateStoreWrapper,), Error = Infallible> + Clone {
+) -> impl Filter<Extract = (Arc<CertificateStore>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.certificate_store.clone())
 }
 
 /// With certificate pending store
 pub(crate) fn with_certificate_pending_store(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = (CertificatePendingStoreWrapper,), Error = Infallible> + Clone {
+) -> impl Filter<Extract = (Arc<CertificatePendingStore>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.certificate_pending_store.clone())
 }
 
 /// With protocol parameters store
 pub(crate) fn with_protocol_parameters_store(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = (ProtocolParametersStoreWrapper,), Error = Infallible> + Clone {
+) -> impl Filter<Extract = (Arc<ProtocolParametersStore>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.protocol_parameters_store.clone())
 }
 

--- a/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
@@ -55,18 +55,18 @@ fn snapshot_digest(
 }
 
 mod handlers {
-    use crate::dependency::SnapshotStoreWrapper;
     use crate::http_server::routes::reply;
     use crate::http_server::SERVER_BASE_PATH;
-    use crate::Configuration;
+    use crate::{Configuration, SnapshotStore};
     use slog_scope::{debug, warn};
     use std::convert::Infallible;
     use std::str::FromStr;
+    use std::sync::Arc;
     use warp::http::{StatusCode, Uri};
 
     /// Snapshots
     pub async fn snapshots(
-        snapshot_store: SnapshotStoreWrapper,
+        snapshot_store: Arc<dyn SnapshotStore>,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("snapshots");
 
@@ -82,7 +82,7 @@ mod handlers {
     /// Download a file if and only if it's a snapshot archive
     pub async fn ensure_downloaded_file_is_a_snapshot(
         reply: warp::fs::File,
-        snapshot_store: SnapshotStoreWrapper,
+        snapshot_store: Arc<dyn SnapshotStore>,
     ) -> Result<impl warp::Reply, Infallible> {
         let filepath = reply.path().to_path_buf();
         debug!(
@@ -113,7 +113,7 @@ mod handlers {
     pub async fn snapshot_download(
         digest: String,
         config: Configuration,
-        snapshot_store: SnapshotStoreWrapper,
+        snapshot_store: Arc<dyn SnapshotStore>,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("snapshot_download/{}", digest);
 
@@ -148,7 +148,7 @@ mod handlers {
     /// Snapshot by digest
     pub async fn snapshot_digest(
         digest: String,
-        snapshot_store: SnapshotStoreWrapper,
+        snapshot_store: Arc<dyn SnapshotStore>,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("snapshot_digest/{}", digest);
 

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::prelude::*;
@@ -14,18 +15,16 @@ use mithril_common::crypto_helper::{
     PROTOCOL_VERSION,
 };
 use mithril_common::entities::{self, SignerWithStake};
-use mithril_common::store::{StakeStorer, StoreError};
+use mithril_common::store::{StakeStore, StakeStorer, StoreError};
 use mithril_common::{
     NEXT_SIGNER_EPOCH_RETRIEVAL_OFFSET, SIGNER_EPOCH_RECORDING_OFFSET,
     SIGNER_EPOCH_RETRIEVAL_OFFSET,
 };
 
-use crate::dependency::{
-    ProtocolParametersStoreWrapper, SingleSignatureStoreWrapper, StakeStoreWrapper,
-    VerificationKeyStoreWrapper,
-};
 use crate::store::{SingleSignatureStorer, VerificationKeyStorer};
-use crate::ProtocolParametersStorer;
+use crate::{
+    ProtocolParametersStore, ProtocolParametersStorer, SingleSignatureStore, VerificationKeyStore,
+};
 
 #[cfg(test)]
 use mockall::automock;
@@ -243,25 +242,25 @@ pub struct MultiSignerImpl {
     avk: Option<ProtocolAggregateVerificationKey>,
 
     /// Verification key store
-    verification_key_store: VerificationKeyStoreWrapper,
+    verification_key_store: Arc<VerificationKeyStore>,
 
     /// Stake store
-    stake_store: StakeStoreWrapper,
+    stake_store: Arc<StakeStore>,
 
     /// Single signature store
-    single_signature_store: SingleSignatureStoreWrapper,
+    single_signature_store: Arc<SingleSignatureStore>,
 
     /// Protocol parameters store
-    protocol_parameters_store: ProtocolParametersStoreWrapper,
+    protocol_parameters_store: Arc<ProtocolParametersStore>,
 }
 
 impl MultiSignerImpl {
     /// MultiSignerImpl factory
     pub fn new(
-        verification_key_store: VerificationKeyStoreWrapper,
-        stake_store: StakeStoreWrapper,
-        single_signature_store: SingleSignatureStoreWrapper,
-        protocol_parameters_store: ProtocolParametersStoreWrapper,
+        verification_key_store: Arc<VerificationKeyStore>,
+        stake_store: Arc<StakeStore>,
+        single_signature_store: Arc<SingleSignatureStore>,
+        protocol_parameters_store: Arc<ProtocolParametersStore>,
     ) -> Self {
         debug!("New MultiSignerImpl created");
         Self {

--- a/mithril-client/src/aggregator.rs
+++ b/mithril-client/src/aggregator.rs
@@ -36,7 +36,7 @@ pub enum AggregatorHandlerError {
     #[error("json parsing failed: '{0}'")]
     JsonParseFailed(String),
 
-    /// Error raised when an IO error occured (ie: snapshot writting on disk fails).
+    /// Error raised when an IO error occured (ie: snapshot writing on disk fails).
     #[error("io error: {0}")]
     IOError(#[from] io::Error),
 

--- a/mithril-client/src/main.rs
+++ b/mithril-client/src/main.rs
@@ -124,11 +124,12 @@ async fn main() -> Result<(), String> {
     let genesis_verifier = ProtocolGenesisVerifier::from_verification_key(genesis_verification_key);
 
     // Init runtime
-    let mut runtime = Runtime::new(config.network.clone());
-    runtime
-        .with_aggregator_handler(aggregator_handler)
-        .with_certificate_verifier(certificate_verifier)
-        .with_genesis_verifier(genesis_verifier);
+    let mut runtime = Runtime::new(
+        config.network.clone(),
+        aggregator_handler,
+        certificate_verifier,
+        genesis_verifier,
+    );
 
     // Execute commands
     match &args.command {

--- a/mithril-client/src/runtime.rs
+++ b/mithril-client/src/runtime.rs
@@ -38,14 +38,14 @@ pub enum RuntimeError {
     CertificateRetriever(#[from] CertificateRetrieverError),
 
     /// Error raised when the digest computation fails.
-    #[error("immutale digester error: '{0}'")]
+    #[error("immutable digester error: '{0}'")]
     ImmutableDigester(#[from] ImmutableDigesterError),
 
     /// Error raised when the digest stored in the signed message doesn't match the
     /// [certificate](https://mithril.network/mithril-common/doc/mithril_common/entities/struct.Certificate.html)
     /// hash.
-    #[error("digest unmatch error: '{0}'")]
-    DigestUnmatch(String),
+    #[error("digest doesn't match error: '{0}'")]
+    DigestDoesntMatch(String),
 
     /// Error raised when verification fails.
     #[error("verification error: '{0}'")]
@@ -66,7 +66,7 @@ pub struct Runtime {
     /// Genesis verifier dependency that verifies the genesis signatures
     genesis_verifier: ProtocolGenesisVerifier,
 
-    /// Digester dependency that computes the digest used as the message ot be signed and embedded in the multisignature
+    /// Digester dependency that computes the digest used as the message ot be signed and embedded in the multi-signature
     digester: Option<Box<dyn ImmutableDigester>>,
 }
 
@@ -167,7 +167,7 @@ impl Runtime {
             unpacked_snapshot_digest.clone(),
         );
         if protocol_message.compute_hash() != certificate.signed_message {
-            return Err(RuntimeError::DigestUnmatch(unpacked_snapshot_digest));
+            return Err(RuntimeError::DigestDoesntMatch(unpacked_snapshot_digest));
         }
         self.certificate_verifier
             .verify_certificate_chain(
@@ -631,7 +631,7 @@ mod tests {
     #[tokio::test]
     async fn test_restore_snapshot_ko_restore_unpack_snapshot() {
         let digest = "digest123";
-        let certificate_hash = "certhash123";
+        let certificate_hash = "cert_hash123";
         let fake_certificate = fake_data::certificate(certificate_hash.to_string());
         let fake_snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
         let (mut mock_aggregator_handler, mut mock_verifier, _mock_digester, genesis_verifier) =

--- a/mithril-client/src/runtime.rs
+++ b/mithril-client/src/runtime.rs
@@ -58,13 +58,13 @@ pub struct Runtime {
     pub network: String,
 
     /// Aggregator handler dependency that interacts with an aggregator
-    aggregator_handler: Option<Arc<dyn AggregatorHandler>>,
+    aggregator_handler: Arc<dyn AggregatorHandler>,
 
     /// Certificate verifier dependency that verifies certificates and their multi signatures
-    certificate_verifier: Option<Box<dyn CertificateVerifier>>,
+    certificate_verifier: Box<dyn CertificateVerifier>,
 
     /// Genesis verifier dependency that verifies the genesis signatures
-    genesis_verifier: Option<ProtocolGenesisVerifier>,
+    genesis_verifier: ProtocolGenesisVerifier,
 
     /// Digester dependency that computes the digest used as the message ot be signed and embedded in the multisignature
     digester: Option<Box<dyn ImmutableDigester>>,
@@ -72,41 +72,19 @@ pub struct Runtime {
 
 impl Runtime {
     /// Runtime factory
-    pub fn new(network: String) -> Self {
+    pub fn new(
+        network: String,
+        aggregator_handler: Arc<dyn AggregatorHandler>,
+        certificate_verifier: Box<dyn CertificateVerifier>,
+        genesis_verifier: ProtocolGenesisVerifier,
+    ) -> Self {
         Self {
             network,
-            aggregator_handler: None,
-            certificate_verifier: None,
-            genesis_verifier: None,
+            aggregator_handler,
+            certificate_verifier,
+            genesis_verifier,
             digester: None,
         }
-    }
-
-    /// With AggregatorHandler
-    pub fn with_aggregator_handler(
-        &mut self,
-        aggregator_handler: Arc<dyn AggregatorHandler>,
-    ) -> &mut Self {
-        self.aggregator_handler = Some(aggregator_handler);
-        self
-    }
-
-    /// With Certificate Verifier
-    pub fn with_certificate_verifier(
-        &mut self,
-        certificate_verifier: Box<dyn CertificateVerifier>,
-    ) -> &mut Self {
-        self.certificate_verifier = Some(certificate_verifier);
-        self
-    }
-
-    /// With Genesis Verifier
-    pub fn with_genesis_verifier(
-        &mut self,
-        genesis_verifier: ProtocolGenesisVerifier,
-    ) -> &mut Self {
-        self.genesis_verifier = Some(genesis_verifier);
-        self
     }
 
     /// With Digester
@@ -115,39 +93,19 @@ impl Runtime {
         self
     }
 
-    /// Get AggregatorHandler
-    fn get_aggregator_handler(&self) -> Result<&Arc<dyn AggregatorHandler>, RuntimeError> {
-        self.aggregator_handler
-            .as_ref()
-            .ok_or_else(|| RuntimeError::MissingDependency("aggregator handler".to_string()))
-    }
-
-    /// Get Certificate Verifier
-    fn get_certificate_verifier(&self) -> Result<&Box<dyn CertificateVerifier>, RuntimeError> {
-        self.certificate_verifier
-            .as_ref()
-            .ok_or_else(|| RuntimeError::MissingDependency("certificate verifier".to_string()))
-    }
-
-    /// Get Genesis Verifier
-    fn get_genesis_verifier(&self) -> Result<&ProtocolGenesisVerifier, RuntimeError> {
-        self.genesis_verifier
-            .as_ref()
-            .ok_or_else(|| RuntimeError::MissingDependency("genesis verifier".to_string()))
-    }
-
     /// Get Digester
-    fn get_digester(&self) -> Result<&Box<dyn ImmutableDigester>, RuntimeError> {
-        self.digester
-            .as_ref()
-            .ok_or_else(|| RuntimeError::MissingDependency("digester".to_string()))
+    fn get_digester(&self) -> Result<&dyn ImmutableDigester, RuntimeError> {
+        match self.digester.as_ref() {
+            Some(digester) => Ok(&**digester),
+            None => Err(RuntimeError::MissingDependency("digester".to_string())),
+        }
     }
 
     /// List snapshots
     pub async fn list_snapshots(&self) -> Result<Vec<SnapshotListItem>, RuntimeError> {
         debug!("List snapshots");
         Ok(self
-            .get_aggregator_handler()?
+            .aggregator_handler
             .list_snapshots()
             .await?
             .iter()
@@ -158,10 +116,7 @@ impl Runtime {
     /// Show a snapshot
     pub async fn show_snapshot(&self, digest: &str) -> Result<Snapshot, RuntimeError> {
         debug!("Show snapshot {}", digest);
-        Ok(self
-            .get_aggregator_handler()?
-            .get_snapshot_details(digest)
-            .await?)
+        Ok(self.aggregator_handler.get_snapshot_details(digest).await?)
     }
 
     /// Download a snapshot by digest
@@ -171,17 +126,14 @@ impl Runtime {
         location_index: isize,
     ) -> Result<(String, String), RuntimeError> {
         debug!("Download snapshot {}", digest);
-        let snapshot = self
-            .get_aggregator_handler()?
-            .get_snapshot_details(digest)
-            .await?;
+        let snapshot = self.aggregator_handler.get_snapshot_details(digest).await?;
         let from = snapshot
             .locations
             .get((location_index - 1) as usize)
             .ok_or_else(|| RuntimeError::InvalidInput("invalid location index".to_string()))?
             .to_owned();
         match self
-            .get_aggregator_handler()?
+            .aggregator_handler
             .download_snapshot(digest, &from)
             .await
         {
@@ -193,18 +145,12 @@ impl Runtime {
     /// Restore a snapshot by digest
     pub async fn restore_snapshot(&mut self, digest: &str) -> Result<String, RuntimeError> {
         debug!("Restore snapshot {}", digest);
-        let snapshot = &self
-            .get_aggregator_handler()?
-            .get_snapshot_details(digest)
-            .await?;
+        let snapshot = &self.aggregator_handler.get_snapshot_details(digest).await?;
         let certificate = self
-            .get_aggregator_handler()?
+            .aggregator_handler
             .get_certificate_details(&snapshot.certificate_hash)
             .await?;
-        let unpacked_path = &self
-            .get_aggregator_handler()?
-            .unpack_snapshot(digest)
-            .await?;
+        let unpacked_path = &self.aggregator_handler.unpack_snapshot(digest).await?;
         if self.get_digester().is_err() {
             self.with_digester(Box::new(CardanoImmutableDigester::new(
                 Path::new(unpacked_path).into(),
@@ -223,11 +169,11 @@ impl Runtime {
         if protocol_message.compute_hash() != certificate.signed_message {
             return Err(RuntimeError::DigestUnmatch(unpacked_snapshot_digest));
         }
-        self.get_certificate_verifier()?
+        self.certificate_verifier
             .verify_certificate_chain(
                 certificate,
-                self.get_aggregator_handler()?.as_certificate_retriever(),
-                self.get_genesis_verifier()?,
+                self.aggregator_handler.as_certificate_retriever(),
+                &self.genesis_verifier,
             )
             .await?;
         Ok(unpacked_path.to_owned())
@@ -370,6 +316,26 @@ mod tests {
         }
     }
 
+    fn get_dependencies() -> (
+        MockAggregatorHandlerImpl,
+        MockCertificateVerifierImpl,
+        MockDigesterImpl,
+        ProtocolGenesisVerifier,
+    ) {
+        let mock_aggregator_handler = MockAggregatorHandlerImpl::new();
+        let mock_verifier = MockCertificateVerifierImpl::new();
+        let mock_digester = MockDigesterImpl::new();
+        let genesis_verifier =
+            ProtocolGenesisSigner::create_deterministic_genesis_signer().create_genesis_verifier();
+
+        (
+            mock_aggregator_handler,
+            mock_verifier,
+            mock_digester,
+            genesis_verifier,
+        )
+    }
+
     #[tokio::test]
     async fn test_list_snapshots_ok() {
         let network = "testnet".to_string();
@@ -378,12 +344,17 @@ mod tests {
             .iter()
             .map(|snapshot| convert_to_list_item(snapshot, network.clone()))
             .collect::<Vec<SnapshotListItem>>();
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
+        let (mut mock_aggregator_handler, mock_verifier, _mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_list_snapshots()
             .return_once(move || Ok(fake_snapshots));
-        let mut client = Runtime::new(network.clone());
-        client.with_aggregator_handler(Arc::new(mock_aggregator_handler));
+        let client = Runtime::new(
+            network.clone(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
         let snapshot_list_items = client.list_snapshots().await;
         snapshot_list_items.as_ref().expect("unexpected error");
         assert_eq!(
@@ -394,7 +365,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_snapshots_ko() {
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
+        let (mut mock_aggregator_handler, mock_verifier, _mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_list_snapshots()
             .return_once(move || {
@@ -402,8 +374,12 @@ mod tests {
                     "error occurred".to_string(),
                 ))
             });
-        let mut client = Runtime::new("testnet".to_string());
-        client.with_aggregator_handler(Arc::new(mock_aggregator_handler));
+        let client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
         let snapshot_list_items = client.list_snapshots().await;
         assert!(
             matches!(snapshot_list_items, Err(RuntimeError::AggregatorHandler(_))),
@@ -417,12 +393,17 @@ mod tests {
         let digest = "digest123";
         let fake_snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
         let snapshot_item_expected = fake_snapshot.clone();
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
+        let (mut mock_aggregator_handler, mock_verifier, _mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_get_snapshot_details()
             .return_once(move |_| Ok(fake_snapshot));
-        let mut client = Runtime::new("testnet".to_string());
-        client.with_aggregator_handler(Arc::new(mock_aggregator_handler));
+        let client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
         let snapshot_item = client.show_snapshot(digest).await;
         snapshot_item.as_ref().expect("unexpected error");
         assert_eq!(snapshot_item.unwrap(), snapshot_item_expected);
@@ -431,7 +412,8 @@ mod tests {
     #[tokio::test]
     async fn test_show_snapshot_ko() {
         let digest = "digest123";
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
+        let (mut mock_aggregator_handler, mock_verifier, _mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_get_snapshot_details()
             .return_once(move |_| {
@@ -439,8 +421,12 @@ mod tests {
                     "error occurred".to_string(),
                 ))
             });
-        let mut client = Runtime::new("testnet".to_string());
-        client.with_aggregator_handler(Arc::new(mock_aggregator_handler));
+        let client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
         let snapshot_item = client.show_snapshot(digest).await;
         assert!(
             matches!(snapshot_item, Err(RuntimeError::AggregatorHandler(_))),
@@ -452,8 +438,8 @@ mod tests {
     #[tokio::test]
     async fn test_restore_snapshot_ok() {
         let fake_certificate = fake_data::certificate("cert-hash-123".to_string());
-        let genesis_verifier =
-            ProtocolGenesisSigner::create_deterministic_genesis_signer().create_genesis_verifier();
+        let (mut mock_aggregator_handler, mut mock_verifier, mut mock_digester, genesis_verifier) =
+            get_dependencies();
         let digest_compute = fake_certificate
             .protocol_message
             .get_message_part(&ProtocolMessagePartKey::SnapshotDigest)
@@ -461,9 +447,6 @@ mod tests {
             .to_owned();
         let digest_restore = digest_compute.clone();
         let fake_snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
-        let mut mock_verifier = MockCertificateVerifierImpl::new();
-        let mut mock_digester = MockDigesterImpl::new();
         mock_aggregator_handler
             .expect_as_certificate_retriever()
             .return_once(move || Arc::new(MockAggregatorHandlerImpl::new()));
@@ -484,12 +467,13 @@ mod tests {
         mock_digester
             .expect_compute_digest()
             .return_once(move |_| Ok(digest_compute));
-        let mut client = Runtime::new("testnet".to_string());
-        client
-            .with_aggregator_handler(Arc::new(mock_aggregator_handler))
-            .with_certificate_verifier(Box::new(mock_verifier))
-            .with_genesis_verifier(genesis_verifier)
-            .with_digester(Box::new(mock_digester));
+        let mut client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
+        client.with_digester(Box::new(mock_digester));
         let restore = client.restore_snapshot(&digest_restore).await;
         restore.expect("unexpected error");
     }
@@ -497,8 +481,8 @@ mod tests {
     #[tokio::test]
     async fn test_restore_snapshot_ko_certificate_chain_fail() {
         let fake_certificate = fake_data::certificate("cert-hash-123".to_string());
-        let genesis_verifier =
-            ProtocolGenesisSigner::create_deterministic_genesis_signer().create_genesis_verifier();
+        let (mut mock_aggregator_handler, mut mock_verifier, mut mock_digester, genesis_verifier) =
+            get_dependencies();
         let digest_compute = fake_certificate
             .protocol_message
             .get_message_part(&ProtocolMessagePartKey::SnapshotDigest)
@@ -506,9 +490,6 @@ mod tests {
             .to_owned();
         let digest_restore = digest_compute.clone();
         let fake_snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
-        let mut mock_verifier = MockCertificateVerifierImpl::new();
-        let mut mock_digester = MockDigesterImpl::new();
         mock_aggregator_handler
             .expect_as_certificate_retriever()
             .return_once(move || Arc::new(MockAggregatorHandlerImpl::new()));
@@ -529,12 +510,13 @@ mod tests {
         mock_digester
             .expect_compute_digest()
             .return_once(move |_| Ok(digest_compute));
-        let mut client = Runtime::new("testnet".to_string());
-        client
-            .with_aggregator_handler(Arc::new(mock_aggregator_handler))
-            .with_certificate_verifier(Box::new(mock_verifier))
-            .with_genesis_verifier(genesis_verifier)
-            .with_digester(Box::new(mock_digester));
+        let mut client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
+        client.with_digester(Box::new(mock_digester));
         let restore = client.restore_snapshot(&digest_restore).await;
         assert!(
             matches!(restore, Err(RuntimeError::Protocol(_))),
@@ -555,9 +537,8 @@ mod tests {
         let mut fake_certificate1 = fake_certificate.clone();
         fake_certificate1.hash = "another-hash".to_string();
         let fake_snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
-        let mock_verifier = MockCertificateVerifierImpl::new();
-        let mut mock_digester = MockDigesterImpl::new();
+        let (mut mock_aggregator_handler, mock_verifier, mut mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_get_snapshot_details()
             .return_once(move |_| Ok(fake_snapshot));
@@ -573,11 +554,13 @@ mod tests {
                 expected_number: 3,
             })
         });
-        let mut client = Runtime::new("testnet".to_string());
-        client
-            .with_aggregator_handler(Arc::new(mock_aggregator_handler))
-            .with_certificate_verifier(Box::new(mock_verifier))
-            .with_digester(Box::new(mock_digester));
+        let mut client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
+        client.with_digester(Box::new(mock_digester));
         let restore = client.restore_snapshot(&digest_restore).await;
         assert!(
             matches!(restore, Err(RuntimeError::ImmutableDigester(_))),
@@ -589,8 +572,8 @@ mod tests {
     #[tokio::test]
     async fn test_restore_snapshot_ko_get_snapshot_details() {
         let digest = "digest123";
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
-        let mock_verifier = MockCertificateVerifierImpl::new();
+        let (mut mock_aggregator_handler, mock_verifier, _mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_get_snapshot_details()
             .return_once(move |_| {
@@ -599,10 +582,12 @@ mod tests {
                 ))
             });
 
-        let mut client = Runtime::new("testnet".to_string());
-        client
-            .with_aggregator_handler(Arc::new(mock_aggregator_handler))
-            .with_certificate_verifier(Box::new(mock_verifier));
+        let mut client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
         let restore = client.restore_snapshot(digest).await;
         assert!(
             matches!(restore, Err(RuntimeError::AggregatorHandler(_))),
@@ -615,8 +600,8 @@ mod tests {
     async fn test_restore_snapshot_ko_get_certificate_details() {
         let digest = "digest123";
         let fake_snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
-        let mock_verifier = MockCertificateVerifierImpl::new();
+        let (mut mock_aggregator_handler, mock_verifier, _mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_get_snapshot_details()
             .return_once(move |_| Ok(fake_snapshot));
@@ -629,10 +614,12 @@ mod tests {
                 ))
             });
 
-        let mut client = Runtime::new("testnet".to_string());
-        client
-            .with_aggregator_handler(Arc::new(mock_aggregator_handler))
-            .with_certificate_verifier(Box::new(mock_verifier));
+        let mut client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
         let restore = client.restore_snapshot(digest).await;
         assert!(
             matches!(restore, Err(RuntimeError::CertificateRetriever(_))),
@@ -647,8 +634,8 @@ mod tests {
         let certificate_hash = "certhash123";
         let fake_certificate = fake_data::certificate(certificate_hash.to_string());
         let fake_snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
-        let mut mock_aggregator_handler = MockAggregatorHandlerImpl::new();
-        let mut mock_verifier = MockCertificateVerifierImpl::new();
+        let (mut mock_aggregator_handler, mut mock_verifier, _mock_digester, genesis_verifier) =
+            get_dependencies();
         mock_aggregator_handler
             .expect_get_snapshot_details()
             .return_once(move |_| Ok(fake_snapshot));
@@ -665,10 +652,12 @@ mod tests {
         mock_verifier
             .expect_verify_multi_signature()
             .return_once(|_, _, _, _| Ok(()));
-        let mut client = Runtime::new("testnet".to_string());
-        client
-            .with_aggregator_handler(Arc::new(mock_aggregator_handler))
-            .with_certificate_verifier(Box::new(mock_verifier));
+        let mut client = Runtime::new(
+            "testnet".to_string(),
+            Arc::new(mock_aggregator_handler),
+            Box::new(mock_verifier),
+            genesis_verifier,
+        );
         let restore = client.restore_snapshot(digest).await;
         assert!(
             matches!(restore, Err(RuntimeError::AggregatorHandler(_))),


### PR DESCRIPTION
- Remove all Wrapper type that only wrap on one level, usually behind an `Arc` or a `Box` (meaning every wrapper except the one over `MultiSigner`)
- Simplify Client dependencies by making most of them mandatory.
- Fix some typos in the Client.

If ok we should wait for #438 merge before merging this PR.