### PR TITLE
Update KES

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,9 +1793,9 @@ dependencies = [
 
 [[package]]
 name = "kes-summed-ed25519"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff5ba36dcf3798c53cfe222f22038ac63b1a3ef676a68af50a990d2775280cfb"
+checksum = "091ace8c9cd5555e89df0cecf77e09aa658907fbc4a316d350a4344cafdb8c4b"
 dependencies = [
  "blake2 0.9.2",
  "ed25519-dalek",
@@ -2086,6 +2086,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "sha2 0.10.6",
  "slog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2032,7 +2032,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "async-trait",
  "clap 4.1.8",
@@ -2126,7 +2126,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "async-trait",
  "clap 4.1.8",
@@ -2151,11 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-<<<<<<< HEAD
-version = "0.2.6"
-=======
-version = "0.2.5"
->>>>>>> 624faa66ef (bump stm and common versions)
+version = "0.2.7"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2059,7 +2059,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2151,7 +2151,11 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
+<<<<<<< HEAD
 version = "0.2.6"
+=======
+version = "0.2.5"
+>>>>>>> 624faa66ef (bump stm and common versions)
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.30"
+version = "0.2.31"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.2.10"
+version = "0.2.11"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/CHANGELOG.md
+++ b/mithril-common/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.2.20 (15-03-2023)
+Initial CHANGELOG registry.
+### Added
+- New version of KES signature, which requires buffer allocation prior to key generation.
+- Added wrapper struct to KES signature to allow copying the data. The new version of KES does not allow it anymore.

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.25"
+version = "0.2.26"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -27,7 +27,7 @@ glob = "0.3"
 hex = "0.4.3"
 http = "0.2.6"
 jsonschema = "0.16.0"
-kes-summed-ed25519 = { version = "0.1.1", features = ["serde_enabled"] }
+kes-summed-ed25519 = { version = "0.2.0", features = ["serde_enabled", "sk_clone_enabled"]}
 lazy_static = "1.4.0"
 mockall = "0.11.0"
 nom = "7.1"
@@ -39,6 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.7"
 serde_cbor = "0.11.2"
 serde_json = "1.0"
+serde_with = "2.2.0"
 serde_yaml = "0.9.10"
 sha2 = "0.10.2"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -27,7 +27,7 @@ glob = "0.3"
 hex = "0.4.3"
 http = "0.2.6"
 jsonschema = "0.16.0"
-kes-summed-ed25519 = { version = "0.2.0", features = ["serde_enabled", "sk_clone_enabled"]}
+kes-summed-ed25519 = { version = "0.2.0", features = ["serde_enabled", "sk_clone_enabled"] }
 lazy_static = "1.4.0"
 mockall = "0.11.0"
 nom = "7.1"

--- a/mithril-common/src/chain_observer/cli_observer.rs
+++ b/mithril-common/src/chain_observer/cli_observer.rs
@@ -635,7 +635,9 @@ pool1qz2vzszautc2c8mljnqre2857dpmheq7kgt6vav0s38tvvhxm6w   1.051e-6
     #[tokio::test]
     async fn test_get_current_kes_period() {
         let keypair = ColdKeyGenerator::create_deterministic_keypair([0u8; 32]);
-        let (_, kes_verification_key) = Sum6Kes::keygen(&mut [0u8; 32]);
+        let mut dummy_key_buffer = [0u8; Sum6Kes::SIZE + 4];
+        let mut dummy_seed = [0u8; 32];
+        let (_, kes_verification_key) = Sum6Kes::keygen(&mut dummy_key_buffer, &mut dummy_seed);
         let operational_certificate = OpCert::new(kes_verification_key, 0, 0, keypair);
         let observer = CardanoCliChainObserver::new(Box::new(TestCliRunner {}));
         let kes_period = observer

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -13,12 +13,23 @@
 
 use hex::FromHex;
 use kes_summed_ed25519::kes::Sum6Kes;
+use kes_summed_ed25519::traits::KesSk;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
+use serde_with::{As, Bytes};
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 use thiserror::Error;
+
+/// We need to create this struct because the design of Sum6Kes takes
+/// a reference to a mutable pointer. It is therefore not possible to
+/// implement Ser/Deser using serde.
+// We need this helper structure, because we are currently getting the key
+// from a file, instead of directly consuming a buffer.
+// todo: create the KES key directly from a buffer instead of deserialising from disk
+#[derive(Clone, Serialize, Deserialize)]
+pub struct Sum6KesBytes(#[serde(with = "As::<Bytes>")] pub [u8; 612]);
 
 /// Parse error
 #[derive(Error, Debug)]
@@ -85,7 +96,7 @@ pub trait SerDeShelleyFileFormat: Serialize + DeserializeOwned {
     }
 }
 
-impl SerDeShelleyFileFormat for Sum6Kes {
+impl SerDeShelleyFileFormat for Sum6KesBytes {
     const TYPE: &'static str = "KesSigningKey_ed25519_kes_2^6";
     const DESCRIPTION: &'static str = "KES Signing Key";
 
@@ -110,6 +121,12 @@ impl SerDeShelleyFileFormat for Sum6Kes {
     }
 }
 
+impl<'a> From<&'a mut Sum6KesBytes> for Sum6Kes<'a> {
+    fn from(value: &'a mut Sum6KesBytes) -> Self {
+        Self::from_bytes(&mut value.0).expect("Invalid data format")
+    }
+}
+
 #[cfg(all(test))]
 mod test {
     use super::*;
@@ -122,8 +139,8 @@ mod test {
         let cbor_string = "590260fe77acdfa56281e4b05198f5136018057a65f425411f0990cac4aca0f2917aa00a3d51e191f6f425d870aca3c6a2a41833621f5729d7bc0e3dfc3ae77d057e5e1253b71def7a54157b9f98973ca3c49edd9f311e5f4b23ac268b56a6ac040c14c6d2217925492e42f00dc89a2a01ff363571df0ca0db5ba37001cee56790cc01cd69c6aa760fca55a65a110305ea3c11da0a27be345a589329a584ebfc499c43c55e8c6db5d9c0b014692533ee78abd7ac1e79f7ec9335c7551d31668369b4d5111db78072f010043e35e5ca7f11acc3c05b26b9c7fe56f02aa41544f00cb7685e87f34c73b617260ade3c7b8d8c4df46693694998f85ad80d2cbab0b575b6ccd65d90574e84368169578bff57f751bc94f7eec5c0d7055ec88891a69545eedbfbd3c5f1b1c1fe09c14099f6b052aa215efdc5cb6cdc84aa810db41dbe8cb7d28f7c4beb75cc53915d3ac75fc9d0bf1c734a46e401e15150c147d013a938b7e07cc4f25a582b914e94783d15896530409b8acbe31ef471de8a1988ac78dfb7510729eff008084885f07df870b65e4f382ca15908e1dcda77384b5c724350de90cec22b1dcbb1cdaed88da08bb4772a82266ec154f5887f89860d0920dba705c45957ef6d93e42f6c9509c966277d368dd0eefa67c8147aa15d40a222f7953a4f34616500b310d00aa1b5b73eb237dc4f76c0c16813d321b2fc5ac97039be25b22509d1201d61f4ccc11cd4ff40fffe39f0e937b4722074d8e073a775d7283b715d46f79ce128e3f1362f35615fa72364d20b6db841193d96e58d9d8e86b516bbd1f05e45b39823a93f6e9f29d9e01acf2c12c072d1c64e0afbbabf6903ef542e".to_string();
 
         let file_format = ShelleyFileFormat {
-            file_type: Sum6Kes::TYPE.to_string(),
-            description: Sum6Kes::DESCRIPTION.to_string(),
+            file_type: Sum6KesBytes::TYPE.to_string(),
+            description: Sum6KesBytes::DESCRIPTION.to_string(),
             cbor_hex: cbor_string,
         };
 
@@ -134,8 +151,9 @@ mod test {
 
         write!(file, "{json_str}").expect("Unexpected error writing to file.");
 
-        let kes_sk = Sum6Kes::from_file(&sk_dir);
+        let mut kes_sk_bytes =
+            Sum6KesBytes::from_file(&sk_dir).expect("Failure parsing Shelley file format.");
 
-        assert!(kes_sk.is_ok(), "Failure parsing Shelley file format.");
+        let _kes_sk = Sum6Kes::from(&mut kes_sk_bytes); // Panics if data is incorrect
     }
 }

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -125,7 +125,8 @@ impl StmInitializerWrapper {
         let stm_initializer = StmInitializer::setup(params, stake, rng);
         let kes_signature = if let Some(kes_sk_path) = kes_sk_path {
             let mut kes_sk_bytes = Sum6KesBytes::from_file(kes_sk_path)?;
-            let mut kes_sk = Sum6Kes::from(&mut kes_sk_bytes);
+            let mut kes_sk = Sum6Kes::try_from(&mut kes_sk_bytes)
+                .map_err(ProtocolInitializerErrorWrapper::Codec)?;
             let kes_sk_period = kes_sk.get_period();
             let provided_period = kes_period.unwrap_or_default();
             if kes_sk_period > provided_period {

--- a/mithril-common/src/crypto_helper/cardano/opcert.rs
+++ b/mithril-common/src/crypto_helper/cardano/opcert.rs
@@ -187,7 +187,9 @@ mod tests {
     fn test_vector_opcert() {
         let temp_dir = setup_temp_directory();
         let keypair = ColdKeyGenerator::create_deterministic_keypair([0u8; 32]);
-        let (_, kes_verification_key) = Sum6Kes::keygen(&mut [0u8; 32]);
+        let mut dummy_key_buffer = [0u8; Sum6Kes::SIZE + 4];
+        let mut dummy_seed = [0u8; 32];
+        let (_, kes_verification_key) = Sum6Kes::keygen(&mut dummy_key_buffer, &mut dummy_seed);
         let operational_certificate = OpCert::new(kes_verification_key, 0, 0, keypair);
         assert!(operational_certificate.validate().is_ok());
 

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -11,7 +11,7 @@ mod types;
 
 #[cfg(any(test, feature = "test_only"))]
 pub use cardano::ColdKeyGenerator;
-pub use cardano::{KESPeriod, OpCert, SerDeShelleyFileFormat};
+pub use cardano::{KESPeriod, OpCert, SerDeShelleyFileFormat, Sum6KesBytes};
 pub use codec::*;
 pub use era::{
     EraMarkersSigner, EraMarkersVerifier, EraMarkersVerifierError, EraMarkersVerifierSecretKey,

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.21"
+version = "0.2.22"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.2.1 (04-01-2022)
+## 0.2.5 (15-03-2023)
+### Added
+- Included helper functions for unsafe code
+- Added tests for batch verification
+## 0.2.1 (04-01-2023)
 ### Added
 - Batch verification for `StmAggrSig`.
 

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mithril-stm"
-version = "0.2.6"
+version = "0.2.7"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes updates the KES dependency to version 0.2.0. The breaking changes were that the library now uses a reference to a mutable slice of `u8` as the secret key. This forces the library user to allocate a buffer of bytes when creating a secret key. 

(we will do a version bump with a few crypto changes)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

