### PR TITLE
Add commit hash to toml before build in CI

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -23,6 +23,12 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-cache-v${{ inputs.cache-version }}
+        
+    - name: Add commit short sha to Cargo.tomls version
+      shell: bash
+      run: |
+        pip3 install toml
+        python3 ./.github/workflows/scripts/edit-cargo-toml-version.py -l $(echo ${{ github.sha }} | cut -c1-7)
 
     - name: Cargo build
       uses: actions-rs/cargo@v1

--- a/.github/workflows/scripts/edit-cargo-toml-version.py
+++ b/.github/workflows/scripts/edit-cargo-toml-version.py
@@ -1,0 +1,55 @@
+import argparse
+import glob
+import os
+
+import toml
+
+
+def dir_path(path):
+    if os.path.isdir(path):
+        return path
+    else:
+        raise NotADirectoryError(path)
+
+
+def append_label_to_cargo_toml_version(cargo_toml_path, label: str, dry_run: bool):
+    cargo_toml = toml.load(cargo_toml_path)
+    print(f"Editing {cargo_toml_path} ...")
+
+    if 'package' not in cargo_toml:
+        print("No package section (probably a workspace file), skipping this Cargo.toml")
+        return
+
+    new_version = f"{cargo_toml['package']['version'].split('-', 1)[0]}-{label}"
+    print(f"{cargo_toml_path} new version: {new_version}")
+
+    if not dry_run:
+        cargo_toml['package']['version'] = new_version
+
+        with open(cargo_toml_path, "w") as f:
+            toml.dump(cargo_toml, f)
+
+
+def main(args):
+    workdir = os.path.relpath(args.working_dir)
+    print(f"Searching for Cargo.toml(s) in '{workdir}' to edit their version label ...")
+
+    cargo_tomls = glob.glob(f"{workdir}/**/Cargo.toml", recursive=True)
+    print(f"Cargo.toml(s) found: {cargo_tomls}")
+
+    for cargo_toml in cargo_tomls:
+        append_label_to_cargo_toml_version(cargo_toml, args.semver_label, args.dry_run)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog="Cargo.toml semver label editor",
+        description="Edit all Cargo.toml in the given path and subdirectories by replacing their label with the given"
+                    " '--semver-label'.")
+    parser.add_argument("-l", "--semver-label", required=True,
+                        help="Label to suffix to the Cargo.toml(s) semver version")
+    parser.add_argument("-d", "--working-dir", type=dir_path, default="./",
+                        help="Directory in which Cargo.toml will be searched")
+    parser.add_argument("--dry-run", action="store_true")
+
+    main(parser.parse_args())


### PR DESCRIPTION
## Content

This PR includes add a new CI step right before the `cargo build` that search all `Cargo.toml` files in the repository to edit their semver version to add the current commit short sha in the version label.

This means that the binaries built by the CI will report the commit sha when using `-V, --version`:
```bash
$ ./mithril-signer -V
mithril-signer 0.1.0-0757aef
```

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

This PR also enhance the python package script: better help, better naming, add a main function.

## Issue(s)

Relates to #500 and #543