### PR TITLE
Add Daedalus/Mithril benchmark video

### DIFF
--- a/docs/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/root/manual/getting-started/bootstrap-cardano-node.md
@@ -18,6 +18,13 @@ Thanks to a **Mithril Client** connected to a **Mithril Aggregator**, you will r
 
 :::
 
+# Video demonstration
+
+In this video you will see how fast the bootstrapping of a Cardano node with Mithril is compared to classical bootstrapping (benchmark done on mainnet with Daedalus wallet).
+
+<iframe style={{width: '100%', height: '480px'}} src="https://www.youtube.com/embed/5qjJNRgEzYo" title="Daedalus Bootstrap Benchmark on mainnet with/without Mithril" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="true"></iframe>
+
+
 ## Pre-requisites
 
 * Install a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain (latest stable version).


### PR DESCRIPTION
## Content
This PR adds the video of the Daedalus benchmark with/without Mithril that was run on `mainnet`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website

## Issue(s)
Closes #606 
