### PR TITLE
Fix documentation

### DIFF
--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -362,8 +362,8 @@ sudo bash -c 'cat > /etc/squid/squid.conf << EOF
 # Listening port (port 3128 is recommended)
 http_port **YOUR_RELAY_LISTENING_PORT**
 
-# ACL for internal IP of your relay node
-acl relay_internal_ip src **YOUR_RELAY_INTERNAL_IP**
+# ACL for internal IP of your block producer node
+acl relay_internal_ip src **YOUR_BLOCK_PRODUCER_INTERNAL_IP**
 
 # ACL for aggregator endpoint
 acl aggregator_domain dstdomain .mithril.network
@@ -380,7 +380,7 @@ EOF'
 ```
 
 With this configuration, the proxy will:
-- accept incoming traffic made to the internal IP of the relay machine
+- accept incoming traffic made from the internal IP of the block producing machine
 - accept incoming traffic made to the listening port of the proxy
 - accept incoming HTTPS traffic proxied to `mithril.network` domain hosts
 - deny all other traffic

--- a/docs/root/networks-matrix.md
+++ b/docs/root/networks-matrix.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 Here is an up to date list of all the **Mithril Networks**, their configurations and their status:
 
-> Last update: 02/28/2023
+> Last update: 07/05/2023
 
 <Tabs>
   <TabItem value="preview" label="Preview" default>
@@ -28,7 +28,7 @@ Here is an up to date list of all the **Mithril Networks**, their configurations
 | **Era Reader Adapter Type** | `cardano-chain`
 | **Era Reader Address** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.addr` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.addr)
 | **Era Reader Verification Key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.vkey)
-| **Build From** |  **Latest Pre-Release** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/releases?q=pre-release) 
+| **Build From** |  **Latest Pre-Release** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/releases?q=pre) 
 
 <br/>
 

--- a/docs/versioned_docs/version-maintained/networks-matrix.md
+++ b/docs/versioned_docs/version-maintained/networks-matrix.md
@@ -9,7 +9,7 @@ import TabItem from '@theme/TabItem';
 
 Here is an up to date list of all the **Mithril Networks**, their configurations and their status:
 
-> Last update: 02/28/2023
+> Last update: 07/05/2023
 
 <Tabs>
   <TabItem value="preview" label="Preview" default>
@@ -28,7 +28,7 @@ Here is an up to date list of all the **Mithril Networks**, their configurations
 | **Era Reader Adapter Type** | `cardano-chain`
 | **Era Reader Address** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.addr` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.addr)
 | **Era Reader Verification Key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/era.vkey)
-| **Build From** |  **Latest Pre-Release** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/releases?q=pre-release) 
+| **Build From** |  **Latest Pre-Release** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/releases?q=pre) 
 
 <br/>
 


### PR DESCRIPTION
## Content
This PR includes a fix on the documentation:
- Update the link to the latest pre-release version (broken since we changed the suffix of the pre-release to be `pre`)
- Update the configuration of the Mithril relay to use block producer internal IP in the `src` ACL configuration (instead of relay internal IP)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)
