### PR TITLE
Upgrade to Cardano 1.35.4

### DIFF
--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -44,7 +44,7 @@ For more information about the **Mithril Protocol**, please refer to the [About 
   * Read rights on the `Database` folder (`--database-path` setting of the **Cardano Node**)
   * Read/Write rights on the `Inter Process Communication` file (usually `CARDANO_NODE_SOCKET_PATH` env var used to launch the **Cardano Node**)
 
-* Install a recent version of the [`cardano-cli`](https://hydra.iohk.io/job/Cardano/cardano-node/linux.native.cardano-cli) (version 1.35.3+)
+* Install a recent version of the [`cardano-cli`](https://hydra.iohk.io/job/Cardano/cardano-node/linux.native.cardano-cli) (version 1.35.4+)
 
 * Install a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain (latest stable version).
 

--- a/mithril-aggregator/Dockerfile.ci
+++ b/mithril-aggregator/Dockerfile.ci
@@ -14,7 +14,7 @@ COPY mithril-aggregator/mithril-aggregator /app/bin/mithril-aggregator
 COPY mithril-aggregator/config /app/config
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/17062577/download/1/cardano-node-1.35.2-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/21343721/download/1/cardano-node-1.35.4-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN /app/bin/cardano-cli --version
 RUN rm -f cardano-bin.tar.gz

--- a/mithril-infra/assets/docker/Dockerfile.cardano
+++ b/mithril-infra/assets/docker/Dockerfile.cardano
@@ -1,4 +1,4 @@
-FROM inputoutput/cardano-node:1.35.3
+FROM inputoutput/cardano-node:1.35.4
 
 # Fix env file rights
 # In order to be able to interact with the Cardano node trough its 'node.socket'

--- a/mithril-infra/assets/docker/docker-compose-aggregator.yaml
+++ b/mithril-infra/assets/docker/docker-compose-aggregator.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node-aggregator:
-    image: cardano-node/1.35.3-modified
+    image: cardano-node/1.35.4-modified
     container_name: cardano-node-aggregator
     build:
       context: .

--- a/mithril-infra/assets/docker/docker-compose-signer-unverified.yaml
+++ b/mithril-infra/assets/docker/docker-compose-signer-unverified.yaml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   cardano-node-signer:
-    image: cardano-node/1.35.3-modified
+    image: cardano-node/1.35.4-modified
     container_name: cardano-node-signer-${SIGNER_ID}
     build:
       context: .

--- a/mithril-signer/Dockerfile.ci
+++ b/mithril-signer/Dockerfile.ci
@@ -14,7 +14,7 @@ COPY mithril-signer/mithril-signer /app/bin/mithril-signer
 COPY mithril-signer/config /app/config
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/17062577/download/1/cardano-node-1.35.2-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://hydra.iohk.io/build/21343721/download/1/cardano-node-1.35.4-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN /app/bin/cardano-cli --version
 RUN rm -f cardano-bin.tar.gz


### PR DESCRIPTION
## Content
This PR includes an update of the docker images used in the CI and in the infrastructure of the deployed environments to use cardano-node / cardano-cli in version `1.35.4`. In the next days, the `preview` network will not be able to run on a previous version.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #594 
