### PR TITLE
Fix failing end to end test in Hydra CI 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2233,7 +2233,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.1.26"
+version = "0.1.27"
 dependencies = [
  "async-trait",
  "clap",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.1.26"
+version = "0.1.27"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
@@ -85,7 +85,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn wait_the_expected_time() {
+    async fn wait_for_the_expected_time() {
         let now = Instant::now();
 
         assert_eq!(
@@ -97,7 +97,7 @@ mod tests {
 
         let elapsed = now.elapsed().as_millis();
         assert!(
-            (10..=12).contains(&elapsed),
+            (10..=15).contains(&elapsed),
             "Failure, after one loop the elapsed time was not ~10ms, elapsed: {elapsed}"
         );
     }


### PR DESCRIPTION
## Content
This PR includes a fix in order to avoid consistent failure from the `wait_for_the_expected_time` test of the end to end test on the Hydra CI as seen in https://ci.iog.io/build/175030/nixlog/1

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
