### PR TITLE
Align signer & aggregator state machines logs

### DIFF
--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -44,7 +44,7 @@ mod handlers {
     pub async fn certificate_pending(
         certificate_pending_store: Arc<CertificatePendingStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("certificate_pending");
+        debug!("⇄ HTTP SERVER: certificate_pending");
 
         match certificate_pending_store.get().await {
             Ok(Some(certificate_pending)) => Ok(reply::json(&certificate_pending, StatusCode::OK)),
@@ -61,7 +61,10 @@ mod handlers {
         certificate_hash: String,
         certificate_store: Arc<CertificateStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("certificate_certificate_hash/{}", certificate_hash);
+        debug!(
+            "⇄ HTTP SERVER: certificate_certificate_hash/{}",
+            certificate_hash
+        );
 
         match certificate_store.get_from_hash(&certificate_hash).await {
             Ok(Some(certificate)) => Ok(reply::json(&certificate, StatusCode::OK)),

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -37,7 +37,7 @@ mod handlers {
         protocol_parameters_store: Arc<ProtocolParametersStore>,
         multi_signer: MultiSignerWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("epoch_settings");
+        debug!("⇄ HTTP SERVER: epoch_settings");
 
         match multi_signer.read().await.get_current_beacon().await {
             Some(beacon) => match protocol_parameters_store

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -34,7 +34,7 @@ mod handlers {
         signature: entities::SingleSignatures,
         multi_signer: MultiSignerWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("register_signatures/{:?}", signature);
+        debug!("⇄ HTTP SERVER: register_signatures/{:?}", signature);
 
         let mut multi_signer = multi_signer.write().await;
         match multi_signer.register_single_signature(&signature).await {

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -35,7 +35,7 @@ mod handlers {
         signer: entities::Signer,
         multi_signer: MultiSignerWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("register_signer/{:?}", signer);
+        debug!("⇄ HTTP SERVER: register_signer/{:?}", signer);
 
         let mut multi_signer = multi_signer.write().await;
         match key_decode_hex(&signer.verification_key) {

--- a/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
@@ -68,7 +68,7 @@ mod handlers {
     pub async fn snapshots(
         snapshot_store: Arc<dyn SnapshotStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("snapshots");
+        debug!("⇄ HTTP SERVER: snapshots");
 
         match snapshot_store.list_snapshots().await {
             Ok(snapshots) => Ok(reply::json(&snapshots, StatusCode::OK)),
@@ -86,7 +86,7 @@ mod handlers {
     ) -> Result<impl warp::Reply, Infallible> {
         let filepath = reply.path().to_path_buf();
         debug!(
-            "ensure_downloaded_file_is_a_snapshot / file: `{}`",
+            "⇄ HTTP SERVER: ensure_downloaded_file_is_a_snapshot / file: `{}`",
             filepath.display()
         );
 
@@ -115,7 +115,7 @@ mod handlers {
         config: Configuration,
         snapshot_store: Arc<dyn SnapshotStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("snapshot_download/{}", digest);
+        debug!("⇄ HTTP SERVER: snapshot_download/{}", digest);
 
         match snapshot_store.get_snapshot_details(digest).await {
             Ok(Some(snapshot)) => {
@@ -150,7 +150,7 @@ mod handlers {
         digest: String,
         snapshot_store: Arc<dyn SnapshotStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("snapshot_digest/{}", digest);
+        debug!("⇄ HTTP SERVER: snapshot_digest/{}", digest);
 
         match snapshot_store.get_snapshot_details(digest).await {
             Ok(snapshot) => match snapshot {

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -104,7 +104,10 @@ impl AggregatorRuntime {
                 error!("STATE MACHINE: an error occurred: "; "error" => ?e);
             }
 
-            info!("Sleeping for {} ms", self.state_sleep.as_millis());
+            info!(
+                "… Cycle finished, Sleeping for {} ms",
+                self.state_sleep.as_millis()
+            );
             sleep(self.state_sleep).await;
         }
     }

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -31,10 +31,10 @@ pub enum AggregatorState {
 
 impl Display for AggregatorState {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            AggregatorState::Idle(_) => write!(f, "idle"),
-            AggregatorState::Ready(_) => write!(f, "ready"),
-            AggregatorState::Signing(_) => write!(f, "signing"),
+        match self {
+            AggregatorState::Idle(state) => write!(f, "Idle - {:?}", state.current_beacon),
+            AggregatorState::Ready(state) => write!(f, "Ready - {:?}", state.current_beacon),
+            AggregatorState::Signing(state) => write!(f, "Signing - {:?}", state.current_beacon),
         }
     }
 }
@@ -81,7 +81,11 @@ impl AggregatorRuntime {
 
     /// Return the actual state of the state machine.
     pub fn get_state(&self) -> String {
-        self.state.to_string()
+        match self.state {
+            AggregatorState::Idle(_) => "idle".to_string(),
+            AggregatorState::Ready(_) => "ready".to_string(),
+            AggregatorState::Signing(_) => "signing".to_string(),
+        }
     }
 
     /// Launches an infinite loop ticking the state machine.
@@ -101,7 +105,7 @@ impl AggregatorRuntime {
     /// Perform one tick of the state machine.
     pub async fn cycle(&mut self) -> Result<(), RuntimeError> {
         info!("================================================================================");
-        info!("STATE MACHINE: new cycle"; "current_state" => ?self.state);
+        info!("STATE MACHINE: new cycle"; "current_state" => self.state.to_string());
 
         match self.state.clone() {
             AggregatorState::Idle(state) => {

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -54,11 +54,6 @@ pub struct AggregatorRuntime {
 }
 
 impl AggregatorRuntime {
-    /// Return the actual state of the state machine.
-    pub fn get_state(&self) -> String {
-        self.state.to_string()
-    }
-
     /// Create a new instance of the state machine.
     pub async fn new(
         state_sleep: Duration,
@@ -84,14 +79,18 @@ impl AggregatorRuntime {
         })
     }
 
+    /// Return the actual state of the state machine.
+    pub fn get_state(&self) -> String {
+        self.state.to_string()
+    }
+
     /// Launches an infinite loop ticking the state machine.
     pub async fn run(&mut self) {
-        info!("Starting runtime");
-        debug!("current state: {}", self.state);
+        info!("state machine: launching");
 
         loop {
             if let Err(e) = self.cycle().await {
-                error!("{:?}", e)
+                error!("state machine: an error occured: "; "error" => ?e);
             }
 
             info!("Sleeping for {} ms", self.state_sleep.as_millis());
@@ -106,14 +105,17 @@ impl AggregatorRuntime {
 
         match self.state.clone() {
             AggregatorState::Idle(state) => {
-                let chain_beacon: Beacon = self.runner.get_beacon_from_chain().await?;
+                let chain_beacon = self.runner.get_beacon_from_chain().await?;
 
                 if state.current_beacon.is_none()
                     || chain_beacon
                         .compare_to_older(state.current_beacon.as_ref().unwrap())?
                         .is_new_beacon()
                 {
-                    trace!("new beacon found = {:?}", chain_beacon);
+                    debug!(
+                        "→ new Beacon settings found, trying to transition to READY";
+                        "new_beacon" => ?chain_beacon
+                    );
 
                     if self
                         .try_transition_from_idle_to_ready(
@@ -126,10 +128,10 @@ impl AggregatorRuntime {
                             current_beacon: chain_beacon,
                         });
                     } else {
-                        trace!("Could not transition from IDLE to READY");
+                        debug!(" ⋅ could not transition from IDLE to READY");
                     }
                 } else {
-                    trace!("nothing to do in IDLE state")
+                    debug!(" ⋅ Beacon didn't change, waiting…")
                 }
             }
             AggregatorState::Ready(state) => {
@@ -140,7 +142,7 @@ impl AggregatorRuntime {
                     .is_new_epoch()
                 {
                     // transition READY > IDLE
-                    trace!("new epoch found = {:?}", chain_beacon);
+                    debug!("→ Epoch has changed, transitioning to IDLE"; "new_beacon" => ?chain_beacon);
                     self.state = AggregatorState::Idle(IdleState {
                         current_beacon: Some(state.current_beacon),
                     });
@@ -150,12 +152,13 @@ impl AggregatorRuntime {
                     .await?
                 {
                     // READY > READY
-                    info!("a certificate already exist for this beacon"; "beacon" => ?state.current_beacon);
+                    info!(" ⋅ a certificate already exist for this beacon, waiting…"; "beacon" => ?state.current_beacon);
                     self.state = AggregatorState::Ready(ReadyState {
                         current_beacon: chain_beacon,
                     });
                 } else {
                     // transition READY > SIGNING
+                    debug!("→ transitioning to SIGNING");
                     let new_state = self
                         .transition_from_ready_to_signing(state.current_beacon)
                         .await?;
@@ -169,22 +172,19 @@ impl AggregatorRuntime {
                     .compare_to_older(&state.current_beacon)?
                     .is_new_beacon()
                 {
-                    trace!(
-                        "new beacon found, immutable file number = {}",
-                        chain_beacon.immutable_file_number
-                    );
+                    debug!("→ Beacon changed, transitioning to IDLE"; "new_beacon" => ?chain_beacon);
                     let new_state = self
                         .transition_from_signing_to_idle_new_beacon(state)
                         .await?;
                     self.state = AggregatorState::Idle(new_state);
                 } else if self.runner.is_multisig_created().await? {
-                    trace!("new multi-signature found");
+                    debug!("→ a multi-signature have been created, build a snapshot & a certificate and transitioning back to IDLE");
                     let new_state = self
                         .transition_from_signing_to_idle_multisignature(state)
                         .await?;
                     self.state = AggregatorState::Idle(new_state);
                 } else {
-                    trace!("nothing to do in SIGNING state")
+                    debug!(" ⋅ not enough signature yet to aggregate a mult-signature, waiting…");
                 }
             }
         }
@@ -198,7 +198,7 @@ impl AggregatorRuntime {
         maybe_current_beacon: Option<Beacon>,
         new_beacon: Beacon,
     ) -> Result<bool, RuntimeError> {
-        debug!("trying transition from IDLE to READY state");
+        trace!("trying transition from IDLE to READY state");
 
         self.runner.update_beacon(&new_beacon).await?;
 
@@ -212,7 +212,7 @@ impl AggregatorRuntime {
 
         let is_chain_valid = self.runner.is_certificate_chain_valid().await?;
         if !is_chain_valid {
-            warn!("the certificate chain is invalid");
+            warn!(" > the certificate chain is invalid");
         }
         Ok(is_chain_valid)
     }
@@ -223,7 +223,7 @@ impl AggregatorRuntime {
         &self,
         state: SigningState,
     ) -> Result<IdleState, RuntimeError> {
-        debug!("launching transition from SIGNING to IDLE state");
+        trace!("launching transition from SIGNING to IDLE state");
         self.runner.drop_pending_certificate().await?;
         let ongoing_snapshot = self
             .runner
@@ -253,7 +253,7 @@ impl AggregatorRuntime {
         &self,
         state: SigningState,
     ) -> Result<IdleState, RuntimeError> {
-        debug!("launching transition from SIGNING to IDLE state");
+        trace!("launching transition from SIGNING to IDLE state");
         self.runner.drop_pending_certificate().await?;
 
         Ok(IdleState {
@@ -267,7 +267,7 @@ impl AggregatorRuntime {
         &mut self,
         new_beacon: Beacon,
     ) -> Result<SigningState, RuntimeError> {
-        debug!("launching transition from READY to SIGNING state");
+        trace!("launching transition from READY to SIGNING state");
         self.runner.update_beacon(&new_beacon).await?;
 
         let digester_result = self.runner.compute_digest(&new_beacon).await?;

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -253,7 +253,14 @@ impl CertificateVerifier for MithrilCertificateVerifier {
         certificate_retriever: Arc<dyn CertificateRetriever>,
         genesis_verifier: &ProtocolGenesisVerifier,
     ) -> Result<Option<Certificate>, CertificateVerifierError> {
-        debug!(self.logger, "Verify certificate {:#?}", certificate);
+        debug!(
+            self.logger,
+            "Verifying certificate";
+            "certificate_hash" => &certificate.hash,
+            "certificate_previous_hash" => &certificate.previous_hash,
+            "certificate_beacon" => ?certificate.beacon
+        );
+
         certificate
             .hash
             .eq(&certificate.compute_hash())

--- a/mithril-common/src/entities/beacon.rs
+++ b/mithril-common/src/entities/beacon.rs
@@ -2,6 +2,7 @@ use crate::entities::{Epoch, ImmutableFileNumber};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
 use thiserror::Error;
 
 /// Beacon represents a point in the Cardano chain at which a Mithril certificate should be produced
@@ -80,6 +81,16 @@ impl PartialOrd for Beacon {
         }
         self.immutable_file_number
             .partial_cmp(&other.immutable_file_number)
+    }
+}
+
+impl Display for Beacon {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Beacon (network: {}, epoch: {}, immutable_file_number: {})",
+            self.network, self.epoch, self.immutable_file_number
+        )
     }
 }
 

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -100,7 +100,10 @@ impl StateMachine {
                 error!("STATE MACHINE: an error occured: "; "error" => ?e);
             }
 
-            info!("Sleeping for {} ms", self.state_sleep.as_millis());
+            info!(
+                "… Cycle finished, Sleeping for {} ms",
+                self.state_sleep.as_millis()
+            );
             sleep(self.state_sleep);
         }
     }


### PR DESCRIPTION
With this PR logs from Signers & Aggregator state machines will use the same semantic.

I've a question: should we pass to info level all logs from the `cycle` methods of both state machines ? I think it would make sense to show what's happening without flooding the logs too much, else on info only level most logs would only be `new cycle [...] current_state: [...]`.