### PR TITLE
check API version

### DIFF
--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -24,13 +24,14 @@ pub fn routes(
         "mithril-api-version",
         HeaderValue::from_static(MITHRIL_API_VERSION),
     );
-
+    let header_must_be = warp::header::exact("API_VERSION", MITHRIL_API_VERSION);
     warp::any().and(warp::path(SERVER_BASE_PATH)).and(
         certificate_routes::routes(dependency_manager.clone())
             .or(snapshot_routes::routes(dependency_manager.clone()))
             .or(signer_routes::routes(dependency_manager.clone()))
             .or(signatures_routes::routes(dependency_manager.clone()))
             .or(epoch_routes::routes(dependency_manager))
+            .and(header_must_be)
             .with(cors)
             .with(warp::reply::with::headers(headers)),
     )

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -66,3 +66,40 @@ pub async fn handle_custom(reject: Rejection) -> Result<impl Reply, Rejection> {
         Err(reject)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_no_version() {
+        let filters = header_must_be();
+        warp::test::request()
+            .path("/aggregator/whatever")
+            .filter(&filters)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_bad_version() {
+        let filters = header_must_be();
+        warp::test::request()
+            .header("mithril-api-version", "0.0.999")
+            .path("/aggregator/whatever")
+            .filter(&filters)
+            .await
+            .unwrap_err();
+    }
+
+    #[tokio::test]
+    async fn test_good_version() {
+        let filters = header_must_be();
+        warp::test::request()
+            .header("mithril-api-version", MITHRIL_API_VERSION)
+            .path("/aggregator/whatever")
+            .filter(&filters)
+            .await
+            .unwrap();
+    }
+}

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -7,9 +7,16 @@ use crate::DependencyManager;
 use mithril_common::MITHRIL_API_VERSION;
 
 use reqwest::header::{HeaderMap, HeaderValue};
+use reqwest::StatusCode;
 use std::sync::Arc;
 use warp::http::Method;
-use warp::{Filter, Rejection};
+use warp::reject::Reject;
+use warp::{Filter, Rejection, Reply};
+
+#[derive(Debug)]
+pub struct VersionMismatchError;
+
+impl Reject for VersionMismatchError {}
 
 /// Routes
 pub fn routes(
@@ -33,9 +40,10 @@ pub fn routes(
                 .or(signer_routes::routes(dependency_manager.clone()))
                 .or(signatures_routes::routes(dependency_manager.clone()))
                 .or(epoch_routes::routes(dependency_manager))
-                .with(cors)
-                .with(warp::reply::with::headers(headers)),
+                .with(cors),
         )
+        .recover(handle_custom)
+        .with(warp::reply::with::headers(headers))
 }
 
 /// API Version verification
@@ -45,8 +53,16 @@ fn header_must_be() -> impl Filter<Extract = (), Error = Rejection> + Copy {
             match maybe_header {
                 None => Ok(()),
                 Some(version) if version == MITHRIL_API_VERSION => Ok(()),
-                Some(_version) => Err(warp::reject()),
+                Some(_version) => Err(warp::reject::custom(VersionMismatchError)),
             }
         })
         .untuple_one()
+}
+
+pub async fn handle_custom(reject: Rejection) -> Result<impl Reply, Rejection> {
+    if reject.find::<VersionMismatchError>().is_some() {
+        Ok(StatusCode::PRECONDITION_FAILED)
+    } else {
+        Err(reject)
+    }
 }

--- a/mithril-signer/src/certificate_handler.rs
+++ b/mithril-signer/src/certificate_handler.rs
@@ -45,10 +45,7 @@ pub enum CertificateHandlerError {
 /// convenient methods to error enum
 impl CertificateHandlerError {
     pub fn is_api_version_mismatch(&self) -> bool {
-        match self {
-            Self::ApiVersionMismatch(_) => true,
-            _ => false,
-        }
+        matches!(self, Self::ApiVersionMismatch(_))
     }
 }
 

--- a/mithril-signer/src/certificate_handler.rs
+++ b/mithril-signer/src/certificate_handler.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use reqwest::{self, Client, RequestBuilder, StatusCode};
+use reqwest::{self, Client, RequestBuilder, Response, StatusCode};
 use slog_scope::debug;
 use std::io;
 use thiserror::Error;
@@ -35,6 +35,21 @@ pub enum CertificateHandlerError {
     /// Mostly network errors.
     #[error("io error: {0}")]
     IOError(#[from] io::Error),
+
+    /// Incompatible API version error
+    #[error("HTTP API version mismatch: {0}")]
+    ApiVersionMismatch(String),
+}
+
+#[cfg(test)]
+/// convenient methods to error enum
+impl CertificateHandlerError {
+    pub fn is_api_version_mismatch(&self) -> bool {
+        match self {
+            Self::ApiVersionMismatch(_) => true,
+            _ => false,
+        }
+    }
 }
 
 /// Trait for mocking and testing a `CertificateHandler`
@@ -79,6 +94,22 @@ impl CertificateHandlerHTTPClient {
     pub fn prepare_request_builder(&self, request_builder: RequestBuilder) -> RequestBuilder {
         request_builder.header("API_VERSION", MITHRIL_API_VERSION)
     }
+
+    /// API version error handling
+    fn handle_api_error(&self, response: &Response) -> CertificateHandlerError {
+        if let Some(version) = response.headers().get("mithril-api-version") {
+            CertificateHandlerError::ApiVersionMismatch(format!(
+                "server version: '{}', signer version: '{}'",
+                version.to_str().unwrap(),
+                MITHRIL_API_VERSION
+            ))
+        } else {
+            CertificateHandlerError::ApiVersionMismatch(format!(
+                "version precondition failed, sent version '{}'.",
+                MITHRIL_API_VERSION
+            ))
+        }
+    }
 }
 
 #[async_trait]
@@ -99,6 +130,7 @@ impl CertificateHandler for CertificateHandlerHTTPClient {
                     Ok(epoch_settings) => Ok(Some(epoch_settings)),
                     Err(err) => Err(CertificateHandlerError::JsonParseFailed(err.to_string())),
                 },
+                StatusCode::PRECONDITION_FAILED => Err(self.handle_api_error(&response)),
                 _ => Err(CertificateHandlerError::RemoteServerTechnical(
                     response.text().await.unwrap_or_default(),
                 )),
@@ -125,6 +157,7 @@ impl CertificateHandler for CertificateHandlerHTTPClient {
                     Ok(pending_certificate) => Ok(Some(pending_certificate)),
                     Err(err) => Err(CertificateHandlerError::JsonParseFailed(err.to_string())),
                 },
+                StatusCode::PRECONDITION_FAILED => Err(self.handle_api_error(&response)),
                 StatusCode::NO_CONTENT => Ok(None),
                 _ => Err(CertificateHandlerError::RemoteServerTechnical(
                     response.text().await.unwrap_or_default(),
@@ -148,6 +181,7 @@ impl CertificateHandler for CertificateHandlerHTTPClient {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => Ok(()),
+                StatusCode::PRECONDITION_FAILED => Err(self.handle_api_error(&response)),
                 StatusCode::BAD_REQUEST => Err(CertificateHandlerError::RemoteServerLogical(
                     format!("bad request: {}", response.text().await.unwrap_or_default()),
                 )),
@@ -176,6 +210,7 @@ impl CertificateHandler for CertificateHandlerHTTPClient {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => Ok(()),
+                StatusCode::PRECONDITION_FAILED => Err(self.handle_api_error(&response)),
                 StatusCode::BAD_REQUEST => Err(CertificateHandlerError::RemoteServerLogical(
                     format!("bad request: {}", response.text().await.unwrap_or_default()),
                 )),
@@ -326,6 +361,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_epoch_settings_ko_412() {
+        let (server, config) = setup_test();
+        let _snapshots_mock = server.mock(|when, then| {
+            when.path("/epoch-settings");
+            then.status(412).header("mithril-api-version", "0.0.999");
+        });
+        let certificate_handler = CertificateHandlerHTTPClient::new(config.aggregator_endpoint);
+        let epoch_settings = certificate_handler
+            .retrieve_epoch_settings()
+            .await
+            .unwrap_err();
+
+        assert!(epoch_settings.is_api_version_mismatch());
+    }
+
+    #[tokio::test]
     async fn test_epoch_settings_ko_500() {
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
@@ -357,6 +408,22 @@ mod tests {
             pending_certificate_expected,
             pending_certificate.unwrap().unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_certificate_pending_ko_412() {
+        let (server, config) = setup_test();
+        let _snapshots_mock = server.mock(|when, then| {
+            when.path("/certificate-pending");
+            then.status(412).header("mithril-api-version", "0.0.999");
+        });
+        let certificate_handler = CertificateHandlerHTTPClient::new(config.aggregator_endpoint);
+        let error = certificate_handler
+            .retrieve_pending_certificate()
+            .await
+            .unwrap_err();
+
+        assert!(error.is_api_version_mismatch());
     }
 
     #[tokio::test]
@@ -402,7 +469,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_signer_ok_400() {
+    async fn test_register_signer_ko_412() {
+        let (server, config) = setup_test();
+        let _snapshots_mock = server.mock(|when, then| {
+            when.method(POST).path("/register-signer");
+            then.status(412).header("mithril-api-version", "0.0.999");
+        });
+        let single_signers = fake_data::signers(1);
+        let single_signer = single_signers.first().unwrap();
+        let certificate_handler = CertificateHandlerHTTPClient::new(config.aggregator_endpoint);
+        let error = certificate_handler
+            .register_signer(single_signer)
+            .await
+            .unwrap_err();
+
+        assert!(error.is_api_version_mismatch());
+    }
+
+    #[tokio::test]
+    async fn test_register_signer_ko_400() {
         let single_signers = fake_data::signers(1);
         let single_signer = single_signers.first().unwrap();
         let (server, config) = setup_test();
@@ -428,7 +513,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_signer_ok_500() {
+    async fn test_register_signer_ko_500() {
         let single_signers = fake_data::signers(1);
         let single_signer = single_signers.first().unwrap();
         let (server, config) = setup_test();
@@ -458,6 +543,23 @@ mod tests {
             .register_signatures(&single_signatures)
             .await;
         register_signatures.expect("unexpected error");
+    }
+
+    #[tokio::test]
+    async fn test_register_signatures_ko_412() {
+        let (server, config) = setup_test();
+        let _snapshots_mock = server.mock(|when, then| {
+            when.method(POST).path("/register-signatures");
+            then.status(412).header("mithril-api-version", "0.0.999");
+        });
+        let single_signatures = fake_data::single_signatures((1..5).collect());
+        let certificate_handler = CertificateHandlerHTTPClient::new(config.aggregator_endpoint);
+        let error = certificate_handler
+            .register_signatures(&single_signatures)
+            .await
+            .unwrap_err();
+
+        assert!(error.is_api_version_mismatch());
     }
 
     #[tokio::test]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EpochSettings"
+        "412":
+          description: API version mismatch
         default:
           description: epoch settings error
           content:
@@ -60,6 +62,8 @@ paths:
                 $ref: "#/components/schemas/CertificatePending"
         "204":
           description: no pending certificate available
+        "412":
+          description: API version mismatch
         default:
           description: pending certificate error
           content:
@@ -89,6 +93,8 @@ paths:
                 $ref: "#/components/schemas/Certificate"
         "404":
           description: certificate not found
+        "412":
+          description: API version mismatch
         default:
           description: pending certificate error
           content:
@@ -109,6 +115,8 @@ paths:
                 type: array
                 items:
                   $ref: "#/components/schemas/Snapshot"
+        "412":
+          description: API version mismatch
         default:
           description: snapshot retrieval error
           content:
@@ -139,6 +147,8 @@ paths:
                 format: binary
         "404":
           description: snapshot not found
+        "412":
+          description: API version mismatch
         default:
           description: snapshot retrieval error
           content:
@@ -168,6 +178,8 @@ paths:
                 $ref: "#/components/schemas/Snapshot"
         "404":
           description: snapshot not found
+        "412":
+          description: API version mismatch
         default:
           description: snapshot retrieval error
           content:
@@ -195,6 +207,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        "412":
+          description: API version mismatch
         default:
           description: signer registration error
           content:
@@ -224,6 +238,8 @@ paths:
                 $ref: "#/components/schemas/Error"
         "409":
           description: signatures registration already done
+        "412":
+          description: API version mismatch
         default:
           description: signatures registration error
           content:


### PR DESCRIPTION
## Content
This PR adds an API version check when requesting the Aggregator. If the API version does not match, the HTTP call is rejected.

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Closes #633 
