### PR TITLE
Update `StmSig` verification steps order

### DIFF
--- a/mithril-core/src/stm.rs
+++ b/mithril-core/src/stm.rs
@@ -664,10 +664,10 @@ impl<D: Clone + Digest> StmSig<D> {
     ) -> Result<(), StmSignatureError<D>> {
         let msgp = avk.mt_commitment.concat_with_msg(msg);
 
+        self.sigma.verify(&msgp, &self.pk)?;
         self.check_indices(params, &msgp, avk)?;
         avk.mt_commitment
             .check(&MTLeaf(self.pk, self.stake), &self.path)?;
-        self.sigma.verify(&msgp, &self.pk)?;
         Ok(())
     }
 


### PR DESCRIPTION
## Content
This PR updates `StmSig` verification steps order and checks in `mithril-core`:
* First that the signature is valid (triggers `StmSignatureError::SingleSignatureInvalid` if not)
* Before checking that the lottery was won (triggers `StmSignatureError::LotteryLost` if not)

This will help users of the library get more understandable message when the message signed on the Signer and the Aggregator are not the same: `A provided signature is invalid` instead of `Lottery for this epoch was lost.`

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [x] Add dev blog post (if relevant)
