### PR TITLE
Upgrade Rust outdated dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2079,7 +2079,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.62"
+version = "0.2.63"
 dependencies = [
  "async-trait",
  "bech32",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "bincode",
  "blake2 0.10.6",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "mithrildemo"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "base64 0.21.2",
  "blake2 0.10.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,21 +552,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
-dependencies = [
- "bitflags",
- "clap_lex 0.2.4",
- "indexmap",
- "textwrap",
-]
-
-[[package]]
-name = "clap"
-version = "4.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
+checksum = "93aae7a4192245f70fe75dd9157fc7b4a5bf53e88d30bd4396f7d8f9284d5acc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -575,37 +563,28 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.3.4"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
+checksum = "4f423e341edefb78c9caba2d9c7f7687d0e72e89df3ce3394554754393ac3990"
 dependencies = [
  "anstream",
  "anstyle",
  "bitflags",
- "clap_lex 0.5.0",
+ "clap_lex",
  "once_cell",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.3.2"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
+checksum = "191d9573962933b4027f932c600cd252ce27a8ad5979418fe78e43c07996f27b"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
  "syn 2.0.18",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
 ]
 
 [[package]]
@@ -730,20 +709,20 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
  "anes",
- "atty",
  "cast",
  "ciborium",
- "clap 3.2.25",
+ "clap",
  "criterion-plot",
  "futures",
+ "is-terminal",
  "itertools",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
@@ -969,9 +948,9 @@ dependencies = [
 
 [[package]]
 name = "directories"
-version = "4.0.1"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f51c5d4ddabd36886dd3e1438cb358cdcb0d7c499cb99cb4ac2e38e18b5cb210"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys",
 ]
@@ -988,13 +967,14 @@ dependencies = [
 
 [[package]]
 name = "dirs-sys"
-version = "0.3.7"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1113,9 +1093,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fancy-regex"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0678ab2d46fa5195aaf59ad034c083d351377d4af57f3e073c074d0da3e3c766"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
 dependencies = [
  "bit-set",
  "regex",
@@ -1211,9 +1191,9 @@ dependencies = [
 
 [[package]]
 name = "fraction"
-version = "0.12.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa5de57a62c2440ece64342ea59efb7171aa7d016faf8dfcb8795066a17146b"
+checksum = "3027ae1df8d41b4bed2241c8fdad4acc1e7af60c8e17743534b545e77182d678"
 dependencies = [
  "lazy_static",
  "num",
@@ -1357,8 +1337,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1749,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "iso8601"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "296af15e112ec6dc38c9fd3ae027b5337a75466e8eed757bd7d5cf742ea85eb6"
+checksum = "924e5d73ea28f59011fec52a0d12185d496a9b075d360657aed2a5707f701153"
 dependencies = [
  "nom",
 ]
@@ -1793,22 +1775,23 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ca9e2b45609132ae2214d50482c03aeee78826cd6fd53a8940915b81acedf16"
+checksum = "e48354c4c4f088714424ddf090de1ff84acc82b2f08c192d46d226ae2529a465"
 dependencies = [
  "ahash 0.8.3",
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytecount",
- "clap 4.3.4",
+ "clap",
  "fancy-regex",
  "fraction",
+ "getrandom 0.2.10",
  "iso8601",
  "itoa",
- "lazy_static",
  "memchr",
  "num-cmp",
+ "once_cell",
  "parking_lot",
  "percent-encoding",
  "regex",
@@ -1844,7 +1827,7 @@ dependencies = [
  "ed25519-dalek",
  "rand_core 0.5.1",
  "serde",
- "serde_with",
+ "serde_with 2.3.3",
  "zeroize",
 ]
 
@@ -2034,7 +2017,7 @@ version = "0.3.30"
 dependencies = [
  "async-trait",
  "chrono",
- "clap 4.3.4",
+ "clap",
  "cloud-storage",
  "config",
  "flate2",
@@ -2070,7 +2053,7 @@ version = "0.3.5"
 dependencies = [
  "async-recursion",
  "async-trait",
- "clap 4.3.4",
+ "clap",
  "cli-table",
  "config",
  "directories",
@@ -2123,7 +2106,7 @@ dependencies = [
  "serde_bytes",
  "serde_cbor",
  "serde_json",
- "serde_with",
+ "serde_with 3.0.0",
  "serde_yaml",
  "sha2 0.10.6",
  "slog",
@@ -2145,7 +2128,7 @@ name = "mithril-end-to-end"
 version = "0.1.22"
 dependencies = [
  "async-trait",
- "clap 4.3.4",
+ "clap",
  "glob",
  "hex",
  "mithril-common",
@@ -2167,7 +2150,7 @@ name = "mithril-signer"
 version = "0.2.50"
 dependencies = [
  "async-trait",
- "clap 4.3.4",
+ "clap",
  "config",
  "hex",
  "httpmock",
@@ -2215,9 +2198,9 @@ dependencies = [
 name = "mithrildemo"
 version = "0.1.13"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.2",
  "blake2 0.10.6",
- "clap 4.3.4",
+ "clap",
  "hex",
  "log",
  "mithril-common",
@@ -2489,6 +2472,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "ordered-multimap"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2497,12 +2486,6 @@ dependencies = [
  "dlv-list",
  "hashbrown",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
 
 [[package]]
 name = "parking"
@@ -3217,7 +3200,23 @@ dependencies = [
  "indexmap",
  "serde",
  "serde_json",
- "serde_with_macros",
+ "serde_with_macros 2.3.3",
+ "time 0.3.22",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f02d8aa6e3c385bf084924f660ce2a3a6bd333ba55b35e8590b321f35d88513"
+dependencies = [
+ "base64 0.21.2",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros 3.0.0",
  "time 0.3.22",
 ]
 
@@ -3226,6 +3225,18 @@ name = "serde_with_macros"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "881b6f881b17d13214e5d494c939ebab463d01264ce1811e9d4ac3a882e7695f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.18",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc7d5d3932fb12ce722ee5e64dd38c504efba37567f0c402f6ca728c3b8b070"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3595,12 +3606,6 @@ name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithrildemo"
-version = "0.1.13"
+version = "0.1.14"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -9,7 +9,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-base64 = "0.13.0"
+base64 = "0.21.2"
 blake2 = "0.10.4"
 clap = { version = "4.0.18", features = ["derive"] }
 hex = "0.4.3"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.5"
+version = "0.3.6"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.52"
 clap = { version = "4.0", features = ["derive", "env"] }
 cli-table = "0.4"
 config = "0.13.1"
-directories = "4.0.1"
+directories = "5.0.1"
 flate2 = "1.0.23"
 futures = "0.3"
 hex = "0.4.3"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -26,7 +26,7 @@ fixed = "1.15.0"
 glob = "0.3"
 hex = "0.4.3"
 http = "0.2.6"
-jsonschema = "0.16.0"
+jsonschema = "0.17.0"
 kes-summed-ed25519 = { version = "0.2.0", features = ["serde_enabled", "sk_clone_enabled"] }
 lazy_static = "1.4.0"
 mockall = "0.11.0"
@@ -39,7 +39,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.7"
 serde_cbor = "0.11.2"
 serde_json = "1.0"
-serde_with = "2.2.0"
+serde_with = "3.0.0"
 serde_yaml = "0.9.10"
 sha2 = "0.10.2"
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_debug"] }
@@ -62,7 +62,7 @@ mithril-stm = { path = "../mithril-stm" }
 mithril-stm = { path = "../mithril-stm", default-features = false, features = ["num-integer-backend"] }
 
 [dev-dependencies]
-criterion = { version = "0.4.0", features = ["html_reports", "async_tokio"] }
+criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 slog-async = "2.7.0"
 slog-scope = "4.4.0"
 slog-term = "2.9.0"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.62"
+version = "0.2.63"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -34,7 +34,7 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bincode = "1.3.3"
-criterion   = { version = "0.4.0", features = ["html_reports"] }
+criterion   = { version = "0.5.1", features = ["html_reports"] }
 hex = "0.4.3"
 num-bigint  = "0.4.0"
 num-rational = "0.4.0"

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mithril-stm"
-version = "0.2.15"
+version = "0.2.16"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes an upgrade of the outdated Rust dependencies except for:
- `sqlite` which requires a refactoring of the `Cursor` and `Row`
- `rand-chacha-dalek-compat` which creates a build error `error: the crate mithril-common v0.2.62 depends on crate rand_chacha v0.3.1 multiple times with different names`

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

