### PR TITLE
Produce versions table in Release description

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - 'mithril-explorer/**'
       - '.github/workflows/docs.yml'
 
+concurrency:
+  group: ci-build-test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-ubuntu-X64:
     runs-on: ubuntu-22.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,10 @@ on:
     branches: # only run on branch push, tag push will be ignored
       - '**'
 
+concurrency:
+  group: ci-docs-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   cargo-doc:
     runs-on: ubuntu-22.04

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -89,6 +89,29 @@ jobs:
           title: Mithril v${{ github.ref_name }}
           files: package/*
 
+      - name: Prepare crates versions table
+        run: |
+          cat > ./versions-manifest.txt << EOF
+
+            ## Crates Versions
+            |  Crate  |  Version  |
+            |---------- |-------------|
+          EOF
+
+          cargo metadata --quiet --no-deps | \
+            jq -r '.packages | sort_by(.name) | .[] | select([.name] | inside(["mithrildemo", "mithril-end-to-end"]) | not) | "| \(.name) | `\(.version)` |"' \
+            >> ./versions-manifest.txt
+
+      - name: Update release body with crates versions table
+        id: update_release
+        uses: tubone24/update_release@v1.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ github.ref_name }} 
+        with:
+          is_append_body: true
+          body_path: ./versions-manifest.txt
+
   build-push-docker:
     runs-on: ubuntu-22.04
     strategy:


### PR DESCRIPTION
## Content
This PR includes an updated Pre-release workflow that appends the version table of the crates inside a Release.
Also it adds an automatic cancellation of CI and docs workflows currently running when a newer version is triggered.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Authors
@Alenar 
@jpraynaud 

## Issue(s)
Closes #599
