### PR TITLE
Stm reduce transmute

### DIFF
--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -14,8 +14,8 @@ use blst::min_sig::{
 };
 use blst::{
     blst_p1, blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_to_affine,
-    blst_p1_uncompress,blst_p2_deserialize, blst_scalar_from_bendian, blst_p2, blst_p2_affine, blst_p2_from_affine, blst_p2_to_affine,
-    blst_scalar, p1_affines, p2_affines,
+    blst_p1_uncompress, blst_p2, blst_p2_affine, blst_p2_deserialize, blst_p2_from_affine,
+    blst_p2_to_affine, blst_scalar, blst_scalar_from_bendian, p1_affines, p2_affines,
 };
 
 use rand_core::{CryptoRng, RngCore};

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -13,9 +13,10 @@ use blst::min_sig::{
     Signature as BlstSig,
 };
 use blst::{
-    blst_p1, blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_to_affine,
-    blst_p1_uncompress, blst_p2, blst_p2_affine, blst_p2_deserialize, blst_p2_from_affine,
-    blst_p2_to_affine, blst_scalar, blst_scalar_from_bendian, p1_affines, p2_affines,
+    blst_p1, blst_p1_affine, blst_p1_compress, blst_p1_deserialize, blst_p1_from_affine,
+    blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_affine, blst_p2_deserialize,
+    blst_p2_from_affine, blst_p2_to_affine, blst_scalar, blst_scalar_from_bendian, p1_affines,
+    p2_affines,
 };
 
 use rand_core::{CryptoRng, RngCore};
@@ -452,10 +453,10 @@ impl Signature {
             .iter()
             .map(|&sig| unsafe {
                 let mut projective_p1 = blst_p1::default();
-                blst_p1_from_affine(
-                    &mut projective_p1,
-                    &std::mem::transmute::<BlstSig, blst_p1_affine>(sig),
-                );
+                let mut affine_p1 = blst_p1_affine::default();
+                let ser_sig = sig.serialize().as_ptr();
+                blst_p1_deserialize(&mut affine_p1, ser_sig);
+                blst_p1_from_affine(&mut projective_p1, &affine_p1);
                 projective_p1
             })
             .collect();

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -440,10 +440,10 @@ impl Signature {
             .iter()
             .map(|vk| unsafe {
                 let mut projective_p2 = blst_p2::default();
-                blst_p2_from_affine(
-                    &mut projective_p2,
-                    &std::mem::transmute::<BlstVk, blst_p2_affine>(vk.0),
-                );
+                let mut affine_p2 = blst_p2_affine::default();
+                let ser_vk = vk.0.serialize().as_ptr();
+                blst_p2_deserialize(&mut affine_p2, ser_vk);
+                blst_p2_from_affine(&mut projective_p2, &affine_p2);
                 projective_p2
             })
             .collect();

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -14,10 +14,10 @@ use blst::min_sig::{
     Signature as BlstSig,
 };
 use blst::{
-    blst_p1, blst_p1_affine, blst_p1_compress, blst_p1_deserialize, blst_p1_from_affine,
-    blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_affine, blst_p2_affine_serialize,
-    blst_p2_deserialize, blst_p2_from_affine, blst_p2_to_affine, blst_scalar,
-    blst_scalar_from_bendian, p1_affines, p2_affines,
+    blst_p1, blst_p1_affine, blst_p1_affine_serialize, blst_p1_compress, blst_p1_deserialize,
+    blst_p1_from_affine, blst_p1_to_affine, blst_p1_uncompress, blst_p2, blst_p2_affine,
+    blst_p2_affine_serialize, blst_p2_deserialize, blst_p2_from_affine, blst_p2_to_affine,
+    blst_scalar, blst_scalar_from_bendian, p1_affines, p2_affines,
 };
 
 use rand_core::{CryptoRng, RngCore};
@@ -474,8 +474,10 @@ impl Signature {
         };
         let aggr_sig: BlstSig = unsafe {
             let mut affine_p1 = blst_p1_affine::default();
+            let mut ser_affine_p1: [u8; 96] = [0u8; 96];
             blst_p1_to_affine(&mut affine_p1, &grouped_sigs.mult(scalars.as_slice(), 128));
-            std::mem::transmute::<blst_p1_affine, BlstSig>(affine_p1)
+            blst_p1_affine_serialize(ser_affine_p1.as_mut_ptr(), &affine_p1);
+            blst::min_sig::Signature::deserialize(&ser_affine_p1).unwrap()
         };
 
         Ok((VerificationKey(aggr_vk), Signature(aggr_sig)))

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -201,7 +201,7 @@ impl From<&SigningKey> for ProofOfPossession {
         let k1 = sk.0.sign(POP, &[], &[]);
         let k2 = unsafe {
             let ser_sk = sk.0.serialize().as_ptr();
-            let mut sk_scalar= blst_scalar::default();
+            let mut sk_scalar = blst_scalar::default();
             blst_scalar_from_bendian(&mut sk_scalar, ser_sk);
             let mut out = blst_p1::default();
             blst_sk_to_pk_in_g1(&mut out, &sk_scalar);


### PR DESCRIPTION
## Content
<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->
This PR aims to reduce or completely remove the use of `transmute` in `multi_sig.rs`. 

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Comments
The following are the benchmark results giving the regression between the versions with `transmute` and `serde`.  The performance has regressed drastically. So, we should consider another way to prevent the possible problems of using `transmute` which is also efficient. As we discussed, a helper structure for unsafe codes could be better @iquerejeta.

```shell
STM/Blake2b/Key registration/k: 25, m: 150, nr_parties: 300
                        time:   [502.24 ms 502.95 ms 503.73 ms]
                        change: [+26.772% +27.320% +27.940%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Play all lotteries/k: 25, m: 150, nr_parties: 300
                        time:   [908.94 µs 910.58 µs 912.56 µs]
                        change: [+31.221% +31.619% +32.056%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Aggregation/k: 25, m: 150, nr_parties: 300
                        time:   [24.401 ms 24.622 ms 24.895 ms]
                        change: [+26.608% +27.610% +29.137%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Key registration/k: 250, m: 1523, nr_parties: 2000
                        time:   [3.3481 s 3.3779 s 3.4273 s]
                        change: [+23.353% +27.009% +30.851%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Play all lotteries/k: 250, m: 1523, nr_parties: 2000
                        time:   [7.5255 ms 7.5313 ms 7.5375 ms]
                        change: [+30.692% +30.971% +31.228%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Aggregation/k: 250, m: 1523, nr_parties: 2000
                        time:   [238.58 ms 238.82 ms 239.12 ms]
                        change: [+24.642% +24.856% +25.077%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Batch Verification/k: 25, m: 150, nr_parties: 300/batch size: 1
                        time:   [2.9301 ms 2.9354 ms 2.9427 ms]
                        change: [+30.118% +30.369% +30.663%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Batch Verification/k: 25, m: 150, nr_parties: 300/batch size: 10
                        time:   [23.629 ms 23.650 ms 23.674 ms]
                        change: [+31.475% +31.664% +31.845%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Batch Verification/k: 25, m: 150, nr_parties: 300/batch size: 20
                        time:   [46.031 ms 46.192 ms 46.431 ms]
                        change: [+32.254% +32.681% +33.157%] (p = 0.00 < 0.05)
                        Performance has regressed.
STM/Blake2b/Batch Verification/k: 25, m: 150, nr_parties: 300/batch size: 100
                        time:   [230.16 ms 230.38 ms 230.62 ms]
                        change: [+31.979% +32.165% +32.361%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Batch Verification/k: 250, m: 1523, nr_parties: 2000/batch size: 1
                        time:   [4.3937 ms 4.4235 ms 4.4583 ms]
                        change: [+18.011% +19.305% +20.655%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Batch Verification/k: 250, m: 1523, nr_parties: 2000/batch size: 10
                        time:   [45.043 ms 45.313 ms 45.601 ms]
                        change: [+22.106% +23.430% +24.636%] (p = 0.00 < 0.05)
                        Performance has regressed.
STM/Blake2b/Batch Verification/k: 250, m: 1523, nr_parties: 2000/batch size: 20
                        time:   [97.238 ms 100.43 ms 104.30 ms]
                        change: [+44.286% +49.695% +54.132%] (p = 0.00 < 0.05)
                        Performance has regressed.

STM/Blake2b/Batch Verification/k: 250, m: 1523, nr_parties: 2000/batch size: 100
                        time:   [396.87 ms 397.68 ms 398.52 ms]
                        change: [+34.851% +35.222% +35.516%] (p = 0.00 < 0.05)
                        Performance has regressed.
``` 




## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Closes #532
