### PR TITLE
Add dynamic matrix in CI for end to end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   build-ubuntu-X64:
     runs-on: ubuntu-22.04
+    outputs:
+      eras: ${{ steps.eras-test-lab.outputs.eras }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -59,6 +61,13 @@ jobs:
           name: mithril-end-to-end-${{ runner.os }}-${{ runner.arch }}
           path: target/release/mithril-end-to-end
           if-no-files-found: error
+
+      - name: Prepare test lab eras
+        id: eras-test-lab
+        run: |
+          ERAS=$(./target/release/mithril-aggregator era list --json)
+          echo "Test Lab Eras: $ERAS"
+          echo "eras=$ERAS" >> $GITHUB_OUTPUT
   
   build:
     strategy:
@@ -178,7 +187,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        era: [ thales ]
+        era: ${{ fromJSON(needs.build-ubuntu-X64.outputs.eras) }}
         run_id: [1,2,3]
     steps:
       - name: Checkout sources

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.17"
+version = "0.2.18"
 dependencies = [
  "async-trait",
  "bech32",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.20"
+version = "0.2.21"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.17"
+version = "0.2.18"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/chain_observer/model.rs
+++ b/mithril-common/src/chain_observer/model.rs
@@ -69,11 +69,12 @@ impl TxDatum {
 
 /// [TxDatumFieldValue] represents a fiel value of TxDatum.
 #[derive(Debug, EnumDiscriminants, Serialize, Display)]
-#[serde(untagged)]
+#[serde(untagged, rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
-#[strum_discriminants(derive(Serialize, Display))]
+#[strum_discriminants(derive(Serialize, Hash, Display))]
 #[strum_discriminants(name(TxDatumFieldTypeName))]
 #[strum_discriminants(strum(serialize_all = "lowercase"))]
+#[strum_discriminants(serde(rename_all = "lowercase"))]
 pub enum TxDatumFieldValue {
     /// Bytes datum field value.
     Bytes(String),
@@ -86,7 +87,7 @@ pub enum TxDatumFieldValue {
 #[derive(Debug, Serialize)]
 pub struct TxDatumBuilder {
     constructor: usize,
-    fields: Vec<HashMap<String, TxDatumFieldValue>>,
+    fields: Vec<HashMap<TxDatumFieldTypeName, TxDatumFieldValue>>,
 }
 
 impl TxDatumBuilder {
@@ -101,10 +102,7 @@ impl TxDatumBuilder {
     /// Add a field to the builder
     pub fn add_field(&mut self, field_value: TxDatumFieldValue) -> &mut TxDatumBuilder {
         let mut field = HashMap::new();
-        field.insert(
-            TxDatumFieldTypeName::from(&field_value).to_string(),
-            field_value,
-        );
+        field.insert(TxDatumFieldTypeName::from(&field_value), field_value);
         self.fields.push(field);
 
         self

--- a/mithril-common/src/era/supported_era.rs
+++ b/mithril-common/src/era/supported_era.rs
@@ -9,6 +9,7 @@ pub type UnsupportedEraError = strum::ParseError;
 #[derive(
     Display, EnumString, EnumIter, Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize,
 )]
+#[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum SupportedEra {
     /// Thales era


### PR DESCRIPTION
## Content
This PR includes a dynamic generation of the matrix cases of the end to end tests in the CI. It now uses the list of available eras and combines them with the number of runs by era.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #760 
