### PR TITLE
Simplify aggregator integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.37"
+version = "0.3.38"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.66"
+version = "0.2.67"
 dependencies = [
  "async-trait",
  "bech32",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.37"
+version = "0.3.38"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -138,8 +138,10 @@ pub enum SimulateFromChainParams {
 
 #[doc(hidden)]
 impl DependencyManager {
+    /// `TEST METHOD ONLY`
+    ///
     /// Get the first two epochs that will be used by a newly started aggregator
-    async fn get_genesis_epochs(&self) -> (Epoch, Epoch) {
+    pub async fn get_genesis_epochs(&self) -> (Epoch, Epoch) {
         let current_epoch = self
             .chain_observer
             .get_current_epoch()

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -27,31 +27,12 @@ async fn certificate_chain() {
         .with_protocol_parameters(protocol_parameters.clone())
         .build();
     let signers = fixture.signers_fixture();
+    tester.init_state_from_fixture(&fixture).await.unwrap();
     let mut signers_with_stake = fixture.signers_with_stake();
-    tester
-        .chain_observer
-        .set_signers(signers_with_stake.clone())
-        .await;
-    tester
-        .deps_builder
-        .build_dependency_container()
-        .await
-        .unwrap()
-        .prepare_for_genesis(
-            signers_with_stake.clone(),
-            signers_with_stake.clone(),
-            &protocol_parameters,
-        )
-        .await;
-    let mut current_epoch = tester
-        .chain_observer
-        .get_current_epoch()
-        .await
-        .unwrap()
-        .unwrap();
+    let mut current_epoch = observer.current_epoch().await;
 
     comment!("Boostrap the genesis certificate, {:?}", current_epoch);
-    tester.register_genesis_certificate(&signers).await.unwrap();
+    tester.register_genesis_certificate(&fixture).await.unwrap();
 
     comment!("Increase immutable number");
     tester.increase_immutable_number().await.unwrap();

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -1,9 +1,7 @@
 mod test_extensions;
 
 use mithril_aggregator::{Configuration, VerificationKeyStorer};
-use mithril_common::{
-    chain_observer::ChainObserver, entities::ProtocolParameters, test_utils::MithrilFixtureBuilder,
-};
+use mithril_common::{entities::ProtocolParameters, test_utils::MithrilFixtureBuilder};
 use test_extensions::{utilities::get_test_dir, RuntimeTester, SignedEntityTypeDiscriminants};
 
 #[tokio::test]
@@ -42,12 +40,11 @@ async fn certificate_chain() {
     cycle!(tester, "signing");
     tester.register_signers(&signers).await.unwrap();
     cycle_err!(tester, "signing");
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::MithrilStakeDistribution)
-        .await
-        .unwrap();
     tester
-        .send_single_signatures(&signed_entity_type, &signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            &signers,
+        )
         .await
         .unwrap();
 
@@ -60,12 +57,11 @@ async fn certificate_chain() {
     comment!("The state machine should get back to signing to sign CardanoImmutableFilesFull");
     tester.increase_immutable_number().await.unwrap();
     cycle!(tester, "signing");
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::CardanoImmutableFilesFull)
-        .await
-        .unwrap();
     tester
-        .send_single_signatures(&signed_entity_type, &signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            &signers,
+        )
         .await
         .unwrap();
     comment!("The state machine should issue a certificate for the CardanoImmutableFilesFull");
@@ -80,12 +76,11 @@ async fn certificate_chain() {
     );
     tester.increase_immutable_number().await.unwrap();
     cycle!(tester, "signing");
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::CardanoImmutableFilesFull)
-        .await
-        .unwrap();
     tester
-        .send_single_signatures(&signed_entity_type, &signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            &signers,
+        )
         .await
         .unwrap();
     cycle!(tester, "ready");
@@ -147,12 +142,11 @@ async fn certificate_chain() {
         "Signers register & send signatures, the new certificate should be link to the first of the previous epoch"
     );
     tester.register_signers(&new_signers).await.unwrap();
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::MithrilStakeDistribution)
-        .await
-        .unwrap();
     tester
-        .send_single_signatures(&signed_entity_type, &signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            &signers,
+        )
         .await
         .unwrap();
     cycle!(tester, "ready");
@@ -192,12 +186,11 @@ async fn certificate_chain() {
     tester.register_signers(&signers).await.unwrap();
     cycle!(tester, "signing");
 
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::MithrilStakeDistribution)
-        .await
-        .unwrap();
     tester
-        .send_single_signatures(&signed_entity_type, &signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            &signers,
+        )
         .await
         .unwrap();
     cycle!(tester, "ready");
@@ -213,13 +206,12 @@ async fn certificate_chain() {
     cycle!(tester, "ready");
     tester.register_signers(&signers).await.unwrap();
     cycle!(tester, "signing");
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::MithrilStakeDistribution)
-        .await
-        .unwrap();
 
     tester
-        .send_single_signatures(&signed_entity_type, &new_signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            &new_signers,
+        )
         .await
         .unwrap();
     cycle!(tester, "ready");
@@ -256,12 +248,11 @@ async fn certificate_chain() {
     tester.increase_immutable_number().await.unwrap();
     cycle!(tester, "signing");
 
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::CardanoImmutableFilesFull)
-        .await
-        .unwrap();
     tester
-        .send_single_signatures(&signed_entity_type, &new_signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            &new_signers,
+        )
         .await
         .unwrap();
     cycle!(tester, "ready");

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -1,8 +1,11 @@
 mod test_extensions;
 
 use mithril_aggregator::{Configuration, VerificationKeyStorer};
-use mithril_common::{entities::ProtocolParameters, test_utils::MithrilFixtureBuilder};
-use test_extensions::{utilities::get_test_dir, RuntimeTester, SignedEntityTypeDiscriminants};
+use mithril_common::{
+    entities::{Beacon, ProtocolParameters, SignedEntityTypeDiscriminants},
+    test_utils::MithrilFixtureBuilder,
+};
+use test_extensions::{utilities::get_test_dir, RuntimeTester};
 
 #[tokio::test]
 async fn certificate_chain() {
@@ -16,7 +19,8 @@ async fn certificate_chain() {
         data_stores_directory: get_test_dir("certificate_chain").join("aggregator.sqlite3"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(configuration).await;
+    let mut tester =
+        RuntimeTester::build(Beacon::new("net".to_string(), 1, 1), configuration).await;
     let observer = tester.observer.clone();
 
     comment!("Create signers & declare stake distribution");

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -22,7 +22,6 @@ async fn create_certificate() {
         ..Configuration::new_sample()
     };
     let mut tester = RuntimeTester::build(configuration).await;
-    let observer = tester.observer.clone();
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()
@@ -47,12 +46,11 @@ async fn create_certificate() {
     cycle_err!(tester, "signing");
 
     comment!("signers send their single signature");
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::MithrilStakeDistribution)
-        .await
-        .unwrap();
     tester
-        .send_single_signatures(&signed_entity_type, &signers)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            &signers,
+        )
         .await
         .unwrap();
 
@@ -70,13 +68,12 @@ async fn create_certificate() {
     // With one state machine per signed entity type this problem will disappear.
     tester.increase_immutable_number().await.unwrap();
     cycle!(tester, "signing");
-    let signed_entity_type = observer
-        .get_current_signed_entity_type(SignedEntityTypeDiscriminants::CardanoImmutableFilesFull)
-        .await
-        .unwrap();
     let signers_who_sign = &signers[0..=6];
     tester
-        .send_single_signatures(&signed_entity_type, signers_who_sign)
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            signers_who_sign,
+        )
         .await
         .unwrap();
 

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -30,25 +30,10 @@ async fn create_certificate() {
         .with_protocol_parameters(protocol_parameters.clone())
         .build();
     let signers = fixture.signers_fixture();
-    let signers_with_stake = fixture.signers_with_stake();
-    tester
-        .chain_observer
-        .set_signers(signers_with_stake.clone())
-        .await;
-    tester
-        .deps_builder
-        .build_dependency_container()
-        .await
-        .unwrap()
-        .prepare_for_genesis(
-            signers_with_stake.clone(),
-            signers_with_stake,
-            &protocol_parameters,
-        )
-        .await;
+    tester.init_state_from_fixture(&fixture).await.unwrap();
 
     comment!("Boostrap the genesis certificate");
-    tester.register_genesis_certificate(&signers).await.unwrap();
+    tester.register_genesis_certificate(&fixture).await.unwrap();
 
     comment!("Increase immutable number");
     tester.increase_immutable_number().await.unwrap();

--- a/mithril-aggregator/tests/era_checker.rs
+++ b/mithril-aggregator/tests/era_checker.rs
@@ -56,32 +56,10 @@ async fn testing_eras() {
         .with_signers(5)
         .with_protocol_parameters(protocol_parameters.clone())
         .build();
-    let signers = fixture.signers_fixture();
-    let signers_with_stake = fixture.signers_with_stake();
-    tester
-        .chain_observer
-        .set_signers(signers_with_stake.clone())
-        .await;
-    tester
-        .deps_builder
-        .build_dependency_container()
-        .await
-        .unwrap()
-        .prepare_for_genesis(
-            signers_with_stake.clone(),
-            signers_with_stake.clone(),
-            &protocol_parameters,
-        )
-        .await;
-    let _ = tester
-        .chain_observer
-        .get_current_epoch()
-        .await
-        .unwrap()
-        .unwrap();
+    tester.init_state_from_fixture(&fixture).await.unwrap();
 
     comment!("Boostrap the genesis certificate");
-    tester.register_genesis_certificate(&signers).await.unwrap();
+    tester.register_genesis_certificate(&fixture).await.unwrap();
 
     comment!("Increase immutable number");
     tester.increase_immutable_number().await.unwrap();

--- a/mithril-aggregator/tests/era_checker.rs
+++ b/mithril-aggregator/tests/era_checker.rs
@@ -1,7 +1,6 @@
 mod test_extensions;
 use mithril_aggregator::{Configuration, RuntimeError};
 use mithril_common::{
-    chain_observer::ChainObserver,
     entities::{Epoch, ProtocolParameters},
     era::{EraMarker, SupportedEra},
     test_utils::MithrilFixtureBuilder,

--- a/mithril-aggregator/tests/simple.rs
+++ b/mithril-aggregator/tests/simple.rs
@@ -26,28 +26,12 @@ async fn simple_scenario() {
         .with_signers(5)
         .with_protocol_parameters(protocol_parameters.clone())
         .build();
-    let signers = fixture.signers_fixture();
-    let signers_with_stake: Vec<SignerWithStake> = fixture.signers_with_stake();
-    tester
-        .chain_observer
-        .set_signers(signers_with_stake.clone())
-        .await;
-    tester
-        .deps_builder
-        .build_dependency_container()
-        .await
-        .unwrap()
-        .prepare_for_genesis(
-            signers_with_stake.clone(),
-            signers_with_stake.clone(),
-            &protocol_parameters,
-        )
-        .await;
+    tester.init_state_from_fixture(&fixture).await.unwrap();
 
     cycle!(tester, "idle");
 
     comment!("Boostrap the genesis certificate");
-    tester.register_genesis_certificate(&signers).await.unwrap();
+    tester.register_genesis_certificate(&fixture).await.unwrap();
 
     comment!("Increase immutable number");
     tester.increase_immutable_number().await.unwrap();

--- a/mithril-aggregator/tests/simple.rs
+++ b/mithril-aggregator/tests/simple.rs
@@ -1,7 +1,10 @@
 mod test_extensions;
 
 use mithril_aggregator::Configuration;
-use mithril_common::{entities::ProtocolParameters, test_utils::MithrilFixtureBuilder};
+use mithril_common::{
+    entities::{Beacon, ProtocolParameters},
+    test_utils::MithrilFixtureBuilder,
+};
 use test_extensions::{utilities::get_test_dir, RuntimeTester};
 
 #[tokio::test]
@@ -16,7 +19,8 @@ async fn simple_scenario() {
         data_stores_directory: get_test_dir("simple_scenario").join("aggregator.sqlite3"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(configuration).await;
+    let mut tester =
+        RuntimeTester::build(Beacon::new("net".to_string(), 1, 1), configuration).await;
 
     comment!("Create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()

--- a/mithril-aggregator/tests/simple.rs
+++ b/mithril-aggregator/tests/simple.rs
@@ -1,10 +1,7 @@
 mod test_extensions;
 
 use mithril_aggregator::Configuration;
-use mithril_common::{
-    entities::{ProtocolParameters, SignerWithStake},
-    test_utils::MithrilFixtureBuilder,
-};
+use mithril_common::{entities::ProtocolParameters, test_utils::MithrilFixtureBuilder};
 use test_extensions::{utilities::get_test_dir, RuntimeTester};
 
 #[tokio::test]

--- a/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
@@ -2,8 +2,10 @@ use mithril_aggregator::{
     certifier_service::CertifierService, dependency_injection::DependenciesBuilder,
     entities::OpenMessage, ticker_service::TickerService,
 };
-use mithril_common::entities::{Beacon, Epoch};
-use mithril_common::{entities::SignedEntityType, BeaconProvider};
+use mithril_common::{
+    entities::{Beacon, Epoch, SignedEntityType},
+    BeaconProvider,
+};
 use std::sync::Arc;
 
 // An observer that allow to inspect currently available open messages.

--- a/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
@@ -3,7 +3,7 @@ use mithril_aggregator::{
     entities::OpenMessage, ticker_service::TickerService,
 };
 use mithril_common::{
-    entities::{Beacon, Epoch, SignedEntityType},
+    entities::{Beacon, Epoch, SignedEntityType, SignedEntityTypeDiscriminants},
     BeaconProvider,
 };
 use std::sync::Arc;
@@ -13,13 +13,6 @@ pub struct AggregatorObserver {
     beacon_provider: Arc<dyn BeaconProvider>,
     certifier_service: Arc<dyn CertifierService>,
     ticker_service: Arc<dyn TickerService>,
-}
-
-#[derive(Debug, Clone, Copy)]
-pub enum SignedEntityTypeDiscriminants {
-    MithrilStakeDistribution,
-    CardanoStakeDistribution,
-    CardanoImmutableFilesFull,
 }
 
 impl AggregatorObserver {

--- a/mithril-aggregator/tests/test_extensions/expected_certificate.rs
+++ b/mithril-aggregator/tests/test_extensions/expected_certificate.rs
@@ -1,0 +1,52 @@
+use mithril_common::entities::{
+    Beacon, HexEncodedAgregateVerificationKey, PartyId, SignedEntityType, SignerWithStake, Stake,
+};
+use std::collections::BTreeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedCertificate {
+    identifier: String,
+    previous_identifier: Option<String>,
+    beacon: Beacon,
+    signers: BTreeMap<PartyId, Stake>,
+    avk: HexEncodedAgregateVerificationKey,
+    signed_type: Option<SignedEntityType>,
+}
+
+impl ExpectedCertificate {
+    pub fn new(
+        beacon: Beacon,
+        signers: &[SignerWithStake],
+        avk: HexEncodedAgregateVerificationKey,
+        signed_type: SignedEntityType,
+        previous_identifier: String,
+    ) -> Self {
+        Self {
+            identifier: Self::identifier(&signed_type),
+            previous_identifier: Some(previous_identifier),
+            beacon,
+            signers: BTreeMap::from_iter(signers.iter().map(|s| (s.party_id.clone(), s.stake))),
+            avk,
+            signed_type: Some(signed_type),
+        }
+    }
+
+    pub fn new_genesis(beacon: Beacon, avk: HexEncodedAgregateVerificationKey) -> Self {
+        Self {
+            identifier: Self::genesis_identifier(&beacon),
+            previous_identifier: None,
+            beacon,
+            signers: BTreeMap::new(),
+            avk,
+            signed_type: None,
+        }
+    }
+
+    pub fn identifier(signed_types: &SignedEntityType) -> String {
+        format!("certificate-{:?}", signed_types)
+    }
+
+    pub fn genesis_identifier(beacon: &Beacon) -> String {
+        format!("genesis-{:?}", beacon)
+    }
+}

--- a/mithril-aggregator/tests/test_extensions/mod.rs
+++ b/mithril-aggregator/tests/test_extensions/mod.rs
@@ -7,6 +7,8 @@ pub mod runtime_tester;
 #[macro_use]
 pub mod utilities;
 pub mod aggregator_observer;
+mod expected_certificate;
 
-pub use aggregator_observer::{AggregatorObserver, SignedEntityTypeDiscriminants};
+pub use aggregator_observer::AggregatorObserver;
+pub use expected_certificate::ExpectedCertificate;
 pub use runtime_tester::RuntimeTester;

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -325,7 +325,7 @@ impl RuntimeTester {
     pub async fn update_stake_distribution(
         &mut self,
         signers_with_stake: Vec<SignerWithStake>,
-    ) -> Result<Vec<SignerFixture>, String> {
+    ) -> Result<MithrilFixture, String> {
         self.chain_observer
             .set_signers(signers_with_stake.clone())
             .await;
@@ -354,7 +354,7 @@ impl RuntimeTester {
             ))
             .build();
 
-        Ok(fixture.signers_fixture())
+        Ok(fixture)
     }
 
     /// Update the digester result using the current beacon

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.66"
+version = "0.2.67"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -111,5 +111,6 @@ impl SignedEntityTypeDiscriminants {
         }
     }
 }
+
 #[cfg(test)]
 mod tests {}

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -3,13 +3,14 @@ use std::sync::Arc;
 use crate::{
     certificate_chain::CertificateGenesisProducer,
     crypto_helper::{
-        key_decode_hex, key_encode_hex, OpCert, ProtocolClerk, ProtocolGenesisSigner,
-        ProtocolInitializer, ProtocolKeyRegistration, ProtocolSigner,
-        ProtocolSignerVerificationKeySignature, ProtocolStakeDistribution,
+        key_decode_hex, key_encode_hex, OpCert, ProtocolAggregateVerificationKey, ProtocolClerk,
+        ProtocolGenesisSigner, ProtocolInitializer, ProtocolKeyRegistration, ProtocolSigner,
+        ProtocolSignerVerificationKey, ProtocolSignerVerificationKeySignature,
+        ProtocolStakeDistribution,
     },
     entities::{
-        Beacon, Certificate, ProtocolMessage, ProtocolParameters, Signer, SignerWithStake,
-        SingleSignatures, StakeDistribution,
+        Beacon, Certificate, HexEncodedAgregateVerificationKey, ProtocolMessage,
+        ProtocolParameters, Signer, SignerWithStake, SingleSignatures, StakeDistribution,
     },
 };
 
@@ -86,30 +87,44 @@ impl MithrilFixture {
         self.stake_distribution.clone()
     }
 
-    /// Create a genesis certificate using the fixture signers for the given beacon
-    pub fn create_genesis_certificate(&self, beacon: &Beacon) -> Certificate {
+    /// Create a [ProtocolClerk] based on this fixture protocol parameters & signers
+    pub fn create_clerk(&self) -> ProtocolClerk {
         let mut key_registration = ProtocolKeyRegistration::init(&self.stake_distribution);
 
         for signer in self.signers.clone() {
-            let verification_key =
-                key_decode_hex(&signer.signer_with_stake.verification_key).unwrap();
             key_registration
                 .register(
                     Some(signer.signer_with_stake.party_id.to_owned()),
                     signer.operational_certificate(),
                     signer.verification_key_signature(),
                     signer.signer_with_stake.kes_period,
-                    verification_key,
+                    signer.verification_key(),
                 )
                 .unwrap();
         }
-
         let closed_registration = key_registration.close();
-        let clerk = ProtocolClerk::from_registration(
+
+        ProtocolClerk::from_registration(
             &self.protocol_parameters.clone().into(),
             &closed_registration,
-        );
-        let genesis_avk = clerk.compute_avk();
+        )
+    }
+
+    /// Compute the Aggregate Verification Key for this fixture.
+    pub fn compute_avk(&self) -> ProtocolAggregateVerificationKey {
+        let clerk = self.create_clerk();
+        clerk.compute_avk()
+    }
+
+    /// Compute the Aggregate Verification Key for this fixture and returns it has a [HexEncodedAgregateVerificationKey].
+    pub fn compute_and_encode_avk(&self) -> HexEncodedAgregateVerificationKey {
+        let avk = self.compute_avk();
+        key_encode_hex(avk).unwrap()
+    }
+
+    /// Create a genesis certificate using the fixture signers for the given beacon
+    pub fn create_genesis_certificate(&self, beacon: &Beacon) -> Certificate {
+        let genesis_avk = self.compute_avk();
         let genesis_signer = ProtocolGenesisSigner::create_deterministic_genesis_signer();
         let genesis_producer = CertificateGenesisProducer::new(Some(Arc::new(genesis_signer)));
         let genesis_protocol_message =
@@ -152,7 +167,12 @@ impl SignerFixture {
         }
     }
 
-    /// Decode this verification key signature certificate if any
+    /// Decode this signer verification key certificate
+    pub fn verification_key(&self) -> ProtocolSignerVerificationKey {
+        key_decode_hex(&self.signer_with_stake.verification_key).unwrap()
+    }
+
+    /// Decode this signer verification key signature certificate if any
     pub fn verification_key_signature(&self) -> Option<ProtocolSignerVerificationKeySignature> {
         self.signer_with_stake
             .verification_key_signature

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -35,6 +35,18 @@ pub struct SignerFixture {
     pub protocol_initializer: ProtocolInitializer,
 }
 
+impl From<SignerFixture> for SignerWithStake {
+    fn from(fixture: SignerFixture) -> Self {
+        fixture.signer_with_stake
+    }
+}
+
+impl From<&SignerFixture> for SignerWithStake {
+    fn from(fixture: &SignerFixture) -> Self {
+        fixture.signer_with_stake.clone()
+    }
+}
+
 impl MithrilFixture {
     /// [MithrilFixture] factory.
     pub fn new(


### PR DESCRIPTION
## Content

This PR simplify the integration tests of the aggregator by replacing most asserts by a new macro `assert_last_certificate_eq`.
Before we to manually get multiple information in the tested aggregator to do our assertion, the new mactro streamlined this and a new type, `ExpectedCertificate`, allow to specify the subset of data that is meaningful to verify in a Certificate. 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
To make the new macro work the capacity to get a `SignedEntity` by its Certificate id had to be added to the `SignedEntityStorer`.
