### PR TITLE
:fire: Test `mainnet` setup 

### DIFF
--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -74,7 +74,7 @@ serde_json = "1.0"
 serde_yaml = "0.9.10"
 
 [features]
-default = []
+default = ["allow_skip_signer_certification"]
 portable = ["mithril-stm/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 allow_skip_signer_certification = []
 

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -27,6 +27,6 @@ tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
 
 [features]
-default = []
+default = ["allow_skip_signer_certification"]
 portable = ["mithril-common/portable"]
 allow_skip_signer_certification = []


### PR DESCRIPTION
## Content

:warning: This PR **must not be merged**, for test purpose only!

This PR includes a setup for testing the new `cardano-cli` (`8.1.1`) on the `mainnet` network:
- Activate `allow_skip_signer_certification` feature

## Issue(s)
Relates to #777