### PR TITLE
Upgrade SQLite to `3.40` in aggregator infra

### DIFF
--- a/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
@@ -39,7 +39,7 @@ This is the node of the **Mithril Network** responsible for collecting individua
 
 * Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 
-* Ensure SQLite3 library is installed on your system and its version is at least `3.35` (released Apr. 2021) on Debian/Ubuntu: `apt install libsqlite3` and `sqlite3 --version`.
+* Ensure SQLite3 library is installed on your system and its version is at least `3.40`. Run `sqlite3 --version` to check your version.
 
 ## Download source
 

--- a/docs/root/manual/getting-started/run-mithril-devnet.md
+++ b/docs/root/manual/getting-started/run-mithril-devnet.md
@@ -39,7 +39,7 @@ More information about this private Cardano/Mithril `devnet` is available [here]
 
 * Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 
-* Ensure SQLite3 library is installed on your system and its version is at least `3.35` (released Apr. 2021) on Debian/Ubuntu: `apt install libsqlite3` and `sqlite3 --version`.
+* Ensure SQLite3 library is installed on your system and its version is at least  `3.40`. Run `sqlite3 --version` to check your version.
 
 ## Download source
 

--- a/mithril-aggregator/README.md
+++ b/mithril-aggregator/README.md
@@ -12,7 +12,7 @@ This is a first version of the Mithril Aggregagator
 
 - Install a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain (latest stable version).
 - Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
-- Ensure `libsqlite3` is installed on your system and check its version is at least `3.35`. Run `apt install libsqlite3` and `sqlite3 --version`
+- Ensure `libsqlite3` is installed on your system and check its version is at least `3.40`. Run `sqlite3 --version` to check your version.
 
 ## Mithril test networks
 

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -65,7 +65,7 @@ mod handlers {
             String::new()
         };
 
-        if epoch_str.is_empty() {
+        if !epoch_str.is_empty() {
             headers.push(("epoch", epoch_str.as_str()));
         }
         match signer_registerer.register_signer(&signer).await {

--- a/mithril-infra/assets/startup-vm.sh
+++ b/mithril-infra/assets/startup-vm.sh
@@ -8,7 +8,12 @@ sudo apt update -y
 sudo apt install -y jq tree ca-certificates curl gnupg lsb-release 
 
 # Install sqlite3
-sudo apt install -y sqlite3
+curl http://ftp.fr.debian.org/debian/pool/main/s/sqlite3/libsqlite3-0_3.40.1-1_amd64.deb -o libsqlite3-0_3.40.1-1_amd64.deb
+dpkg -i libsqlite3-0_3.40.1-1_amd64.deb
+rm -f libsqlite3-0_3.40.1-1_amd64.deb
+curl http://ftp.fr.debian.org/debian/pool/main/s/sqlite3/sqlite3_3.40.1-1_amd64.deb -o sqlite3_3.40.1-1_amd64.deb
+dpkg -i sqlite3_3.40.1-1_amd64.deb
+rm -f sqlite3_3.40.1-1_amd64.deb
 
 # Install docker & docker-compose
 sudo mkdir -p /etc/apt/keyrings


### PR DESCRIPTION
## Content
This PR includes the update of SQLite to `3.40` in the infra of the Aggregator

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] Update documentation website (if relevant)

## Issue(s)
Closes #765
