### PR TITLE
Fix mislabeled critical error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.37"
+version = "0.2.38"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -271,7 +271,7 @@ impl AggregatorRuntime {
         let multi_signature = self.runner.create_multi_signature().await?;
 
         let multi_signature = if multi_signature.is_none() {
-            return Err(RuntimeError::Critical {
+            return Err(RuntimeError::KeepState {
                 message: "not enough signature yet to aggregate a multi-signature, waiting…"
                     .to_string(),
                 nested_error: None,


### PR DESCRIPTION
## Content
This PR fixes a non critical error that has been mislabeled as critical error when the quorum is not reached for producing a multi-signature in the aggregator

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #824
