### PR TITLE
Upgrade instances capacity infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,7 +445,7 @@ jobs:
           terraform_backend_bucket: hydra-terraform-admin
           google_region: europe-west1
           google_zone: europe-west1-b
-          google_machine_type: e2-medium
+          google_machine_type: e2-standard-2
           
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -211,7 +211,7 @@ jobs:
           terraform_backend_bucket: hydra-terraform-admin
           google_region: europe-west1
           google_zone: europe-west1-b
-          google_machine_type: e2-medium
+          google_machine_type: e2-standard-2
           
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
## Content
This PR includes an upgrade that moves `testing-preview` and `pre-release-preview` to higher memory instances `e2-standard-2`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

