### PR TITLE
Implement filtered Signers in Certificate

### DIFF
--- a/docs/blog/2022-09-07-genesis-certificate-feature.md
+++ b/docs/blog/2022-09-07-genesis-certificate-feature.md
@@ -2,7 +2,7 @@
 title: Genesis Certificate support added
 authors:
 - name: Mithril Team
-tags: [genesis, breaking-change]
+tags: [genesis, certificate, breaking-change]
 ---
 
 **Update**: The PR has been merged and the feature is being deployed on the GCP Mithril Aggregator.

--- a/docs/blog/2022-09-12-certificate-signers-list.md
+++ b/docs/blog/2022-09-12-certificate-signers-list.md
@@ -1,0 +1,22 @@
+---
+title: Signers list computation in Certificates
+authors:
+- name: Mithril Team
+tags: [certificate]
+---
+
+### The way the Signers list is computed inside a Certificate on the Mithril Aggregator is changing
+
+**PR**: `Implement filtered Signers in Certificate` [#494](https://github.com/input-output-hk/mithril/pull/494)
+
+**Issue**: `Record 'contributing' Signers only in Certificate` [#495](https://github.com/input-output-hk/mithril/issues/495)
+
+Before this change, the list of Signers displayed in the `Certificate` detail of the [Mithril Explorer](https://mithril.network/explorer/) was the list of **all eligible** Signers of the epoch used for signing (those who have successfully registered with the Mithril Aggregator `2` epochs earlier).
+
+Now that this change has been merged, the list of Signers displayed will only include the **contributing** Signers, which means only those who have successfully sent individual signatures.
+
+Note that the already existing `Certificates` will not be updated as this would break the `Certificate Chain` and therefore would involve the bootstraping of a new `Genesis Certificate`.
+
+This change is transparent to the Signer nodes runned by the SPOs and does not require any specific action from them.
+
+Feel free to reach out to us on the [Discord channel](https://discord.gg/5kaErDKDRq) for questions and/or help.

--- a/mithril-infra/docker-compose.yaml
+++ b/mithril-infra/docker-compose.yaml
@@ -110,7 +110,7 @@ services:
       - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
       - NETWORK=${NETWORK}
       - PARTY_ID=pool10g0tvpyc3phkym8r6hamdulyzd6shzjldpahyvdkljl7ur2adfe # ADA Capital / https://preview.cexplorer.io/pool/pool10g0tvpyc3phkym8r6hamdulyzd6shzjldpahyvdkljl7ur2adfe
-      - RUN_INTERVAL=60000
+      - RUN_INTERVAL=240000
       - DB_DIRECTORY=/db
       - DATA_STORES_DIRECTORY=/mithril-signer-0
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
@@ -137,7 +137,7 @@ services:
       - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
       - NETWORK=${NETWORK}
       - PARTY_ID=pool1t2zfh44yjhgxxrmt563k0wjw9v7vc7jn29vpyyz4vrq4yk8k4m6 # APEX / https://preview.cexplorer.io/pool/pool1t2zfh44yjhgxxrmt563k0wjw9v7vc7jn29vpyyz4vrq4yk8k4m6
-      - RUN_INTERVAL=60000
+      - RUN_INTERVAL=240000
       - DB_DIRECTORY=/db
       - DATA_STORES_DIRECTORY=/mithril-signer-1
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket


### PR DESCRIPTION
## Content
This PR includes:
* Update the `Certificate` creation so that only Signers with valid `Single Signatures` are included in its `signers` field 
* Reduce the runtime interval of the GCP hosted Signers from `60s` to `240s`

## Pre-submit checklist
- Branch
  - [x] Tests are provided (if possible)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [x] Add dev blog post (if relevant)

### Issue(s)
Closes #495 