### PR TITLE
Upgrade Rust `1.70.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,9 +128,11 @@ jobs:
         shell: bash
         run: |
           set -o pipefail && \
-          cargo test --no-fail-fast ${{ matrix.test-args }} \
-              -- -Z unstable-options --format json --report-time \
-              | tee >(cargo2junit > test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}.xml)
+          cargo test --no-fail-fast ${{ matrix.test-args }}
+          # TODO: Previous command that uses unstable options which are not supported anymore in stable toolchain
+          #cargo test --no-fail-fast ${{ matrix.test-args }} \
+          #    -- -Z unstable-options --format json --report-time \
+          #    | tee >(cargo2junit > test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}.xml)
 
       - name: Upload Tests Results
         uses: actions/upload-artifact@v3
@@ -230,7 +232,9 @@ jobs:
           if-no-files-found: error
   
   publish-tests-results:
-    if: success() || failure()
+    # TODO: reactivate when cargo test errors export to json works in stable version
+    #if: success() || failure()
+    if: false
     runs-on: ubuntu-22.04
     needs: 
       - test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.24"
+version = "0.3.25"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mithril-stm"
-version = "0.2.13"
+version = "0.2.14"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/src/eligibility_check.rs
+++ b/mithril-stm/src/eligibility_check.rs
@@ -61,6 +61,7 @@ pub(crate) fn ev_lt_phi(phi_f: f64, ev: [u8; 64], stake: Stake, total_stake: Sta
 /// Therefore, a good integral bound is the maximum value that `|ln(1.0 - phi_f)|` can take with
 /// `phi_f \in [0, 0.95]` (if we expect to have `phi_f > 0.95` this bound should be extended),
 /// which is `3`. Hence, we set `M = 3`.
+#[allow(clippy::redundant_clone)]
 fn taylor_comparison(bound: usize, cmp: Ratio<BigInt>, x: Ratio<BigInt>) -> bool {
     let mut new_x = x.clone();
     let mut phi: Ratio<BigInt> = One::one();


### PR DESCRIPTION
## Content
This PR includes fix for new clippy warnings with Rust `1.70.0` and attempts fixing the tests failing in the CI because of use of `-Z unstable-options` in the `cargo test` command.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #958 
