### PR TITLE
Deactivate uncertified signers in networks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,11 +438,11 @@ jobs:
             }
           mithril_signers: |
             {
-              "1" = {
-                type    = "unverified",
-                pool_id = "pool18r62tz408lkgfu6pq5svwzkh2vslkeg6mf72qf3h8njgvzhx9ce",
-              },
               "2" = {
+                type    = "verified",
+                pool_id = "",
+              },
+              "3" = {
                 type    = "verified",
                 pool_id = "",
               },

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -199,10 +199,6 @@ jobs:
             }
           mithril_signers: |
             {
-              "1" = {
-                type    = "unverified"
-                pool_id = "pool18r62tz408lkgfu6pq5svwzkh2vslkeg6mf72qf3h8njgvzhx9ce",
-              },
               "2" = {
                 type    = "verified",
                 pool_id = "",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,10 +127,6 @@ jobs:
             }
           mithril_signers: |
             {
-              "1" = {
-                type    = "unverified",
-                pool_id = "pool1zr907nmfsq5kalxdjju349nwg6f03lyfmcjfqcz52jf45gcgh03",
-              },
               "2" = {
                 type    = "verified",
                 pool_id = "",


### PR DESCRIPTION
## Content
This PR deactivates all the uncertified signers in:
* `testing-preview`
* `pre-release-preview`
* `release-preprod`

Also adds a new slot for a verified signer in `testing-preview`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #621 
