### PR TITLE
Upgrade VM `testing-preview` & `pre-release-preview` networks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,7 +465,7 @@ jobs:
           terraform_backend_bucket: hydra-terraform-admin
           google_region: europe-west1
           google_zone: europe-west1-b
-          google_machine_type: e2-highmem-2
+          google_machine_type: e2-highmem-4
           
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -207,7 +207,7 @@ jobs:
           terraform_backend_bucket: hydra-terraform-admin
           google_region: europe-west1
           google_zone: europe-west1-b
-          google_machine_type: e2-standard-2
+          google_machine_type: e2-highmem-2
           
     runs-on: ubuntu-22.04
 


### PR DESCRIPTION
## Content
This PR includes an upgrade to VM of testing networks in order to avoid OOM:
- `testing-preview` to `e2-highmem-4`
- `pre-release-preview` to `e2-highmem-2`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #801
