### PR TITLE
Fix badge workflow CI status in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <a href='https://github.com/input-output-hk/mithril/actions'>
-    <img src="https://img.shields.io/github/workflow/status/input-output-hk/mithril/CI?label=Tests&style=for-the-badge">
+    <img src="https://img.shields.io/github/actions/workflow/status/input-output-hk/mithril/ci.yml?label=Tests&style=for-the-badge&branch=main">
   </a>
   <a href='https://github.com/input-output-hk/mithril/issues'>
     <img src="https://img.shields.io/github/issues/input-output-hk/mithril?label=Issues&style=for-the-badge">


### PR DESCRIPTION
## Content
This PR includes a fix of the badge showing the status of the CI workflow on the `README` file of the repository which was not displayed anymore and needed to be updated, as explained in https://github.com/badges/shields/issues/8671.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
