### PR TITLE
Update rust dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,9 @@ jobs:
       - name: Build Debian packages
         shell: bash
         run: |
-          cargo deb -p mithril-aggregator
-          cargo deb -p mithril-signer
-          cargo deb -p mithril-client
+          cargo deb --no-build -p mithril-aggregator
+          cargo deb --no-build -p mithril-signer
+          cargo deb --no-build -p mithril-client
       
       - name: Publish Debian packages
         uses: actions/upload-artifact@v3
@@ -44,7 +44,6 @@ jobs:
           name: mithril-end-to-end-${{ runner.os }}-${{ runner.arch }}
           path: target/release/mithril-end-to-end
           if-no-files-found: error
-  
   
   build:
     strategy:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57e6e951cfbb2db8de1828d49073a113a29fd7117b1596caa781a258c7e38d72"
+checksum = "464b3811b747f8f7ebc8849c9c728c39f6ac98a055edad93baf9eb330e3f8f9d"
 dependencies = [
  "cfg-if",
  "getrandom 0.2.8",
@@ -114,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "async-global-executor"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da5b41ee986eed3f524c380e6d64965aea573882a8907682ad100f7859305ca"
+checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
 dependencies = [
  "async-channel",
  "async-executor",
@@ -129,16 +129,16 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e21f3a490c72b3b0cf44962180e60045de2925d8dff97918f7ee43c8f637c7"
+checksum = "e8121296a9f05be7f34aa4196b1747243b3b62e048bb7906f644f3fbfc490cf7"
 dependencies = [
+ "async-lock",
  "autocfg",
  "concurrent-queue",
  "futures-lite",
  "libc",
  "log",
- "once_cell",
  "parking",
  "polling",
  "slab",
@@ -149,11 +149,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e97a171d191782fba31bb902b14ad94e24a68145032b7eedf871ab0bc0d077b6"
+checksum = "c8101efe8695a6c17e02911402145357e718ac92d3ff88ae8419e84b1707b685"
 dependencies = [
  "event-listener",
+ "futures-lite",
 ]
 
 [[package]]
@@ -264,9 +265,9 @@ checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "basic-cookies"
@@ -416,9 +417,9 @@ checksum = "2c676a478f63e9fa2dd5368a42f28bba0d6c560b775f38583c8bbaa7fcd67c9c"
 
 [[package]]
 name = "bytemuck"
-version = "1.12.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f5715e491b5a1598fc2bef5a606847b5dc1d48ea625bd3c02c00de8285591da"
+checksum = "5aec14f5d4e6e3f927cd0c81f72e5710d95ee9019fbeb4b3021193867491bfd8"
 
 [[package]]
 name = "byteorder"
@@ -452,9 +453,9 @@ checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "581f5dba903aac52ea3feb5ec4810848460ee833876f1f9b0fdeab1f19091574"
 
 [[package]]
 name = "cfg-if"
@@ -507,18 +508,13 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "atty",
  "bitflags",
- "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
  "textwrap",
 ]
 
@@ -530,24 +526,11 @@ checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 4.0.18",
+ "clap_derive",
  "clap_lex 0.3.0",
  "once_cell",
  "strsim",
  "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -611,7 +594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7602ac4363f68ac757d6b87dd5d850549a14d37489902ae639c06ecec06ad275"
 dependencies = [
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes",
  "chrono",
  "dotenv",
@@ -709,7 +692,7 @@ dependencies = [
  "atty",
  "cast",
  "ciborium",
- "clap 3.2.22",
+ "clap 3.2.23",
  "criterion-plot",
  "itertools",
  "lazy_static",
@@ -853,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.56+curl-7.83.1"
+version = "0.4.59+curl-7.86.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093e169dd4de29e468fa649fbae11cdcd5551c81fe5bf1b0677adad7ef3d26f"
+checksum = "6cfce34829f448b08f55b7db6d0009e23e2e86a34e8c2b366269bf5799b4a407"
 dependencies = [
  "cc",
  "libc",
@@ -882,9 +865,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f83d0ebf42c6eafb8d7c52f7e5f2d3003b89c7aa4fd2b79229209459a849af8"
+checksum = "6b7d4e43b25d3c994662706a1d4fcfc32aaa6afd287502c111b237093bb23f3a"
 dependencies = [
  "cc",
  "cxxbridge-flags",
@@ -894,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d050484b55975889284352b0ffc2ecbda25c0c55978017c132b29ba0818a86"
+checksum = "84f8829ddc213e2c1368e51a2564c552b65a8cb6a28f31e576270ac81d5e5827"
 dependencies = [
  "cc",
  "codespan-reporting",
@@ -909,15 +892,15 @@ dependencies = [
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d2199b00553eda8012dfec8d3b1c75fce747cf27c169a270b3b99e3448ab78"
+checksum = "e72537424b474af1460806647c41d4b6d35d09ef7fe031c5c2fa5766047cc56a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.79"
+version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb67a6de1f602736dd7eaead0080cf3435df806c61b24b13328db128c58868f"
+checksum = "309e4fb93eed90e1e14bea0da16b209f81813ba9fc7830c20ed151dd7bc0a4d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -926,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+checksum = "b0dd3cd20dc6b5a876612a6e5accfe7f3dd883db6d07acfbf14c128f61550dfa"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -936,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+checksum = "a784d2ccaf7c98501746bf0be29b2022ba41fd62a2e622af997a03e9f972859f"
 dependencies = [
  "fnv",
  "ident_case",
@@ -950,9 +933,9 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.14.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+checksum = "7618812407e9402654622dd402b0a89dff9ba93badd6540781526117b92aab7e"
 dependencies = [
  "darling_core",
  "quote",
@@ -1331,8 +1314,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1365,9 +1350,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
 dependencies = [
  "bytes",
  "fnv",
@@ -1412,7 +1397,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bitflags",
  "bytes",
  "headers-core",
@@ -1506,7 +1491,7 @@ dependencies = [
  "assert-json-diff",
  "async-object-pool",
  "async-trait",
- "base64 0.13.0",
+ "base64 0.13.1",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
@@ -1527,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.20"
+version = "0.14.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
+checksum = "abfba89e19b959ca163c7752ba59d737c1ceea53a5d31a149c805446fc958064"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1564,9 +1549,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.51"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a6ef98976b22b3b7f2f3a806f858cb862044cfa66805aa3ad84cb3d3b785ed"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1711,9 +1696,9 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
 dependencies = [
- "ahash 0.8.0",
+ "ahash 0.8.1",
  "anyhow",
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytecount",
  "clap 4.0.18",
  "fancy-regex",
@@ -1729,7 +1714,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "time 0.3.15",
+ "time 0.3.16",
  "url",
  "uuid",
 ]
@@ -1816,9 +1801,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libnghttp2-sys"
@@ -1931,14 +1916,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ee1c23c7c63b0c9250c339ffdc69255f110b298b901b9f6c82547b7b87caaf"
+checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.36.1",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -1949,7 +1934,7 @@ dependencies = [
  "blake2 0.10.4",
  "blst",
  "criterion",
- "digest 0.9.0",
+ "digest 0.10.5",
  "hex",
  "num-bigint 0.4.3",
  "num-rational",
@@ -2061,7 +2046,7 @@ name = "mithril-end-to-end"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "clap 3.2.22",
+ "clap 4.0.18",
  "glob",
  "hex",
  "mithril-common",
@@ -2107,8 +2092,8 @@ dependencies = [
 name = "mithrildemo"
 version = "0.1.0"
 dependencies = [
- "base64 0.13.0",
- "clap 3.2.22",
+ "base64 0.13.1",
+ "clap 4.0.18",
  "hex",
  "log",
  "mithril-common",
@@ -2165,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
 dependencies = [
  "lazy_static",
  "libc",
@@ -2317,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "oorandom"
@@ -2367,9 +2352,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.76"
+version = "0.9.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5230151e44c0f05157effb743e8d517472843121cf9243e8b81393edb5acd9ce"
+checksum = "b03b84c3b2d099b81f0953422b4d4ad58761589d0229b5506356afca05a3670a"
 dependencies = [
  "autocfg",
  "cc",
@@ -2390,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.3.0"
+version = "6.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+checksum = "3baf96e39c5359d2eb0dd6ccb42c62b91d9678aa68160d261b9e0ccbf9e9dea9"
 
 [[package]]
 name = "parking"
@@ -2435,7 +2420,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "once_cell",
  "regex",
 ]
@@ -2549,9 +2534,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plotters"
@@ -2583,9 +2568,9 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
+checksum = "ab4609a838d88b73d8238967b60dd115cc08d38e2bbaf51ee1e4b695f89122e2"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -2873,7 +2858,7 @@ version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "431949c384f4e2ae07605ccaa56d1d9d2ecdb5cadd4f9577ccfab29f2e5149fc"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2926,7 +2911,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "bitflags",
  "serde",
 ]
@@ -2958,7 +2943,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -3012,9 +2997,9 @@ dependencies = [
 
 [[package]]
 name = "scoped-tls"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -3053,9 +3038,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.146"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6df50b7a60a0ad48e1b42eb38373eac8ff785d619fb14db917b4e63d5439361f"
+checksum = "d193d69bae983fc11a79df82342761dfbf28a99fc8d203dca4c3c1b590948965"
 dependencies = [
  "serde_derive",
 ]
@@ -3081,9 +3066,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.146"
+version = "1.0.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a714fd32ba1d66047ce7d53dabd809e9922d538f9047de13cc4cffca47b36205"
+checksum = "4f1d362ca8fc9c3e3a7484440752472d68a6caa98f1ab81d99b5dfe517cec852"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3129,14 +3114,14 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "368f2d60d049ea019a84dcd6687b0d1e0030fe663ae105039bdf967ed5e6a9a7"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "chrono",
  "hex",
  "indexmap",
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -3153,9 +3138,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8613d593412a0deb7bbd8de9d908efff5a0cb9ccd8f62c641e7b2ed2f57291d1"
+checksum = "6d232d893b10de3eb7258ff01974d6ee20663d8e833263c99409d4b13a0209da"
 dependencies = [
  "indexmap",
  "itoa 1.0.4",
@@ -3294,7 +3279,7 @@ dependencies = [
  "hostname",
  "slog",
  "slog-json",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -3306,7 +3291,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -3330,7 +3315,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.15",
+ "time 0.3.16",
 ]
 
 [[package]]
@@ -3368,9 +3353,9 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "sqlite"
-version = "0.27.0"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2df8edd55685048550daaaf2be9024182f3523086cc86f7d50c136e55173e8c"
+checksum = "e66cb949f931ece6201d72bffad3f3601b94998a345793713dd13af70a77c185"
 dependencies = [
  "libc",
  "sqlite3-sys",
@@ -3503,9 +3488,9 @@ checksum = "507e9898683b6c43a9aa55b64259b721b52ba226e0f3779137e50ad114a4c90b"
 
 [[package]]
 name = "textwrap"
-version = "0.15.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -3558,22 +3543,32 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d634a985c4d4238ec39cacaed2e7ae552fbd3c476b552c1deac3021b7d7eaf0c"
+checksum = "0fab5c8b9980850e06d92ddbe3ab839c062c801f3927c0fb8abd6fc8e918fbca"
 dependencies = [
  "itoa 1.0.4",
  "libc",
  "num_threads",
  "serde",
+ "time-core",
  "time-macros",
 ]
 
 [[package]]
-name = "time-macros"
-version = "0.2.4"
+name = "time-core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
+name = "time-macros"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bb801831d812c562ae7d2bfb531f26e66e4e1f6b17307ba4149c5064710e5b"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -3757,7 +3752,7 @@ version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e27992fd6a8c29ee7eef28fc78349aa244134e10ad447ce3b9f0ac0ed0fa4ce0"
 dependencies = [
- "base64 0.13.0",
+ "base64 0.13.1",
  "byteorder",
  "bytes",
  "http",

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -10,7 +10,7 @@ repository = { workspace = true }
 
 [dependencies]
 base64 = "0.13.0"
-clap = { version = "3.1.6", features = ["derive"] }
+clap = { version = "4.0.18", features = ["derive"] }
 hex = "0.4.3"
 log = "0.4.14"
 mithril-common = { path = "../../mithril-common", features = ["allow_skip_signer_certification"] }

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -468,7 +468,7 @@ pub fn write_artifacts<T: Serialize>(artifact_name: &str, value: &T) {
     let artifacts_file_path = env::current_dir()
         .unwrap()
         .join(path::Path::new(&artifacts_file_path_name));
-    fs::create_dir_all(&artifacts_file_path.parent().unwrap()).unwrap();
+    fs::create_dir_all(artifacts_file_path.parent().unwrap()).unwrap();
     let mut artifacts_file = fs::File::create(&artifacts_file_path).unwrap();
     write!(
         artifacts_file,

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -200,7 +200,7 @@ pub mod tests {
             db_directory: PathBuf::new(),
             snapshot_directory: PathBuf::new(),
             data_stores_directory: PathBuf::new(),
-            genesis_verification_key: key_encode_hex(&genesis_verification_key).unwrap(),
+            genesis_verification_key: key_encode_hex(genesis_verification_key).unwrap(),
             store_retention_limit: None,
         };
         let snapshot_store = Arc::new(LocalSnapshotStore::new(

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -830,7 +830,7 @@ impl MultiSigner for MultiSignerImpl {
                     .await
                     .ok_or_else(ProtocolError::UnavailableMessage)?;
                 let aggregate_verification_key =
-                    key_encode_hex(&self.avk.as_ref().unwrap()).map_err(ProtocolError::Codec)?;
+                    key_encode_hex(self.avk.as_ref().unwrap()).map_err(ProtocolError::Codec)?;
                 let multi_signature =
                     key_encode_hex(&multi_signature).map_err(ProtocolError::Codec)?;
                 let genesis_signature = "".to_string();

--- a/mithril-aggregator/tests/test_extensions/dependency.rs
+++ b/mithril-aggregator/tests/test_extensions/dependency.rs
@@ -44,7 +44,7 @@ pub async fn initialize_dependencies(
         db_directory: PathBuf::new(),
         snapshot_directory: PathBuf::new(),
         data_stores_directory: PathBuf::new(),
-        genesis_verification_key: key_encode_hex(&genesis_verification_key).unwrap(),
+        genesis_verification_key: key_encode_hex(genesis_verification_key).unwrap(),
         store_retention_limit: None,
     };
     let certificate_pending_store = Arc::new(CertificatePendingStore::new(Box::new(

--- a/mithril-client/src/aggregator.rs
+++ b/mithril-client/src/aggregator.rs
@@ -176,7 +176,7 @@ impl AggregatorHandler for AggregatorHTTPClient {
             Ok(response) => match response.status() {
                 StatusCode::OK => {
                     let local_path = archive_file_path(digest, &self.network)?;
-                    fs::create_dir_all(&local_path.parent().unwrap())?;
+                    fs::create_dir_all(local_path.parent().unwrap())?;
                     let mut local_file = fs::File::create(&local_path)?;
                     let bytes_total = response.content_length().ok_or_else(|| {
                         AggregatorHandlerError::RemoteServerTechnical(
@@ -300,14 +300,14 @@ mod tests {
             .unwrap()
             .join(path::Path::new(source_directory_name))
             .join(path::Path::new(data_file_name));
-        fs::create_dir_all(&source_file_path.parent().unwrap()).unwrap();
+        fs::create_dir_all(source_file_path.parent().unwrap()).unwrap();
         let mut source_file = fs::File::create(&source_file_path).unwrap();
         write!(source_file, "{}", data_expected).unwrap();
         let archive_file = fs::File::create(&archive_file_path).unwrap();
         let archive_encoder = GzEncoder::new(&archive_file, Compression::default());
         let mut archive_builder = tar::Builder::new(archive_encoder);
         archive_builder
-            .append_dir_all(".", &source_file_path.parent().unwrap())
+            .append_dir_all(".", source_file_path.parent().unwrap())
             .unwrap();
         archive_builder.into_inner().unwrap().finish().unwrap();
     }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -221,7 +221,7 @@ impl CertificateVerifier for MithrilCertificateVerifier {
         {
             Some(next_aggregate_verification_key)
                 if valid_certificate_has_different_epoch_as_previous(
-                    *next_aggregate_verification_key,
+                    next_aggregate_verification_key,
                 ) =>
             {
                 Ok(Some(previous_certificate.to_owned()))

--- a/mithril-common/src/crypto_helper/cardano/opcert.rs
+++ b/mithril-common/src/crypto_helper/cardano/opcert.rs
@@ -112,7 +112,7 @@ impl OpCert {
     /// Compute protocol party id as pool id bech 32
     pub fn compute_protocol_party_id(&self) -> Result<ProtocolPartyId, OpCertError> {
         let mut hasher = Blake2b::<U28>::new();
-        hasher.update(&self.cold_vk.as_bytes());
+        hasher.update(self.cold_vk.as_bytes());
         let mut pool_id = [0u8; 28];
         pool_id.copy_from_slice(hasher.finalize().as_slice());
         bech32::encode("pool", pool_id.to_base32(), Variant::Bech32)

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -161,7 +161,7 @@ pub fn setup_signers_from_stake_distribution(
             (
                 SignerWithStake::new(
                     party_id,
-                    key_encode_hex(&protocol_initializer.verification_key())
+                    key_encode_hex(protocol_initializer.verification_key())
                         .expect("key_encode_hex of verification_key should not fail"),
                     protocol_initializer
                         .verification_key_signature()

--- a/mithril-common/src/digesters/cardano_immutable_digester.rs
+++ b/mithril-common/src/digesters/cardano_immutable_digester.rs
@@ -31,7 +31,7 @@ impl CardanoImmutableDigester {
 impl ImmutableDigester for CardanoImmutableDigester {
     async fn compute_digest(&self, beacon: &Beacon) -> Result<String, ImmutableDigesterError> {
         let up_to_file_number = beacon.immutable_file_number;
-        let immutables = ImmutableFile::list_completed_in_dir(&*self.db_directory)?
+        let immutables = ImmutableFile::list_completed_in_dir(&self.db_directory)?
             .into_iter()
             .filter(|f| f.number <= up_to_file_number)
             .collect::<Vec<_>>();

--- a/mithril-common/src/digesters/immutable_file.rs
+++ b/mithril-common/src/digesters/immutable_file.rs
@@ -127,9 +127,10 @@ mod tests {
 
         if parent_dir.exists() {
             fs::remove_dir_all(&parent_dir)
-                .expect(&*format!("Could not remove dir {:?}", parent_dir));
+                .unwrap_or_else(|_| panic!("Could not remove dir {:?}", parent_dir));
         }
-        fs::create_dir_all(&parent_dir).expect(&*format!("Could not create dir {:?}", parent_dir));
+        fs::create_dir_all(&parent_dir)
+            .unwrap_or_else(|_| panic!("Could not create dir {:?}", parent_dir));
 
         parent_dir
     }

--- a/mithril-common/src/entities/certificate_metadata.rs
+++ b/mithril-common/src/entities/certificate_metadata.rs
@@ -58,7 +58,7 @@ impl CertificateMetadata {
     pub fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.protocol_version.as_bytes());
-        hasher.update(&self.protocol_parameters.compute_hash().as_bytes());
+        hasher.update(self.protocol_parameters.compute_hash().as_bytes());
         hasher.update(self.initiated_at.as_bytes());
         hasher.update(self.sealed_at.as_bytes());
         self.signers

--- a/mithril-core/Cargo.toml
+++ b/mithril-core/Cargo.toml
@@ -11,7 +11,7 @@ repository = { workspace = true }
 [dependencies]
 blake2      = "0.10.4"
 blst = { version = "0.3.10" }
-digest      = { version = "0.9.0", features = ["alloc"] }
+digest      = { version = "0.10.5", features = ["alloc"] }
 num-bigint  = { version = "0.4.0", optional = true }
 num-rational = { version = "0.4.0", optional = true }
 num-traits  = { version = "0.2.14", optional = true }

--- a/mithril-core/src/error.rs
+++ b/mithril-core/src/error.rs
@@ -60,7 +60,7 @@ pub enum StmAggregateSignatureError<D: Digest + FixedOutput> {
 
     /// The IVK is invalid after aggregating the keys
     #[error("Aggregated key does not correspond to the expected key.")]
-    IvkInvalid(VerificationKey),
+    IvkInvalid(Box<VerificationKey>),
 
     /// There is a duplicate index
     #[error("Indices are not unique.")]

--- a/mithril-core/src/merkle_tree.rs
+++ b/mithril-core/src/merkle_tree.rs
@@ -218,7 +218,7 @@ impl<D: Clone + Digest + FixedOutput> MerkleTreeCommitment<D> {
     pub fn check(&self, val: &MTLeaf, proof: &Path<D>) -> Result<(), MerkleTreeError<D>> {
         let mut idx = proof.index;
 
-        let mut h = D::digest(&val.to_bytes()).to_vec();
+        let mut h = D::digest(val.to_bytes()).to_vec();
         for p in &proof.values {
             if (idx & 0b1) == 0 {
                 h = D::new().chain_update(h).chain_update(p).finalize().to_vec();
@@ -314,7 +314,7 @@ impl<D: Clone + Digest> MerkleTreeCommitmentBatchCompat<D> {
                 if ordered_indices[i] & 1 == 0 {
                     new_hashes.push(
                         D::new()
-                            .chain(&values.get(0).ok_or(MerkleTreeError::SerializationError)?)
+                            .chain(values.get(0).ok_or(MerkleTreeError::SerializationError)?)
                             .chain(&leaves[i])
                             .finalize()
                             .to_vec(),
@@ -335,7 +335,7 @@ impl<D: Clone + Digest> MerkleTreeCommitmentBatchCompat<D> {
                         new_hashes.push(
                             D::new()
                                 .chain(&leaves[i])
-                                .chain(&values.get(0).ok_or(MerkleTreeError::SerializationError)?)
+                                .chain(values.get(0).ok_or(MerkleTreeError::SerializationError)?)
                                 .finalize()
                                 .to_vec(),
                         );
@@ -344,7 +344,7 @@ impl<D: Clone + Digest> MerkleTreeCommitmentBatchCompat<D> {
                         new_hashes.push(
                             D::new()
                                 .chain(&leaves[i])
-                                .chain(&D::digest(&[0u8]))
+                                .chain(&D::digest([0u8]))
                                 .finalize()
                                 .to_vec(),
                         );
@@ -375,11 +375,11 @@ impl<D: Digest + FixedOutput> MerkleTree<D> {
         let mut nodes = vec![vec![0u8]; num_nodes];
 
         for i in 0..leaves.len() {
-            nodes[num_nodes - n + i] = D::digest(&leaves[i].to_bytes()).to_vec();
+            nodes[num_nodes - n + i] = D::digest(leaves[i].to_bytes()).to_vec();
         }
 
         for i in (0..num_nodes - n).rev() {
-            let z = D::digest(&[0u8]).to_vec();
+            let z = D::digest([0u8]).to_vec();
             let left = if left_child(i) < num_nodes {
                 &nodes[left_child(i)]
             } else {
@@ -445,7 +445,7 @@ impl<D: Digest + FixedOutput> MerkleTree<D> {
             let h = if sibling(idx) < self.nodes.len() {
                 self.nodes[sibling(idx)].clone()
             } else {
-                D::digest(&[0u8]).to_vec()
+                D::digest([0u8]).to_vec()
             };
             proof.push(h.clone());
             idx = parent(idx);

--- a/mithril-core/src/multi_sig.rs
+++ b/mithril-core/src/multi_sig.rs
@@ -360,8 +360,8 @@ impl Signature {
         let hasher = Blake2b512::new()
             .chain_update(b"map")
             .chain_update(msg)
-            .chain_update(&index.to_le_bytes())
-            .chain_update(&self.to_bytes())
+            .chain_update(index.to_le_bytes())
+            .chain_update(self.to_bytes())
             .finalize();
 
         let mut output = [0u8; 64];
@@ -413,7 +413,7 @@ impl Signature {
     ) -> Result<(), MultiSignatureError> {
         let mut hashed_sigs = Blake2b::<U16>::new();
         for sig in sigs {
-            hashed_sigs.update(&sig.to_bytes());
+            hashed_sigs.update(sig.to_bytes());
         }
 
         // First we generate the scalars
@@ -423,7 +423,7 @@ impl Signature {
         let mut signatures = Vec::with_capacity(vks.len());
         for (index, sig) in sigs.iter().enumerate() {
             let mut hasher = hashed_sigs.clone();
-            hasher.update(&index.to_be_bytes());
+            hasher.update(index.to_be_bytes());
             signatures.push(&sig.0);
             scalar_bytes[..16].copy_from_slice(hasher.finalize().as_slice());
             scalars.push(blst_scalar { b: scalar_bytes });

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -153,9 +153,11 @@ mod tests {
         let test_dir = std::env::temp_dir().join("mithril_test");
 
         if test_dir.exists() {
-            fs::remove_dir_all(&test_dir).expect(&*format!("Could not remove dir {:?}", test_dir));
+            fs::remove_dir_all(&test_dir)
+                .unwrap_or_else(|_| panic!("Could not remove dir {:?}", test_dir));
         }
-        fs::create_dir_all(&test_dir).expect(&*format!("Could not create dir {:?}", test_dir));
+        fs::create_dir_all(&test_dir)
+            .unwrap_or_else(|_| panic!("Could not create dir {:?}", test_dir));
 
         test_dir
     }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -10,7 +10,7 @@ repository = { workspace = true }
 
 [dependencies]
 async-trait = "0.1.52"
-clap = { version = "3.1.6", features = ["derive"] }
+clap = { version = "4.0.18", features = ["derive"] }
 glob = "0.3"
 hex = "0.4.3"
 mithril-common = { path = "../../mithril-common" }

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -105,7 +105,7 @@ fn build_logger() -> Logger {
 
 fn create_workdir_if_not_exist_clean_otherwise(work_dir: &Path) {
     if work_dir.exists() {
-        fs::remove_dir_all(&work_dir).expect("Previous work dir removal failed");
+        fs::remove_dir_all(work_dir).expect("Previous work dir removal failed");
     }
-    fs::create_dir(&work_dir).expect("Work dir creation failure");
+    fs::create_dir(work_dir).expect("Work dir creation failure");
 }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
@@ -34,9 +34,11 @@ mod tests {
             .join("mithril_test")
             .join(subfolder_name);
         if temp_dir.exists() {
-            fs::remove_dir_all(&temp_dir).expect(&*format!("Could not remove dir {:?}", temp_dir));
+            fs::remove_dir_all(&temp_dir)
+                .unwrap_or_else(|_| panic!("Could not remove dir {:?}", temp_dir));
         }
-        fs::create_dir_all(&temp_dir).expect(&*format!("Could not create dir {:?}", temp_dir));
+        fs::create_dir_all(&temp_dir)
+            .unwrap_or_else(|_| panic!("Could not create dir {:?}", temp_dir));
 
         temp_dir
     }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
@@ -22,7 +22,7 @@ impl MithrilCommand {
         env_vars: HashMap<&str, &str>,
         default_args: &[&str],
     ) -> Result<MithrilCommand, String> {
-        let process_path = bin_dir.canonicalize().unwrap().join(&name);
+        let process_path = bin_dir.canonicalize().unwrap().join(name);
         let log_path = work_dir.join(format!("{}.log", name));
 
         // ugly but it's far easier for callers to manipulate string literals


### PR DESCRIPTION
## Content
This PR updates rust dependencies & the global cargo lock.

It also contains a CI improvement: Avoid recompilation when macking Debian packages using `cargo deb`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
