### PR TITLE
Enhance Mithril networks documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,12 @@ jobs:
             cargo-${{ runner.os }}-cache-v${{ secrets.CACHE_VERSION }}-mithril-core
             cargo-${{ runner.os }}-cache-v${{ secrets.CACHE_VERSION }}-
 
+      - name: Install cargo tools
+        if: ${{ steps.cargo-cache.outputs.cache-hit == false }}
+        run: |
+          cargo install cargo2junit 2>/dev/null || true # Suppress the "binary `xyz` already exists in destination" error
+          cargo install cargo-sort 2>/dev/null || true
+
       - name: Cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
@@ -26,7 +26,7 @@ The [Mithril test networks](../../../manual/developer-docs/references.md#mithril
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 * `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 :::
 
@@ -151,13 +151,13 @@ Run 'serve' command in release with default configuration
 Run 'serve' command in release with a specific mode
 
 ```bash
-./mithril-aggregator -r testnet serve
+./mithril-aggregator -r preview serve
 ```
 
 Run 'serve' command in release with a custom configuration via env vars
 
 ```bash
-GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=testnet ./mithril-aggregator serve
+GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=**YOUR_TEST_NETWORK** ./mithril-aggregator serve
 ```
 
 ## Release build and run binary 'genesis' command
@@ -224,7 +224,7 @@ This allows the Mithril Aggregator node to import the signed payload of the `Gen
 Run 'genesis import' command in release with a custom configuration via env vars
 
 ```bash
-GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=testnet ./mithril-aggregator genesis import --signed-payload-path **YOUR_SIGNED_PAYLOAD_PATH**
+GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=**YOUR_TEST_NETWORK** ./mithril-aggregator genesis import --signed-payload-path **YOUR_SIGNED_PAYLOAD_PATH**
 ```
 
 :::tip

--- a/docs/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-client.md
@@ -28,7 +28,7 @@ The [Mithril test networks](../../../manual/developer-docs/references.md#mithril
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 * `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 :::
 
@@ -142,13 +142,13 @@ Run in release with default configuration
 Run in release with a specific mode
 
 ```bash
-./mithril-client -r testnet
+./mithril-client -r preview
 ```
 
 Run in release with a custom configuration via env vars
 
 ```bash
-GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) NETWORK=testnet AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-client
+GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) NETWORK=**YOUR_TEST_NETWORK** AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-client
 ```
 
 :::tip

--- a/docs/root/manual/developer-docs/nodes/mithril-signer.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-signer.md
@@ -28,7 +28,7 @@ The [Mithril test networks](../../../manual/developer-docs/references.md#mithril
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 * `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 :::
 
@@ -45,7 +45,6 @@ In this documentation, we use the generic `testnet` identifier, but you need to 
 * Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 
 * Ensure SQLite3 library is installed on your system and its version is at least `1.35` (released Apr. 2021) on Debian/Ubuntu: `apt install libsqlite3` and `sqlite3 --version`.
-
 
 ## Download source
 
@@ -137,13 +136,13 @@ Run in release with default configuration
 Run in release with a specific mode
 
 ```bash
-./mithril-signer -r testnet
+./mithril-signer -r preview
 ```
 
 Run in release with a custom configuration via env vars
 
 ```bash
-NETWORK=testnet AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-signer
+NETWORK=**YOUR_TEST_NETWORK** AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-signer
 ```
 
 :::tip

--- a/docs/root/manual/developer-docs/references.md
+++ b/docs/root/manual/developer-docs/references.md
@@ -42,4 +42,4 @@ The Mithril Networks are aligned with the Cardano Networks and have the same nam
 | `testnet` | `1097911063` | :x: | - | - | Deprecated, not supported anymore
 | `preprod` | `1` | :x: | - | - | Not implemented yet
 | `preview` | `2` | :heavy_check_mark: | [:arrow_upper_right:](https://aggregator.api.mithril.network/aggregator) | [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) | Supported
-| `devnet` | `42` | :heavy_check_mark: | [:arrow_upper_right:](http://localhost:8080/aggregator>) | - | Supported on the `devnet` only
+| `devnet` | `42` | :heavy_check_mark: | [:arrow_upper_right:](http://localhost:8080/aggregator) | - | Supported on the `devnet` only

--- a/docs/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/root/manual/getting-started/bootstrap-cardano-node.md
@@ -138,7 +138,7 @@ SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
 List the available snapshots with which you can bootstrap a Cardano node
 
 ```bash
-NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client list
+GENESIS_VERIFICATION_KEY=$GENESIS_VERIFICATION_KEY NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client list
 ```
 
 You will see a list of snapshots
@@ -164,7 +164,7 @@ You will see a list of snapshots
 Get some more details from a specific snapshot (Optional)
 
 ```bash
-NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client show $SNAPSHOT_DIGEST
+GENESIS_VERIFICATION_KEY=$GENESIS_VERIFICATION_KEY NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client show $SNAPSHOT_DIGEST
 ```
 
 You will see more information about a snapshot
@@ -189,7 +189,7 @@ You will see more information about a snapshot
 Download the selected snapshot from the remote location to your remote location
 
 ```bash
-NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client download $SNAPSHOT_DIGEST
+GENESIS_VERIFICATION_KEY=$GENESIS_VERIFICATION_KEY NETWORK=$NETWORK AGGREGATOR_ENDPOINT=$AGGREGATOR_ENDPOINT ./mithril-client download $SNAPSHOT_DIGEST
 ```
 
 You will see that the selected snapshot archive has been downloaded locally

--- a/docs/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/root/manual/getting-started/bootstrap-cardano-node.md
@@ -18,7 +18,7 @@ The [Mithril test networks](../../manual/developer-docs/references.md#mithril-ne
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 * `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 :::
 
@@ -120,7 +120,7 @@ If you want to dig deeper, you can get access to several level of logs from the 
 
 ```bash
 # Cardano network
-NETWORK=testnet
+NETWORK=**YOUR_TEST_NETWORK**
 
 # Aggregator API endpoint URL
 AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator
@@ -225,7 +225,7 @@ docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind
 Launch an empty Cardano node and make it live in minutes!
 
 ```bash
-docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="$(pwd)/data/testnet/$SNAPSHOT_DIGEST/db",target=/data/db/ -e NETWORK=testnet inputoutput/cardano-node
+docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="$(pwd)/data/testnet/$SNAPSHOT_DIGEST/db",target=/data/db/ -e NETWORK=**YOUR_TEST_NETWORK** inputoutput/cardano-node
 ```
 
 You will see the node start by validating the files injested from the snapshot archive

--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -18,7 +18,7 @@ The [Mithril test networks](../../manual/developer-docs/references.md#mithril-ne
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 * `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 :::
 
@@ -161,7 +161,7 @@ First create an env file that will be used by the service
 ```bash
 sudo cat > /opt/mithril/mithril-signer.env << EOF
 PARTY_ID=YOUR_POOL_ID_BECH32
-NETWORK=testnet
+NETWORK=**YOUR_TEST_NETWORK**
 AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator
 RUN_INTERVAL=60000
 DB_DIRECTORY=/cardano/db

--- a/mithril-aggregator/README.md
+++ b/mithril-aggregator/README.md
@@ -14,7 +14,6 @@ This is a first version of the Mithril Aggregagator
 - Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 - Ensure `libsqlite3` is installed on your system and check its version is at least `1.35`. Run `apt install libsqlite3` and `sqlite3 --version`
 
-
 ## Mithril test networks
 
 The Mithril test networks are:
@@ -23,7 +22,7 @@ The Mithril test networks are:
 - `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 - `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 ## Download source code
 
@@ -117,13 +116,13 @@ Run 'serve' command in release with default configuration
 Run 'serve' command in release with a specific mode
 
 ```bash
-./mithril-aggregator serve -r testnet
+./mithril-aggregator serve -r preview
 ```
 
 Run 'serve' command in release with a custom configuration via env vars
 
 ```bash
-GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=testnet ./mithril-aggregator serve
+GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=**YOUR_TEST_NETWORK** ./mithril-aggregator serve
 ```
 
 ## Release build and run binary 'genesis' command
@@ -201,7 +200,7 @@ Or with a custom export path (to override the default value `./mithril-genesis-s
 Run 'genesis import' command in release with a custom configuration via env vars
 
 ```bash
-GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=testnet ./mithril-aggregator genesis import
+GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) RUN_INTERVAL=60000 NETWORK=**YOUR_TEST_NETWORK** ./mithril-aggregator genesis import
 ```
 
 ```

--- a/mithril-client/README.md
+++ b/mithril-client/README.md
@@ -23,7 +23,7 @@ The Mithril test networks are:
 * `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 * `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 ## Download source code
 
@@ -69,10 +69,10 @@ make build
 
 # Run and show list of snapshots for the testnet config file
 # Run in a specific mode
-./mithril-client -r testnet list
+./mithril-client -r preview list
 
 # Run with custom configuration with env vars
-GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) NETWORK=testnet AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-client
+GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/TEST_ONLY_genesis.vkey) NETWORK=**YOUR_TEST_NETWORK** AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-client
 ```
 
 You can use the `--json` option in order to display results in `JSON` format for the `list` and `show` commands:

--- a/mithril-signer/README.md
+++ b/mithril-signer/README.md
@@ -31,7 +31,7 @@ The Mithril test networks are:
 - `preprod`: Test network with magic id `1`, not implemented yet on the IOG hosted Mithril Aggregator
 - `testnet`: Legacy test network with magic id `1097911063`, used to be on the IOG hosted Mithril Aggregator, now deprecated
 
-In this documentation, we use the generic `testnet` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
+In this documentation, we use the generic `**YOUR_TEST_NETWORK**` identifier, but you need to replace it with the identifier of the network that runs on your Cardano node
 
 ## Development test and build
 
@@ -66,10 +66,10 @@ make build
 ./mithril-signer
 
 # Run in a specific mode
-./mithril-signer -r testnet
+./mithril-signer -r preview
 
 # Run with custom configuration with env vars
-NETWORK=testnet AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-signer
+NETWORK=**YOUR_TEST_NETWORK** AGGREGATOR_ENDPOINT=https://aggregator.api.mithril.network/aggregator ./mithril-signer
 ```
 
 ## Build and run Docker container


### PR DESCRIPTION
## Content
This PR includes documentation enhancements about the usage of the `Mithril networks` and attempts to avoid confusion between `testnet` (the legacy network) and `test networks` (aka `preview` and `preprod`). Also the documentation now uses a generic `**YOUR_TEST_NETWORK**`.

## Issue(s)
Closes #527 