### PR TITLE
Fix devnet Dockerfiles

### DIFF
--- a/mithril-aggregator/Dockerfile
+++ b/mithril-aggregator/Dockerfile
@@ -20,7 +20,8 @@ COPY Cargo.lock /mithril-common/
 # Build the app using a dummy main in order to cache dependencies
 COPY mithril-aggregator/Cargo.toml /app
 COPY Cargo.lock /app/
-RUN mkdir -p /app/src/ && echo "fn  main () {}" > /app/src/main.rs
+COPY ./mithril-aggregator /app/
+RUN rm -f /app/src/main.rs && echo "fn  main () {}" > /app/src/main.rs
 RUN cargo build --release --manifest-path /app/Cargo.toml
 
 # Copy the rest of the files into the container

--- a/mithril-client/Dockerfile
+++ b/mithril-client/Dockerfile
@@ -20,7 +20,8 @@ COPY Cargo.lock /mithril-common/
 # Build the app using a dummy main in order to cache dependencies
 COPY mithril-client/Cargo.toml /app
 COPY Cargo.lock /app/
-RUN mkdir -p /app/src/ && echo "fn  main () {}" > /app/src/main.rs
+COPY ./mithril-client /app/
+RUN rm -f /app/src/main.rs && echo "fn  main () {}" > /app/src/main.rs
 RUN cargo build --release --manifest-path /app/Cargo.toml
 
 # Copy the rest of the files into the container

--- a/mithril-signer/Dockerfile
+++ b/mithril-signer/Dockerfile
@@ -20,7 +20,8 @@ COPY Cargo.lock /mithril-common/
 # Build the app using a dummy main in order to cache dependencies
 COPY mithril-signer/Cargo.toml /app
 COPY Cargo.lock /app/
-RUN mkdir -p /app/src/ && echo "fn  main () {}" > /app/src/main.rs
+COPY ./mithril-signer /app/
+RUN rm -f /app/src/main.rs && echo "fn  main () {}" > /app/src/main.rs
 RUN cargo build --release --manifest-path /app/Cargo.toml
 
 # Copy the rest of the files into the container


### PR DESCRIPTION
## Content
This PR includes a fix on the `Dockerfiles` used by the `devnet` so that they can handle multiple bins in the crates along with build cache trick (for fast build)

## Issue(s)
Relates to #475
