### PR TITLE
Fix devnet Dockerfiles

### DIFF
--- a/mithril-aggregator/Dockerfile
+++ b/mithril-aggregator/Dockerfile
@@ -20,8 +20,8 @@ COPY Cargo.lock /mithril-common/
 # Build the app using a dummy main in order to cache dependencies
 COPY mithril-aggregator/Cargo.toml /app
 COPY Cargo.lock /app/
-COPY ./mithril-aggregator /app/
-RUN rm -f /app/src/main.rs && echo "fn  main () {}" > /app/src/main.rs
+RUN mkdir -p /app/src/ && echo "fn  main () {}" > /app/src/main.rs
+RUN mkdir -p /app/src/bin/ && echo "fn  main () {}" > /app/src/bin/mithril-aggregator-migrate.rs
 RUN cargo build --release --manifest-path /app/Cargo.toml
 
 # Copy the rest of the files into the container

--- a/mithril-client/Dockerfile
+++ b/mithril-client/Dockerfile
@@ -20,8 +20,7 @@ COPY Cargo.lock /mithril-common/
 # Build the app using a dummy main in order to cache dependencies
 COPY mithril-client/Cargo.toml /app
 COPY Cargo.lock /app/
-COPY ./mithril-client /app/
-RUN rm -f /app/src/main.rs && echo "fn  main () {}" > /app/src/main.rs
+RUN mkdir -p /app/src/ && echo "fn  main () {}" > /app/src/main.rs
 RUN cargo build --release --manifest-path /app/Cargo.toml
 
 # Copy the rest of the files into the container

--- a/mithril-signer/Dockerfile
+++ b/mithril-signer/Dockerfile
@@ -20,8 +20,8 @@ COPY Cargo.lock /mithril-common/
 # Build the app using a dummy main in order to cache dependencies
 COPY mithril-signer/Cargo.toml /app
 COPY Cargo.lock /app/
-COPY ./mithril-signer /app/
-RUN rm -f /app/src/main.rs && echo "fn  main () {}" > /app/src/main.rs
+RUN mkdir -p /app/src/ && echo "fn  main () {}" > /app/src/main.rs
+RUN mkdir -p /app/src/bin/ && echo "fn  main () {}" > /app/src/bin/mithril-signer-migrate.rs
 RUN cargo build --release --manifest-path /app/Cargo.toml
 
 # Copy the rest of the files into the container


### PR DESCRIPTION
## Content
This PR includes a fix on the `Dockerfiles` used by the `devnet` so that they can handle `migrator` bins in the crates along with build cache trick (for fast build). This is a fix of a previous attempt (PR #519) that was not working properly due to docker build cache. The solution seems to be to reproduce the trick of empty main file for all binaries declared in `cargo.toml` instead.

## Issue(s)
Relates to #475