### PR TITLE
Fix docker image prefix Pre-Release/Release

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -125,7 +125,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             pre-release
-            type=raw,value={{branch}}-{{sha}}
+            type=raw,value=${{ github.ref_name }}-{{sha}}
 
       - name: Download built artifacts (Linux-x64)
         uses: dawidd6/action-download-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             latest
-            type=raw,value={{branch}}-{{sha}}
+            type=raw,value=${{ github.ref_name }}-{{sha}}
 
       - name: Download built artifacts (Linux-x64)
         uses: dawidd6/action-download-artifact@v2


### PR DESCRIPTION
## Content
This PR includes a fix in the Pre-Release and Release CD workflows for tagging Docker images

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #500
