### PR TITLE
Add Debian packaging to CI

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -5,25 +5,9 @@ inputs:
     description: Arguments to pass to 'cargo build'
     required: false
     default: ''
-  cache-version:
-    description: Version of the current cache
-    required: false
-    default: ''
 runs:
   using: "composite"
   steps:
-    - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
-
-    - name: Rust Cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        key: ${{ runner.os }}-cache-v${{ inputs.cache-version }}
-        
     - name: Add commit short sha to Cargo.tomls version
       shell: bash
       run: |

--- a/.github/workflows/actions/toolchain-and-cache/action.yml
+++ b/.github/workflows/actions/toolchain-and-cache/action.yml
@@ -1,0 +1,31 @@
+name: toolchain-and-cache
+description: Install the stable cargo toolchain, the given cargo tools, and try to restore cache
+inputs:
+  cache-version:
+    description: Version of the current cache
+    required: false
+    default: ''
+  cargo-tools:
+    description: Space seperated list of cargo tools to install
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Install stable toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: stable
+        override: true
+
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ runner.os }}-cache-v${{ inputs.cache-version }}
+
+    - name: Install cargo tools
+      if: inputs.cargo-tools != ''
+      shell: bash
+      run: |
+        cargo install ${{ inputs.cargo-tools }} 2>/dev/null || true # Suppress the "binary `xyz` already exists in destination" error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Build Mithril workspace & publish artifacts
-        uses: ./.github/workflows/actions/build-upload-mithril-artifact
+      - name: Install stable toolchain and restore cache
+        uses: ./.github/workflows/actions/toolchain-and-cache
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
+
+      - name: Build Mithril workspace & publish artifacts
+        uses: ./.github/workflows/actions/build-upload-mithril-artifact
 
       - name: Publish End-to-end runner (${{ runner.os }}-${{ runner.arch }})
         uses: actions/upload-artifact@v3
@@ -44,11 +47,15 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
+
+      - name: Install stable toolchain and restore cache
+        uses: ./.github/workflows/actions/toolchain-and-cache
+        with:
+          cache-version: ${{ secrets.CACHE_VERSION }}
       
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}
           build-args: ${{ matrix.build-args }}
   
   test:
@@ -75,22 +82,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable toolchain, tools, and restore cache
+        uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-cache-v${{ secrets.CACHE_VERSION }}
-
-      - name: Install cargo tools
-        shell: bash
-        run: |
-          cargo install cargo2junit 2>/dev/null || true # Suppress the "binary `xyz` already exists in destination" error
+          cache-version: ${{ secrets.CACHE_VERSION }}
+          cargo-tools: cargo2junit
 
       - name: Run tests
         shell: bash
@@ -114,24 +110,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable toolchain, tools, and restore cache
+        uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          profile: minimal
-          toolchain: stable
-          components: clippy, rustfmt
-          override: true
-      
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-cache-v${{ secrets.CACHE_VERSION }}
-
-      - name: Install cargo tools
-        if: steps.cargo-cache.outputs.cache-hit == false
-        shell: bash
-        run: |
-          cargo install cargo-sort 2>/dev/null || true # Suppress the "binary `xyz` already exists in destination" error
+          cache-version: ${{ secrets.CACHE_VERSION }}
+          cargo-tools: cargo-sort
 
       - name: Cargo check
         uses: actions-rs/cargo@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,28 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain and restore cache
+      - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
+          cargo-tools: cargo-deb
 
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
+
+      - name: Build Debian packages
+        shell: bash
+        run: |
+          cargo deb -p mithril-aggregator
+          cargo deb -p mithril-signer
+          cargo deb -p mithril-client
+      
+      - name: Publish Debian packages
+        uses: actions/upload-artifact@v3
+        with:
+          name: mithril-deb-packages-${{ runner.os }}-${{ runner.arch }}
+          path: target/debian/*.deb
+          if-no-files-found: error
 
       - name: Publish End-to-end runner (${{ runner.os }}-${{ runner.arch }})
         uses: actions/upload-artifact@v3
@@ -29,6 +44,7 @@ jobs:
           name: mithril-end-to-end-${{ runner.os }}-${{ runner.arch }}
           path: target/release/mithril-end-to-end
           if-no-files-found: error
+  
   
   build:
     strategy:
@@ -294,6 +310,12 @@ jobs:
         with:
           name: mithril-distribution-Linux-X64
           path: ./package-Linux-X64
+
+      - name: Download Debian packages (Linux-X64)
+        uses: actions/download-artifact@v3
+        with:
+          name: mithril-deb-packages-Linux-x64
+          path: ./package
 
       - name: Download built artifacts (macOS-X64)
         uses: actions/download-artifact@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,17 +12,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install stable toolchain and restore cache
+        uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          key: ${{ runner.os }}-cache-v${{ secrets.CACHE_VERSION }}
+          cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Generate cargo doc
         uses: actions-rs/cargo@v1

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -25,6 +25,15 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
 
+      - name: Download Debian packages (Linux-X64)
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: mithril-deb-packages-Linux-x64
+          path: ./package
+          commit: ${{ github.sha }}
+          workflow: ci.yml
+          workflow_conclusion: success
+
       - name: Download built artifacts (macOS-x64)
         uses: dawidd6/action-download-artifact@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,11 @@ members = [
   "mithril-signer",
   "mithril-test-lab/mithril-end-to-end"
 ]
+
+[workspace.package]
+authors = ["dev@iohk.io"]
+documentation =  "https://mithril.network/doc"
+edition = "2021"
+homepage = "https://mithril.network"
+license = "Apache-2.0"
+repository = "https://github.com/input-output-hk/mithril/"

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "mithrildemo"
 version = "0.1.0"
-edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = { workspace = true }
+edition = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 base64 = "0.13.0"

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "mithril-aggregator"
 version = "0.1.0"
-edition = "2021"
 description = "A Mithril Aggregator server"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = { workspace = true }
+edition = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 async-trait = "0.1.52"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "mithril-client"
 version = "0.1.0"
-edition = "2021"
 description = "A Mithril Client"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = { workspace = true }
+edition = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 async-trait = "0.1.52"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "mithril-common"
 version = "0.1.0"
-edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = { workspace = true }
+edition = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]

--- a/mithril-core/Cargo.toml
+++ b/mithril-core/Cargo.toml
@@ -2,6 +2,11 @@
 name    = "mithril"
 version = "0.1.0"
 edition = "2018"
+authors = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 blake2      = "0.10.4"

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,9 +1,13 @@
 [package]
 name = "mithril-signer"
 version = "0.1.0"
-edition = "2021"
 description = "A Mithril Signer"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = { workspace = true }
+edition = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 async-trait = "0.1.52"

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "mithril-end-to-end"
 version = "0.1.0"
-edition = "2021"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = { workspace = true }
+edition = { workspace = true }
+documentation = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+repository = { workspace = true }
 
 [dependencies]
 async-trait = "0.1.52"


### PR DESCRIPTION
## Content
This PR add debian packaging to the CI for ubuntu builds. Those packages are included in the unstable & (pre-)release. 

## Pre-submit checklist

- Branch
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested

## Comments
This PR add workspace level metada in the root `Cargo.toml` to share attributes such as license, doc & repo links, ...

## Todo later
Compute sha256 files for the deb packages and add them to the release. 

## Issue(s)
Relates to #500 & #543 