### PR TITLE
Fix curl commands for latest snapshot digest in docs

### DIFF
--- a/docs/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-client.md
@@ -200,7 +200,7 @@ export MITHRIL_IMAGE_ID=**YOUR_MITHRIL_IMAGE_ID**
 export NETWORK=**YOUR_CARDANO_NETWORK**
 export AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT**
 export GENESIS_VERIFICATION_KEY=$(wget -q -O - **YOUR_GENESIS_VERIFICATION_KEY**)
-export SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
 ```
 
 Here is an example configuration for the `release-preprod` network and the `latest` stable Docker image
@@ -210,7 +210,7 @@ export MITHRIL_IMAGE_ID=latest
 export NETWORK=preprod
 export AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator
 export GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey)
-export SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
 ```
 
 Then create a shell function for the Mithril Client

--- a/docs/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/root/manual/getting-started/bootstrap-cardano-node.md
@@ -212,7 +212,7 @@ export GENESIS_VERIFICATION_KEY=$(wget -q -O - **YOUR_GENESIS_VERIFICATION_KEY**
 
 # Digest of the latest produced snapshot for convenience of the demo
 # You can also modify this variable and set it to the value of the digest of a snapshot that you can retrieve at step 2
-export SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
 ```
 
 ### Step 2: Select A Snapshot

--- a/docs/root/manual/getting-started/run-mithril-devnet.md
+++ b/docs/root/manual/getting-started/run-mithril-devnet.md
@@ -445,7 +445,7 @@ AGGREGATOR_ENDPOINT=http://localhost:8080/aggregator
 
 # Digest of the latest produced snapshot for convenience of the demo
 # You can also modify this variable and set it to the value of the digest of a snapshot that you can retrieve at step 2
-SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
 ```
 
 ### Step 2: Select A Snapshot

--- a/docs/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-client.md
@@ -200,7 +200,7 @@ export MITHRIL_IMAGE_ID=**YOUR_MITHRIL_IMAGE_ID**
 export NETWORK=**YOUR_CARDANO_NETWORK**
 export AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT**
 export GENESIS_VERIFICATION_KEY=$(wget -q -O - **YOUR_GENESIS_VERIFICATION_KEY**)
-export SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
 ```
 
 Here is an example configuration for the `release-preprod` network and the `latest` stable Docker image
@@ -210,7 +210,7 @@ export MITHRIL_IMAGE_ID=latest
 export NETWORK=preprod
 export AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator
 export GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey)
-export SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
 ```
 
 Then create a shell function for the Mithril Client

--- a/docs/versioned_docs/version-maintained/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/versioned_docs/version-maintained/manual/getting-started/bootstrap-cardano-node.md
@@ -212,7 +212,7 @@ export GENESIS_VERIFICATION_KEY=$(wget -q -O - **YOUR_GENESIS_VERIFICATION_KEY**
 
 # Digest of the latest produced snapshot for convenience of the demo
 # You can also modify this variable and set it to the value of the digest of a snapshot that you can retrieve at step 2
-export SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
 ```
 
 ### Step 2: Select A Snapshot

--- a/docs/versioned_docs/version-maintained/manual/getting-started/run-mithril-devnet.md
+++ b/docs/versioned_docs/version-maintained/manual/getting-started/run-mithril-devnet.md
@@ -445,7 +445,7 @@ AGGREGATOR_ENDPOINT=http://localhost:8080/aggregator
 
 # Digest of the latest produced snapshot for convenience of the demo
 # You can also modify this variable and set it to the value of the digest of a snapshot that you can retrieve at step 2
-SNAPSHOT_DIGEST=$(curl -s $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
+SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/snapshots | jq -r '.[0].digest')
 ```
 
 ### Step 2: Select A Snapshot


### PR DESCRIPTION
## Content
This PR includes a fix on the curl commands used to compute the latest snapshot digest in the docs:
- Add follow redirect with `L` option
- Update route to `artifact/snapshots` in the next version

## Pre-submit checklist

- Branch
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update documentation website (if relevant)

