### PR TITLE
Simplify signature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bincode",
  "blake2 0.10.5",

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -271,7 +271,13 @@ mod tests {
         let decoded_sig: ProtocolSingleSignature = key_decode_hex(&sign_result.signature).unwrap();
         assert!(
             decoded_sig
-                .verify(&protocol_parameters, &avk, &expected_message)
+                .verify(
+                    &protocol_parameters,
+                    &protocol_signer.verification_key(),
+                    &protocol_signer.get_stake(),
+                    &avk,
+                    &expected_message
+                )
                 .is_ok(),
             "produced single signature should be valid"
         );

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mithril-stm"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -116,8 +116,8 @@ fn main() {
     let avk = clerk.compute_avk();
 
     // Check all parties can verify every sig
-    for s in sigs.iter() {
-        assert!(s.verify(&params, &avk, &msg).is_ok(), "Verification failed");
+    for (s, p) in sigs.iter().zip(ps.iter()) {
+        assert!(s.verify(&params, &p.verification_key(), &p.get_stake(), &avk, &msg).is_ok(), "Verification failed");
     }
 
     // Aggregate with random parties

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -143,7 +143,7 @@ fn main() {
 
 Here we give the benchmark results of STM for size and time. We run the benchmarks on macOS 12.6 on an Apple M1 Pro machine with 16 GB of RAM.
 
-Note that the size of an individual signature with one valid index is **176 bytes** and increases linearly in the length of valid indices (where an index is 8 bytes).
+Note that the size of an individual signature with one valid index is **72 bytes** (48 bytes from `sigma`, 8 bytes from `party_index`, 8 bytes for the `length` of winning indices and at least 8 bytes for a single winning `index`) and increases linearly in the length of valid indices (where an index is 8 bytes).
 
 ```shell
 +----------------------+

--- a/mithril-stm/src/merkle_tree.rs
+++ b/mithril-stm/src/merkle_tree.rs
@@ -91,6 +91,12 @@ impl MTLeaf {
     }
 }
 
+impl From<MTLeaf> for (StmVerificationKey, Stake) {
+    fn from(leaf: MTLeaf) -> (StmVerificationKey, Stake) {
+        (leaf.0, leaf.1)
+    }
+}
+
 impl PartialOrd for MTLeaf {
     /// Ordering of MT Values.
     ///

--- a/mithril-stm/src/merkle_tree.rs
+++ b/mithril-stm/src/merkle_tree.rs
@@ -1,8 +1,9 @@
 //! Creation and verification of Merkle Trees
 use crate::error::MerkleTreeError;
 use crate::multi_sig::VerificationKey;
-use crate::stm::Stake;
-use blake2::digest::{Digest, FixedOutput};
+use crate::stm::{Stake, StmVerificationKey};
+use blake2::digest::{consts::U32, Digest, FixedOutput};
+use blake2::Blake2b;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::convert::TryFrom;
@@ -74,6 +75,14 @@ pub struct MerkleTree<D: Digest> {
 }
 
 impl MTLeaf {
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Result<Self, MerkleTreeError<Blake2b<U32>>> {
+        let pk = StmVerificationKey::from_bytes(bytes)
+            .map_err(|_| MerkleTreeError::SerializationError)?;
+        let mut u64_bytes = [0u8; 8];
+        u64_bytes.copy_from_slice(&bytes[96..]);
+        let stake = Stake::from_be_bytes(u64_bytes);
+        Ok(MTLeaf(pk, stake))
+    }
     pub(crate) fn to_bytes(self) -> [u8; 104] {
         let mut result = [0u8; 104];
         result[..96].copy_from_slice(&self.0.to_bytes());

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -556,13 +556,9 @@ impl<D: Digest + Clone + FixedOutput> StmClerk<D> {
         StmAggrVerificationKey::from(&self.closed_reg)
     }
 
-    /// Get the (VK, stake) of a party given it's index.
+    /// Get the (VK, stake) of a party given its index.
     pub fn get_reg_party(&self, party_index: &Index) -> Option<(StmVerificationKey, Stake)> {
-        if *party_index as usize >= self.closed_reg.reg_parties.len() {
-            return None;
-        }
-
-        Some(self.closed_reg.reg_parties[*party_index as usize].into())
+       self.closed_reg.reg_parties.get(*party_index as usize).map(|r| r.into())
     }
 }
 

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -558,7 +558,10 @@ impl<D: Digest + Clone + FixedOutput> StmClerk<D> {
 
     /// Get the (VK, stake) of a party given its index.
     pub fn get_reg_party(&self, party_index: &Index) -> Option<(StmVerificationKey, Stake)> {
-       self.closed_reg.reg_parties.get(*party_index as usize).map(|r| r.into())
+        self.closed_reg
+            .reg_parties
+            .get(*party_index as usize)
+            .map(|&r| r.into())
     }
 }
 

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -169,7 +169,6 @@ pub struct StmInitializer {
 /// Participant in the protocol can sign messages.
 /// This instance can only be generated out of an `StmInitializer` and a `ClosedKeyReg`.
 /// This ensures that a `MerkleTree` root is not computed before all participants have registered.
-#[allow(dead_code)]
 #[derive(Debug, Clone)]
 pub struct StmSigner<D: Digest> {
     mt_index: u64,
@@ -399,6 +398,16 @@ impl<D: Clone + Digest + FixedOutput> StmSigner<D> {
     pub fn get_closed_reg(self) -> ClosedKeyReg<D> {
         self.closed_reg
     }
+
+    /// Extract the verification key.
+    pub fn verification_key(&self) -> StmVerificationKey {
+        self.vk
+    }
+
+    /// Extract stake from the signer.
+    pub fn get_stake(&self) -> Stake {
+        self.stake
+    }
 }
 
 impl<D: Digest + Clone + FixedOutput> StmClerk<D> {
@@ -545,6 +554,15 @@ impl<D: Digest + Clone + FixedOutput> StmClerk<D> {
     /// Compute the `StmAggrVerificationKey` related to the used registration.
     pub fn compute_avk(&self) -> StmAggrVerificationKey<D> {
         StmAggrVerificationKey::from(&self.closed_reg)
+    }
+
+    /// Get the (VK, stake) of a party given it's index.
+    pub fn get_reg_party(&self, party_index: &Index) -> Option<(StmVerificationKey, Stake)> {
+        if *party_index as usize >= self.closed_reg.reg_parties.len() {
+            return None;
+        }
+
+        Some(self.closed_reg.reg_parties[*party_index as usize].into())
     }
 }
 


### PR DESCRIPTION
## Content
This PR removes the verification key and the stake from the signature. These values are no longer required, as individual signatures no longer contain the merkle paths (it is now responsibility of the aggregator to include these values in the certificate). This required some changes in the multi_signer and single_signer, as these folders were verifying single signatures. 

Now, in order to verify aggregate signatures, they include not only the individual signatures but also the corresponding `RegParty`, to be able to verify the batched membership proof (batched merkle path).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
This PR closes #619 .
