### PR TITLE
Fix master certificate retrieval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2036,7 +2036,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.36"
+version = "0.3.37"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.36"
+version = "0.3.37"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR fix master certificate retrieval on a edge case:
If on the queried epoch, epoch with already existing certificates, a genesis certificate is added then the returned certificate when asking the master of that epoch would not be the new genesis but the first certificate of the epoch.

This PR also fix a bad behavior when `CertificateRecord` are converted back to `Certificate`: this would recompute the certificate hash, meaning that the real hash, used as the id of the certificate table, would be lost.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1006 
