### PR TITLE
Fix signer unable to sign with `2304.0 prerelease`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2001,7 +2001,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.9"
+version = "0.2.10"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.9"
+version = "0.2.10"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -221,6 +221,7 @@ impl AggregatorRuntime {
 
         if maybe_current_beacon.is_none() || maybe_current_beacon.unwrap().epoch < new_beacon.epoch
         {
+            self.runner.close_signer_registration_round().await?;
             self.runner.update_stake_distribution(&new_beacon).await?;
             self.runner
                 .open_signer_registration_round(&new_beacon)
@@ -366,6 +367,10 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
+            .expect_close_signer_registration_round()
+            .once()
+            .returning(|| Ok(()));
+        runner
             .expect_open_signer_registration_round()
             .once()
             .returning(|_| Ok(()));
@@ -408,6 +413,10 @@ mod tests {
             .with(predicate::eq(fake_data::beacon()))
             .once()
             .returning(|_| Ok(()));
+        runner
+            .expect_close_signer_registration_round()
+            .once()
+            .returning(|| Ok(()));
         runner
             .expect_open_signer_registration_round()
             .once()

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -79,6 +79,9 @@ pub trait SignerRegistrationRoundOpener: Sync + Send {
         registration_epoch: Epoch,
         stake_distribution: StakeDistribution,
     ) -> Result<(), SignerRegistrationError>;
+
+    /// Close a signer registration round
+    async fn close_registration_round(&self) -> Result<(), SignerRegistrationError>;
 }
 
 /// Implementation of a [SignerRegisterer]
@@ -124,6 +127,13 @@ impl SignerRegistrationRoundOpener for MithrilSignerRegisterer {
             epoch: registration_epoch,
             stake_distribution,
         });
+
+        Ok(())
+    }
+
+    async fn close_registration_round(&self) -> Result<(), SignerRegistrationError> {
+        let mut current_round = self.current_round.write().await;
+        *current_round = None;
 
         Ok(())
     }


### PR DESCRIPTION
## Content
This PR includes an attempt to fix the problem that SPOs encountered after having installed the 2304.0-prerelease distribution on their signer node running on the pre-release-preview network. Almost all the SPOs received error messages preventing them to contribute to the creation of the multi-signatures.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
⚠ After deploying the fix on the signer node we will need a `2` epochs delay to get signer contributing to signatures

## Issue(s)
Relates to #716