### PR TITLE
Deploy using push trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,18 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - 'main'
+      - 'hotfix**'
   pull_request:
-    types: [opened, reopened, synchronize, closed]
+    types: [opened, reopened, synchronize]
     paths-ignore: # ignore docs only changes since they use a dedicated workflows: docs.yml
       - 'docs/**'
       - 'mithril-explorer/**'
       - '.github/workflows/docs.yml'
+    branches-ignore:
+      - 'hotfix**' # hotfix are handled by the push trigger
 
 concurrency:
   group: ci-build-test-${{ github.ref }}
@@ -248,7 +254,7 @@ jobs:
       packages: write
 
     env:
-      PUSH_PACKAGES: ${{ github.event.action == 'closed' && github.event.pull_request.merged == true && (github.base_ref == 'main' || startsWith('hotfix', github.base_ref)) }}
+      PUSH_PACKAGES: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.ref)) }}
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository_owner }}/${{ matrix.project }}
       DOCKER_FILE: ./${{ matrix.project }}/Dockerfile.ci
@@ -272,7 +278,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             unstable
-            type=raw,value=${{ github.base_ref }}-{{sha}}
+            type=raw,value=${{ github.base_ref || github.ref_name }}-{{sha}}
 
       - name: Download built artifacts
         uses: actions/download-artifact@v3
@@ -289,7 +295,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
 
   unstable-release:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true && (github.base_ref == 'main' || startsWith('hotfix', github.base_ref))
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.ref))
     runs-on: ubuntu-22.04
     needs:
       - build
@@ -418,7 +424,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Get Docker image id
-      run: echo "DOCKER_IMAGE_ID=${{ github.base_ref }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
+      run: echo "DOCKER_IMAGE_ID=${{ github.base_ref || github.ref_name }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
 
     - name: Prepare service account credentials
       run: |
@@ -462,7 +468,7 @@ jobs:
         GOOGLE_APPLICATION_CREDENTIALS=./google-application-credentials.json terraform plan --var-file=./env.variables.tfvars
 
     - name: Terraform Apply
-      if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.base_ref == 'main' 
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
       run: |
         GOOGLE_APPLICATION_CREDENTIALS=./google-application-credentials.json terraform apply -auto-approve --var-file=./env.variables.tfvars
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -371,6 +371,8 @@ jobs:
           files: package/*
 
   deploy-testing:
+    # Don't run on pull request from forks since they don't have access to all the needed secrets
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,11 @@
 name: Documentations & Explorer
 
 on:
+  push:
+    branches:
+      - 'main'
   pull_request:
-    types: [opened, reopened, synchronize, closed]
+    types: [opened, reopened, synchronize]
 
 concurrency:
   group: ci-docs-${{ github.ref }}
@@ -116,7 +119,7 @@ jobs:
             out/*
 
   publish-docs:
-    if: github.event.action == 'closed' && github.event.pull_request.merged == true && github.base_ref == 'main' 
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-22.04
     needs:
       - cargo-doc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,12 +110,11 @@ jobs:
           command: package
           args: -p mithril-stm --list
 
-      # We use the '--dry-run' arg until we have a valid CRATES_IO_API_TOKEN to avoid the workflow to crash
       - name: Cargo publish
         uses: actions-rs/cargo@v1
         with:
           command: publish
-          args: -p mithril-stm --token ${{ secrets.CRATES_IO_API_TOKEN }} --dry-run
+          args: -p mithril-stm --token ${{ secrets.CRATES_IO_API_TOKEN }}
 
   deploy-release:
     strategy:


### PR DESCRIPTION
## Content

This PR replace the "pull request closed" trigger with a push trigger on the `main` or `hotfix*` branches. It also disable running the `deploy-testing` job when the triggering pull request comes from a fork (since [they don't have all the secrets needed to run it](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflows-in-forked-repositories)).

This means that only merge coming from this repository branches will trigger a deployment and that only those merge can be tagged for a version (else the `pre-release` workflow will fail since no artifacts would have been built).
This is ok since we need anyway to do a commit to update the version and/or the documentation each time we do a new distribution release.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
Hopefully having a push trigger on the main branch will produce proper cache that will be correctly reused by the PR workflow :pray:.

This PR also remove the `dry-run` arg to the crate deployment since a valid `CRATES_IO_API_TOKEN` have been added to this repository secret.

## Issue(s)

Relates to #597 and #613
