### PR TITLE
Upgrade `devnet` to Cardano `1.35.4`

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -4,7 +4,7 @@ inputs:
   build-args:
     description: Arguments to pass to 'cargo build'
     required: false
-    default: '-p mithril-aggregator -p mithril-client -p mithril-common -p mithril-signer -p mithril-stm'
+    default: '--features portable -p mithril-aggregator -p mithril-client -p mithril-common -p mithril-signer -p mithril-stm'
 runs:
   using: "composite"
   steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,10 @@ jobs:
   run-test-lab:
     runs-on: ubuntu-22.04
     needs: [ build-ubuntu-X64 ]
+    strategy:
+      fail-fast: false
+      matrix:
+        run_id: [1,2,3]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -205,7 +209,7 @@ jobs:
         if:  ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:
-          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}
+          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-run_id_${{ matrix.run_id }}
           path: |
             ./artifacts/*
             # including node.sock makes the upload fails so exclude them:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       # We separate the build in 2 steps as we want to avoid side effects with Rust feature unification.
       - name: Cargo build - Tooling
         shell: bash
-        run: cargo build --release --workspace --exclude mithril-aggregator --exclude mithril-client --exclude mithril-signer --exclude mithril-stm
+        run: cargo build --features portable --release --workspace --exclude mithril-aggregator --exclude mithril-client --exclude mithril-signer --exclude mithril-stm
 
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
@@ -96,14 +96,11 @@ jobs:
         
         include:
           - os: ubuntu-22.04
-            build-args: --workspace
-            test-args: --workspace
+            test-args: --features portable --workspace
           # Only test client on windows & mac (since its the only binaries supported for those os for now)
           - os: macos-12
-            build-args: -p mithril-client
             test-args: -p mithril-client
           - os: windows-latest
-            build-args: -p mithril-client
             test-args: -p mithril-client
     
     runs-on: ${{ matrix.os }}
@@ -122,7 +119,7 @@ jobs:
         shell: bash
         run: |
           set -o pipefail && \
-          cargo test --features portable --no-fail-fast ${{ matrix.test-args }} \
+          cargo test --no-fail-fast ${{ matrix.test-args }} \
               -- -Z unstable-options --format json --report-time \
               | tee >(cargo2junit > test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}.xml)
 

--- a/mithril-aggregator/Dockerfile
+++ b/mithril-aggregator/Dockerfile
@@ -57,7 +57,7 @@ WORKDIR /app/
 RUN chown -R appuser /app/
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://storage.googleapis.com/mithril-cardano-node-archive/cardano-1.34.1.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.4-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN /app/bin/cardano-cli --version
 RUN rm -f cardano-bin.tar.gz

--- a/mithril-aggregator/src/command_args.rs
+++ b/mithril-aggregator/src/command_args.rs
@@ -111,7 +111,7 @@ async fn do_first_launch_initialization_if_needed(
         epoch => (
             epoch.offset_to_signer_retrieval_epoch()?,
             epoch.offset_to_next_signer_retrieval_epoch(),
-            epoch.offset_to_next_signer_retrieval_epoch() + 1,
+            epoch.offset_to_next_signer_retrieval_epoch().next(),
         ),
     };
 

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -209,10 +209,14 @@ impl DependencyManager {
 
     /// `TEST METHOD ONLY`
     ///
-    /// Fill the first two epoch of the [ProtocolParametersStore] with the given value.
+    /// Fill up to the first three epochs of the [ProtocolParametersStore] with the given value.
     pub async fn init_protocol_parameter_store(&self, protocol_parameters: &ProtocolParameters) {
         let (work_epoch, epoch_to_sign) = self.get_genesis_epochs().await;
-        for epoch in [work_epoch, epoch_to_sign] {
+        let mut epochs_to_save = Vec::new();
+        epochs_to_save.push(work_epoch);
+        epochs_to_save.push(epoch_to_sign);
+        epochs_to_save.push(epoch_to_sign.next());
+        for epoch in epochs_to_save {
             self.protocol_parameters_store
                 .save_protocol_parameters(epoch, protocol_parameters.clone())
                 .await

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -432,7 +432,7 @@ impl MultiSigner for MultiSignerImpl {
             .as_ref()
             .ok_or_else(ProtocolError::UnavailableBeacon)?
             .epoch
-            .offset_to_recording_epoch();
+            .offset_to_protocol_parameters_recording_epoch();
 
         self.protocol_parameters_store
             .save_protocol_parameters(epoch, protocol_parameters.to_owned().into())
@@ -767,6 +767,10 @@ mod tests {
                     ),
                     (
                         beacon.epoch.offset_to_next_signer_retrieval_epoch(),
+                        fake_data::protocol_parameters(),
+                    ),
+                    (
+                        beacon.epoch.offset_to_next_signer_retrieval_epoch().next(),
                         fake_data::protocol_parameters(),
                     ),
                 ]))

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -789,7 +789,7 @@ pub mod tests {
 
         let saved_protocol_parameters = deps
             .protocol_parameters_store
-            .get_protocol_parameters(beacon.epoch + 1)
+            .get_protocol_parameters(beacon.epoch.offset_to_protocol_parameters_recording_epoch())
             .await
             .unwrap()
             .unwrap_or_else(|| {

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -28,7 +28,7 @@ pub enum SignerRegistrationError {
     Codec(String),
 
     /// Chain observer error.
-    #[error("chaim observer error: '{0}'")]
+    #[error("chain observer error: '{0}'")]
     ChainObserver(String),
 
     /// Signer is already registered.

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -77,7 +77,7 @@ impl GenesisTools {
         let protocol_parameters_store = dependencies.protocol_parameters_store.clone();
 
         let protocol_parameters = protocol_parameters_store
-            .get_protocol_parameters(beacon.epoch)
+            .get_protocol_parameters(beacon.epoch.offset_to_signer_retrieval_epoch()?)
             .await?
             .ok_or_else(|| "Missing protocol parameters".to_string())?;
 

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -22,6 +22,9 @@ impl Epoch {
     /// The epoch offset used for signers stake distribution and verification keys recording.
     pub const SIGNER_RECORDING_OFFSET: u64 = 1;
 
+    /// The epoch offset used for aggregator protocol parameters recording.
+    pub const PROTOCOL_PARAMETERS_RECORDING_OFFSET: u64 = 2;
+
     /// Computes a new Epoch by applying an epoch offset.
     ///
     /// Will fail if the computed epoch is negative.
@@ -46,6 +49,21 @@ impl Epoch {
     /// Apply the [recording offset][Self::SIGNER_RECORDING_OFFSET] to this epoch
     pub fn offset_to_recording_epoch(&self) -> Self {
         *self + Self::SIGNER_RECORDING_OFFSET
+    }
+
+    /// Apply the [protocol parameters recording offset][Self::PROTOCOL_PARAMETERS_RECORDING_OFFSET] to this epoch
+    pub fn offset_to_protocol_parameters_recording_epoch(&self) -> Self {
+        *self + Self::PROTOCOL_PARAMETERS_RECORDING_OFFSET
+    }
+
+    /// Computes the next Epoch
+    pub fn next(&self) -> Self {
+        *self + 1
+    }
+
+    /// Computes the previous Epoch
+    pub fn previous(&self) -> Result<Self, EpochError> {
+        self.offset_by(-1)
     }
 }
 
@@ -161,5 +179,15 @@ mod tests {
         let mut epoch = Epoch(14);
         epoch -= 6_u64;
         assert_eq!(Epoch(8), epoch);
+    }
+
+    #[test]
+    fn test_previous() {
+        assert_eq!(Epoch(2), Epoch(3).previous().unwrap());
+    }
+
+    #[test]
+    fn test_next() {
+        assert_eq!(Epoch(4), Epoch(3).next());
     }
 }

--- a/mithril-signer/Dockerfile
+++ b/mithril-signer/Dockerfile
@@ -56,7 +56,7 @@ COPY --from=rustbuilder /app/config /app/config
 WORKDIR /app/
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz https://storage.googleapis.com/mithril-cardano-node-archive/cardano-1.34.1.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.4-linux.tar.gz
 RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
 RUN /app/bin/cardano-cli --version
 RUN rm -f cardano-bin.tar.gz

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -215,7 +215,10 @@ impl StateMachine {
         let beacon = self.runner.get_current_beacon().await?;
         self.runner.update_stake_distribution(beacon.epoch).await?;
         self.runner
-            .register_signer_to_aggregator(beacon.epoch, &epoch_settings.next_protocol_parameters)
+            .register_signer_to_aggregator(
+                epoch_settings.epoch,
+                &epoch_settings.next_protocol_parameters,
+            )
             .await?;
 
         Ok(RegisteredState { beacon })

--- a/mithril-test-lab/mithril-devnet/devnet-log.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-log.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Default values
 if [ -z "${ROOT}" ]; then 
   ROOT="artifacts"

--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -529,7 +529,7 @@ ls -1 node-*/pool.env
 echo "====================================================================="
 
 cat >> activate.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 EOF
@@ -653,7 +653,7 @@ echo "====================================================================="
 echo
 
 cat >> delegate.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 CURRENT_EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli query tip \\
@@ -719,7 +719,7 @@ echo "====================================================================="
 echo
 
 cat >> query-mithril.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 AGGREGATOR_API_ENDPOINT="http://0.0.0.0:8080/aggregator"
 
@@ -734,7 +734,7 @@ echo
 EOF
 
 cat >> query-cardano.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo ">> Query chain tip"
 CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query tip \\
@@ -764,7 +764,7 @@ echo
 EOF
 
 cat >> query-unused.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo
 echo ">> Query utxo1 utxo 'utxo1.addr'"
@@ -805,7 +805,7 @@ echo "====================================================================="
 echo
 
 cat >> pools.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query stake-pools \\
     --cardano-mode \\
@@ -1124,7 +1124,7 @@ echo
 echo "To start the nodes, in separate terminals use:"
 echo
 cat >> start-cardano.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo ">> Start Cardano network"
 killall cardano-node 2>&1 /dev/null
@@ -1137,7 +1137,7 @@ for NODE in ${BFT_NODES}; do
   echo ./${ROOT}/${NODE}/start-node.sh
 
   cat >> ${NODE}/start-node.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./cardano-node run \\
   --config                          ${NODE}/configuration.yaml \\
@@ -1166,7 +1166,7 @@ for NODE in ${POOL_NODES}; do
   echo ./${ROOT}/${NODE}/start-node.sh
 
   cat >> ${NODE}/start-node.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 ./cardano-node run \\
   --config                          ${NODE}/configuration.yaml \\
@@ -1218,7 +1218,7 @@ EOF
 chmod u+x start-cardano.sh
 
 cat >> start-mithril.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo ">> Start Mithril network"
 if [ -z "\${MITHRIL_IMAGE_ID}" ]; then 
@@ -1279,7 +1279,7 @@ EOF
 chmod u+x start-mithril.sh
 
 cat >> stop.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo ">> Stop Cardano network"
 killall cardano-node
@@ -1299,7 +1299,7 @@ EOF
 chmod u+x stop.sh
 
 cat >> log-mithril.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 SEPARATOR="====================================================================="
 
@@ -1325,7 +1325,7 @@ EOF
 chmod u+x log-mithril.sh
 
 cat >> log-cardano.sh <<EOF
-#!/bin/bash
+#!/usr/bin/env bash
 
 SEPARATOR="====================================================================="
 

--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -317,7 +317,7 @@ echo "====================================================================="
 # Shelley era. Set up our template
 mkdir shelley
 curl -s ${ALONZO_GENESIS_URL} -o shelley/genesis.alonzo.spec.json
-./cardano-cli genesis create --testnet-magic ${NETWORK_MAGIC} --genesis-dir shelley
+./cardano-cli genesis create --testnet-magic ${NETWORK_MAGIC} --genesis-dir shelley --start-time $(date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # Then edit the genesis.spec.json ...
 

--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -48,7 +48,8 @@ SECURITY_PARAM=2
 NODE_PORT_START=3000
 NODE_ADDR_PREFIX="172.16.238"
 NODE_ADDR_INCREMENT=10
-CARDANO_BINARY_URL="https://storage.googleapis.com/mithril-cardano-node-archive/cardano-1.34.1.tar.gz"
+CARDANO_BINARY_URL="https://update-cardano-mainnet.iohk.io/cardano-node-releases/cardano-node-1.35.4-linux.tar.gz"
+ALONZO_GENESIS_URL="https://book.world.dev.cardano.org/environments/pv8/alonzo-genesis.json"
 
 GENESIS_VERIFICATION_KEY=5b33322c3235332c3138362c3230312c3137372c31312c3131372c3133352c3138372c3136372c3138312c3138382c32322c35392c3230362c3130352c3233312c3135302c3231352c33302c37382c3231322c37362c31362c3235322c3138302c37322c3133342c3133372c3234372c3136312c36385d
 GENESIS_SECRET_KEY=5b3131382c3138342c3232342c3137332c3136302c3234312c36312c3134342c36342c39332c3130362c3232392c38332c3133342c3138392c34302c3138392c3231302c32352c3138342c3136302c3134312c3233372c32362c3136382c35342c3233392c3230342c3133392c3131392c31332c3139395d
@@ -315,6 +316,7 @@ echo "====================================================================="
 
 # Shelley era. Set up our template
 mkdir shelley
+curl -s ${ALONZO_GENESIS_URL} -o shelley/genesis.alonzo.spec.json
 ./cardano-cli genesis create --testnet-magic ${NETWORK_MAGIC} --genesis-dir shelley
 
 # Then edit the genesis.spec.json ...
@@ -324,7 +326,7 @@ mkdir shelley
 # cycling KES keys
 sed -i shelley/genesis.spec.json \
     -e 's/"slotLength": 1/"slotLength": '${SLOT_LENGTH}'/' \
-    -e 's/"activeSlotsCoeff": 5.0e-2/"activeSlotsCoeff": 0.05/' \
+    -e 's/"activeSlotsCoeff": 5.0e-2/"activeSlotsCoeff": 0.50/' \
     -e 's/"securityParam": 2160/"securityParam": '${SECURITY_PARAM}'/' \
     -e 's/"epochLength": 432000/"epochLength": '${EPOCH_LENGTH}'/' \
     -e 's/"maxLovelaceSupply": 0/"maxLovelaceSupply": 1000000000/' \
@@ -629,9 +631,10 @@ echo
 
 cat >> delegate.sh <<EOF
 #!/bin/bash
+set -e
 
-CURRENT_EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli query tip  \\
-                    --cardano-mode  \\
+CURRENT_EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli query tip \\
+                    --cardano-mode \\
                     --testnet-magic ${NETWORK_MAGIC} | jq .epoch)
 echo ">>>> Current Epoch: \${CURRENT_EPOCH}"
 EOF
@@ -646,11 +649,14 @@ for N in ${POOL_NODES_N}; do
     
     AMOUNT_STAKED=\$(( $N*1000000 +  DELEGATION_ROUND*1 ))
 
+    TX_IN=\$(CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli query utxo \\
+      --testnet-magic ${NETWORK_MAGIC}  --address \$(cat addresses/utxo${N}.addr) --out-file tmp.txt \\
+      && cat tmp.txt | jq  -r 'to_entries | [last] | .[0].key' \\
+      && rm -f tmp.txt)
+
     CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli transaction build \\
         --alonzo-era \\
-        --tx-in \$(CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli query utxo  \\
-                    --testnet-magic ${NETWORK_MAGIC}  \\
-                    --address \$(cat addresses/utxo${N}.addr) | tail -n 1  | awk '{print \$1;}')#0 \\
+        --tx-in \${TX_IN} \\
         --tx-out \$(cat addresses/user${N}.addr)+\${AMOUNT_STAKED} \\
         --change-address \$(cat addresses/utxo${N}.addr) \\
         --testnet-magic ${NETWORK_MAGIC} \\
@@ -708,27 +714,27 @@ cat >> query-cardano.sh <<EOF
 #!/bin/bash
 
 echo ">> Query chain tip"
-CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query tip  \\
-    --cardano-mode  \\
+CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query tip \\
+    --cardano-mode \\
     --testnet-magic ${NETWORK_MAGIC}
 
 echo
 echo ">> Query whole utxo"
-CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query utxo  \\
-    --cardano-mode  \\
-    --testnet-magic ${NETWORK_MAGIC}   \\
+CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query utxo \\
+    --cardano-mode \\
+    --testnet-magic ${NETWORK_MAGIC} \\
     --whole-utxo
 echo
 
 echo ">> Query stake pools"
 CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query stake-pools \\
-    --cardano-mode  \\
+    --cardano-mode \\
     --testnet-magic ${NETWORK_MAGIC}
 echo
 
 echo ">> Query stake distribution"
 CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query stake-distribution \\
-    --cardano-mode  \\
+    --cardano-mode \\
     --testnet-magic ${NETWORK_MAGIC}
 echo
 
@@ -739,28 +745,28 @@ cat >> query-unused.sh <<EOF
 
 echo
 echo ">> Query utxo1 utxo 'utxo1.addr'"
-CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query utxo  \\
-    --cardano-mode  \\
-    --testnet-magic ${NETWORK_MAGIC}  \\
+CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query utxo \\
+    --cardano-mode \\
+    --testnet-magic ${NETWORK_MAGIC} \\
     --address \$(cat addresses/utxo1.addr)
 
 echo
 echo ">> Query user1 utxo 'user1.addr'"
-CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query utxo  \\
-    --cardano-mode  \\
-    --testnet-magic ${NETWORK_MAGIC}  \\
+CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query utxo \\
+    --cardano-mode \\
+    --testnet-magic ${NETWORK_MAGIC} \\
     --address \$(cat addresses/user1.addr)
 
 echo ">> Query stake pool params"
 echo CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query pool-params \\
-    --cardano-mode  \\
+    --cardano-mode \\
     --testnet-magic ${NETWORK_MAGIC} \\
     --stake-pool-id \${STAKE_POOL_ID}
 echo
 
 echo ">> Query stake pool snapshot"
 echo CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query stake-snapshot \\
-    --cardano-mode  \\
+    --cardano-mode \\
     --testnet-magic ${NETWORK_MAGIC} \\
     --stake-pool-id \${STAKE_POOL_ID}
 echo
@@ -779,7 +785,7 @@ cat >> pools.sh <<EOF
 #!/bin/bash
 
 CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query stake-pools \\
-    --cardano-mode  \\
+    --cardano-mode \\
     --testnet-magic ${NETWORK_MAGIC}
 EOF
 
@@ -1164,8 +1170,8 @@ cat >> start-cardano.sh <<EOF
 echo ">> Wait for Cardano network to be ready"
 while true
 do
-    EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query tip  \\
-        --cardano-mode  \\
+    EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query tip \\
+        --cardano-mode \\
         --testnet-magic ${NETWORK_MAGIC} 2> /dev/null | jq .epoch | sed -e "s/null//" | sed -e "s/ //" | tr -d '\n')
     if [ "\$EPOCH" != "" ] ; then
         echo ">>>> Ready!"
@@ -1224,8 +1230,8 @@ cat >> start-mithril.sh <<EOF
 echo ">> Wait for Mithril signers to be registered"
 while true
 do
-    EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query tip  \\
-        --cardano-mode  \\
+    EPOCH=\$(CARDANO_NODE_SOCKET_PATH=node-bft1/ipc/node.sock ./cardano-cli query tip \\
+        --cardano-mode \\
         --testnet-magic ${NETWORK_MAGIC} 2> /dev/null | jq .epoch | sed -e "s/null//" | sed -e "s/ //" | tr -d '\n')
     if [ \$EPOCH -ge 2 ] ; then
         echo ">>>> Ready!"

--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -620,12 +620,12 @@ do
                 if [ "\$POOL_STAKE_PREVIOUS_EPOCH" != "0" ] ; then
                     break
                 else
-                    echo ">>>> Stakes are not retrievable for this pool yet..."
+                    echo ">>>> Stakes are not retrievable for this pool yet... [attempt \$POOL_STAKE_RETRIEVAL_WAIT_ROUNDS]"
                     sleep 2
                 fi
                 POOL_STAKE_RETRIEVAL_WAIT_ROUNDS=\$(( \$POOL_STAKE_RETRIEVAL_WAIT_ROUNDS + 1 ))
                 if [ "\$POOL_STAKE_RETRIEVAL_WAIT_ROUNDS" -gt "\$POOL_STAKE_RETRIEVAL_WAIT_ROUNDS_MAX" ] ; then
-                    echo ">>>> Error: too many attempts of stakes retrieval for this pool"
+                    echo ">>>> Timeout: could not retrieve stakes of pool \$POOL_ID within \$POOL_STAKE_RETRIEVAL_WAIT_ROUNDS_MAX attempts"
                     exit 1
                 fi
             done
@@ -633,12 +633,12 @@ do
         done
         break
     else
-        echo ">>>> Cardano pools are not activated yet..."
+        echo ">>>> Cardano pools are not activated yet... [attempt \$POOLS_ACTIVATION_WAIT_ROUNDS]"
         sleep 2
     fi
     POOLS_ACTIVATION_WAIT_ROUNDS=\$(( \$POOLS_ACTIVATION_WAIT_ROUNDS + 1 ))
     if [ "\$POOLS_ACTIVATION_WAIT_ROUNDS" -gt "\$POOLS_ACTIVATION_WAIT_ROUNDS_MAX" ] ; then
-        echo ">>>> Error: too many attempts of pools activation wait rounds"
+        echo ">>>> Timeout: pools could not be activated within \$POOLS_ACTIVATION_WAIT_ROUNDS_MAX attempts"
         exit 1
     fi
 done
@@ -1202,12 +1202,12 @@ do
         echo ">>>> Cardano network is ready!"
         break
     else
-        echo ">>>> Cardano network is not ready yet..."
+        echo ">>>> Cardano network is not ready yet... [attempt \$CARDANO_ACTIVATION_WAIT_ROUNDS]"
         sleep 2
     fi
     CARDANO_ACTIVATION_WAIT_ROUNDS=\$(( \$CARDANO_ACTIVATION_WAIT_ROUNDS + 1 ))
     if [ "\$CARDANO_ACTIVATION_WAIT_ROUNDS" -gt "\$CARDANO_ACTIVATION_WAIT_ROUNDS_MAX" ] ; then
-        echo ">>>> Error: too many attempts of Cardano network activation wait rounds"
+        echo ">>>> Timeout: Cardano network could no start within \$CARDANO_ACTIVATION_WAIT_ROUNDS_MAX attempts"
         exit 1
     fi
 done

--- a/mithril-test-lab/mithril-devnet/devnet-query.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-query.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Default values
 if [ -z "${ROOT}" ]; then 
   ROOT="artifacts"

--- a/mithril-test-lab/mithril-devnet/devnet-run.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Default values

--- a/mithril-test-lab/mithril-devnet/devnet-run.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-run.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e
+
 # Default values
 if [ -z "${ROOT}" ]; then 
   ROOT="artifacts"
@@ -65,13 +68,13 @@ echo " Schedule Cardano Stake Delegation"
 echo "====================================================================="
 echo
 DELEGATION_ROUND=0
-echo ">> Begin scheduled delegation"
+echo ">> Begin scheduled stakes delegation"
 while true
 do
-    echo ">> $(date +"%T"): Wait ${DELEGATE_PERIOD}s until next delegation round..."
+    echo ">> $(date +"%T"): Wait ${DELEGATE_PERIOD}s until next stakes delegation round..."
     sleep ${DELEGATE_PERIOD}
     DELEGATION_ROUND=$(( $DELEGATION_ROUND + 1 ))
-    echo ">> Run delegation round #${DELEGATION_ROUND}!"
+    echo ">> Run stakes delegation round #${DELEGATION_ROUND}!"
     DELEGATION_ROUND=${DELEGATION_ROUND} ./delegate.sh
 done
 echo

--- a/mithril-test-lab/mithril-devnet/devnet-stop.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-stop.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Default values
 if [ -z "${ROOT}" ]; then 
   ROOT="artifacts"

--- a/mithril-test-lab/mithril-devnet/devnet-visualize.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-visualize.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Default values
 if [ -z "${ROOT}" ]; then 
   ROOT="artifacts"

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -29,8 +29,8 @@ impl Spec {
             .await?
             .unwrap_or_default();
 
-        // Wait 1 epoch after start epoch for the aggregator to be able to bootstrap a genesis certificate
-        let mut target_epoch = start_epoch + 1;
+        // Wait 2 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
+        let mut target_epoch = start_epoch + 2;
         wait_for_target_epoch(
             self.infrastructure.chain_observer(),
             target_epoch,

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -61,8 +61,8 @@ impl Spec {
         .await?;
         update_protocol_parameters(self.infrastructure.aggregator_mut()).await?;
 
-        // Wait 4 epochs after protocol parameters update, so that we make sure that we use new protocol parameters as well as new stake distribution a few times
-        target_epoch += 4;
+        // Wait 5 epochs after protocol parameters update, so that we make sure that we use new protocol parameters as well as new stake distribution a few times
+        target_epoch += 5;
         wait_for_target_epoch(
             self.infrastructure.chain_observer(),
             target_epoch,

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -39,11 +39,11 @@ pub struct Args {
     number_of_pool_nodes: u8,
 
     /// Length of a Cardano slot in the devnet (in s)
-    #[clap(long, default_value_t = 0.25)]
+    #[clap(long, default_value_t = 0.10)]
     cardano_slot_length: f64,
 
     /// Length of a Cardano epoch in the devnet (in s)
-    #[clap(long, default_value_t = 45.0)]
+    #[clap(long, default_value_t = 100.0)]
     cardano_epoch_length: f64,
 }
 

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -39,11 +39,11 @@ pub struct Args {
     number_of_pool_nodes: u8,
 
     /// Length of a Cardano slot in the devnet (in s)
-    #[clap(long, default_value_t = 0.10)]
+    #[clap(long, default_value_t = 0.18)]
     cardano_slot_length: f64,
 
     /// Length of a Cardano epoch in the devnet (in s)
-    #[clap(long, default_value_t = 100.0)]
+    #[clap(long, default_value_t = 60.0)]
     cardano_epoch_length: f64,
 }
 

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -26,7 +26,7 @@ impl Aggregator {
         let server_port_parameter = server_port.to_string();
         let env = HashMap::from([
             ("NETWORK", "devnet"),
-            ("RUN_INTERVAL", "800"),
+            ("RUN_INTERVAL", "600"),
             ("SERVER_IP", "0.0.0.0"),
             ("SERVER_PORT", &server_port_parameter),
             ("URL_SNAPSHOT_MANIFEST", ""),

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
@@ -27,7 +27,7 @@ impl Signer {
         let data_stores_path = format!("./stores/signer-{}", party_id);
         let mut env = HashMap::from([
             ("NETWORK", "devnet"),
-            ("RUN_INTERVAL", "400"),
+            ("RUN_INTERVAL", "300"),
             ("AGGREGATOR_ENDPOINT", &aggregator_endpoint),
             ("DB_DIRECTORY", pool_node.db_path.to_str().unwrap()),
             ("DATA_STORES_DIRECTORY", &data_stores_path),


### PR DESCRIPTION
## Content
This PR includes an upgrade of the `devnet` Cardano nodes to `1.35.4`.
It also fixes few flakiness that were identified during the testing of the upgrade, and brings some optimization like:
* Adding matrix runs of the end to end tests in order to detect early flakiness
* And better handling of timeout for the launch of the Cardano `devnet` to provide fast fail

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #523 
