### PR TITLE
Implement new Stake Distribution computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.52"
+version = "0.2.53"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.42"
+version = "0.2.43"
 dependencies = [
  "async-trait",
  "clap 4.2.7",

--- a/docs/blog/2022-09-13-stake-distribution-retrieval.md
+++ b/docs/blog/2022-09-13-stake-distribution-retrieval.md
@@ -5,6 +5,8 @@ authors:
 tags: [stake-distribution, certificate]
 ---
 
+**Update**: The Stake Distribution computation is evolving with the release of Cardano node `8.0.0`: the computation now relies on the new `cardano-cli query stake-snapshot --all-stake-pools` command that retrieves the Stake Distribution all at once and that is way faster. Prior versions of the Cardano node `1.35+` are backward compatible and will keep implementing the algorithm detailed below.
+
 ### The way the Mithril nodes retrieve the Stake Distribution is changing
 
 **PR**: `Fix Stake Distribution retrieval` [#499](https://github.com/input-output-hk/mithril/pull/499)

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.17"
+version = "0.3.18"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.52"
+version = "0.2.53"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.42"
+version = "0.2.43"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes the implementation of the new Stake Distribution computation:
- Use the new `query stake-snapshot --all-stake-pools` command when available (Cardano node `8.0.0+`)
- Fallback on the (now) legacy former computation of the Stake Distribution otherwise (Cardano node `1.35.7-`)

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Add dev blog post (if relevant)

## Issue(s)
Closes #919 
