### PR TITLE
Fix Stake Distribution retrieval

### DIFF
--- a/docs/blog/2022-09-13-stake-distribution-retrieval.md
+++ b/docs/blog/2022-09-13-stake-distribution-retrieval.md
@@ -1,0 +1,27 @@
+---
+title: Stake Distribution retrieval fixed
+authors:
+- name: Mithril Team
+tags: [stake-distribution, certificate]
+---
+
+### The way the Mithril nodes retrieve the Stake Distribution is changing
+
+**PR**: `Fix Stake Distribution retrieval` [#499](https://github.com/input-output-hk/mithril/pull/499)
+
+**Issue**: `Stake distribution discrepancy` [#497](https://github.com/input-output-hk/mithril/issues/497)
+
+We have noticed that the way the Mithril nodes computed the `Stake Distribution` was erroneous: the epoch that was used to make the computation was the **current epoch** instead of the **previous epoch**. This has lead to some de-synchronization between the Signers and the hosted GCP Aggregator for a few epochs.
+
+Indeed, the `Stake Distribution` retrieved from the Cardano node depended on the time at which it was done: the nodes where having differents values that prevented them from being able to work together to produce valid multi-signatures. The problem is related to the epoch that is used (**current epoch**) to make the computation of the `Stake Distribution` when the `cardano-cli query stake-distribution` command is ran, whereas the Mithril protocol needs to work with the **previous epoch**.
+
+A workaround is being implemented in this fix that will compute differently the `Stake Distribution` to target the **previous epoch**. To do so, the Stake value that is now retrieved sequentially for each pool available in the `cardano-cli query stake-distribution` by using the command `cardano-cli query stake-snapshot --stake-pool-id **pool-id*`. This guarantees that the `Stake Distribution` is computed deterministically on all nodes of the Mithril Network.
+
+We will continue our efforts to enhance the way the `Stake Distribution` is retrieved in the future, and so that it works smoothly on the `mainnet` (where the numbers of pools is bigger `~3,000` vs `~100` on the `preview` network).
+
+The SPOs need to recompile their Signer node in order to compute correctly the `Stake Distributions` on their node (as in this [guide](https://mithril.network/doc/manual/getting-started/run-signer-node)).
+It should then take up to `2` epochs before they are able to successfully register their individual signatures with the Aggregator.
+
+More information about the `Certificate Chain` and the epochs retrieval requirements is available [here](https://mithril.network/doc/mithril/mithril-protocol/certificates).
+
+Feel free to reach out to us on the [Discord channel](https://discord.gg/5kaErDKDRq) for questions and/or help.

--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -588,9 +588,25 @@ do
         echo ">>>> Activated!"
         POOL_IDX=1
         ./pools.sh | while read POOL_ID ; do
-            echo ">>>> Found PoolId: \$POOL_ID"
+            echo ">>>> Detected PoolId: \$POOL_ID"
             echo PARTY_ID=\${POOL_ID} > node-pool\${POOL_IDX}/pool.env
             POOL_IDX=\$(( \$POOL_IDX + 1))
+        done
+        ./pools.sh | while read POOL_ID ; do
+            echo ">>>> Retrieve stakes PoolId: \$POOL_ID"
+            while true
+            do
+                POOL_STAKE_PREVIOUS_EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli query stake-snapshot \\
+                    --stake-pool-id \$POOL_ID \\
+                    --testnet-magic ${NETWORK_MAGIC} | jq .poolStakeMark)
+                if [ "\$POOL_STAKE_PREVIOUS_EPOCH" != "0" ] ; then
+                    break
+                else
+                    echo ">>>> Not retrievable yet"
+                    sleep 2
+                fi
+            done
+            echo ">>>> Stakes retrieved PoolId: \$POOL_ID / \$POOL_STAKE_PREVIOUS_EPOCH"
         done
         break
     else


### PR DESCRIPTION
## Content
This PR includes a fix on the Stake Distribution retrieval. It makes use `cardano-cli query stake-snapshot` to retrieve an accurate stake distribution for each available stake pool. This allows to retrieve the `Stake Distribution` at the correct `Epoch` (previous)

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (not needed)
  - [x] Update documentation website (not needed)
  - [x] Add dev blog post

## Comments
Once this PR is merged, the SPO will need to recompile their node and signing should work as expected after `2` epochs

## Issue
Closes #497 
