### PR TITLE
Update kes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "bech32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1801,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "kes-summed-ed25519"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bd03f6fbbd46e0197115047ace8236ae5a8d434c12083f782db9c4eeefa900"
+checksum = "ff5ba36dcf3798c53cfe222f22038ac63b1a3ef676a68af50a990d2775280cfb"
 dependencies = [
  "blake2 0.9.2",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1802,7 +1802,8 @@ dependencies = [
 [[package]]
 name = "kes-summed-ed25519"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/kes?rev=1418efa#1418efaacaca52ba48bdee0bab56bea1bb1d1ce4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9bd03f6fbbd46e0197115047ace8236ae5a8d434c12083f782db9c4eeefa900"
 dependencies = [
  "blake2 0.9.2",
  "ed25519-dalek",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.0"
+version = "0.2.1"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -27,7 +27,7 @@ glob = "0.3"
 hex = "0.4.3"
 http = "0.2.6"
 jsonschema = "0.16.0"
-kes-summed-ed25519 = { version = "0.1.0", features = ["serde_enabled"] }
+kes-summed-ed25519 = { version = "0.1.1", features = ["serde_enabled"] }
 mockall = "0.11.0"
 nom = "7.1"
 rand-chacha-dalek-compat = { package = "rand_chacha", version = "0.2" }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -27,7 +27,7 @@ glob = "0.3"
 hex = "0.4.3"
 http = "0.2.6"
 jsonschema = "0.16.0"
-kes-summed-ed25519 = { git = "https://github.com/input-output-hk/kes", rev = "1418efa", features = ["serde_enabled"] }
+kes-summed-ed25519 = { version = "0.1.0", features = ["serde_enabled"] }
 mockall = "0.11.0"
 nom = "7.1"
 rand-chacha-dalek-compat = { package = "rand_chacha", version = "0.2" }

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -87,3 +87,33 @@ impl SerDeShelleyFileFormat for Sum6Kes {
     const TYPE: &'static str = "KesSigningKey_ed25519_kes_2^6";
     const DESCRIPTION: &'static str = "KES Signing Key";
 }
+
+#[cfg(all(test))]
+mod test {
+    use super::*;
+
+    #[test]
+    fn compat_with_shelly_format() {
+        let temp_dir = std::env::temp_dir().join("testing");
+        fs::create_dir_all(&temp_dir).expect("temp dir creation should not fail");
+        let sk_dir = temp_dir.join("dummy.skey");
+        let cbor_string = "590260fe77acdfa56281e4b05198f5136018057a65f425411f0990cac4aca0f2917aa00a3d51e191f6f425d870aca3c6a2a41833621f5729d7bc0e3dfc3ae77d057e5e1253b71def7a54157b9f98973ca3c49edd9f311e5f4b23ac268b56a6ac040c14c6d2217925492e42f00dc89a2a01ff363571df0ca0db5ba37001cee56790cc01cd69c6aa760fca55a65a110305ea3c11da0a27be345a589329a584ebfc499c43c55e8c6db5d9c0b014692533ee78abd7ac1e79f7ec9335c7551d31668369b4d5111db78072f010043e35e5ca7f11acc3c05b26b9c7fe56f02aa41544f00cb7685e87f34c73b617260ade3c7b8d8c4df46693694998f85ad80d2cbab0b575b6ccd65d90574e84368169578bff57f751bc94f7eec5c0d7055ec88891a69545eedbfbd3c5f1b1c1fe09c14099f6b052aa215efdc5cb6cdc84aa810db41dbe8cb7d28f7c4beb75cc53915d3ac75fc9d0bf1c734a46e401e15150c147d013a938b7e07cc4f25a582b914e94783d15896530409b8acbe31ef471de8a1988ac78dfb7510729eff008084885f07df870b65e4f382ca15908e1dcda77384b5c724350de90cec22b1dcbb1cdaed88da08bb4772a82266ec154f5887f89860d0920dba705c45957ef6d93e42f6c9509c966277d368dd0eefa67c8147aa15d40a222f7953a4f34616500b310d00aa1b5b73eb237dc4f76c0c16813d321b2fc5ac97039be25b22509d1201d61f4ccc11cd4ff40fffe39f0e937b4722074d8e073a775d7283b715d46f79ce128e3f1362f35615fa72364d20b6db841193d96e58d9d8e86b516bbd1f05e45b39823a93f6e9f29d9e01acf2c12c072d1c64e0afbbabf6903ef542e".to_string();
+
+        let file_format = ShelleyFileFormat {
+            file_type: Sum6Kes::TYPE.to_string(),
+            description: Sum6Kes::DESCRIPTION.to_string(),
+            cbor_hex: cbor_string,
+        };
+
+        let mut file =
+            fs::File::create(sk_dir.clone()).expect("Unexpected error with file creation.");
+        let json_str =
+            serde_json::to_string(&file_format).expect("Unexpected error with serialisation.");
+
+        write!(file, "{}", json_str).expect("Unexpected error writing to file.");
+
+        let kes_sk = Sum6Kes::from_file(&sk_dir);
+
+        assert!(kes_sk.is_ok(), "Failure parsing Shelley file format.");
+    }
+}

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -125,21 +125,21 @@ impl StmInitializerWrapper {
 
             let kes_sk_period = kes_sk.get_period();
             let provided_period = kes_period.unwrap_or_default();
-            if kes_sk_period <= provided_period {
-                // We need to perform the evolutions
-                for period in kes_sk_period..provided_period {
-                    kes_sk
-                        .update()
-                        .map_err(|_| ProtocolInitializerErrorWrapper::KesUpdate(period))?;
-                }
-
-                Some(kes_sk.sign(&stm_initializer.verification_key().to_bytes()))
-            } else {
+            if kes_sk_period > provided_period {
                 return Err(ProtocolInitializerErrorWrapper::KesMismatch(
                     kes_sk_period,
                     provided_period,
                 ));
             }
+
+            // We need to perform the evolutions
+            for period in kes_sk_period..provided_period {
+                kes_sk
+                    .update()
+                    .map_err(|_| ProtocolInitializerErrorWrapper::KesUpdate(period))?;
+            }
+
+            Some(kes_sk.sign(&stm_initializer.verification_key().to_bytes()))
         } else {
             println!("WARNING: Non certified signer registration by providing only a Pool Id is decommissionned and must be used for tests only!");
             None

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -145,7 +145,7 @@ impl StmInitializerWrapper {
 
     /// Extract the verification key signature.
     pub fn verification_key_signature(&self) -> Option<ProtocolSignerVerificationKeySignature> {
-        self.kes_signature.clone()
+        self.kes_signature
     }
 
     /// Extract the stake of the party

--- a/mithril-common/src/crypto_helper/cardano/opcert.rs
+++ b/mithril-common/src/crypto_helper/cardano/opcert.rs
@@ -9,7 +9,7 @@ use blake2::{digest::consts::U28, Blake2b, Digest};
 #[cfg(any(test, feature = "test_only"))]
 use ed25519_dalek::{Keypair as EdKeypair, Signer};
 use ed25519_dalek::{PublicKey as EdPublicKey, Signature as EdSignature, Verifier};
-use kes_summed_ed25519::common::PublicKey as KesPublicKey;
+use kes_summed_ed25519::PublicKey as KesPublicKey;
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sha2::Sha256;

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -4,8 +4,9 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use mithril_common::crypto_helper::{
-    key_decode_hex, key_encode_hex, ProtocolClerk, ProtocolInitializer, ProtocolKeyRegistration,
-    ProtocolPartyId, ProtocolRegistrationError, ProtocolSigner, ProtocolStakeDistribution,
+    key_decode_hex, key_encode_hex, KESPeriod, ProtocolClerk, ProtocolInitializer,
+    ProtocolKeyRegistration, ProtocolPartyId, ProtocolRegistrationError, ProtocolSigner,
+    ProtocolStakeDistribution,
 };
 use mithril_common::entities::{
     PartyId, ProtocolMessage, ProtocolParameters, SignerWithStake, SingleSignatures, Stake,
@@ -38,7 +39,7 @@ impl MithrilProtocolInitializerBuilder {
         stake: &Stake,
         protocol_parameters: &ProtocolParameters,
         kes_secret_key_path: Option<PathBuf>,
-        kes_period: Option<usize>,
+        kes_period: Option<KESPeriod>,
     ) -> Result<ProtocolInitializer, MithrilProtocolInitializerBuilderError> {
         let mut rng = rand_core::OsRng;
         let protocol_initializer = ProtocolInitializer::setup(


### PR DESCRIPTION
## Content
This PR adapts the code to the new version of the KES library. Signatures and Public keys are compatible with older versions. However, secret keys are not. This should not be a backwards compatibility problem, as new nodes will still be compatible with older versions of the protocol and viceversa. However, secret keys serialised with the current library cannot be deserialised with an old version (or by the haskell node). The opposite, however, does work. New nodes will be able to deserialise previous file formats (or ones generated by the haskell node). 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
