### PR TITLE
Fix Aggregator store migrator

### DIFF
--- a/mithril-aggregator/src/bin/mithril-aggregator-migrate.rs
+++ b/mithril-aggregator/src/bin/mithril-aggregator-migrate.rs
@@ -182,7 +182,7 @@ impl AutomaticMigrationCommand {
         }
         let base_dir = &self.db_dir;
 
-        migrate(base_dir, "certificate", StoreType::Certificate).await?;
+        migrate(base_dir, "cert", StoreType::Certificate).await?;
         migrate(
             base_dir,
             "pending_certificate",


### PR DESCRIPTION
## Content

This PR includes a fix of the Aggregator store migrator: the path of the source directory for certificates was incorrect, which made the migration import `0` certificates without failing.

## Issue(s)

Relates to #475 
