### PR TITLE
Fix verify signature links in release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,7 @@ jobs:
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           PROCEDURE_FILE_PATH: ./release-notes-addon.txt
+          DOWNLOAD_URL_BASE: ${{ github.server_url }}/${{ github.repository }}/releases/download/unstable
         run: ./.github/workflows/scripts/verify-distribution.sh
 
       - name: List packaged assets

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -102,6 +102,7 @@ jobs:
         env:
           GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
           PROCEDURE_FILE_PATH: ./release-notes-addon.txt
+          DOWNLOAD_URL_BASE: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}
         run: ./.github/workflows/scripts/verify-distribution.sh
           
       - name: List packaged assets

--- a/.github/workflows/scripts/verify-distribution.sh
+++ b/.github/workflows/scripts/verify-distribution.sh
@@ -16,10 +16,16 @@ if [ -z "${GPG_SECRET_KEY}" ]; then
     exit 1
 fi
 
+if [ -z "${DOWNLOAD_URL_BASE}" ]; then
+    echo Missing environment variable: DOWNLOAD_URL_BASE
+    exit 1
+fi
+
 # Create a procedure to verify the checksum and the GPG signature for a downloaded asset from the package
 main() {
     PROCEDURE_FILE_PATH=$1
-    GPG_SECRET_KEY=$2
+    DOWNLOAD_URL_BASE=$2
+    GPG_SECRET_KEY=$3
     mkdir gpghome
     chmod 700 gpghome
     echo "$GPG_SECRET_KEY" | gpg --homedir gpghome --batch --import
@@ -32,7 +38,7 @@ main() {
 <p>
 
 * **Step 1**: Identify the downloaded asset on your computer ***YOUR_ASSET_FILE***
-* **Step 2**: Download the signed checksum file from this link [CHECKSUM.asc](./CHECKSUM.asc) and save it in the same folder as the asset
+* **Step 2**: Download the signed checksum file from this link [CHECKSUM.asc](${DOWNLOAD_URL_BASE}/CHECKSUM.asc) and save it in the same folder as the asset
 * **Step 3**: In your terminal, go to the asset folder by running:
 \`\`\`
 cd ***YOUR_ASSET_FOLDER***
@@ -45,7 +51,7 @@ You must see:
 \`\`\`
 ./***YOUR_ASSET_FILE***: OK
 \`\`\`
-* **Step 5**: Download the public key file from this link [gpg-public.key](./gpg-public.key) and save it in the same folder as the asset
+* **Step 5**: Download the public key file from this link [gpg-public.key](${DOWNLOAD_URL_BASE}/gpg-public.key) and save it in the same folder as the asset
 * **Step 6**: Then import the GPG public key:
 \`\`\`
 gpg --import ./gpg-public.key
@@ -85,4 +91,4 @@ EOF
     rm -rf gpghome
 }
 
-main "$PROCEDURE_FILE_PATH" "$GPG_SECRET_KEY" 
+main "$PROCEDURE_FILE_PATH" "$DOWNLOAD_URL_BASE" "$GPG_SECRET_KEY"

--- a/docs/blog/2022-12-05-release-process/index.md
+++ b/docs/blog/2022-12-05-release-process/index.md
@@ -49,4 +49,4 @@ Here is a high-level picture of this process:
 
 ### Further Reading
 
-* The Mithril developers have redacted an ADR [Release proces and versioning](https://mithril.network/doc/adr/3/) that also describes more technically this process.
+* The Mithril developers have redacted an ADR [Release process and versioning](https://mithril.network/doc/adr/3/) that also describes more technically this process.

--- a/mithril-infra/README.md
+++ b/mithril-infra/README.md
@@ -118,8 +118,8 @@ export DEBUG=1
 export NETWORK=preview
 export NETWORK_MAGIC=2
 
-# Selet Cardano node
-export CARDANO_NODE=cardano-node-signer-1
+# Select Cardano node
+export CARDANO_NODE=cardano-node-relay-signer-1
 
 # Select Mithril signer node
 export SIGNER_NODE=mithril-signer-1


### PR DESCRIPTION
## Content
This PR includes a fix of the computation of the download links provided in the verification procedure in the release notes for `CHECKSUM` and `GPG Public Key`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #587 
