### PR TITLE
Fix retrieve open message from correct epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.25"
+version = "0.3.26"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2142,7 +2142,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "async-trait",
  "clap 4.3.0",
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "async-trait",
  "clap 4.3.0",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.25"
+version = "0.3.26"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/certifier_service.rs
+++ b/mithril-aggregator/src/certifier_service.rs
@@ -231,10 +231,13 @@ impl CertifierService for MithrilCertifierService {
         protocol_message: &ProtocolMessage,
     ) -> StdResult<OpenMessage> {
         debug!("CertifierService::create_open_message(signed_entity_type: {signed_entity_type:?}, protocol_message: {protocol_message:?})");
-        let current_epoch = self.current_epoch.read().await;
         let open_message = self
             .open_message_repository
-            .create_open_message(*current_epoch, signed_entity_type, protocol_message)
+            .create_open_message(
+                signed_entity_type.get_epoch(),
+                signed_entity_type,
+                protocol_message,
+            )
             .await?;
         info!("CertifierService::create_open_message: created open message for {signed_entity_type:?}");
         debug!(

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1104,7 +1104,7 @@ impl DependenciesBuilder {
         ));
         let certificate_verifier = self.get_certificate_verifier().await?;
         let genesis_verifier = self.get_genesis_verifier().await?;
-        let multisigner = self.get_multi_signer().await?;
+        let multi_signer = self.get_multi_signer().await?;
         let logger = self.get_logger().await?;
 
         Ok(Arc::new(MithrilCertifierService::new(
@@ -1113,8 +1113,7 @@ impl DependenciesBuilder {
             certificate_repository,
             certificate_verifier,
             genesis_verifier,
-            multisigner,
-            Epoch(0),
+            multi_signer,
             logger,
         )))
     }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.47"
+version = "0.2.48"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -366,11 +366,7 @@ impl Runner for SignerRunner {
             .await?;
 
         // 2 set the next signers keys and stakes in the message
-        let epoch = match signed_entity_type {
-            SignedEntityType::MithrilStakeDistribution(epoch) => epoch,
-            SignedEntityType::CardanoImmutableFilesFull(beacon) => &beacon.epoch,
-            SignedEntityType::CardanoStakeDistribution(epoch) => epoch,
-        };
+        let epoch = signed_entity_type.get_epoch();
         let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
         let next_protocol_initializer = self
             .services

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.1.19"
+version = "0.1.20"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -255,7 +255,7 @@ async fn update_protocol_parameters(aggregator: &mut Aggregator) -> Result<(), S
     let protocol_parameters_new = ProtocolParameters {
         k: 150,
         m: 200,
-        phi_f: 0.80,
+        phi_f: 0.85,
     };
     info!(
         "> updating protocol parameters to {:?}...",


### PR DESCRIPTION
## Content
This PR includes a fix on the way the open message is retrieved by signed entity type: it aligns the queries used to retrieve open message with/without single signatures in the Open Message Repository.

**Note**: 
- this will avoid collision such as described in the logs where an open message is `not certified` when used in `get_current_non_certified_open_message_for_signed_entity_type` fucntion, and `certified` in the `create_certificate` function
- the probable cause is that there must be `2` different open messages created during the same epoch but with `2` different epochs in the signed entity type field. It looks like this happens when there is a de-synchronization of the epoch inside the `CertifierService` and the epoch given by the `ChainObserver`. This is probably a cause of the bug #954

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #953
