### PR TITLE
Fix client Docker image crash

### DIFF
--- a/mithril-client/Dockerfile.ci
+++ b/mithril-client/Dockerfile.ci
@@ -4,7 +4,7 @@
 FROM ubuntu:22.04
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser


### PR DESCRIPTION
## Content
This PR includes a fix to client docker image built from CI that is crashing with a `/app/bin/mithril-client: error while loading shared libraries: libsqlite3.so.0: cannot open shared object file: No such file or directory` error.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #769 
