### PR TITLE
Make `Artifact` usable as trait object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -871,6 +871,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4056f63fce3b82d852c3da92b08ea59959890813a7f4ce9c0ff85b10cf301b"
+dependencies = [
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "curl"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1131,6 +1141,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "erased-serde"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1408,6 +1427,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "ghost"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e77ac7b51b8e6313251737fcef4b1c01a2ea102bde68415b62c0ee9268fec357"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1710,6 +1740,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7741301a6d6a9b28ce77c0fb77a4eb116b6bc8f3bef09923f7743d059c4157d3"
+dependencies = [
+ "ctor 0.2.0",
+ "ghost",
 ]
 
 [[package]]
@@ -2091,6 +2131,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-util",
+ "typetag",
  "uuid",
  "warp",
 ]
@@ -2165,6 +2206,7 @@ dependencies = [
  "strum_macros",
  "thiserror",
  "tokio",
+ "typetag",
  "walkdir",
  "warp",
 ]
@@ -3918,6 +3960,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "typetag"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6898cc6f6a32698cc3e14d5632a14d2b23ed9f7b11e6b8e05ce685990acc22"
+dependencies = [
+ "erased-serde",
+ "inventory",
+ "once_cell",
+ "serde",
+ "typetag-impl",
+]
+
+[[package]]
+name = "typetag-impl"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3e1c30cedd24fc597f7d37a721efdbdc2b1acae012c1ef1218f4c7c2c0f3e7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
 name = "ucd-trie"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4034,7 +4100,7 @@ version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2209b78d1249f7e6f3293657c9779fe31ced465df091bbd433a1cf88e916ec55"
 dependencies = [
- "ctor",
+ "ctor 0.1.26",
  "version_check",
 ]
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -32,6 +32,7 @@ tar = "0.4.38"
 thiserror = "1.0.31"
 tokio = { version = "1.17.0", features = ["full"] }
 tokio-util = { version = "0.7.1", features = ["codec"] }
+typetag = "0.2.8"
 uuid = { version = "1.3.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 warp = "0.3"
 

--- a/mithril-aggregator/src/artifact_builder/dummy_artifact.rs
+++ b/mithril-aggregator/src/artifact_builder/dummy_artifact.rs
@@ -22,6 +22,7 @@ impl DummyArtifact {
     }
 }
 
+#[typetag::serde]
 impl Artifact for DummyArtifact {}
 
 /// A [DummyArtifact] builder

--- a/mithril-aggregator/src/artifact_builder/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/artifact_builder/mithril_stake_distribution.rs
@@ -24,6 +24,7 @@ impl MithrilStakeDistribution {
     }
 }
 
+#[typetag::serde]
 impl Artifact for MithrilStakeDistribution {}
 
 /// A [MithrilStakeDistributionArtifact] builder

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -115,7 +115,7 @@ pub struct DependencyManager {
     pub signable_builder_service: Arc<SignableBuilderService>,
 
     /// Artifact Builder Service
-    pub artifact_builder_service: Arc<ArtifactBuilderService>,
+    pub artifact_builder_service: Arc<dyn ArtifactBuilderService>,
 
     /// Certifier Service
     pub certifier_service: Arc<dyn CertifierService>,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -49,6 +49,7 @@ strum = "0.24.1"
 strum_macros = "0.24.1"
 thiserror = "1.0.31"
 tokio = { version = "1.17.0", features = ["full"] }
+typetag = "0.2.8"
 walkdir = "2"
 warp = "0.3"
 

--- a/mithril-common/src/signable_builder/interface.rs
+++ b/mithril-common/src/signable_builder/interface.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Debug;
 
 use crate::{entities::ProtocolMessage, StdResult};
@@ -14,7 +13,8 @@ pub trait Signable: Send + Sync {
 }
 
 /// Artifact is a trait for types that represent signed artifacts
-pub trait Artifact: Serialize + DeserializeOwned + PartialEq + Debug + Send + Sync {}
+#[typetag::serde(tag = "type")]
+pub trait Artifact: Debug + Send + Sync {}
 
 /// SignableBuilder is trait for building a signable for a beacon
 #[async_trait]


### PR DESCRIPTION
## Content
This PR includes:
- A fix that makes the `Artifact` trait usable as trait object (compliant with `object safety`)
- The conversion of the `ArtifactBuilderService` to a trait

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #870 
