### PR TITLE
add API version in HTTP headers

### DIFF
--- a/mithril-aggregator/src/http_server/mod.rs
+++ b/mithril-aggregator/src/http_server/mod.rs
@@ -2,9 +2,3 @@ mod routes;
 mod server;
 
 pub use server::{Server, SERVER_BASE_PATH};
-
-/// Mithril API protocol version
-/// this is the same as the one in openapi.yml file.
-/// If you want to update this version to reflect changes in the protocol,
-/// please also update the entry in the openapi.yml
-pub const MITHRIL_API_VERSION: &str = "0.0.1";

--- a/mithril-aggregator/src/http_server/mod.rs
+++ b/mithril-aggregator/src/http_server/mod.rs
@@ -2,3 +2,5 @@ mod routes;
 mod server;
 
 pub use server::{Server, SERVER_BASE_PATH};
+
+pub const MITHRIL_API_VERSION: &str = "0.1.0";

--- a/mithril-aggregator/src/http_server/mod.rs
+++ b/mithril-aggregator/src/http_server/mod.rs
@@ -3,4 +3,8 @@ mod server;
 
 pub use server::{Server, SERVER_BASE_PATH};
 
-pub const MITHRIL_API_VERSION: &str = "0.1.0";
+/// Mithril API protocol version
+/// this is the same as the one in openapi.yml file.
+/// If you want to update this version to reflect changes in the protocol,
+/// please also update the entry in the openapi.yml
+pub const MITHRIL_API_VERSION: &str = "0.0.1";

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -1,8 +1,11 @@
 use crate::http_server::routes::{
     certificate_routes, epoch_routes, signatures_routes, signer_routes, snapshot_routes,
 };
-use crate::http_server::{MITHRIL_API_VERSION, SERVER_BASE_PATH};
+use crate::http_server::SERVER_BASE_PATH;
 use crate::DependencyManager;
+
+use mithril_common::MITHRIL_API_VERSION;
+
 use reqwest::header::{HeaderMap, HeaderValue};
 use std::sync::Arc;
 use warp::http::Method;

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -1,8 +1,9 @@
 use crate::http_server::routes::{
     certificate_routes, epoch_routes, signatures_routes, signer_routes, snapshot_routes,
 };
-use crate::http_server::SERVER_BASE_PATH;
+use crate::http_server::{MITHRIL_API_VERSION, SERVER_BASE_PATH};
 use crate::DependencyManager;
+use reqwest::header::{HeaderMap, HeaderValue};
 use std::sync::Arc;
 use warp::http::Method;
 use warp::Filter;
@@ -15,6 +16,11 @@ pub fn routes(
         .allow_any_origin()
         .allow_headers(vec!["content-type"])
         .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "mithril-api-version",
+        HeaderValue::from_static(MITHRIL_API_VERSION),
+    );
 
     warp::any().and(warp::path(SERVER_BASE_PATH)).and(
         certificate_routes::routes(dependency_manager.clone())
@@ -22,6 +28,7 @@ pub fn routes(
             .or(signer_routes::routes(dependency_manager.clone()))
             .or(signatures_routes::routes(dependency_manager.clone()))
             .or(epoch_routes::routes(dependency_manager))
-            .with(cors),
+            .with(cors)
+            .with(warp::reply::with::headers(headers)),
     )
 }

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -35,3 +35,9 @@ pub const NEXT_SIGNER_EPOCH_RETRIEVAL_OFFSET: i64 = 0;
 
 /// The epoch offset used for signers stake distribution and verification keys recording.
 pub const SIGNER_EPOCH_RECORDING_OFFSET: i64 = 1;
+
+/// Mithril API protocol version
+/// this is the same as the one in openapi.yml file.
+/// If you want to update this version to reflect changes in the protocol,
+/// please also update the entry in the openapi.yml
+pub const MITHRIL_API_VERSION: &str = "0.0.1";

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,5 +1,9 @@
 openapi: "3.0.0"
 info:
+  # The protocol version is embedded in the code as constant in the
+  # `mithril-aggregator/src/http_server/mod.rs` file. If you plan to update it
+  # here to reflect changes in the API, please also update the constant in the
+  # Rust file.
   version: 0.0.1
   title: Mithril Aggregator Server
   description: |


### PR DESCRIPTION
## Content
This patch adds a new HTTP response header that advertise the version of the Mithril Protocol supported by the server.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Relates to #YYY or Closes #YYY
