### PR TITLE
Fix sign distribution CI v2

### DIFF
--- a/.github/workflows/scripts/sign-distribution.sh
+++ b/.github/workflows/scripts/sign-distribution.sh
@@ -18,7 +18,7 @@ main() {
     chmod 700 gpghome
     echo "$GPG_SECRET_KEY" | gpg --homedir gpghome --batch --import
     gpg --homedir gpghome --list-secret-keys
-    gpg --homedir gpghome -export --armor mithril@iohk.io > ./package/gpg-public.key
+    gpg --homedir gpghome --export --armor mithril@iohk.io > ./package/gpg-public.key
     cd ./package
     find . -type f -print | grep -v CHECKSUM | sort -n | xargs -I '{}' sha256sum '{}' > ./CHECKSUM
     gpg --homedir ../gpghome --clear-sign ./CHECKSUM


### PR DESCRIPTION
## Content
This PR includes a fix in the script that signs the distribution assets that prevented the CI to complete successfully (second attempt).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #587
