### PR TITLE
Add flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,165 @@
+{
+  "nodes": {
+    "crane": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay"
+      },
+      "locked": {
+        "lastModified": 1678152261,
+        "narHash": "sha256-cPRDxwygVMleiSEGELrvAiq9vYAN4c3KK/K4UEO13vU=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "5291dd0aa7a52d607fc952763ef60714e4c881d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1678379998,
+        "narHash": "sha256-TZdfNqftHhDuIFwBcN9MUThx5sQXCTeZk9je5byPKRw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c13d60b89adea3dc20704c045ec4d50dd964d447",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678724065,
+        "narHash": "sha256-MjeRjunqfGTBGU401nxIjs7PC9PZZ1FBCZp/bRB3C2M=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b8afc8489dc96f29f69bec50fdc51e27883f89c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1678375444,
+        "narHash": "sha256-XIgHfGvjFvZQ8hrkfocanCDxMefc/77rXeHvYdzBMc8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "130fa0baaa2b93ec45523fdcde942f6844ee9f6e",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": [
+          "crane",
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "crane",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1677812689,
+        "narHash": "sha256-EakqhgRnjVeYJv5+BJx/NZ7/eFTMBxc4AhICUNquhUg=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "e53e8853aa7b0688bc270e9e6a681d22e01cf299",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1678901796,
+        "narHash": "sha256-9myDjq948gHbiv16HnFQZaswQEpNodE/CuGCfDNnv/g=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "0f560a84215e79facd2833b20bfdc2033266f126",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,86 @@
+{
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    treefmt-nix.url = "github:numtide/treefmt-nix";
+    treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+    crane.url = "github:ipetkov/crane";
+    crane.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+
+      imports = [inputs.treefmt-nix.flakeModule];
+
+      perSystem = {
+        pkgs,
+        config,
+        system,
+        self',
+        ...
+      }: let
+        inherit (inputs.nixpkgs) lib;
+        craneLib = inputs.crane.lib.${system};
+
+        clean = root:
+          lib.cleanSourceWith {
+            src = lib.cleanSource root;
+            filter = orig_path: type: let
+              path = builtins.toString orig_path;
+              base = builtins.baseNameOf path;
+              parentDir = builtins.baseNameOf (builtins.dirOf path);
+              matchesSuffix = lib.any (suffix: lib.hasSuffix suffix base) [".rs" ".toml" ".md"];
+              isCargoFile = base == "Cargo.lock";
+              isCargoConfig = parentDir == ".cargo" && base == "config";
+              isOpenApiYaml = base == "openapi.yaml";
+            in
+              type == "directory" || matchesSuffix || isCargoFile || isCargoConfig || isOpenApiYaml;
+          };
+
+        buildPackage = name: cargoToml:
+          craneLib.buildPackage {
+            inherit (craneLib.crateNameFromCargoToml {inherit cargoToml;}) pname version;
+            cargoExtraArgs = "-p ${name}";
+            src = clean ./.;
+            buildInputs = [
+              pkgs.gnum4
+              pkgs.pkg-config
+              pkgs.openssl
+            ];
+          };
+      in {
+        packages = {
+          mithril-client = buildPackage "mithril-client" ./mithril-client/Cargo.toml;
+          mithril-aggregator = buildPackage "mithril-aggregator" ./mithril-aggregator/Cargo.toml;
+          mithril-signer = buildPackage "mithril-signer" ./mithril-signer/Cargo.toml;
+        };
+
+        devShells.default = pkgs.mkShell {
+          inputsFrom = [self'.packages.mithril-client];
+
+          nativeBuildInputs = [
+            pkgs.cargo
+            pkgs.rustc
+            config.treefmt.package
+          ];
+
+          shellHook = ''
+            ln -sf ${config.treefmt.build.configFile} treefmt.toml
+          '';
+        };
+
+        formatter = pkgs.writeShellApplication {
+          name = "treefmt";
+          text = "exec ${config.treefmt.package}/bin/treefmt";
+        };
+
+        treefmt = {
+          programs.alejandra.enable = true;
+          programs.rustfmt.enable = true;
+          projectRootFile = "flake.nix";
+        };
+      };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
               pkgs.gnum4
               pkgs.pkg-config
               pkgs.openssl
-            ];
+            ] ++ lib.optional (pkgs.stdenv.isDarwin) [pkgs.darwin.apple_sdk.frameworks.Security];
           };
       in {
         packages = {
@@ -63,10 +63,12 @@
           nativeBuildInputs = [
             pkgs.cargo
             pkgs.rustc
+            pkgs.libiconv
             config.treefmt.package
           ];
 
           shellHook = ''
+            export RUST_BACKTRACE=1
             ln -sf ${config.treefmt.build.configFile} treefmt.toml
           '';
         };


### PR DESCRIPTION
## Content
<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->
This PR includes the `flake.nix` and `flake.lock` files, enabling easy building using `nix` for the `mithril-client`, `mithril-signer`, and `mithril-aggregator` packages.

It also adds a minimal devShell for cargo and rustc, as well as setup for formatting using the standard `nix fmt` or `treefmt` commands.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

Once merged, they can be used with `nix build` or `nix run` under the following flake URLs:

* `github:input-output-hk/mithril#mithril-client`
* `github:input-output-hk/mithril#mithril-signer`
* `github:input-output-hk/mithril#mithril-aggregator`