### PR TITLE
Doc & Build CI: Switch to pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: # only run on branch push, tag push will be ignored
-      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
     paths-ignore: # ignore docs only changes since they use a dedicated workflows: docs.yml
       - 'docs/**'
       - 'mithril-explorer/**'
@@ -249,12 +248,11 @@ jobs:
       packages: write
 
     env:
-      PUSH_PACKAGES: ${{ github.ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.ref) }}
+      PUSH_PACKAGES: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true && (github.base_ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.base_ref)) }}
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/${{ matrix.project }}
       DOCKER_FILE: ./${{ matrix.project }}/Dockerfile.ci
       CONTEXT: .
-      GITHUB_REF: ${{ github.ref}}
 
     steps:
       - name: Checkout
@@ -274,7 +272,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             unstable
-            type=raw,value={{branch}}-{{sha}}
+            type=raw,value={{base_ref}}-{{sha}}
 
       - name: Download built artifacts
         uses: actions/download-artifact@v3
@@ -291,7 +289,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
   unstable-release:
-    if: github.ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.ref)
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && (github.base_ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.base_ref))
     runs-on: ubuntu-22.04
     needs:
       - build
@@ -460,7 +458,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS=./google-application-credentials.json terraform plan --var-file=./env.variables.tfvars
 
     - name: Terraform Apply
-      if: github.ref == 'refs/heads/main'
+      if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.base_ref == 'refs/heads/main' 
       run: |
         GOOGLE_APPLICATION_CREDENTIALS=./google-application-credentials.json terraform apply -auto-approve --var-file=./env.variables.tfvars
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,8 @@
 name: Documentations & Explorer
 
 on:
-  push:
-    branches: # only run on branch push, tag push will be ignored
-      - '**'
+  pull_request:
+    types: [opened, reopened, synchronize, closed]
 
 concurrency:
   group: ci-docs-${{ github.ref }}
@@ -117,7 +116,7 @@ jobs:
             out/*
 
   publish-docs:
-    if: github.ref == 'refs/heads/main'
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.base_ref == 'refs/heads/main' 
     runs-on: ubuntu-22.04
     needs:
       - cargo-doc


### PR DESCRIPTION
## Content

This PR switch the event trigger used for the `ci` and `docs` workflows to `pull_request` (from `push`).

Using this trigger add the ability to run those workflows on PR from forks (if we approve them, see: [Approving workflow runs from public forks](https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks)).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Fix #597