### PR TITLE
Fix Dockerfile CI images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1519,9 +1519,9 @@ dependencies = [
 
 [[package]]
 name = "itertools"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8bf247779e67a9082a4790b45e71ac7cfd1321331a5c856a74a9faebdab78d0"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
@@ -1690,9 +1690,9 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
+checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2157,9 +2157,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
+checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
 name = "oorandom"
@@ -2709,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.11"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75aa69a3f06bbcc66ede33af2af253c6f7a86b1ca0033f60c580a27074fbf92"
+checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
  "base64 0.13.0",
  "bytes",
@@ -2725,10 +2725,10 @@ dependencies = [
  "hyper-tls",
  "ipnet",
  "js-sys",
- "lazy_static",
  "log",
  "mime",
  "native-tls",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "serde",

--- a/mithril-aggregator/Dockerfile.ci
+++ b/mithril-aggregator/Dockerfile.ci
@@ -1,10 +1,10 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-aggregator executable has been built
 # on a debian-compatible x86-64 environment
-FROM rust:latest
+FROM ubuntu:latest
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl1.1 ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-aggregator/src/store/protocol_parameters_store.rs
+++ b/mithril-aggregator/src/store/protocol_parameters_store.rs
@@ -117,10 +117,7 @@ mod tests {
         let protocol_parameters = setup_protocol_parameters(1);
         let store = init_store(0, None);
         let res = store
-            .save_protocol_parameters(
-                protocol_parameters[0].0,
-                (&protocol_parameters[0].1).to_owned(),
-            )
+            .save_protocol_parameters(protocol_parameters[0].0, protocol_parameters[0].1.clone())
             .await
             .unwrap();
 
@@ -132,10 +129,7 @@ mod tests {
         let protocol_parameters = setup_protocol_parameters(2);
         let store = init_store(1, None);
         let res = store
-            .save_protocol_parameters(
-                protocol_parameters[0].0,
-                (&protocol_parameters[1].1).to_owned(),
-            )
+            .save_protocol_parameters(protocol_parameters[0].0, protocol_parameters[1].1.clone())
             .await
             .unwrap();
 
@@ -163,7 +157,7 @@ mod tests {
         let store = init_store(2, Some(2));
         let protocol_parameters = setup_protocol_parameters(3);
         let _ = store
-            .save_protocol_parameters(Epoch(3), (&protocol_parameters[2].1).to_owned())
+            .save_protocol_parameters(Epoch(3), protocol_parameters[2].1.clone())
             .await
             .unwrap();
         assert_eq!(None, store.get_protocol_parameters(Epoch(1)).await.unwrap());

--- a/mithril-client/Dockerfile.ci
+++ b/mithril-client/Dockerfile.ci
@@ -1,10 +1,10 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-client executable has been built
 # on a debian-compatible x86-64 environment
-FROM rust:latest
+FROM ubuntu:latest
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl1.1 ca-certificates wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-client/src/aggregator.rs
+++ b/mithril-client/src/aggregator.rs
@@ -221,7 +221,7 @@ impl AggregatorHandler for AggregatorHTTPClient {
         let local_path = archive_file_path(digest, &self.network)?;
         local_path
             .exists()
-            .then(|| ())
+            .then_some(())
             .ok_or_else(|| AggregatorHandlerError::ArchiveNotFound(local_path.clone()))?;
 
         let snapshot_file_tar_gz = fs::File::open(local_path.clone())?;

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -66,7 +66,7 @@ impl Certificate {
         multi_signature: String,
         genesis_signature: String,
     ) -> Certificate {
-        let signed_message = (&protocol_message.compute_hash()).to_owned();
+        let signed_message = protocol_message.compute_hash();
         let mut certificate = Certificate {
             hash: "".to_string(),
             previous_hash,

--- a/mithril-signer/Dockerfile.ci
+++ b/mithril-signer/Dockerfile.ci
@@ -1,10 +1,10 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-signer executable has been built
 # on a debian-compatible x86-64 environment
-FROM rust:latest
+FROM ubuntu:latest
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl1.1 ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-signer/src/protocol_initializer_store.rs
+++ b/mithril-signer/src/protocol_initializer_store.rs
@@ -143,7 +143,7 @@ mod tests {
         let res = store
             .save_protocol_initializer(
                 protocol_initializers[0].0,
-                (&protocol_initializers[0].1).to_owned(),
+                protocol_initializers[0].1.clone(),
             )
             .await
             .unwrap();
@@ -158,7 +158,7 @@ mod tests {
         let res = store
             .save_protocol_initializer(
                 protocol_initializers[0].0,
-                (&protocol_initializers[1].1).to_owned(),
+                protocol_initializers[1].1.clone(),
             )
             .await
             .unwrap();
@@ -190,7 +190,7 @@ mod tests {
         let _ = store
             .save_protocol_initializer(
                 protocol_initializers[0].0,
-                (&protocol_initializers[0].1).to_owned(),
+                protocol_initializers[0].1.clone(),
             )
             .await
             .unwrap();


### PR DESCRIPTION
## Content
This PR includes to avoid getting `libssl` shared libraries errors that is blocking the GCP nodes following merge of #517:
`error while loading shared libraries: libssl.so.3: cannot open shared object file: No such file or directory`

Replaces `FROM ubuntu:latest` instead of `FROM rust:latest`

## Comments
This is not the best fix as we could probably use a "slimer" image.
We will address that issue more in depth in #318 

## Issue(s)
Relates to #517 
