### PR TITLE
Add query KES period info for test SPOs

### DIFF
--- a/mithril-infra/assets/tools/pool/query-stake-pool.sh
+++ b/mithril-infra/assets/tools/pool/query-stake-pool.sh
@@ -34,6 +34,11 @@ CARDANO_CLI_CMD query pool-params \
 --testnet-magic $NETWORK_MAGIC \
 --stake-pool-id $POOL_ID | jq .
 
+# Query KES period info
+CARDANO_CLI_CMD query kes-period-info \
+--testnet-magic $NETWORK_MAGIC \
+--op-cert-file ${POOL_ARTIFACTS_DIR}/opcert.cert
+
 # Query current leadership schedule
 CARDANO_CLI_CMD query leadership-schedule \
 --testnet-magic $NETWORK_MAGIC \


### PR DESCRIPTION
## Content
This PR includes a query to retrieve KES period info for test SPOs. This will help us know when we need to renew operational certificates. 

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
