### PR TITLE
Extract signer registration from muti-signer in Aggregator

### DIFF
--- a/mithril-aggregator/src/command_args.rs
+++ b/mithril-aggregator/src/command_args.rs
@@ -9,28 +9,23 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::Duration;
 
-use mithril_common::certificate_chain::MithrilCertificateVerifier;
-use mithril_common::chain_observer::{CardanoCliRunner, ChainObserver};
-use mithril_common::crypto_helper::ProtocolGenesisVerifier;
-use mithril_common::database::{ApplicationNodeType, DatabaseVersionChecker};
-use mithril_common::digesters::{CardanoImmutableDigester, ImmutableFileSystemObserver};
-use mithril_common::entities::{Epoch, HexEncodedGenesisSecretKey};
-use mithril_common::store::adapter::SQLiteAdapter;
-use mithril_common::store::StakeStore;
 use mithril_common::{
-    crypto_helper::{key_decode_hex, ProtocolGenesisSigner},
+    certificate_chain::MithrilCertificateVerifier,
+    chain_observer::{CardanoCliRunner, ChainObserver},
+    crypto_helper::{key_decode_hex, ProtocolGenesisSigner, ProtocolGenesisVerifier},
+    database::{ApplicationNodeType, DatabaseVersionChecker},
+    digesters::{CardanoImmutableDigester, ImmutableFileSystemObserver},
+    entities::{Epoch, HexEncodedGenesisSecretKey},
+    store::{adapter::SQLiteAdapter, StakeStore},
     BeaconProviderImpl,
 };
 
-use crate::tools::GenesisToolsDependency;
 use crate::{
-    tools::GenesisTools, AggregatorConfig, AggregatorRunner, AggregatorRuntime,
-    CertificatePendingStore, Configuration, DependencyManager, GenesisConfiguration,
-    ProtocolParametersStore, Server,
-};
-use crate::{
-    CertificateStore, DefaultConfiguration, GzipSnapshotter, MultiSignerImpl,
-    ProtocolParametersStorer, SingleSignatureStore, VerificationKeyStore,
+    tools::{GenesisTools, GenesisToolsDependency},
+    AggregatorConfig, AggregatorRunner, AggregatorRuntime, CertificatePendingStore,
+    CertificateStore, Configuration, DefaultConfiguration, DependencyManager, GenesisConfiguration,
+    GzipSnapshotter, MithrilSignerRegisterer, MultiSignerImpl, ProtocolParametersStore,
+    ProtocolParametersStorer, Server, SingleSignatureStore, VerificationKeyStore,
 };
 
 fn setup_genesis_dependencies(
@@ -377,6 +372,10 @@ impl ServeCommand {
         let genesis_verifier = Arc::new(ProtocolGenesisVerifier::from_verification_key(
             genesis_verification_key,
         ));
+        let signer_registerer = Arc::new(MithrilSignerRegisterer::new(
+            chain_observer.clone(),
+            verification_key_store.clone(),
+        ));
 
         // Snapshotter - Ensure its ongoing snapshot directory exist
         let ongoing_snapshot_directory = config.snapshot_directory.join("pending_snapshot");
@@ -408,6 +407,8 @@ impl ServeCommand {
             snapshotter,
             certificate_verifier,
             genesis_verifier,
+            signer_registerer: signer_registerer.clone(),
+            signer_registration_round_opener: signer_registerer.clone(),
         };
         let dependency_manager = Arc::new(dependency_manager);
 

--- a/mithril-aggregator/src/command_args.rs
+++ b/mithril-aggregator/src/command_args.rs
@@ -45,7 +45,7 @@ fn setup_genesis_dependencies(
     );
     let immutable_file_observer = Arc::new(ImmutableFileSystemObserver::new(&config.db_directory));
     let beacon_provider = Arc::new(BeaconProviderImpl::new(
-        chain_observer.clone(),
+        chain_observer,
         immutable_file_observer,
         config.get_network()?,
     ));
@@ -85,7 +85,6 @@ fn setup_genesis_dependencies(
         stake_store,
         single_signature_store,
         protocol_parameters_store.clone(),
-        chain_observer,
     )));
     let dependencies = GenesisToolsDependency {
         beacon_provider,
@@ -365,7 +364,6 @@ impl ServeCommand {
             stake_store.clone(),
             single_signature_store.clone(),
             protocol_parameters_store.clone(),
-            chain_observer.clone(),
         )));
         let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(slog_scope::logger()));
         let genesis_verification_key = key_decode_hex(&config.genesis_verification_key)?;

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -320,13 +320,11 @@ pub mod tests {
             Box::new(MemoryAdapter::new(None).unwrap()),
             None,
         ));
-        let chain_observer = Arc::new(FakeObserver::default());
         let multi_signer = MultiSignerImpl::new(
             verification_key_store.clone(),
             stake_store.clone(),
             single_signature_store.clone(),
             protocol_parameters_store.clone(),
-            chain_observer,
         );
         let multi_signer = Arc::new(RwLock::new(multi_signer));
         let immutable_file_observer = Arc::new(DumbImmutableFileObserver::default());

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -12,12 +12,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use crate::configuration::*;
 use crate::multi_signer::MultiSigner;
 use crate::snapshot_stores::SnapshotStore;
 use crate::snapshot_uploaders::SnapshotUploader;
 use crate::{
-    CertificatePendingStore, CertificateStore, ProtocolParametersStore, ProtocolParametersStorer,
+    configuration::*, CertificatePendingStore, CertificateStore, ProtocolParametersStore,
+    ProtocolParametersStorer, SignerRegisterer, SignerRegistrationRoundOpener,
     SingleSignatureStore, Snapshotter, VerificationKeyStore, VerificationKeyStorer,
 };
 
@@ -76,6 +76,12 @@ pub struct DependencyManager {
 
     /// Genesis signature verifier service.
     pub genesis_verifier: Arc<ProtocolGenesisVerifier>,
+
+    /// Signer registerer service
+    pub signer_registerer: Arc<dyn SignerRegisterer>,
+
+    /// Signer registration round opener service
+    pub signer_registration_round_opener: Arc<dyn SignerRegistrationRoundOpener>,
 }
 
 #[doc(hidden)]
@@ -248,8 +254,8 @@ pub mod tests {
     use crate::{
         AggregatorConfig, CertificatePendingStore, CertificateStore, Configuration,
         DependencyManager, DumbSnapshotUploader, DumbSnapshotter, LocalSnapshotStore,
-        MultiSignerImpl, ProtocolParametersStore, SingleSignatureStore, SnapshotStoreType,
-        SnapshotUploaderType, VerificationKeyStore,
+        MithrilSignerRegisterer, MultiSignerImpl, ProtocolParametersStore, SingleSignatureStore,
+        SnapshotStoreType, SnapshotUploaderType, VerificationKeyStore,
     };
     use mithril_common::certificate_chain::MithrilCertificateVerifier;
     use mithril_common::crypto_helper::{key_encode_hex, ProtocolGenesisSigner};
@@ -331,6 +337,11 @@ pub mod tests {
             CardanoNetwork::TestNet(42),
         ));
         let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(slog_scope::logger()));
+        let signer_registerer = Arc::new(MithrilSignerRegisterer::new(
+            chain_observer.clone(),
+            verification_key_store.clone(),
+        ));
+
         let dependency_manager = DependencyManager {
             config,
             snapshot_store,
@@ -349,6 +360,8 @@ pub mod tests {
             snapshotter: Arc::new(DumbSnapshotter::new()),
             certificate_verifier,
             genesis_verifier,
+            signer_registerer: signer_registerer.clone(),
+            signer_registration_round_opener: signer_registerer,
         };
 
         let config = AggregatorConfig::new(

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -1,7 +1,6 @@
-use crate::dependency::MultiSignerWrapper;
 use crate::{
-    CertificatePendingStore, CertificateStore, Configuration, DependencyManager,
-    ProtocolParametersStore, SnapshotStore,
+    dependency::MultiSignerWrapper, CertificatePendingStore, CertificateStore, Configuration,
+    DependencyManager, ProtocolParametersStore, SignerRegisterer, SnapshotStore,
 };
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -40,6 +39,13 @@ pub fn with_multi_signer(
     dependency_manager: Arc<DependencyManager>,
 ) -> impl Filter<Extract = (MultiSignerWrapper,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.multi_signer.clone())
+}
+
+/// With signer registerer middleware
+pub fn with_signer_registerer(
+    dependency_manager: Arc<DependencyManager>,
+) -> impl Filter<Extract = (Arc<dyn SignerRegisterer>,), Error = Infallible> + Clone {
+    warp::any().map(move || dependency_manager.signer_registerer.clone())
 }
 
 /// With config middleware

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -18,6 +18,7 @@ mod dependency;
 mod http_server;
 mod multi_signer;
 mod runtime;
+mod signer_registerer;
 mod snapshot_stores;
 mod snapshot_uploaders;
 mod snapshotter;
@@ -35,6 +36,10 @@ pub use command_args::MainOpts;
 pub use dependency::DependencyManager;
 pub use http_server::Server;
 pub use runtime::{AggregatorConfig, AggregatorRunner, AggregatorRunnerTrait, AggregatorRuntime};
+pub use signer_registerer::{
+    MithrilSignerRegisterer, SignerRegisterer, SignerRegistrationError, SignerRegistrationRound,
+    SignerRegistrationRoundOpener,
+};
 pub use snapshot_uploaders::{
     DumbSnapshotUploader, LocalSnapshotUploader, RemoteSnapshotUploader, SnapshotUploader,
 };

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -1,6 +1,6 @@
 use crate::certificate_creator::CertificateCreationError;
 use crate::snapshot_stores::SnapshotStoreError;
-use crate::{ProtocolError, SnapshotError};
+use crate::{ProtocolError, SignerRegistrationError, SnapshotError};
 
 use mithril_common::certificate_chain::CertificateVerifierError;
 use mithril_common::chain_observer::ChainObserverError;
@@ -56,6 +56,9 @@ pub enum RuntimeError {
 
     #[error("beacon comparison error: {0}")]
     BeaconComparisonError(#[from] BeaconComparisonError),
+
+    #[error("signer registration error: {0}")]
+    SignerRegistration(#[from] SignerRegistrationError),
 
     #[error("general error: {0}")]
     General(Box<dyn StdError + Sync + Send>),

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -223,6 +223,9 @@ impl AggregatorRuntime {
         {
             self.runner.update_stake_distribution(&new_beacon).await?;
             self.runner
+                .open_signer_registration_round(&new_beacon)
+                .await?;
+            self.runner
                 .update_protocol_parameters_in_multisigner(&new_beacon)
                 .await?;
         }
@@ -363,6 +366,10 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
+            .expect_open_signer_registration_round()
+            .once()
+            .returning(|_| Ok(()));
+        runner
             .expect_update_protocol_parameters_in_multisigner()
             .with(predicate::eq(fake_data::beacon()))
             .once()
@@ -399,6 +406,10 @@ mod tests {
         runner
             .expect_update_stake_distribution()
             .with(predicate::eq(fake_data::beacon()))
+            .once()
+            .returning(|_| Ok(()));
+        runner
+            .expect_open_signer_registration_round()
             .once()
             .returning(|_| Ok(()));
         runner

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -45,22 +45,33 @@ pub enum SignerRegistrationError {
 }
 
 /// Represents the information needed to handle a signer registration round
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignerRegistrationRound {
     epoch: Epoch,
     stake_distribution: StakeDistribution,
 }
 
+#[cfg(test)]
+impl SignerRegistrationRound {
+    pub fn dummy(epoch: Epoch, stake_distribution: StakeDistribution) -> Self {
+        Self {
+            epoch,
+            stake_distribution,
+        }
+    }
+}
+
 /// Trait to register a signer
-#[async_trait]
 #[cfg_attr(test, automock)]
+#[async_trait]
 pub trait SignerRegisterer: Sync + Send {
     /// Register a signer
     async fn register_signer(&self, signer: &Signer) -> Result<(), SignerRegistrationError>;
 }
 
-// Trait to open a signer registration round
-#[async_trait]
+/// Trait to open a signer registration round
 #[cfg_attr(test, automock)]
+#[async_trait]
 pub trait SignerRegistrationRoundOpener: Sync + Send {
     /// Open a signer registration round
     async fn open_registration_round(
@@ -93,6 +104,11 @@ impl MithrilSignerRegisterer {
             chain_observer,
             verification_key_store,
         }
+    }
+
+    #[cfg(test)]
+    pub async fn get_current_round(&self) -> Option<SignerRegistrationRound> {
+        self.current_round.read().await.as_ref().cloned()
     }
 }
 

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -1,0 +1,300 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::RwLock;
+
+use crate::{VerificationKeyStore, VerificationKeyStorer};
+use mithril_common::{
+    chain_observer::ChainObserver,
+    crypto_helper::{
+        key_decode_hex, KESPeriod, ProtocolKeyRegistration, ProtocolRegistrationError,
+    },
+    entities::{Epoch, Signer, StakeDistribution},
+    store::StoreError,
+};
+
+#[cfg(test)]
+use mockall::automock;
+
+/// Error type for signer registerer service.
+#[derive(Error, Debug)]
+pub enum SignerRegistrationError {
+    /// No signer registration round opened yet
+    #[error("a signer registration round has not yet to be opened")]
+    RegistrationRoundNotYetOpened,
+
+    /// Codec error.
+    #[error("codec error: '{0}'")]
+    Codec(String),
+
+    /// Chain observer error.
+    #[error("chaim observer error: '{0}'")]
+    ChainObserver(String),
+
+    /// Signer is already registered.
+    #[error("signer already registered")]
+    ExistingSigner(),
+
+    /// Store error.
+    #[error("store error: {0}")]
+    StoreError(#[from] StoreError),
+
+    /// Signer registration failed.
+    #[error("signer registration failed")]
+    FailedSignerRegistration(#[from] ProtocolRegistrationError),
+}
+
+/// Represents the information needed to handle a signer registration round
+pub struct SignerRegistrationRound {
+    epoch: Epoch,
+    stake_distribution: StakeDistribution,
+}
+
+/// Trait to register a signer
+#[async_trait]
+#[cfg_attr(test, automock)]
+pub trait SignerRegisterer: Sync + Send {
+    /// Register a signer
+    async fn register_signer(&self, signer: &Signer) -> Result<(), SignerRegistrationError>;
+}
+
+// Trait to open a signer registration round
+#[async_trait]
+#[cfg_attr(test, automock)]
+pub trait SignerRegistrationRoundOpener: Sync + Send {
+    /// Open a signer registration round
+    async fn open_registration_round(
+        &self,
+        registration_epoch: Epoch,
+        stake_distribution: StakeDistribution,
+    ) -> Result<(), SignerRegistrationError>;
+}
+
+/// Implementation of a [SignerRegisterer]
+pub struct MithrilSignerRegisterer {
+    /// Current signer registration round
+    current_round: RwLock<Option<SignerRegistrationRound>>,
+
+    /// Chain observer service.
+    chain_observer: Arc<dyn ChainObserver>,
+
+    /// Verification key store
+    verification_key_store: Arc<VerificationKeyStore>,
+}
+
+impl MithrilSignerRegisterer {
+    /// MithrilSignerRegisterer factory
+    pub fn new(
+        chain_observer: Arc<dyn ChainObserver>,
+        verification_key_store: Arc<VerificationKeyStore>,
+    ) -> Self {
+        Self {
+            current_round: RwLock::new(None),
+            chain_observer,
+            verification_key_store,
+        }
+    }
+}
+
+#[async_trait]
+impl SignerRegistrationRoundOpener for MithrilSignerRegisterer {
+    async fn open_registration_round(
+        &self,
+        registration_epoch: Epoch,
+        stake_distribution: StakeDistribution,
+    ) -> Result<(), SignerRegistrationError> {
+        let mut current_round = self.current_round.write().await;
+        *current_round = Some(SignerRegistrationRound {
+            epoch: registration_epoch,
+            stake_distribution,
+        });
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SignerRegisterer for MithrilSignerRegisterer {
+    async fn register_signer(&self, signer: &Signer) -> Result<(), SignerRegistrationError> {
+        let registration_round = self.current_round.read().await;
+        let registration_round = registration_round
+            .as_ref()
+            .ok_or(SignerRegistrationError::RegistrationRoundNotYetOpened)?;
+
+        let mut key_registration = ProtocolKeyRegistration::init(
+            &registration_round
+                .stake_distribution
+                .iter()
+                .map(|(k, v)| (k.to_owned(), *v))
+                .collect::<Vec<_>>(),
+        );
+        let party_id_register = match signer.party_id.as_str() {
+            "" => None,
+            party_id => Some(party_id.to_string()),
+        };
+        let verification_key =
+            key_decode_hex(&signer.verification_key).map_err(SignerRegistrationError::Codec)?;
+        let verification_key_signature = match &signer.verification_key_signature {
+            Some(verification_key_signature) => Some(
+                key_decode_hex(verification_key_signature)
+                    .map_err(SignerRegistrationError::Codec)?,
+            ),
+            _ => None,
+        };
+        let operational_certificate = match &signer.operational_certificate {
+            Some(operational_certificate) => Some(
+                key_decode_hex(operational_certificate).map_err(SignerRegistrationError::Codec)?,
+            ),
+            _ => None,
+        };
+        let kes_period = match &operational_certificate {
+            Some(operational_certificate) => Some(
+                self.chain_observer
+                    .get_current_kes_period(operational_certificate)
+                    .await
+                    .map_err(|e| SignerRegistrationError::ChainObserver(e.to_string()))?
+                    .unwrap_or_default()
+                    - operational_certificate.start_kes_period as KESPeriod,
+            ),
+            None => None,
+        };
+        let party_id_save = key_registration.register(
+            party_id_register.clone(),
+            operational_certificate,
+            verification_key_signature,
+            kes_period,
+            verification_key,
+        )?;
+        let mut signer_save = signer.to_owned();
+        signer_save.party_id = party_id_save;
+
+        match self
+            .verification_key_store
+            .save_verification_key(registration_round.epoch, signer_save)
+            .await?
+        {
+            Some(_) => Err(SignerRegistrationError::ExistingSigner()),
+            None => Ok(()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use mithril_common::{
+        chain_observer::FakeObserver,
+        crypto_helper::tests_setup::setup_signers,
+        entities::{Epoch, PartyId, Signer},
+        fake_data,
+        store::adapter::MemoryAdapter,
+    };
+
+    use crate::{
+        MithrilSignerRegisterer, SignerRegisterer, SignerRegistrationRoundOpener,
+        VerificationKeyStore, VerificationKeyStorer,
+    };
+
+    #[tokio::test]
+    async fn can_register_signer_if_registration_round_is_opened_with_operational_certificate() {
+        let chain_observer = FakeObserver::default();
+        let verification_key_store = Arc::new(VerificationKeyStore::new(
+            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, Signer>>::new(None).unwrap()),
+            None,
+        ));
+        let signer_registerer =
+            MithrilSignerRegisterer::new(Arc::new(chain_observer), verification_key_store.clone());
+        let registration_epoch = Epoch(1);
+        let signers = setup_signers(5, &fake_data::protocol_parameters().into());
+        let signer_to_register: Signer = signers[0].0.clone().into();
+        assert!(signer_to_register.operational_certificate.is_some());
+        let stake_distribution = signers
+            .into_iter()
+            .map(|s| (s.0.party_id, s.0.stake))
+            .collect::<HashMap<_, _>>();
+
+        signer_registerer
+            .open_registration_round(registration_epoch, stake_distribution)
+            .await
+            .expect("signer registration round opening should not fail");
+
+        signer_registerer
+            .register_signer(&signer_to_register)
+            .await
+            .expect("signer registration should not fail");
+
+        let registered_signers = &verification_key_store
+            .get_verification_keys(registration_epoch)
+            .await
+            .expect("registered signers retrieval should not fail");
+
+        assert_eq!(
+            &Some(HashMap::from([(
+                signer_to_register.party_id.clone(),
+                signer_to_register
+            )])),
+            registered_signers
+        );
+    }
+
+    #[tokio::test]
+    async fn can_register_signer_if_registration_round_is_opened_without_operational_certificate() {
+        let chain_observer = FakeObserver::default();
+        let verification_key_store = Arc::new(VerificationKeyStore::new(
+            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, Signer>>::new(None).unwrap()),
+            None,
+        ));
+        let signer_registerer =
+            MithrilSignerRegisterer::new(Arc::new(chain_observer), verification_key_store.clone());
+        let registration_epoch = Epoch(1);
+        let signers = setup_signers(5, &fake_data::protocol_parameters().into());
+        let signer_to_register: Signer = signers[1].0.clone().into();
+        assert!(signer_to_register.operational_certificate.is_none());
+        let stake_distribution = signers
+            .into_iter()
+            .map(|s| (s.0.party_id, s.0.stake))
+            .collect::<HashMap<_, _>>();
+
+        signer_registerer
+            .open_registration_round(registration_epoch, stake_distribution)
+            .await
+            .expect("signer registration round opening should not fail");
+
+        signer_registerer
+            .register_signer(&signer_to_register)
+            .await
+            .expect("signer registration should not fail");
+
+        let registered_signers = &verification_key_store
+            .get_verification_keys(registration_epoch)
+            .await
+            .expect("registered signers retrieval should not fail");
+
+        assert_eq!(
+            &Some(HashMap::from([(
+                signer_to_register.party_id.clone(),
+                signer_to_register
+            )])),
+            registered_signers
+        );
+    }
+
+    #[tokio::test]
+    async fn cant_register_signer_if_registration_round_is_not_opened() {
+        let chain_observer = FakeObserver::default();
+        let verification_key_store = Arc::new(VerificationKeyStore::new(
+            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, Signer>>::new(None).unwrap()),
+            None,
+        ));
+        let signer_registerer =
+            MithrilSignerRegisterer::new(Arc::new(chain_observer), verification_key_store.clone());
+        let signers = setup_signers(5, &fake_data::protocol_parameters().into());
+        let signer_to_register: Signer = signers[1].0.clone().into();
+
+        signer_registerer
+            .register_signer(&signer_to_register)
+            .await
+            .expect_err("signer registration should fail if no round opened");
+    }
+}

--- a/mithril-aggregator/tests/test_extensions/dependency.rs
+++ b/mithril-aggregator/tests/test_extensions/dependency.rs
@@ -1,8 +1,8 @@
 use mithril_aggregator::{
     AggregatorConfig, CertificatePendingStore, CertificateStore, Configuration, DependencyManager,
-    DumbSnapshotUploader, DumbSnapshotter, LocalSnapshotStore, MultiSignerImpl,
-    ProtocolParametersStore, SingleSignatureStore, SnapshotStoreType, SnapshotUploaderType,
-    VerificationKeyStore,
+    DumbSnapshotUploader, DumbSnapshotter, LocalSnapshotStore, MithrilSignerRegisterer,
+    MultiSignerImpl, ProtocolParametersStore, SingleSignatureStore, SnapshotStoreType,
+    SnapshotUploaderType, VerificationKeyStore,
 };
 use mithril_common::certificate_chain::MithrilCertificateVerifier;
 use mithril_common::chain_observer::FakeObserver;
@@ -87,6 +87,11 @@ pub async fn initialize_dependencies(
         5,
     ));
     let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(slog_scope::logger()));
+    let signer_registerer = Arc::new(MithrilSignerRegisterer::new(
+        chain_observer.clone(),
+        verification_key_store.clone(),
+    ));
+
     let dependency_manager = DependencyManager {
         config,
         snapshot_store,
@@ -105,6 +110,8 @@ pub async fn initialize_dependencies(
         snapshotter,
         certificate_verifier,
         genesis_verifier,
+        signer_registerer: signer_registerer.clone(),
+        signer_registration_round_opener: signer_registerer,
     };
 
     let config = AggregatorConfig::new(

--- a/mithril-aggregator/tests/test_extensions/dependency.rs
+++ b/mithril-aggregator/tests/test_extensions/dependency.rs
@@ -74,7 +74,6 @@ pub async fn initialize_dependencies(
         stake_store.clone(),
         single_signature_store.clone(),
         protocol_parameters_store.clone(),
-        chain_observer.clone(),
     );
     let multi_signer = Arc::new(RwLock::new(multi_signer));
     let beacon_provider = Arc::new(BeaconProviderImpl::new(

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -182,12 +182,11 @@ impl RuntimeTester {
         Ok(new_epoch)
     }
 
-    /// Register the given signers in the multi-signers
+    /// Register the given signers in the registerer
     pub async fn register_signers(&self, signers: &[TestSigner]) -> Result<(), String> {
-        let mut multisigner = self.deps.multi_signer.write().await;
-
         for (signer_with_stake, _protocol_signer, _protocol_initializer) in signers {
-            multisigner
+            self.deps
+                .signer_registerer
                 .register_signer(&signer_with_stake.to_owned().into())
                 .await
                 .map_err(|e| format!("Registering a signer should not fail: {:?}", e))?;

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -252,7 +252,7 @@ impl KeyRegWrapper {
             if cfg!(not(feature = "allow_skip_signer_certification")) {
                 Err(ProtocolRegistrationErrorWrapper::OpCertMissing)?
             }
-            println!("WARNING: Uncertified signer regsitration by providing a Pool Id is deprecated and will be removed soon! (Pool Id: {:?})", party_id);
+            println!("WARNING: Uncertified signer registration by providing a Pool Id is deprecated and will be removed soon! (Pool Id: {:?})", party_id);
             party_id.ok_or(ProtocolRegistrationErrorWrapper::PartyIdMissing)?
         };
 


### PR DESCRIPTION
## Content
This PR extracts the signer registration from the multi-signer in he Aggregator and remove this responsibility from it.

## Pre-submit checklist

- Branch
  - [x] Tests are provided
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Authors
@Alenar 
@ghubertpalo 
@jpraynaud 

## Issue(s)
Closes #642 
