### PR TITLE
Add test-client workflow

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -15,10 +15,8 @@ runs:
         python3 ./.github/workflows/scripts/edit-cargo-toml-version.py -l $(echo ${{ github.sha }} | cut -c1-7)
 
     - name: Cargo build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release ${{ inputs.build-args }}
+      shell: bash
+      run: cargo build --release ${{ inputs.build-args }}
 
     - name: Publish Mithril Distribution (${{ runner.os }}-${{ runner.arch }})
       uses: actions/upload-artifact@v3

--- a/.github/workflows/actions/toolchain-and-cache/action.yml
+++ b/.github/workflows/actions/toolchain-and-cache/action.yml
@@ -13,11 +13,10 @@ runs:
   using: "composite"
   steps:
     - name: Install stable toolchain
-      uses: actions-rs/toolchain@v1
+      uses: dtolnay/rust-toolchain@master
       with:
-        profile: minimal
         toolchain: stable
-        override: true
+        components: clippy, rustfmt
 
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,9 +233,9 @@ jobs:
 
       - name: Publish Unit Test Results
         if: success() || failure()
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          files: ./**/test-results-*.xml
+          junit_files: ./**/test-results-*.xml
 
   docker-mithril:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,10 +141,6 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
           cargo-tools: cargo-sort clippy-sarif sarif-fmt
 
-      - name: Cargo check
-        shell: bash
-        run: cargo check --release --all-targets
-
       - name: Clippy Check
         if: success() || failure()
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,28 +139,38 @@ jobs:
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
-          cargo-tools: cargo-sort
+          cargo-tools: cargo-sort clippy-sarif sarif-fmt
 
       - name: Cargo check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --release --all-targets
+        shell: bash
+        run: cargo check --release --all-targets
 
       - name: Clippy Check
-        uses: actions-rs/clippy-check@v1
+        if: success() || failure()
+        run: |
+          cargo clippy \
+            --all-features --all-targets --no-deps --message-format=json \
+            | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+          
+          # Make this step fail if any warning has been found
+          if [[ $(cat rust-clippy-results.sarif | jq '.runs[0].results') != "[]" ]]; then
+            false
+          fi
+
+      - name: Upload clippy analysis results to GitHub
+        if: success() || failure()
+        uses: github/codeql-action/upload-sarif@v2
         with:
-          name: clippy
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets --no-deps -- -D warnings
+          sarif_file: rust-clippy-results.sarif
+          wait-for-processing: true
 
       - name: Cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --check
+        if: success() || failure()
+        shell: bash
+        run: cargo fmt --check
 
       - name: Cargo sort
+        if: success() || failure()
         shell: bash
         run: cargo sort -w -c
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,10 +24,7 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
 
       - name: Generate cargo doc
-        uses: actions-rs/cargo@v1
-        with:
-          command: doc
-          args: --no-deps -p mithril-stm -p mithril-common -p mithril-aggregator -p mithril-signer -p mithril-client
+        run: cargo doc --no-deps -p mithril-stm -p mithril-common -p mithril-aggregator -p mithril-signer -p mithril-client
 
       - name: Publish Mithril-rust-doc
         uses: actions/upload-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,28 +93,21 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: stable
 
       - name: Cargo publish dry run
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -p mithril-stm --dry-run
+        shell: bash
+        run: cargo publish -p mithril-stm --dry-run
 
       - name: Cargo package list
-        uses: actions-rs/cargo@v1
-        with:
-          command: package
-          args: -p mithril-stm --list
+        shell: bash
+        run: cargo package -p mithril-stm --list
 
       - name: Cargo publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
-          args: -p mithril-stm --token ${{ secrets.CRATES_IO_API_TOKEN }}
+        shell: bash
+        run: cargo publish -p mithril-stm --token ${{ secrets.CRATES_IO_API_TOKEN }}
 
   deploy-release:
     strategy:

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -1,0 +1,110 @@
+name: Mithril Client multi-platform test
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: |
+          SHA of the commit on which the mithril-client binary should be obtained, a "ci.yml" workflow must have run
+          on it else no binary would be available leading to the failure of this.
+          
+          If not provided the last commit on the main branch will be used instead.
+        required: false
+        type: string
+      network:
+        required: true
+        type: string
+        default: preview
+      aggregator_endpoint:
+        required: true
+        type: string
+        default: https://aggregator.pre-release-preview.api.mithril.network/aggregator
+      genesis_verification_key:
+        description: The genesis verification key, if empty the "TEST_ONLY_genesis.vkey" file at the project root will be used
+        required: false
+        type: string
+      enable_debug:
+        description: Enable debug output ("-vvv") for the mithril-client calls
+        required: true
+        type: bool
+        default: false
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04, macos-12, windows-latest ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Prepare environment variables
+        id: prepare
+        shell: bash
+        run: |
+          if [[ -n "${{ inputs.commit_sha }}" ]]; then
+            echo "sha=${{ inputs.commit_sha }}" >> $GITHUB_OUTPUT
+          else
+            echo "branch=main" >> $GITHUB_OUTPUT
+          fi
+          
+          if [[ "${{ inputs.enable_debug }}" == "true" ]]; then
+            echo "debug_level=-vvv" >> $GITHUB_OUTPUT
+          fi
+          
+          if [[ -n "${{ inputs.network }}" ]]; then
+            echo "NETWORK=${{ inputs.network }}" >> $GITHUB_ENV
+          else
+            echo "NETWORK=preview" >> $GITHUB_ENV
+          fi
+          
+          if [[ -n "${{ inputs.aggregator_endpoint }}" ]]; then
+            echo "AGGREGATOR_ENDPOINT=${{ inputs.aggregator_endpoint }}" >> $GITHUB_ENV
+          else
+            echo "AGGREGATOR_ENDPOINT=https://aggregator.pre-release-preview.api.mithril.network/aggregator" >> $GITHUB_ENV
+          fi
+          
+          if [[ -n "${{ inputs.genesis_verification_key }}" ]]; then
+            echo "GENESIS_VERIFICATION_KEY=${{ inputs.genesis_verification_key }}" >> $GITHUB_ENV
+          else
+            echo "GENESIS_VERIFICATION_KEY=$(cat TEST_ONLY_genesis.vkey)" >> $GITHUB_ENV
+          fi
+          
+      - name: Checkout binary
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
+          path: ./bin
+          commit: ${{ steps.prepare.outputs.sha }} 
+          branch: ${{ steps.prepare.outputs.branch }}
+          workflow: ci.yml
+          workflow_conclusion: success
+      
+      - name: Set permissions
+        shell: bash
+        working-directory: ./bin
+        run: chmod +x ./mithril-client
+      
+      - name: Show client version
+        shell: bash
+        working-directory: ./bin
+        run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} --version
+      
+      - name: List and get last snapshot digest
+        shell: bash
+        working-directory: ./bin
+        run: |
+          ./mithril-client ${{ steps.prepare.outputs.debug_level }} list
+          echo "SNAPSHOT_DIGEST=$(./mithril-client list --json | jq -r '.[0].digest')" >> $GITHUB_ENV
+      
+      - name: Download Latest Snapshot
+        shell: bash
+        working-directory: ./bin
+        run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} download $SNAPSHOT_DIGEST
+        
+      - name: Restore Latest Snapshot
+        shell: bash
+        working-directory: ./bin
+        run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} restore $SNAPSHOT_DIGEST 


### PR DESCRIPTION
## Content

This PR includes the "Mithril Client multi-platform test" workflow that can be manually triggered to test that a `mithril-client` can list, download and restore on each supported environment (linux, macOs, windows).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

This PR also fix partially #550 by replacing all `action-rs` actions with either an up to date equivalent or direct command line calls.

## Issue(s)

Closes #601 