### PR TITLE
retry when artifact creation failed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.43"
+version = "0.3.44"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.71"
+version = "0.2.70"
 dependencies = [
  "async-trait",
  "bech32",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.43"
+version = "0.3.44"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -197,6 +197,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
                     "RUNNER: get_current_non_certified_open_message_for_signed_entity_type: existing open message found, not already certified";
                     "signed_entity_type" => ?signed_entity_type
                 );
+
                 Some(existing_open_message)
             }
             Some(_) => {
@@ -204,6 +205,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
                     "RUNNER: get_current_non_certified_open_message_for_signed_entity_type: existing open message found, already certified";
                     "signed_entity_type" => ?signed_entity_type
                 );
+
                 None
             }
             None => {
@@ -211,12 +213,16 @@ impl AggregatorRunnerTrait for AggregatorRunner {
                     "RUNNER: get_current_non_certified_open_message_for_signed_entity_type: no open message found, a new one will be created";
                     "signed_entity_type" => ?signed_entity_type
                 );
-                // In order to fix flakiness in the end to end tests, we are compelled to update the beacon (of the multi-signer)
-                // This avoids the computation of the next AVK on the wrong epoch (in 'compute_protocol_message')
-                // TODO: remove 'current_beacon' from the multi-signer state which will avoid this fix
+                // In order to fix flakiness in the end to end tests, we are
+                // compelled to update the beacon (of the multi-signer) This
+                // avoids the computation of the next AVK on the wrong epoch (in
+                // 'compute_protocol_message')
+                // TODO: remove 'current_beacon' from the multi-signer state
+                // which will avoid this fix
                 let chain_beacon: Beacon = self.get_beacon_from_chain().await?;
                 self.update_beacon(&chain_beacon).await?;
                 let protocol_message = self.compute_protocol_message(signed_entity_type).await?;
+
                 Some(
                     self.create_open_message(signed_entity_type, &protocol_message)
                         .await?,


### PR DESCRIPTION
## Content
This PR makes the aggregator retry when artifact creation fails. If the artifact creation still fails, the state machine is reset.

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Closes #984 
