### PR TITLE
Fix aggregator `SIGNING` state dead-loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2030,7 +2030,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.28"
+version = "0.3.29"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a fix to the aggregator getting stuck in the `SIGNING` state when the artifact creation fails.

## Pre-submit checklist

- Branch
  - [ ] Crates versions are updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested

## Issue(s)
Closes #953 
