### PR TITLE
Fix make build portable

### DIFF
--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -41,4 +41,4 @@ slog-term = "2.9.0"
 tempfile = "3.3.0"
 
 [features]
-portable = ["mithril-common/portable"]
+portable = ["mithril-common/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it

--- a/mithril-aggregator/Makefile
+++ b/mithril-aggregator/Makefile
@@ -5,7 +5,8 @@ CARGO = cargo
 all: test build
 
 build:
-	${CARGO} build --release
+	# We use 'portable' feature to avoid SIGILL crashes
+	${CARGO} build --release --features portable
 	cp ../target/release/mithril-aggregator .
 
 run: build

--- a/mithril-client/Makefile
+++ b/mithril-client/Makefile
@@ -10,7 +10,8 @@ CARGO = cargo
 all: test build
 
 build:
-	${CARGO} build --release
+	# We use 'portable' feature to avoid SIGILL crashes
+	${CARGO} build --release --features portable
 	cp ../target/release/mithril-client .
 
 run: build

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -64,7 +64,7 @@ slog-term = "2.9.0"
 
 [features]
 default = []
-portable = ["mithril-stm/portable"]
+portable = ["mithril-stm/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 test_only = []
 allow_skip_signer_certification = []
 

--- a/mithril-common/Makefile
+++ b/mithril-common/Makefile
@@ -5,7 +5,8 @@ CARGO = cargo
 all: test build
 
 build:
-	${CARGO} build --release
+	# We use 'portable' feature to avoid SIGILL crashes
+	${CARGO} build --release --features portable
 
 test:
 	${CARGO} test

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -34,4 +34,4 @@ mockall = "0.11.0"
 slog-term = "2.9.0"
 
 [features]
-portable = ["mithril-common/portable"]
+portable = ["mithril-common/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it

--- a/mithril-signer/Makefile
+++ b/mithril-signer/Makefile
@@ -5,7 +5,8 @@ CARGO = cargo
 all: test build
 
 build:
-	${CARGO} build --release
+	# We use 'portable' feature to avoid SIGILL crashes
+	${CARGO} build --release --features portable
 	cp ../target/release/mithril-signer .
 
 run: build

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -58,5 +58,5 @@ harness = false
 default = ["rug-backend"]
 rug-backend = ["rug/default"]
 num-integer-backend = ["num-bigint", "num-rational", "num-traits"]
-portable = ["blst/portable"]
+portable = ["blst/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 benchmark-internals = [] # For benchmarking multi_sig


### PR DESCRIPTION
## Content
This PR activates by default the `portable` feature when building the nodes (to be aligned with the CI build features)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
