### PR TITLE
Fix KES key update

### DIFF
--- a/mithril-common/src/crypto_helper/cardano/opcert.rs
+++ b/mithril-common/src/crypto_helper/cardano/opcert.rs
@@ -41,7 +41,8 @@ struct RawOpCert(RawFields, EdPublicKey);
 pub struct OpCert {
     pub(crate) kes_vk: KesPublicKey,
     pub(crate) issue_number: u64,
-    pub(crate) start_kes_period: u64, // this is not the kes period used in signing/verifying
+    /// KES period at which KES key is initalized
+    pub start_kes_period: u64,
     pub(crate) cert_sig: EdSignature,
     pub(crate) cold_vk: EdPublicKey,
 }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use mockall::automock;
 
 use mithril_common::crypto_helper::{
-    key_decode_hex, OpCert, ProtocolSignerVerificationKey, SerDeShelleyFileFormat,
+    key_decode_hex, KESPeriod, OpCert, ProtocolSignerVerificationKey, SerDeShelleyFileFormat,
 };
 use mithril_common::entities::{PartyId, ProtocolParameters};
 use mithril_common::{
@@ -192,7 +192,8 @@ impl Runner for SignerRunner {
                     .chain_observer
                     .get_current_kes_period(&operational_certificate)
                     .await?
-                    .unwrap_or_default(),
+                    .unwrap_or_default()
+                    - operational_certificate.start_kes_period as KESPeriod,
             ),
             None => None,
         };

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -353,7 +353,7 @@ components:
           type: string
           format: byte
         kes_period:
-          description: The KES Period at which the verification key has been signed by the KES secret key
+          description: The number of updates of the KES secret key that signed the verification key
           type: integer
           format: int64
       example:


### PR DESCRIPTION
## Content
This PR includes a fix that updates KES keys to the current period: 
`kes_period = current_kes_period - start_kes_period`

We still verify the full range of KES period for backward compatibility and until the `preview` network is respin

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
In order to use the correct KES period, we need to manually evolve the key (as it is done in memory on the Cardano node

## Contributors
- @iquerejeta 
- @jpraynaud 

## Issue(s)
Relates to #548
