### PR TITLE
Fix package names in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
       - name: Download Debian packages (Linux-X64)
         uses: actions/download-artifact@v3
         with:
-          name: mithril-deb-packages-Linux-x64
+          name: mithril-deb-packages-Linux-X64
           path: ./package
 
       - name: Download built artifacts (macOS-X64)

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Download built artifacts (Linux-x64)
         uses: dawidd6/action-download-artifact@v2
         with:
-          name: mithril-distribution-Linux-x64
+          name: mithril-distribution-Linux-X64
           path: ./package-Linux-X64
           commit: ${{ github.sha }}
           workflow: ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Download Debian packages (Linux-X64)
         uses: dawidd6/action-download-artifact@v2
         with:
-          name: mithril-deb-packages-Linux-x64
+          name: mithril-deb-packages-Linux-X64
           path: ./package
           commit: ${{ github.sha }}
           workflow: ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Download built artifacts (macOS-x64)
         uses: dawidd6/action-download-artifact@v2
         with:
-          name: mithril-distribution-macOS-x64
+          name: mithril-distribution-macOS-X64
           path: ./package-macOS-X64
           commit: ${{ github.sha }}
           workflow: ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Download built artifacts (Windows-x64)
         uses: dawidd6/action-download-artifact@v2
         with:
-          name: mithril-distribution-Windows-x64
+          name: mithril-distribution-Windows-X64
           path: ./package-Windows-X64
           commit: ${{ github.sha }}
           workflow: ci.yml
@@ -130,7 +130,7 @@ jobs:
       - name: Download built artifacts (Linux-x64)
         uses: dawidd6/action-download-artifact@v2
         with:
-          name: mithril-distribution-Linux-x64
+          name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}
           commit: ${{ github.sha }}
           workflow: ci.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Download built artifacts (Linux-x64)
         uses: dawidd6/action-download-artifact@v2
         with:
-          name: mithril-distribution-Linux-x64
+          name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}
           commit: ${{ github.sha }}
           workflow: ci.yml


### PR DESCRIPTION
## Content
This PR fix the names used to download previously uploaded packages in CI workflows

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #500, #543 and #579
