### PR TITLE
CI: Build linux binaries using ubuntu 20-04 and add vulnerabilities check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}
+          cache-version: 20.04-${{ secrets.CACHE_VERSION }}
           cargo-tools: cargo-deb
 
       # We separate the build in 2 steps as we want to avoid side effects with Rust feature unification.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   build-ubuntu-X64:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     outputs:
       eras: ${{ steps.eras-test-lab.outputs.eras }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,9 @@ jobs:
         if: success() || failure()
         shell: bash
         run: cargo sort -w -c
+      
+      - name: Dependency & Vulnerabilities Review
+        uses: actions/dependency-review-action@v3
 
   run-test-lab:
     runs-on: ubuntu-22.04

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-doc",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/docs/root/compiled-binaries.md
+++ b/docs/root/compiled-binaries.md
@@ -6,8 +6,13 @@ hide_table_of_contents: true
 
 ## Download compiled binary
 
-Each Release / Pre-Release distribution comes with pre compiled binaries ready to use or wrapped in a debian package.
+Each Release / Pre-Release distribution comes with pre compiled binaries ready to use or wrapped in a debian package
+for linux¹.
 
-You can download them from the Release / Pre-Release distribution page that depends on the Mithril Network you are targeting.
+You can download them from the Release / Pre-Release distribution page that depends on the Mithril Network you
+are targeting.
 
 These links are available in the **Build From** column of the above **Mithril Networks** table.
+
+¹ The Linux binaries target `glibc`, and have a minimum requirement of `glibc 2.31` (compatible with `Ubuntu 20.04`
+or `Debian Bullseye`). 

--- a/docs/root/compiled-binaries.md
+++ b/docs/root/compiled-binaries.md
@@ -4,8 +4,6 @@ hide_title: true
 hide_table_of_contents: true
 ---
 
-## Download compiled binary
-
 Each Release / Pre-Release distribution comes with pre compiled binaries ready to use or wrapped in a debian package
 for linux¹.
 

--- a/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
@@ -39,8 +39,6 @@ This is the node of the **Mithril Network** responsible for collecting individua
 
 * Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 
-* Ensure SQLite3 library is installed on your system and its version is at least `3.40`. Run `sqlite3 --version` to check your version.
-
 ## Download source
 
 Download from GitHub (HTTPS)

--- a/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
@@ -370,6 +370,8 @@ If you want to dig deeper, you can get access to several level of logs from the 
 :::
 
 
+## Download pre-built binary
+
 <CompiledBinaries />
 
 ## Build and run Docker container

--- a/docs/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-client.md
@@ -184,6 +184,8 @@ If you want to dig deeper, you can get access to several level of logs from the 
 
 :::
 
+## Download pre-built binary
+
 <CompiledBinaries />
 
 ## Run Docker container

--- a/docs/root/manual/developer-docs/nodes/mithril-signer.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-signer.md
@@ -41,8 +41,6 @@ This is the node of the **Mithril Network** responsible for producing individual
 
 * Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 
-* Ensure SQLite3 library is installed on your system and its version is at least `3.35` (released Apr. 2021) on Debian/Ubuntu: `apt install libsqlite3` and `sqlite3 --version`.
-
 ## Download source
 
 Download from GitHub (HTTPS)

--- a/docs/root/manual/developer-docs/nodes/mithril-signer.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-signer.md
@@ -168,6 +168,8 @@ If you want to dig deeper, you can get access to several level of logs from the 
 
 :::
 
+## Download pre-built binary
+
 <CompiledBinaries />
 
 ## Build and run Docker container

--- a/docs/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/root/manual/getting-started/bootstrap-cardano-node.md
@@ -156,6 +156,8 @@ If you want to dig deeper, you can get access to several level of logs from the 
 
 :::
 
+## Download pre-built binary
+
 <CompiledBinaries />
 
 ## Run Docker container

--- a/docs/root/manual/getting-started/run-mithril-devnet.md
+++ b/docs/root/manual/getting-started/run-mithril-devnet.md
@@ -39,8 +39,6 @@ More information about this private Cardano/Mithril `devnet` is available [here]
 
 * Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 
-* Ensure SQLite3 library is installed on your system and its version is at least  `3.40`. Run `sqlite3 --version` to check your version.
-
 ## Download source
 
 Download from GitHub (HTTPS)

--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -139,6 +139,8 @@ Build executable
 make build
 ```
 
+### Download pre-built binary
+
 <CompiledBinaries />
 
 ### Verify binary

--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -81,8 +81,6 @@ This guide is working only on a Linux machine.
 
 * Install OpenSSL development libraries, for example on Ubuntu/Debian/Mint run `apt install libssl-dev`
 
-* Ensure the SQLite3 version is at least `3.35` (released Apr. 2021)
-
 * Install a recent version of `jq` (version `1.6+`) `apt install jq`
 
 * Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version `5.2+`) `apt install squid`

--- a/docs/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-client.md
@@ -184,6 +184,8 @@ If you want to dig deeper, you can get access to several level of logs from the 
 
 :::
 
+## Download pre-built binary
+
 <CompiledBinaries />
 
 ## Run Docker container

--- a/mithril-aggregator/Dockerfile
+++ b/mithril-aggregator/Dockerfile
@@ -1,17 +1,7 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM ubuntu:20.04 AS rustbuilder
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Upgrade and install build base
-RUN apt-get update && apt-get install -y libssl-dev curl wget build-essential pkg-config make m4
-
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN cargo --version
+FROM rust:bullseye AS rustbuilder
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-aggregator/Dockerfile
+++ b/mithril-aggregator/Dockerfile
@@ -1,7 +1,9 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM ubuntu:22.04 AS rustbuilder
+FROM ubuntu:20.04 AS rustbuilder
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # Upgrade and install build base
 RUN apt-get update && apt-get install -y libssl-dev curl wget build-essential pkg-config make m4
@@ -37,7 +39,7 @@ RUN /app/target/release/mithril-aggregator --version
 ###############################
 # STEP 2: build a small image
 ###############################
-FROM ubuntu:22.04
+FROM debian:11-slim
 
 # Args
 ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.1/cardano-node-8.1.1-linux.tar.gz

--- a/mithril-aggregator/Dockerfile.ci
+++ b/mithril-aggregator/Dockerfile.ci
@@ -1,13 +1,13 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-aggregator executable has been built
 # on a debian-compatible x86-64 environment
-FROM ubuntu:22.04
+FROM debian:11-slim
 
 # Args
 ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.1/cardano-node-8.1.1-linux.tar.gz
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-client/Dockerfile
+++ b/mithril-client/Dockerfile
@@ -1,17 +1,7 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM ubuntu:20.04 AS rustbuilder
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Upgrade and install build base
-RUN apt-get update && apt-get install -y libssl-dev curl wget build-essential pkg-config make m4
-
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN cargo --version
+FROM rust:bullseye AS rustbuilder
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-client/Dockerfile
+++ b/mithril-client/Dockerfile
@@ -1,7 +1,9 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM ubuntu:22.04 AS rustbuilder
+FROM ubuntu:20.04 AS rustbuilder
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # Upgrade and install build base
 RUN apt-get update && apt-get install -y libssl-dev curl wget build-essential pkg-config make m4
@@ -37,10 +39,10 @@ RUN /app/target/release/mithril-client --version
 ###############################
 # STEP 2: build a small image
 ###############################
-FROM ubuntu:22.04
+FROM debian:11-slim
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
 
 # Import the user and group files from the builder
 COPY --from=rustbuilder /etc/passwd /etc/passwd

--- a/mithril-client/Dockerfile.ci
+++ b/mithril-client/Dockerfile.ci
@@ -1,10 +1,10 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-client executable has been built
 # on a debian-compatible x86-64 environment
-FROM ubuntu:22.04
+FROM debian:11-slim
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
 
 # Create appuser
 RUN adduser --disabled-password appuser

--- a/mithril-signer/Dockerfile
+++ b/mithril-signer/Dockerfile
@@ -1,17 +1,7 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM ubuntu:20.04 AS rustbuilder
-
-ENV DEBIAN_FRONTEND noninteractive
-
-# Upgrade and install build base
-RUN apt-get update && apt-get install -y libssl-dev curl wget build-essential pkg-config make m4
-
-# Install Rust
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-RUN cargo --version
+FROM rust:bullseye AS rustbuilder
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-signer/Dockerfile
+++ b/mithril-signer/Dockerfile
@@ -1,7 +1,9 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM ubuntu:22.04 AS rustbuilder
+FROM ubuntu:20.04 AS rustbuilder
+
+ENV DEBIAN_FRONTEND noninteractive
 
 # Upgrade and install build base
 RUN apt-get update && apt-get install -y libssl-dev curl wget build-essential pkg-config make m4
@@ -38,7 +40,7 @@ RUN /app/target/release/mithril-signer --version
 ###############################
 # STEP 2: build a small image
 ###############################
-FROM ubuntu:22.04
+FROM debian:11-slim
 
 # Args
 ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.1/cardano-node-8.1.1-linux.tar.gz

--- a/mithril-signer/Dockerfile.ci
+++ b/mithril-signer/Dockerfile.ci
@@ -1,13 +1,13 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-signer executable has been built
 # on a debian-compatible x86-64 environment
-FROM ubuntu:22.04
+FROM debian:11-slim
 
 # Args
 ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.1/cardano-node-8.1.1-linux.tar.gz
 
 # Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser


### PR DESCRIPTION
## Content
This PR changes the ubuntu version used to build the linux binaries in order to depends on a earlier version of glibc (2.31 instead of 2.35) to be compatible with more systems.
The minimum required version is now stated in the documentation. 

It also add the [dependency-review](https://github.com/marketplace/actions/dependency-review) action to our check step. 

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
This PR also update the documentation regarding the fact that sqlite is not required anymore to build & run the binaries (see #837). 

## Issue(s)
Closes #874, Closes #1037, Relates to #834 and #837
