### PR TITLE
Enhance Mithril networks infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,6 +381,7 @@ jobs:
           mithril_signers: |
             {
               "1" = {
+                type    = "unverified"
                 pool_id = "pool18r62tz408lkgfu6pq5svwzkh2vslkeg6mf72qf3h8njgvzhx9ce",
               },
             }

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -163,6 +163,7 @@ jobs:
           mithril_signers: |
             {
               "1" = {
+                type    = "unverified"
                 pool_id = "pool18r62tz408lkgfu6pq5svwzkh2vslkeg6mf72qf3h8njgvzhx9ce",
               },
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
           mithril_signers: |
             {
               "1" = {
+                type    = "unverified"
                 pool_id = "pool1zr907nmfsq5kalxdjju349nwg6f03lyfmcjfqcz52jf45gcgh03",
               },
             }

--- a/mithril-infra/assets/docker/docker-compose-signer-unverified-light.yaml
+++ b/mithril-infra/assets/docker/docker-compose-signer-unverified-light.yaml
@@ -1,0 +1,38 @@
+# Unverified Mithril Signer node running on top of shared Cardano node (from Mithril Aggregator)
+
+version: "3.9"
+
+services:
+  mithril-signer:
+    image: ghcr.io/input-output-hk/mithril-signer:${IMAGE_ID}
+    container_name: mithril-signer-${SIGNER_ID}
+    restart: always
+    user: ${CURRENT_UID}
+    profiles:
+      - mithril
+      - all
+    environment:
+      - RUST_BACKTRACE=1
+      - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
+      - NETWORK=${NETWORK}
+      - PARTY_ID=${PARTY_ID}
+      - RUN_INTERVAL=120000
+      - DB_DIRECTORY=/mithril-aggregator/cardano/db
+      - DATA_STORES_DIRECTORY=/mithril-signer-${SIGNER_ID}/mithril/stores
+      - STORE_RETENTION_LIMIT=5
+      - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
+      - CARDANO_CLI_PATH=/app/bin/cardano-cli
+    volumes:
+      - ../data/${NETWORK}/mithril-signer-${SIGNER_ID}/mithril:/mithril-signer-${SIGNER_ID}/mithril
+      - ../data/${NETWORK}/mithril-aggregator/cardano/db:/mithril-aggregator/cardano/db
+      - ../data/${NETWORK}/mithril-aggregator/cardano/ipc:/ipc
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "5"
+
+networks:
+  default:
+    external:
+      name: mithril_network

--- a/mithril-infra/assets/docker/docker-compose-signer-unverified.yaml
+++ b/mithril-infra/assets/docker/docker-compose-signer-unverified.yaml
@@ -1,3 +1,5 @@
+# Unverified Mithril Signer node running on top of its own Cardano node
+
 version: "3.9"
 
 services:
@@ -47,15 +49,15 @@ services:
       - AGGREGATOR_ENDPOINT=http://mithril-aggregator:8080/aggregator
       - NETWORK=${NETWORK}
       - PARTY_ID=${PARTY_ID}
-      - RUN_INTERVAL=240000
-      - DB_DIRECTORY=/db
+      - RUN_INTERVAL=120000
+      - DB_DIRECTORY=/mithril-signer-${SIGNER_ID}/cardano/db
       - DATA_STORES_DIRECTORY=/mithril-signer-${SIGNER_ID}/mithril/stores
       - STORE_RETENTION_LIMIT=5
       - CARDANO_NODE_SOCKET_PATH=/ipc/node.socket
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
     volumes:
       - ../data/${NETWORK}/mithril-signer-${SIGNER_ID}/mithril:/mithril-signer-${SIGNER_ID}/mithril
-      - ../data/${NETWORK}/mithril-signer-${SIGNER_ID}/cardano/db:/db
+      - ../data/${NETWORK}/mithril-signer-${SIGNER_ID}/cardano/db:/mithril-signer-${SIGNER_ID}/cardano/db
       - ../data/${NETWORK}/mithril-signer-${SIGNER_ID}/cardano/ipc:/ipc
     logging:
       driver: "json-file"

--- a/mithril-infra/assets/startup-vm.sh
+++ b/mithril-infra/assets/startup-vm.sh
@@ -5,7 +5,7 @@ rm -f /startup-ready.txt
 
 # Update and install dependencies
 sudo apt update -y
-sudo apt install -y tree ca-certificates curl gnupg lsb-release 
+sudo apt install -y jq tree ca-certificates curl gnupg lsb-release 
 
 # Install sqlite3
 sudo apt install -y sqlite3

--- a/mithril-infra/main.vm.tf
+++ b/mithril-infra/main.vm.tf
@@ -59,6 +59,10 @@ resource "google_compute_resource_policy" "policy" {
         start_time    = "04:00"
       }
     }
+    retention_policy {
+      max_retention_days    = var.google_snapshot_max_retention_days
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
   }
 }
 

--- a/mithril-infra/main.vm.tf
+++ b/mithril-infra/main.vm.tf
@@ -31,10 +31,7 @@ resource "google_compute_instance" "vm_instance" {
   metadata_startup_script = file("./assets/startup-vm.sh")
 
   boot_disk {
-    initialize_params {
-      size  = 200
-      image = "ubuntu-os-cloud/ubuntu-2204-lts"
-    }
+    source = google_compute_disk.boot.name
   }
 
   network_interface {
@@ -42,6 +39,18 @@ resource "google_compute_instance" "vm_instance" {
     access_config {
       nat_ip = google_compute_address.mithril-external-address.address
     }
+  }
+}
+
+resource "google_compute_disk" "boot" {
+  name     = "${local.environment_name}-boot"
+  type     = var.google_compute_instance_boot_disk_type
+  zone     = var.google_zone
+  size     = var.google_compute_instance_boot_disk_size
+  image    = var.google_compute_instance_boot_disk_image
+  snapshot = var.google_compute_instance_boot_disk_snapshot
+  labels = {
+    environment = local.environment_name
   }
 }
 
@@ -68,6 +77,6 @@ resource "google_compute_resource_policy" "policy" {
 
 resource "google_compute_disk_resource_policy_attachment" "attachment" {
   name = google_compute_resource_policy.policy.name
-  disk = google_compute_instance.vm_instance.name
+  disk = google_compute_disk.boot.name
   zone = var.google_zone
 }

--- a/mithril-infra/mithril.signer.tf
+++ b/mithril-infra/mithril.signer.tf
@@ -34,7 +34,7 @@ resource "null_resource" "mithril_signer" {
       "export IMAGE_ID=${var.mithril_image_id}",
       "export CURRENT_UID=$(id -u)",
       "export DOCKER_GID=$(getent group docker | cut -d: -f3)",
-      "docker-compose -p $SIGNER_ID -f /home/curry/docker/docker-compose-signer-unverified.yaml --profile all up -d",
+      "docker-compose -p $SIGNER_ID -f /home/curry/docker/docker-compose-signer-${each.value.type}.yaml --profile all up -d",
     ]
   }
 }

--- a/mithril-infra/variables.tf
+++ b/mithril-infra/variables.tf
@@ -119,10 +119,12 @@ variable "mithril_protocol_parameters" {
 
 variable "mithril_signers" {
   type = map(object({
+    type    = string
     pool_id = string
   }))
   default = {
     "1" = {
+      type    = "unverified",
       pool_id = "pool15qde6mnkc0jgycm69ua0grwxmmu0tke54h5uhml0j8ndw3kcu9x",
     }
   }

--- a/mithril-infra/variables.tf
+++ b/mithril-infra/variables.tf
@@ -37,6 +37,30 @@ variable "google_machine_type" {
   default     = "e2-medium"
 }
 
+variable "google_compute_instance_boot_disk_size" {
+  type        = number
+  description = "Size of the boot disk in GB"
+  default     = 200
+}
+
+variable "google_compute_instance_boot_disk_type" {
+  type        = string
+  description = "Type of disk"
+  default     = "pd-standard"
+}
+
+variable "google_compute_instance_boot_disk_image" {
+  type        = string
+  description = "Image of the boot disk"
+  default     = "ubuntu-os-cloud/ubuntu-2204-lts"
+}
+
+variable "google_compute_instance_boot_disk_snapshot" {
+  type        = string
+  description = "Snapshot used to restore the boot disk"
+  default     = ""
+}
+
 variable "google_service_credentials_json_file" {
   type        = string
   description = "The credentials of the GCP service account"

--- a/mithril-infra/variables.tf
+++ b/mithril-infra/variables.tf
@@ -48,6 +48,12 @@ variable "google_storage_bucket_max_age" {
   default     = 14
 }
 
+variable "google_snapshot_max_retention_days" {
+  type        = number
+  description = "Number of days after a disk snapshot is dropped"
+  default     = 30
+}
+
 locals {
   google_service_credentials_json_file_decoded = jsondecode(file(var.google_service_credentials_json_file))
   google_service_account_private_key           = local.google_service_credentials_json_file_decoded.private_key


### PR DESCRIPTION
## Content
This PR includes new features on the Mithril networks infrastructure:
* Add a retention delay for the VM compute disk snasphots
* Enhance the customization of VM boot disk
* Allow to restore a VM from a snapshot 
* Add a light unverified signer type (working on the Aggregator Cardano node instead of its own)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
:warning: this PR includes some breaking changes that could lead to data loss on the networks!
The modification of the boot disk involves a re-deployment via terraform.
In order to not lose data (to do on each Mithril network, i.e. `testing-preview`, `pre-release-preview` and `preprod-preview`:
* Stop all the docker containers
* Make manual snapshot of the data with `gcloud` command
* Apply `terraform` new configuration
* Restore the saved data in the `/home/curry/data` folder after mounting a temporary compute disk created from the snapshot on the VM
* Restart docker containers
* Run the workflows

## Issue(s)
Relates to #542 and #500
