### PR TITLE
Create/Migrate `signer_registration` store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.43"
+version = "0.2.44"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.43"
+version = "0.2.44"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -151,6 +151,7 @@ create table open_message (
         // Migration 6
         // Add the `signer_registration` table and migration data from the previous
         // `verification_key` JSON format.
+        // TODO: activate FK w/ signer table exists `foreign key (signer_id) references signer(signer_id)`
         SqlMigration::new(
             6,
             r#"
@@ -164,9 +165,7 @@ create table signer_registration (
     stake                       integer,
     created_at                  text        not null default current_timestamp,
     primary key (epoch_setting_id, signer_id)
-    -- TODO: activate FK w/ signer table exists
-    -- foreign key (signer_id) references signer(signer_id)
-    foreign key (epoch_setting_id) references epoch_settings(epoch_setting_id)
+    foreign key (epoch_setting_id) references epoch_setting(epoch_setting_id)
 );
 create table if not exists verification_key (key_hash text primary key, key json not null, value json not null);
 insert into signer_registration (signer_id, 

--- a/mithril-aggregator/src/database/provider/epoch_setting.rs
+++ b/mithril-aggregator/src/database/provider/epoch_setting.rs
@@ -190,7 +190,7 @@ impl<'conn> Provider<'conn> for UpdateEpochSettingProvider<'conn> {
     }
 }
 
-/// Provider to remove old data from theepoch_setting table
+/// Provider to remove old data from the epoch_setting table
 pub struct DeleteEpochSettingProvider<'conn> {
     connection: &'conn Connection,
 }
@@ -249,6 +249,7 @@ impl<'conn> DeleteEpochSettingProvider<'conn> {
         self.find(filters)
     }
 }
+
 /// Service to deal with epoch settings (read & write).
 pub struct EpochSettingStore {
     connection: Arc<Mutex<Connection>>,

--- a/mithril-aggregator/src/database/provider/mod.rs
+++ b/mithril-aggregator/src/database/provider/mod.rs
@@ -2,9 +2,11 @@
 mod certificate;
 mod epoch_setting;
 mod open_message;
+mod signer_registration;
 mod stake_pool;
 
 pub use certificate::*;
 pub use epoch_setting::*;
 pub use open_message::*;
+pub use signer_registration::*;
 pub use stake_pool::*;

--- a/mithril-aggregator/src/database/provider/signer_registration.rs
+++ b/mithril-aggregator/src/database/provider/signer_registration.rs
@@ -653,22 +653,16 @@ mod tests {
     }
 
     #[test]
-    fn get_signer_registration_record_by_signer_id_and_epoch() {
+    fn get_signer_registration_record_by_signer_id() {
         let connection = Connection::open(":memory:").unwrap();
         let provider = SignerRegistrationRecordProvider::new(&connection);
         let condition = provider
-            .condition_by_signer_id_and_epoch("signer-123".to_string(), &Epoch(1))
+            .condition_by_signer_id("signer-123".to_string())
             .unwrap();
         let (filter, values) = condition.expand();
 
-        assert_eq!(
-            "signer_id = ?1 and epoch_setting_id = ?2".to_string(),
-            filter
-        );
-        assert_eq!(
-            vec![Value::String("signer-123".to_string()), Value::Integer(1)],
-            values
-        );
+        assert_eq!("signer_id = ?1".to_string(), filter);
+        assert_eq!(vec![Value::String("signer-123".to_string())], values);
     }
 
     #[test]

--- a/mithril-aggregator/src/database/provider/signer_registration.rs
+++ b/mithril-aggregator/src/database/provider/signer_registration.rs
@@ -1,0 +1,907 @@
+use std::{collections::HashMap, sync::Arc};
+
+use sqlite::{Connection, Value};
+
+use async_trait::async_trait;
+
+use mithril_common::{
+    crypto_helper::KESPeriod,
+    entities::{
+        Epoch, HexEncodedOpCert, HexEncodedVerificationKey, HexEncodedVerificationKeySignature,
+        PartyId, SignerWithStake, Stake,
+    },
+    sqlite::{
+        EntityCursor, HydrationError, Projection, Provider, SourceAlias, SqLiteEntity,
+        WhereCondition,
+    },
+    store::adapter::{AdapterError, StoreAdapter},
+};
+
+use mithril_common::StdError;
+use tokio::sync::Mutex;
+
+/// SignerRegistration record is the representation of a stored signer_registration.
+#[derive(Debug, PartialEq, Clone)]
+pub struct SignerRegistrationRecord {
+    /// Signer id.
+    signer_id: String,
+
+    /// Epoch of creation of the signer_registration.
+    epoch_setting_id: Epoch,
+
+    /// Verification key of the signer
+    verification_key: HexEncodedVerificationKey,
+
+    /// Signature of the verification key of the signer
+    verification_key_signature: Option<HexEncodedVerificationKeySignature>,
+
+    /// Operational certificate of the stake pool operator associated to the signer
+    operational_certificate: Option<HexEncodedOpCert>,
+
+    /// The kes period used to compute the verification key signature
+    kes_period: Option<KESPeriod>,
+
+    /// The stake associated to the signer
+    stake: Option<Stake>,
+
+    /// Date and time when the signer_registration was created
+    created_at: String,
+}
+
+impl SignerRegistrationRecord {
+    fn from_signer_with_stake(other: SignerWithStake, epoch: Epoch) -> Self {
+        SignerRegistrationRecord {
+            signer_id: other.party_id,
+            epoch_setting_id: epoch,
+            verification_key: other.verification_key,
+            verification_key_signature: other.verification_key_signature,
+            operational_certificate: other.operational_certificate,
+            kes_period: other.kes_period,
+            stake: Some(other.stake),
+            created_at: "".to_string(),
+        }
+    }
+}
+
+impl From<SignerRegistrationRecord> for SignerWithStake {
+    fn from(other: SignerRegistrationRecord) -> SignerWithStake {
+        SignerWithStake {
+            party_id: other.signer_id,
+            verification_key: other.verification_key,
+            verification_key_signature: other.verification_key_signature,
+            operational_certificate: other.operational_certificate,
+            kes_period: other.kes_period,
+            stake: other.stake.unwrap_or_default(),
+        }
+    }
+}
+
+impl SqLiteEntity for SignerRegistrationRecord {
+    fn hydrate(row: sqlite::Row) -> Result<Self, HydrationError>
+    where
+        Self: Sized,
+    {
+        let signer_id = row.get::<String, _>(0);
+        let epoch_setting_id_int = row.get::<i64, _>(1);
+        let verification_key = row.get::<String, _>(2);
+        let verification_key_signature = row.get::<Option<String>, _>(3);
+        let operational_certificate = row.get::<Option<String>, _>(4);
+        let kes_period_int = row.get::<Option<i64>, _>(5);
+        let stake_int = row.get::<Option<i64>, _>(6);
+        let created_at = row.get::<String, _>(7);
+
+        let signer_registration_record = Self {
+            signer_id,
+            epoch_setting_id: Epoch(epoch_setting_id_int.try_into().map_err(|e| {
+                HydrationError::InvalidData(format!(
+                    "Could not cast i64 ({epoch_setting_id_int}) to u64. Error: '{e}'"
+                ))
+            })?),
+            verification_key,
+            verification_key_signature,
+            operational_certificate,
+            kes_period: match kes_period_int {
+                Some(kes_period_int) => Some(kes_period_int.try_into().map_err(|e| {
+                    HydrationError::InvalidData(format!(
+                        "Could not cast i64 ({kes_period_int}) to u64. Error: '{e}'"
+                    ))
+                })?),
+                None => None,
+            },
+            stake: match stake_int {
+                Some(stake_int) => Some(stake_int.try_into().map_err(|e| {
+                    HydrationError::InvalidData(format!(
+                        "Could not cast i64 ({stake_int}) to u64. Error: '{e}'"
+                    ))
+                })?),
+                None => None,
+            },
+            created_at,
+        };
+
+        Ok(signer_registration_record)
+    }
+
+    fn get_projection() -> Projection {
+        let mut projection = Projection::default();
+        projection.add_field("signer_id", "{:signer_registration:}.signer_id", "text");
+        projection.add_field(
+            "epoch_setting_id",
+            "{:signer_registration:}.epoch_setting_id",
+            "integer",
+        );
+        projection.add_field(
+            "verification_key",
+            "{:signer_registration:}.verification_key",
+            "text",
+        );
+        projection.add_field(
+            "verification_key_signature",
+            "{:signer_registration:}.verification_key_signature",
+            "text",
+        );
+        projection.add_field(
+            "operational_certificate",
+            "{:signer_registration:}.operational_certificate",
+            "text",
+        );
+        projection.add_field(
+            "kes_period",
+            "{:signer_registration:}.kes_period",
+            "integer",
+        );
+        projection.add_field("stake", "{:signer_registration:}.stake", "integer");
+        projection.add_field("created_at", "{:signer_registration:}.created_at", "text");
+
+        projection
+    }
+}
+
+/// Simple [SignerRegistrationRecord] provider.
+pub struct SignerRegistrationRecordProvider<'client> {
+    client: &'client Connection,
+}
+
+impl<'client> SignerRegistrationRecordProvider<'client> {
+    /// Create a new provider
+    pub fn new(client: &'client Connection) -> Self {
+        Self { client }
+    }
+
+    fn condition_by_signer_id_and_epoch(
+        &self,
+        signer_id: String,
+        epoch: &Epoch,
+    ) -> Result<WhereCondition, StdError> {
+        let epoch = i64::try_from(epoch.0).unwrap();
+
+        Ok(WhereCondition::new(
+            "signer_id = ?1 and epoch_setting_id = ?2",
+            vec![Value::String(signer_id), Value::Integer(epoch)],
+        ))
+    }
+
+    fn condition_by_epoch(&self, epoch: &Epoch) -> Result<WhereCondition, StdError> {
+        let epoch: i64 = i64::try_from(epoch.0)?;
+
+        Ok(WhereCondition::new(
+            "epoch_setting_id = ?*",
+            vec![Value::Integer(epoch)],
+        ))
+    }
+
+    /// Get SignerRegistrationRecords for given signer id and epoch.
+    pub fn get_by_signer_id_and_epoch(
+        &self,
+        signer_id: String,
+        epoch: &Epoch,
+    ) -> Result<EntityCursor<SignerRegistrationRecord>, StdError> {
+        let filters = self.condition_by_signer_id_and_epoch(signer_id, epoch)?;
+        let signer_registration_record = self.find(filters)?;
+
+        Ok(signer_registration_record)
+    }
+
+    /// Get SignerRegistrationRecords for a given Epoch.
+    pub fn get_by_epoch(
+        &self,
+        epoch: &Epoch,
+    ) -> Result<EntityCursor<SignerRegistrationRecord>, StdError> {
+        let filters = self.condition_by_epoch(epoch)?;
+        let signer_registration_record = self.find(filters)?;
+
+        Ok(signer_registration_record)
+    }
+
+    /// Get all SignerRegistrationRecords.
+    pub fn get_all(&self) -> Result<EntityCursor<SignerRegistrationRecord>, StdError> {
+        let filters = WhereCondition::default();
+        let signer_registration_record = self.find(filters)?;
+
+        Ok(signer_registration_record)
+    }
+}
+
+impl<'client> Provider<'client> for SignerRegistrationRecordProvider<'client> {
+    type Entity = SignerRegistrationRecord;
+
+    fn get_connection(&'client self) -> &'client Connection {
+        self.client
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[("{:signer_registration:}", "sr")]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+        format!("select {projection} from signer_registration as sr where {condition} order by ROWID desc")
+    }
+}
+
+/// Query to update the signer_registration record
+pub struct UpdateSignerRegistrationRecordProvider<'conn> {
+    connection: &'conn Connection,
+}
+
+impl<'conn> UpdateSignerRegistrationRecordProvider<'conn> {
+    /// Create a new instance
+    pub fn new(connection: &'conn Connection) -> Self {
+        Self { connection }
+    }
+
+    fn get_update_condition(
+        &self,
+        signer_registration_record: SignerRegistrationRecord,
+    ) -> WhereCondition {
+        WhereCondition::new(
+            "(signer_id, epoch_setting_id, verification_key, verification_key_signature, operational_certificate, kes_period, stake, created_at) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            vec![
+                Value::String(signer_registration_record.signer_id),
+                Value::Integer(
+                    i64::try_from(signer_registration_record.epoch_setting_id.0).unwrap(),
+                ),
+                Value::String(signer_registration_record.verification_key),
+                signer_registration_record
+                            .verification_key_signature
+                            .map(Value::String)
+                            .unwrap_or(Value::Null),
+                signer_registration_record
+                            .operational_certificate
+                            .map(Value::String)
+                            .unwrap_or(Value::Null),
+                signer_registration_record
+                            .kes_period
+                            .map(|k| Value::Integer(i64::try_from(k).unwrap()))
+                            .unwrap_or(Value::Null),
+                signer_registration_record
+                            .stake
+                            .map(|s| Value::Integer(i64::try_from(s).unwrap()))
+                            .unwrap_or(Value::Null),
+                            Value::String(signer_registration_record.created_at),
+            ],
+        )
+    }
+
+    fn persist(
+        &self,
+        signer_registration_record: SignerRegistrationRecord,
+    ) -> Result<SignerRegistrationRecord, StdError> {
+        let filters = self.get_update_condition(signer_registration_record.clone());
+
+        let entity = self.find(filters)?.next().unwrap_or_else(|| {
+            panic!(
+                "No entity returned by the persister, signer_registration_record = {signer_registration_record:?}"
+            )
+        });
+
+        Ok(entity)
+    }
+}
+
+impl<'conn> Provider<'conn> for UpdateSignerRegistrationRecordProvider<'conn> {
+    type Entity = SignerRegistrationRecord;
+
+    fn get_connection(&'conn self) -> &'conn Connection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        // it is important to alias the fields with the same name as the table
+        // since the table cannot be aliased in a RETURNING statement in SQLite.
+        let projection = Self::Entity::get_projection().expand(SourceAlias::new(&[(
+            "{:signer_registration:}",
+            "signer_registration",
+        )]));
+
+        format!("insert or replace into signer_registration {condition} returning {projection}")
+    }
+}
+
+/// Provider to remove old data from the signer_registration table
+pub struct DeleteSignerRegistrationRecordProvider<'conn> {
+    connection: &'conn Connection,
+}
+
+impl<'conn> Provider<'conn> for DeleteSignerRegistrationRecordProvider<'conn> {
+    type Entity = SignerRegistrationRecord;
+
+    fn get_connection(&'conn self) -> &'conn Connection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        // it is important to alias the fields with the same name as the table
+        // since the table cannot be aliased in a RETURNING statement in SQLite.
+        let projection = Self::Entity::get_projection().expand(SourceAlias::new(&[(
+            "{:signer_registration:}",
+            "signer_registration",
+        )]));
+
+        format!("delete from signer_registration where {condition} returning {projection}")
+    }
+}
+
+impl<'conn> DeleteSignerRegistrationRecordProvider<'conn> {
+    /// Create a new instance
+    pub fn new(connection: &'conn Connection) -> Self {
+        Self { connection }
+    }
+
+    /// Create the SQL condition to delete a record given the Epoch.
+    fn get_delete_condition_by_epoch(&self, epoch: Epoch) -> WhereCondition {
+        let epoch_threshold = Value::Integer(i64::try_from(epoch.0).unwrap());
+
+        WhereCondition::new("epoch_setting_id = ?*", vec![epoch_threshold])
+    }
+
+    /// Delete the epoch setting data given the Epoch
+    pub fn delete(&self, epoch: Epoch) -> Result<EntityCursor<SignerRegistrationRecord>, StdError> {
+        let filters = self.get_delete_condition_by_epoch(epoch);
+
+        self.find(filters)
+    }
+
+    /// Create the SQL condition to prune data older than the given Epoch.
+    fn get_prune_condition(&self, epoch_threshold: Epoch) -> WhereCondition {
+        let epoch_threshold = Value::Integer(i64::try_from(epoch_threshold.0).unwrap());
+
+        WhereCondition::new("epoch_setting_id < ?*", vec![epoch_threshold])
+    }
+
+    /// Prune the epoch setting data older than the given epoch.
+    pub fn prune(
+        &self,
+        epoch_threshold: Epoch,
+    ) -> Result<EntityCursor<SignerRegistrationRecord>, StdError> {
+        let filters = self.get_prune_condition(epoch_threshold);
+
+        self.find(filters)
+    }
+}
+
+/// Service to deal with signer_registration (read & write).
+pub struct SignerRegistrationStoreAdapter {
+    connection: Arc<Mutex<Connection>>,
+}
+
+impl SignerRegistrationStoreAdapter {
+    /// Create a new SignerRegistrationStoreAdapter service
+    pub fn new(connection: Arc<Mutex<Connection>>) -> Self {
+        Self { connection }
+    }
+}
+
+#[async_trait]
+impl StoreAdapter for SignerRegistrationStoreAdapter {
+    type Key = Epoch;
+    type Record = HashMap<PartyId, SignerWithStake>;
+
+    async fn store_record(
+        &mut self,
+        key: &Self::Key,
+        record: &Self::Record,
+    ) -> Result<(), AdapterError> {
+        let connection = &*self.connection.lock().await;
+        let provider = UpdateSignerRegistrationRecordProvider::new(connection);
+        connection
+            .execute("begin transaction")
+            .map_err(|e| AdapterError::QueryError(e.into()))?;
+
+        for signer_with_stake in record.values() {
+            let _signer_registration_record = provider
+                .persist(SignerRegistrationRecord::from_signer_with_stake(
+                    signer_with_stake.to_owned(),
+                    *key,
+                ))
+                .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
+        }
+
+        connection
+            .execute("commit transaction")
+            .map_err(|e| AdapterError::QueryError(e.into()))?;
+
+        Ok(())
+    }
+
+    async fn get_record(&self, key: &Self::Key) -> Result<Option<Self::Record>, AdapterError> {
+        let connection = &*self.connection.lock().await;
+        let provider = SignerRegistrationRecordProvider::new(connection);
+        let cursor = provider
+            .get_by_epoch(key)
+            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
+        let mut signer_with_stakes = HashMap::new();
+        for signer_registration_record in cursor {
+            signer_with_stakes.insert(
+                signer_registration_record.signer_id.to_string(),
+                signer_registration_record.into(),
+            );
+        }
+        if signer_with_stakes.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(signer_with_stakes))
+        }
+    }
+
+    async fn record_exists(&self, key: &Self::Key) -> Result<bool, AdapterError> {
+        Ok(self.get_record(key).await?.is_some())
+    }
+
+    async fn get_last_n_records(
+        &self,
+        how_many: usize,
+    ) -> Result<Vec<(Self::Key, Self::Record)>, AdapterError> {
+        let connection = &*self.connection.lock().await;
+        let provider = SignerRegistrationRecordProvider::new(connection);
+        let cursor = provider
+            .get_all()
+            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev();
+        let signer_with_stake_by_epoch: HashMap<Self::Key, Self::Record> = cursor.fold(
+            HashMap::<Self::Key, Self::Record>::new(),
+            |mut acc, signer_registration_record| {
+                let epoch = signer_registration_record.epoch_setting_id;
+                let mut signer_with_stakes: Self::Record =
+                    if let Some(signer_with_stakes) = acc.get_mut(&epoch) {
+                        signer_with_stakes.to_owned()
+                    } else {
+                        HashMap::new()
+                    };
+                signer_with_stakes.insert(
+                    signer_registration_record.signer_id.to_string(),
+                    signer_registration_record.into(),
+                );
+                acc.insert(epoch, signer_with_stakes);
+                acc
+            },
+        );
+        Ok(signer_with_stake_by_epoch
+            .into_iter()
+            .take(how_many)
+            .collect())
+    }
+
+    async fn remove(&mut self, key: &Self::Key) -> Result<Option<Self::Record>, AdapterError> {
+        let connection = &*self.connection.lock().await;
+        let provider = DeleteSignerRegistrationRecordProvider::new(connection);
+        let cursor = provider
+            .delete(*key)
+            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
+        let mut signer_with_stakes = HashMap::new();
+        for signer_registration_record in cursor {
+            signer_with_stakes.insert(
+                signer_registration_record.signer_id.to_string(),
+                signer_registration_record.into(),
+            );
+        }
+
+        if signer_with_stakes.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(signer_with_stakes))
+        }
+    }
+
+    async fn get_iter(&self) -> Result<Box<dyn Iterator<Item = Self::Record> + '_>, AdapterError> {
+        let records = self.get_last_n_records(usize::MAX).await?;
+        Ok(Box::new(records.into_iter().map(|(_k, v)| v)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{BTreeMap, HashMap};
+
+    use mithril_common::test_utils::MithrilFixtureBuilder;
+
+    use crate::database::migration::get_migrations;
+
+    use super::*;
+
+    pub fn setup_signer_registration_db(
+        connection: &Connection,
+        signer_with_stakes_by_epoch: Vec<(Epoch, Vec<SignerWithStake>)>,
+    ) -> Result<(), StdError> {
+        for migration in get_migrations() {
+            connection.execute(&migration.alterations)?;
+        }
+
+        if signer_with_stakes_by_epoch.is_empty() {
+            return Ok(());
+        }
+
+        let query = {
+            // leverage the expanded parameter from this provider which is unit
+            // tested on its own above.
+            let update_provider = UpdateSignerRegistrationRecordProvider::new(connection);
+            let (sql_values, _) = update_provider
+                .get_update_condition(SignerRegistrationRecord::from_signer_with_stake(
+                    signer_with_stakes_by_epoch
+                        .first()
+                        .unwrap()
+                        .1
+                        .first()
+                        .unwrap()
+                        .to_owned(),
+                    Epoch(1),
+                ))
+                .expand();
+            format!("insert into signer_registration {sql_values}")
+        };
+
+        for (epoch, signer_with_stakes) in signer_with_stakes_by_epoch {
+            for signer_with_stake in signer_with_stakes {
+                let signer_registration_record =
+                    SignerRegistrationRecord::from_signer_with_stake(signer_with_stake, epoch);
+                let mut statement = connection.prepare(&query)?;
+
+                statement
+                    .bind(1, signer_registration_record.signer_id.as_str())
+                    .unwrap();
+                statement
+                    .bind(2, signer_registration_record.epoch_setting_id.0 as i64)
+                    .unwrap();
+                statement
+                    .bind(3, signer_registration_record.verification_key.as_str())
+                    .unwrap();
+                statement
+                    .bind(
+                        4,
+                        &signer_registration_record
+                            .verification_key_signature
+                            .map(Value::String)
+                            .unwrap_or(Value::Null),
+                    )
+                    .unwrap();
+                statement
+                    .bind(
+                        5,
+                        &signer_registration_record
+                            .operational_certificate
+                            .map(Value::String)
+                            .unwrap_or(Value::Null),
+                    )
+                    .unwrap();
+                statement
+                    .bind(
+                        6,
+                        &signer_registration_record
+                            .kes_period
+                            .map(|k| Value::Integer(k as i64))
+                            .unwrap_or(Value::Null),
+                    )
+                    .unwrap();
+                statement
+                    .bind(
+                        7,
+                        &signer_registration_record
+                            .stake
+                            .map(|s| Value::Integer(s as i64))
+                            .unwrap_or(Value::Null),
+                    )
+                    .unwrap();
+                statement
+                    .bind(8, signer_registration_record.created_at.as_str())
+                    .unwrap();
+                statement.next().unwrap();
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_convert_signer_registrations() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+        let signer_with_stakes = fixture.signers_with_stake();
+
+        let mut signer_registration_records: Vec<SignerRegistrationRecord> = Vec::new();
+        for signer_with_stake in signer_with_stakes.clone() {
+            signer_registration_records.push(SignerRegistrationRecord::from_signer_with_stake(
+                signer_with_stake,
+                Epoch(1),
+            ));
+        }
+        let mut signer_with_stakes_new: Vec<SignerWithStake> = Vec::new();
+        for signer_registration_record in signer_registration_records {
+            signer_with_stakes_new.push(signer_registration_record.into());
+        }
+        assert_eq!(signer_with_stakes, signer_with_stakes_new);
+    }
+
+    #[test]
+    fn projection() {
+        let projection = SignerRegistrationRecord::get_projection();
+        let aliases = SourceAlias::new(&[("{:signer_registration:}", "sr")]);
+
+        assert_eq!(
+            "sr.signer_id as signer_id, sr.epoch_setting_id as epoch_setting_id, sr.verification_key as verification_key, sr.verification_key_signature as verification_key_signature, sr.operational_certificate as operational_certificate, sr.kes_period as kes_period, sr.stake as stake, sr.created_at as created_at"
+                .to_string(),
+            projection.expand(aliases)
+        );
+    }
+
+    #[test]
+    fn get_signer_registration_record_by_epoch() {
+        let connection = Connection::open(":memory:").unwrap();
+        let provider = SignerRegistrationRecordProvider::new(&connection);
+        let condition = provider.condition_by_epoch(&Epoch(17)).unwrap();
+        let (filter, values) = condition.expand();
+
+        assert_eq!("epoch_setting_id = ?1".to_string(), filter);
+        assert_eq!(vec![Value::Integer(17)], values);
+    }
+
+    #[test]
+    fn get_signer_registration_record_by_signer_id_and_epoch() {
+        let connection = Connection::open(":memory:").unwrap();
+        let provider = SignerRegistrationRecordProvider::new(&connection);
+        let condition = provider
+            .condition_by_signer_id_and_epoch("signer-123".to_string(), &Epoch(1))
+            .unwrap();
+        let (filter, values) = condition.expand();
+
+        assert_eq!(
+            "signer_id = ?1 and epoch_setting_id = ?2".to_string(),
+            filter
+        );
+        assert_eq!(
+            vec![Value::String("signer-123".to_string()), Value::Integer(1)],
+            values
+        );
+    }
+
+    #[test]
+    fn update_signer_registration_record() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+        let signer_with_stakes = fixture.signers_with_stake();
+        let signer_registration_record = SignerRegistrationRecord::from_signer_with_stake(
+            signer_with_stakes.first().unwrap().to_owned(),
+            Epoch(1),
+        );
+        let connection = Connection::open(":memory:").unwrap();
+        let provider = UpdateSignerRegistrationRecordProvider::new(&connection);
+        let condition = provider.get_update_condition(signer_registration_record.clone());
+        let (values, params) = condition.expand();
+
+        assert_eq!(
+            "(signer_id, epoch_setting_id, verification_key, verification_key_signature, operational_certificate, kes_period, stake, created_at) values (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)".to_string(),
+            values
+        );
+        assert_eq!(
+            vec![
+                Value::String(signer_registration_record.signer_id),
+                Value::Integer(
+                    i64::try_from(signer_registration_record.epoch_setting_id.0).unwrap(),
+                ),
+                Value::String(signer_registration_record.verification_key),
+                signer_registration_record
+                    .verification_key_signature
+                    .map(Value::String)
+                    .unwrap(),
+                signer_registration_record
+                    .operational_certificate
+                    .map(Value::String)
+                    .unwrap(),
+                Value::Integer(signer_registration_record.kes_period.unwrap() as i64),
+                Value::Integer(signer_registration_record.stake.unwrap() as i64),
+                Value::String(signer_registration_record.created_at),
+            ],
+            params
+        );
+    }
+
+    #[test]
+    fn delete() {
+        let connection = Connection::open(":memory:").unwrap();
+        let provider = DeleteSignerRegistrationRecordProvider::new(&connection);
+        let condition = provider.get_delete_condition_by_epoch(Epoch(5));
+        let (condition, params) = condition.expand();
+
+        assert_eq!("epoch_setting_id = ?1".to_string(), condition);
+        assert_eq!(vec![Value::Integer(5)], params);
+    }
+
+    #[test]
+    fn prune() {
+        let connection = Connection::open(":memory:").unwrap();
+        let provider = DeleteSignerRegistrationRecordProvider::new(&connection);
+        let condition = provider.get_prune_condition(Epoch(5));
+        let (condition, params) = condition.expand();
+
+        assert_eq!("epoch_setting_id < ?1".to_string(), condition);
+        assert_eq!(vec![Value::Integer(5)], params);
+    }
+
+    #[test]
+    fn test_get_signer_registration_records() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+        let signer_with_stakes = fixture.signers_with_stake();
+        let signer_with_stakes_by_epoch: Vec<(Epoch, Vec<SignerWithStake>)> = (0..=3)
+            .map(|e| (Epoch(e), signer_with_stakes.clone()))
+            .collect();
+
+        let connection = Connection::open(":memory:").unwrap();
+        setup_signer_registration_db(&connection, signer_with_stakes_by_epoch.clone()).unwrap();
+
+        let provider = SignerRegistrationRecordProvider::new(&connection);
+
+        let signer_registration_records: Vec<SignerRegistrationRecord> =
+            provider.get_by_epoch(&Epoch(1)).unwrap().collect();
+        let expected_signer_registration_records: Vec<SignerRegistrationRecord> =
+            signer_with_stakes_by_epoch[1]
+                .1
+                .iter()
+                .map(|sr| SignerRegistrationRecord::from_signer_with_stake(sr.clone(), Epoch(1)))
+                .rev()
+                .collect();
+        assert_eq!(
+            expected_signer_registration_records,
+            signer_registration_records
+        );
+
+        let signer_registration_records: Vec<SignerRegistrationRecord> =
+            provider.get_by_epoch(&Epoch(3)).unwrap().collect();
+        let expected_signer_registration_records: Vec<SignerRegistrationRecord> =
+            signer_with_stakes_by_epoch[3]
+                .1
+                .iter()
+                .map(|sr| SignerRegistrationRecord::from_signer_with_stake(sr.clone(), Epoch(3)))
+                .rev()
+                .collect();
+        assert_eq!(
+            expected_signer_registration_records,
+            signer_registration_records
+        );
+
+        let cursor = provider.get_by_epoch(&Epoch(5)).unwrap();
+        assert_eq!(0, cursor.count());
+
+        let signer_registration_records: Vec<SignerRegistrationRecord> =
+            provider.get_all().unwrap().collect();
+        let expected_signer_registration_records: Vec<SignerRegistrationRecord> =
+            signer_with_stakes_by_epoch
+                .iter()
+                .fold(
+                    Vec::<SignerRegistrationRecord>::new(),
+                    |mut acc, (epoch, signer_with_stakes)| {
+                        acc.extend(
+                            signer_with_stakes
+                                .iter()
+                                .map(|sr| {
+                                    SignerRegistrationRecord::from_signer_with_stake(
+                                        sr.clone(),
+                                        *epoch,
+                                    )
+                                })
+                                .collect::<Vec<SignerRegistrationRecord>>(),
+                        );
+                        acc
+                    },
+                )
+                .into_iter()
+                .rev()
+                .collect();
+        assert_eq!(
+            expected_signer_registration_records,
+            signer_registration_records
+        );
+    }
+
+    #[test]
+    fn test_update_signer_registration_record() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+        let signer_with_stakes = fixture.signers_with_stake();
+        let signer_with_stakes_copy = signer_with_stakes
+            .iter()
+            .map(|s| {
+                let mut s_new = s.clone();
+                s_new.stake += 10;
+                s_new
+            })
+            .collect::<Vec<SignerWithStake>>();
+
+        let connection = Connection::open(":memory:").unwrap();
+        setup_signer_registration_db(&connection, Vec::new()).unwrap();
+
+        let provider = UpdateSignerRegistrationRecordProvider::new(&connection);
+
+        for signer_with_stake in signer_with_stakes {
+            let signer_registration_record =
+                SignerRegistrationRecord::from_signer_with_stake(signer_with_stake, Epoch(1));
+            let signer_registration_record_saved = provider
+                .persist(signer_registration_record.clone())
+                .unwrap();
+            assert_eq!(signer_registration_record, signer_registration_record_saved);
+        }
+
+        for signer_with_stake in signer_with_stakes_copy {
+            let signer_registration_record =
+                SignerRegistrationRecord::from_signer_with_stake(signer_with_stake, Epoch(1));
+            let signer_registration_record_saved = provider
+                .persist(signer_registration_record.clone())
+                .unwrap();
+            assert_eq!(signer_registration_record, signer_registration_record_saved);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_store_adapter() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+        let signer_with_stakes = fixture.signers_with_stake();
+        let signer_with_stakes_by_epoch: Vec<(Epoch, HashMap<PartyId, SignerWithStake>)> = (0..1)
+            .map(|e| {
+                (
+                    Epoch(e),
+                    signer_with_stakes
+                        .clone()
+                        .into_iter()
+                        .map(|s| (s.party_id.to_owned(), s))
+                        .collect(),
+                )
+            })
+            .collect();
+
+        let connection = Connection::open(":memory:").unwrap();
+        setup_signer_registration_db(&connection, Vec::new()).unwrap();
+
+        let mut signer_registration_store_adapter =
+            SignerRegistrationStoreAdapter::new(Arc::new(Mutex::new(connection)));
+
+        for (epoch, signer_with_stakes) in &signer_with_stakes_by_epoch {
+            assert!(signer_registration_store_adapter
+                .store_record(epoch, signer_with_stakes)
+                .await
+                .is_ok());
+        }
+
+        for (epoch, signer_with_stakes) in &signer_with_stakes_by_epoch {
+            assert!(signer_registration_store_adapter
+                .record_exists(epoch)
+                .await
+                .unwrap());
+            assert_eq!(
+                Some(signer_with_stakes.to_owned()),
+                signer_registration_store_adapter
+                    .get_record(epoch)
+                    .await
+                    .unwrap()
+            );
+        }
+        assert_eq!(
+            signer_with_stakes_by_epoch
+                .clone()
+                .into_iter()
+                .map(|(k, v)| (k, BTreeMap::from_iter(v.into_iter())))
+                .collect::<Vec<(Epoch, BTreeMap<PartyId, SignerWithStake>)>>(),
+            signer_registration_store_adapter
+                .get_last_n_records(signer_with_stakes_by_epoch.len())
+                .await
+                .unwrap()
+                .into_iter()
+                .rev()
+                .map(|(k, v)| (k, BTreeMap::from_iter(v.into_iter())))
+                .collect::<Vec<(Epoch, BTreeMap<PartyId, SignerWithStake>)>>()
+        )
+    }
+}

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -4,9 +4,7 @@ use mithril_common::{
     chain_observer::ChainObserver,
     crypto_helper::ProtocolGenesisVerifier,
     digesters::{ImmutableDigester, ImmutableFileObserver},
-    entities::{
-        Certificate, Epoch, ProtocolParameters, Signer, SignerWithStake, StakeDistribution,
-    },
+    entities::{Certificate, Epoch, ProtocolParameters, SignerWithStake, StakeDistribution},
     era::{EraChecker, EraReader},
     store::StakeStorer,
     BeaconProvider,
@@ -253,11 +251,7 @@ impl DependencyManager {
     }
 
     async fn fill_verification_key_store(&self, target_epoch: Epoch, signers: &[SignerWithStake]) {
-        for signer in signers
-            .iter()
-            .map(|s| s.to_owned().into())
-            .collect::<Vec<Signer>>()
-        {
+        for signer in signers {
             self.verification_key_store
                 .save_verification_key(target_epoch, signer.clone())
                 .await

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -36,7 +36,9 @@ use warp::Filter;
 
 use crate::{
     configuration::{ExecutionEnvironment, LIST_SNAPSHOTS_MAX_ITEMS},
-    database::provider::{CertificateStoreAdapter, EpochSettingStore, StakePoolStore},
+    database::provider::{
+        CertificateStoreAdapter, EpochSettingStore, SignerRegistrationStoreAdapter, StakePoolStore,
+    },
     event_store::{EventMessage, EventStore, TransmitterService},
     http_server::routes::router,
     stake_distribution_service::{MithrilStakeDistributionService, StakeDistributionService},
@@ -424,12 +426,7 @@ impl DependenciesBuilder {
         > = match self.configuration.environment {
             ExecutionEnvironment::Production => {
                 let adapter =
-                    SQLiteAdapter::new("verification_key", self.get_sqlite_connection().await?)
-                        .map_err(|e| DependenciesBuilderError::Initialization {
-                            message: "Cannot create SQLite adapter for VerificationKeyStore."
-                                .to_string(),
-                            error: Some(e.into()),
-                        })?;
+                    SignerRegistrationStoreAdapter::new(self.get_sqlite_connection().await?);
 
                 Box::new(adapter)
             }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -12,8 +12,8 @@ use mithril_common::{
         ImmutableFileObserver, ImmutableFileSystemObserver,
     },
     entities::{
-        Beacon, Certificate, CertificatePending, Epoch, PartyId, ProtocolParameters, Signer,
-        SingleSignatures,
+        Beacon, Certificate, CertificatePending, Epoch, PartyId, ProtocolParameters,
+        SignerWithStake, SingleSignatures,
     },
     era::{
         adapters::{EraReaderAdapterBuilder, EraReaderDummyAdapter},
@@ -419,30 +419,31 @@ impl DependenciesBuilder {
     }
 
     async fn build_verification_key_store(&mut self) -> Result<Arc<VerificationKeyStore>> {
-        let adapter: Box<dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, Signer>>> =
-            match self.configuration.environment {
-                ExecutionEnvironment::Production => {
-                    let adapter =
-                        SQLiteAdapter::new("verification_key", self.get_sqlite_connection().await?)
-                            .map_err(|e| DependenciesBuilderError::Initialization {
-                                message: "Cannot create SQLite adapter for VerificationKeyStore."
-                                    .to_string(),
-                                error: Some(e.into()),
-                            })?;
-
-                    Box::new(adapter)
-                }
-                _ => {
-                    let adapter = MemoryAdapter::new(None).map_err(|e| {
-                        DependenciesBuilderError::Initialization {
-                            message: "Cannot create Memory adapter for VerificationKeyStore."
+        let adapter: Box<
+            dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, SignerWithStake>>,
+        > = match self.configuration.environment {
+            ExecutionEnvironment::Production => {
+                let adapter =
+                    SQLiteAdapter::new("verification_key", self.get_sqlite_connection().await?)
+                        .map_err(|e| DependenciesBuilderError::Initialization {
+                            message: "Cannot create SQLite adapter for VerificationKeyStore."
                                 .to_string(),
                             error: Some(e.into()),
-                        }
-                    })?;
-                    Box::new(adapter)
-                }
-            };
+                        })?;
+
+                Box::new(adapter)
+            }
+            _ => {
+                let adapter = MemoryAdapter::new(None).map_err(|e| {
+                    DependenciesBuilderError::Initialization {
+                        message: "Cannot create Memory adapter for VerificationKeyStore."
+                            .to_string(),
+                        error: Some(e.into()),
+                    }
+                })?;
+                Box::new(adapter)
+            }
+        };
 
         Ok(Arc::new(VerificationKeyStore::new(
             adapter,

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -839,7 +839,7 @@ mod tests {
             verification_key_store
                 .save_verification_key(
                     start_epoch.offset_to_recording_epoch(),
-                    signer_with_stake.to_owned().into(),
+                    signer_with_stake.to_owned(),
                 )
                 .await
                 .expect("register should have succeeded");

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -652,8 +652,10 @@ mod tests {
         let beacon = fake_data::beacon();
         let verification_key_store = VerificationKeyStore::new(
             Box::new(
-                MemoryAdapter::<Epoch, HashMap<entities::PartyId, entities::Signer>>::new(None)
-                    .unwrap(),
+                MemoryAdapter::<Epoch, HashMap<entities::PartyId, entities::SignerWithStake>>::new(
+                    None,
+                )
+                .unwrap(),
             ),
             None,
         );

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -223,7 +223,7 @@ mod tests {
 
     use mithril_common::{
         chain_observer::FakeObserver,
-        entities::{Epoch, PartyId, Signer},
+        entities::{Epoch, PartyId, Signer, SignerWithStake},
         store::adapter::MemoryAdapter,
         test_utils::MithrilFixtureBuilder,
     };
@@ -237,7 +237,7 @@ mod tests {
     async fn can_register_signer_if_registration_round_is_opened_with_operational_certificate() {
         let chain_observer = FakeObserver::default();
         let verification_key_store = Arc::new(VerificationKeyStore::new(
-            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, Signer>>::new(None).unwrap()),
+            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
             None,
         ));
         let signer_registerer =
@@ -275,7 +275,7 @@ mod tests {
     async fn can_register_signer_if_registration_round_is_opened_without_operational_certificate() {
         let chain_observer = FakeObserver::default();
         let verification_key_store = Arc::new(VerificationKeyStore::new(
-            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, Signer>>::new(None).unwrap()),
+            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
             None,
         ));
         let signer_registerer =
@@ -316,7 +316,7 @@ mod tests {
     async fn cant_register_signer_if_registration_round_is_not_opened() {
         let chain_observer = FakeObserver::default();
         let verification_key_store = Arc::new(VerificationKeyStore::new(
-            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, Signer>>::new(None).unwrap()),
+            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
             None,
         ));
         let signer_registerer =

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -208,7 +208,7 @@ impl SignerRegisterer for MithrilSignerRegisterer {
 
         match self
             .verification_key_store
-            .save_verification_key(registration_round.epoch, signer_save.clone().into())
+            .save_verification_key(registration_round.epoch, signer_save.clone())
             .await?
         {
             Some(_) => Err(SignerRegistrationError::ExistingSigner(signer_save)),

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -3,7 +3,7 @@ use mithril_common::store::StorePruner;
 use std::collections::HashMap;
 use tokio::sync::RwLock;
 
-use mithril_common::entities::{Epoch, PartyId, Signer};
+use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake};
 use mithril_common::store::{adapter::StoreAdapter, StoreError};
 
 type Adapter = Box<dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, Signer>>>;
@@ -15,8 +15,8 @@ pub trait VerificationKeyStorer {
     async fn save_verification_key(
         &self,
         epoch: Epoch,
-        signer: Signer,
-    ) -> Result<Option<Signer>, StoreError>;
+        signer: SignerWithStake,
+    ) -> Result<Option<SignerWithStake>, StoreError>;
 
     /// Returns a HashMap of [Signer] indexed by [PartyId] for the given `Beacon`.
     async fn get_verification_keys(
@@ -61,13 +61,13 @@ impl VerificationKeyStorer for VerificationKeyStore {
     async fn save_verification_key(
         &self,
         epoch: Epoch,
-        signer: Signer,
-    ) -> Result<Option<Signer>, StoreError> {
+        signer: SignerWithStake,
+    ) -> Result<Option<SignerWithStake>, StoreError> {
         let mut signers = match self.adapter.read().await.get_record(&epoch).await? {
             Some(s) => s,
             None => HashMap::new(),
         };
-        let prev_signer = signers.insert(signer.party_id.to_owned(), signer);
+        let prev_signer = signers.insert(signer.party_id.to_owned(), signer.clone().into());
         self.adapter
             .write()
             .await
@@ -75,7 +75,7 @@ impl VerificationKeyStorer for VerificationKeyStore {
             .await?;
         self.prune().await?;
 
-        Ok(prev_signer)
+        Ok(prev_signer.map(|prev_signer| SignerWithStake::from_signer(prev_signer, signer.stake)))
     }
 
     async fn get_verification_keys(
@@ -135,12 +135,13 @@ mod tests {
         let res = store
             .save_verification_key(
                 Epoch(0),
-                Signer {
+                SignerWithStake {
                     party_id: "0".to_string(),
                     verification_key: "OK".to_string(),
                     verification_key_signature: None,
                     operational_certificate: None,
                     kes_period: None,
+                    stake: 10,
                 },
             )
             .await
@@ -155,12 +156,13 @@ mod tests {
         let res = store
             .save_verification_key(
                 Epoch(1),
-                Signer {
+                SignerWithStake {
                     party_id: "1".to_string(),
                     verification_key: "test".to_string(),
                     verification_key_signature: None,
                     operational_certificate: None,
                     kes_period: None,
+                    stake: 10,
                 },
             )
             .await
@@ -168,12 +170,13 @@ mod tests {
 
         assert!(res.is_some());
         assert_eq!(
-            Signer {
+            SignerWithStake {
                 party_id: "1".to_string(),
                 verification_key: "vkey 1".to_string(),
                 verification_key_signature: None,
                 operational_certificate: None,
                 kes_period: None,
+                stake: 10,
             },
             res.unwrap(),
         );
@@ -207,12 +210,13 @@ mod tests {
         let _ = store
             .save_verification_key(
                 Epoch(3),
-                Signer {
+                SignerWithStake {
                     party_id: "party_id".to_string(),
                     verification_key: "whatever".to_string(),
                     verification_key_signature: None,
                     operational_certificate: None,
                     kes_period: None,
+                    stake: 10,
                 },
             )
             .await


### PR DESCRIPTION
## Content
This PR includes the following steps:

- [x] Create the `signer_registration` table
- [x] Migrate the `signer_registration` table
- [x] Update `VerificationKeyStore` to work with `SignerWithStake`
- [x] Implement `SignerRegistrationStore` providers
- [x] Implement `SignerRegistrationStore` adapter
- [x] Wire `SignerRegistrationStore` as the new `VerificationKeyStore` dependency

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #828  
