### PR TITLE
add warning when event can not send epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2019,7 +2019,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.21"
+version = "0.2.22"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -59,10 +59,13 @@ mod handlers {
             Some(version) => vec![("signer-node-version", version)],
             None => Vec::new(),
         };
-        let epoch_str = if let Ok(beacon) = beacon_provider.get_current_beacon().await {
-            format!("{}", beacon.epoch)
-        } else {
-            String::new()
+        let epoch_str = match beacon_provider.get_current_beacon().await {
+            Ok(beacon) => format!("{}", beacon.epoch),
+            Err(e) => {
+                warn!("Could not read beacon to add in event: {e}");
+
+                String::new()
+            }
         };
 
         if epoch_str.is_empty() {


### PR DESCRIPTION
## Content
This PR adds a warning when the Epoch can not be fetched when sending an event.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [X] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
None
