### PR TITLE
Signer verification key discrepancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2118,7 +2118,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.45"
+version = "0.3.46"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.72"
+version = "0.2.73"
 dependencies = [
  "async-trait",
  "bech32",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.45"
+version = "0.3.46"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/provider/signer_registration.rs
+++ b/mithril-aggregator/src/database/provider/signer_registration.rs
@@ -1,28 +1,24 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlite::{Connection, Value};
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 use tokio::sync::Mutex;
 
-use crate::VerificationKeyStorer;
-use mithril_common::entities::Signer;
-use mithril_common::store::StoreError;
 use mithril_common::{
     crypto_helper::KESPeriod,
     entities::{
         Epoch, HexEncodedOpCert, HexEncodedVerificationKey, HexEncodedVerificationKeySignature,
-        PartyId, SignerWithStake, Stake,
+        PartyId, Signer, SignerWithStake, Stake,
     },
     sqlite::{
         EntityCursor, HydrationError, Projection, Provider, SourceAlias, SqLiteEntity,
         WhereCondition,
     },
-    store::adapter::{AdapterError, StoreAdapter},
+    store::{adapter::AdapterError, StoreError},
     StdError,
 };
+
+use crate::VerificationKeyStorer;
 
 /// SignerRegistration record is the representation of a stored signer_registration.
 #[derive(Debug, PartialEq, Clone)]
@@ -469,141 +465,9 @@ impl VerificationKeyStorer for SignerRegistrationStore {
     }
 }
 
-/// Service to deal with signer_registration (read & write).
-pub struct SignerRegistrationStoreAdapter {
-    connection: Arc<Mutex<Connection>>,
-}
-
-impl SignerRegistrationStoreAdapter {
-    /// Create a new SignerRegistrationStoreAdapter service
-    pub fn new(connection: Arc<Mutex<Connection>>) -> Self {
-        Self { connection }
-    }
-}
-
-#[async_trait]
-impl StoreAdapter for SignerRegistrationStoreAdapter {
-    type Key = Epoch;
-    type Record = HashMap<PartyId, SignerWithStake>;
-
-    async fn store_record(
-        &mut self,
-        key: &Self::Key,
-        record: &Self::Record,
-    ) -> Result<(), AdapterError> {
-        let connection = &*self.connection.lock().await;
-        let provider = InsertOrReplaceSignerRegistrationRecordProvider::new(connection);
-        connection
-            .execute("begin transaction")
-            .map_err(|e| AdapterError::QueryError(e.into()))?;
-
-        for signer_with_stake in record.values() {
-            let _signer_registration_record = provider
-                .persist(SignerRegistrationRecord::from_signer_with_stake(
-                    signer_with_stake.to_owned(),
-                    *key,
-                ))
-                .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
-        }
-
-        connection
-            .execute("commit transaction")
-            .map_err(|e| AdapterError::QueryError(e.into()))?;
-
-        Ok(())
-    }
-
-    async fn get_record(&self, key: &Self::Key) -> Result<Option<Self::Record>, AdapterError> {
-        let connection = &*self.connection.lock().await;
-        let provider = SignerRegistrationRecordProvider::new(connection);
-        let cursor = provider
-            .get_by_epoch(key)
-            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
-        let mut signer_with_stakes = HashMap::new();
-        for signer_registration_record in cursor {
-            signer_with_stakes.insert(
-                signer_registration_record.signer_id.to_string(),
-                signer_registration_record.into(),
-            );
-        }
-        if signer_with_stakes.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(signer_with_stakes))
-        }
-    }
-
-    async fn record_exists(&self, key: &Self::Key) -> Result<bool, AdapterError> {
-        Ok(self.get_record(key).await?.is_some())
-    }
-
-    async fn get_last_n_records(
-        &self,
-        how_many: usize,
-    ) -> Result<Vec<(Self::Key, Self::Record)>, AdapterError> {
-        let connection = &*self.connection.lock().await;
-        let provider = SignerRegistrationRecordProvider::new(connection);
-        let cursor = provider
-            .get_all()
-            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?
-            .collect::<Vec<_>>()
-            .into_iter()
-            .rev();
-        let signer_with_stake_by_epoch: BTreeMap<Self::Key, Self::Record> = cursor.fold(
-            BTreeMap::<Self::Key, Self::Record>::new(),
-            |mut acc, signer_registration_record| {
-                let epoch = signer_registration_record.epoch_setting_id;
-                let mut signer_with_stakes: Self::Record =
-                    if let Some(signer_with_stakes) = acc.get_mut(&epoch) {
-                        signer_with_stakes.to_owned()
-                    } else {
-                        HashMap::new()
-                    };
-                signer_with_stakes.insert(
-                    signer_registration_record.signer_id.to_string(),
-                    signer_registration_record.into(),
-                );
-                acc.insert(epoch, signer_with_stakes);
-                acc
-            },
-        );
-        Ok(signer_with_stake_by_epoch
-            .into_iter()
-            .rev()
-            .take(how_many)
-            .collect())
-    }
-
-    async fn remove(&mut self, key: &Self::Key) -> Result<Option<Self::Record>, AdapterError> {
-        let connection = &*self.connection.lock().await;
-        let provider = DeleteSignerRegistrationRecordProvider::new(connection);
-        let cursor = provider
-            .delete(*key)
-            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
-        let mut signer_with_stakes = HashMap::new();
-        for signer_registration_record in cursor {
-            signer_with_stakes.insert(
-                signer_registration_record.signer_id.to_string(),
-                signer_registration_record.into(),
-            );
-        }
-
-        if signer_with_stakes.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(signer_with_stakes))
-        }
-    }
-
-    async fn get_iter(&self) -> Result<Box<dyn Iterator<Item = Self::Record> + '_>, AdapterError> {
-        let records = self.get_last_n_records(usize::MAX).await?;
-        Ok(Box::new(records.into_iter().map(|(_k, v)| v)))
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
 
     use mithril_common::test_utils::MithrilFixtureBuilder;
 
@@ -937,66 +801,6 @@ mod tests {
                 .unwrap();
             assert_eq!(signer_registration_record, signer_registration_record_saved);
         }
-    }
-
-    #[tokio::test]
-    async fn test_store_adapter() {
-        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
-        let signer_with_stakes = fixture.signers_with_stake();
-        let signer_with_stakes_by_epoch: Vec<(Epoch, HashMap<PartyId, SignerWithStake>)> = (0..5)
-            .map(|e| {
-                (
-                    Epoch(e),
-                    signer_with_stakes
-                        .clone()
-                        .into_iter()
-                        .map(|s| (s.party_id.to_owned(), s))
-                        .collect(),
-                )
-            })
-            .collect();
-
-        let connection = Connection::open(":memory:").unwrap();
-        setup_signer_registration_db(&connection, Vec::new()).unwrap();
-
-        let mut signer_registration_store_adapter =
-            SignerRegistrationStoreAdapter::new(Arc::new(Mutex::new(connection)));
-
-        for (epoch, signer_with_stakes) in &signer_with_stakes_by_epoch {
-            assert!(signer_registration_store_adapter
-                .store_record(epoch, signer_with_stakes)
-                .await
-                .is_ok());
-        }
-
-        for (epoch, signer_with_stakes) in &signer_with_stakes_by_epoch {
-            assert!(signer_registration_store_adapter
-                .record_exists(epoch)
-                .await
-                .unwrap());
-            assert_eq!(
-                Some(signer_with_stakes.to_owned()),
-                signer_registration_store_adapter
-                    .get_record(epoch)
-                    .await
-                    .unwrap()
-            );
-        }
-        assert_eq!(
-            signer_with_stakes_by_epoch
-                .clone()
-                .into_iter()
-                .map(|(k, v)| (k, BTreeMap::from_iter(v.into_iter())))
-                .collect::<Vec<(Epoch, BTreeMap<PartyId, SignerWithStake>)>>(),
-            signer_registration_store_adapter
-                .get_last_n_records(signer_with_stakes_by_epoch.len())
-                .await
-                .unwrap()
-                .into_iter()
-                .rev()
-                .map(|(k, v)| (k, BTreeMap::from_iter(v.into_iter())))
-                .collect::<Vec<(Epoch, BTreeMap<PartyId, SignerWithStake>)>>()
-        )
     }
 
     pub fn init_signer_registration_store(

--- a/mithril-aggregator/src/dependency.rs
+++ b/mithril-aggregator/src/dependency.rs
@@ -25,8 +25,7 @@ use crate::{
     signer_registerer::SignerRecorder,
     ticker_service::TickerService,
     CertificatePendingStore, CertificateStore, ProtocolParametersStore, ProtocolParametersStorer,
-    SignerRegisterer, SignerRegistrationRoundOpener, Snapshotter, VerificationKeyStore,
-    VerificationKeyStorer,
+    SignerRegisterer, SignerRegistrationRoundOpener, Snapshotter, VerificationKeyStorer,
 };
 use crate::{event_store::TransmitterService, multi_signer::MultiSigner};
 use crate::{
@@ -63,7 +62,7 @@ pub struct DependencyManager {
     pub certificate_store: Arc<CertificateStore>,
 
     /// Verification key store.
-    pub verification_key_store: Arc<VerificationKeyStore>,
+    pub verification_key_store: Arc<dyn VerificationKeyStorer>,
 
     /// Protocol parameter store.
     pub protocol_parameters_store: Arc<ProtocolParametersStore>,
@@ -249,7 +248,7 @@ impl DependencyManager {
     /// Fill the stores of a [DependencyManager] in a way to simulate an aggregator genesis state.
     ///
     /// For the current and the next epoch:
-    /// * Fill the [VerificationKeyStore] with the given signers keys.
+    /// * Fill the [VerificationKeyStorer] with the given signers keys.
     /// * Fill the [StakeStore] with the given signers stakes.
     /// * Fill the [ProtocolParametersStore] with the given parameters.
     pub async fn prepare_for_genesis(

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -41,10 +41,13 @@ use crate::{
     },
     certifier_service::{CertifierService, MithrilCertifierService},
     configuration::ExecutionEnvironment,
-    database::provider::{
-        CertificateRepository, CertificateStoreAdapter, EpochSettingStore, OpenMessageRepository,
-        SignedEntityStoreAdapter, SignedEntityStorer, SignerRegistrationStoreAdapter, SignerStore,
-        SingleSignatureRepository, StakePoolStore,
+    database::{
+        provider::SignerRegistrationStore,
+        provider::{
+            CertificateRepository, CertificateStoreAdapter, EpochSettingStore,
+            OpenMessageRepository, SignedEntityStoreAdapter, SignedEntityStorer, SignerStore,
+            SingleSignatureRepository, StakePoolStore,
+        },
     },
     event_store::{EventMessage, EventStore, TransmitterService},
     http_server::routes::router,
@@ -57,7 +60,7 @@ use crate::{
     CertificateStore, Configuration, DependencyManager, DumbSnapshotUploader, DumbSnapshotter,
     GzipSnapshotter, LocalSnapshotUploader, MithrilSignerRegisterer, MultiSigner, MultiSignerImpl,
     ProtocolParametersStore, ProtocolParametersStorer, RemoteSnapshotUploader, SnapshotUploader,
-    SnapshotUploaderType, Snapshotter, VerificationKeyStore, VerificationKeyStorer,
+    SnapshotUploaderType, Snapshotter, VerificationKeyStorer,
 };
 
 use super::{DependenciesBuilderError, Result};
@@ -399,11 +402,9 @@ impl DependenciesBuilder {
     }
 
     async fn build_verification_key_store(&mut self) -> Result<Arc<dyn VerificationKeyStorer>> {
-        Ok(Arc::new(VerificationKeyStore::new(
-            Box::new(SignerRegistrationStoreAdapter::new(
-                self.get_sqlite_connection().await?,
-            )),
-            self.configuration.store_retention_limit,
+        Ok(Arc::new(SignerRegistrationStore::new(
+            self.get_sqlite_connection().await?,
+            self.configuration.store_retention_limit.map(|l| l as u64),
         )))
     }
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -643,6 +643,7 @@ impl DependenciesBuilder {
             self.get_chain_observer().await?,
             self.get_verification_key_store().await?,
             self.get_signer_recorder().await?,
+            self.configuration.store_retention_limit.map(|l| l as u64),
         );
 
         Ok(Arc::new(registerer))

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -404,7 +404,6 @@ impl DependenciesBuilder {
     async fn build_verification_key_store(&mut self) -> Result<Arc<dyn VerificationKeyStorer>> {
         Ok(Arc::new(SignerRegistrationStore::new(
             self.get_sqlite_connection().await?,
-            self.configuration.store_retention_limit.map(|l| l as u64),
         )))
     }
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -57,7 +57,7 @@ use crate::{
     CertificateStore, Configuration, DependencyManager, DumbSnapshotUploader, DumbSnapshotter,
     GzipSnapshotter, LocalSnapshotUploader, MithrilSignerRegisterer, MultiSigner, MultiSignerImpl,
     ProtocolParametersStore, ProtocolParametersStorer, RemoteSnapshotUploader, SnapshotUploader,
-    SnapshotUploaderType, Snapshotter, VerificationKeyStore,
+    SnapshotUploaderType, Snapshotter, VerificationKeyStore, VerificationKeyStorer,
 };
 
 use super::{DependenciesBuilderError, Result};
@@ -99,7 +99,7 @@ pub struct DependenciesBuilder {
     pub certificate_store: Option<Arc<CertificateStore>>,
 
     /// Verification key store.
-    pub verification_key_store: Option<Arc<VerificationKeyStore>>,
+    pub verification_key_store: Option<Arc<dyn VerificationKeyStorer>>,
 
     /// Protocol parameter store.
     pub protocol_parameters_store: Option<Arc<ProtocolParametersStore>>,
@@ -398,7 +398,7 @@ impl DependenciesBuilder {
         Ok(self.certificate_store.as_ref().cloned().unwrap())
     }
 
-    async fn build_verification_key_store(&mut self) -> Result<Arc<VerificationKeyStore>> {
+    async fn build_verification_key_store(&mut self) -> Result<Arc<dyn VerificationKeyStorer>> {
         Ok(Arc::new(VerificationKeyStore::new(
             Box::new(SignerRegistrationStoreAdapter::new(
                 self.get_sqlite_connection().await?,
@@ -407,8 +407,8 @@ impl DependenciesBuilder {
         )))
     }
 
-    /// Get a configured [VerificationKeyStore].
-    pub async fn get_verification_key_store(&mut self) -> Result<Arc<VerificationKeyStore>> {
+    /// Get a configured [VerificationKeyStorer].
+    pub async fn get_verification_key_store(&mut self) -> Result<Arc<dyn VerificationKeyStorer>> {
         if self.verification_key_store.is_none() {
             self.verification_key_store = Some(self.build_verification_key_store().await?);
         }

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -595,10 +595,9 @@ mod tests {
 
     async fn setup_multi_signer() -> MultiSignerImpl {
         let beacon = fake_data::beacon();
-        let verification_key_store = VerificationKeyStore::new(
-            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
-            None,
-        );
+        let verification_key_store = VerificationKeyStore::new(Box::new(
+            MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap(),
+        ));
         let stake_store = StakeStore::new(
             Box::new(MemoryAdapter::<Epoch, StakeDistribution>::new(None).unwrap()),
             None,

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -15,7 +15,7 @@ use mithril_common::{
 
 use crate::{
     entities::OpenMessage, store::VerificationKeyStorer, ProtocolParametersStore,
-    ProtocolParametersStorer, VerificationKeyStore,
+    ProtocolParametersStorer,
 };
 
 #[cfg(test)]
@@ -194,7 +194,7 @@ pub struct MultiSignerImpl {
     current_beacon: Option<entities::Beacon>,
 
     /// Verification key store
-    verification_key_store: Arc<VerificationKeyStore>,
+    verification_key_store: Arc<dyn VerificationKeyStorer>,
 
     /// Stake store
     stake_store: Arc<dyn StakeStorer>,
@@ -206,7 +206,7 @@ pub struct MultiSignerImpl {
 impl MultiSignerImpl {
     /// MultiSignerImpl factory
     pub fn new(
-        verification_key_store: Arc<VerificationKeyStore>,
+        verification_key_store: Arc<dyn VerificationKeyStorer>,
         stake_store: Arc<dyn StakeStorer>,
         protocol_parameters_store: Arc<ProtocolParametersStore>,
     ) -> Self {
@@ -587,7 +587,7 @@ mod tests {
     use crate::{store::VerificationKeyStore, ProtocolParametersStore};
     use mithril_common::{
         crypto_helper::tests_setup::*,
-        entities::SignedEntityType,
+        entities::{PartyId, SignedEntityType},
         store::{adapter::MemoryAdapter, StakeStore},
         test_utils::{fake_data, MithrilFixtureBuilder},
     };
@@ -596,12 +596,7 @@ mod tests {
     async fn setup_multi_signer() -> MultiSignerImpl {
         let beacon = fake_data::beacon();
         let verification_key_store = VerificationKeyStore::new(
-            Box::new(
-                MemoryAdapter::<Epoch, HashMap<entities::PartyId, entities::SignerWithStake>>::new(
-                    None,
-                )
-                .unwrap(),
-            ),
+            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
             None,
         );
         let stake_store = StakeStore::new(

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -733,6 +733,7 @@ pub mod tests {
             deps.chain_observer.clone(),
             deps.verification_key_store.clone(),
             deps.signer_recorder.clone(),
+            None,
         ));
         deps.signer_registration_round_opener = signer_registration_round_opener.clone();
         let stake_store = deps.stake_store.clone();
@@ -772,6 +773,7 @@ pub mod tests {
             deps.chain_observer.clone(),
             deps.verification_key_store.clone(),
             deps.signer_recorder.clone(),
+            None,
         ));
         deps.signer_registration_round_opener = signer_registration_round_opener.clone();
         let deps = Arc::new(deps);

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
 
-use crate::{VerificationKeyStore, VerificationKeyStorer};
 use mithril_common::{
     chain_observer::ChainObserver,
     crypto_helper::{
@@ -13,6 +12,8 @@ use mithril_common::{
     store::StoreError,
     StdError,
 };
+
+use crate::VerificationKeyStorer;
 
 #[cfg(test)]
 use mockall::automock;
@@ -131,7 +132,7 @@ pub struct MithrilSignerRegisterer {
     chain_observer: Arc<dyn ChainObserver>,
 
     /// Verification key store
-    verification_key_store: Arc<VerificationKeyStore>,
+    verification_key_store: Arc<dyn VerificationKeyStorer>,
 
     /// Signer recorder
     signer_recorder: Arc<dyn SignerRecorder>,
@@ -141,7 +142,7 @@ impl MithrilSignerRegisterer {
     /// MithrilSignerRegisterer factory
     pub fn new(
         chain_observer: Arc<dyn ChainObserver>,
-        verification_key_store: Arc<VerificationKeyStore>,
+        verification_key_store: Arc<dyn VerificationKeyStorer>,
         signer_recorder: Arc<dyn SignerRecorder>,
     ) -> Self {
         Self {

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -136,6 +136,10 @@ pub struct MithrilSignerRegisterer {
 
     /// Signer recorder
     signer_recorder: Arc<dyn SignerRecorder>,
+
+    /// Number of epochs before previous records will be deleted at the next registration round
+    /// opening
+    verification_key_epoch_retention_limit: Option<u64>,
 }
 
 impl MithrilSignerRegisterer {
@@ -144,12 +148,14 @@ impl MithrilSignerRegisterer {
         chain_observer: Arc<dyn ChainObserver>,
         verification_key_store: Arc<dyn VerificationKeyStorer>,
         signer_recorder: Arc<dyn SignerRecorder>,
+        verification_key_epoch_retention_limit: Option<u64>,
     ) -> Self {
         Self {
             current_round: RwLock::new(None),
             chain_observer,
             verification_key_store,
             signer_recorder,
+            verification_key_epoch_retention_limit,
         }
     }
 
@@ -171,6 +177,12 @@ impl SignerRegistrationRoundOpener for MithrilSignerRegisterer {
             epoch: registration_epoch,
             stake_distribution,
         });
+
+        if let Some(retention_limit) = self.verification_key_epoch_retention_limit {
+            self.verification_key_store
+                .prune_verification_keys(registration_epoch - retention_limit)
+                .await?;
+        }
 
         Ok(())
     }
@@ -278,6 +290,7 @@ impl SignerRegisterer for MithrilSignerRegisterer {
 mod tests {
     use std::{collections::HashMap, sync::Arc};
 
+    use mithril_common::test_utils::fake_data;
     use mithril_common::{
         chain_observer::FakeObserver,
         entities::{Epoch, PartyId, Signer, SignerWithStake},
@@ -294,7 +307,6 @@ mod tests {
 
     #[tokio::test]
     async fn can_register_signer_if_registration_round_is_opened_with_operational_certificate() {
-        let chain_observer = FakeObserver::default();
         let verification_key_store = Arc::new(VerificationKeyStore::new(Box::new(
             MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap(),
         )));
@@ -304,9 +316,10 @@ mod tests {
             .returning(|_| Ok(()))
             .once();
         let signer_registerer = MithrilSignerRegisterer::new(
-            Arc::new(chain_observer),
+            Arc::new(FakeObserver::default()),
             verification_key_store.clone(),
             Arc::new(signer_recorder),
+            None,
         );
         let registration_epoch = Epoch(1);
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
@@ -339,7 +352,6 @@ mod tests {
 
     #[tokio::test]
     async fn can_register_signer_if_registration_round_is_opened_without_operational_certificate() {
-        let chain_observer = FakeObserver::default();
         let verification_key_store = Arc::new(VerificationKeyStore::new(Box::new(
             MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap(),
         )));
@@ -349,9 +361,10 @@ mod tests {
             .returning(|_| Ok(()))
             .once();
         let signer_registerer = MithrilSignerRegisterer::new(
-            Arc::new(chain_observer),
+            Arc::new(FakeObserver::default()),
             verification_key_store.clone(),
             Arc::new(signer_recorder),
+            None,
         );
         let registration_epoch = Epoch(1);
         let fixture = MithrilFixtureBuilder::default()
@@ -387,15 +400,15 @@ mod tests {
 
     #[tokio::test]
     async fn cant_register_signer_if_registration_round_is_not_opened() {
-        let chain_observer = FakeObserver::default();
         let verification_key_store = Arc::new(VerificationKeyStore::new(Box::new(
             MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap(),
         )));
         let signer_recorder = MockSignerRecorder::new();
         let signer_registerer = MithrilSignerRegisterer::new(
-            Arc::new(chain_observer),
+            Arc::new(FakeObserver::default()),
             verification_key_store.clone(),
             Arc::new(signer_recorder),
+            None,
         );
         let registration_epoch = Epoch(1);
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
@@ -405,5 +418,53 @@ mod tests {
             .register_signer(registration_epoch, &signer_to_register)
             .await
             .expect_err("signer registration should fail if no round opened");
+    }
+
+    #[tokio::test]
+    async fn should_prune_verification_keys_older_than_two_epochs_at_round_opening() {
+        let initial_keys = (1..=5)
+            .map(|epoch| {
+                let signers: HashMap<PartyId, SignerWithStake> = HashMap::from_iter(
+                    fake_data::signers_with_stakes(1)
+                        .into_iter()
+                        .map(|s| (s.party_id.to_owned(), s)),
+                );
+                (Epoch(epoch), signers)
+            })
+            .collect();
+        let verification_key_store = Arc::new(VerificationKeyStore::new(Box::new(
+            MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(Some(initial_keys))
+                .unwrap(),
+        )));
+        let signer_recorder = MockSignerRecorder::new();
+        let signer_registerer = MithrilSignerRegisterer::new(
+            Arc::new(FakeObserver::default()),
+            verification_key_store.clone(),
+            Arc::new(signer_recorder),
+            Some(2),
+        );
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+
+        signer_registerer
+            .open_registration_round(Epoch(5), fixture.stake_distribution())
+            .await
+            .expect("Opening a registration round should not fail");
+
+        for epoch in 1..=3 {
+            let verification_keys = verification_key_store
+                .get_verification_keys(Epoch(epoch))
+                .await
+                .unwrap();
+            assert_eq!(None, verification_keys);
+        }
+
+        let verification_keys = verification_key_store
+            .get_verification_keys(Epoch(4))
+            .await
+            .unwrap();
+        assert!(
+            verification_keys.is_some(),
+            "Verification keys of the previous epoch should not have been pruned"
+        );
     }
 }

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -295,10 +295,9 @@ mod tests {
     #[tokio::test]
     async fn can_register_signer_if_registration_round_is_opened_with_operational_certificate() {
         let chain_observer = FakeObserver::default();
-        let verification_key_store = Arc::new(VerificationKeyStore::new(
-            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
-            None,
-        ));
+        let verification_key_store = Arc::new(VerificationKeyStore::new(Box::new(
+            MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap(),
+        )));
         let mut signer_recorder = MockSignerRecorder::new();
         signer_recorder
             .expect_record_signer_id()
@@ -341,10 +340,9 @@ mod tests {
     #[tokio::test]
     async fn can_register_signer_if_registration_round_is_opened_without_operational_certificate() {
         let chain_observer = FakeObserver::default();
-        let verification_key_store = Arc::new(VerificationKeyStore::new(
-            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
-            None,
-        ));
+        let verification_key_store = Arc::new(VerificationKeyStore::new(Box::new(
+            MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap(),
+        )));
         let mut signer_recorder = MockSignerRecorder::new();
         signer_recorder
             .expect_record_signer_id()
@@ -390,10 +388,9 @@ mod tests {
     #[tokio::test]
     async fn cant_register_signer_if_registration_round_is_not_opened() {
         let chain_observer = FakeObserver::default();
-        let verification_key_store = Arc::new(VerificationKeyStore::new(
-            Box::new(MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap()),
-            None,
-        ));
+        let verification_key_store = Arc::new(VerificationKeyStore::new(Box::new(
+            MemoryAdapter::<Epoch, HashMap<PartyId, SignerWithStake>>::new(None).unwrap(),
+        )));
         let signer_recorder = MockSignerRecorder::new();
         let signer_registerer = MithrilSignerRegisterer::new(
             Arc::new(chain_observer),

--- a/mithril-aggregator/src/store/mod.rs
+++ b/mithril-aggregator/src/store/mod.rs
@@ -7,3 +7,8 @@ pub use certificate_store::CertificateStore;
 pub use pending_certificate_store::CertificatePendingStore;
 pub use protocol_parameters_store::{ProtocolParametersStore, ProtocolParametersStorer};
 pub use verification_key_store::{VerificationKeyStore, VerificationKeyStorer};
+
+#[cfg(test)]
+pub use verification_key_store::test_suite as verification_key_store_test_suite;
+#[cfg(test)]
+pub(crate) use verification_key_store::test_verification_key_storer;

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -8,10 +8,11 @@ use mithril_common::store::{adapter::StoreAdapter, StoreError};
 
 type Adapter = Box<dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, SignerWithStake>>>;
 
-/// Mocking trait for `VerificationKeyStore`.
+/// Store and get signers verification keys for given epoch.
 #[async_trait]
 pub trait VerificationKeyStorer: Sync + Send {
-    /// Save the verification key, for the given [Signer] for the given [Epoch].
+    /// Save the verification key, for the given [Signer] for the given [Epoch], returns the
+    /// previous values if one already existed.
     async fn save_verification_key(
         &self,
         epoch: Epoch,
@@ -88,24 +89,74 @@ impl VerificationKeyStorer for VerificationKeyStore {
     }
 }
 
+/// Macro that generate tests that a [VerificationKeyStorer] must pass
 #[cfg(test)]
-mod tests {
-    use super::*;
+macro_rules! test_verification_key_storer {
+    ($suit_name:ident => $store_builder:expr) => {
+        #[cfg(test)]
+        mod $suit_name {
+            use crate::store::verification_key_store_test_suite as test_suite;
 
-    use mithril_common::store::adapter::MemoryAdapter;
+            #[tokio::test]
+            async fn save_key_in_empty_store() {
+                test_suite::save_key_in_empty_store(&$store_builder).await;
+            }
 
-    fn init_store(
+            #[tokio::test]
+            async fn update_signer_in_store() {
+                test_suite::update_signer_in_store(&$store_builder).await;
+            }
+
+            #[tokio::test]
+            async fn get_verification_keys_for_empty_epoch() {
+                test_suite::get_verification_keys_for_empty_epoch(&$store_builder).await;
+            }
+
+            #[tokio::test]
+            async fn get_verification_keys_for_existing_epoch() {
+                test_suite::get_verification_keys_for_existing_epoch(&$store_builder).await;
+            }
+
+            #[tokio::test]
+            async fn check_retention_limit() {
+                test_suite::check_retention_limit(&$store_builder).await;
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+pub(crate) use test_verification_key_storer;
+
+#[macro_use]
+#[cfg(test)]
+pub mod test_suite {
+    use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake};
+    use std::collections::{BTreeMap, HashMap};
+    use std::sync::Arc;
+
+    use crate::VerificationKeyStorer;
+
+    /// A builder of [VerificationKeyStorer], the arguments are:
+    /// * initial_data
+    /// * optional retention limit
+    type StoreBuilder = dyn Fn(
+        Vec<(Epoch, HashMap<PartyId, SignerWithStake>)>,
+        Option<usize>,
+    ) -> Arc<dyn VerificationKeyStorer>;
+
+    fn build_signers(
         nb_epoch: u64,
-        signers_per_epoch: u64,
-        retention_limit: Option<usize>,
-    ) -> VerificationKeyStore {
-        let mut values: Vec<(Epoch, HashMap<PartyId, SignerWithStake>)> = Vec::new();
+        signers_per_epoch: usize,
+    ) -> Vec<(Epoch, HashMap<PartyId, SignerWithStake>)> {
+        let mut values = vec![];
 
         for epoch in 1..=nb_epoch {
-            let mut signers: HashMap<PartyId, SignerWithStake> = HashMap::new();
+            let mut signers: HashMap<PartyId, SignerWithStake> =
+                HashMap::with_capacity(signers_per_epoch);
 
             for party_idx in 1..=signers_per_epoch {
-                let party_id = format!("{party_idx}");
+                let party_id = format!("party_id:e{epoch}:{party_idx}");
                 signers.insert(
                     party_id.clone(),
                     SignerWithStake {
@@ -121,19 +172,12 @@ mod tests {
             values.push((Epoch(epoch), signers));
         }
 
-        let values = if !values.is_empty() {
-            Some(values)
-        } else {
-            None
-        };
-        let adapter: MemoryAdapter<Epoch, HashMap<PartyId, SignerWithStake>> =
-            MemoryAdapter::new(values).unwrap();
-        VerificationKeyStore::new(Box::new(adapter), retention_limit)
+        values
     }
 
-    #[tokio::test]
-    async fn save_key_in_empty_store() {
-        let store = init_store(0, 0, None);
+    pub async fn save_key_in_empty_store(store_builder: &StoreBuilder) {
+        let signers = build_signers(0, 0);
+        let store = store_builder(signers, None);
         let res = store
             .save_verification_key(
                 Epoch(0),
@@ -152,15 +196,15 @@ mod tests {
         assert!(res.is_none());
     }
 
-    #[tokio::test]
-    async fn update_signer_in_store() {
-        let store = init_store(1, 1, None);
+    pub async fn update_signer_in_store(store_builder: &StoreBuilder) {
+        let signers = build_signers(1, 1);
+        let store = store_builder(signers, None);
         let res = store
             .save_verification_key(
                 Epoch(1),
                 SignerWithStake {
-                    party_id: "1".to_string(),
-                    verification_key: "test".to_string(),
+                    party_id: "party_id:e1:1".to_string(),
+                    verification_key: "new_vkey".to_string(),
                     verification_key_signature: None,
                     operational_certificate: None,
                     kes_period: None,
@@ -170,40 +214,50 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(res.is_some());
         assert_eq!(
-            SignerWithStake {
-                party_id: "1".to_string(),
-                verification_key: "vkey 1".to_string(),
+            Some(SignerWithStake {
+                party_id: "party_id:e1:1".to_string(),
+                verification_key: "vkey party_id:e1:1".to_string(),
                 verification_key_signature: None,
                 operational_certificate: None,
                 kes_period: None,
                 stake: 10,
-            },
-            res.unwrap(),
+            }),
+            res,
         );
     }
 
-    #[tokio::test]
-    async fn get_verification_keys_for_empty_epoch() {
-        let store = init_store(2, 1, None);
+    pub async fn get_verification_keys_for_empty_epoch(store_builder: &StoreBuilder) {
+        let signers = build_signers(2, 1);
+        let store = store_builder(signers, None);
         let res = store.get_verification_keys(Epoch(0)).await.unwrap();
 
         assert!(res.is_none());
     }
 
-    #[tokio::test]
-    async fn get_verification_keys_for_existing_epoch() {
-        let store = init_store(2, 2, None);
-        let res = store.get_verification_keys(Epoch(1)).await.unwrap();
+    pub async fn get_verification_keys_for_existing_epoch(store_builder: &StoreBuilder) {
+        let signers = build_signers(2, 2);
+        let expected_signers: Option<BTreeMap<PartyId, Signer>> = signers
+            .iter()
+            .filter(|(e, _)| e == 1)
+            .cloned()
+            .map(|(_, signers)| {
+                BTreeMap::from_iter(signers.into_iter().map(|(p, s)| (p, s.into())))
+            })
+            .next();
+        let store = store_builder(signers, None);
+        let res = store
+            .get_verification_keys(Epoch(1))
+            .await
+            .unwrap()
+            .map(|x| BTreeMap::from_iter(x.into_iter()));
 
-        assert!(res.is_some());
-        assert_eq!(2, res.unwrap().len());
+        assert_eq!(expected_signers, res);
     }
 
-    #[tokio::test]
-    async fn check_retention_limit() {
-        let store = init_store(2, 2, Some(2));
+    pub async fn check_retention_limit(store_builder: &StoreBuilder) {
+        let signers = build_signers(2, 2);
+        let store = store_builder(signers, Some(2));
         assert!(store
             .get_verification_keys(Epoch(1))
             .await
@@ -223,10 +277,42 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(store
-            .get_verification_keys(Epoch(1))
-            .await
-            .unwrap()
-            .is_none());
+        let first_epoch_keys = store.get_verification_keys(Epoch(1)).await.unwrap();
+        assert_eq!(None, first_epoch_keys);
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::{
+        entities::{Epoch, PartyId, SignerWithStake},
+        store::adapter::MemoryAdapter,
+    };
+    use std::{collections::HashMap, sync::Arc};
+
+    use crate::{VerificationKeyStore, VerificationKeyStorer};
+
+    pub fn init_store(
+        initial_data: Vec<(Epoch, HashMap<PartyId, SignerWithStake>)>,
+        retention_limit: Option<usize>,
+    ) -> Arc<dyn VerificationKeyStorer> {
+        let values = if initial_data.is_empty() {
+            None
+        } else {
+            Some(initial_data)
+        };
+
+        let adapter: MemoryAdapter<Epoch, HashMap<PartyId, SignerWithStake>> =
+            MemoryAdapter::new(values).unwrap();
+
+        Arc::new(VerificationKeyStore::new(
+            Box::new(adapter),
+            retention_limit,
+        ))
+    }
+
+    test_verification_key_storer!(
+        test_verification_key_store =>
+        crate::store::verification_key_store::tests::init_store
+    );
 }

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -10,7 +10,7 @@ type Adapter = Box<dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, Signe
 
 /// Mocking trait for `VerificationKeyStore`.
 #[async_trait]
-pub trait VerificationKeyStorer {
+pub trait VerificationKeyStorer: Sync + Send {
     /// Save the verification key, for the given [Signer] for the given [Epoch].
     async fn save_verification_key(
         &self,
@@ -24,6 +24,7 @@ pub trait VerificationKeyStorer {
         epoch: Epoch,
     ) -> Result<Option<HashMap<PartyId, Signer>>, StoreError>;
 }
+
 /// Store for the `VerificationKey`.
 pub struct VerificationKeyStore {
     adapter: RwLock<Adapter>,

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -1,9 +1,10 @@
 mod test_extensions;
 
-use mithril_aggregator::{Configuration, VerificationKeyStorer};
+use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
         Beacon, Epoch, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
+        StakeDistribution,
     },
     test_utils::MithrilFixtureBuilder,
 };
@@ -130,13 +131,16 @@ async fn certificate_chain() {
 
     comment!("Change stake distribution");
     let next_fixture = {
-        let mut updated_signers = initial_fixture.signers_with_stake();
-        for (i, signer) in updated_signers.iter_mut().enumerate() {
-            signer.stake += (i * 1000) as u64;
-        }
+        let updated_stake_distribution = StakeDistribution::from_iter(
+            initial_fixture
+                .signers_with_stake()
+                .into_iter()
+                .enumerate()
+                .map(|(i, s)| (s.party_id, s.stake + (i as u64) * 1000)),
+        );
 
         tester
-            .update_stake_distribution(updated_signers)
+            .update_stake_distribution(updated_stake_distribution)
             .await
             .unwrap()
     };

--- a/mithril-aggregator/tests/genesis_to_signing.rs
+++ b/mithril-aggregator/tests/genesis_to_signing.rs
@@ -5,10 +5,10 @@ use mithril_common::{
     entities::{Beacon, ProtocolParameters},
     test_utils::MithrilFixtureBuilder,
 };
-use test_extensions::{utilities::get_test_dir, RuntimeTester};
+use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
 
 #[tokio::test]
-async fn simple_scenario() {
+async fn genesis_to_signing() {
     let protocol_parameters = ProtocolParameters {
         k: 5,
         m: 100,
@@ -16,7 +16,7 @@ async fn simple_scenario() {
     };
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
-        data_stores_directory: get_test_dir("simple_scenario").join("aggregator.sqlite3"),
+        data_stores_directory: get_test_dir("genesis_to_signing").join("aggregator.sqlite3"),
         ..Configuration::new_sample()
     };
     let mut tester =
@@ -33,6 +33,14 @@ async fn simple_scenario() {
 
     comment!("Boostrap the genesis certificate");
     tester.register_genesis_certificate(&fixture).await.unwrap();
+
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new_genesis(
+            Beacon::new("devnet".to_string(), 1, 1),
+            fixture.compute_and_encode_avk()
+        )
+    );
 
     comment!("Increase immutable number");
     tester.increase_immutable_number().await.unwrap();

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.72"
+version = "0.2.73"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -137,6 +137,18 @@ impl PartialEq<Epoch> for u64 {
     }
 }
 
+impl PartialEq<u64> for &Epoch {
+    fn eq(&self, other: &u64) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<&Epoch> for u64 {
+    fn eq(&self, other: &&Epoch) -> bool {
+        other.0.eq(self)
+    }
+}
+
 impl Display for Epoch {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
@@ -200,5 +212,13 @@ mod tests {
     #[test]
     fn test_next() {
         assert_eq!(Epoch(4), Epoch(3).next());
+    }
+
+    #[test]
+    fn test_eq() {
+        assert_eq!(Epoch(3), 3);
+        assert_eq!(&Epoch(4), 4);
+        assert_eq!(5, Epoch(5));
+        assert_eq!(6, &Epoch(6));
     }
 }


### PR DESCRIPTION
## Content

This PR replace the `SignerRegistrationStoreAdapter` with a new `VerificationKeyStorer` implementation: `SignerRegistrationStore`.
This new implementation use the database provider directly instead of being a `StoreAdapter` meaning that when calling `save_verification_key` only the given value will be saved or updated, the previous store worked only on the epoch level saving all values by batch for a given epoch.
We have a guess that this previous behavior is the reason behind #1015, but since we could not establish the exact scenario that happen in this ticket we don't have tests to ensure that this will effectively solve this bug.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
This PR also change who do the pruning of old keys, before it was done in the `VerificationKeyStorer::save_verification_key` meaning that feeding it with a epoch in the future would prune all previous keys. Now it's the responsability of the `SignerRegistrationRoundOpener` to prune them when opening a new registration round.

## Issue(s)
Relates to #1015