### PR TITLE
Fix `make` errors from root v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPONENTS = mithril-common mithril-stm mithril-aggregator mithril-client mithril-signer demo/protocol-demo mithril-test-lab
+COMPONENTS = mithril-common mithril-stm mithril-aggregator mithril-client mithril-signer demo/protocol-demo mithril-test-lab/mithril-end-to-end
 GOALS := $(or $(MAKECMDGOALS),all)
 
 .PHONY: $(GOALS) $(COMPONENTS)

--- a/mithril-test-lab/Makefile
+++ b/mithril-test-lab/Makefile
@@ -1,5 +1,0 @@
-%:
-    @:
-
-.PHONY: all build test check debug run clean help doc
-


### PR DESCRIPTION
## Content
This PR includes a better fix than the one provided in #684, and does not need to introduce a `Makefile` in the `mithril-test-lab` folder (which this PR removes)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
