### PR TITLE
Decommission signer registration with declarative PoolId

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -4,7 +4,7 @@ inputs:
   build-args:
     description: Arguments to pass to 'cargo build'
     required: false
-    default: ''
+    default: '-p mithril-aggregator -p mithril-client -p mithril-common -p mithril-signer -p mithril-stm'
 runs:
   using: "composite"
   steps:
@@ -14,10 +14,10 @@ runs:
         pip3 install toml
         python3 ./.github/workflows/scripts/edit-cargo-toml-version.py -l $(echo ${{ github.sha }} | cut -c1-7)
 
-    - name: Cargo build
+    - name: Cargo build - Distribution
       shell: bash
       run: cargo build --release ${{ inputs.build-args }}
-
+        
     - name: Publish Mithril Distribution (${{ runner.os }}-${{ runner.arch }})
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,11 @@ jobs:
           cache-version: ${{ secrets.CACHE_VERSION }}
           cargo-tools: cargo-deb
 
+      # We separate the build in 2 steps as we want to avoid side effects with Rust feature unification.
+      - name: Cargo build - Tooling
+        shell: bash
+        run: cargo build --release --workspace --exclude mithril-aggregator --exclude mithril-client --exclude mithril-signer --exclude mithril-stm
+
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2142,13 +2142,15 @@ dependencies = [
 
 [[package]]
 name = "mithrildemo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.13.1",
+ "blake2 0.10.5",
  "clap 4.0.29",
  "hex",
  "log",
  "mithril-common",
+ "mithril-stm",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "serde",

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithrildemo"
-version = "0.1.0"
+version = "0.1.1"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }
@@ -10,14 +10,23 @@ repository = { workspace = true }
 
 [dependencies]
 base64 = "0.13.0"
+blake2 = "0.10.4"
 clap = { version = "4.0.18", features = ["derive"] }
 hex = "0.4.3"
 log = "0.4.14"
-mithril-common = { path = "../../mithril-common", features = ["allow_skip_signer_certification"] }
+mithril-common = { path = "../../mithril-common" }
 rand_chacha = "0.3.1"
 rand_core   = "0.6.3"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+[target.'cfg(not(windows))'.dependencies]
+# non-windows: use default rug backend
+mithril-stm = { path = "../../mithril-stm" }
+
+[target.'cfg(windows)'.dependencies]
+# Windows doesn't support rug backend, fallback to num-integer
+mithril-stm = { path = "../../mithril-stm", default-features = false, features = ["num-integer-backend"] }
+
 [features]
-portable = ["mithril-common/portable"]
+portable = ["mithril-common/portable", "mithril-stm/portable"]

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -7,11 +7,12 @@ use std::fs;
 use std::io::Write;
 use std::path;
 
-use mithril_common::crypto_helper::{
-    key_decode_hex, key_encode_hex, ProtocolClerk, ProtocolInitializerNotCertified,
-    ProtocolKeyRegistrationNotCertified, ProtocolMultiSignature, ProtocolParameters,
-    ProtocolPartyId, ProtocolSigner, ProtocolSignerVerificationKey, ProtocolSingleSignature,
-    ProtocolStake,
+use mithril_common::crypto_helper::{key_decode_hex, key_encode_hex};
+
+use crate::types::{
+    ProtocolClerk, ProtocolInitializerNotCertified, ProtocolKeyRegistrationNotCertified,
+    ProtocolMultiSignature, ProtocolParameters, ProtocolPartyId, ProtocolSigner,
+    ProtocolSignerVerificationKey, ProtocolSingleSignature, ProtocolStake,
 };
 
 /// Player artifacts

--- a/demo/protocol-demo/src/main.rs
+++ b/demo/protocol-demo/src/main.rs
@@ -1,4 +1,5 @@
 mod demonstrator;
+mod types;
 
 use crate::demonstrator::{Demonstrator, ProtocolDemonstrator};
 use clap::Parser;

--- a/demo/protocol-demo/src/types.rs
+++ b/demo/protocol-demo/src/types.rs
@@ -1,0 +1,40 @@
+use mithril_stm::key_reg::KeyReg;
+use mithril_stm::stm::{
+    Stake, StmAggrSig, StmClerk, StmInitializer, StmParameters, StmSig, StmSigner,
+    StmVerificationKeyPoP,
+};
+
+use blake2::{digest::consts::U32, Blake2b};
+
+// Protocol types alias
+type D = Blake2b<U32>;
+
+/// The id of a mithril party.
+pub type ProtocolPartyId = String;
+
+/// Alias of [MithrilStm:Stake](type@mithril_stm::stm::Stake).
+pub type ProtocolStake = Stake;
+
+/// Alias of [MithrilStm::StmParameters](struct@mithril_stm::stm::StmParameters).
+pub type ProtocolParameters = StmParameters;
+
+/// Alias of [MithrilStm:StmSigner](struct@mithril_stm::stm::StmSigner).
+pub type ProtocolSigner = StmSigner<D>;
+
+/// Alias of [MithrilStm:StmClerk](struct@mithril_stm::stm::StmClerk).
+pub type ProtocolClerk = StmClerk<D>;
+
+/// Alias of [MithrilStm:StmInitializer](struct@mithril_stm::stm::StmInitializer).
+pub type ProtocolInitializerNotCertified = StmInitializer;
+
+/// Alias of [MithrilStm:KeyReg](struct@mithril_stm::key_reg::KeyReg). (Test only)
+pub type ProtocolKeyRegistrationNotCertified = KeyReg;
+
+/// Alias of [MithrilStm:StmSig](struct@mithril_stm::stm::StmSig).
+pub type ProtocolSingleSignature = StmSig;
+
+/// Alias of [MithrilStm:StmAggrSig](struct@mithril_stm::stm::StmAggrSig).
+pub type ProtocolMultiSignature = StmAggrSig<D>;
+
+/// Alias of [MithrilStm:StmVerificationKeyPoP](type@mithril_stm::stm::StmVerificationKeyPoP).
+pub type ProtocolSignerVerificationKey = StmVerificationKeyPoP;

--- a/docs/blog/2022-10-11-keys-certification-badge/index.md
+++ b/docs/blog/2022-10-11-keys-certification-badge/index.md
@@ -5,6 +5,10 @@ authors:
 tags: [cardano, poolId, operational-certificate, kes-keys, mithril-keys, hybrid-mode]
 ---
 
+**Update 2022/12/19**: The signer registration with **declarative** PoolId has been decommissioned.
+
+**Update 2022/11/30**: The signer registration with **declarative** PoolId has been deprecated and the **certified** PoolId is now the stable mode.
+
 ### The way the Mithril nodes handle the Certification of the SPOs is evolving
 
 **PR**: `New STM registration procedure` [#433](https://github.com/input-output-hk/mithril/pull/433)

--- a/docs/root/manual/developer-docs/nodes/mithril-signer.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-signer.md
@@ -182,7 +182,7 @@ Here is a list of the available parameters:
 | `db_directory` | `--db-directory` | - | `DB_DIRECTORY` | Directory to snapshot from the **Cardano Node** | `/db` | - | :heavy_check_mark: |
 | `network` | - | - | `NETWORK` | Cardano network | - | `testnet` or `mainnet` or `devnet` | :heavy_check_mark: |
 `network_magic` | - | - | `NETWORK_MAGIC` | Cardano Network Magic number (for `testnet` and `devnet`) | - | `1097911063` or `42` | - |
-| `party_id` | - | - | `PARTY_ID` | Party Id of the signer, usually the `Pool Id` of the SPO | - | `pool1pxaqe80sqpde7902er5kf6v0c7y0sv6d5g676766v2h829fvs3x` | - | Mandatory in `Pool Id Declaration Mode`  where the owner is not verified (soon to be deprecated)
+| `party_id` | - | - | `PARTY_ID` | Party Id of the signer, usually the `Pool Id` of the SPO | - | `pool1pxaqe80sqpde7902er5kf6v0c7y0sv6d5g676766v2h829fvs3x` | - | Mandatory in `Pool Id Declaration Mode`  where the owner is not verified (decommissioned, only available when built with `allow_skip_signer_certification` feature, for test only)
 | `run_interval` | - | - | `RUN_INTERVAL` | Interval between two runtime cycles in ms | - | `60000` | :heavy_check_mark: |
 | `aggregator_endpoint` | - | - | `AGGREGATOR_ENDPOINT` | Aggregator node endpoint | - | `https://aggregator.pre-release-preview.api.mithril.network/aggregator` | :heavy_check_mark: |
 | `data_stores_directory` | - | - | `DATA_STORES_DIRECTORY` | Directory to store signer data (Stakes, Protocol initializers, ...) | - | `./mithril-signer/stores` | :heavy_check_mark: |

--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -35,10 +35,8 @@ For more information about the **Mithril Protocol**, please refer to the [About 
 ## What you'll need
 
 * Operating a **Cardano Node** as a **Stake Pool**:
-  * **Stable**:
-    * The Cardano `Operational Certificate` file of the pool
-    * The Cardano `KES Secret Key` file of the pool
-  * **Deprecated**: The Cardano `Pool Id` in a `BECH32` format such as `pool1frevxe70aqw2ce58c0muyesnahl88nfjjsp25h85jwakzgd2g2l`
+  * The Cardano `Operational Certificate` file of the pool
+  * The Cardano `KES Secret Key` file of the pool
 
 * Access to the file system of a `relay` **Cardano Node** running on the `testnet`:
   * Read rights on the `Database` folder (`--database-path` setting of the **Cardano Node**)
@@ -54,29 +52,14 @@ For more information about the **Mithril Protocol**, please refer to the [About 
 
 ## Mithril Keys Certification
 
-:::danger
 
-The cryptographic certification of the Mithril keys is an experimental feature. We strongly recommend that you first setup a Mithril Signer node in the stable mode. Once you are able to sign in the stable mode is a good time to start experimenting with the keys certification.
+### Certify your Pool Id
 
-Your feedback is very important, so feel free to contact us on the #moria channel on the IOG [Discord server](https://discord.gg/5kaErDKDRq), or to file an issue on GitHub.
-
-:::
-
-### Stable mode: Certify your Pool Id
-
-In this mode, you declare your Cardano `Operational Certificate` file and `KES Secret Key` file which allows to:
+You must declare your Cardano `Operational Certificate` file and `KES Secret Key` file which allows to:
 
 * Compute automatically the `PoolId`
 * Verify that you are the owner of the `PoolId`, and thus of the associated stakes used by Mithril protocol
 * Verify that you are the owner of the Mithril `Signer Secret Key`, and thus allowed to contribute to the multi-signatures and certificate production of the Mithril network
-
-This mode is displayed with a specific **Stable** mention in this document.
-
-### Deprecated mode: Declare your Pool Id
-
-In this mode, the Cardano `Pool Id` that you specify is not strictly verified. It is associated to Cardano stakes based on your declaration. This mode is deprecated and replaced by the certification mode above.
-
-This mode is presented in the setup of this document with a specific **Deprecated** mention.
 
 ## Building your own executable
 
@@ -164,17 +147,9 @@ sudo mv mithril-signer /opt/mithril
 * `User=cardano`:
 Replace this value with the correct user. We assume that the user used to run the **Cardano Node** is `cardano`. The **Mithril Signer** must imperatively run with the same user.
 
-* **Stable mode**: in the `/opt/mithril/mithril-signer/service.env` env file:
+* In the `/opt/mithril/mithril-signer/service.env` env file:
   * `KES_SECRET_KEY_PATH=/cardano/keys/kes.skey`: replace `/cardano/keys/kes.skey` with the path to your Cardano `KES Secret Key` file
   * `OPERATIONAL_CERTIFICATE_PATH=/cardano/cert/opcert.cert`: replace `/cardano/cert/opcert.cert` with the path to your Cardano `Operational Certificate` file
-  * `DB_DIRECTORY=/cardano/db`: replace `/cardano/db` with the path to the database folder of the **Cardano Node** (the one in `--database-path`)
-  * `CARDANO_NODE_SOCKET_PATH=/cardano/ipc/node.socket`: replace with the path to the IPC file (`CARDANO_NODE_SOCKET_PATH` env var)
-  * `CARDANO_CLI_PATH=/app/bin/cardano-cli`: replace with the path to the `cardano-cli` executable
-  * `DATA_STORES_DIRECTORY=/opt/mithril/stores`: replace with the path to a folder where the **Mithril Signer** will store its data (`/opt/mithril/stores` e.g.)
-  * `STORE_RETENTION_LIMIT`: if set, this will limit the number of records in some internal stores (5 is a good fit).
-
-* **Deprecated mode**: in the `/opt/mithril/mithril-signer/service.env` env file:
-  * `PARTY_ID=YOUR_POOL_ID_BECH32`: replace `YOUR_POOL_ID_BECH32` with your BECH32 `Pool Id`
   * `DB_DIRECTORY=/cardano/db`: replace `/cardano/db` with the path to the database folder of the **Cardano Node** (the one in `--database-path`)
   * `CARDANO_NODE_SOCKET_PATH=/cardano/ipc/node.socket`: replace with the path to the IPC file (`CARDANO_NODE_SOCKET_PATH` env var)
   * `CARDANO_CLI_PATH=/app/bin/cardano-cli`: replace with the path to the `cardano-cli` executable
@@ -185,28 +160,10 @@ Replace this value with the correct user. We assume that the user used to run th
 
 First create an env file that will be used by the service:
 
-* **Stable mode**:
-
 ```bash
 sudo bash -c 'cat > /opt/mithril/mithril-signer.env << EOF
 KES_SECRET_KEY_PATH=**YOUR_KES_SECRET_KEY_PATH**
 OPERATIONAL_CERTIFICATE_PATH=**YOUR_OPERATIONAL_CERTIFICATE_PATH**
-NETWORK=**YOUR_CARDANO_NETWORK**
-AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT**
-RUN_INTERVAL=60000
-DB_DIRECTORY=/cardano/db
-CARDANO_NODE_SOCKET_PATH=/cardano/ipc/node.socket
-CARDANO_CLI_PATH=/app/bin/cardano-cli
-DATA_STORES_DIRECTORY=/opt/mithril/stores
-STORE_RETENTION_LIMIT=5
-EOF'
-```
-
-* **Deprecated mode**:
-
-```bash
-sudo bash -c 'cat > /opt/mithril/mithril-signer.env << EOF
-PARTY_ID=**YOUR_POOL_ID_BECH32**
 NETWORK=**YOUR_CARDANO_NETWORK**
 AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT**
 RUN_INTERVAL=60000

--- a/docs/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
+++ b/docs/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
@@ -72,12 +72,6 @@ In this mode, you declare your Cardano `Operational Certificate` file and `KES S
 
 This mode is displayed with a specific **Stable** mention in this document.
 
-### Deprecated mode: Declare your Pool Id
-
-In this mode, the Cardano `Pool Id` that you specify is not strictly verified. It is associated to Cardano stakes based on your declaration. This mode is deprecated and replaced by the certification mode above.
-
-This mode is presented in the setup of this document with a specific **Deprecated** mention.
-
 ## Building your own executable
 
 ### Download source

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -35,7 +35,7 @@ warp = "0.3"
 
 [dev-dependencies]
 httpmock = "0.6.6"
-mithril-common = { path = "../mithril-common", features = ["test_only"] }
+mithril-common = { path = "../mithril-common", features = ["test_only", "allow_skip_signer_certification"] }
 mockall = "0.11.0"
 slog-term = "2.9.0"
 tempfile = "3.3.0"

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -616,11 +616,15 @@ pub mod tests {
     };
     use crate::{MithrilSignerRegisterer, ProtocolParametersStorer, SignerRegistrationRound};
     use mithril_common::chain_observer::FakeObserver;
-    use mithril_common::crypto_helper::tests_setup::setup_certificate_chain;
-    use mithril_common::crypto_helper::{key_decode_hex, ProtocolMultiSignature};
+    use mithril_common::crypto_helper::{
+        key_decode_hex,
+        tests_setup::{setup_certificate_chain, setup_signers},
+        ProtocolMultiSignature,
+    };
     use mithril_common::digesters::DumbImmutableFileObserver;
     use mithril_common::entities::{
-        Beacon, CertificatePending, Epoch, HexEncodedKey, ProtocolMessage, StakeDistribution,
+        Beacon, CertificatePending, Epoch, HexEncodedKey, ProtocolMessage, SignerWithStake,
+        StakeDistribution,
     };
     use mithril_common::{entities::ProtocolMessagePartKey, fake_data, store::StakeStorer};
     use mithril_common::{BeaconProviderImpl, CardanoNetwork};
@@ -856,10 +860,13 @@ pub mod tests {
         let beacon = runner.get_beacon_from_chain().await.unwrap();
         runner.update_beacon(&beacon).await.unwrap();
 
-        let signers = fake_data::signers_with_stakes(5);
+        let protocol_parameters = fake_data::protocol_parameters();
+        let signers = setup_signers(5, &protocol_parameters.clone().into())
+            .into_iter()
+            .map(|s| s.0)
+            .collect::<Vec<SignerWithStake>>();
         let current_signers = signers[1..3].to_vec();
         let next_signers = signers[2..5].to_vec();
-        let protocol_parameters = fake_data::protocol_parameters();
         deps.simulate_genesis(
             current_signers.clone(),
             next_signers.clone(),

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -54,7 +54,7 @@ mithril-stm = { path = "../mithril-stm", default-features = false, features = ["
 slog-scope = "4.4.0"
 
 [features]
-default = ["allow_skip_signer_certification"]
+default = []
 portable = ["mithril-stm/portable"]
 test_only = []
 allow_skip_signer_certification = []

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -131,6 +131,7 @@ impl StmInitializerWrapper {
                 &stm_initializer.verification_key().to_bytes(),
             ))
         } else {
+            println!("WARNING: Non certified signer registration by providing only a Pool Id is decommissionned and must be used for tests only!");
             None
         };
 
@@ -252,7 +253,6 @@ impl KeyRegWrapper {
             if cfg!(not(feature = "allow_skip_signer_certification")) {
                 Err(ProtocolRegistrationErrorWrapper::OpCertMissing)?
             }
-            println!("WARNING: Uncertified signer registration by providing a Pool Id is decommissionned and must be used for tests only! (Pool Id: {:?})", party_id);
             party_id.ok_or(ProtocolRegistrationErrorWrapper::PartyIdMissing)?
         };
 

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -252,7 +252,7 @@ impl KeyRegWrapper {
             if cfg!(not(feature = "allow_skip_signer_certification")) {
                 Err(ProtocolRegistrationErrorWrapper::OpCertMissing)?
             }
-            println!("WARNING: Uncertified signer registration by providing a Pool Id is deprecated and will be removed soon! (Pool Id: {:?})", party_id);
+            println!("WARNING: Uncertified signer registration by providing a Pool Id is decommissionned and must be used for tests only! (Pool Id: {:?})", party_id);
             party_id.ok_or(ProtocolRegistrationErrorWrapper::PartyIdMissing)?
         };
 

--- a/mithril-common/src/crypto_helper/codec.rs
+++ b/mithril-common/src/crypto_helper/codec.rs
@@ -25,27 +25,24 @@ where
 
 #[cfg(test)]
 pub mod tests {
-    use super::super::tests_setup::*;
-    use super::super::types::*;
-    use super::*;
+    use serde::{Deserialize, Serialize};
 
-    use rand_chacha::ChaCha20Rng;
-    use rand_core::SeedableRng;
+    use super::{key_decode_hex, key_encode_hex};
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
+    struct TestSerialize {
+        inner_string: String,
+    }
 
     #[test]
     fn test_key_encode_decode_hex() {
-        let protocol_params = setup_protocol_parameters();
-        let stake = 100;
-        let seed = [0u8; 32];
-        let mut rng = ChaCha20Rng::from_seed(seed);
-        let protocol_initializer =
-            ProtocolInitializerNotCertified::setup(protocol_params, stake, &mut rng);
-        let verification_key: ProtocolSignerVerificationKey =
-            protocol_initializer.verification_key();
-        let verification_key_hex =
-            key_encode_hex(verification_key).expect("unexpected hex encoding error");
-        let verification_key_restored =
-            key_decode_hex(&verification_key_hex).expect("unexpected hex decoding error");
-        assert_eq!(verification_key, verification_key_restored);
+        let test_to_serialize = TestSerialize {
+            inner_string: "my inner string".to_string(),
+        };
+        let test_to_serialize_hex =
+            key_encode_hex(&test_to_serialize).expect("unexpected hex encoding error");
+        let test_to_serialize_restored =
+            key_decode_hex(&test_to_serialize_hex).expect("unexpected hex decoding error");
+        assert_eq!(test_to_serialize, test_to_serialize_restored);
     }
 }

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -281,6 +281,8 @@ pub fn setup_certificate_chain(
                     .unwrap()
                 }
                 _ => {
+                    fake_certificate.metadata.signers =
+                        signers.iter().map(|s| s.0.to_owned()).collect();
                     let mut single_signatures = Vec::new();
                     signers.iter().for_each(|(_, protocol_signer, _)| {
                         if let Some(signature) =

--- a/mithril-common/src/crypto_helper/types.rs
+++ b/mithril-common/src/crypto_helper/types.rs
@@ -8,9 +8,6 @@ use mithril_stm::stm::{
 };
 use mithril_stm::AggregationError;
 
-#[cfg(any(test, feature = "allow_skip_signer_certification"))]
-use mithril_stm::{key_reg::KeyReg, stm::StmInitializer};
-
 use blake2::{digest::consts::U32, Blake2b};
 use ed25519_dalek;
 use kes_summed_ed25519::kes::Sum6KesSig;
@@ -78,12 +75,3 @@ pub type ProtocolRegistrationError = ProtocolRegistrationErrorWrapper;
 
 /// Alias of [MithrilStm:AggregationError](enum@mithril_stm::AggregationError).
 pub type ProtocolAggregationError = AggregationError;
-
-// Test only
-/// (Test only) Alias of [MithrilStm:StmInitializer](struct@mithril_stm::stm::StmInitializer).
-#[cfg(any(test, feature = "allow_skip_signer_certification"))]
-pub type ProtocolInitializerNotCertified = StmInitializer;
-
-/// (Test only) Alias of [MithrilStm:KeyReg](struct@mithril_stm::key_reg::KeyReg). (Test only)
-#[cfg(any(test, feature = "allow_skip_signer_certification"))]
-pub type ProtocolKeyRegistrationNotCertified = KeyReg;

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -27,6 +27,6 @@ tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 
 [features]
-default = ["allow_skip_signer_certification"]
+default = []
 portable = ["mithril-common/portable"]
 allow_skip_signer_certification = []


### PR DESCRIPTION
## Content
This PR decommissions the declarative `PoolId` signer registration mode. Once this PR is merged SPOs will be required to provide their `Operational Certificate` and `KES Secret Key` to certify that they are the owner of a `PoolId`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website
  - [x] Update dev blog post

## Issue(s)
Closes #621 
