### PR TITLE
Use cargo-nextest to run test on CI and reenable tests report

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+## cargo nextest configuration file
+
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+
+[profile.ci.junit]
+path = "tests-result.junit.xml"
+report-name = "mithril-tests"

--- a/.github/workflows/actions/toolchain-and-cache/action.yml
+++ b/.github/workflows/actions/toolchain-and-cache/action.yml
@@ -22,9 +22,17 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-cache-v${{ inputs.cache-version }}
-
+    
+    - name: Install cargo tools installer
+      uses: taiki-e/install-action@v2
+      if: inputs.cargo-tools != ''
+      with:
+        tool: cargo-binstall
+    
     - name: Install cargo tools
       if: inputs.cargo-tools != ''
       shell: bash
       run: |
-        cargo install ${{ inputs.cargo-tools }} 2>/dev/null || true # Suppress the "binary `xyz` already exists in destination" error
+        # Sometimes without the `--force` options the installed binaries are not found by cargo
+        # leading to error such as: `error: no such command: `my-tool``
+        cargo binstall --force --no-confirm ${{ inputs.cargo-tools }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,17 +122,17 @@ jobs:
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
-          cargo-tools: cargo2junit
+          cargo-tools: cargo-nextest
+      
+      - name: Build tests
+        run: cargo nextest run --no-run ${{ matrix.test-args }}
 
       - name: Run tests
         shell: bash
         run: |
-          set -o pipefail && \
-          cargo test --no-fail-fast ${{ matrix.test-args }}
-          # TODO: Previous command that uses unstable options which are not supported anymore in stable toolchain
-          #cargo test --no-fail-fast ${{ matrix.test-args }} \
-          #    -- -Z unstable-options --format json --report-time \
-          #    | tee >(cargo2junit > test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}.xml)
+          cargo nextest run --profile ci ${{ matrix.test-args }}
+          # Rename junit file to include runner info
+          mv target/nextest/ci/tests-result.junit.xml test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}.xml
 
       - name: Upload Tests Results
         uses: actions/upload-artifact@v3
@@ -140,7 +140,7 @@ jobs:
         with:
           name: test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}
           path: |
-            ./**/test-results-*.xml
+            ./test-results-*.xml
   
   check:
     runs-on: ubuntu-22.04
@@ -232,9 +232,7 @@ jobs:
           if-no-files-found: error
   
   publish-tests-results:
-    # TODO: reactivate when cargo test errors export to json works in stable version
-    #if: success() || failure()
-    if: false
+    if: success() || failure()
     runs-on: ubuntu-22.04
     needs: 
       - test


### PR DESCRIPTION
## Content
This PR changes the runner that are used for tests in CI to [`cargo-nextest`](https://nexte.st/index.html). This give the following benefits :

- Re-enable tests reports in our PR using [nextest junit support](https://nexte.st/book/junit.html) without the need of `cargo2junit` and unstable cargo features.
- Faster tests because of nextest execution model being more aggressive with parallelization (ie: integration tests can run in parallel of units test).

This PR also changes the way third party cargo tools are retrieved in the CI: instead of using `cargo install` that retrieve the tool source and compile them (making our github caches heavier) we now use [`cargo binstall`](https://github.com/cargo-bins/cargo-binstall) to retrieve precompiled binaries.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #978
