### PR TITLE
Enhance errors catching in end to end test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "async-trait",
  "clap 4.1.4",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.1.2"
+version = "0.1.3"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -166,13 +166,17 @@ impl Devnet {
 
         info!("Starting the Devnet"; "script" => &run_script_path.display());
 
-        run_command
+        let status = run_command
             .spawn()
             .map_err(|e| format!("Failed to start the devnet: {e}"))?
             .wait()
             .await
             .map_err(|e| format!("Error while starting the devnet: {e}"))?;
-        Ok(())
+        match status.code() {
+            Some(0) => Ok(()),
+            Some(code) => Err(format!("Run devnet exited with status code: {code}")),
+            None => Err("Run devnet terminated by signal".to_string()),
+        }
     }
 
     pub async fn stop(&self) -> Result<(), String> {
@@ -185,13 +189,17 @@ impl Devnet {
 
         info!("Stopping the Devnet"; "script" => &stop_script_path.display());
 
-        stop_command
+        let status = stop_command
             .spawn()
             .map_err(|e| format!("Failed to stop the devnet: {e}"))?
             .wait()
             .await
             .map_err(|e| format!("Error while stopping the devnet: {e}"))?;
-        Ok(())
+        match status.code() {
+            Some(0) => Ok(()),
+            Some(code) => Err(format!("Stop devnet exited with status code: {code}")),
+            None => Err("Stop devnet terminated by signal".to_string()),
+        }
     }
 
     pub async fn delegate_stakes(&self) -> Result<(), String> {
@@ -204,13 +212,17 @@ impl Devnet {
 
         info!("Delegating stakes to the pools"; "script" => &run_script_path.display());
 
-        run_command
+        let status = run_command
             .spawn()
             .map_err(|e| format!("Failed to delegate stakes to the pools: {e}"))?
             .wait()
             .await
             .map_err(|e| format!("Error while delegating stakes to the pools: {e}"))?;
-        Ok(())
+        match status.code() {
+            Some(0) => Ok(()),
+            Some(code) => Err(format!("Delegating stakes exited with status code: {code}")),
+            None => Err("Delegating stakes terminated by signal".to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
## Content
This PR includes a fix on the end to end test to use the exit code of commands executed with shell when interacting with the `devnet`. This will stop the end to end test if starting the `devnet` or delegating stakes fails e.g.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

