### PR TITLE
Create new `Pythagoras` era

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         era: ${{ fromJSON(needs.build-ubuntu-X64.outputs.eras) }}
-        run_id: [1,2,3]
+        run_id: [1,2,3,4,5,6,7,8,9,10]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3

--- a/mithril-aggregator/src/certifier_service.rs
+++ b/mithril-aggregator/src/certifier_service.rs
@@ -225,10 +225,13 @@ impl CertifierService for MithrilCertifierService {
         protocol_message: &ProtocolMessage,
     ) -> StdResult<OpenMessage> {
         debug!("CertifierService::create_open_message(signed_entity_type: {signed_entity_type:?}, protocol_message: {protocol_message:?})");
-        let current_epoch = self.current_epoch.read().await;
         let open_message = self
             .open_message_repository
-            .create_open_message(*current_epoch, signed_entity_type, protocol_message)
+            .create_open_message(
+                signed_entity_type.get_epoch(),
+                signed_entity_type,
+                protocol_message,
+            )
             .await?;
         info!("CertifierService::create_open_message: created open message for {signed_entity_type:?}");
         debug!(

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -98,6 +98,7 @@ pub mod tests {
     use crate::http_server::SERVER_BASE_PATH;
     use crate::signed_entity_service::MockSignedEntityService;
     use mithril_common::entities::{Epoch, SignedEntity, SignedEntityType};
+    use mithril_common::era::SupportedEra;
     use mithril_common::signable_builder::Artifact;
     use mithril_common::sqlite::HydrationError;
     use mithril_common::test_utils::apispec::APISpec;
@@ -167,7 +168,7 @@ pub mod tests {
             .await;
 
         APISpec::verify_conformity(
-            APISpec::get_all_spec_files(),
+            vec![APISpec::get_era_spec_file(SupportedEra::Pythagoras)],
             method,
             path,
             "application/json",
@@ -196,7 +197,7 @@ pub mod tests {
             .await;
 
         APISpec::verify_conformity(
-            APISpec::get_all_spec_files(),
+            vec![APISpec::get_era_spec_file(SupportedEra::Pythagoras)],
             method,
             path,
             "application/json",
@@ -232,7 +233,7 @@ pub mod tests {
             .await;
 
         APISpec::verify_conformity(
-            APISpec::get_all_spec_files(),
+            vec![APISpec::get_era_spec_file(SupportedEra::Pythagoras)],
             method,
             path,
             "application/json",
@@ -261,7 +262,7 @@ pub mod tests {
             .await;
 
         APISpec::verify_conformity(
-            APISpec::get_all_spec_files(),
+            vec![APISpec::get_era_spec_file(SupportedEra::Pythagoras)],
             method,
             path,
             "application/json",
@@ -290,7 +291,7 @@ pub mod tests {
             .await;
 
         APISpec::verify_conformity(
-            APISpec::get_all_spec_files(),
+            vec![APISpec::get_era_spec_file(SupportedEra::Pythagoras)],
             method,
             path,
             "application/json",

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -6,6 +6,7 @@ use crate::{
     dependency::MultiSignerWrapper, CertificatePendingStore, CertificateStore, Configuration,
     DependencyManager, ProtocolParametersStore, SignerRegisterer,
 };
+use mithril_common::era::EraChecker;
 use mithril_common::BeaconProvider;
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -81,9 +82,16 @@ pub fn with_ticker_service(
     warp::any().map(move || dependency_manager.ticker_service.clone())
 }
 
-/// With signed entity service
+/// With signed entity service middleware
 pub fn with_signed_entity_service(
     dependency_manager: Arc<DependencyManager>,
 ) -> impl Filter<Extract = (Arc<dyn SignedEntityService>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.signed_entity_service.clone())
+}
+
+/// With era checker middleware
+pub fn with_era_checker(
+    dependency_manager: Arc<DependencyManager>,
+) -> impl Filter<Extract = (Arc<EraChecker>,), Error = Infallible> + Clone {
+    warp::any().map(move || dependency_manager.era_checker.clone())
 }

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -2,7 +2,10 @@ mod test_extensions;
 
 use mithril_aggregator::{Configuration, VerificationKeyStorer};
 use mithril_common::{
-    chain_observer::ChainObserver, entities::ProtocolParameters, test_utils::MithrilFixtureBuilder,
+    chain_observer::ChainObserver,
+    entities::{Epoch, ProtocolParameters},
+    era::{EraMarker, SupportedEra},
+    test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{utilities::get_test_dir, RuntimeTester, SignedEntityTypeDiscriminants};
 
@@ -20,6 +23,14 @@ async fn certificate_chain() {
     };
     let mut tester = RuntimeTester::build(configuration).await;
     let observer = tester.observer.clone();
+
+    comment!("use Pythagoras era");
+    tester
+        .set_era_markers(vec![EraMarker::new(
+            &SupportedEra::Pythagoras.to_string(),
+            Some(Epoch(0)),
+        )])
+        .await;
 
     comment!("Create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -4,7 +4,8 @@ use std::collections::BTreeSet;
 
 use mithril_aggregator::Configuration;
 use mithril_common::{
-    entities::{ProtocolMessagePartKey, ProtocolParameters},
+    entities::{Epoch, ProtocolMessagePartKey, ProtocolParameters},
+    era::{EraMarker, SupportedEra},
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{utilities::get_test_dir, RuntimeTester, SignedEntityTypeDiscriminants};
@@ -23,6 +24,14 @@ async fn create_certificate() {
     };
     let mut tester = RuntimeTester::build(configuration).await;
     let observer = tester.observer.clone();
+
+    comment!("use Pythagoras era");
+    tester
+        .set_era_markers(vec![EraMarker::new(
+            &SupportedEra::Pythagoras.to_string(),
+            Some(Epoch(0)),
+        )])
+        .await;
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()

--- a/mithril-common/src/era/supported_era.rs
+++ b/mithril-common/src/era/supported_era.rs
@@ -28,6 +28,9 @@ impl UnsupportedEraError {
 pub enum SupportedEra {
     /// Thales era
     Thales,
+
+    /// Pythagoras era
+    Pythagoras,
 }
 
 impl SupportedEra {

--- a/mithril-common/src/test_utils/apispec.rs
+++ b/mithril-common/src/test_utils/apispec.rs
@@ -170,7 +170,7 @@ impl<'a> APISpec<'a> {
 
     /// Get spec file for era
     pub fn get_era_spec_file(era: SupportedEra) -> String {
-        format!("../openapi-{}", era)
+        format!("../openapi-{}.yaml", era)
     }
 
     /// Get all spec files

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -366,11 +366,7 @@ impl Runner for SignerRunner {
             .await?;
 
         // 2 set the next signers keys and stakes in the message
-        let epoch = match signed_entity_type {
-            SignedEntityType::MithrilStakeDistribution(epoch) => epoch,
-            SignedEntityType::CardanoImmutableFilesFull(beacon) => &beacon.epoch,
-            SignedEntityType::CardanoStakeDistribution(epoch) => epoch,
-        };
+        let epoch = signed_entity_type.get_epoch();
         let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
         let next_protocol_initializer = self
             .services

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -47,7 +47,7 @@ pub struct Args {
     cardano_epoch_length: f64,
 
     /// Mithril era to run
-    #[clap(long, default_value = "thales")]
+    #[clap(long, default_value = "pythagoras")]
     mithril_era: String,
 }
 

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -39,7 +39,7 @@ pub struct Args {
     number_of_pool_nodes: u8,
 
     /// Length of a Cardano slot in the devnet (in s)
-    #[clap(long, default_value_t = 0.08)]
+    #[clap(long, default_value_t = 0.18)]
     cardano_slot_length: f64,
 
     /// Length of a Cardano epoch in the devnet (in s)

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -1,15 +1,18 @@
 use crate::{Aggregator, Client, Devnet, Signer, DEVNET_MAGIC_ID};
 use mithril_common::chain_observer::{CardanoCliChainObserver, CardanoCliRunner};
 use mithril_common::entities::ProtocolParameters;
+use mithril_common::era::SupportedEra;
 use mithril_common::CardanoNetwork;
 use std::borrow::BorrowMut;
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 use std::sync::Arc;
 
 pub struct MithrilInfrastructure {
     work_dir: PathBuf,
     bin_dir: PathBuf,
     devnet: Devnet,
+    mithril_era: SupportedEra,
     aggregator: Aggregator,
     signers: Vec<Signer>,
     cardano_chain_observer: Arc<CardanoCliChainObserver>,
@@ -74,10 +77,14 @@ impl MithrilInfrastructure {
             ),
         )));
 
+        let mithril_era = SupportedEra::from_str(mithril_era)
+            .map_err(|e| format!("Could not parse era {mithril_era}: {e}"))?;
+
         Ok(Self {
             work_dir: work_dir.to_path_buf(),
             bin_dir: bin_dir.to_path_buf(),
             devnet,
+            mithril_era,
             aggregator,
             signers,
             cardano_chain_observer,
@@ -86,6 +93,10 @@ impl MithrilInfrastructure {
 
     pub fn devnet(&self) -> &Devnet {
         &self.devnet
+    }
+
+    pub fn mithril_era(&self) -> &SupportedEra {
+        &self.mithril_era
     }
 
     pub fn aggregator(&self) -> &Aggregator {

--- a/openapi-pythagoras.yaml
+++ b/openapi-pythagoras.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.5
+  version: 0.2.0
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.
@@ -181,6 +181,57 @@ paths:
           description: API version mismatch
         default:
           description: snapshot retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /artifact/mithril-stake-distributions:
+    get:
+      summary: Get most recent Mithril stake distributions
+      description: |
+        Returns the list of the most recent Mithril stake distributions
+      responses:
+        "200":
+          description: Mithril stake distribution found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MithrilStakeDistributionListMessage"
+        "412":
+          description: API version mismatch
+        default:
+          description: Mithril stake distribution retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /artifact/mithril-stake-distribution/{hash}:
+    get:
+      summary: Get Mithril stake distribution information
+      description: |
+        Returns the information of a Mithril stake distribution
+      parameters:
+        - name: hash
+          in: path
+          description: Hash of the Mithril stake distribution to retrieve
+          required: true
+          schema:
+            type: string
+            format: bytes
+          example: "NQVhBc9frGFwBtdCKgWw4P24qQwAsB0vSvijo8FImr5kRZL"
+      responses:
+        "200":
+          description: Mithril stake distribution found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MithrilStakeDistributionMessage"
+        "404":
+          description: Mithril stake distribution not found
+        "412":
+          description: API version mismatch
+        default:
+          description: Mithril stake distribution retrieval error
           content:
             application/json:
               schema:
@@ -697,6 +748,81 @@ components:
       description: This message represents a snapshot file and its metadata.
       allOf:
         - $ref: "#/components/schemas/Snapshot"
+
+    MithrilStakeDistributionListMessage:
+      description: MithrilStakeDistributionListMessage represents a list of Mithril stake distribution
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        required:
+          - epoch
+          - hash
+        properties:
+          epoch:
+            description: Cardano chain epoch number
+            type: integer
+            format: int64
+          hash:
+            description: Hash of the Mithril stake distribution
+            type: string
+            format: bytes
+          certificate_hash:
+            description: Hash of the associated certificate
+            type: string
+            format: bytes
+        example:
+          {
+          "epoch": 123,
+          "hash":"24qQwKgWw4mr5kRZLIUA9XAsB0vSvijo8FIfrGFwBtdCNQVhBc9PXu7RiCHSRem3MmHoKbo",
+          "certificate_hash": "AsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKbo"
+          }
+
+    MithrilStakeDistributionMessage:
+      description: This message represents a Mithril stake distribution.
+      type: object
+      additionalProperties: false
+      required:
+        - epoch
+        - hash
+        - signers
+      properties:
+        epoch:
+          description: Cardano chain epoch number
+          type: integer
+          format: int64
+        hash:
+          description: Hash of the Mithril stake distribution
+          type: string
+          format: bytes
+        certificate_hash:
+          description: Hash of the associated certificate
+          type: string
+          format: bytes
+        signers:
+          description: The list of the signers with their stakes and verification keys
+          type: array
+          items:
+            $ref: "#/components/schemas/SignerWithStake"
+      example:
+        {
+        "epoch": 123,
+        "hash":"24qQwKgWw4mr5kRZLIUA9XAsB0vSvijo8FIfrGFwBtdCNQVhBc9PXu7RiCHSRem3MmHoKbo",
+        "certificate_hash": "AsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKbo",
+        "signers":
+            [
+              {
+                "party_id": "1234567890",
+                "verification_key": "AsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKbo",
+                "stake": "1234",
+              },
+              {
+                "party_id": "2345678900",
+                "verification_key": "NQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdC",
+                "stake": "2345",
+              },
+            ],
+        }
 
     Error:
       description: Internal error representation


### PR DESCRIPTION
## Content
This PR includes the creation of the new `Pythagoras` era:
- Enable Mithril Stake Distribution open messages on the new `Pythagoras` era only
- Bump Open API version to a new minor `0.2` version on the new `Pythagoras` era
- Deactivate the redirect routes of the snapshots for the new `Pythagoras` era

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #941 
