### PR TITLE
helper for unsafe code

### DIFF
--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -5,6 +5,7 @@
 use crate::error::{blst_err_to_mithril, MultiSignatureError};
 use crate::stm::Index;
 use blake2::{digest::consts::U16, Blake2b, Blake2b512, Digest};
+use unsafe_helpers::*;
 
 // We use `min_sig` resulting in signatures of 48 bytes and public keys of
 // 96. We can switch that around if desired by using `min_vk`.
@@ -26,7 +27,6 @@ use std::{
     hash::{Hash, Hasher},
     iter::Sum,
 };
-
 /// String used to generate the proofs of possession.
 const POP: &[u8] = b"PoP";
 
@@ -468,92 +468,6 @@ impl Ord for Signature {
 }
 
 // ---------------------------------------------------------------------
-// Unsafe helpers
-// ---------------------------------------------------------------------
-
-fn verify_miller_loop(vk: &BlstVk, k2: &blst_p1) -> bool {
-    use blst::{
-        blst_fp12, blst_fp12_finalverify, blst_p1_affine_generator, blst_p2_affine_generator,
-    };
-    unsafe {
-        let g1_p = *blst_p1_affine_generator();
-        let mvk_p = std::mem::transmute::<&BlstVk, &blst_p2_affine>(vk);
-        let ml_lhs = blst_fp12::miller_loop(mvk_p, &g1_p);
-
-        let mut k2_p = blst_p1_affine::default();
-        blst_p1_to_affine(&mut k2_p, k2);
-        let g2_p = *blst_p2_affine_generator();
-        let ml_rhs = blst_fp12::miller_loop(&g2_p, &k2_p);
-
-        blst_fp12_finalverify(&ml_lhs, &ml_rhs)
-    }
-}
-
-fn compress_p1(k2: &blst_p1) -> [u8; 48] {
-    let mut bytes = [0u8; 48];
-    unsafe { blst_p1_compress(bytes.as_mut_ptr(), k2) }
-    bytes
-}
-
-fn uncompress_p1(bytes: &[u8]) -> blst_p1 {
-    unsafe {
-        let mut point = blst_p1_affine::default();
-        let mut out = blst_p1::default();
-        blst_p1_uncompress(&mut point, bytes.as_ptr());
-        blst_p1_from_affine(&mut out, &point);
-        out
-    }
-}
-
-fn scalar_to_pk_in_g1(sk: &SigningKey) -> blst_p1 {
-    use blst::blst_sk_to_pk_in_g1;
-    unsafe {
-        let sk_scalar = std::mem::transmute::<&BlstSk, &blst_scalar>(&sk.0);
-        let mut out = blst_p1::default();
-        blst_sk_to_pk_in_g1(&mut out, sk_scalar);
-        out
-    }
-}
-
-fn vk_from_p2_affine(vk: &VerificationKey) -> blst_p2 {
-    unsafe {
-        let mut projective_p2 = blst_p2::default();
-        blst_p2_from_affine(
-            &mut projective_p2,
-            &std::mem::transmute::<BlstVk, blst_p2_affine>(vk.0),
-        );
-        projective_p2
-    }
-}
-
-fn sig_to_p1(sig: &BlstSig) -> blst_p1 {
-    unsafe {
-        let mut projective_p1 = blst_p1::default();
-        blst_p1_from_affine(
-            &mut projective_p1,
-            &std::mem::transmute::<BlstSig, blst_p1_affine>(*sig),
-        );
-        projective_p1
-    }
-}
-
-fn p2_affine_to_vk(grouped_vks: &p2_affines, scalars: &[u8]) -> BlstVk {
-    unsafe {
-        let mut affine_p2 = blst_p2_affine::default();
-        blst_p2_to_affine(&mut affine_p2, &grouped_vks.mult(scalars, 128));
-        std::mem::transmute::<blst_p2_affine, BlstVk>(affine_p2)
-    }
-}
-
-fn p1_affine_to_sig(grouped_sigs: &p1_affines, scalars: &[u8]) -> BlstSig {
-    unsafe {
-        let mut affine_p1 = blst_p1_affine::default();
-        blst_p1_to_affine(&mut affine_p1, &grouped_sigs.mult(scalars, 128));
-        std::mem::transmute::<blst_p1_affine, BlstSig>(affine_p1)
-    }
-}
-
-// ---------------------------------------------------------------------
 // Serde implementation
 // ---------------------------------------------------------------------
 
@@ -620,6 +534,95 @@ impl_serde!(SigningKey, SigningKeyVisitor, 32);
 impl_serde!(VerificationKey, VerificationKeyVisitor, 96);
 impl_serde!(ProofOfPossession, ProofOfPossessionVisitor, 96);
 impl_serde!(Signature, SignatureVisitor, 48);
+
+// ---------------------------------------------------------------------
+// Unsafe helpers
+// ---------------------------------------------------------------------
+mod unsafe_helpers {
+    use super::*;
+    use blst::{
+        blst_fp12, blst_fp12_finalverify, blst_p1_affine_generator, blst_p2_affine_generator,
+        blst_sk_to_pk_in_g1,
+    };
+
+    pub(crate) fn verify_miller_loop(vk: &BlstVk, k2: &blst_p1) -> bool {
+        unsafe {
+            let g1_p = *blst_p1_affine_generator();
+            let mvk_p = std::mem::transmute::<&BlstVk, &blst_p2_affine>(vk);
+            let ml_lhs = blst_fp12::miller_loop(mvk_p, &g1_p);
+
+            let mut k2_p = blst_p1_affine::default();
+            blst_p1_to_affine(&mut k2_p, k2);
+            let g2_p = *blst_p2_affine_generator();
+            let ml_rhs = blst_fp12::miller_loop(&g2_p, &k2_p);
+
+            blst_fp12_finalverify(&ml_lhs, &ml_rhs)
+        }
+    }
+
+    pub(crate) fn compress_p1(k2: &blst_p1) -> [u8; 48] {
+        let mut bytes = [0u8; 48];
+        unsafe { blst_p1_compress(bytes.as_mut_ptr(), k2) }
+        bytes
+    }
+
+    pub(crate) fn uncompress_p1(bytes: &[u8]) -> blst_p1 {
+        unsafe {
+            let mut point = blst_p1_affine::default();
+            let mut out = blst_p1::default();
+            blst_p1_uncompress(&mut point, bytes.as_ptr());
+            blst_p1_from_affine(&mut out, &point);
+            out
+        }
+    }
+
+    pub(crate) fn scalar_to_pk_in_g1(sk: &SigningKey) -> blst_p1 {
+        unsafe {
+            let sk_scalar = std::mem::transmute::<&BlstSk, &blst_scalar>(&sk.0);
+            let mut out = blst_p1::default();
+            blst_sk_to_pk_in_g1(&mut out, sk_scalar);
+            out
+        }
+    }
+
+    pub(crate) fn vk_from_p2_affine(vk: &VerificationKey) -> blst_p2 {
+        unsafe {
+            let mut projective_p2 = blst_p2::default();
+            blst_p2_from_affine(
+                &mut projective_p2,
+                &std::mem::transmute::<BlstVk, blst_p2_affine>(vk.0),
+            );
+            projective_p2
+        }
+    }
+
+    pub(crate) fn sig_to_p1(sig: &BlstSig) -> blst_p1 {
+        unsafe {
+            let mut projective_p1 = blst_p1::default();
+            blst_p1_from_affine(
+                &mut projective_p1,
+                &std::mem::transmute::<BlstSig, blst_p1_affine>(*sig),
+            );
+            projective_p1
+        }
+    }
+
+    pub(crate) fn p2_affine_to_vk(grouped_vks: &p2_affines, scalars: &[u8]) -> BlstVk {
+        unsafe {
+            let mut affine_p2 = blst_p2_affine::default();
+            blst_p2_to_affine(&mut affine_p2, &grouped_vks.mult(scalars, 128));
+            std::mem::transmute::<blst_p2_affine, BlstVk>(affine_p2)
+        }
+    }
+
+    pub(crate) fn p1_affine_to_sig(grouped_sigs: &p1_affines, scalars: &[u8]) -> BlstSig {
+        unsafe {
+            let mut affine_p1 = blst_p1_affine::default();
+            blst_p1_to_affine(&mut affine_p1, &grouped_sigs.mult(scalars, 128));
+            std::mem::transmute::<blst_p1_affine, BlstSig>(affine_p1)
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -519,23 +519,23 @@ impl Ord for Signature {
 // Transmute helpers
 // ---------------------------------------------------------------------
 
-pub fn vk_to_p2_affine(vk: &VerificationKey) -> &'static blst_p2_affine {
+fn vk_to_p2_affine(vk: &VerificationKey) -> &'static blst_p2_affine {
     unsafe { std::mem::transmute::<&BlstVk, &blst_p2_affine>(&vk.0) }
 }
 
-pub fn p2_affine_to_vk(affine_p2: blst_p2_affine) -> BlstVk {
+fn p2_affine_to_vk(affine_p2: blst_p2_affine) -> BlstVk {
     unsafe { std::mem::transmute::<blst_p2_affine, BlstVk>(affine_p2) }
 }
 
-pub fn p1_affine_to_sig(affine_p1: blst_p1_affine) -> BlstSig {
+fn p1_affine_to_sig(affine_p1: blst_p1_affine) -> BlstSig {
     unsafe { std::mem::transmute::<blst_p1_affine, BlstSig>(affine_p1) }
 }
 
-pub fn sig_to_p1_affine(sig: BlstSig) -> blst_p1_affine {
+fn sig_to_p1_affine(sig: BlstSig) -> blst_p1_affine {
     unsafe { std::mem::transmute::<BlstSig, blst_p1_affine>(sig) }
 }
 
-pub fn sk_to_scalar(sk: &SigningKey) -> &blst_scalar {
+fn sk_to_scalar(sk: &SigningKey) -> &blst_scalar {
     unsafe { std::mem::transmute::<&BlstSk, &blst_scalar>(&sk.0) }
 }
 

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -414,10 +414,7 @@ impl Signature {
             .iter()
             .map(|vk| unsafe {
                 let mut projective_p2 = blst_p2::default();
-                blst_p2_from_affine(
-                    &mut projective_p2,
-                    vk_to_p2_affine(vk),
-                );
+                blst_p2_from_affine(&mut projective_p2, vk_to_p2_affine(vk));
                 projective_p2
             })
             .collect();
@@ -426,10 +423,7 @@ impl Signature {
             .iter()
             .map(|&sig| unsafe {
                 let mut projective_p1 = blst_p1::default();
-                blst_p1_from_affine(
-                    &mut projective_p1,
-                    &sig_to_p1_affine(sig),
-                );
+                blst_p1_from_affine(&mut projective_p1, &sig_to_p1_affine(sig));
                 projective_p1
             })
             .collect();
@@ -521,45 +515,28 @@ impl Ord for Signature {
     }
 }
 
-
-
 // ---------------------------------------------------------------------
 // Transmute helpers
 // ---------------------------------------------------------------------
 
 pub fn vk_to_p2_affine(vk: &VerificationKey) -> &'static blst_p2_affine {
-    unsafe {
-        let result = std::mem::transmute::<&BlstVk, &blst_p2_affine>(&vk.0);
-        return result;
-    };
+    unsafe { std::mem::transmute::<&BlstVk, &blst_p2_affine>(&vk.0) }
 }
 
 pub fn p2_affine_to_vk(affine_p2: blst_p2_affine) -> BlstVk {
-    unsafe {
-        let result = std::mem::transmute::<blst_p2_affine, BlstVk>(affine_p2);
-        return result;
-    };
+    unsafe { std::mem::transmute::<blst_p2_affine, BlstVk>(affine_p2) }
 }
 
 pub fn p1_affine_to_sig(affine_p1: blst_p1_affine) -> BlstSig {
-    unsafe {
-        let result = std::mem::transmute::<blst_p1_affine, BlstSig>(affine_p1);
-        return result;
-    };
+    unsafe { std::mem::transmute::<blst_p1_affine, BlstSig>(affine_p1) }
 }
 
-pub fn sig_to_p1_affine(sig: BlstSig) -> blst_p1_affine  {
-    unsafe {
-        let result = std::mem::transmute::<BlstSig, blst_p1_affine>(sig);
-        return result;
-    };
+pub fn sig_to_p1_affine(sig: BlstSig) -> blst_p1_affine {
+    unsafe { std::mem::transmute::<BlstSig, blst_p1_affine>(sig) }
 }
 
-pub fn sk_to_scalar(sk: &SigningKey) -> &blst_scalar  {
-    unsafe {
-        let result = std::mem::transmute::<&BlstSk, &blst_scalar>(&sk.0);
-        return result;
-    };
+pub fn sk_to_scalar(sk: &SigningKey) -> &blst_scalar {
+    unsafe { std::mem::transmute::<&BlstSk, &blst_scalar>(&sk.0) }
 }
 
 // ---------------------------------------------------------------------

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -14,9 +14,6 @@ use blst::min_sig::{
     Signature as BlstSig,
 };
 use blst::{blst_p1, blst_p2, p1_affines, p2_affines, BLST_ERROR};
-// blst_p1_affine, blst_p1_compress, blst_p1_from_affine, blst_p1_to_affine,
-//     blst_p1_uncompress, blst_p2, blst_p2_affine, blst_p2_from_affine, blst_p2_to_affine,
-//     blst_scalar, p1_affines, p2_affines, BLST_ERROR,
 
 use rand_core::{CryptoRng, RngCore};
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
@@ -209,6 +206,7 @@ impl VerificationKeyPoP {
         }
         Ok(())
     }
+
     /// Convert to a 144 byte string.
     ///
     /// # Layout
@@ -531,6 +529,7 @@ impl_serde!(Signature, SignatureVisitor, 48);
 // ---------------------------------------------------------------------
 // Unsafe helpers
 // ---------------------------------------------------------------------
+
 mod unsafe_helpers {
     use super::*;
     use crate::error::MultiSignatureError::SerializationError;
@@ -541,6 +540,7 @@ mod unsafe_helpers {
         blst_scalar, blst_sk_to_pk_in_g1,
     };
 
+    /// Check manually if the pairing `e(g1,mvk) = e(k2,g2)` holds.
     pub(crate) fn verify_pairing(vk: &VerificationKey, pop: &ProofOfPossession) -> bool {
         unsafe {
             let g1_p = *blst_p1_affine_generator();
@@ -578,9 +578,9 @@ mod unsafe_helpers {
 
     pub(crate) fn scalar_to_pk_in_g1(sk: &SigningKey) -> blst_p1 {
         unsafe {
-            let sk_scalar = std::mem::transmute::<BlstSk, blst_scalar>(sk.0.clone());
+            let sk_scalar = std::mem::transmute::<&BlstSk, &blst_scalar>(&sk.0);
             let mut out = blst_p1::default();
-            blst_sk_to_pk_in_g1(&mut out, &sk_scalar);
+            blst_sk_to_pk_in_g1(&mut out, sk_scalar);
             out
         }
     }


### PR DESCRIPTION
## Content
<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->
This PR includes the helper functions that store all usage of unsafe code in `multi_sig.rs`. 

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Closes #690 
