### PR TITLE
Fix snapshot download command error with --download-dir option in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.3"
+version = "0.3.4"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/dependencies/builder.rs
+++ b/mithril-client/src/dependencies/builder.rs
@@ -181,7 +181,6 @@ impl DependenciesBuilder {
 
     async fn build_snapshot_service(&mut self) -> StdResult<Arc<dyn SnapshotService>> {
         let snapshot_service = MithrilClientSnapshotService::new(
-            self.config.clone(),
             self.get_snapshot_client().await?,
             self.get_certificate_client().await?,
             self.get_certificate_verifier().await?,


### PR DESCRIPTION
## Content
This PR includes a fix related to an error mentioned in #979 issue.
`db_pathdir` value was always empty and was an unwanted duplicate of `unpack_dir` as explained in the issue.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [X] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->
`MithrilClientSnapshotService` config has been removed as it's no longer used.
All tests passed.

## Issue(s)
Closes #979 
