### PR TITLE
Add open message domain type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2063,7 +2063,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.0"
+version = "0.3.1"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/certifier_service.rs
+++ b/mithril-aggregator/src/certifier_service.rs
@@ -260,13 +260,14 @@ impl CertifierService for MithrilCertifierService {
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<Certificate>> {
         debug!("CertifierService::create_certificate(signed_entity_type: {signed_entity_type:?})");
-        let open_message = self
+        let open_message_record = self
             .get_open_message_record(signed_entity_type)
             .await?
             .ok_or_else(|| {
                 warn!("CertifierService::create_certificate: OpenMessage not found for type {signed_entity_type:?}.");
                 CertifierServiceError::NotFound(signed_entity_type.clone())
             })?;
+        let open_message: OpenMessage = open_message_record.clone().into();
 
         if open_message.is_certified {
             warn!("CertifierService::create_certificate: open message {signed_entity_type:?} is already certified, cannot create certificate.");
@@ -343,7 +344,7 @@ impl CertifierService for MithrilCertifierService {
             .create_certificate(certificate)
             .await?;
 
-        let mut open_message_certified: OpenMessageRecord = open_message.into();
+        let mut open_message_certified: OpenMessageRecord = open_message_record.into();
         open_message_certified.is_certified = true;
         self.open_message_repository
             .update_open_message(&open_message_certified)

--- a/mithril-aggregator/src/database/provider/open_message.rs
+++ b/mithril-aggregator/src/database/provider/open_message.rs
@@ -25,7 +25,7 @@ type StdResult<T> = Result<T, StdError>;
 /// generated if possible.
 #[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct OpenMessage {
+pub struct OpenMessageRecord {
     /// OpenMessage unique identifier
     pub open_message_id: Uuid,
 
@@ -45,7 +45,7 @@ pub struct OpenMessage {
     pub created_at: NaiveDateTime,
 }
 
-impl OpenMessage {
+impl OpenMessageRecord {
     #[cfg(test)]
     /// Create a dumb OpenMessage instance mainly for test purposes
     pub fn dummy() -> Self {
@@ -64,8 +64,8 @@ impl OpenMessage {
     }
 }
 
-impl From<OpenMessageWithSingleSignatures> for OpenMessage {
-    fn from(value: OpenMessageWithSingleSignatures) -> Self {
+impl From<OpenMessageWithSingleSignaturesRecord> for OpenMessageRecord {
+    fn from(value: OpenMessageWithSingleSignaturesRecord) -> Self {
         Self {
             open_message_id: value.open_message_id,
             epoch: value.epoch,
@@ -77,7 +77,7 @@ impl From<OpenMessageWithSingleSignatures> for OpenMessage {
     }
 }
 
-impl SqLiteEntity for OpenMessage {
+impl SqLiteEntity for OpenMessageRecord {
     fn hydrate(row: Row) -> Result<Self, HydrationError>
     where
         Self: Sized,
@@ -199,7 +199,7 @@ impl<'client> OpenMessageProvider<'client> {
 }
 
 impl<'client> Provider<'client> for OpenMessageProvider<'client> {
-    type Entity = OpenMessage;
+    type Entity = OpenMessageRecord;
 
     fn get_definition(&self, condition: &str) -> String {
         let aliases = SourceAlias::new(&[
@@ -245,7 +245,7 @@ impl<'client> InsertOpenMessageProvider<'client> {
 }
 
 impl<'client> Provider<'client> for InsertOpenMessageProvider<'client> {
-    type Entity = OpenMessage;
+    type Entity = OpenMessageRecord;
 
     fn get_connection(&'client self) -> &'client Connection {
         self.connection
@@ -267,7 +267,7 @@ impl<'client> UpdateOpenMessageProvider<'client> {
         Self { connection }
     }
 
-    fn get_update_condition(&self, open_message: &OpenMessage) -> StdResult<WhereCondition> {
+    fn get_update_condition(&self, open_message: &OpenMessageRecord) -> StdResult<WhereCondition> {
         let expression = "(open_message_id, epoch_setting_id, beacon, signed_entity_type_id, protocol_message, is_certified) values (?*, ?*, ?*, ?*, ?*, ?*)";
         let beacon_str = open_message.signed_entity_type.get_json_beacon()?;
         let parameters = vec![
@@ -284,7 +284,7 @@ impl<'client> UpdateOpenMessageProvider<'client> {
 }
 
 impl<'client> Provider<'client> for UpdateOpenMessageProvider<'client> {
-    type Entity = OpenMessage;
+    type Entity = OpenMessageRecord;
 
     fn get_connection(&'client self) -> &'client Connection {
         self.connection
@@ -316,7 +316,7 @@ impl<'client> DeleteOpenMessageProvider<'client> {
 }
 
 impl<'client> Provider<'client> for DeleteOpenMessageProvider<'client> {
-    type Entity = OpenMessage;
+    type Entity = OpenMessageRecord;
 
     fn get_connection(&'client self) -> &'client Connection {
         self.connection
@@ -332,7 +332,7 @@ impl<'client> Provider<'client> for DeleteOpenMessageProvider<'client> {
 
 /// Open Message with associated single signatures if any.
 #[derive(Debug, Clone)]
-pub struct OpenMessageWithSingleSignatures {
+pub struct OpenMessageWithSingleSignaturesRecord {
     /// OpenMessage unique identifier
     pub open_message_id: Uuid,
 
@@ -355,7 +355,7 @@ pub struct OpenMessageWithSingleSignatures {
     pub created_at: NaiveDateTime,
 }
 
-impl OpenMessageWithSingleSignatures {
+impl OpenMessageWithSingleSignaturesRecord {
     /// Gather all signers party_id for this open message
     pub fn get_signers_id(&self) -> Vec<PartyId> {
         self.single_signatures
@@ -365,7 +365,7 @@ impl OpenMessageWithSingleSignatures {
     }
 }
 
-impl SqLiteEntity for OpenMessageWithSingleSignatures {
+impl SqLiteEntity for OpenMessageWithSingleSignaturesRecord {
     fn hydrate(row: Row) -> Result<Self, HydrationError>
     where
         Self: Sized,
@@ -378,7 +378,7 @@ impl SqLiteEntity for OpenMessageWithSingleSignatures {
                 ))
             })?;
 
-        let open_message = OpenMessage::hydrate(row)?;
+        let open_message = OpenMessageRecord::hydrate(row)?;
 
         let open_message = Self {
             open_message_id: open_message.open_message_id,
@@ -440,7 +440,7 @@ impl<'client> OpenMessageWithSingleSignaturesProvider<'client> {
 }
 
 impl<'client> Provider<'client> for OpenMessageWithSingleSignaturesProvider<'client> {
-    type Entity = OpenMessageWithSingleSignatures;
+    type Entity = OpenMessageWithSingleSignaturesRecord;
 
     fn get_definition(&self, condition: &str) -> String {
         let aliases = SourceAlias::new(&[
@@ -485,7 +485,7 @@ impl OpenMessageRepository {
     pub async fn get_open_message(
         &self,
         signed_entity_type: &SignedEntityType,
-    ) -> StdResult<Option<OpenMessage>> {
+    ) -> StdResult<Option<OpenMessageRecord>> {
         let lock = self.connection.lock().await;
         let provider = OpenMessageProvider::new(&lock);
         let filters = provider
@@ -502,7 +502,7 @@ impl OpenMessageRepository {
         epoch: Epoch,
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
-    ) -> StdResult<OpenMessage> {
+    ) -> StdResult<OpenMessageRecord> {
         let lock = self.connection.lock().await;
         let provider = InsertOpenMessageProvider::new(&lock);
         let filters = provider.get_insert_condition(epoch, signed_entity_type, protocol_message)?;
@@ -514,7 +514,10 @@ impl OpenMessageRepository {
     }
 
     /// Updates an [OpenMessage] in the database.
-    pub async fn update_open_message(&self, open_message: &OpenMessage) -> StdResult<OpenMessage> {
+    pub async fn update_open_message(
+        &self,
+        open_message: &OpenMessageRecord,
+    ) -> StdResult<OpenMessageRecord> {
         let lock = self.connection.lock().await;
         let provider = UpdateOpenMessageProvider::new(&lock);
         let filters = provider.get_update_condition(open_message)?;
@@ -540,7 +543,7 @@ impl OpenMessageRepository {
     pub async fn get_open_message_with_single_signatures(
         &self,
         signed_entity_type: &SignedEntityType,
-    ) -> StdResult<Option<OpenMessageWithSingleSignatures>> {
+    ) -> StdResult<Option<OpenMessageWithSingleSignaturesRecord>> {
         let lock = self.connection.lock().await;
         let provider = OpenMessageWithSingleSignaturesProvider::new(&lock);
         let filters = provider.get_signed_entity_type_condition(signed_entity_type);
@@ -564,7 +567,7 @@ mod tests {
 
     #[test]
     fn open_message_with_single_signature_projection() {
-        let projection = OpenMessageWithSingleSignatures::get_projection();
+        let projection = OpenMessageWithSingleSignaturesRecord::get_projection();
         let aliases = SourceAlias::new(&[
             ("{:open_message:}", "open_message"),
             ("{:single_signature:}", "single_signature"),
@@ -578,7 +581,7 @@ mod tests {
 
     #[test]
     fn open_message_projection() {
-        let projection = OpenMessage::get_projection();
+        let projection = OpenMessageRecord::get_projection();
         let aliases = SourceAlias::new(&[("{:open_message:}", "open_message")]);
 
         assert_eq!(
@@ -659,7 +662,7 @@ mod tests {
     fn update_provider_condition() {
         let connection = Connection::open(":memory:").unwrap();
         let provider = UpdateOpenMessageProvider::new(&connection);
-        let open_message = OpenMessage {
+        let open_message = OpenMessageRecord {
             open_message_id: Uuid::new_v4(),
             epoch: Epoch(12),
             signed_entity_type: SignedEntityType::dummy(),
@@ -836,7 +839,7 @@ mod tests {
         setup_single_signature_db(&connection, single_signature_records.clone()).unwrap();
         let repository = OpenMessageRepository::new(Arc::new(Mutex::new(connection)));
 
-        let mut open_message = OpenMessage::dummy();
+        let mut open_message = OpenMessageRecord::dummy();
         open_message.open_message_id = single_signature_records[0].open_message_id;
         repository.update_open_message(&open_message).await.unwrap();
 
@@ -857,7 +860,7 @@ mod tests {
         setup_single_signature_db(&connection, Vec::new()).unwrap();
         let repository = OpenMessageRepository::new(Arc::new(Mutex::new(connection)));
 
-        let open_message = OpenMessage::dummy();
+        let open_message = OpenMessageRecord::dummy();
         repository
             .create_open_message(
                 open_message.epoch,

--- a/mithril-aggregator/src/database/provider/open_message.rs
+++ b/mithril-aggregator/src/database/provider/open_message.rs
@@ -1,6 +1,6 @@
 use mithril_common::StdError;
 
-use mithril_common::entities::{PartyId, ProtocolMessage, SingleSignatures};
+use mithril_common::entities::{ProtocolMessage, SingleSignatures};
 use mithril_common::{
     entities::{Epoch, SignedEntityType},
     sqlite::{HydrationError, Projection, SqLiteEntity, WhereCondition},
@@ -353,16 +353,6 @@ pub struct OpenMessageWithSingleSignaturesRecord {
 
     /// Message creation datetime, it is set by the database.
     pub created_at: NaiveDateTime,
-}
-
-impl OpenMessageWithSingleSignaturesRecord {
-    /// Gather all signers party_id for this open message
-    pub fn get_signers_id(&self) -> Vec<PartyId> {
-        self.single_signatures
-            .iter()
-            .map(|sig| sig.party_id.to_owned())
-            .collect()
-    }
 }
 
 impl SqLiteEntity for OpenMessageWithSingleSignaturesRecord {

--- a/mithril-aggregator/src/database/provider/single_signature.rs
+++ b/mithril-aggregator/src/database/provider/single_signature.rs
@@ -16,7 +16,7 @@ use mithril_common::StdError;
 use tokio::sync::Mutex;
 use uuid::Uuid;
 
-use super::OpenMessage;
+use super::OpenMessageRecord;
 
 /// SingleSignature record is the representation of a stored single_signature.
 #[derive(Debug, PartialEq, Clone)]
@@ -285,7 +285,7 @@ impl SingleSignatureRepository {
     pub async fn create_single_signature(
         &self,
         single_signature: &SingleSignatures,
-        open_message: &OpenMessage,
+        open_message: &OpenMessageRecord,
     ) -> Result<SingleSignatureRecord, StdError> {
         let connection = self.connection.lock().await;
         let single_signature = SingleSignatureRecord::from_single_signatures(

--- a/mithril-aggregator/src/entities/mod.rs
+++ b/mithril-aggregator/src/entities/mod.rs
@@ -1,0 +1,6 @@
+//! Entities module
+//!
+//! This module provide domain entities for the services & state machine.
+mod open_message;
+
+pub use open_message::OpenMessage;

--- a/mithril-aggregator/src/entities/open_message.rs
+++ b/mithril-aggregator/src/entities/open_message.rs
@@ -1,0 +1,134 @@
+use mithril_common::entities::{Epoch, ProtocolMessage, SignedEntityType, SingleSignatures};
+
+use crate::database::provider::{OpenMessageRecord, OpenMessageWithSingleSignaturesRecord};
+
+/// ## OpenMessage
+///
+/// An open message is a message open for signatures. Every signer may send a
+/// single signature for this message from which a multi signature will be
+/// generated if possible.
+#[derive(Debug, Clone, PartialEq)]
+pub struct OpenMessage {
+    /// OpenMessage unique identifier
+    // pub open_message_id: Uuid, // do we need it in the entity ?
+
+    /// Epoch
+    pub epoch: Epoch,
+
+    /// Type of message
+    pub signed_entity_type: SignedEntityType,
+
+    /// Message used by the Mithril Protocol
+    pub protocol_message: ProtocolMessage,
+
+    /// Has this message been converted into a Certificate?
+    pub is_certified: bool,
+
+    /// associated single signatures
+    pub single_signatures: Vec<SingleSignatures>,
+}
+
+impl OpenMessage {
+    #[cfg(test)]
+    /// Create a dumb OpenMessage instance mainly for test purposes
+    pub fn dummy() -> Self {
+        use mithril_common::test_utils::fake_data;
+
+        let beacon = mithril_common::test_utils::fake_data::beacon();
+        let epoch = beacon.epoch;
+        let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon);
+
+        Self {
+            epoch,
+            signed_entity_type,
+            protocol_message: ProtocolMessage::new(),
+            is_certified: false,
+            single_signatures: vec![
+                fake_data::single_signatures(vec![1, 4, 5]),
+                fake_data::single_signatures(vec![2, 3, 8]),
+            ],
+        }
+    }
+}
+
+impl From<OpenMessageRecord> for OpenMessage {
+    fn from(record: OpenMessageRecord) -> Self {
+        Self {
+            epoch: record.epoch,
+            signed_entity_type: record.signed_entity_type,
+            protocol_message: record.protocol_message,
+            is_certified: record.is_certified,
+            single_signatures: vec![],
+        }
+    }
+}
+
+impl From<OpenMessageWithSingleSignaturesRecord> for OpenMessage {
+    fn from(record: OpenMessageWithSingleSignaturesRecord) -> Self {
+        Self {
+            epoch: record.epoch,
+            signed_entity_type: record.signed_entity_type,
+            protocol_message: record.protocol_message,
+            is_certified: record.is_certified,
+            single_signatures: record.single_signatures,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::database::provider::{OpenMessageRecord, OpenMessageWithSingleSignaturesRecord};
+    use mithril_common::{
+        entities::{Epoch, ProtocolMessage, SignedEntityType},
+        test_utils::fake_data,
+    };
+    use std::vec;
+    use uuid::Uuid;
+
+    use super::OpenMessage;
+
+    #[test]
+    fn test_from_record() {
+        let record = OpenMessageRecord {
+            open_message_id: Uuid::new_v4(),
+            epoch: Epoch(1),
+            signed_entity_type: SignedEntityType::dummy(),
+            protocol_message: ProtocolMessage::default(),
+            is_certified: false,
+            created_at: chrono::Local::now().naive_local(),
+        };
+        let expected = OpenMessage {
+            epoch: Epoch(1),
+            signed_entity_type: SignedEntityType::dummy(),
+            protocol_message: ProtocolMessage::default(),
+            is_certified: false,
+            single_signatures: vec![],
+        };
+        let result: OpenMessage = record.into();
+
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_from_record_with_single_signatures() {
+        let record = OpenMessageWithSingleSignaturesRecord {
+            open_message_id: Uuid::new_v4(),
+            epoch: Epoch(1),
+            signed_entity_type: SignedEntityType::dummy(),
+            protocol_message: ProtocolMessage::default(),
+            is_certified: false,
+            created_at: chrono::Local::now().naive_local(),
+            single_signatures: vec![fake_data::single_signatures(vec![1, 4, 5])],
+        };
+        let expected = OpenMessage {
+            epoch: Epoch(1),
+            signed_entity_type: SignedEntityType::dummy(),
+            protocol_message: ProtocolMessage::default(),
+            is_certified: false,
+            single_signatures: vec![fake_data::single_signatures(vec![1, 4, 5])],
+        };
+        let result: OpenMessage = record.into();
+
+        assert_eq!(expected, result);
+    }
+}

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -18,6 +18,7 @@ mod configuration;
 pub mod database;
 mod dependency;
 pub mod dependency_injection;
+pub mod entities;
 pub mod event_store;
 mod http_server;
 mod message_adapters;

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -14,7 +14,7 @@ use mithril_common::{
 };
 
 use crate::{
-    database::provider::OpenMessageWithSingleSignatures, store::VerificationKeyStorer,
+    database::provider::OpenMessageWithSingleSignaturesRecord, store::VerificationKeyStorer,
     ProtocolParametersStore, ProtocolParametersStorer, VerificationKeyStore,
 };
 
@@ -184,7 +184,7 @@ pub trait MultiSigner: Sync + Send {
     /// Creates a multi signature from single signatures
     async fn create_multi_signature(
         &self,
-        open_message: &OpenMessageWithSingleSignatures,
+        open_message: &OpenMessageWithSingleSignaturesRecord,
     ) -> Result<Option<ProtocolMultiSignature>, ProtocolError>;
 }
 
@@ -539,7 +539,7 @@ impl MultiSigner for MultiSignerImpl {
     /// Creates a multi signature from single signatures
     async fn create_multi_signature(
         &self,
-        open_message: &OpenMessageWithSingleSignatures,
+        open_message: &OpenMessageWithSingleSignaturesRecord,
     ) -> Result<Option<ProtocolMultiSignature>, ProtocolError> {
         debug!("MultiSigner:create_multi_signature({open_message:?})");
         let protocol_parameters = self
@@ -805,7 +805,7 @@ mod tests {
             "they should be at least one signature that can be registered without reaching the quorum"
         );
 
-        let mut open_message = OpenMessageWithSingleSignatures {
+        let mut open_message = OpenMessageWithSingleSignaturesRecord {
             open_message_id: Uuid::parse_str("193d1442-e89b-43cf-9519-04d8db9a12ff").unwrap(),
             epoch: start_epoch,
             signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -14,8 +14,8 @@ use mithril_common::{
 };
 
 use crate::{
-    database::provider::OpenMessageWithSingleSignaturesRecord, store::VerificationKeyStorer,
-    ProtocolParametersStore, ProtocolParametersStorer, VerificationKeyStore,
+    entities::OpenMessage, store::VerificationKeyStorer, ProtocolParametersStore,
+    ProtocolParametersStorer, VerificationKeyStore,
 };
 
 #[cfg(test)]
@@ -184,7 +184,7 @@ pub trait MultiSigner: Sync + Send {
     /// Creates a multi signature from single signatures
     async fn create_multi_signature(
         &self,
-        open_message: &OpenMessageWithSingleSignaturesRecord,
+        open_message: &OpenMessage,
     ) -> Result<Option<ProtocolMultiSignature>, ProtocolError>;
 }
 
@@ -539,7 +539,7 @@ impl MultiSigner for MultiSignerImpl {
     /// Creates a multi signature from single signatures
     async fn create_multi_signature(
         &self,
-        open_message: &OpenMessageWithSingleSignaturesRecord,
+        open_message: &OpenMessage,
     ) -> Result<Option<ProtocolMultiSignature>, ProtocolError> {
         debug!("MultiSigner:create_multi_signature({open_message:?})");
         let protocol_parameters = self
@@ -582,7 +582,6 @@ impl MultiSigner for MultiSignerImpl {
 mod tests {
     use super::*;
     use crate::{store::VerificationKeyStore, ProtocolParametersStore};
-    use chrono::Local;
     use mithril_common::{
         crypto_helper::tests_setup::*,
         entities::SignedEntityType,
@@ -590,7 +589,6 @@ mod tests {
         test_utils::{fake_data, MithrilFixtureBuilder},
     };
     use std::{collections::HashMap, sync::Arc};
-    use uuid::Uuid;
 
     async fn setup_multi_signer() -> MultiSignerImpl {
         let beacon = fake_data::beacon();
@@ -805,8 +803,7 @@ mod tests {
             "they should be at least one signature that can be registered without reaching the quorum"
         );
 
-        let mut open_message = OpenMessageWithSingleSignaturesRecord {
-            open_message_id: Uuid::parse_str("193d1442-e89b-43cf-9519-04d8db9a12ff").unwrap(),
+        let mut open_message = OpenMessage {
             epoch: start_epoch,
             signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(
                 multi_signer.current_beacon.clone().unwrap(),
@@ -814,7 +811,7 @@ mod tests {
             protocol_message: message.clone(),
             is_certified: false,
             single_signatures: Vec::new(),
-            created_at: Local::now().naive_local(),
+            ..OpenMessage::dummy()
         };
 
         // No signatures registered: multi-signer can't create the multi-signature

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::database::provider::OpenMessage;
+use crate::database::provider::OpenMessageRecord;
 use crate::snapshot_uploaders::SnapshotLocation;
 use crate::snapshotter::OngoingSnapshot;
 use crate::RuntimeError;
@@ -172,7 +172,7 @@ pub trait AggregatorRunnerTrait: Sync + Send {
         &self,
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
-    ) -> Result<OpenMessage, Box<dyn StdError + Sync + Send>>;
+    ) -> Result<OpenMessageRecord, Box<dyn StdError + Sync + Send>>;
 }
 
 /// The runner responsibility is to expose a code API for the state machine. It
@@ -614,7 +614,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
-    ) -> Result<OpenMessage, Box<dyn StdError + Sync + Send>> {
+    ) -> Result<OpenMessageRecord, Box<dyn StdError + Sync + Send>> {
         self.dependencies
             .certifier_service
             .create_open_message(signed_entity_type, protocol_message)

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::database::provider::OpenMessageRecord;
+use crate::entities::OpenMessage;
 use crate::snapshot_uploaders::SnapshotLocation;
 use crate::snapshotter::OngoingSnapshot;
 use crate::RuntimeError;
@@ -172,7 +172,7 @@ pub trait AggregatorRunnerTrait: Sync + Send {
         &self,
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
-    ) -> Result<OpenMessageRecord, Box<dyn StdError + Sync + Send>>;
+    ) -> Result<OpenMessage, Box<dyn StdError + Sync + Send>>;
 }
 
 /// The runner responsibility is to expose a code API for the state machine. It
@@ -614,7 +614,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
-    ) -> Result<OpenMessageRecord, Box<dyn StdError + Sync + Send>> {
+    ) -> Result<OpenMessage, Box<dyn StdError + Sync + Send>> {
         self.dependencies
             .certifier_service
             .create_open_message(signed_entity_type, protocol_message)

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -1,5 +1,5 @@
 use crate::{
-    database::provider::OpenMessage,
+    database::provider::OpenMessageRecord,
     runtime::{AggregatorRunnerTrait, RuntimeError},
 };
 
@@ -22,7 +22,7 @@ pub struct ReadyState {
 #[derive(Clone, Debug, PartialEq)]
 pub struct SigningState {
     current_beacon: Beacon,
-    open_message: OpenMessage,
+    open_message: OpenMessageRecord,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -359,7 +359,7 @@ impl AggregatorRuntime {
 #[cfg(test)]
 mod tests {
 
-    use crate::database::provider::OpenMessage;
+    use crate::database::provider::OpenMessageRecord;
 
     use super::super::runner::MockAggregatorRunner;
     use super::*;
@@ -607,7 +607,7 @@ mod tests {
         runner
             .expect_create_open_message()
             .once()
-            .returning(|_, _| Ok(OpenMessage::dummy()));
+            .returning(|_, _| Ok(OpenMessageRecord::dummy()));
 
         let mut runtime = init_runtime(
             Some(AggregatorState::Ready(ReadyState {
@@ -642,7 +642,7 @@ mod tests {
 
                 beacon
             },
-            open_message: OpenMessage::dummy(),
+            open_message: OpenMessageRecord::dummy(),
         };
         let mut runtime = init_runtime(Some(AggregatorState::Signing(state)), runner).await;
         runtime.cycle().await.unwrap();
@@ -663,7 +663,7 @@ mod tests {
             .returning(|_| Ok(None));
         let state = SigningState {
             current_beacon: fake_data::beacon(),
-            open_message: OpenMessage::dummy(),
+            open_message: OpenMessageRecord::dummy(),
         };
         let mut runtime = init_runtime(Some(AggregatorState::Signing(state)), runner).await;
         runtime

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -359,7 +359,7 @@ mod tests {
 
     use std::path::Path;
 
-    use crate::database::provider::OpenMessageRecord;
+    use crate::entities::OpenMessage;
     use crate::snapshotter::OngoingSnapshot;
 
     use super::super::runner::MockAggregatorRunner;
@@ -607,7 +607,7 @@ mod tests {
         runner
             .expect_create_open_message()
             .once()
-            .returning(|_, _| Ok(OpenMessageRecord::dummy()));
+            .returning(|_, _| Ok(OpenMessage::dummy()));
 
         let mut runtime = init_runtime(
             Some(AggregatorState::Ready(ReadyState {

--- a/mithril-aggregator/tests/test_extensions/open_message_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/open_message_observer.rs
@@ -1,6 +1,4 @@
-use mithril_aggregator::{
-    certifier_service::CertifierService, database::provider::OpenMessageWithSingleSignaturesRecord,
-};
+use mithril_aggregator::{certifier_service::CertifierService, entities::OpenMessage};
 use mithril_common::{entities::SignedEntityType, BeaconProvider};
 use std::sync::Arc;
 
@@ -23,9 +21,7 @@ impl OpenMessageObserver {
     }
 
     // Get the current [open message][OpenMessageWithSingleSignatures] for [cardano immutables][SignedEntityType::CardanoImmutableFilesFull]
-    pub async fn get_current_immutable_message(
-        &self,
-    ) -> Result<Option<OpenMessageWithSingleSignaturesRecord>, String> {
+    pub async fn get_current_immutable_message(&self) -> Result<Option<OpenMessage>, String> {
         let immutable_signer_entity_type = SignedEntityType::CardanoImmutableFilesFull(
             self.beacon_provider
                 .get_current_beacon()

--- a/mithril-aggregator/tests/test_extensions/open_message_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/open_message_observer.rs
@@ -1,5 +1,5 @@
 use mithril_aggregator::{
-    certifier_service::CertifierService, database::provider::OpenMessageWithSingleSignatures,
+    certifier_service::CertifierService, database::provider::OpenMessageWithSingleSignaturesRecord,
 };
 use mithril_common::{entities::SignedEntityType, BeaconProvider};
 use std::sync::Arc;
@@ -25,7 +25,7 @@ impl OpenMessageObserver {
     // Get the current [open message][OpenMessageWithSingleSignatures] for [cardano immutables][SignedEntityType::CardanoImmutableFilesFull]
     pub async fn get_current_immutable_message(
         &self,
-    ) -> Result<Option<OpenMessageWithSingleSignatures>, String> {
+    ) -> Result<Option<OpenMessageWithSingleSignaturesRecord>, String> {
         let immutable_signer_entity_type = SignedEntityType::CardanoImmutableFilesFull(
             self.beacon_provider
                 .get_current_beacon()


### PR DESCRIPTION
## Content

This PR add an OpenMessage domain type that is used by the aggregator services & state machine instead of the record types in order to have a clear split between the domain and the database. 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
Also reintroduce a test in the aggregator state machine that we forgot to uncomment & fix in #866.

## Issue(s)
Closes #878 