### PR TITLE
Cleanup multi-signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.36"
+version = "0.2.37"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2089,7 +2089,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.32"
+version = "0.2.33"
 dependencies = [
  "async-trait",
  "bech32",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.36"
+version = "0.2.37"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -193,7 +193,8 @@ pub trait MultiSigner: Sync + Send {
 
     /// Creates a multi signature from single signatures
     async fn create_multi_signature(
-        &mut self,
+        &self,
+        message: &entities::ProtocolMessage,
     ) -> Result<Option<ProtocolMultiSignature>, ProtocolError>;
 }
 
@@ -588,14 +589,10 @@ impl MultiSigner for MultiSignerImpl {
 
     /// Creates a multi signature from single signatures
     async fn create_multi_signature(
-        &mut self,
+        &self,
+        message: &entities::ProtocolMessage,
     ) -> Result<Option<ProtocolMultiSignature>, ProtocolError> {
         debug!("Create multi signature");
-        let message = &self
-            .get_current_message()
-            .await
-            .ok_or_else(ProtocolError::UnavailableMessage)?;
-
         let beacon = self
             .current_beacon
             .as_ref()
@@ -892,7 +889,7 @@ mod tests {
 
         // No signatures registered: multi-signer can't create the multi-signature
         assert!(multi_signer
-            .create_multi_signature()
+            .create_multi_signature(&message)
             .await
             .expect("create multi signature should not fail")
             .is_none());
@@ -905,7 +902,7 @@ mod tests {
                 .expect("register single signature should not fail");
         }
         assert!(multi_signer
-            .create_multi_signature()
+            .create_multi_signature(&message)
             .await
             .expect("create multi signature should not fail")
             .is_none());
@@ -919,7 +916,7 @@ mod tests {
         }
         assert!(
             multi_signer
-                .create_multi_signature()
+                .create_multi_signature(&message)
                 .await
                 .expect("create multi signature should not fail")
                 .is_some(),

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use chrono::prelude::*;
 use hex::ToHex;
 use slog_scope::{debug, warn};
 use std::sync::Arc;
@@ -205,9 +204,6 @@ pub struct MultiSignerImpl {
     /// Beacon that is currently used
     current_beacon: Option<entities::Beacon>,
 
-    /// Signing start datetime of current message
-    current_initiated_at: Option<DateTime<Utc>>,
-
     /// Verification key store
     verification_key_store: Arc<VerificationKeyStore>,
 
@@ -233,7 +229,6 @@ impl MultiSignerImpl {
         Self {
             current_message: None,
             current_beacon: None,
-            current_initiated_at: None,
             verification_key_store,
             stake_store,
             single_signature_store,
@@ -342,7 +337,6 @@ impl MultiSigner for MultiSignerImpl {
     ) -> Result<(), ProtocolError> {
         debug!("Update current_message"; "protocol_message" =>  #?message, "signed message" => message.compute_hash().encode_hex::<String>());
 
-        self.current_initiated_at = Some(Utc::now());
         self.current_message = Some(message);
         Ok(())
     }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -555,13 +555,13 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     ) -> Result<Option<ProtocolMultiSignature>, Box<dyn StdError + Sync + Send>> {
         debug!("RUNNER: create multi-signature");
 
-        Ok(self
-            .dependencies
-            .multi_signer
-            .write()
+        let multi_signer = self.dependencies.multi_signer.read().await;
+        let message = multi_signer
+            .get_current_message()
             .await
-            .create_multi_signature()
-            .await?)
+            .ok_or_else(ProtocolError::UnavailableMessage)?;
+
+        Ok(multi_signer.create_multi_signature(&message).await?)
     }
 
     async fn create_snapshot_archive(

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -51,7 +51,7 @@ async fn certificate_chain() {
     cycle!(tester, "ready");
     cycle!(tester, "signing");
     tester.register_signers(&signers).await.unwrap();
-    cycle!(tester, "signing");
+    cycle_err!(tester, "signing");
     tester.send_single_signatures(&signers).await.unwrap();
 
     comment!("The state machine should have issued a multisignature");

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -49,7 +49,7 @@ async fn create_certificate() {
 
     comment!("register signers");
     tester.register_signers(&signers).await.unwrap();
-    cycle!(tester, "signing");
+    cycle_err!(tester, "signing");
 
     comment!("change the immutable number to alter the beacon");
     tester.increase_immutable_number().await.unwrap();

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -37,7 +37,7 @@ macro_rules! cycle_err {
         $tester
             .cycle()
             .await
-            .expect_err("cycle tick shoudl have returned an error");
+            .expect_err("cycle tick should have returned an error");
         assert_eq!($expected_state, $tester.runtime.get_state());
     }};
 }
@@ -240,7 +240,7 @@ impl RuntimeTester {
 
     /// "Send", actually register, the given single signatures in the multi-signers
     pub async fn send_single_signatures(&self, signers: &[SignerFixture]) -> Result<(), String> {
-        let mut multisigner = self.deps.multi_signer.write().await;
+        let multisigner = self.deps.multi_signer.read().await;
         let message = multisigner
             .get_current_message()
             .await
@@ -258,7 +258,7 @@ impl RuntimeTester {
                 );
 
                 multisigner
-                    .register_single_signature(&single_signatures)
+                    .register_single_signature(&message, &single_signatures)
                     .await
                     .map_err(|e| {
                         format!("registering a winning lottery signature should not fail: {e:?}")

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -31,6 +31,17 @@ macro_rules! cycle {
     }};
 }
 
+#[macro_export]
+macro_rules! cycle_err {
+    ( $tester:expr, $expected_state:expr ) => {{
+        $tester
+            .cycle()
+            .await
+            .expect_err("cycle tick shoudl have returned an error");
+        assert_eq!($expected_state, $tester.runtime.get_state());
+    }};
+}
+
 pub struct RuntimeTester {
     pub snapshot_uploader: Arc<DumbSnapshotUploader>,
     pub chain_observer: Arc<FakeObserver>,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.32"
+version = "0.2.33"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a cleanup of the multi-signer:
- Removing unused functions
- Reducing the state to the minimum possible at the moment: keep only `current_message`, `current_beacon` and the dependencies
- Refactor function signatures for register single signatures and create multi-signature

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #824 
