### PR TITLE
Fix clippy warnings from Rust `1.66.0`

### DIFF
--- a/mithril-aggregator/src/certificate_creator.rs
+++ b/mithril-aggregator/src/certificate_creator.rs
@@ -51,7 +51,7 @@ impl CertificateCreator for MithrilCertificateCreator {
             signers,
         );
         let multi_signature =
-            key_encode_hex(&multi_signature).map_err(CertificateCreationError::Codec)?;
+            key_encode_hex(multi_signature).map_err(CertificateCreationError::Codec)?;
         let genesis_signature = "".to_string();
 
         Ok(entities::Certificate::new(

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -5,7 +5,7 @@ use warp::Filter;
 
 pub fn routes(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     certificate_pending(dependency_manager.clone())
         .or(certificate_certificate_hash(dependency_manager))
 }
@@ -13,7 +13,7 @@ pub fn routes(
 /// GET /certificate-pending
 fn certificate_pending(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("certificate-pending")
         .and(warp::get())
         .and(middlewares::with_certificate_pending_store(
@@ -25,7 +25,7 @@ fn certificate_pending(
 /// GET /certificate/{certificate_hash}
 fn certificate_certificate_hash(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("certificate" / String)
         .and(warp::get())
         .and(middlewares::with_certificate_store(dependency_manager))
@@ -95,7 +95,7 @@ mod tests {
 
     fn setup_router(
         dependency_manager: Arc<DependencyManager>,
-    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
             .allow_headers(vec!["content-type"])

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -5,14 +5,14 @@ use warp::Filter;
 
 pub fn routes(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     epoch_settings(dependency_manager)
 }
 
 /// GET /epoch-settings
 fn epoch_settings(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("epoch-settings")
         .and(warp::get())
         .and(middlewares::with_protocol_parameters_store(
@@ -94,7 +94,7 @@ mod tests {
 
     fn setup_router(
         dependency_manager: Arc<DependencyManager>,
-    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
             .allow_headers(vec!["content-type"])

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -14,7 +14,7 @@ use warp::Filter;
 /// Routes
 pub fn routes(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     let cors = warp::cors()
         .allow_any_origin()
         .allow_headers(vec!["content-type"])

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -5,14 +5,14 @@ use warp::Filter;
 
 pub fn routes(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     register_signatures(dependency_manager)
 }
 
 /// POST /register-signatures
 fn register_signatures(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("register-signatures")
         .and(warp::post())
         .and(warp::body::json())
@@ -68,7 +68,7 @@ mod tests {
 
     fn setup_router(
         dependency_manager: Arc<DependencyManager>,
-    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
             .allow_headers(vec!["content-type"])

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -5,14 +5,14 @@ use warp::Filter;
 
 pub fn routes(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     register_signer(dependency_manager)
 }
 
 /// POST /register-signer
 fn register_signer(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("register-signer")
         .and(warp::post())
         .and(warp::body::json())
@@ -80,7 +80,7 @@ mod tests {
 
     fn setup_router(
         dependency_manager: Arc<DependencyManager>,
-    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
             .allow_headers(vec!["content-type"])

--- a/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
@@ -5,7 +5,7 @@ use warp::Filter;
 
 pub fn routes(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     snapshots(dependency_manager.clone())
         .or(serve_snapshots_dir(dependency_manager.clone()))
         .or(snapshot_download(dependency_manager.clone()))
@@ -15,7 +15,7 @@ pub fn routes(
 /// GET /snapshots
 fn snapshots(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("snapshots")
         .and(warp::get())
         .and(middlewares::with_snapshot_store(dependency_manager))
@@ -25,7 +25,7 @@ fn snapshots(
 /// GET /snapshots/{digest}/download
 fn snapshot_download(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("snapshot" / String / "download")
         .and(warp::get())
         .and(middlewares::with_config(dependency_manager.clone()))
@@ -35,7 +35,7 @@ fn snapshot_download(
 
 fn serve_snapshots_dir(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     let config = dependency_manager.config.clone();
 
     warp::path("snapshot_download")
@@ -47,7 +47,7 @@ fn serve_snapshots_dir(
 /// GET /snapshot/digest
 fn snapshot_digest(
     dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("snapshot" / String)
         .and(warp::get())
         .and(middlewares::with_snapshot_store(dependency_manager))
@@ -182,7 +182,7 @@ mod tests {
 
     fn setup_router(
         dependency_manager: Arc<DependencyManager>,
-    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
             .allow_headers(vec!["content-type"])

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -564,7 +564,7 @@ impl MultiSigner for MultiSignerImpl {
                         signer.verification_key_signature.to_owned(),
                         signer.operational_certificate.to_owned(),
                         signer.kes_period.to_owned(),
-                        *stake as u64,
+                        *stake,
                     )
                 })
             })
@@ -598,7 +598,7 @@ impl MultiSigner for MultiSignerImpl {
                         signer.verification_key_signature.to_owned(),
                         signer.operational_certificate.to_owned(),
                         signer.kes_period.to_owned(),
-                        *stake as u64,
+                        *stake,
                     )
                 })
             })
@@ -851,7 +851,7 @@ mod tests {
 
         offset_epoch(
             &mut multi_signer,
-            (SIGNER_EPOCH_RECORDING_OFFSET - SIGNER_EPOCH_RETRIEVAL_OFFSET) as i64,
+            SIGNER_EPOCH_RECORDING_OFFSET - SIGNER_EPOCH_RETRIEVAL_OFFSET,
         )
         .await;
 
@@ -887,7 +887,7 @@ mod tests {
 
         offset_epoch(
             &mut multi_signer,
-            (SIGNER_EPOCH_RECORDING_OFFSET - SIGNER_EPOCH_RETRIEVAL_OFFSET) as i64,
+            SIGNER_EPOCH_RECORDING_OFFSET - SIGNER_EPOCH_RETRIEVAL_OFFSET,
         )
         .await;
 
@@ -952,7 +952,7 @@ mod tests {
 
         offset_epoch(
             &mut multi_signer,
-            (SIGNER_EPOCH_RECORDING_OFFSET - SIGNER_EPOCH_RETRIEVAL_OFFSET) as i64,
+            SIGNER_EPOCH_RECORDING_OFFSET - SIGNER_EPOCH_RETRIEVAL_OFFSET,
         )
         .await;
         // We have to update the current message AFTER we reached the epoch for

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -549,8 +549,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .get_single_signatures(&working_certificate.beacon)
             .await?
             .unwrap_or_default()
-            .into_iter()
-            .map(|(party_id, _single_signature)| party_id)
+            .into_keys()
             .collect::<Vec<_>>();
         let multi_signature = multisigner.get_multi_signature().await?.ok_or_else(|| {
             RuntimeError::General("no multi signature generated".to_string().into())

--- a/mithril-client/src/aggregator.rs
+++ b/mithril-client/src/aggregator.rs
@@ -443,7 +443,7 @@ mod tests {
         let location = server.url(url_path);
         let local_file_path = aggregator_client.download_snapshot(digest, &location).await;
         local_file_path.as_ref().expect("unexpected error");
-        let data_downloaded = fs::read_to_string(&local_file_path.unwrap()).unwrap();
+        let data_downloaded = fs::read_to_string(local_file_path.unwrap()).unwrap();
 
         assert_eq!(data_downloaded, data_expected);
     }

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -67,7 +67,7 @@ pub trait SerDeShelleyFileFormat: Serialize + DeserializeOwned {
 
     /// Serialize a Cardano Key to file
     fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), ParseError> {
-        let cbor_string = hex::encode(&serde_cbor::to_vec(&self)?);
+        let cbor_string = hex::encode(serde_cbor::to_vec(&self)?);
 
         let file_format = ShelleyFileFormat {
             file_type: Self::TYPE.to_string(),

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -296,7 +296,7 @@ pub fn setup_certificate_chain(
                             fake_certificate.signed_message.as_bytes(),
                         )
                         .unwrap();
-                    fake_certificate.multi_signature = key_encode_hex(&multi_signature).unwrap();
+                    fake_certificate.multi_signature = key_encode_hex(multi_signature).unwrap();
                     fake_certificate.genesis_signature = "".to_string()
                 }
             }

--- a/mithril-common/src/digesters/immutable_file.rs
+++ b/mithril-common/src/digesters/immutable_file.rs
@@ -138,7 +138,7 @@ mod tests {
     fn create_fake_files(parent_dir: &Path, child_filenames: &[&str]) {
         for filename in child_filenames {
             let file = parent_dir.join(Path::new(filename));
-            let mut source_file = File::create(&file).unwrap();
+            let mut source_file = File::create(file).unwrap();
             write!(source_file, "This is a test file named '{}'", filename).unwrap();
         }
     }

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -57,7 +57,7 @@ where
         k,
         m,
         nparties,
-        aggr.to_bytes().len() as usize,
+        aggr.to_bytes().len(),
     );
 }
 

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -903,7 +903,7 @@ mod tests {
                     .map(|(a, stake)| (*a, (stake * adversary_stake) / adversary_sum))
                     .collect();
 
-                let adversaries = adversaries.into_iter().map(|(key, _)| key).collect();
+                let adversaries = adversaries.into_keys().collect();
                 (
                     Just(adversaries),
                     arb_honest_for_adversaries(


### PR DESCRIPTION
## Content
This PR includes a fix to remove clippy warnings that arose with the new version of Rust `1.66.0`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

