### PR TITLE
Fix API version sent in wrong header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "clap 4.1.1",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "async-trait",
  "clap 4.1.1",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.10"
+version = "0.2.11"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -4,7 +4,9 @@ use crate::http_server::routes::{
 use crate::http_server::SERVER_BASE_PATH;
 use crate::DependencyManager;
 
-use mithril_common::{MITHRIL_API_VERSION, MITHRIL_API_VERSION_REQUIREMENT};
+use mithril_common::{
+    MITHRIL_API_VERSION, MITHRIL_API_VERSION_HEADER, MITHRIL_API_VERSION_REQUIREMENT,
+};
 
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::StatusCode;
@@ -34,7 +36,7 @@ pub fn routes(
         .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
     let mut headers = HeaderMap::new();
     headers.insert(
-        "mithril-api-version",
+        MITHRIL_API_VERSION_HEADER,
         HeaderValue::from_static(MITHRIL_API_VERSION),
     );
     warp::any()
@@ -54,7 +56,7 @@ pub fn routes(
 
 /// API Version verification
 fn header_must_be() -> impl Filter<Extract = (), Error = Rejection> + Copy {
-    warp::header::optional("mithril-api-version")
+    warp::header::optional(MITHRIL_API_VERSION_HEADER)
         .and_then(|maybe_header: Option<String>| async move {
             match maybe_header {
                 None => Ok(()),
@@ -97,7 +99,7 @@ mod tests {
     async fn test_parse_version_error() {
         let filters = header_must_be();
         warp::test::request()
-            .header("mithril-api-version", "not_a_version")
+            .header(MITHRIL_API_VERSION_HEADER, "not_a_version")
             .path("/aggregator/whatever")
             .filter(&filters)
             .await
@@ -110,7 +112,7 @@ mod tests {
     async fn test_bad_version() {
         let filters = header_must_be();
         warp::test::request()
-            .header("mithril-api-version", "0.0.999")
+            .header(MITHRIL_API_VERSION_HEADER, "0.0.999")
             .path("/aggregator/whatever")
             .filter(&filters)
             .await
@@ -121,7 +123,7 @@ mod tests {
     async fn test_good_version() {
         let filters = header_must_be();
         warp::test::request()
-            .header("mithril-api-version", MITHRIL_API_VERSION)
+            .header(MITHRIL_API_VERSION_HEADER, MITHRIL_API_VERSION)
             .path("/aggregator/whatever")
             .filter(&filters)
             .await

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.2.6"
+version = "0.2.7"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator.rs
+++ b/mithril-client/src/aggregator.rs
@@ -106,7 +106,7 @@ impl AggregatorHTTPClient {
 
     /// Forge a client request adding protocol version in the headers.
     pub fn prepare_request_builder(&self, request_builder: RequestBuilder) -> RequestBuilder {
-        request_builder.header("API_VERSION", MITHRIL_API_VERSION)
+        request_builder.header("mithril-api-version", MITHRIL_API_VERSION)
     }
 
     /// Download certificate details

--- a/mithril-client/src/aggregator.rs
+++ b/mithril-client/src/aggregator.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 use flate2::read::GzDecoder;
 use futures::StreamExt;
+use mithril_common::MITHRIL_API_VERSION_HEADER;
 use reqwest::{self, Response, StatusCode};
 use reqwest::{Client, RequestBuilder};
 use slog_scope::debug;
@@ -106,7 +107,7 @@ impl AggregatorHTTPClient {
 
     /// Forge a client request adding protocol version in the headers.
     pub fn prepare_request_builder(&self, request_builder: RequestBuilder) -> RequestBuilder {
-        request_builder.header("mithril-api-version", MITHRIL_API_VERSION)
+        request_builder.header(MITHRIL_API_VERSION_HEADER, MITHRIL_API_VERSION)
     }
 
     /// Download certificate details
@@ -147,7 +148,7 @@ impl AggregatorHTTPClient {
 
     /// API version error handling
     fn handle_api_error(&self, response: &Response) -> AggregatorHandlerError {
-        if let Some(version) = response.headers().get("mithril-api-version") {
+        if let Some(version) = response.headers().get(MITHRIL_API_VERSION_HEADER) {
             AggregatorHandlerError::ApiVersionMismatch(format!(
                 "server version: '{}', signer version: '{}'",
                 version.to_str().unwrap(),
@@ -390,7 +391,8 @@ mod tests {
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
             when.path("/snapshots");
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let aggregator_client =
             AggregatorHTTPClient::new(config.network, config.aggregator_endpoint);
@@ -456,7 +458,8 @@ mod tests {
         let digest = "digest123";
         let _snapshots_mock = server.mock(|when, then| {
             when.path(format!("/snapshot/{digest}"));
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let aggregator_client =
             AggregatorHTTPClient::new(config.network, config.aggregator_endpoint);
@@ -520,7 +523,8 @@ mod tests {
         let url_path = "/download";
         let _snapshots_mock = server.mock(|when, then| {
             when.path(url_path.to_string());
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let aggregator_client =
             AggregatorHTTPClient::new(config.network, config.aggregator_endpoint);
@@ -593,7 +597,8 @@ mod tests {
         let certificate_hash = "certificate-hash-123";
         let _snapshots_mock = server.mock(|when, then| {
             when.path(format!("/certificate/{certificate_hash}"));
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let aggregator_client =
             AggregatorHTTPClient::new(config.network, config.aggregator_endpoint);

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.9"
+version = "0.2.10"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -34,6 +34,9 @@ use semver::{Version, VersionReq};
 /// please also update the entry in the openapi.yml
 pub const MITHRIL_API_VERSION: &str = "0.1.1";
 
+/// Mithril API protocol version header name
+pub const MITHRIL_API_VERSION_HEADER: &str = "mithril-api-version";
+
 lazy_static! {
     /// The [SemVer version requirement][semver::VersionReq] associated with the [MITHRIL_API_VERSION].
     ///

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.7"
+version = "0.2.8"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/certificate_handler.rs
+++ b/mithril-signer/src/certificate_handler.rs
@@ -94,7 +94,7 @@ impl CertificateHandlerHTTPClient {
 
     /// Forge a client request adding protocol version in the headers.
     pub fn prepare_request_builder(&self, request_builder: RequestBuilder) -> RequestBuilder {
-        request_builder.header("API_VERSION", MITHRIL_API_VERSION)
+        request_builder.header("mithril-api-version", MITHRIL_API_VERSION)
     }
 
     /// API version error handling

--- a/mithril-signer/src/certificate_handler.rs
+++ b/mithril-signer/src/certificate_handler.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 use mithril_common::{
     entities::{CertificatePending, EpochSettings, Signer, SingleSignatures},
     messages::{CertificatePendingMessage, EpochSettingsMessage},
-    MITHRIL_API_VERSION,
+    MITHRIL_API_VERSION, MITHRIL_API_VERSION_HEADER,
 };
 
 #[cfg(test)]
@@ -94,12 +94,12 @@ impl CertificateHandlerHTTPClient {
 
     /// Forge a client request adding protocol version in the headers.
     pub fn prepare_request_builder(&self, request_builder: RequestBuilder) -> RequestBuilder {
-        request_builder.header("mithril-api-version", MITHRIL_API_VERSION)
+        request_builder.header(MITHRIL_API_VERSION_HEADER, MITHRIL_API_VERSION)
     }
 
     /// API version error handling
     fn handle_api_error(&self, response: &Response) -> CertificateHandlerError {
-        if let Some(version) = response.headers().get("mithril-api-version") {
+        if let Some(version) = response.headers().get(MITHRIL_API_VERSION_HEADER) {
             CertificateHandlerError::ApiVersionMismatch(format!(
                 "server version: '{}', signer version: '{}'",
                 version.to_str().unwrap(),
@@ -381,7 +381,8 @@ mod tests {
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
             when.path("/epoch-settings");
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let certificate_handler = CertificateHandlerHTTPClient::new(config.aggregator_endpoint);
         let epoch_settings = certificate_handler
@@ -431,7 +432,8 @@ mod tests {
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
             when.path("/certificate-pending");
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let certificate_handler = CertificateHandlerHTTPClient::new(config.aggregator_endpoint);
         let error = certificate_handler
@@ -489,7 +491,8 @@ mod tests {
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signer");
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let single_signers = fake_data::signers(1);
         let single_signer = single_signers.first().unwrap();
@@ -566,7 +569,8 @@ mod tests {
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
-            then.status(412).header("mithril-api-version", "0.0.999");
+            then.status(412)
+                .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
         let single_signatures = fake_data::single_signatures((1..5).collect());
         let certificate_handler = CertificateHandlerHTTPClient::new(config.aggregator_endpoint);


### PR DESCRIPTION
## Content
This PR includes a fix to use the API enforcement. No verification is actually done without this fix. as the header sent by client and signer nodes is not the one verified by the aggregator.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

