### PR TITLE
Fix clippy warnings from Rust `1.68.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2060,7 +2060,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.22"
+version = "0.2.23"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2104,7 +2104,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "async-trait",
  "clap 4.1.6",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "bincode",
  "blake2 0.10.6",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "mithrildemo"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.13.1",
  "blake2 0.10.6",

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithrildemo"
-version = "0.1.3"
+version = "0.1.4"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -305,12 +305,10 @@ impl Demonstrator {
     pub fn new<R: RngCore + CryptoRng>(config: &crate::Config, rng: &mut R) -> Self {
         // Generate parties
         let parties = (0..config.nparties)
-            .into_iter()
             .map(|party_id| Party::new(party_id, 1 + rng.next_u64() % 999))
             .collect::<Vec<_>>();
         // Generate messages
         let messages = (0..config.nmessages)
-            .into_iter()
             .map(|_| {
                 let mut msg = [0u8; 16];
                 rng.fill_bytes(&mut msg);

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.22"
+version = "0.2.23"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/chain_observer/cli_observer.rs
+++ b/mithril-common/src/chain_observer/cli_observer.rs
@@ -548,8 +548,8 @@ pool1qz2vzszautc2c8mljnqre2857dpmheq7kgt6vav0s38tvvhxm6w   1.051e-6
             CardanoNetwork::TestNet(10),
         );
 
-        assert_eq!("Command { std: \"cardano-cli\" \"query\" \"tip\" \"--testnet-magic\" \"10\", kill_on_drop: false }", format!("{:?}", runner.command_for_epoch()));
-        assert_eq!("Command { std: \"cardano-cli\" \"query\" \"stake-distribution\" \"--testnet-magic\" \"10\", kill_on_drop: false }", format!("{:?}", runner.command_for_stake_distribution()));
+        assert_eq!("Command { std: CARDANO_NODE_SOCKET_PATH=\"/tmp/whatever.sock\" \"cardano-cli\" \"query\" \"tip\" \"--testnet-magic\" \"10\", kill_on_drop: false }", format!("{:?}", runner.command_for_epoch()));
+        assert_eq!("Command { std: CARDANO_NODE_SOCKET_PATH=\"/tmp/whatever.sock\" \"cardano-cli\" \"query\" \"stake-distribution\" \"--testnet-magic\" \"10\", kill_on_drop: false }", format!("{:?}", runner.command_for_stake_distribution()));
     }
 
     #[tokio::test]
@@ -560,8 +560,8 @@ pool1qz2vzszautc2c8mljnqre2857dpmheq7kgt6vav0s38tvvhxm6w   1.051e-6
             CardanoNetwork::DevNet(25),
         );
 
-        assert_eq!("Command { std: \"cardano-cli\" \"query\" \"tip\" \"--cardano-mode\" \"--testnet-magic\" \"25\", kill_on_drop: false }", format!("{:?}", runner.command_for_epoch()));
-        assert_eq!("Command { std: \"cardano-cli\" \"query\" \"stake-distribution\" \"--cardano-mode\" \"--testnet-magic\" \"25\", kill_on_drop: false }", format!("{:?}", runner.command_for_stake_distribution()));
+        assert_eq!("Command { std: CARDANO_NODE_SOCKET_PATH=\"/tmp/whatever.sock\" \"cardano-cli\" \"query\" \"tip\" \"--cardano-mode\" \"--testnet-magic\" \"25\", kill_on_drop: false }", format!("{:?}", runner.command_for_epoch()));
+        assert_eq!("Command { std: CARDANO_NODE_SOCKET_PATH=\"/tmp/whatever.sock\" \"cardano-cli\" \"query\" \"stake-distribution\" \"--cardano-mode\" \"--testnet-magic\" \"25\", kill_on_drop: false }", format!("{:?}", runner.command_for_stake_distribution()));
     }
 
     #[tokio::test]
@@ -573,11 +573,11 @@ pool1qz2vzszautc2c8mljnqre2857dpmheq7kgt6vav0s38tvvhxm6w   1.051e-6
         );
 
         assert_eq!(
-            "Command { std: \"cardano-cli\" \"query\" \"tip\" \"--mainnet\", kill_on_drop: false }",
+            "Command { std: CARDANO_NODE_SOCKET_PATH=\"/tmp/whatever.sock\" \"cardano-cli\" \"query\" \"tip\" \"--mainnet\", kill_on_drop: false }",
             format!("{:?}", runner.command_for_epoch())
         );
         assert_eq!(
-            "Command { std: \"cardano-cli\" \"query\" \"stake-distribution\" \"--mainnet\", kill_on_drop: false }",
+            "Command { std: CARDANO_NODE_SOCKET_PATH=\"/tmp/whatever.sock\" \"cardano-cli\" \"query\" \"stake-distribution\" \"--mainnet\", kill_on_drop: false }",
             format!("{:?}", runner.command_for_stake_distribution())
         );
     }

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -163,7 +163,6 @@ pub fn setup_certificate_chain(
     let genesis_producer = CertificateGenesisProducer::new(Some(Arc::new(genesis_signer)));
     let protocol_parameters = setup_protocol_parameters();
     let mut epochs = (1..total_certificates + 2)
-        .into_iter()
         .map(|i| match certificates_per_epoch {
             0 => panic!("expected at least 1 certificate per epoch"),
             1 => Epoch(i),

--- a/mithril-common/src/test_utils/fixture_builder.rs
+++ b/mithril-common/src/test_utils/fixture_builder.rs
@@ -89,7 +89,7 @@ impl MithrilFixtureBuilder {
 
     fn generate_stake_distribution(&self) -> ProtocolStakeDistribution {
         let mut kes_keys_seed = [0u8; 32];
-        let signers_party_ids = (0..self.number_of_signers).into_iter().map(|party_index| {
+        let signers_party_ids = (0..self.number_of_signers).map(|party_index| {
             if self.enable_signers_certification {
                 build_party_with_operational_certificate(party_index, &mut kes_keys_seed)
             } else {

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mithril-stm"
-version = "0.2.4"
+version = "0.2.5"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -22,7 +22,6 @@ where
     rng.fill_bytes(&mut msg);
 
     let parties = (0..nparties)
-        .into_iter()
         .map(|_| 1 + (rng.next_u64() % 9999))
         .collect::<Vec<_>>();
 

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -28,7 +28,6 @@ where
     );
 
     let stakes = (0..nr_parties)
-        .into_iter()
         .map(|_| 1 + (rng.next_u64() % 9999))
         .collect::<Vec<_>>();
 
@@ -105,7 +104,6 @@ fn batch_benches<H>(
             batch_params.push(params);
 
             let stakes = (0..nr_parties)
-                .into_iter()
                 .map(|_| 1 + (rng.next_u64() % 9999))
                 .collect::<Vec<_>>();
 

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -28,7 +28,6 @@ fn main() {
 
     let mut total_stake: Stake = 0;
     let stakes = (0..nparties)
-        .into_iter()
         .map(|_| {
             let stake = rng.next_u64() % 999;
             total_stake += stake;

--- a/mithril-stm/tests/test_stm_protocol.rs
+++ b/mithril-stm/tests/test_stm_protocol.rs
@@ -18,7 +18,6 @@ fn initialization_phase(
     params: StmParameters,
 ) -> (Vec<StmSigner<H>>, Vec<(StmVerificationKey, Stake)>) {
     let parties = (0..nparties)
-        .into_iter()
         .map(|_| 1 + (rng.next_u64() % 9999))
         .collect::<Vec<_>>();
 

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.1.5"
+version = "0.1.6"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -124,7 +124,6 @@ impl Devnet {
 
     pub fn topology(&self) -> DevnetTopology {
         let bft_nodes = (1..=self.number_of_bft_nodes)
-            .into_iter()
             .map(|n| BftNode {
                 db_path: self.artifacts_dir.join(format!("node-bft{n}/db")),
                 socket_path: self
@@ -134,7 +133,6 @@ impl Devnet {
             .collect::<Vec<_>>();
 
         let pool_nodes = (1..=self.number_of_pool_nodes)
-            .into_iter()
             .map(|n| PoolNode {
                 db_path: self.artifacts_dir.join(format!("node-pool{n}/db")),
                 socket_path: self


### PR DESCRIPTION
## Content
This PR includes a fix to remove clippy warnings that arose with the new version of Rust `1.68.0`

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

