### PR TITLE
Fix stake distribution computation for zero stake pools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.20"
+version = "0.3.21"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2167,7 +2167,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.54"
+version = "0.2.55"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.43"
+version = "0.2.44"
 dependencies = [
  "async-trait",
  "clap 4.2.7",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.20"
+version = "0.3.21"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.54"
+version = "0.2.55"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/chain_observer/cli_observer.rs
+++ b/mithril-common/src/chain_observer/cli_observer.rs
@@ -382,7 +382,9 @@ impl CardanoCliChainObserver {
                 .ok_or(ChainObserverError::InvalidContent(
                     format!("Stake could not be converted to integer for {pool_id_bech32}").into(),
                 ))?;
-            stake_distribution.insert(pool_id_bech32, stakes);
+            if stakes > 0 {
+                stake_distribution.insert(pool_id_bech32, stakes);
+            }
         }
 
         Ok(Some(stake_distribution))
@@ -605,6 +607,11 @@ pool1qz2vzszautc2c8mljnqre2857dpmheq7kgt6vav0s38tvvhxm6w   1.051e-6
             "stakeGo": 1200000000000,
             "stakeMark": 1200000000001,
             "stakeSet": 1200000000002
+        },
+        "00000ffff93effbf3ce788aebd3e7506b80322bd3995ad432e61fad5": {
+            "stakeGo": 0,
+            "stakeMark": 0,
+            "stakeSet": 1300000000002
         }
     },
     "total": {

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.43"
+version = "0.2.44"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a fix on the new stake distribution computation that does not include pools with zero stake.
This will avoid a discrepancy in the AVK computation between legacy and new versions.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #919
