### PR TITLE
embed beacon in open_message type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2062,7 +2062,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2125,7 +2125,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.37"
+version = "0.2.38"
 dependencies = [
  "async-trait",
  "bech32",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.2.47"
+version = "0.2.48"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.37"
+version = "0.2.38"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -26,7 +26,7 @@ pub use epoch_settings::EpochSettings;
 pub use http_server_error::{ClientError, InternalServerError};
 pub use protocol_message::{ProtocolMessage, ProtocolMessagePartKey, ProtocolMessagePartValue};
 pub use protocol_parameters::ProtocolParameters;
-pub use signed_entity_type::SignedEntityType;
+pub use signed_entity_type::*;
 pub use signer::{Signer, SignerWithStake};
 pub use single_signatures::SingleSignatures;
 pub use snapshot::Snapshot;


### PR DESCRIPTION
## Content
Since each message type has its own beacon, it is now embedded in `SignedEntityType` in the `OpenMessage` type.

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Closes #848 
