### PR TITLE
Add era command in aggregator cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.19"
+version = "0.2.20"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.16"
+version = "0.2.17"
 dependencies = [
  "async-trait",
  "bech32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,6 +2113,8 @@ dependencies = [
  "slog-scope",
  "slog-term",
  "sqlite",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
  "walkdir",
@@ -3521,6 +3523,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.19"
+version = "0.2.20"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -244,13 +244,6 @@ impl GenesisConfiguration {
     }
 }
 
-/// Configuration expected for Era commands.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct EraConfiguration {
-    /// Era markers verification key
-    pub era_markers_verification_key: Option<String>,
-}
-
 /// Default configuration with all the default values for configurations.
 #[derive(Debug, Clone)]
 pub struct DefaultConfiguration {

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -244,6 +244,13 @@ impl GenesisConfiguration {
     }
 }
 
+/// Configuration expected for Era commands.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EraConfiguration {
+    /// Era markers verification key
+    pub era_markers_verification_key: Option<String>,
+}
+
 /// Default configuration with all the default values for configurations.
 #[derive(Debug, Clone)]
 pub struct DefaultConfiguration {

--- a/mithril-aggregator/src/tools/era.rs
+++ b/mithril-aggregator/src/tools/era.rs
@@ -1,0 +1,110 @@
+use std::{error::Error, sync::Arc};
+
+use mithril_common::{
+    chain_observer::{TxDatumBuilder, TxDatumFieldTypeName, TxDatumFieldValue},
+    crypto_helper::{key_encode_hex, EraMarkersSigner, EraMarkersVerifier},
+    entities::Epoch,
+    era::{adapters::EraMarkersPayloadCardanoChain, EraMarker, SupportedEra},
+};
+
+type EraToolsResult<R> = Result<R, Box<dyn Error>>;
+
+pub struct EraToolsDependency {
+    /// Era markers signature verifier service.
+    pub era_markers_verifier: Option<Arc<EraMarkersVerifier>>,
+}
+
+pub struct EraTools {}
+
+impl EraTools {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    pub async fn from_dependencies(_dependencies: EraToolsDependency) -> EraToolsResult<Self> {
+        Ok(Self::new())
+    }
+
+    /// Get list of supported eras
+    pub fn get_supported_eras_list(&self) -> EraToolsResult<String> {
+        Ok(serde_json::to_string(&SupportedEra::eras())?)
+    }
+
+    /// Generate TxDatum for eras
+    pub fn generate_tx_datum(
+        &self,
+        current_era_epoch: Epoch,
+        maybe_next_era_epoch: Option<Epoch>,
+        era_markers_signer: &EraMarkersSigner,
+    ) -> EraToolsResult<String> {
+        if maybe_next_era_epoch.unwrap_or_default() >= current_era_epoch {
+            Err("next era epoch must be strictly greater than the current era epoch".to_string())?;
+        }
+
+        let mut era_markers = Vec::new();
+        for (index, era) in SupportedEra::eras().into_iter().enumerate() {
+            let era_marker = match index {
+                0 => EraMarker::new(&era.to_string(), Some(current_era_epoch)),
+                1 => EraMarker::new(&era.to_string(), maybe_next_era_epoch),
+                _ => unreachable!(),
+            };
+            era_markers.push(era_marker);
+        }
+        let era_markers_payload = EraMarkersPayloadCardanoChain {
+            markers: era_markers,
+            signature: None,
+        }
+        .sign(era_markers_signer)?;
+
+        let tx_datum = TxDatumBuilder::new()
+            .add_field(
+                TxDatumFieldTypeName::Bytes,
+                TxDatumFieldValue::Bytes(
+                    key_encode_hex(era_markers_payload)
+                        .map_err(|e| format!("era markerspayload could not be hex encoded: {e}"))?,
+                ),
+            )
+            .build()?;
+
+        Ok(tx_datum.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_tools() -> EraTools {
+        EraTools {}
+    }
+
+    #[test]
+    fn get_supported_eras_list() {
+        let era_tools = build_tools();
+        let supported_eras_list_serialized = era_tools
+            .get_supported_eras_list()
+            .expect("get_supported_eras_list should not fail");
+        let supported_eras_list: Vec<SupportedEra> =
+            serde_json::from_str(&supported_eras_list_serialized)
+                .expect("supported_eras_list_serialized should be a valid JSON");
+        assert_eq!(supported_eras_list, SupportedEra::eras());
+    }
+
+    #[test]
+    fn generate_tx_datum_ok() {
+        let era_markers_signer = EraMarkersSigner::create_deterministic_signer();
+        let era_tools = build_tools();
+        let _ = era_tools
+            .generate_tx_datum(Epoch(1), None, &era_markers_signer)
+            .expect("generate_tx_datum should not fail");
+    }
+
+    #[test]
+    fn generate_tx_datum_wrong_epochs() {
+        let era_markers_signer = EraMarkersSigner::create_deterministic_signer();
+        let era_tools = build_tools();
+        let _ = era_tools
+            .generate_tx_datum(Epoch(1), Some(Epoch(2)), &era_markers_signer)
+            .expect_err("generate_tx_datum should have failed");
+    }
+}

--- a/mithril-aggregator/src/tools/era.rs
+++ b/mithril-aggregator/src/tools/era.rs
@@ -1,18 +1,13 @@
-use std::{error::Error, sync::Arc};
+use std::error::Error;
 
 use mithril_common::{
     chain_observer::{TxDatumBuilder, TxDatumFieldValue},
-    crypto_helper::{key_encode_hex, EraMarkersSigner, EraMarkersVerifier},
+    crypto_helper::{key_encode_hex, EraMarkersSigner},
     entities::Epoch,
     era::{adapters::EraMarkersPayloadCardanoChain, EraMarker, SupportedEra},
 };
 
 type EraToolsResult<R> = Result<R, Box<dyn Error>>;
-
-pub struct EraToolsDependency {
-    /// Era markers signature verifier service.
-    pub era_markers_verifier: Option<Arc<EraMarkersVerifier>>,
-}
 
 pub struct EraTools {}
 
@@ -21,16 +16,12 @@ impl EraTools {
         Self {}
     }
 
-    pub async fn from_dependencies(_dependencies: EraToolsDependency) -> EraToolsResult<Self> {
-        Ok(Self::new())
-    }
-
     /// Get list of supported eras
-    pub fn get_supported_eras_list(&self) -> EraToolsResult<String> {
-        Ok(serde_json::to_string(&SupportedEra::eras())?)
+    pub fn get_supported_eras_list(&self) -> EraToolsResult<Vec<SupportedEra>> {
+        Ok(SupportedEra::eras())
     }
 
-    /// Generate TxDatum for eras
+    /// Generate TxDatum for eras with sanity check of epochs
     pub fn generate_tx_datum(
         &self,
         current_era_epoch: Epoch,
@@ -78,12 +69,9 @@ mod tests {
     #[test]
     fn get_supported_eras_list() {
         let era_tools = build_tools();
-        let supported_eras_list_serialized = era_tools
+        let supported_eras_list = era_tools
             .get_supported_eras_list()
             .expect("get_supported_eras_list should not fail");
-        let supported_eras_list: Vec<SupportedEra> =
-            serde_json::from_str(&supported_eras_list_serialized)
-                .expect("supported_eras_list_serialized should be a valid JSON");
         assert_eq!(supported_eras_list, SupportedEra::eras());
     }
 

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -4,7 +4,7 @@ mod genesis;
 mod remote_file_uploader;
 
 pub use digest_helpers::extract_digest_from_path;
-pub use era::{EraTools, EraToolsDependency};
+pub use era::EraTools;
 pub use genesis::{GenesisTools, GenesisToolsDependency};
 pub use remote_file_uploader::{GcpFileUploader, RemoteFileUploader};
 

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -1,8 +1,10 @@
 mod digest_helpers;
+mod era;
 mod genesis;
 mod remote_file_uploader;
 
 pub use digest_helpers::extract_digest_from_path;
+pub use era::{EraTools, EraToolsDependency};
 pub use genesis::{GenesisTools, GenesisToolsDependency};
 pub use remote_file_uploader::{GcpFileUploader, RemoteFileUploader};
 

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -44,6 +44,8 @@ sha2 = "0.10.2"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
 slog-scope = "4.4.0"
 sqlite = "0.28"
+strum = "0.24.1"
+strum_macros = "0.24.1"
 thiserror = "1.0.31"
 tokio = { version = "1.17.0", features = ["full"] }
 walkdir = "2"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.16"
+version = "0.2.17"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/chain_observer/cli_observer.rs
+++ b/mithril-common/src/chain_observer/cli_observer.rs
@@ -587,7 +587,7 @@ pool1qz2vzszautc2c8mljnqre2857dpmheq7kgt6vav0s38tvvhxm6w   1.051e-6
         let observer = CardanoCliChainObserver::new(Box::new(TestCliRunner {}));
         let address = "addrtest_123456".to_string();
         let datums = observer.get_current_datums(&address).await.unwrap();
-        assert_eq!(vec![TxDatum("{\"constructor\":0,\"fields\":[{\"bytes\":\"5b0a20207b0a20202020226e616d65223a20227468616c6573222c0a202020202265706f6368223a203132330a20207d2c0a20207b0a20202020226e616d65223a20227079746861676f726173222c0a202020202265706f6368223a206e756c6c0a20207d0a5d0a\"}]}".to_string())], datums);
+        assert_eq!(vec![TxDatum(r#"{"constructor":0,"fields":[{"bytes":"5b0a20207b0a20202020226e616d65223a20227468616c6573222c0a202020202265706f6368223a203132330a20207d2c0a20207b0a20202020226e616d65223a20227079746861676f726173222c0a202020202265706f6368223a206e756c6c0a20207d0a5d0a"}]}"#.to_string())], datums);
     }
 
     #[tokio::test]

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -10,4 +10,6 @@ pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
 #[cfg(any(test, feature = "test_only"))]
 pub use fake_observer::FakeObserver;
 pub use interface::{ChainObserver, ChainObserverError};
-pub use model::{ChainAddress, TxDatum};
+pub use model::{
+    ChainAddress, TxDatum, TxDatumBuilder, TxDatumError, TxDatumFieldTypeName, TxDatumFieldValue,
+};

--- a/mithril-common/src/chain_observer/model.rs
+++ b/mithril-common/src/chain_observer/model.rs
@@ -1,23 +1,25 @@
+use serde::Serialize;
 use serde_json::Value;
 use std::{collections::HashMap, error::Error as StdError};
+use strum_macros::Display;
 use thiserror::Error;
 
-/// [ChainAddress] represents an on chain address
+/// [ChainAddress] represents an on chain address.
 pub type ChainAddress = String;
 
 /// [TxDatum] related errors.
 #[derive(Debug, Error)]
 pub enum TxDatumError {
-    /// Generic [TxDatum] error.
-    #[error("general error {0}")]
-    _General(Box<dyn StdError + Sync + Send>),
-
     /// Error raised when the content could not be parsed.
-    #[error("could not parse content: {0}")]
+    #[error("could not parse tx datum: {0}")]
     InvalidContent(Box<dyn StdError + Sync + Send>),
+
+    /// Error raised when building the tx datum failed.
+    #[error("could not build tx datum: {0}")]
+    Build(serde_json::Error),
 }
 
-/// [TxDatum] represents transaction Datum
+/// [TxDatum] represents transaction Datum.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TxDatum(pub String);
 
@@ -25,7 +27,7 @@ impl TxDatum {
     /// Retrieves the nth field of the datum with given type
     pub fn get_nth_field_by_type(
         &self,
-        type_name: &str,
+        type_name: &TxDatumFieldTypeName,
         index: usize,
     ) -> Result<Value, Box<dyn StdError>> {
         let tx_datum_raw = &self.0;
@@ -48,7 +50,7 @@ impl TxDatum {
         // 3- Filter the vec (keep the ones that match the given type), and retrieve the nth entry of this filtered vec
         let field_value = fields
             .iter()
-            .filter(|&field| field.get(type_name).is_some())
+            .filter(|&field| field.get(type_name.to_string()).is_some())
             .nth(index)
             .ok_or_else(|| {
                 TxDatumError::InvalidContent(
@@ -58,10 +60,76 @@ impl TxDatum {
                     .into(),
                 )
             })?
-            .get(type_name)
+            .get(type_name.to_string())
             .unwrap();
 
         Ok(field_value.to_owned())
+    }
+}
+
+/// [TxDatumFieldTypeName] represents a fiel type name of TxDatum.
+#[derive(Debug, Serialize, Hash, PartialEq, Eq, Display)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum TxDatumFieldTypeName {
+    /// Bytes datum field type name.
+    Bytes,
+    /// Integer datum field type name
+    #[allow(dead_code)]
+    Int,
+}
+
+/// [TxDatumFieldValue] represents a fiel value of TxDatum.
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub enum TxDatumFieldValue {
+    /// Bytes datum field value.
+    Bytes(String),
+    /// Integer datum field value
+    #[allow(dead_code)]
+    Int(u32),
+}
+
+/// [TxDatumBuilder] is a [TxDatum] builder utility.
+#[derive(Debug, Serialize)]
+pub struct TxDatumBuilder {
+    constructor: usize,
+    fields: Vec<HashMap<TxDatumFieldTypeName, TxDatumFieldValue>>,
+}
+
+impl TxDatumBuilder {
+    /// [TxDatumBuilder] factory
+    pub fn new() -> Self {
+        Self {
+            constructor: 0,
+            fields: Vec::new(),
+        }
+    }
+
+    /// Add a field to the builder
+    pub fn add_field(
+        &mut self,
+        field_type: TxDatumFieldTypeName,
+        field_value: TxDatumFieldValue,
+    ) -> &mut TxDatumBuilder {
+        let mut field = HashMap::new();
+        field.insert(field_type, field_value);
+        self.fields.push(field);
+
+        self
+    }
+
+    /// Build a [TxDatum]
+    pub fn build(&self) -> Result<TxDatum, TxDatumError> {
+        Ok(TxDatum(
+            serde_json::to_string(&self).map_err(TxDatumError::Build)?,
+        ))
+    }
+}
+
+impl Default for TxDatumBuilder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
@@ -70,7 +138,33 @@ mod test {
     use super::*;
 
     fn dummy_tx_datum() -> TxDatum {
-        TxDatum("{\"constructor\":0,\"fields\":[{\"bytes\":\"bytes0\"}, {\"int\":0}, {\"int\":1}, {\"bytes\":\"bytes1\"}, {\"bytes\":\"bytes2\"}, {\"int\":2}]}".to_string())
+        let mut tx_datum_builder = TxDatumBuilder::new();
+        let tx_datum = tx_datum_builder
+            .add_field(
+                TxDatumFieldTypeName::Bytes,
+                TxDatumFieldValue::Bytes("bytes0".to_string()),
+            )
+            .add_field(TxDatumFieldTypeName::Int, TxDatumFieldValue::Int(0))
+            .add_field(TxDatumFieldTypeName::Int, TxDatumFieldValue::Int(1))
+            .add_field(
+                TxDatumFieldTypeName::Bytes,
+                TxDatumFieldValue::Bytes("bytes1".to_string()),
+            )
+            .add_field(
+                TxDatumFieldTypeName::Bytes,
+                TxDatumFieldValue::Bytes("bytes2".to_string()),
+            )
+            .add_field(TxDatumFieldTypeName::Int, TxDatumFieldValue::Int(2))
+            .build()
+            .expect("tx_datum build should not fail");
+        tx_datum
+    }
+
+    #[test]
+    fn test_build_tx_datum() {
+        let tx_datum = dummy_tx_datum();
+        let tx_datum_expected = TxDatum("{\"constructor\":0,\"fields\":[{\"bytes\":\"bytes0\"},{\"int\":0},{\"int\":1},{\"bytes\":\"bytes1\"},{\"bytes\":\"bytes2\"},{\"int\":2}]}".to_string());
+        assert_eq!(tx_datum_expected, tx_datum);
     }
 
     #[test]
@@ -79,7 +173,7 @@ mod test {
         assert_eq!(
             "bytes0",
             tx_datum
-                .get_nth_field_by_type("bytes", 0)
+                .get_nth_field_by_type(&TxDatumFieldTypeName::Bytes, 0)
                 .unwrap()
                 .as_str()
                 .unwrap()
@@ -87,7 +181,7 @@ mod test {
         assert_eq!(
             "bytes1",
             tx_datum
-                .get_nth_field_by_type("bytes", 1)
+                .get_nth_field_by_type(&TxDatumFieldTypeName::Bytes, 1)
                 .unwrap()
                 .as_str()
                 .unwrap()
@@ -95,13 +189,13 @@ mod test {
         assert_eq!(
             "bytes2",
             tx_datum
-                .get_nth_field_by_type("bytes", 2)
+                .get_nth_field_by_type(&TxDatumFieldTypeName::Bytes, 2)
                 .unwrap()
                 .as_str()
                 .unwrap()
         );
         tx_datum
-            .get_nth_field_by_type("bytes", 100)
+            .get_nth_field_by_type(&TxDatumFieldTypeName::Bytes, 100)
             .expect_err("should have returned an error");
     }
 
@@ -111,7 +205,7 @@ mod test {
         assert_eq!(
             0,
             tx_datum
-                .get_nth_field_by_type("int", 0)
+                .get_nth_field_by_type(&TxDatumFieldTypeName::Int, 0)
                 .unwrap()
                 .as_u64()
                 .unwrap()
@@ -119,7 +213,7 @@ mod test {
         assert_eq!(
             1,
             tx_datum
-                .get_nth_field_by_type("int", 1)
+                .get_nth_field_by_type(&TxDatumFieldTypeName::Int, 1)
                 .unwrap()
                 .as_u64()
                 .unwrap()
@@ -127,13 +221,13 @@ mod test {
         assert_eq!(
             2,
             tx_datum
-                .get_nth_field_by_type("int", 2)
+                .get_nth_field_by_type(&TxDatumFieldTypeName::Int, 2)
                 .unwrap()
                 .as_u64()
                 .unwrap()
         );
         tx_datum
-            .get_nth_field_by_type("int", 100)
+            .get_nth_field_by_type(&TxDatumFieldTypeName::Int, 100)
             .expect_err("should have returned an error");
     }
 }

--- a/mithril-common/src/chain_observer/model.rs
+++ b/mithril-common/src/chain_observer/model.rs
@@ -71,7 +71,7 @@ impl TxDatum {
 #[derive(Debug, EnumDiscriminants, Serialize, Display)]
 #[serde(untagged)]
 #[strum(serialize_all = "lowercase")]
-#[strum_discriminants(derive(Serialize, Hash, Display))]
+#[strum_discriminants(derive(Serialize, Display))]
 #[strum_discriminants(name(TxDatumFieldTypeName))]
 #[strum_discriminants(strum(serialize_all = "lowercase"))]
 pub enum TxDatumFieldValue {
@@ -145,7 +145,7 @@ mod test {
     #[test]
     fn test_build_tx_datum() {
         let tx_datum = dummy_tx_datum();
-        let tx_datum_expected = TxDatum("{\"constructor\":0,\"fields\":[{\"bytes\":\"bytes0\"},{\"int\":0},{\"int\":1},{\"bytes\":\"bytes1\"},{\"bytes\":\"bytes2\"},{\"int\":2}]}".to_string());
+        let tx_datum_expected = TxDatum(r#"{"constructor":0,"fields":[{"bytes":"bytes0"},{"int":0},{"int":1},{"bytes":"bytes1"},{"bytes":"bytes2"},{"int":2}]}"#.to_string());
         assert_eq!(tx_datum_expected, tx_datum);
     }
 

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -29,7 +29,8 @@ pub use signer::{Signer, SignerWithStake};
 pub use single_signatures::SingleSignatures;
 pub use snapshot::Snapshot;
 pub use type_alias::{
-    HexEncodedAgregateVerificationKey, HexEncodedDigest, HexEncodedGenesisSecretKey,
+    HexEncodedAgregateVerificationKey, HexEncodedDigest, HexEncodedEraMarkersSecretKey,
+    HexEncodedEraMarkersSignature, HexEncodedEraMarkersVerificationKey, HexEncodedGenesisSecretKey,
     HexEncodedGenesisSignature, HexEncodedGenesisVerificationKey, HexEncodedKey,
     HexEncodedMultiSignature, HexEncodedOpCert, HexEncodedSingleSignature,
     HexEncodedVerificationKey, HexEncodedVerificationKeySignature, ImmutableFileName,

--- a/mithril-common/src/entities/type_alias.rs
+++ b/mithril-common/src/entities/type_alias.rs
@@ -56,3 +56,12 @@ pub type HexEncodedGenesisSignature = HexEncodedKey;
 
 /// Hex encoded Sha256 Digest
 pub type HexEncodedDigest = HexEncodedKey;
+
+/// Hex encoded Era Markers Secret Key
+pub type HexEncodedEraMarkersSecretKey = HexEncodedKey;
+
+/// Hex encoded Era Markers Verification Key
+pub type HexEncodedEraMarkersVerificationKey = HexEncodedKey;
+
+/// Hex encoded Era Markers Signature
+pub type HexEncodedEraMarkersSignature = HexEncodedKey;

--- a/mithril-common/src/era/adapters/bootstrap.rs
+++ b/mithril-common/src/era/adapters/bootstrap.rs
@@ -13,7 +13,7 @@ pub struct BootstrapAdapter;
 impl EraReaderAdapter for BootstrapAdapter {
     async fn read(&self) -> Result<Vec<EraMarker>, Box<dyn std::error::Error + Sync + Send>> {
         Ok(vec![EraMarker::new(
-            &SupportedEra::Thales.to_string(),
+            &SupportedEra::eras().first().unwrap().to_string(),
             Some(Epoch(1)),
         )])
     }

--- a/mithril-common/src/era/adapters/cardano_chain.rs
+++ b/mithril-common/src/era/adapters/cardano_chain.rs
@@ -1,5 +1,5 @@
 use crate::{
-    chain_observer::{ChainAddress, ChainObserver},
+    chain_observer::{ChainAddress, ChainObserver, TxDatumFieldTypeName},
     crypto_helper::{
         key_decode_hex, EraMarkersSigner, EraMarkersVerifier, EraMarkersVerifierSignature,
         EraMarkersVerifierVerificationKey,
@@ -127,7 +127,11 @@ impl EraReaderAdapter for CardanoChainAdapter {
             .await?;
         let markers_list = tx_datums
             .into_iter()
-            .filter_map(|datum| datum.get_nth_field_by_type("bytes", 0).ok())
+            .filter_map(|datum| {
+                datum
+                    .get_nth_field_by_type(&TxDatumFieldTypeName::Bytes, 0)
+                    .ok()
+            })
             .filter_map(|field_value| field_value.as_str().map(|s| s.to_string()))
             .filter_map(|field_value_str| key_decode_hex(&field_value_str).ok())
             .filter_map(|era_markers_payload: EraMarkersPayload| {
@@ -144,7 +148,7 @@ impl EraReaderAdapter for CardanoChainAdapter {
 
 #[cfg(test)]
 mod test {
-    use crate::chain_observer::{FakeObserver, TxDatum};
+    use crate::chain_observer::{FakeObserver, TxDatum, TxDatumBuilder, TxDatumFieldValue};
     use crate::crypto_helper::{key_encode_hex, EraMarkersSigner};
     use crate::entities::Epoch;
 
@@ -154,10 +158,13 @@ mod test {
         payloads
             .into_iter()
             .map(|payload| {
-                TxDatum(format!(
-                    "{{\"constructor\":0,\"fields\":[{{\"bytes\":\"{}\"}}]}}",
-                    key_encode_hex(payload).unwrap()
-                ))
+                TxDatumBuilder::new()
+                    .add_field(
+                        TxDatumFieldTypeName::Bytes,
+                        TxDatumFieldValue::Bytes(key_encode_hex(payload).unwrap()),
+                    )
+                    .build()
+                    .unwrap()
             })
             .collect()
     }

--- a/mithril-common/src/era/adapters/cardano_chain.rs
+++ b/mithril-common/src/era/adapters/cardano_chain.rs
@@ -4,6 +4,7 @@ use crate::{
         key_decode_hex, EraMarkersSigner, EraMarkersVerifier, EraMarkersVerifierSignature,
         EraMarkersVerifierVerificationKey,
     },
+    entities::HexEncodedEraMarkersSignature,
     era::{EraMarker, EraReaderAdapter},
 };
 use async_trait::async_trait;
@@ -14,8 +15,6 @@ use std::sync::Arc;
 use thiserror::Error;
 
 type GeneralError = Box<dyn StdError + Sync + Send>;
-
-type HexEncodeEraMarkerSignature = String;
 
 /// [EraMarkersPayload] related errors.
 #[derive(Debug, Error)]
@@ -44,8 +43,11 @@ pub enum EraMarkersPayloadError {
 /// Era markers payload
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EraMarkersPayload {
-    markers: Vec<EraMarker>,
-    signature: Option<HexEncodeEraMarkerSignature>,
+    /// List of Era markers
+    pub markers: Vec<EraMarker>,
+
+    /// Era markers signature
+    pub signature: Option<HexEncodedEraMarkersSignature>,
 }
 
 impl EraMarkersPayload {
@@ -79,7 +81,6 @@ impl EraMarkersPayload {
     }
 
     /// Sign an era markers payload
-    #[allow(dead_code)]
     pub fn sign(self, signer: &EraMarkersSigner) -> Result<Self, EraMarkersPayloadError> {
         let signature = signer
             .sign(

--- a/mithril-common/src/era/adapters/cardano_chain.rs
+++ b/mithril-common/src/era/adapters/cardano_chain.rs
@@ -160,10 +160,7 @@ mod test {
             .into_iter()
             .map(|payload| {
                 TxDatumBuilder::new()
-                    .add_field(
-                        TxDatumFieldTypeName::Bytes,
-                        TxDatumFieldValue::Bytes(key_encode_hex(payload).unwrap()),
-                    )
+                    .add_field(TxDatumFieldValue::Bytes(key_encode_hex(payload).unwrap()))
                     .build()
                     .unwrap()
             })

--- a/mithril-common/src/era/adapters/mod.rs
+++ b/mithril-common/src/era/adapters/mod.rs
@@ -7,6 +7,9 @@ mod file;
 
 pub use bootstrap::BootstrapAdapter as EraReaderBootstrapAdapter;
 pub use builder::{AdapterBuilder as EraReaderAdapterBuilder, AdapterType as EraReaderAdapterType};
-pub use cardano_chain::CardanoChainAdapter as EraReaderCardanoChainAdapter;
+pub use cardano_chain::{
+    CardanoChainAdapter as EraReaderCardanoChainAdapter,
+    EraMarkersPayload as EraMarkersPayloadCardanoChain,
+};
 pub use dummy::DummyAdapter as EraReaderDummyAdapter;
 pub use file::FileAdapter as EraReaderFileAdapter;

--- a/mithril-common/src/era/supported_era.rs
+++ b/mithril-common/src/era/supported_era.rs
@@ -1,4 +1,4 @@
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use strum::IntoEnumIterator;
 use strum_macros::{Display, EnumIter, EnumString};
 
@@ -6,7 +6,9 @@ use strum_macros::{Display, EnumIter, EnumString};
 pub type UnsupportedEraError = strum::ParseError;
 
 /// The era that the software is running or will run
-#[derive(Display, EnumString, EnumIter, Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(
+    Display, EnumString, EnumIter, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize,
+)]
 #[strum(serialize_all = "lowercase")]
 pub enum SupportedEra {
     /// Thales era

--- a/mithril-common/src/era/supported_era.rs
+++ b/mithril-common/src/era/supported_era.rs
@@ -1,75 +1,48 @@
-use std::str::FromStr;
-
 use serde::Deserialize;
-use thiserror::Error;
+use strum::IntoEnumIterator;
+use strum_macros::{Display, EnumIter, EnumString};
+
+/// Error related to [SupportedEra] String parsing implementation.
+pub type UnsupportedEraError = strum::ParseError;
 
 /// The era that the software is running or will run
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[derive(Display, EnumString, EnumIter, Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[strum(serialize_all = "lowercase")]
 pub enum SupportedEra {
     /// Thales era
     Thales,
 }
 
 impl SupportedEra {
+    /// Retrieve the list of supported eras
+    pub fn eras() -> Vec<Self> {
+        Self::iter().collect()
+    }
+
     /// Retrieve a dummy era (for test only)
     #[cfg(any(test, feature = "test_only"))]
     pub fn dummy() -> Self {
-        Self::Thales
-    }
-}
-
-/// Error related to [SupportedEra] String parsing implementation.
-#[derive(Error, Debug)]
-#[error("Unable to transform era '{0}' into a currently supported era.")]
-pub struct UnsupportedEraError(String);
-
-impl FromStr for SupportedEra {
-    type Err = UnsupportedEraError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let s = s.trim().to_lowercase();
-
-        let era = match s.as_str() {
-            "thales" => Self::Thales,
-            _ => return Err(UnsupportedEraError(s)),
-        };
-
-        // This is intended to make the compiler to complain when a new variant
-        // is added in order not to forget to add a conversion for the new
-        // variant.
-        match era {
-            Self::Thales => Ok(Self::Thales),
-        }
-    }
-}
-
-impl ToString for SupportedEra {
-    fn to_string(&self) -> String {
-        match self {
-            Self::Thales => "thales".to_owned(),
-        }
+        Self::eras().first().unwrap().to_owned()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    const ERA_NAME: &str = "thales";
+    use std::str::FromStr;
 
     #[test]
-    fn from_str() {
-        let supported_era =
-            SupportedEra::from_str(ERA_NAME).expect("This era name should be supported.");
+    fn correct_number_of_eras() {
+        let total_eras = SupportedEra::eras().len();
 
-        assert_eq!(SupportedEra::dummy(), supported_era);
+        assert!(total_eras > 0);
+        assert!(total_eras <= 2);
     }
 
     #[test]
-    fn from_bad_str() {
-        let era_name = &format!("  {} ", ERA_NAME.to_ascii_uppercase());
-        let supported_era =
-            SupportedEra::from_str(era_name).expect("This era name should be supported.");
+    fn from_str() {
+        let supported_era = SupportedEra::from_str(&SupportedEra::dummy().to_string())
+            .expect("This era name should be supported.");
 
         assert_eq!(SupportedEra::dummy(), supported_era);
     }


### PR DESCRIPTION
## Content
This PR includes a Era command in the aggregator cli that:
- Lists the supported eras
- Generate a `TxDatum` JSON that can be used in an on-chain transaction


## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #755
