### PR TITLE
Fix rfc3339 datetime migration

### DIFF
--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.35"
+version = "0.3.36"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR fix the migration that migrate dates in the aggregator database to the rfc 3339 format.
The `created_at` & `artifact` columns of the `signed_entity` table were swapped, leading to an error when querying any artifacts.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #946, Fix a bug introduced in #994
