### PR TITLE
Fix clean epoch Certifier service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.26"
+version = "0.3.27"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/provider/open_message.rs
+++ b/mithril-aggregator/src/database/provider/open_message.rs
@@ -312,7 +312,7 @@ impl<'client> DeleteOpenMessageProvider<'client> {
 
     fn get_epoch_condition(&self, epoch: Epoch) -> WhereCondition {
         WhereCondition::new(
-            "epoch_setting_id <= ?*",
+            "epoch_setting_id < ?*",
             vec![Value::Integer(epoch.0 as i64)],
         )
     }
@@ -547,7 +547,7 @@ impl OpenMessageRepository {
             .ok_or_else(|| panic!("Updating an open_message should not return nothing."))
     }
 
-    /// Remove all the [OpenMessageRecord] for the given Epoch in the database.
+    /// Remove all the [OpenMessageRecord] for the strictly previous epochs of the given epoch in the database.
     /// It returns the number of messages removed.
     pub async fn clean_epoch(&self, epoch: Epoch) -> StdResult<usize> {
         let lock = self.connection.lock().await;
@@ -712,7 +712,7 @@ mod tests {
         let provider = DeleteOpenMessageProvider::new(&connection);
         let (expr, params) = provider.get_epoch_condition(Epoch(12)).expand();
 
-        assert_eq!("epoch_setting_id <= ?1".to_string(), expr);
+        assert_eq!("epoch_setting_id < ?1".to_string(), expr);
         assert_eq!(vec![Value::Integer(12)], params,);
     }
 


### PR DESCRIPTION
## Content
This PR includes a fix to the clean of open messages: they must be cleaned only for an epoch strictly lower than the one given by the chain observer.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #953 
