### PR TITLE
Enhance ImmutableDigesterError::NotEnoughImmutable error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,4 @@ mithril-stm/proptest-regressions/
 mithril-infra/.terraform*
 mithril-infra/terraform.tfstate*
 mithril-infra/*.tfvars
-
+justfile

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "async-trait",
  "bech32",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.59"
+version = "0.2.60"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/digesters/cardano_immutable_digester.rs
+++ b/mithril-common/src/digesters/cardano_immutable_digester.rs
@@ -60,11 +60,13 @@ impl ImmutableDigester for CardanoImmutableDigester {
             None => Err(ImmutableDigesterError::NotEnoughImmutable {
                 expected_number: up_to_file_number,
                 found_number: None,
+                db_dir: self.db_directory.clone(),
             }),
             Some(last_immutable_file) if last_immutable_file.number < up_to_file_number => {
                 Err(ImmutableDigesterError::NotEnoughImmutable {
                     expected_number: up_to_file_number,
                     found_number: Some(last_immutable_file.number),
+                    db_dir: self.db_directory.clone(),
                 })
             }
             Some(_) => {
@@ -242,6 +244,7 @@ mod tests {
                 ImmutableDigesterError::NotEnoughImmutable {
                     expected_number: beacon.immutable_file_number,
                     found_number: None,
+                    db_dir: immutable_db.dir,
                 }
             ),
             format!("{result:?}")
@@ -278,6 +281,7 @@ mod tests {
                 ImmutableDigesterError::NotEnoughImmutable {
                     expected_number: beacon.immutable_file_number,
                     found_number: None,
+                    db_dir: immutable_db.dir,
                 }
             ),
             format!("{result:?}")
@@ -304,6 +308,7 @@ mod tests {
                 ImmutableDigesterError::NotEnoughImmutable {
                     expected_number: beacon.immutable_file_number,
                     found_number: Some(5),
+                    db_dir: immutable_db.dir,
                 }
             ),
             format!("{result:?}")

--- a/mithril-common/src/digesters/dumb_immutable_observer.rs
+++ b/mithril-common/src/digesters/dumb_immutable_observer.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::{
     digesters::{ImmutableDigester, ImmutableDigesterError},
     entities::Beacon,
@@ -41,6 +43,7 @@ impl ImmutableDigester for DumbImmutableDigester {
             Err(ImmutableDigesterError::NotEnoughImmutable {
                 expected_number: beacon.immutable_file_number,
                 found_number: None,
+                db_dir: PathBuf::new(),
             })
         }
     }

--- a/mithril-common/src/digesters/immutable_digester.rs
+++ b/mithril-common/src/digesters/immutable_digester.rs
@@ -3,7 +3,7 @@ use crate::{
     entities::{Beacon, ImmutableFileNumber},
 };
 use async_trait::async_trait;
-use std::io;
+use std::{io, path::PathBuf};
 use thiserror::Error;
 
 /// A digester than can compute the digest used for mithril signatures
@@ -55,12 +55,14 @@ pub enum ImmutableDigesterError {
 
     /// Error raised when there's less than the required number of completed immutables in
     /// the cardano database or even no immutable at all.
-    #[error("At least two immutables chunk should exists")]
+    #[error("At least two immutable chunks should exist in directory '{db_dir}': expected {expected_number} but found {found_number:?}.")]
     NotEnoughImmutable {
         /// Expected last [ImmutableFileNumber].
         expected_number: ImmutableFileNumber,
         /// Last [ImmutableFileNumber] found when listing [ImmutableFiles][crate::digesters::ImmutableFile].
         found_number: Option<ImmutableFileNumber>,
+        /// A cardano node DB directory
+        db_dir: PathBuf,
     },
 
     /// Error raised when the digest computation failed.


### PR DESCRIPTION
## Content
This PR includes an update of the `NotEnoughImmutable` error message. It now displays the `db_dir`, `expected_number` and `found_number` when not enough immutable files are found in the Cardano node DB directory.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [X] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Close #969
