### PR TITLE
#757 replace unixepoch with strftime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.17"
+version = "0.2.19"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.17"
+version = "0.2.19"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/event_store/event.rs
+++ b/mithril-aggregator/src/event_store/event.rs
@@ -66,7 +66,7 @@ impl SqLiteEntity for Event {
     fn get_projection() -> Projection {
         let mut projection = Projection::default();
         projection.add_field("event_id", "event_id", "int");
-        projection.add_field("created_at", "unixepoch(created_at)", "string");
+        projection.add_field("created_at", "strftime('%s', created_at)", "string");
         projection.add_field("source", "source", "string");
         projection.add_field("action", "action", "string");
         projection.add_field("content", "content", "string");
@@ -191,7 +191,7 @@ mod tests {
         let connection = Connection::open(":memory:").unwrap();
         let provider = EventPersisterProvider::new(&connection);
         assert_eq!(
-            r#"insert into event (source, action, content) values (?1, ?2, ?3) returning event_id as event_id, unixepoch(created_at) as created_at, source as source, action as action, content as content"#,
+            r#"insert into event (source, action, content) values (?1, ?2, ?3) returning event_id as event_id, strftime('%s', created_at) as created_at, source as source, action as action, content as content"#,
             provider.get_definition(None)
         )
     }


### PR DESCRIPTION
## Content
This makes the aggregator compatible with Sqlite versions more recent than 3.38. 

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [X] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Closes #757 
