### PR TITLE
Fix 'UnregisteredInitializer' error on signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2143,7 +2143,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "async-trait",
  "clap 4.1.4",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.13"
+version = "0.2.14"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -3,10 +3,12 @@
 //! These wrappers allows keeping mithril-stm agnostic to Cardano, while providing some
 //! guarantees that mithril-stm will not be misused in the context of Cardano.  
 
-use crate::crypto_helper::cardano::{OpCert, ParseError, SerDeShelleyFileFormat};
-use crate::crypto_helper::types::{
-    ProtocolPartyId, ProtocolSignerVerificationKey, ProtocolSignerVerificationKeySignature,
-    ProtocolStakeDistribution,
+use crate::crypto_helper::{
+    cardano::{OpCert, ParseError, SerDeShelleyFileFormat},
+    types::{
+        ProtocolParameters, ProtocolPartyId, ProtocolSignerVerificationKey,
+        ProtocolSignerVerificationKeySignature, ProtocolStakeDistribution,
+    },
 };
 
 use mithril_stm::key_reg::{ClosedKeyReg, KeyReg};
@@ -159,6 +161,11 @@ impl StmInitializerWrapper {
     /// Extract the verification key signature.
     pub fn verification_key_signature(&self) -> Option<ProtocolSignerVerificationKeySignature> {
         self.kes_signature
+    }
+
+    /// Extract the protocol parameters of the initializer
+    pub fn get_protocol_parameters(&self) -> ProtocolParameters {
+        self.stm_initializer.params
     }
 
     /// Extract the stake of the party

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.11"
+version = "0.2.12"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a fix to the error received by some signers when attempting to create a single signature: `ProtocolInitializerNotRegistered(CoreRegister(UnregisteredInitializer))`

After investigation, it appears that this error occurs when a signer is signing a message and is not registered for the next epoch: in that case the signer should be able to sign and should only skip signing at the next epoch. The fix replaces the usage of a protocol initializer with a clerk instead to compute the aggregate verification key that is embedded in the signed message.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #730 
