### PR TITLE
Fix `make` errors from root

### DIFF
--- a/mithril-test-lab/Makefile
+++ b/mithril-test-lab/Makefile
@@ -1,0 +1,5 @@
+%:
+    @:
+
+.PHONY: all build test check debug run clean help doc
+


### PR DESCRIPTION
## Content
<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->
This PR adds a `Makefile` to `mithril-test-lab`. This will avoid receiving errors when using the 'make build' command from the root of the repository. This also applies to other arguments of the `make` command: `test check debug run clean help doc`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

