### PR TITLE
Add Certificate list route to aggregator REST API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.23"
+version = "0.3.24"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.23"
+version = "0.3.24"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -3,20 +3,13 @@ use crate::event_store::{EventMessage, TransmitterService};
 use crate::signed_entity_service::SignedEntityService;
 use crate::ticker_service::TickerService;
 use crate::{
-    dependency::MultiSignerWrapper, CertificatePendingStore, CertificateStore, Configuration,
-    DependencyManager, ProtocolParametersStore, SignerRegisterer,
+    dependency::MultiSignerWrapper, CertificatePendingStore, Configuration, DependencyManager,
+    ProtocolParametersStore, SignerRegisterer,
 };
 use mithril_common::BeaconProvider;
 use std::convert::Infallible;
 use std::sync::Arc;
 use warp::Filter;
-
-/// With certificate store middleware
-pub fn with_certificate_store(
-    dependency_manager: Arc<DependencyManager>,
-) -> impl Filter<Extract = (Arc<CertificateStore>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.certificate_store.clone())
-}
 
 /// With certificate pending store
 pub(crate) fn with_certificate_pending_store(

--- a/mithril-aggregator/src/message_adapters/mod.rs
+++ b/mithril-aggregator/src/message_adapters/mod.rs
@@ -1,5 +1,6 @@
 mod from_register_signature;
 mod from_register_signer;
+mod to_certificate_list_message;
 mod to_certificate_message;
 mod to_certificate_pending_message;
 mod to_epoch_settings_message;
@@ -10,6 +11,7 @@ mod to_snapshot_message;
 
 pub use from_register_signature::FromRegisterSingleSignatureAdapter;
 pub use from_register_signer::FromRegisterSignerAdapter;
+pub use to_certificate_list_message::ToCertificateListMessageAdapter;
 pub use to_certificate_message::ToCertificateMessageAdapter;
 pub use to_certificate_pending_message::ToCertificatePendingMessageAdapter;
 pub use to_epoch_settings_message::ToEpochSettingsMessageAdapter;

--- a/mithril-aggregator/src/message_adapters/to_certificate_list_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_list_message.rs
@@ -1,0 +1,47 @@
+use mithril_common::entities::Certificate;
+use mithril_common::messages::{CertificateListItemMessage, CertificateListMessage};
+
+/// Adapter to convert a list of [Certificate] to [CertificateListMessage] instances
+pub struct ToCertificateListMessageAdapter;
+
+impl ToCertificateListMessageAdapter {
+    /// Method to trigger the conversion
+    pub fn adapt(certificates: Vec<Certificate>) -> CertificateListMessage {
+        certificates
+            .into_iter()
+            .map(|certificate| CertificateListItemMessage {
+                hash: certificate.hash,
+                previous_hash: certificate.previous_hash,
+                beacon: certificate.beacon,
+                signed_message: certificate.signed_message,
+                initiated_at: certificate.metadata.initiated_at,
+                sealed_at: certificate.metadata.sealed_at,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::test_utils::fake_data;
+
+    use super::*;
+
+    #[test]
+    fn adapt_ok() {
+        let certificate = fake_data::certificate("hash123".to_string());
+
+        let certificate_list_message =
+            ToCertificateListMessageAdapter::adapt(vec![certificate.clone()]);
+        let certificate_list_message_expected = vec![CertificateListItemMessage {
+            hash: certificate.hash,
+            previous_hash: certificate.previous_hash,
+            beacon: certificate.beacon,
+            signed_message: certificate.signed_message,
+            initiated_at: certificate.metadata.initiated_at,
+            sealed_at: certificate.metadata.sealed_at,
+        }];
+
+        assert_eq!(certificate_list_message_expected, certificate_list_message);
+    }
+}

--- a/mithril-aggregator/src/message_adapters/to_certificate_list_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_list_message.rs
@@ -1,5 +1,7 @@
 use mithril_common::entities::Certificate;
-use mithril_common::messages::{CertificateListItemMessage, CertificateListMessage};
+use mithril_common::messages::{
+    CertificateListItemMessage, CertificateListItemMessageMetadata, CertificateListMessage,
+};
 
 /// Adapter to convert a list of [Certificate] to [CertificateListMessage] instances
 pub struct ToCertificateListMessageAdapter;
@@ -13,9 +15,16 @@ impl ToCertificateListMessageAdapter {
                 hash: certificate.hash,
                 previous_hash: certificate.previous_hash,
                 beacon: certificate.beacon,
+                metadata: CertificateListItemMessageMetadata {
+                    protocol_version: certificate.metadata.protocol_version,
+                    protocol_parameters: certificate.metadata.protocol_parameters,
+                    initiated_at: certificate.metadata.initiated_at,
+                    sealed_at: certificate.metadata.sealed_at,
+                    total_signers: certificate.metadata.signers.len(),
+                },
+                protocol_message: certificate.protocol_message,
                 signed_message: certificate.signed_message,
-                initiated_at: certificate.metadata.initiated_at,
-                sealed_at: certificate.metadata.sealed_at,
+                aggregate_verification_key: certificate.aggregate_verification_key,
             })
             .collect()
     }
@@ -37,9 +46,16 @@ mod tests {
             hash: certificate.hash,
             previous_hash: certificate.previous_hash,
             beacon: certificate.beacon,
+            metadata: CertificateListItemMessageMetadata {
+                protocol_version: certificate.metadata.protocol_version,
+                protocol_parameters: certificate.metadata.protocol_parameters,
+                initiated_at: certificate.metadata.initiated_at,
+                sealed_at: certificate.metadata.sealed_at,
+                total_signers: certificate.metadata.signers.len(),
+            },
+            protocol_message: certificate.protocol_message,
             signed_message: certificate.signed_message,
-            initiated_at: certificate.metadata.initiated_at,
-            sealed_at: certificate.metadata.sealed_at,
+            aggregate_verification_key: certificate.aggregate_verification_key,
         }];
 
         assert_eq!(certificate_list_message_expected, certificate_list_message);

--- a/mithril-common/src/messages/certificate_list.rs
+++ b/mithril-common/src/messages/certificate_list.rs
@@ -1,0 +1,102 @@
+use serde::{Deserialize, Serialize};
+
+use crate::entities::Beacon;
+
+use crate::entities::Epoch;
+
+/// Message structure of a certificate list
+pub type CertificateListMessage = Vec<CertificateListItemMessage>;
+
+/// Message structure of a certificate list item
+// TODO: select final fields for the list
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct CertificateListItemMessage {
+    /// Hash of the current certificate
+    /// Computed from the other fields of the certificate
+    /// aka H(Cp,n))
+    pub hash: String,
+
+    /// Hash of the previous certificate in the chain
+    /// This is either the hash of the first certificate of the epoch in the chain
+    /// Or the first certificate of the previous epoch in the chain (if the certificate is the first of its epoch)
+    /// aka H(FC(n))
+    pub previous_hash: String,
+
+    /// Mithril beacon on the Cardano chain
+    /// aka BEACON(p,n)
+    pub beacon: Beacon,
+
+    /// Message that is signed by the signers
+    /// aka H(MSG(p,n) || AVK(n-1))
+    pub signed_message: String,
+
+    /// Date and time when the certificate was initiated
+    /// Represents the time at which the single signatures registration is opened
+    /// part of METADATA(p,n)
+    pub initiated_at: String,
+
+    /// Date and time when the certificate was sealed
+    /// Represents the time at which the quorum of single signatures was reached so that they were aggregated into a multi signature
+    /// part of METADATA(p,n)
+    pub sealed_at: String,
+}
+
+impl CertificateListItemMessage {
+    /// Return a dummy test entity (test-only).
+    pub fn dummy() -> Self {
+        Self {
+            hash: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
+            previous_hash: "d5daf6c03ace4a9c074e951844075b9b373bafc4e039160e3e2af01823e9abfb"
+                .to_string(),
+            beacon: Beacon {
+                network: "preview".to_string(),
+                epoch: Epoch(86),
+                immutable_file_number: 1728,
+            },
+            signed_message: "eca9866c06a9fb98a34686449ff0c03f75f8ddd9a126840e5cdd77cda2ffc4de"
+                .to_string(),
+            initiated_at: "2023-01-19T13:43:05.618857482Z".to_string(),
+            sealed_at: "2023-01-19T13:45:17.628757381Z".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn golden_message() -> CertificateListMessage {
+        vec![CertificateListItemMessage {
+            hash: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
+            previous_hash: "d5daf6c03ace4a9c074e951844075b9b373bafc4e039160e3e2af01823e9abfb"
+                .to_string(),
+            beacon: Beacon {
+                network: "preview".to_string(),
+                epoch: Epoch(86),
+                immutable_file_number: 1728,
+            },
+            signed_message: "eca9866c06a9fb98a34686449ff0c03f75f8ddd9a126840e5cdd77cda2ffc4de"
+                .to_string(),
+            initiated_at: "2023-01-19T13:43:05.618857482Z".to_string(),
+            sealed_at: "2023-01-19T13:45:17.628757381Z".to_string(),
+        }]
+    }
+
+    // Test the retro compatibility with possible future upgrades.
+    #[test]
+    fn test_v1() {
+        let json = r#"[{
+"hash":"0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6",
+"previous_hash":"d5daf6c03ace4a9c074e951844075b9b373bafc4e039160e3e2af01823e9abfb",
+"beacon":{"network":"preview","epoch":86,"immutable_file_number":1728},
+"signed_message":"eca9866c06a9fb98a34686449ff0c03f75f8ddd9a126840e5cdd77cda2ffc4de",
+"initiated_at":"2023-01-19T13:43:05.618857482Z",
+"sealed_at":"2023-01-19T13:45:17.628757381Z"
+}]"#;
+        let message: CertificateListMessage = serde_json::from_str(json).expect(
+            "This JSON is expected to be succesfully parsed into a CertificateListMessage instance.",
+        );
+
+        assert_eq!(golden_message(), message);
+    }
+}

--- a/mithril-common/src/messages/mod.rs
+++ b/mithril-common/src/messages/mod.rs
@@ -1,6 +1,7 @@
 //! Messages module
 //! This module aims at providing shared structures for API communications.
 mod certificate;
+mod certificate_list;
 mod certificate_pending;
 mod epoch_settings;
 mod interface;
@@ -12,6 +13,7 @@ mod snapshot;
 mod snapshot_list;
 
 pub use certificate::CertificateMessage;
+pub use certificate_list::{CertificateListItemMessage, CertificateListMessage};
 pub use certificate_pending::{CertificatePendingMessage, SignerMessage};
 pub use epoch_settings::EpochSettingsMessage;
 pub use interface::MessageAdapter;

--- a/mithril-common/src/messages/mod.rs
+++ b/mithril-common/src/messages/mod.rs
@@ -13,7 +13,9 @@ mod snapshot;
 mod snapshot_list;
 
 pub use certificate::CertificateMessage;
-pub use certificate_list::{CertificateListItemMessage, CertificateListMessage};
+pub use certificate_list::{
+    CertificateListItemMessage, CertificateListItemMessageMetadata, CertificateListMessage,
+};
 pub use certificate_pending::{CertificatePendingMessage, SignerMessage};
 pub use epoch_settings::EpochSettingsMessage;
 pub use interface::MessageAdapter;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -561,6 +561,116 @@ components:
           "next_aggregate_verification_key": "NQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdCwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQ+IvVzKLgmaLiyb+xyV6Npbxvu+KhLuxU7R7q3JUmOkESHoro6N",
         }
 
+    CertificateListItemMessageMetadata:
+      description: CertificateListItemMessageMetadata represents the metadata associated to a CertificateListItemMessage
+      type: object
+      additionalProperties: false
+      required:
+        - version
+        - parameters
+        - initiated_at
+        - sealed_at
+        - total_signers
+      properties:
+        version:
+          description: Version of the protocol
+          type: string
+          format: bytes
+        parameters:
+          $ref: "#/components/schemas/ProtocolParameters"
+        initiated_at:
+          description: Date and time at which the certificate was initialized and ready to accept single signatures from signers
+          type: string
+          format: date-time
+        sealed_at:
+          description: Date and time at which the certificate was sealed (when the quorum of single signatures was reached so that a multi signature could be aggregated from them)
+          type: string
+          format: date-time
+        total_signers:
+          description: The number of the signers with their stakes and verification keys
+          type: integer
+          format: int64
+      example:
+        {
+          "version": "0.1.0",
+          "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
+          "initiated_at": "2022-07-17T18:51:23.192811338Z",
+          "sealed_at": "2022-07-17T18:51:35.830832580Z",
+          "total_signers": 3,
+        }
+
+    CertificateListMessage:
+      description: CertificateListMessage represents a list of Mithril certificates
+      type: array
+      items:
+        $ref: "#/components/schemas/CertificateListItemMessage"
+
+    CertificateListItemMessage:
+      description: CertificateListItemMessage represents an item of a list of Mithril certificates
+      type: object
+      additionalProperties: false
+      required:
+        - hash
+        - previous_hash
+        - beacon
+        - metadata
+        - protocol_message
+        - signed_message
+        - aggregate_verification_key
+      properties:
+        hash:
+          description: Hash of the current certificate
+          type: string
+          format: bytes
+        previous_hash:
+          description: Hash of the previous certificate
+          type: string
+          format: bytes
+        beacon:
+          $ref: "#/components/schemas/Beacon"
+        metadata:
+          $ref: "#/components/schemas/CertificateListItemMessageMetadata"
+        protocol_message:
+          description: Protocol message
+          $ref: "#/components/schemas/ProtocolMessage"
+        signed_message:
+          description: Hash of the protocol message that is signed by the signer participants
+          type: string
+          format: bytes
+        aggregate_verification_key:
+          description: Aggregate verification key used to verify the multi signature
+          type: string
+          format: bytes
+      example:
+        {
+          "hash": "AsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKbo",
+          "previous_hash": "wKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQ",
+          "beacon":
+            {
+              "network": "mainnet",
+              "epoch": 329,
+              "immutable_file_number": 7060000,
+            },
+          "metadata":
+            {
+              "version": "0.1.0",
+              "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
+              "initiated_at": "2022-07-17T18:51:23.192811338Z",
+              "sealed_at": "2022-07-17T18:51:35.830832580Z",
+              "signers": 3
+            },
+          "protocol_message":
+            {
+              "message_parts":
+                {
+                  "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                  "next_aggregate_verification_key": "NQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdCwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQ",
+                },
+            },
+          "signed_message": "24qQwKgWw4mr5kRZLIUA9XAsB0vSvijo8FIfrGFwBtdCNQVhBc9PXu7RiCHSRem3MmHoKbo",
+          "aggregate_verification_key": "NQVhBc9P24tdCwKgWw4mr5kRZL+IUSRem3MmHoKboAsB0vSvijo8FIfrG/FwBoAsB0vSvijo8FA9XXu7RiCHSRem3MmHoKbqQwKgWw4mr5kRZL+IUA9XXu7RiCHIfrG/FwBtdCNQVhBc9P24qQ"
+        }
+
     CertificateMetadata:
       description: CertificateMetadata represents the metadata associated to a Certificate
       type: object
@@ -610,61 +720,6 @@ components:
                 "stake": "2345",
               },
             ],
-        }
-
-    CertificateListMessage:
-      description: CertificateListMessage represents a list of Mithril certificates
-      type: array
-      items:
-        $ref: "#/components/schemas/CertificateListItemMessage"
-
-    CertificateListItemMessage:
-      description: CertificateListItemMessage represents an item of a list of Mithril certificates
-      type: object
-      additionalProperties: false
-      required:
-        - hash
-        - previous_hash
-        - beacon
-        - signed_message
-        - initiated_at
-        - sealed_at
-      properties:
-        hash:
-          description: Hash of the current certificate
-          type: string
-          format: bytes
-        previous_hash:
-          description: Hash of the previous certificate
-          type: string
-          format: bytes
-        beacon:
-          $ref: "#/components/schemas/Beacon"
-        signed_message:
-          description: Hash of the protocol message that is signed by the signer participants
-          type: string
-          format: bytes
-        initiated_at:
-          description: Date and time at which the certificate was initialized and ready to accept single signatures from signers
-          type: string
-          format: date-time
-        sealed_at:
-          description: Date and time at which the certificate was sealed (when the quorum of single signatures was reached so that a multi signature could be aggregated from them)
-          type: string
-          format: date-time
-      example:
-        {
-          "hash": "AsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKbo",
-          "previous_hash": "wKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQ",
-          "beacon":
-            {
-              "network": "mainnet",
-              "epoch": 329,
-              "immutable_file_number": 7060000,
-            },
-          "signed_message": "24qQwKgWw4mr5kRZLIUA9XAsB0vSvijo8FIfrGFwBtdCNQVhBc9PXu7RiCHSRem3MmHoKbo",
-          "initiated_at": "2022-07-17T18:51:23.192811338Z",
-          "sealed_at": "2022-07-17T18:51:35.830832580Z",
         }
 
     CertificateMessage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.5
+  version: 0.1.6
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.
@@ -71,6 +71,26 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  /certificates:
+    get:
+      summary: Get most recent certificates
+      description: |
+        Returns the list of the most recent certificates
+      responses:
+        "200":
+          description: certificates found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CertificateListMessage"
+        "412":
+          description: API version mismatch
+        default:
+          description: certificates retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
   /certificate/{certificate_hash}:
     get:
       summary: Get certificate by hash
@@ -109,7 +129,7 @@ paths:
         Returns the list of the most recent snapshots
       responses:
         "200":
-          description: snapshot found
+          description: snapshots found
           content:
             application/json:
               schema:
@@ -117,7 +137,7 @@ paths:
         "412":
           description: API version mismatch
         default:
-          description: snapshot retrieval error
+          description: snapshots retrieval error
           content:
             application/json:
               schema:
@@ -590,6 +610,61 @@ components:
                 "stake": "2345",
               },
             ],
+        }
+
+    CertificateListMessage:
+      description: CertificateListMessage represents a list of Mithril certificates
+      type: array
+      items:
+        $ref: "#/components/schemas/CertificateListItemMessage"
+
+    CertificateListItemMessage:
+      description: CertificateListItemMessage represents an item of a list of Mithril certificates
+      type: object
+      additionalProperties: false
+      required:
+        - hash
+        - previous_hash
+        - beacon
+        - signed_message
+        - initiated_at
+        - sealed_at
+      properties:
+        hash:
+          description: Hash of the current certificate
+          type: string
+          format: bytes
+        previous_hash:
+          description: Hash of the previous certificate
+          type: string
+          format: bytes
+        beacon:
+          $ref: "#/components/schemas/Beacon"
+        signed_message:
+          description: Hash of the protocol message that is signed by the signer participants
+          type: string
+          format: bytes
+        initiated_at:
+          description: Date and time at which the certificate was initialized and ready to accept single signatures from signers
+          type: string
+          format: date-time
+        sealed_at:
+          description: Date and time at which the certificate was sealed (when the quorum of single signatures was reached so that a multi signature could be aggregated from them)
+          type: string
+          format: date-time
+      example:
+        {
+          "hash": "AsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQwKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKbo",
+          "previous_hash": "wKgWw4mr5kRZL+IUA9XXu7RiCHSRem3MmHoKboAsB0vSvijo8FIfrG/FwBtdCNQVhBc9P24qQ",
+          "beacon":
+            {
+              "network": "mainnet",
+              "epoch": 329,
+              "immutable_file_number": 7060000,
+            },
+          "signed_message": "24qQwKgWw4mr5kRZLIUA9XAsB0vSvijo8FIfrGFwBtdCNQVhBc9PXu7RiCHSRem3MmHoKbo",
+          "initiated_at": "2022-07-17T18:51:23.192811338Z",
+          "sealed_at": "2022-07-17T18:51:35.830832580Z",
         }
 
     CertificateMessage:


### PR DESCRIPTION
## Content
This PR includes the implementation of a new route `/certificates` that lists the latest certificates produced by the Aggregator

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #892 
