### PR TITLE
Fix clippy warnings from Rust `1.67.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2034,7 +2034,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "async-trait",
  "clap 4.1.1",
@@ -2061,7 +2061,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-trait",
  "clap 4.1.1",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "async-trait",
  "clap 4.1.1",
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -63,9 +63,9 @@ pub struct Party {
 impl Party {
     /// Party factory
     pub fn new(party_id: usize, stake: u64) -> Self {
-        println!("Party #{}: party created with {} stakes", party_id, stake);
+        println!("Party #{party_id}: party created with {stake} stakes");
         Self {
-            party_id: format!("{}", party_id) as ProtocolPartyId,
+            party_id: format!("{party_id}") as ProtocolPartyId,
             stake: stake as ProtocolStake,
             params: None,
             initializer: None,
@@ -225,7 +225,7 @@ impl Verifier {
 
     /// Update protocol parameters
     pub fn update_params(&mut self, params: &ProtocolParameters) {
-        println!("Verifier: protocol params updated to {:?}", params);
+        println!("Verifier: protocol params updated to {params:?}");
         self.params = Some(*params);
     }
 
@@ -242,7 +242,7 @@ impl Verifier {
             .iter()
             .map(|(party_id, stake, _verification_key)| (party_id.to_owned(), *stake))
             .collect::<Vec<_>>();
-        println!("Verifier: protocol keys registration from {:?}", players);
+        println!("Verifier: protocol keys registration from {players:?}");
 
         let mut key_reg = ProtocolKeyRegistrationNotCertified::init();
         for (_party_id, stake, verification_key) in players_with_keys {
@@ -404,7 +404,7 @@ impl ProtocolDemonstrator for Demonstrator {
         let mut multi_signature_artifacts = Vec::new();
         for (i, message) in self.messages.iter().enumerate() {
             // Issue certificates
-            println!("Message #{} to sign: {:?}", i, message);
+            println!("Message #{i} to sign: {message:?}");
             let mut signatures = Vec::<ProtocolSingleSignature>::new();
             for party in self.parties.iter_mut() {
                 if let Some(party_signature) = party.sign_message(message) {
@@ -465,7 +465,7 @@ impl ProtocolDemonstrator for Demonstrator {
 
 /// Write artifacts helper
 pub fn write_artifacts<T: Serialize>(artifact_name: &str, value: &T) {
-    let artifacts_file_path_name = format!("artifacts/{}.json", artifact_name);
+    let artifacts_file_path_name = format!("artifacts/{artifact_name}.json");
     let artifacts_file_path = env::current_dir()
         .unwrap()
         .join(path::Path::new(&artifacts_file_path_name));
@@ -477,7 +477,7 @@ pub fn write_artifacts<T: Serialize>(artifact_name: &str, value: &T) {
         serde_json::to_string_pretty(value).unwrap()
     )
     .unwrap();
-    println!("Artifacts written to {}", artifacts_file_path_name);
+    println!("Artifacts written to {artifacts_file_path_name}");
 }
 
 #[cfg(test)]

--- a/demo/protocol-demo/src/main.rs
+++ b/demo/protocol-demo/src/main.rs
@@ -33,10 +33,7 @@ pub struct Config {
 fn main() {
     let config = Config::parse();
 
-    println!(
-        ">> Launch Mithril protocol demonstrator with configuration: \n{:#?}",
-        config
-    );
+    println!(">> Launch Mithril protocol demonstrator with configuration: \n{config:#?}");
 
     //////////////////////
     // establish phase //
@@ -68,7 +65,7 @@ fn main() {
             println!("\n>> Congrats, protocol terminated with success!\n")
         }
         Err(err) => {
-            println!("\n>> Certificate verification failed: {}\n", err)
+            println!("\n>> Certificate verification failed: {err}\n")
         }
     }
 }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.8"
+version = "0.2.9"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/command_args.rs
+++ b/mithril-aggregator/src/command_args.rs
@@ -309,10 +309,10 @@ impl ServeCommand {
         config_builder = config_builder.add_source(self.clone());
         let config: Configuration = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
-        debug!("SERVE command"; "config" => format!("{:?}", config));
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
+        debug!("SERVE command"; "config" => format!("{config:?}"));
         let sqlite_db_path = Some(config.get_sqlite_file());
         check_database_migration(config.get_sqlite_file())?;
 
@@ -542,10 +542,10 @@ impl ExportGenesisSubCommand {
     ) -> Result<(), Box<dyn Error>> {
         let config: GenesisConfiguration = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
-        debug!("EXPORT GENESIS command"; "config" => format!("{:?}", config));
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
+        debug!("EXPORT GENESIS command"; "config" => format!("{config:?}"));
         println!(
             "Genesis export payload to sign to {}",
             self.target_path.display()
@@ -571,10 +571,10 @@ impl ImportGenesisSubCommand {
     ) -> Result<(), Box<dyn Error>> {
         let config: GenesisConfiguration = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
-        debug!("IMPORT GENESIS command"; "config" => format!("{:?}", config));
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
+        debug!("IMPORT GENESIS command"; "config" => format!("{config:?}"));
         println!(
             "Genesis import signed payload from {}",
             self.signed_payload_path.to_string_lossy()
@@ -602,10 +602,10 @@ impl BootstrapGenesisSubCommand {
     ) -> Result<(), Box<dyn Error>> {
         let config: GenesisConfiguration = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
-        debug!("BOOTSTRAP GENESIS command"; "config" => format!("{:?}", config));
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
+        debug!("BOOTSTRAP GENESIS command"; "config" => format!("{config:?}"));
         println!("Genesis bootstrap for test only!");
         let dependencies = setup_genesis_dependencies(&config)?;
 

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -121,7 +121,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -143,7 +143,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -164,7 +164,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -191,7 +191,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -213,7 +213,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -240,7 +240,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -55,7 +55,7 @@ mod handlers {
                             protocol_parameters,
                             next_protocol_parameters,
                         };
-                        println!("EpochSettings={:?}", epoch_settings);
+                        println!("EpochSettings={epoch_settings:?}");
                         let epoch_settings_message =
                             ToEpochSettingsMessageAdapter::adapt(epoch_settings);
                         Ok(reply::json(&epoch_settings_message, StatusCode::OK))
@@ -116,7 +116,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -137,7 +137,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -101,7 +101,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
@@ -132,7 +132,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
@@ -165,7 +165,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
@@ -198,7 +198,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -112,7 +112,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&signer)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
@@ -142,7 +142,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&signer)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
@@ -176,7 +176,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&signer)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
@@ -209,7 +209,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&signer)
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;

--- a/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/snapshot_routes.rs
@@ -216,7 +216,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -246,7 +246,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -275,7 +275,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -304,7 +304,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -334,7 +334,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -363,7 +363,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -391,7 +391,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 
@@ -421,7 +421,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{}{}", SERVER_BASE_PATH, path))
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
 

--- a/mithril-aggregator/src/main.rs
+++ b/mithril-aggregator/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let result = args.execute().await;
 
     if result.is_err() {
-        eprintln!("ERROR: application ends abnormaly: {:?}", result);
+        eprintln!("ERROR: application ends abnormaly: {result:?}");
     }
 
     result

--- a/mithril-aggregator/src/snapshot_stores/remote_snapshot_store.rs
+++ b/mithril-aggregator/src/snapshot_stores/remote_snapshot_store.rs
@@ -42,8 +42,7 @@ impl SnapshotStore for RemoteSnapshotStore {
                     Err(err) => Err(SnapshotStoreError::Manifest(err.to_string())),
                 },
                 status_error => Err(SnapshotStoreError::Manifest(format!(
-                    "error {} received",
-                    status_error
+                    "error {status_error} received"
                 ))),
             },
             Err(err) => Err(SnapshotStoreError::Manifest(err.to_string())),

--- a/mithril-aggregator/src/snapshot_uploaders/dumb_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/dumb_snapshot_uploader.rs
@@ -24,7 +24,7 @@ impl DumbSnapshotUploader {
         let value = self
             .last_uploaded
             .read()
-            .map_err(|e| format!("Error while saving filepath location: {}", e))?;
+            .map_err(|e| format!("Error while saving filepath location: {e}"))?;
 
         Ok(value.as_ref().map(|v| v.to_string()))
     }
@@ -43,7 +43,7 @@ impl SnapshotUploader for DumbSnapshotUploader {
         let mut value = self
             .last_uploaded
             .write()
-            .map_err(|e| format!("Error while saving filepath location: {}", e))?;
+            .map_err(|e| format!("Error while saving filepath location: {e}"))?;
 
         *value = Some(snapshot_filepath.to_string_lossy().to_string());
 

--- a/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
@@ -33,7 +33,7 @@ impl SnapshotUploader for LocalSnapshotUploader {
         let target_path = &self.target_location.join(archive_name);
         tokio::fs::copy(snapshot_filepath, target_path)
             .await
-            .map_err(|e| format!("Snapshot copy failure: {}", e))?;
+            .map_err(|e| format!("Snapshot copy failure: {e}"))?;
 
         let digest = tools::extract_digest_from_path(Path::new(archive_name));
         let location = format!(
@@ -58,7 +58,7 @@ mod tests {
     use tempfile::tempdir;
 
     fn create_fake_archive(dir: &Path, digest: &str) -> PathBuf {
-        let file_path = dir.join(format!("test.{}.tar.gz", digest));
+        let file_path = dir.join(format!("test.{digest}.tar.gz"));
         let mut file = File::create(&file_path).unwrap();
         writeln!(
             file,

--- a/mithril-aggregator/src/store/certificate_store.rs
+++ b/mithril-aggregator/src/store/certificate_store.rs
@@ -90,7 +90,7 @@ mod test {
         let mut certificates = vec![];
 
         for ix in 0..size {
-            let mut certificate = fake_data::certificate(format!("cert_{:0>2}", ix));
+            let mut certificate = fake_data::certificate(format!("cert_{ix:0>2}"));
             // Change the beacon to properly test [CertificateStore::get_from_beacon]
             certificate.beacon = beacon.clone();
             beacon.immutable_file_number += 1;

--- a/mithril-aggregator/src/store/single_signature_store.rs
+++ b/mithril-aggregator/src/store/single_signature_store.rs
@@ -111,13 +111,13 @@ mod tests {
         for immutable_file_number in 1..=nb_immutable_file_numbers {
             let mut single_signatures: HashMap<PartyId, SingleSignatures> = HashMap::new();
             for party_idx in 1..=single_signers_per_epoch {
-                let party_id = format!("{}", party_idx);
+                let party_id = format!("{party_idx}");
                 let lottery_idx = (1..=single_signatures_per_signers).collect();
                 single_signatures.insert(
                     party_id.clone(),
                     SingleSignatures {
                         party_id,
-                        signature: format!("single-signature {} {:?}", party_idx, lottery_idx),
+                        signature: format!("single-signature {party_idx} {lottery_idx:?}"),
                         won_indexes: lottery_idx,
                     },
                 );

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -104,12 +104,12 @@ mod tests {
             let mut signers: HashMap<PartyId, Signer> = HashMap::new();
 
             for party_idx in 1..=signers_per_epoch {
-                let party_id = format!("{}", party_idx);
+                let party_id = format!("{party_idx}");
                 signers.insert(
                     party_id.clone(),
                     Signer {
                         party_id: party_id.clone(),
-                        verification_key: format!("vkey {}", party_id),
+                        verification_key: format!("vkey {party_id}"),
                         verification_key_signature: None,
                         operational_certificate: None,
                         kes_period: None,

--- a/mithril-aggregator/src/tools/digest_helpers.rs
+++ b/mithril-aggregator/src/tools/digest_helpers.rs
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn should_extract_digest_from_path() {
         let digest = "41e27b9ed5a32531b95b2b7ff3c0757591a06a337efaf19a524a998e348028e7".to_string();
-        let filename = format!("testnet.{}.tar.gz", digest);
+        let filename = format!("testnet.{digest}.tar.gz");
         let result = extract_digest_from_path(Path::new(&filename));
 
         assert_eq!(Ok(digest), result);
@@ -64,7 +64,7 @@ mod tests {
     #[test]
     fn extract_digest_from_path_fail_if_file_named_incorrectly() {
         let digest = "41e27b9ed5a32531b95b2b7ff3c0757591a06a337efaf19a524a998e348028e7".to_string();
-        let filename = format!("{}.zip", digest);
+        let filename = format!("{digest}.zip");
         let result = extract_digest_from_path(Path::new(&filename));
 
         assert_eq!(Err(DigestExtractError::DigestNotFound(filename)), result);
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn extract_digest_from_path_fail_if_tar_file_named_incorrectly() {
         let digest = "41e27b9ed5a32531b95b2b7ff3c0757591a06a337efaf19a524a998e348028e7".to_string();
-        let filename = format!("{}.tar.gz", digest);
+        let filename = format!("{digest}.tar.gz");
         let result = extract_digest_from_path(Path::new(&filename));
 
         assert_eq!(
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn extract_digest_from_path_fail_if_digest_not_hexadecimal() {
         let digest = "not_hexadecimal".to_string();
-        let filename = format!("testnet.{}.tar.gz", digest);
+        let filename = format!("testnet.{digest}.tar.gz");
         let result = extract_digest_from_path(Path::new(&filename));
 
         assert_eq!(Err(DigestExtractError::InvalidDigest(digest)), result);

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -87,7 +87,7 @@ impl RuntimeTester {
         self.runtime
             .cycle()
             .await
-            .map_err(|e| format!("Ticking the state machine should not fail, error: {:?}", e))?;
+            .map_err(|e| format!("Ticking the state machine should not fail, error: {e:?}"))?;
         Ok(())
     }
 
@@ -101,17 +101,14 @@ impl RuntimeTester {
             .beacon_provider
             .get_current_beacon()
             .await
-            .map_err(|e| format!("Querying the current beacon should not fail: {:?}", e))?;
+            .map_err(|e| format!("Querying the current beacon should not fail: {e:?}"))?;
         let protocol_parameters = self
             .deps
             .protocol_parameters_store
             .get_protocol_parameters(beacon.epoch)
             .await
             .map_err(|e| {
-                format!(
-                    "Querying the recording epoch protocol_parameters should not fail: {:?}",
-                    e
-                )
+                format!("Querying the recording epoch protocol_parameters should not fail: {e:?}")
             })?
             .ok_or("A protocol parameters for the epoch should be available")?;
         let first_signer = &&signers
@@ -124,32 +121,22 @@ impl RuntimeTester {
         let genesis_protocol_message = CertificateGenesisProducer::create_genesis_protocol_message(
             &genesis_avk,
         )
-        .map_err(|e| {
-            format!(
-                "Creating the genesis protocol message should not fail: {:?}",
-                e
-            )
-        })?;
+        .map_err(|e| format!("Creating the genesis protocol message should not fail: {e:?}"))?;
         let genesis_signature = genesis_producer
             .sign_genesis_protocol_message(genesis_protocol_message)
-            .map_err(|e| {
-                format!(
-                    "Signing the genesis protocol message should not fail: {:?}",
-                    e
-                )
-            })?;
+            .map_err(|e| format!("Signing the genesis protocol message should not fail: {e:?}"))?;
         let genesis_certificate = CertificateGenesisProducer::create_genesis_certificate(
             protocol_parameters,
             beacon,
             genesis_avk,
             genesis_signature,
         )
-        .map_err(|e| format!("Creating the genesis certificate should not fail: {:?}", e))?;
+        .map_err(|e| format!("Creating the genesis certificate should not fail: {e:?}"))?;
         self.deps
             .certificate_store
             .save(genesis_certificate)
             .await
-            .map_err(|e| format!("Saving the genesis certificate should not fail: {:?}", e))?;
+            .map_err(|e| format!("Saving the genesis certificate should not fail: {e:?}"))?;
         Ok(())
     }
 
@@ -163,16 +150,14 @@ impl RuntimeTester {
             .beacon_provider
             .get_current_beacon()
             .await
-            .map_err(|e| format!("Querying the current beacon should not fail: {:?}", e))?
+            .map_err(|e| format!("Querying the current beacon should not fail: {e:?}"))?
             .immutable_file_number;
 
         if new_immutable_number == updated_number {
             Ok(new_immutable_number)
         } else {
             Err(format!(
-                "beacon_provider immutable file number should've increased, expected:{} / actual:{}",
-                new_immutable_number,
-                updated_number))
+                "beacon_provider immutable file number should've increased, expected:{new_immutable_number} / actual:{updated_number}"))
         }
     }
 
@@ -195,7 +180,7 @@ impl RuntimeTester {
                 .signer_registerer
                 .register_signer(&signer_with_stake.to_owned().into())
                 .await
-                .map_err(|e| format!("Registering a signer should not fail: {:?}", e))?;
+                .map_err(|e| format!("Registering a signer should not fail: {e:?}"))?;
         }
 
         Ok(())
@@ -224,10 +209,7 @@ impl RuntimeTester {
                     .register_single_signature(&single_signatures)
                     .await
                     .map_err(|e| {
-                        format!(
-                            "registering a winning lottery signature should not fail: {:?}",
-                            e
-                        )
+                        format!("registering a winning lottery signature should not fail: {e:?}")
                     })?;
             } else {
                 panic!(
@@ -251,13 +233,13 @@ impl RuntimeTester {
             .certificate_store
             .get_list(1000) // Arbitrary high number to get all of them in store
             .await
-            .map_err(|e| format!("Querying certificate store should not fail {:?}", e))?;
+            .map_err(|e| format!("Querying certificate store should not fail {e:?}"))?;
         let snapshots = self
             .deps
             .snapshot_store
             .list_snapshots()
             .await
-            .map_err(|e| format!("Querying snapshot store should not fail {:?}", e))?;
+            .map_err(|e| format!("Querying snapshot store should not fail {e:?}"))?;
 
         Ok((certificates, snapshots))
     }
@@ -275,17 +257,14 @@ impl RuntimeTester {
             .beacon_provider
             .get_current_beacon()
             .await
-            .map_err(|e| format!("Querying the current beacon should not fail: {:?}", e))?;
+            .map_err(|e| format!("Querying the current beacon should not fail: {e:?}"))?;
         let protocol_parameters = self
             .deps
             .protocol_parameters_store
             .get_protocol_parameters(beacon.epoch.offset_to_recording_epoch())
             .await
             .map_err(|e| {
-                format!(
-                    "Querying the recording epoch protocol_parameters should not fail: {:?}",
-                    e
-                )
+                format!("Querying the recording epoch protocol_parameters should not fail: {e:?}")
             })?
             .ok_or("A protocol parameters for the recording epoch should be available")?;
 
@@ -311,7 +290,7 @@ impl RuntimeTester {
             .beacon_provider
             .get_current_beacon()
             .await
-            .map_err(|e| format!("Querying the current beacon should not fail: {:?}", e))?;
+            .map_err(|e| format!("Querying the current beacon should not fail: {e:?}"))?;
 
         self.digester
             .update_digest(format!(

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.2.5"
+version = "0.2.6"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator.rs
+++ b/mithril-client/src/aggregator.rs
@@ -155,8 +155,7 @@ impl AggregatorHTTPClient {
             ))
         } else {
             AggregatorHandlerError::ApiVersionMismatch(format!(
-                "version precondition failed, sent version '{}'.",
-                MITHRIL_API_VERSION
+                "version precondition failed, sent version '{MITHRIL_API_VERSION}'."
             ))
         }
     }
@@ -314,8 +313,7 @@ impl CertificateRetriever for AggregatorHTTPClient {
 /// Computes local archive filepath
 fn archive_file_path(digest: &str, network: &str) -> Result<PathBuf, AggregatorHandlerError> {
     Ok(env::current_dir()?.join(path::Path::new(&format!(
-        "data/{}/{}/snapshot.archive.tar.gz",
-        network, digest
+        "data/{network}/{digest}/snapshot.archive.tar.gz"
     ))))
 }
 
@@ -362,7 +360,7 @@ mod tests {
             .join(path::Path::new(data_file_name));
         fs::create_dir_all(source_file_path.parent().unwrap()).unwrap();
         let mut source_file = fs::File::create(&source_file_path).unwrap();
-        write!(source_file, "{}", data_expected).unwrap();
+        write!(source_file, "{data_expected}").unwrap();
         let archive_file = fs::File::create(&archive_file_path).unwrap();
         let archive_encoder = GzEncoder::new(&archive_file, Compression::default());
         let mut archive_builder = tar::Builder::new(archive_encoder);
@@ -428,7 +426,7 @@ mod tests {
         let (server, config) = setup_test();
         let snapshot_expected = fake_data::snapshots(1).first().unwrap().to_owned();
         let _snapshots_mock = server.mock(|when, then| {
-            when.path(format!("/snapshot/{}", digest));
+            when.path(format!("/snapshot/{digest}"));
             then.status(200).body(json!(snapshot_expected).to_string());
         });
         let aggregator_client =
@@ -443,7 +441,7 @@ mod tests {
         let digest = "digest123";
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
-            when.path(format!("/snapshot/{}", digest));
+            when.path(format!("/snapshot/{digest}"));
             then.status(404);
         });
         let aggregator_client =
@@ -457,7 +455,7 @@ mod tests {
         let (server, config) = setup_test();
         let digest = "digest123";
         let _snapshots_mock = server.mock(|when, then| {
-            when.path(format!("/snapshot/{}", digest));
+            when.path(format!("/snapshot/{digest}"));
             then.status(412).header("mithril-api-version", "0.0.999");
         });
         let aggregator_client =
@@ -475,7 +473,7 @@ mod tests {
         let digest = "digest123";
         let (server, config) = setup_test();
         let _snapshots_mock = server.mock(|when, then| {
-            when.path(format!("/snapshot/{}", digest));
+            when.path(format!("/snapshot/{digest}"));
             then.status(500);
         });
         let aggregator_client =
@@ -594,7 +592,7 @@ mod tests {
         let (server, config) = setup_test();
         let certificate_hash = "certificate-hash-123";
         let _snapshots_mock = server.mock(|when, then| {
-            when.path(format!("/certificate/{}", certificate_hash));
+            when.path(format!("/certificate/{certificate_hash}"));
             then.status(412).header("mithril-api-version", "0.0.999");
         });
         let aggregator_client =
@@ -611,7 +609,7 @@ mod tests {
         let (server, config) = setup_test();
         let certificate_expected = fake_data::certificate(certificate_hash.to_string());
         let _certificate_mock = server.mock(|when, then| {
-            when.path(format!("/certificate/{}", certificate_hash));
+            when.path(format!("/certificate/{certificate_hash}"));
             then.status(200)
                 .body(json!(certificate_expected).to_string());
         });
@@ -629,7 +627,7 @@ mod tests {
         let certificate_hash = "certificate-hash-123";
         let (server, config) = setup_test();
         let _certificate_mock = server.mock(|when, then| {
-            when.path(format!("/certificate/{}", certificate_hash));
+            when.path(format!("/certificate/{certificate_hash}"));
             then.status(404);
         });
         let aggregator_client =
@@ -645,7 +643,7 @@ mod tests {
         let certificate_hash = "certificate-hash-123";
         let (server, config) = setup_test();
         let _certificate_mock = server.mock(|when, then| {
-            when.path(format!("/certificate/{}", certificate_hash));
+            when.path(format!("/certificate/{certificate_hash}"));
             then.status(500);
         });
         let aggregator_client =

--- a/mithril-client/src/commands/download.rs
+++ b/mithril-client/src/commands/download.rs
@@ -31,9 +31,9 @@ impl DownloadCommand {
         debug!("Download snapshots");
         let config: Config = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
         debug!("{:?}", config);
         let runtime = Runtime::new(config.network.clone());
         let aggregator_handler =
@@ -50,9 +50,9 @@ impl DownloadCommand {
         let output = if self.json {
             serde_json::to_string(&token)?
         } else {
-            format!("success!\n{}", token)
+            format!("success!\n{token}")
         };
-        println!("{}", output);
+        println!("{output}");
         Ok(())
     }
 }

--- a/mithril-client/src/commands/list.rs
+++ b/mithril-client/src/commands/list.rs
@@ -24,9 +24,9 @@ impl ListCommand {
         debug!("List snapshots");
         let config: Config = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
         debug!("{:?}", config);
         let runtime = Runtime::new(config.network.clone());
         let aggregator_handler =

--- a/mithril-client/src/commands/restore.rs
+++ b/mithril-client/src/commands/restore.rs
@@ -44,9 +44,9 @@ impl RestoreCommand {
         debug!("Restore snapshot");
         let config: Config = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
         debug!("{:?}", config);
         let mut runtime = Runtime::new(config.network.clone());
         let aggregator_handler =

--- a/mithril-client/src/commands/show.rs
+++ b/mithril-client/src/commands/show.rs
@@ -27,9 +27,9 @@ impl ShowCommand {
         debug!("Show snapshot");
         let config: Config = config_builder
             .build()
-            .map_err(|e| format!("configuration build error: {}", e))?
+            .map_err(|e| format!("configuration build error: {e}"))?
             .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {}", e))?;
+            .map_err(|e| format!("configuration deserialize error: {e}"))?;
         debug!("{:?}", config);
         let runtime = Runtime::new(config.network.clone());
         let aggregator_handler =

--- a/mithril-client/src/main.rs
+++ b/mithril-client/src/main.rs
@@ -140,5 +140,5 @@ async fn main() -> Result<(), String> {
 
     args.execute()
         .await
-        .map_err(|e| format!("An error occured: {:?}", e))
+        .map_err(|e| format!("An error occured: {e:?}"))
 }

--- a/mithril-client/src/runtime.rs
+++ b/mithril-client/src/runtime.rs
@@ -339,8 +339,7 @@ mod tests {
             .await;
         assert!(
             matches!(snapshot_list_items, Err(RuntimeError::AggregatorHandler(_))),
-            "unexpected error type: {:?}",
-            snapshot_list_items
+            "unexpected error type: {snapshot_list_items:?}"
         );
     }
 
@@ -380,8 +379,7 @@ mod tests {
             .await;
         assert!(
             matches!(snapshot_item, Err(RuntimeError::AggregatorHandler(_))),
-            "unexpected error type: {:?}",
-            snapshot_item
+            "unexpected error type: {snapshot_item:?}"
         );
     }
 
@@ -474,8 +472,7 @@ mod tests {
             .await;
         assert!(
             matches!(restore, Err(RuntimeError::Protocol(_))),
-            "unexpected error type: {:?}",
-            restore
+            "unexpected error type: {restore:?}"
         );
     }
 
@@ -520,8 +517,7 @@ mod tests {
             .await;
         assert!(
             matches!(restore, Err(RuntimeError::ImmutableDigester(_))),
-            "unexpected error type: {:?}",
-            restore
+            "unexpected error type: {restore:?}"
         );
     }
 
@@ -550,8 +546,7 @@ mod tests {
             .await;
         assert!(
             matches!(restore, Err(RuntimeError::AggregatorHandler(_))),
-            "unexpected error type: {:?}",
-            restore
+            "unexpected error type: {restore:?}"
         );
     }
 
@@ -585,8 +580,7 @@ mod tests {
             .await;
         assert!(
             matches!(restore, Err(RuntimeError::CertificateRetriever(_))),
-            "unexpected error type: {:?}",
-            restore
+            "unexpected error type: {restore:?}"
         );
     }
 
@@ -626,8 +620,7 @@ mod tests {
             .await;
         assert!(
             matches!(restore, Err(RuntimeError::AggregatorHandler(_))),
-            "unexpected error type: {:?}",
-            restore
+            "unexpected error type: {restore:?}"
         );
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.8"
+version = "0.2.9"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/benches/digester.rs
+++ b/mithril-common/benches/digester.rs
@@ -27,22 +27,22 @@ fn db_dir() -> PathBuf {
 
 fn create_db(dir: &Path, number_of_immutables: ImmutableFileNumber, file_size: u64) {
     if dir.exists() {
-        fs::remove_dir_all(dir).unwrap_or_else(|e| panic!("Could not remove dir {:?}: {}", dir, e));
+        fs::remove_dir_all(dir).unwrap_or_else(|e| panic!("Could not remove dir {dir:?}: {e}"));
     }
-    fs::create_dir_all(dir).unwrap_or_else(|e| panic!("Could not create dir {:?}: {}", dir, e));
+    fs::create_dir_all(dir).unwrap_or_else(|e| panic!("Could not create dir {dir:?}: {e}"));
 
     // + 1 to simulate "in-progress" immutable trio.
     for filename in (1..=(number_of_immutables + 1)).flat_map(|i| {
         [
-            format!("{:05}.chunk", i),
-            format!("{:05}.primary", i),
-            format!("{:05}.secondary", i),
+            format!("{i:05}.chunk"),
+            format!("{i:05}.primary"),
+            format!("{i:05}.secondary"),
         ]
     }) {
         let file = dir.join(Path::new(&filename));
         let mut source_file = File::create(file).unwrap();
 
-        write!(source_file, "This is a test file named '{}'", filename).unwrap();
+        write!(source_file, "This is a test file named '{filename}'").unwrap();
         writeln!(source_file).unwrap();
         source_file.set_len(file_size).unwrap();
     }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -422,8 +422,7 @@ mod tests {
                 verify,
                 Err(CertificateVerifierError::CertificateChainPreviousHashUnmatch)
             ),
-            "unexpected error type: {:?}",
-            verify
+            "unexpected error type: {verify:?}"
         );
     }
 
@@ -460,8 +459,7 @@ mod tests {
                 verify,
                 Err(CertificateVerifierError::CertificateChainAVKUnmatch)
             ),
-            "unexpected error type: {:?}",
-            verify
+            "unexpected error type: {verify:?}"
         );
     }
 
@@ -487,8 +485,7 @@ mod tests {
                 verify,
                 Err(CertificateVerifierError::CertificateHashUnmatch)
             ),
-            "unexpected error type: {:?}",
-            verify
+            "unexpected error type: {verify:?}"
         );
     }
 
@@ -550,8 +547,7 @@ mod tests {
                 verify,
                 Err(CertificateVerifierError::CertificateChainPreviousHashUnmatch)
             ),
-            "unexpected error type: {:?}",
-            verify
+            "unexpected error type: {verify:?}"
         );
     }
 }

--- a/mithril-common/src/chain_observer/cli_observer.rs
+++ b/mithril-common/src/chain_observer/cli_observer.rs
@@ -217,30 +217,19 @@ impl CardanoCliChainObserver {
         let stake_pool_snapshot: Value = serde_json::from_str(&stake_pool_snapshot_output)
             .map_err(|e| {
                 ChainObserverError::InvalidContent(
-                    format!(
-                        "Error: {:?}, output was = '{}'",
-                        e, stake_pool_snapshot_output
-                    )
-                    .into(),
+                    format!("Error: {e:?}, output was = '{stake_pool_snapshot_output}'").into(),
                 )
             })?;
         if let Value::Number(stake_pool_stake) = &stake_pool_snapshot["poolStakeMark"] {
             return stake_pool_stake.as_u64().ok_or_else(|| {
                 ChainObserverError::InvalidContent(
-                    format!(
-                        "Error: could not parse stake pool value as u64 {:?}",
-                        stake_pool_stake
-                    )
-                    .into(),
+                    format!("Error: could not parse stake pool value as u64 {stake_pool_stake:?}")
+                        .into(),
                 )
             });
         }
         Err(ChainObserverError::InvalidContent(
-            format!(
-                "Error: could not parse stake pool snapshot {:?}",
-                stake_pool_snapshot
-            )
-            .into(),
+            format!("Error: could not parse stake pool snapshot {stake_pool_snapshot:?}").into(),
         ))
     }
 }
@@ -255,7 +244,7 @@ impl ChainObserver for CardanoCliChainObserver {
             .map_err(ChainObserverError::General)?;
         let v: Value = serde_json::from_str(&output).map_err(|e| {
             ChainObserverError::InvalidContent(
-                format!("Error: {:?}, output was = '{}'", e, output).into(),
+                format!("Error: {e:?}, output was = '{output}'").into(),
             )
         })?;
 
@@ -325,7 +314,7 @@ impl ChainObserver for CardanoCliChainObserver {
         let output_cleaned = output.split_at(first_left_curly_bracket_index).1;
         let v: Value = serde_json::from_str(output_cleaned).map_err(|e| {
             ChainObserverError::InvalidContent(
-                format!("Error: {:?}, output was = '{}'", e, output).into(),
+                format!("Error: {e:?}, output was = '{output}'").into(),
             )
         })?;
 

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -80,7 +80,7 @@ pub trait SerDeShelleyFileFormat: Serialize + DeserializeOwned {
         let mut file = fs::File::create(path)?;
         let json_str = serde_json::to_string(&file_format)?;
 
-        write!(file, "{}", json_str)?;
+        write!(file, "{json_str}")?;
         Ok(())
     }
 }
@@ -132,7 +132,7 @@ mod test {
         let json_str =
             serde_json::to_string(&file_format).expect("Unexpected error with serialisation.");
 
-        write!(file, "{}", json_str).expect("Unexpected error writing to file.");
+        write!(file, "{json_str}").expect("Unexpected error writing to file.");
 
         let kes_sk = Sum6Kes::from_file(&sk_dir);
 

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -303,11 +303,11 @@ mod test {
         let keypair = ColdKeyGenerator::create_deterministic_keypair([party_idx as u8; 32]);
         let (kes_secret_key, kes_verification_key) = Sum6Kes::keygen(&mut [party_idx as u8; 32]);
         let operational_certificate = OpCert::new(kes_verification_key, 0, 0, keypair);
-        let kes_secret_key_file = temp_dir.join(format!("kes{}.skey", party_idx));
+        let kes_secret_key_file = temp_dir.join(format!("kes{party_idx}.skey"));
         kes_secret_key
             .to_file(&kes_secret_key_file)
             .expect("KES secret key file export should not fail");
-        let operational_certificate_file = temp_dir.join(format!("pool{}.cert", party_idx));
+        let operational_certificate_file = temp_dir.join(format!("pool{party_idx}.cert"));
         operational_certificate
             .to_file(&operational_certificate_file)
             .expect("operational certificate file export should not fail");

--- a/mithril-common/src/crypto_helper/codec.rs
+++ b/mithril-common/src/crypto_helper/codec.rs
@@ -10,7 +10,7 @@ where
     T: Serialize,
 {
     Ok(serde_json::to_string(&from)
-        .map_err(|e| format!("can't convert to hex: {}", e))?
+        .map_err(|e| format!("can't convert to hex: {e}"))?
         .encode_hex::<String>())
 }
 
@@ -19,8 +19,8 @@ pub fn key_decode_hex<T>(from: &HexEncodedKey) -> Result<T, String>
 where
     T: DeserializeOwned,
 {
-    let from_vec = Vec::from_hex(from).map_err(|e| format!("can't parse from hex: {}", e))?;
-    serde_json::from_slice(from_vec.as_slice()).map_err(|e| format!("can't deserialize: {}", e))
+    let from_vec = Vec::from_hex(from).map_err(|e| format!("can't parse from hex: {e}"))?;
+    serde_json::from_slice(from_vec.as_slice()).map_err(|e| format!("can't deserialize: {e}"))
 }
 
 #[cfg(test)]

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -199,8 +199,8 @@ pub fn setup_certificate_chain(
         .enumerate()
         .map(|(i, epoch)| {
             let immutable_file_number = i as u64 * 10;
-            let digest = format!("digest{}", i);
-            let certificate_hash = format!("certificate_hash-{}", i);
+            let digest = format!("digest{i}");
+            let certificate_hash = format!("certificate_hash-{i}");
             let fixture = fixture_per_epoch.get(&epoch).unwrap();
             let next_fixture = fixture_per_epoch.get(&(epoch + 1)).unwrap();
             let avk = avk_for_signers(&fixture.signers_fixture());

--- a/mithril-common/src/database/db_version.rs
+++ b/mithril-common/src/database/db_version.rs
@@ -28,7 +28,7 @@ impl ApplicationNodeType {
         match node_type {
             "aggregator" => Ok(Self::Aggregator),
             "signer" => Ok(Self::Signer),
-            _ => Err(format!("unknown node type '{}'", node_type).into()),
+            _ => Err(format!("unknown node type '{node_type}'").into()),
         }
     }
 }
@@ -61,12 +61,12 @@ impl SqLiteEntity for DatabaseVersion {
         Ok(Self {
             version: row.get::<i64, _>(0),
             application_type: ApplicationNodeType::new(&row.get::<String, _>(1))
-                .map_err(|e| HydrationError::InvalidData(format!("{}", e)))?,
+                .map_err(|e| HydrationError::InvalidData(format!("{e}")))?,
             updated_at: NaiveDateTime::parse_from_str(
                 &row.get::<String, _>(2),
                 "%Y-%m-%d %H:%M:%S",
             )
-            .map_err(|e| HydrationError::InvalidData(format!("{}", e)))?,
+            .map_err(|e| HydrationError::InvalidData(format!("{e}")))?,
         })
     }
 
@@ -143,7 +143,7 @@ insert into db_version (application_type, version) values ('{application_type}',
         application_type: &ApplicationNodeType,
     ) -> Result<Option<DatabaseVersion>, Box<dyn Error>> {
         let condition = "application_type = ?";
-        let params = [Value::String(format!("{}", application_type))];
+        let params = [Value::String(format!("{application_type}"))];
         let result = self.find(Some(condition), &params)?.next();
 
         Ok(result)

--- a/mithril-common/src/digesters/cache/json_provider.rs
+++ b/mithril-common/src/digesters/cache/json_provider.rs
@@ -122,10 +122,10 @@ mod tests {
 
         if parent_dir.exists() {
             fs::remove_dir_all(&parent_dir)
-                .unwrap_or_else(|e| panic!("Could not remove dir {:?}: {}", parent_dir, e));
+                .unwrap_or_else(|e| panic!("Could not remove dir {parent_dir:?}: {e}"));
         }
         fs::create_dir_all(&parent_dir)
-            .unwrap_or_else(|e| panic!("Could not create dir {:?}: {}", parent_dir, e));
+            .unwrap_or_else(|e| panic!("Could not create dir {parent_dir:?}: {e}"));
 
         parent_dir
     }

--- a/mithril-common/src/digesters/cardano_immutable_digester.rs
+++ b/mithril-common/src/digesters/cardano_immutable_digester.rs
@@ -191,7 +191,7 @@ mod tests {
     }
 
     fn db_builder(dir_name: &str) -> DummyImmutablesDbBuilder {
-        DummyImmutablesDbBuilder::new(&format!("cardano_immutable_digester/{}", dir_name))
+        DummyImmutablesDbBuilder::new(&format!("cardano_immutable_digester/{dir_name}"))
     }
 
     #[test]
@@ -239,7 +239,7 @@ mod tests {
                     found_number: None,
                 }
             ),
-            format!("{:?}", result)
+            format!("{result:?}")
         );
     }
 
@@ -275,7 +275,7 @@ mod tests {
                     found_number: None,
                 }
             ),
-            format!("{:?}", result)
+            format!("{result:?}")
         );
     }
 
@@ -301,7 +301,7 @@ mod tests {
                     found_number: Some(5),
                 }
             ),
-            format!("{:?}", result)
+            format!("{result:?}")
         );
     }
 
@@ -441,9 +441,7 @@ mod tests {
         assert!(
             elapsed_with_cache < (elapsed_without_cache * 9 / 10),
             "digest computation with full cache should be faster than without cache,\
-            time elapsed: with cache {:?}, without cache {:?}",
-            elapsed_with_cache,
-            elapsed_without_cache
+            time elapsed: with cache {elapsed_with_cache:?}, without cache {elapsed_without_cache:?}"
         );
     }
 

--- a/mithril-common/src/digesters/dummy_immutable_db_builder.rs
+++ b/mithril-common/src/digesters/dummy_immutable_db_builder.rs
@@ -101,10 +101,10 @@ impl DummyImmutablesDbBuilder {
 
         if parent_dir.exists() {
             std::fs::remove_dir_all(&parent_dir)
-                .unwrap_or_else(|e| panic!("Could not remove dir {:?}: {}", parent_dir, e));
+                .unwrap_or_else(|e| panic!("Could not remove dir {parent_dir:?}: {e}"));
         }
         std::fs::create_dir_all(&parent_dir)
-            .unwrap_or_else(|e| panic!("Could not create dir {:?}: {}", parent_dir, e));
+            .unwrap_or_else(|e| panic!("Could not create dir {parent_dir:?}: {e}"));
 
         parent_dir
     }
@@ -112,9 +112,9 @@ impl DummyImmutablesDbBuilder {
     fn write_immutable_trio(&self, immutable: ImmutableFileNumber) -> Vec<ImmutableFile> {
         let mut result = vec![];
         for filename in [
-            format!("{:05}.chunk", immutable),
-            format!("{:05}.primary", immutable),
-            format!("{:05}.secondary", immutable),
+            format!("{immutable:05}.chunk"),
+            format!("{immutable:05}.primary"),
+            format!("{immutable:05}.secondary"),
         ] {
             let file = self.write_dummy_file(&filename);
             result.push(ImmutableFile {
@@ -132,7 +132,7 @@ impl DummyImmutablesDbBuilder {
         let file = self.dir.join(Path::new(filename));
         let mut source_file = File::create(&file).unwrap();
 
-        write!(source_file, "This is a test file named '{}'", filename).unwrap();
+        write!(source_file, "This is a test file named '{filename}'").unwrap();
 
         if let Some(file_size) = self.file_size {
             writeln!(source_file).unwrap();

--- a/mithril-common/src/digesters/immutable_file.rs
+++ b/mithril-common/src/digesters/immutable_file.rs
@@ -163,10 +163,10 @@ mod tests {
 
         if parent_dir.exists() {
             fs::remove_dir_all(&parent_dir)
-                .unwrap_or_else(|_| panic!("Could not remove dir {:?}", parent_dir));
+                .unwrap_or_else(|_| panic!("Could not remove dir {parent_dir:?}"));
         }
         fs::create_dir_all(&parent_dir)
-            .unwrap_or_else(|_| panic!("Could not create dir {:?}", parent_dir));
+            .unwrap_or_else(|_| panic!("Could not create dir {parent_dir:?}"));
 
         parent_dir
     }
@@ -175,7 +175,7 @@ mod tests {
         for filename in child_filenames {
             let file = parent_dir.join(Path::new(filename));
             let mut source_file = File::create(file).unwrap();
-            write!(source_file, "This is a test file named '{}'", filename).unwrap();
+            write!(source_file, "This is a test file named '{filename}'").unwrap();
         }
     }
 

--- a/mithril-common/src/entities/cardano_network.rs
+++ b/mithril-common/src/entities/cardano_network.rs
@@ -58,8 +58,7 @@ impl CardanoNetwork {
                 }
             }
             what => Err(CardanoNetworkError::ParseFromCode(format!(
-                "could not parse network '{}', the only recognized networks are: mainnet, devnet, testnet, preview, preprod and private",
-                what
+                "could not parse network '{what}', the only recognized networks are: mainnet, devnet, testnet, preview, preprod and private"
             ))),
         }
     }

--- a/mithril-common/src/store/adapter/memory_adapter.rs
+++ b/mithril-common/src/store/adapter/memory_adapter.rs
@@ -110,7 +110,7 @@ mod tests {
         let mut values: Vec<(u64, String)> = Vec::new();
         if nb > 0 {
             for ix in 1..=nb {
-                values.push((ix, format!("value {}", ix)));
+                values.push((ix, format!("value {ix}")));
             }
 
             MemoryAdapter::new(Some(values)).unwrap()

--- a/mithril-common/src/store/adapter/sqlite_adapter.rs
+++ b/mithril-common/src/store/adapter/sqlite_adapter.rs
@@ -46,8 +46,7 @@ where
 
     fn check_table_exists(connection: &Connection, table_name: &str) -> Result<()> {
         let sql = format!(
-            "select exists(select 1 from sqlite_master where type='table' and name='{}')",
-            table_name
+            "select exists(select 1 from sqlite_master where type='table' and name='{table_name}')"
         );
         let mut statement = connection
             .prepare(sql)
@@ -68,8 +67,7 @@ where
 
     fn create_table(connection: &Connection, table_name: &str) -> Result<()> {
         let sql = format!(
-            "create table {} (key_hash text primary key, key json not null, value json not null)",
-            table_name
+            "create table {table_name} (key_hash text primary key, key json not null, value json not null)"
         );
         connection
             .execute(sql)
@@ -89,8 +87,7 @@ where
     fn serialize_key(&self, key: &K) -> Result<String> {
         serde_json::to_string(&key).map_err(|e| {
             AdapterError::GeneralError(format!(
-                "SQLite adapter: Serde error while serializing store key: {:?}",
-                e
+                "SQLite adapter: Serde error while serializing store key: {e:?}"
             ))
         })
     }
@@ -160,8 +157,7 @@ where
         );
         let value = serde_json::to_string(record).map_err(|e| {
             AdapterError::GeneralError(format!(
-                "SQLite adapter error: could not serialize value before insertion: {:?}",
-                e
+                "SQLite adapter error: could not serialize value before insertion: {e:?}"
             ))
         })?;
         let mut statement = connection
@@ -205,10 +201,7 @@ where
         statement
             .read::<i64>(0)
             .map_err(|e| {
-                AdapterError::GeneralError(format!(
-                    "There should be a result in this case ! {:?}",
-                    e
-                ))
+                AdapterError::GeneralError(format!("There should be a result in this case ! {e:?}"))
             })
             .map(|res| res == 1)
     }
@@ -275,7 +268,7 @@ where
         connection: MutexGuard<Connection>,
         table_name: &str,
     ) -> Result<SQLiteResultIterator<V>> {
-        let sql = format!("select value from {} order by ROWID asc", table_name);
+        let sql = format!("select value from {table_name} order by ROWID asc");
 
         let cursor = connection
             .prepare(sql)
@@ -327,7 +320,7 @@ mod tests {
             });
         }
 
-        dirpath.join(format!("{}.sqlite3", test_name))
+        dirpath.join(format!("{test_name}.sqlite3"))
     }
 
     fn init_db(test_name: &str, tablename: Option<&str>) -> SQLiteAdapter<u64, String> {
@@ -361,7 +354,7 @@ mod tests {
             )
         });
         let mut statement = connection
-            .prepare(format!("select key_hash, key, value from {}", TABLE_NAME))
+            .prepare(format!("select key_hash, key, value from {TABLE_NAME}"))
             .unwrap()
             .into_cursor();
         let row = statement
@@ -385,7 +378,7 @@ mod tests {
             .await
             .unwrap();
         let mut statement = connection
-            .prepare(format!("select key_hash, key, value from {}", TABLE_NAME))
+            .prepare(format!("select key_hash, key, value from {TABLE_NAME}"))
             .unwrap()
             .into_cursor();
         let row = statement

--- a/mithril-common/src/store/stake_store.rs
+++ b/mithril-common/src/store/stake_store.rs
@@ -113,7 +113,7 @@ mod tests {
             let mut signers: StakeDistribution = HashMap::new();
 
             for party_idx in 1..=signers_per_epoch {
-                let party_id = format!("{}", party_idx);
+                let party_id = format!("{party_idx}");
                 signers.insert(party_id.clone(), 100 * party_idx + 1);
             }
             values.push((Epoch(epoch), signers));

--- a/mithril-common/src/store/store_pruner.rs
+++ b/mithril-common/src/store/store_pruner.rs
@@ -101,8 +101,7 @@ mod tests {
             assert_eq!(
                 data_len as usize,
                 store.adapter.read().await.get_iter().await.unwrap().count(),
-                "test no pruning with dataset length = {}",
-                data_len
+                "test no pruning with dataset length = {data_len}"
             );
         }
     }
@@ -118,8 +117,7 @@ mod tests {
             assert_eq!(
                 data_len as usize,
                 store.adapter.read().await.get_iter().await.unwrap().count(),
-                "test pruning with retention limit = {}",
-                data_len
+                "test pruning with retention limit = {data_len}"
             );
         }
     }

--- a/mithril-common/src/test_utils/apispec.rs
+++ b/mithril-common/src/test_utils/apispec.rs
@@ -105,7 +105,7 @@ impl<'a> APISpec<'a> {
                     }
                 }
             }
-            None => Err(format!("unmatched path and method: {} {}", path, method)),
+            None => Err(format!("unmatched path and method: {path} {method}")),
         }
     }
 
@@ -118,7 +118,7 @@ impl<'a> APISpec<'a> {
         match schema {
             Null => match value {
                 Null => Ok(self),
-                _ => Err(format!("Expected nothing but got: {:?}", value)),
+                _ => Err(format!("Expected nothing but got: {value:?}")),
             },
             _ => {
                 let schema = &mut schema.as_object_mut().unwrap().clone();

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -106,7 +106,7 @@ pub fn certificate(certificate_hash: String) -> entities::Certificate {
     );
 
     // Certificate
-    let previous_hash = format!("{}0", certificate_hash);
+    let previous_hash = format!("{certificate_hash}0");
     let aggregate_verification_key = format!("AVK{}", beacon.immutable_file_number).repeat(5);
     let multi_signature = format!("MSIG{}", beacon.immutable_file_number).repeat(200);
     let genesis_signature = "".to_string();
@@ -151,14 +151,14 @@ pub fn single_signatures(won_indexes: Vec<LotteryIndex>) -> SingleSignatures {
 pub fn snapshots(total: u64) -> Vec<entities::Snapshot> {
     (1..total + 1)
         .map(|snapshot_id| {
-            let digest = format!("1{}", snapshot_id).repeat(20);
+            let digest = format!("1{snapshot_id}").repeat(20);
             let beacon = beacon();
             let certificate_hash = "123".to_string();
             let size = snapshot_id * 100000;
             let created_at = "2006-01-02T15:04:05Z".to_string();
             let mut locations = Vec::new();
-            locations.push(format!("http://{}", certificate_hash));
-            locations.push(format!("http2://{}", certificate_hash));
+            locations.push(format!("http://{certificate_hash}"));
+            locations.push(format!("http2://{certificate_hash}"));
             entities::Snapshot::new(
                 digest,
                 beacon,

--- a/mithril-common/src/test_utils/fixture_builder.rs
+++ b/mithril-common/src/test_utils/fixture_builder.rs
@@ -93,7 +93,7 @@ impl MithrilFixtureBuilder {
             if self.enable_signers_certification {
                 build_party_with_operational_certificate(party_index, &mut kes_keys_seed)
             } else {
-                format!("{:<032}", party_index)
+                format!("{party_index:<032}")
             }
         });
 

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.6"
+version = "0.2.7"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/certificate_handler.rs
+++ b/mithril-signer/src/certificate_handler.rs
@@ -107,8 +107,7 @@ impl CertificateHandlerHTTPClient {
             ))
         } else {
             CertificateHandlerError::ApiVersionMismatch(format!(
-                "version precondition failed, sent version '{}'.",
-                MITHRIL_API_VERSION
+                "version precondition failed, sent version '{MITHRIL_API_VERSION}'."
             ))
         }
     }

--- a/mithril-signer/src/main.rs
+++ b/mithril-signer/src/main.rs
@@ -91,9 +91,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
         .add_source(config::Environment::default())
         .build()
-        .map_err(|e| format!("configuration build error: {}", e))?
+        .map_err(|e| format!("configuration build error: {e}"))?
         .try_deserialize()
-        .map_err(|e| format!("configuration deserialize error: {}", e))?;
+        .map_err(|e| format!("configuration deserialize error: {e}"))?;
     let services = ProductionServiceBuilder::new(&config).build().await?;
     DatabaseVersionChecker::new(
         slog_scope::logger(),
@@ -101,7 +101,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         config.get_sqlite_file(),
     )
     .apply()?;
-    debug!("Started"; "run_mode" => &args.run_mode, "config" => format!("{:?}", config));
+    debug!("Started"; "run_mode" => &args.run_mode, "config" => format!("{config:?}"));
 
     let mut state_machine = StateMachine::new(
         SignerState::Unregistered(None),

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -173,8 +173,7 @@ impl Runner for SignerRunner {
             .await?
             .ok_or_else(|| {
                 RuntimeError::NoValueError(format!(
-                    "stakes at epoch {}",
-                    epoch_offset_to_recording_epoch
+                    "stakes at epoch {epoch_offset_to_recording_epoch}"
                 ))
             })?;
         let stake = stake_distribution
@@ -314,7 +313,7 @@ impl Runner for SignerRunner {
             .stake_store
             .get_stakes(epoch)
             .await?
-            .ok_or_else(|| RuntimeError::NoValueError(format!("stakes at epoch {}", epoch)))?;
+            .ok_or_else(|| RuntimeError::NoValueError(format!("stakes at epoch {epoch}")))?;
         let mut signers_with_stake = vec![];
 
         for signer in signers {
@@ -361,8 +360,7 @@ impl Runner for SignerRunner {
             .await?
             .ok_or_else(|| {
                 RuntimeError::NoValueError(format!(
-                    "protocol_initializer at epoch {}",
-                    next_signer_retrieval_epoch
+                    "protocol_initializer at epoch {next_signer_retrieval_epoch}"
                 ))
             })?;
 
@@ -392,8 +390,7 @@ impl Runner for SignerRunner {
             .await?
             .ok_or_else(|| {
                 RuntimeError::NoValueError(format!(
-                    "protocol_initializer at epoch {}",
-                    signer_retrieval_epoch
+                    "protocol_initializer at epoch {signer_retrieval_epoch}"
                 ))
             })?;
         let signature = self.services.single_signer.compute_single_signatures(

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -54,12 +54,9 @@ impl<'a> ProductionServiceBuilder<'a> {
         match &self.config.operational_certificate_path {
             Some(operational_certificate_path) => {
                 let opcert: OpCert = OpCert::from_file(operational_certificate_path)
-                    .map_err(|e| format!("Could not decode operational certificate: {:?}", e))?;
+                    .map_err(|e| format!("Could not decode operational certificate: {e:?}"))?;
                 Ok(opcert.compute_protocol_party_id().map_err(|e| {
-                    format!(
-                        "Could not compute party_id from operational certificate: {:?}",
-                        e
-                    )
+                    format!("Could not compute party_id from operational certificate: {e:?}")
                 })?)
             }
             _ => Ok(self
@@ -95,7 +92,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
     async fn build(&self) -> Result<SignerServices, Box<dyn StdError>> {
         if !self.config.data_stores_directory.exists() {
             fs::create_dir_all(self.config.data_stores_directory.clone())
-                .map_err(|e| format!("Could not create data stores directory: {:?}", e))?;
+                .map_err(|e| format!("Could not create data stores directory: {e:?}"))?;
         }
 
         let sqlite_db_path = Some(self.config.get_sqlite_file());
@@ -181,10 +178,10 @@ mod tests {
 
         if test_dir.exists() {
             fs::remove_dir_all(&test_dir)
-                .unwrap_or_else(|_| panic!("Could not remove dir {:?}", test_dir));
+                .unwrap_or_else(|_| panic!("Could not remove dir {test_dir:?}"));
         }
         fs::create_dir_all(&test_dir)
-            .unwrap_or_else(|_| panic!("Could not create dir {:?}", test_dir));
+            .unwrap_or_else(|_| panic!("Could not create dir {test_dir:?}"));
 
         test_dir
     }

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -56,7 +56,7 @@ impl Display for SignerState {
                 "Unregistered - {}",
                 match state {
                     None => "No Epoch".to_string(),
-                    Some(e) => format!("Epoch({})", e),
+                    Some(e) => format!("Epoch({e})"),
                 }
             ),
             Self::Registered(state) => write!(f, "Registered - {}", state.beacon),

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -240,10 +240,7 @@ impl StateMachineTester {
         let new_immutable = immutable_number + increment;
         self.assert(
             expected == new_immutable,
-            format!(
-                "expected to increase immutable number up to {}, got {}",
-                expected, new_immutable
-            ),
+            format!("expected to increase immutable number up to {expected}, got {new_immutable}"),
         )?;
         self.immutable_observer
             .shall_return(Some(new_immutable))
@@ -262,10 +259,7 @@ impl StateMachineTester {
 
         self.assert(
             expected == new_epoch,
-            format!(
-                "Epoch increased by 1 to {} ({} expected)",
-                new_epoch, expected
-            ),
+            format!("Epoch increased by 1 to {new_epoch} ({expected} expected)"),
         )
     }
 

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mithril-stm"
-version = "0.2.1"
+version = "0.2.2"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/benches/multi_sig.rs
+++ b/mithril-stm/benches/multi_sig.rs
@@ -12,7 +12,7 @@ fn batch_benches(c: &mut Criterion, array_batches: &[usize], nr_sigs: usize) {
     let mut batch_sig = Vec::new();
 
     for &nr_batches in array_batches {
-        let batch_string = format!("Batch size: {}", nr_batches);
+        let batch_string = format!("Batch size: {nr_batches}");
 
         for _ in 0..nr_batches {
             let mut msg = [0u8; 32];

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -15,7 +15,7 @@ where
     H: Digest + Clone + Sync + Send + Default + FixedOutput,
 {
     println!("+-------------------+");
-    println!("| Hash: {} |", hash_name);
+    println!("| Hash: {hash_name} |");
     println!("+-------------------+");
     let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
     let mut msg = [0u8; 16];

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -17,7 +17,7 @@ fn stm_benches<H>(c: &mut Criterion, nr_parties: usize, params: StmParameters, h
 where
     H: Clone + Debug + Digest + Send + Sync + FixedOutput + Default,
 {
-    let mut group = c.benchmark_group(format!("STM/{}", hashing_alg));
+    let mut group = c.benchmark_group(format!("STM/{hashing_alg}"));
     let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
     let mut msg = [0u8; 16];
     rng.fill_bytes(&mut msg);
@@ -82,7 +82,7 @@ fn batch_benches<H>(
 ) where
     H: Clone + Debug + Digest + FixedOutput + Send + Sync,
 {
-    let mut group = c.benchmark_group(format!("STM/{}", hashing_alg));
+    let mut group = c.benchmark_group(format!("STM/{hashing_alg}"));
     let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
 
     let param_string = format!(
@@ -91,7 +91,7 @@ fn batch_benches<H>(
     );
 
     for &nr_batches in array_batches {
-        let batch_string = format!("{}/batch size: {}", param_string, nr_batches);
+        let batch_string = format!("{param_string}/batch size: {nr_batches}");
 
         let mut batch_msgs = Vec::with_capacity(nr_batches);
         let mut batch_params = Vec::with_capacity(nr_batches);

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -115,7 +115,7 @@ fn main() {
     let msig_1 = match clerk.aggregate(&complete_sigs_1, &msg) {
         Ok(s) => s,
         Err(e) => {
-            panic!("Aggregation failed: {:?}", e)
+            panic!("Aggregation failed: {e:?}")
         }
     };
     assert!(msig_1.verify(&msg, &clerk.compute_avk(), &params).is_ok());
@@ -123,7 +123,7 @@ fn main() {
     let msig_2 = match clerk.aggregate(&complete_sigs_2, &msg) {
         Ok(s) => s,
         Err(e) => {
-            panic!("Aggregation failed: {:?}", e)
+            panic!("Aggregation failed: {e:?}")
         }
     };
     assert!(msig_2.verify(&msg, &clerk.compute_avk(), &params).is_ok());

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -1015,10 +1015,10 @@ mod tests {
             }
 
             let dedup_result = clerk.dedup_sigs_for_indices(&msg, &sigs);
-            assert!(dedup_result.is_ok(), "dedup failure {:?}", dedup_result);
+            assert!(dedup_result.is_ok(), "dedup failure {dedup_result:?}");
             for passed_sigs in dedup_result.unwrap() {
                 let verify_result = passed_sigs.verify(&params, &ps[0].vk, &ps[0].stake, &avk, &msg);
-                assert!(verify_result.is_ok(), "verify {:?}", verify_result);
+                assert!(verify_result.is_ok(), "verify {verify_result:?}");
             }
         }
     }
@@ -1044,7 +1044,7 @@ mod tests {
             match msig {
                 Ok(aggr) => {
                     let verify_result = aggr.verify(&msg, &clerk.compute_avk(), &params);
-                    assert!(verify_result.is_ok(), "Verification failed: {:?}", verify_result);
+                    assert!(verify_result.is_ok(), "Verification failed: {verify_result:?}");
                 }
                 Err(AggregationError::NotEnoughSignatures(n, k)) =>
                     assert!(n < params.k || k == params.k),

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.1.0"
+version = "0.1.1"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -39,7 +39,7 @@ impl PoolNode {
         let party_id = content
             .split('=')
             .nth(1)
-            .ok_or(format!("could not get party_id from string '{}'", content))?;
+            .ok_or(format!("could not get party_id from string '{content}'"))?;
 
         Ok(party_id.trim().to_string())
     }
@@ -75,7 +75,7 @@ impl Devnet {
 
         if artifacts_target_dir.exists() {
             fs::remove_dir_all(&artifacts_target_dir)
-                .map_err(|e| format!("Previous artifacts dir removal failed: {}", e))?;
+                .map_err(|e| format!("Previous artifacts dir removal failed: {e}"))?;
         }
 
         let mut bootstrap_command = Command::new(&bootstrap_script_path);
@@ -96,10 +96,10 @@ impl Devnet {
 
         bootstrap_command
             .spawn()
-            .map_err(|e| format!("{} failed to start: {}", bootstrap_script, e))?
+            .map_err(|e| format!("{bootstrap_script} failed to start: {e}"))?
             .wait()
             .await
-            .map_err(|e| format!("{} failed to run: {}", bootstrap_script, e))?;
+            .map_err(|e| format!("{bootstrap_script} failed to run: {e}"))?;
 
         Ok(Devnet {
             artifacts_dir: artifacts_target_dir,
@@ -126,27 +126,27 @@ impl Devnet {
         let bft_nodes = (1..=self.number_of_bft_nodes)
             .into_iter()
             .map(|n| BftNode {
-                db_path: self.artifacts_dir.join(format!("node-bft{}/db", n)),
+                db_path: self.artifacts_dir.join(format!("node-bft{n}/db")),
                 socket_path: self
                     .artifacts_dir
-                    .join(format!("node-bft{}/ipc/node.sock", n)),
+                    .join(format!("node-bft{n}/ipc/node.sock")),
             })
             .collect::<Vec<_>>();
 
         let pool_nodes = (1..=self.number_of_pool_nodes)
             .into_iter()
             .map(|n| PoolNode {
-                db_path: self.artifacts_dir.join(format!("node-pool{}/db", n)),
+                db_path: self.artifacts_dir.join(format!("node-pool{n}/db")),
                 socket_path: self
                     .artifacts_dir
-                    .join(format!("node-pool{}/ipc/node.sock", n)),
-                pool_env_path: self.artifacts_dir.join(format!("node-pool{}/pool.env", n)),
+                    .join(format!("node-pool{n}/ipc/node.sock")),
+                pool_env_path: self.artifacts_dir.join(format!("node-pool{n}/pool.env")),
                 kes_secret_key_path: self
                     .artifacts_dir
-                    .join(format!("node-pool{}/shelley/kes.skey", n)),
+                    .join(format!("node-pool{n}/shelley/kes.skey")),
                 operational_certificate_path: self
                     .artifacts_dir
-                    .join(format!("node-pool{}/shelley/node.cert", n)),
+                    .join(format!("node-pool{n}/shelley/node.cert")),
             })
             .collect::<Vec<_>>();
 
@@ -168,10 +168,10 @@ impl Devnet {
 
         run_command
             .spawn()
-            .map_err(|e| format!("Failed to start the devnet: {}", e))?
+            .map_err(|e| format!("Failed to start the devnet: {e}"))?
             .wait()
             .await
-            .map_err(|e| format!("Error while starting the devnet: {}", e))?;
+            .map_err(|e| format!("Error while starting the devnet: {e}"))?;
         Ok(())
     }
 
@@ -187,10 +187,10 @@ impl Devnet {
 
         stop_command
             .spawn()
-            .map_err(|e| format!("Failed to stop the devnet: {}", e))?
+            .map_err(|e| format!("Failed to stop the devnet: {e}"))?
             .wait()
             .await
-            .map_err(|e| format!("Error while stopping the devnet: {}", e))?;
+            .map_err(|e| format!("Error while stopping the devnet: {e}"))?;
         Ok(())
     }
 
@@ -206,10 +206,10 @@ impl Devnet {
 
         run_command
             .spawn()
-            .map_err(|e| format!("Failed to delegate stakes to the pools: {}", e))?
+            .map_err(|e| format!("Failed to delegate stakes to the pools: {e}"))?
             .wait()
             .await
-            .map_err(|e| format!("Error while delegating stakes to the pools: {}", e))?;
+            .map_err(|e| format!("Error while delegating stakes to the pools: {e}"))?;
         Ok(())
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -78,10 +78,9 @@ impl Aggregator {
                     Ok(())
                 } else {
                     Err(match status.code() {
-                        Some(c) => format!(
-                            "`mithril-aggregator genesis bootstrap` exited with code: {}",
-                            c
-                        ),
+                        Some(c) => {
+                            format!("`mithril-aggregator genesis bootstrap` exited with code: {c}")
+                        }
                         None => {
                             "`mithril-aggregator genesis bootstrap` was terminated with a signal"
                                 .to_string()
@@ -98,7 +97,7 @@ impl Aggregator {
             process
                 .kill()
                 .await
-                .map_err(|e| format!("Could not kill aggregator: {:?}", e))?;
+                .map_err(|e| format!("Could not kill aggregator: {e:?}"))?;
         }
         Ok(())
     }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
@@ -58,11 +58,11 @@ impl Client {
                     Ok(())
                 } else {
                     self.command
-                        .tail_logs(Some(format!("mithril-client {:?}", args).as_str()), 20)
+                        .tail_logs(Some(format!("mithril-client {args:?}").as_str()), 20)
                         .await?;
 
                     Err(match status.code() {
-                        Some(c) => format!("mithril-client exited with code: {}", c),
+                        Some(c) => format!("mithril-client exited with code: {c}"),
                         None => "mithril-client was terminated with a signal".to_string(),
                     })
                 }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
@@ -24,7 +24,7 @@ impl Signer {
     ) -> Result<Self, String> {
         let party_id = pool_node.party_id()?;
         let magic_id = DEVNET_MAGIC_ID.to_string();
-        let data_stores_path = format!("./stores/signer-{}", party_id);
+        let data_stores_path = format!("./stores/signer-{party_id}");
         let mut env = HashMap::from([
             ("NETWORK", "devnet"),
             ("RUN_INTERVAL", "300"),
@@ -53,7 +53,7 @@ impl Signer {
         let args = vec!["-vvv"];
 
         let mut command = MithrilCommand::new("mithril-signer", work_dir, bin_dir, env, &args)?;
-        command.set_log_name(format!("mithril-signer-{}", party_id).as_str());
+        command.set_log_name(format!("mithril-signer-{party_id}").as_str());
 
         Ok(Self {
             party_id,

--- a/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
@@ -18,7 +18,7 @@ pub async fn tail(file_path: &Path, number_of_line: u64) -> Result<String, Strin
         .map_err(|e| format!("Failed to tail file `{}`: {}", file_path.display(), e))?;
 
     String::from_utf8(tail_result.stdout)
-        .map_err(|e| format!("Failed to parse tail output to utf8: {}", e))
+        .map_err(|e| format!("Failed to parse tail output to utf8: {e}"))
 }
 
 #[cfg(test)]
@@ -35,17 +35,17 @@ mod tests {
             .join(subfolder_name);
         if temp_dir.exists() {
             fs::remove_dir_all(&temp_dir)
-                .unwrap_or_else(|_| panic!("Could not remove dir {:?}", temp_dir));
+                .unwrap_or_else(|_| panic!("Could not remove dir {temp_dir:?}"));
         }
         fs::create_dir_all(&temp_dir)
-            .unwrap_or_else(|_| panic!("Could not create dir {:?}", temp_dir));
+            .unwrap_or_else(|_| panic!("Could not create dir {temp_dir:?}"));
 
         temp_dir
     }
 
     fn write_file(path: &Path, file_content: &str) {
         let mut source_file = File::create(path).unwrap();
-        write!(source_file, "{}", file_content).unwrap();
+        write!(source_file, "{file_content}").unwrap();
     }
 
     #[tokio::test]

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
@@ -23,7 +23,7 @@ impl MithrilCommand {
         default_args: &[&str],
     ) -> Result<MithrilCommand, String> {
         let process_path = bin_dir.canonicalize().unwrap().join(name);
-        let log_path = work_dir.join(format!("{}.log", name));
+        let log_path = work_dir.join(format!("{name}.log"));
 
         // ugly but it's far easier for callers to manipulate string literals
         let mut env_vars: HashMap<String, String> = env_vars
@@ -53,7 +53,7 @@ impl MithrilCommand {
     }
 
     pub fn set_log_name(&mut self, name: &str) {
-        self.log_path = self.work_dir.join(format!("{}.log", name));
+        self.log_path = self.work_dir.join(format!("{name}.log"));
     }
 
     pub fn set_env_var(&mut self, name: &str, value: &str) {

--- a/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
@@ -98,8 +98,7 @@ mod tests {
         let elapsed = now.elapsed().as_millis();
         assert!(
             (10..=12).contains(&elapsed),
-            "Failure, after one loop the elapsed time was not ~10ms, elapsed: {}",
-            elapsed
+            "Failure, after one loop the elapsed time was not ~10ms, elapsed: {elapsed}"
         );
     }
 }


### PR DESCRIPTION
## Content
This PR includes a fix to remove clippy warnings that arose with the new version of Rust `1.67.0`

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

