### PR TITLE
Fix deploy-testing docker image id retrieval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -414,7 +414,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Get Docker image id
-      run: echo "DOCKER_IMAGE_ID=${{ github.head_ref || github.ref_name }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+      run: echo "DOCKER_IMAGE_ID=${{ github.base_ref }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
     - name: Prepare service account credentials
       run: |


### PR DESCRIPTION
## Content

This PR fix the retrieval of the docker image id in the `deploy-testing` job in the CI workflow.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #597, fix regression introduced by #613