### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Overriding default $CARGO_PROJECT_NAME with matrix value
         if: ${{ matrix.cargo_project_name }}
@@ -154,7 +154,7 @@ jobs:
     needs: [ build ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -213,7 +213,7 @@ jobs:
     needs: [ build ]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download aggregator
         uses: actions/download-artifact@v3
@@ -341,10 +341,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -352,7 +352,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -366,7 +366,7 @@ jobs:
           path: ${{ matrix.project }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: ${{ env.CONTEXT }}
           file: ${{ env.DOCKER_FILE }}
@@ -420,7 +420,7 @@ jobs:
       - docker-mithril
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download mithril-core-doc artifact
         uses: actions/download-artifact@v3
@@ -507,14 +507,14 @@ jobs:
     steps:
 
     - name: Checkout sources
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Get short SHA
       id: slug
       run: echo "::set-output name=sha8::$(echo ${{ github.sha }} | cut -c1-7)"
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v1
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_wrapper: false
 


### PR DESCRIPTION
## Content

This PR do the available update of our github actions in order to reduce the number of _"Node.js 12 actions are deprecated"_ warnings that are popping our pipelines.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

Note: as said in the related issue most of the actions we use are to be updated to node16, so this task is yet to be completed.

## Issue(s)

Relates to #550 
