### PR TITLE
Accelerate end to end test execution

### DIFF
--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -43,7 +43,7 @@ pub struct Args {
     cardano_slot_length: f64,
 
     /// Length of a Cardano epoch in the devnet (in s)
-    #[clap(long, default_value_t = 60.0)]
+    #[clap(long, default_value_t = 45.0)]
     cardano_epoch_length: f64,
 }
 


### PR DESCRIPTION
## Content
This PR includes an optimization that accelerates the execution of the end to end test by reducing epoch length from `60` to `45`. This enables running the end to end test in less than `~2'30"` on an average when it used to take `~3'00"`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

