### PR TITLE
Fix Cardano relay node topology configuration

### DIFF
--- a/mithril-infra/mithril.signer.tf
+++ b/mithril-infra/mithril.signer.tf
@@ -47,7 +47,7 @@ cat > /home/curry/data/${var.cardano_network}/mithril-signer-${each.key}/cardano
   ]
 }
 EOF
-cat /home/curry/docker/cardano-configurations/network/preview/cardano-node/topology.json | jq '.Producers[1] |= . + { "addr": "${google_compute_address.mithril-external-address.address}", "port": ${local.mithril_signers_block_producer_cardano_port[each.key]}, "valency": 1}' > /home/curry/data/${var.cardano_network}/mithril-signer-${each.key}/cardano/pool/topology-relay.json
+cat /home/curry/docker/cardano-configurations/network/${var.cardano_network}/cardano-node/topology.json | jq '.Producers[1] |= . + { "addr": "${google_compute_address.mithril-external-address.address}", "port": ${local.mithril_signers_block_producer_cardano_port[each.key]}, "valency": 1}' > /home/curry/data/${var.cardano_network}/mithril-signer-${each.key}/cardano/pool/topology-relay.json
 EOT
     ]
   }


### PR DESCRIPTION
## Content
This PR includes a fix to the computation of the verified signer attached Cardano relay node which was always using `preview` configuration in the Mithril infra. This issue prevented the synchronization of the chain on other networks.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
