### PR TITLE
Greg/518/migrate snapshot store

### DIFF
--- a/mithril-aggregator/src/bin/mithril-aggregator-migrate.rs
+++ b/mithril-aggregator/src/bin/mithril-aggregator-migrate.rs
@@ -13,7 +13,7 @@ use mithril_common::{
     crypto_helper::ProtocolParameters,
     entities::{
         Beacon, Certificate, CertificatePending, Epoch, PartyId, Signer, SingleSignatures,
-        StakeDistribution,
+        Snapshot, StakeDistribution,
     },
     store::adapter::{JsonFileStoreAdapter, SQLiteAdapter},
     store::adapter_migration::AdapterMigration,
@@ -106,11 +106,16 @@ enum StoreType {
     Stake,
     SingleSignature,
     ProtocolParameters,
+    Snapshot,
 }
 
 impl StoreType {
     pub async fn migrate(&self, input_file: &Path, output_file: &Path) -> ApplicationResult<()> {
         match self {
+            StoreType::Snapshot => {
+                println!("Migrating snapshot_store data…");
+                migrate_one::<String, Snapshot>(input_file, output_file, "snapshot").await?;
+            }
             StoreType::CertificatePending => {
                 println!("Migrating certificate_pending_store data…");
                 migrate_one::<String, CertificatePending>(
@@ -193,6 +198,7 @@ impl AutomaticMigrationCommand {
         migrate(base_dir, "single_signature", StoreType::SingleSignature).await?;
         migrate(base_dir, "verification_key", StoreType::VerificationKey).await?;
         migrate(base_dir, "stake", StoreType::Stake).await?;
+        migrate(base_dir, "snapshot", StoreType::Snapshot).await?;
 
         Ok(())
     }

--- a/mithril-aggregator/src/bin/mithril-aggregator-migrate.rs
+++ b/mithril-aggregator/src/bin/mithril-aggregator-migrate.rs
@@ -116,7 +116,7 @@ impl StoreType {
                 migrate_one::<String, CertificatePending>(
                     input_file,
                     output_file,
-                    "certificate_pending",
+                    "pending_certificate",
                 )
                 .await?;
             }

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -1,11 +1,12 @@
 use config::ConfigError;
-use mithril_common::entities::ProtocolParameters;
 use serde::{Deserialize, Serialize};
 use std::error::Error;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use mithril_common::{store::adapter::JsonFileStoreAdapter, CardanoNetwork};
+use mithril_common::entities::ProtocolParameters;
+use mithril_common::store::adapter::SQLiteAdapter;
+use mithril_common::CardanoNetwork;
 
 use crate::snapshot_stores::LocalSnapshotStore;
 use crate::tools::GcpFileUploader;
@@ -103,8 +104,9 @@ impl Configuration {
                 self.url_snapshot_manifest.clone(),
             ))),
             SnapshotStoreType::Local => Ok(Arc::new(LocalSnapshotStore::new(
-                Box::new(JsonFileStoreAdapter::new(
-                    self.data_stores_directory.join("snapshot_db"),
+                Box::new(SQLiteAdapter::new(
+                    "snapshot",
+                    Some(self.data_stores_directory.join("aggregator.sqlite3")),
                 )?),
                 LIST_SNAPSHOTS_MAX_ITEMS,
             ))),

--- a/mithril-aggregator/src/main.rs
+++ b/mithril-aggregator/src/main.rs
@@ -40,9 +40,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Init dependencies
     let snapshot_store = config.build_snapshot_store()?;
-    let sqlite_db_path = Some(config.data_stores_directory.join("aggregator.sqlite3"));
-
     let snapshot_uploader = config.build_snapshot_uploader();
+
+    let sqlite_db_path = Some(config.get_sqlite_file());
+
     let certificate_pending_store = Arc::new(CertificatePendingStore::new(Box::new(
         SQLiteAdapter::new("pending_certificate", sqlite_db_path.clone())?,
     )));

--- a/mithril-common/src/store/adapter/jsonfile_store_adapter.rs
+++ b/mithril-common/src/store/adapter/jsonfile_store_adapter.rs
@@ -79,7 +79,7 @@ where
                 metadata,
             ));
         }
-        hashes.sort_by_key(|(_, meta)| meta.created().unwrap());
+        hashes.sort_by_key(|(_, meta)| meta.modified().unwrap());
 
         Ok(Box::new(hashes.into_iter().rev().map(|(hash, _meta)| hash)))
     }

--- a/mithril-common/src/store/adapter/sqlite_adapter.rs
+++ b/mithril-common/src/store/adapter/sqlite_adapter.rs
@@ -559,5 +559,4 @@ mod tests {
             values
         );
     }
-
 }

--- a/mithril-common/src/store/adapter/sqlite_adapter.rs
+++ b/mithril-common/src/store/adapter/sqlite_adapter.rs
@@ -325,7 +325,7 @@ mod tests {
         dirpath.join(format!("{}.sqlite3", test_name))
     }
 
-    fn init_db(test_name: &str) -> SQLiteAdapter<u64, String> {
+    fn init_db(test_name: &str, tablename: Option<&str>) -> SQLiteAdapter<u64, String> {
         let filepath = get_file_path(test_name);
 
         if filepath.exists() {
@@ -336,13 +336,14 @@ mod tests {
                 )
             });
         }
-        SQLiteAdapter::new(TABLE_NAME, Some(filepath)).unwrap()
+        let tablename = tablename.unwrap_or(TABLE_NAME);
+        SQLiteAdapter::new(tablename, Some(filepath)).unwrap()
     }
 
     #[tokio::test]
     async fn test_store_record() {
         let test_name = "test_store_record";
-        let mut adapter = init_db(test_name);
+        let mut adapter = init_db(test_name, None);
         adapter
             .store_record(&1, "one".to_string().borrow())
             .await
@@ -397,7 +398,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_record() {
         let test_name = "test_get_record";
-        let mut adapter = init_db(test_name);
+        let mut adapter = init_db(test_name, None);
         adapter
             .store_record(&1, "one".to_string().borrow())
             .await
@@ -428,7 +429,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_iterator() {
         let test_name = "test_get_iterator";
-        let mut adapter = init_db(test_name);
+        let mut adapter = init_db(test_name, None);
         adapter
             .store_record(&1, "one".to_string().borrow())
             .await
@@ -456,7 +457,7 @@ mod tests {
     #[tokio::test]
     async fn test_record_exists() {
         let test_name = "test_record_exists";
-        let mut adapter = init_db(test_name);
+        let mut adapter = init_db(test_name, None);
         adapter
             .store_record(&1, "one".to_string().borrow())
             .await
@@ -474,7 +475,7 @@ mod tests {
     #[tokio::test]
     async fn test_remove() {
         let test_name = "test_remove";
-        let mut adapter = init_db(test_name);
+        let mut adapter = init_db(test_name, None);
         adapter
             .store_record(&1, "one".to_string().borrow())
             .await
@@ -499,7 +500,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_last_n_records() {
         let test_name = "test_get_last_n_records";
-        let mut adapter = init_db(test_name);
+        let mut adapter = init_db(test_name, None);
         adapter
             .store_record(&1, "one".to_string().borrow())
             .await
@@ -535,7 +536,7 @@ mod tests {
     #[tokio::test]
     async fn check_get_last_n_modified_records() {
         let test_name = "check_get_last_n_modified_records";
-        let mut adapter = init_db(test_name);
+        let mut adapter = init_db(test_name, None);
         adapter
             .store_record(&1, "one".to_string().borrow())
             .await
@@ -558,4 +559,5 @@ mod tests {
             values
         );
     }
+
 }


### PR DESCRIPTION
## Content
This PR includes migration for the Snapshot store from JSON → SQLite. 
It also comes with a patch regarding the SQLite implementation of `remove` method. This method uses a transaction which was never rollback if failed.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None.

## Issue(s)
#518 
