### PR TITLE
Factorize crypto operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.50"
+version = "0.3.51"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.18"
+version = "0.3.19"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.77"
+version = "0.2.78"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
 name = "mithril-common"
 version = "0.2.77"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bech32",
  "blake2 0.10.6",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.50"
+version = "0.3.51"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/certifier_service.rs
+++ b/mithril-aggregator/src/certifier_service.rs
@@ -338,8 +338,7 @@ impl CertifierService for MithrilCertifierService {
             open_message.protocol_message.clone(),
             multi_signer
                 .compute_stake_distribution_aggregate_verification_key()
-                .await?
-                .unwrap(),
+                .await?,
             multi_signature,
             "".to_string(),
         );

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -76,8 +76,4 @@ pub enum RunnerError {
     /// Missing protocol parameters
     #[error("Missing protocol parameters: '{0}'.")]
     MissingProtocolParameters(String),
-
-    /// Missing next aggregate verification key
-    #[error("Missing next aggregate verification key: '{0}'.")]
-    MissingNextAggregateVerificationKey(String),
 }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -412,12 +412,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             ProtocolMessagePartKey::NextAggregateVerificationKey,
             multi_signer
                 .compute_next_stake_distribution_aggregate_verification_key()
-                .await?
-                .ok_or_else(|| {
-                    RunnerError::MissingNextAggregateVerificationKey(format!(
-                        "Next aggregate verification key could not be computed for signer endity type {signed_entity_type:?}"
-                    ))
-                })?,
+                .await?,
         );
 
         Ok(protocol_message)

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -83,8 +83,7 @@ impl GenesisTools {
 
         let genesis_avk = multi_signer
             .compute_next_stake_distribution_aggregate_verification_key()
-            .await?
-            .ok_or_else(|| "Genesis AVK computation failed".to_string())?;
+            .await?;
         let genesis_avk: ProtocolAggregateVerificationKey = key_decode_hex(&genesis_avk)?;
 
         Ok(Self::new(

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.18"
+version = "0.3.19"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/services/mithril_stake_distribution.rs
+++ b/mithril-client/src/services/mithril_stake_distribution.rs
@@ -1,19 +1,18 @@
+use async_trait::async_trait;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-
-use async_trait::async_trait;
 use thiserror::Error;
 
 use mithril_common::{
     certificate_chain::CertificateVerifier,
     crypto_helper::{
-        key_decode_hex, key_encode_hex, ProtocolClerk, ProtocolGenesisVerifier,
-        ProtocolKeyRegistration,
+        key_decode_hex, key_encode_hex, ProtocolAggregateVerificationKey, ProtocolGenesisVerifier,
     },
     entities::{MithrilStakeDistribution, ProtocolMessagePartKey},
     messages::MithrilStakeDistributionListItemMessage,
+    protocol::SignerBuilder,
     StdError, StdResult,
 };
 
@@ -89,54 +88,18 @@ impl AppMithrilStakeDistributionService {
         }
     }
 
-    // This method is shamefully copied from the Aggregator's multisigner. This
-    // WILL be refactored in a hopefully clean API in Common lib.
-    // TODO: Create a structure to handle message verification.
-    async fn create_clerk(
+    async fn compute_avk_from_mithril_stake_distribution(
         &self,
         stake_distribution: &MithrilStakeDistribution,
-    ) -> StdResult<Option<ProtocolClerk>> {
-        let stakes: Vec<(String, u64)> = stake_distribution
-            .signers_with_stake
-            .iter()
-            .map(|signer| (signer.party_id.clone(), signer.stake))
-            .collect();
-        let mut key_registration = ProtocolKeyRegistration::init(&stakes);
-        let mut total_signers = 0;
+    ) -> StdResult<ProtocolAggregateVerificationKey> {
+        let signer_builder = SignerBuilder::new(
+            &stake_distribution.signers_with_stake,
+            &stake_distribution.protocol_parameters,
+        )?;
 
-        for signer in &stake_distribution.signers_with_stake {
-            let operational_certificate = match &signer.operational_certificate {
-                Some(operational_certificate) => key_decode_hex(operational_certificate)?,
-                _ => None,
-            };
-            let verification_key = key_decode_hex(&signer.verification_key)?;
-            let kes_signature = match &signer.verification_key_signature {
-                Some(verification_key_signature) => {
-                    Some(key_decode_hex(verification_key_signature)?)
-                }
-                _ => None,
-            };
-            let kes_period = signer.kes_period;
-            key_registration.register(
-                Some(signer.party_id.to_owned()),
-                operational_certificate,
-                kes_signature,
-                kes_period,
-                verification_key,
-            )?;
-            total_signers += 1;
-        }
-
-        match total_signers {
-            0 => Ok(None),
-            _ => {
-                let closed_registration = key_registration.close();
-                Ok(Some(ProtocolClerk::from_registration(
-                    &stake_distribution.protocol_parameters.clone().into(),
-                    &closed_registration,
-                )))
-            }
-        }
+        Ok(signer_builder
+            .build_multi_signer()
+            .compute_aggregate_verification_key())
     }
 }
 
@@ -187,17 +150,10 @@ impl MithrilStakeDistributionService for AppMithrilStakeDistributionService {
             )
             .await?;
 
-        let clerk = self
-            .create_clerk(&stake_distribution_entity.artifact)
-            .await?
-            .ok_or_else(|| {
-                MithrilStakeDistributionServiceError::CouldNotVerifyStakeDistribution {
-                    hash: hash.to_owned(),
-                    certificate_hash: certificate.hash.clone(),
-                    context: "Cannot verify an empty stake distribution".to_string(),
-                }
-            })?;
-        let avk = key_encode_hex(clerk.compute_avk())?;
+        let avk = key_encode_hex(
+            self.compute_avk_from_mithril_stake_distribution(&stake_distribution_entity.artifact)
+                .await?,
+        )?;
         let mut protocol_message = certificate.protocol_message.clone();
         protocol_message
             .set_message_part(ProtocolMessagePartKey::NextAggregateVerificationKey, avk);

--- a/mithril-client/src/services/mithril_stake_distribution.rs
+++ b/mithril-client/src/services/mithril_stake_distribution.rs
@@ -97,9 +97,7 @@ impl AppMithrilStakeDistributionService {
             &stake_distribution.protocol_parameters,
         )?;
 
-        Ok(signer_builder
-            .build_multi_signer()
-            .compute_aggregate_verification_key())
+        Ok(signer_builder.compute_aggregate_verification_key())
     }
 }
 

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -16,6 +16,7 @@ name = "digester"
 harness = false
 
 [dependencies]
+anyhow = "1.0.71"
 async-trait = "0.1.52"
 bech32 = "0.9.1"
 blake2 = "0.10.4"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.77"
+version = "0.2.78"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/crypto_helper/types.rs
+++ b/mithril-common/src/crypto_helper/types.rs
@@ -3,11 +3,14 @@ use crate::crypto_helper::cardano::{
     StmInitializerWrapper,
 };
 
-use mithril_stm::stm::{
-    Index, Stake, StmAggrSig, StmAggrVerificationKey, StmClerk, StmParameters, StmSig, StmSigner,
-    StmVerificationKeyPoP,
+use mithril_stm::{
+    key_reg::ClosedKeyReg,
+    stm::{
+        Index, Stake, StmAggrSig, StmAggrVerificationKey, StmClerk, StmParameters, StmSig,
+        StmSigner, StmVerificationKeyPoP,
+    },
+    AggregationError,
 };
-use mithril_stm::AggregationError;
 
 use blake2::{digest::consts::U32, Blake2b};
 use ed25519_dalek;
@@ -45,6 +48,9 @@ pub type ProtocolClerk = StmClerk<D>;
 
 /// Alias of a wrapper of [MithrilStm:KeyReg](struct@mithril_stm::key_reg::KeyReg).
 pub type ProtocolKeyRegistration = KeyRegWrapper;
+
+/// Alias of a wrapper of [MithrilStm:ClosedKeyReg](struct@mithril_stm::key_reg::KeyReg).
+pub type ProtocolClosedKeyRegistration = ClosedKeyReg<D>;
 
 /// Alias of [MithrilStm:StmSig](struct@mithril_stm::stm::StmSig).
 pub type ProtocolSingleSignature = StmSig;

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -21,6 +21,7 @@ pub mod entities;
 #[macro_use]
 pub mod era;
 pub mod messages;
+pub mod protocol;
 pub mod signable_builder;
 pub mod sqlite;
 pub mod store;

--- a/mithril-common/src/protocol/mod.rs
+++ b/mithril-common/src/protocol/mod.rs
@@ -1,5 +1,9 @@
 //! Todo: module doc
 
+mod multi_signer;
 mod signer_builder;
+mod single_signer;
 
-pub use signer_builder::*;
+pub use multi_signer::MultiSigner;
+pub use signer_builder::{SignerBuilder, SignerBuilderError};
+pub use single_signer::SingleSigner;

--- a/mithril-common/src/protocol/mod.rs
+++ b/mithril-common/src/protocol/mod.rs
@@ -1,0 +1,5 @@
+//! Todo: module doc
+
+mod signer_builder;
+
+pub use signer_builder::*;

--- a/mithril-common/src/protocol/mod.rs
+++ b/mithril-common/src/protocol/mod.rs
@@ -1,4 +1,8 @@
-//! Todo: module doc
+//! Protocol module
+//!
+//! This module contains types that standardize and make easier mithril protocol operations
+//! such as issuing single signatures, aggregating them as multi-signatures or computing
+//! aggregate verification keys.
 
 mod multi_signer;
 mod signer_builder;

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -1,4 +1,299 @@
-pub struct MultiSigner;
+use anyhow::{anyhow, Context, Result};
+use mithril_stm::stm::StmParameters;
+
+use crate::{
+    crypto_helper::{
+        ProtocolAggregateVerificationKey, ProtocolAggregationError, ProtocolClerk,
+        ProtocolMultiSignature, ProtocolSingleSignature,
+    },
+    entities::{ProtocolMessage, SingleSignatures},
+};
+
+/// MultiSigner is the cryptographic engine in charge of producing multi-signatures from individual signatures
+pub struct MultiSigner {
+    protocol_clerk: ProtocolClerk,
+    protocol_parameters: StmParameters,
+}
+
+impl MultiSigner {
+    pub(super) fn new(protocol_clerk: ProtocolClerk, protocol_parameters: StmParameters) -> Self {
+        Self {
+            protocol_clerk,
+            protocol_parameters,
+        }
+    }
+
+    /// Aggregate the given single signatures into a multi-signature
+    pub fn aggregate_single_signatures(
+        &self,
+        single_signatures: &[SingleSignatures],
+        protocol_message: &ProtocolMessage,
+    ) -> Result<ProtocolMultiSignature, ProtocolAggregationError> {
+        let protocol_signatures: Vec<ProtocolSingleSignature> = single_signatures
+            .iter()
+            .filter_map(|single_signature| single_signature.to_protocol_signature().ok())
+            .collect::<Vec<_>>();
+
+        self.protocol_clerk.aggregate(
+            &protocol_signatures,
+            protocol_message.compute_hash().as_bytes(),
+        )
+    }
+
+    /// Compute aggregate verification key from stake distribution
+    pub fn compute_aggregate_verification_key(&self) -> ProtocolAggregateVerificationKey {
+        self.protocol_clerk.compute_avk()
+    }
+
+    /// Verify a single signature
+    pub fn verify_single_signature(
+        &self,
+        message: &ProtocolMessage,
+        single_signature: &SingleSignatures,
+    ) -> Result<()> {
+        let protocol_signature = single_signature
+            .to_protocol_signature()
+            .map_err(|e| anyhow!(e))
+            .with_context(|| {
+                format!(
+                    "Error while decoding single signature for party: '{}'",
+                    single_signature.party_id
+                )
+            })?;
+
+        let avk = self.compute_aggregate_verification_key();
+
+        // If there is no reg_party, then we simply received a signature from a non-registered
+        // party, and we can ignore the request.
+        let (vk, stake) = self
+            .protocol_clerk
+            .get_reg_party(&protocol_signature.signer_index)
+            .ok_or_else(|| {
+                anyhow!(format!(
+                    "Unregistered party: '{}'",
+                    single_signature.party_id
+                ))
+            })?;
+
+        protocol_signature
+            .verify(
+                &self.protocol_parameters,
+                &vk,
+                &stake,
+                &avk,
+                message.compute_hash().as_bytes(),
+            )
+            .map_err(|e| anyhow!(e))
+            .with_context(|| {
+                format!(
+                    "Invalid signature for party: '{}'",
+                    single_signature.party_id
+                )
+            })?;
+
+        Ok(())
+    }
+}
 
 #[cfg(test)]
-mod test {}
+mod test {
+    use crate::{
+        entities::{ProtocolMessagePartKey, ProtocolParameters},
+        protocol::SignerBuilder,
+        test_utils::{MithrilFixture, MithrilFixtureBuilder, StakeDistributionGenerationMethod},
+    };
+
+    use super::*;
+
+    fn build_multi_signer(fixture: &MithrilFixture) -> MultiSigner {
+        SignerBuilder::new(
+            &fixture.signers_with_stake(),
+            &fixture.protocol_parameters(),
+        )
+        .unwrap()
+        .build_multi_signer()
+    }
+
+    #[test]
+    fn cant_aggregate_if_signatures_list_empty() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let multi_signer = build_multi_signer(&fixture);
+        let message = ProtocolMessage::default();
+
+        let error = multi_signer
+            .aggregate_single_signatures(&[], &message)
+            .expect_err(
+                "Multi-signature should not be created with an empty single signatures list",
+            );
+
+        assert!(
+            matches!(error, ProtocolAggregationError::NotEnoughSignatures(_, _)),
+            "Expected ProtocolAggregationError::NotEnoughSignatures, got: {error:?}"
+        )
+    }
+
+    #[test]
+    fn cant_aggregate_if_no_valid_signatures_given() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
+        let multi_signer = build_multi_signer(&fixture);
+        let message = ProtocolMessage::default();
+        let mut sig = fixture
+            .signers_fixture()
+            .first()
+            .unwrap()
+            .sign(&message)
+            .unwrap();
+        sig.signature = "invalid".to_string();
+
+        let error = multi_signer
+            .aggregate_single_signatures(&[sig], &message)
+            .expect_err("Multi-signature should not be created if no valid signatures given");
+
+        assert!(
+            matches!(error, ProtocolAggregationError::NotEnoughSignatures(_, _)),
+            "Expected ProtocolAggregationError::NotEnoughSignatures, got: {error:?}"
+        )
+    }
+
+    #[test]
+    fn can_aggregate_if_valid_signatures_and_quorum_reached() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(10).build();
+        let multi_signer = build_multi_signer(&fixture);
+        let message = ProtocolMessage::default();
+        let signatures: Vec<SingleSignatures> = fixture
+            .signers_fixture()
+            .iter()
+            .map(|s| s.sign(&message).unwrap())
+            .collect();
+
+        multi_signer
+            .aggregate_single_signatures(&signatures, &message)
+            .expect("Multi-signature should be created");
+    }
+
+    #[test]
+    fn can_aggregate_even_with_one_invalid_signature_if_the_other_are_enough_for_the_quorum() {
+        let fixture = MithrilFixtureBuilder::default()
+            .with_signers(10)
+            .with_stake_distribution(StakeDistributionGenerationMethod::Uniform(20))
+            .with_protocol_parameters(ProtocolParameters::new(6, 200, 1.0))
+            .build();
+        let multi_signer = build_multi_signer(&fixture);
+        let message = ProtocolMessage::default();
+        let mut signatures: Vec<SingleSignatures> = fixture
+            .signers_fixture()
+            .iter()
+            .map(|s| s.sign(&message).unwrap())
+            .collect();
+        signatures[4].signature = "invalid".to_string();
+
+        multi_signer
+            .aggregate_single_signatures(&signatures, &message)
+            .expect("Multi-signature should be created even with one invalid signature");
+    }
+
+    #[test]
+    fn verify_single_signature_fail_if_given_signature_is_invalid() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
+        let multi_signer = build_multi_signer(&fixture);
+        let message = ProtocolMessage::default();
+        let mut single_signature = fixture
+            .signers_fixture()
+            .first()
+            .unwrap()
+            .sign(&message)
+            .unwrap();
+
+        single_signature.signature = "invalid".to_string();
+
+        let error = multi_signer
+            .verify_single_signature(&message, &single_signature)
+            .expect_err("Verify single signature should fail");
+
+        assert!(
+            error
+                .to_string()
+                .contains("Error while decoding single signature for party"),
+            "Expected decoding single signature error, got: {error}, cause: {}",
+            error.root_cause()
+        )
+    }
+
+    #[test]
+    fn verify_single_signature_fail_if_signature_signer_isnt_in_the_registered_parties() {
+        let multi_signer = build_multi_signer(
+            &MithrilFixtureBuilder::default()
+                .with_signers(1)
+                .with_stake_distribution(StakeDistributionGenerationMethod::RandomDistribution {
+                    seed: [3u8; 32],
+                })
+                .build(),
+        );
+        let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
+        let message = ProtocolMessage::default();
+        let single_signature = fixture
+            .signers_fixture()
+            .last()
+            .unwrap()
+            .sign(&message)
+            .unwrap();
+
+        // Will fail because the single signature was issued by a signer from a stake distribution
+        // that is not the one used by the multi-signer.
+        let error = multi_signer
+            .verify_single_signature(&message, &single_signature)
+            .expect_err(
+                "Verify single signature should fail if the signer isn't in the registered parties",
+            );
+
+        assert!(
+            error.to_string().contains("Invalid signature for party"),
+            "Expected invalid signature of party error, got: {error}, cause: {}",
+            error.root_cause()
+        )
+    }
+
+    #[test]
+    fn verify_single_signature_fail_if_signature_signed_message_isnt_the_given_one() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
+        let multi_signer = build_multi_signer(&fixture);
+        let mut signed_message = ProtocolMessage::default();
+        signed_message.set_message_part(
+            ProtocolMessagePartKey::SnapshotDigest,
+            "a_digest".to_string(),
+        );
+        let single_signature = fixture
+            .signers_fixture()
+            .first()
+            .unwrap()
+            .sign(&signed_message)
+            .unwrap();
+
+        let error = multi_signer
+            .verify_single_signature(&ProtocolMessage::default(), &single_signature)
+            .expect_err("Verify single signature should fail");
+
+        assert!(
+            error.to_string().contains("Invalid signature for party"),
+            "Expected invalid signature of party error, got: {error}, cause: {}",
+            error.root_cause()
+        )
+    }
+
+    #[test]
+    fn can_verify_valid_single_signature() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
+        let multi_signer = build_multi_signer(&fixture);
+        let message = ProtocolMessage::default();
+        let single_signature = fixture
+            .signers_fixture()
+            .first()
+            .unwrap()
+            .sign(&message)
+            .unwrap();
+
+        multi_signer
+            .verify_single_signature(&message, &single_signature)
+            .expect("Verify single signature should succeed");
+    }
+}

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -1,0 +1,4 @@
+pub struct MultiSigner;
+
+#[cfg(test)]
+mod test {}

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -1,0 +1,189 @@
+use anyhow::{anyhow, Context, Result};
+use thiserror::Error;
+
+use crate::{
+    crypto_helper::{
+        key_decode_hex, OpCert, ProtocolClosedKeyRegistration, ProtocolKeyRegistration,
+        ProtocolSignerVerificationKey, ProtocolSignerVerificationKeySignature,
+        ProtocolStakeDistribution,
+    },
+    entities::{ProtocolParameters, SignerWithStake},
+};
+
+/// Allow to build Single Or Multi signers to generate a single signature or aggregate them
+#[derive(Debug)]
+pub struct SignerBuilder {
+    protocol_parameters: ProtocolParameters,
+    closed_key_registration: ProtocolClosedKeyRegistration,
+}
+
+/// [SignerBuilder] specific errors
+#[derive(Debug, Error)]
+pub enum SignerBuilderError {
+    /// Error raised when the list of signers given to the builder is empty
+    #[error("The list of signers must not be empty to create a signer builder.")]
+    EmptySigners,
+}
+
+impl SignerBuilder {
+    /// [SignerBuilder] constructor.
+    pub fn new(
+        registered_signers: &[SignerWithStake],
+        protocol_parameters: &ProtocolParameters,
+    ) -> Result<Self> {
+        if registered_signers.is_empty() {
+            return Err(SignerBuilderError::EmptySigners.into());
+        }
+
+        let stake_distribution = registered_signers
+            .iter()
+            .map(|s| s.into())
+            .collect::<ProtocolStakeDistribution>();
+        let mut key_registration = ProtocolKeyRegistration::init(&stake_distribution);
+
+        for signer in registered_signers {
+            let signer_keys =
+                SignerCryptographicKeys::decode_from_signer(signer).with_context(|| {
+                    format!(
+                        "Invalid signers in stake distribution: '{}'",
+                        signer.party_id
+                    )
+                })?;
+            key_registration
+                .register(
+                    Some(signer.party_id.to_owned()),
+                    signer_keys.operational_certificate,
+                    signer_keys.kes_signature,
+                    signer_keys.kes_period,
+                    signer_keys.verification_key,
+                )
+                .with_context(|| {
+                    format!("Registration failed for signer: '{}'", signer.party_id)
+                })?;
+        }
+
+        let closed_registration = key_registration.close();
+        Ok(Self {
+            protocol_parameters: protocol_parameters.clone(),
+            closed_key_registration: closed_registration,
+        })
+    }
+}
+
+struct SignerCryptographicKeys {
+    pub operational_certificate: Option<OpCert>,
+    pub verification_key: ProtocolSignerVerificationKey,
+    pub kes_signature: Option<ProtocolSignerVerificationKeySignature>,
+    pub kes_period: Option<u32>,
+}
+
+impl SignerCryptographicKeys {
+    fn decode_from_signer(signer: &SignerWithStake) -> Result<Self> {
+        let operational_certificate = match &signer.operational_certificate {
+            Some(operational_certificate) => key_decode_hex(operational_certificate)
+                .map_err(|e| anyhow!(e))
+                .with_context(|| "Could not decode operational certificate".to_string())?,
+            _ => None,
+        };
+        let verification_key = key_decode_hex(&signer.verification_key)
+            .map_err(|e| anyhow!(e))
+            .with_context(|| "Could not decode verification key".to_string())?;
+        let kes_signature = match &signer.verification_key_signature {
+            Some(verification_key_signature) => Some(
+                key_decode_hex(verification_key_signature)
+                    .map_err(|e| anyhow!(e))
+                    .with_context(|| "Could not decode verification key signature".to_string())?,
+            ),
+            _ => None,
+        };
+
+        Ok(Self {
+            operational_certificate,
+            verification_key,
+            kes_signature,
+            kes_period: signer.kes_period,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::test_utils::{fake_data, MithrilFixtureBuilder};
+
+    use super::*;
+
+    #[test]
+    fn cant_construct_signer_builder_with_an_empty_signers_list() {
+        let signers = vec![];
+        let protocol_parameters = fake_data::protocol_parameters();
+
+        let error = SignerBuilder::new(&signers, &protocol_parameters).expect_err(
+            "We should not be able to construct a signer builder with an empty signers list",
+        );
+
+        match error.downcast_ref::<SignerBuilderError>() {
+            Some(SignerBuilderError::EmptySigners) => (),
+            None => panic!("Expected an EmptySigners error, got: {error}"),
+        }
+    }
+
+    #[test]
+    fn cant_construct_signer_builder_with_a_signer_with_invalid_keys() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let mut signers = fixture.signers_with_stake();
+        signers[2].operational_certificate = Some("invalid".to_string());
+
+        let error = SignerBuilder::new(&signers, &fixture.protocol_parameters()).expect_err(
+            "We should not be able to construct a signer builder with a signer with invalid keys",
+        );
+
+        assert!(
+            error
+                .to_string()
+                .contains("Invalid signers in stake distribution"),
+            "Expected Invalid signers error, got: {}, cause: {}",
+            error,
+            error.root_cause()
+        );
+    }
+
+    #[test]
+    fn cant_construct_signer_builder_if_a_signer_registration_fail() {
+        // To make this test fail we try to build a SignerBuilder with signers from two
+        // different stake distributions, this will pass the individual check but not the
+        // register check.
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let fixture_with_another_stake_distribution = MithrilFixtureBuilder::default()
+            .with_signers(1)
+            .with_stake_distribution(
+                crate::test_utils::StakeDistributionGenerationMethod::RandomDistribution {
+                    seed: [4u8; 32],
+                },
+            )
+            .build();
+        let mut signers = fixture.signers_with_stake();
+        signers.append(&mut fixture_with_another_stake_distribution.signers_with_stake());
+
+        let error = SignerBuilder::new(&signers, &fixture.protocol_parameters()).expect_err(
+            "We should not be able to construct a signer builder if a signer registration fail",
+        );
+
+        assert!(
+            error.to_string().contains("Registration failed for signer"),
+            "Expected Registration error, got: {}, cause: {}",
+            error,
+            error.root_cause()
+        );
+    }
+
+    #[test]
+    fn can_construct_signer_builder_with_valid_signers() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+
+        SignerBuilder::new(
+            &fixture.signers_with_stake(),
+            &fixture.protocol_parameters(),
+        )
+        .expect("We should be able to construct a signer builder with valid signers");
+    }
+}

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -3,11 +3,12 @@ use thiserror::Error;
 
 use crate::{
     crypto_helper::{
-        key_decode_hex, OpCert, ProtocolClosedKeyRegistration, ProtocolKeyRegistration,
-        ProtocolSignerVerificationKey, ProtocolSignerVerificationKeySignature,
-        ProtocolStakeDistribution,
+        key_decode_hex, OpCert, ProtocolClerk, ProtocolClosedKeyRegistration,
+        ProtocolKeyRegistration, ProtocolSignerVerificationKey,
+        ProtocolSignerVerificationKeySignature, ProtocolStakeDistribution,
     },
     entities::{ProtocolParameters, SignerWithStake},
+    protocol::MultiSigner,
 };
 
 /// Allow to build Single Or Multi signers to generate a single signature or aggregate them
@@ -67,6 +68,10 @@ impl SignerBuilder {
             protocol_parameters: protocol_parameters.clone(),
             closed_key_registration: closed_registration,
         })
+    }
+
+    pub fn build_multi_signer(&self) -> MultiSigner {
+        todo!()
     }
 }
 

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -4,6 +4,7 @@ use rand_core::{CryptoRng, RngCore, SeedableRng};
 use std::path::Path;
 use thiserror::Error;
 
+use crate::crypto_helper::ProtocolAggregateVerificationKey;
 use crate::{
     crypto_helper::{
         key_decode_hex, OpCert, ProtocolClerk, ProtocolClosedKeyRegistration, ProtocolInitializer,
@@ -82,6 +83,15 @@ impl SignerBuilder {
             ProtocolClerk::from_registration(&stm_parameters, &self.closed_key_registration);
 
         MultiSigner::new(clerk, stm_parameters)
+    }
+
+    /// Compute aggregate verification key from stake distribution
+    pub fn compute_aggregate_verification_key(&self) -> ProtocolAggregateVerificationKey {
+        let stm_parameters = self.protocol_parameters.clone().into();
+        let clerk =
+            ProtocolClerk::from_registration(&stm_parameters, &self.closed_key_registration);
+
+        clerk.compute_avk()
     }
 
     fn build_single_signer_with_rng<R: RngCore + CryptoRng>(

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -70,8 +70,13 @@ impl SignerBuilder {
         })
     }
 
+    /// Build a [MultiSigner] based on the registered parties
     pub fn build_multi_signer(&self) -> MultiSigner {
-        todo!()
+        let stm_parameters = self.protocol_parameters.clone().into();
+        let clerk =
+            ProtocolClerk::from_registration(&stm_parameters, &self.closed_key_registration);
+
+        MultiSigner::new(clerk, stm_parameters)
     }
 }
 

--- a/mithril-common/src/protocol/single_signer.rs
+++ b/mithril-common/src/protocol/single_signer.rs
@@ -1,0 +1,5 @@
+/// The SingleSigner is the structure responsible of issuing SingleSignatures.
+pub struct SingleSigner;
+
+#[cfg(test)]
+mod test {}

--- a/mithril-common/src/protocol/single_signer.rs
+++ b/mithril-common/src/protocol/single_signer.rs
@@ -1,5 +1,84 @@
-/// The SingleSigner is the structure responsible of issuing SingleSignatures.
-pub struct SingleSigner;
+use anyhow::{anyhow, Context, Result};
+
+use crate::{
+    crypto_helper::{key_encode_hex, ProtocolSigner},
+    entities::{PartyId, ProtocolMessage, SingleSignatures},
+};
+
+/// The SingleSigner is the structure responsible for issuing SingleSignatures.
+#[cfg_attr(test, derive(Debug))]
+pub struct SingleSigner {
+    party_id: PartyId,
+    protocol_signer: ProtocolSigner,
+}
+
+impl SingleSigner {
+    pub(super) fn new(party_id: PartyId, protocol_signer: ProtocolSigner) -> Self {
+        Self {
+            party_id,
+            protocol_signer,
+        }
+    }
+
+    /// Issue a single signature for the given message.
+    ///
+    /// If no lottery are won None will be returned.
+    pub fn sign(&self, message: &ProtocolMessage) -> Result<Option<SingleSignatures>> {
+        match self.protocol_signer.sign(message.compute_hash().as_bytes()) {
+            Some(signature) => {
+                let won_indexes = signature.indexes.clone();
+                let encoded_signature = key_encode_hex(signature)
+                    .map_err(|err| anyhow!(err))
+                    .with_context(|| {
+                        format!(
+                            "Could not encode protocol signature issued by party: {}",
+                            self.party_id
+                        )
+                    })?;
+
+                Ok(Some(SingleSignatures::new(
+                    self.party_id.to_owned(),
+                    encoded_signature,
+                    won_indexes,
+                )))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Return the partyId associated with this Signer.
+    pub fn get_party_id(&self) -> PartyId {
+        self.party_id.clone()
+    }
+}
 
 #[cfg(test)]
-mod test {}
+mod test {
+    use crate::{
+        entities::ProtocolMessage, protocol::SignerBuilder, test_utils::MithrilFixtureBuilder,
+    };
+
+    #[test]
+    fn single_signer_should_be_able_to_issue_single_signature() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let signers = fixture.signers_fixture();
+        let signer = signers.first().unwrap();
+
+        let (single_signer, _) = SignerBuilder::new(
+            &fixture.signers_with_stake(),
+            &fixture.protocol_parameters(),
+        )
+        .unwrap()
+        .build_test_single_signer(
+            signer.signer_with_stake.clone(),
+            signer.kes_secret_key_path(),
+        )
+        .unwrap();
+
+        let signature = single_signer
+            .sign(&ProtocolMessage::default())
+            .expect("Single signer should be able to issue single signature");
+
+        assert!(signature.is_some());
+    }
+}

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -106,11 +106,9 @@ impl MithrilFixture {
 
     /// Compute the Aggregate Verification Key for this fixture.
     pub fn compute_avk(&self) -> ProtocolAggregateVerificationKey {
-        let multi_signer =
-            SignerBuilder::new(&self.signers_with_stake(), &self.protocol_parameters)
-                .unwrap()
-                .build_multi_signer();
-        multi_signer.compute_aggregate_verification_key()
+        SignerBuilder::new(&self.signers_with_stake(), &self.protocol_parameters)
+            .unwrap()
+            .compute_aggregate_verification_key()
     }
 
     /// Compute the Aggregate Verification Key for this fixture and returns it has a [HexEncodedAgregateVerificationKey].

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -1,4 +1,7 @@
-use std::sync::Arc;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use crate::{
     certificate_chain::CertificateGenesisProducer,
@@ -9,7 +12,7 @@ use crate::{
         ProtocolStakeDistribution,
     },
     entities::{
-        Beacon, Certificate, HexEncodedAgregateVerificationKey, ProtocolMessage,
+        Beacon, Certificate, HexEncodedAgregateVerificationKey, PartyId, ProtocolMessage,
         ProtocolParameters, Signer, SignerWithStake, SingleSignatures, StakeDistribution,
     },
 };
@@ -33,6 +36,8 @@ pub struct SignerFixture {
     pub protocol_signer: ProtocolSigner,
     /// A [ProtocolSigner].
     pub protocol_initializer: ProtocolInitializer,
+    /// The path to this signer kes secret key file
+    pub kes_secret_key_path: Option<PathBuf>,
 }
 
 impl From<SignerFixture> for SignerWithStake {
@@ -171,6 +176,11 @@ impl SignerFixture {
             })
     }
 
+    /// Shortcut to get the party id from the inner signer with stake
+    pub fn party_id(&self) -> PartyId {
+        self.signer_with_stake.party_id.clone()
+    }
+
     /// Decode this signer operational certificate if any
     pub fn operational_certificate(&self) -> Option<OpCert> {
         match &self.signer_with_stake.operational_certificate {
@@ -190,5 +200,10 @@ impl SignerFixture {
             .verification_key_signature
             .as_ref()
             .map(|verification_key_signature| key_decode_hex(verification_key_signature).unwrap())
+    }
+
+    /// Get the path to this signer kes secret key
+    pub fn kes_secret_key_path(&self) -> Option<&Path> {
+        self.kes_secret_key_path.as_deref()
     }
 }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.59"
+version = "0.2.60"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -204,7 +204,7 @@ impl Runner for SignerRunner {
             ),
             None => None,
         };
-        let protocol_initializer = MithrilProtocolInitializerBuilder::new().build(
+        let protocol_initializer = MithrilProtocolInitializerBuilder::build(
             stake,
             protocol_parameters,
             self.config.kes_secret_key_path.clone(),
@@ -725,9 +725,13 @@ mod tests {
         let epoch = pending_certificate.beacon.epoch;
         let mut signer = &mut pending_certificate.signers[0];
 
-        let protocol_initializer = MithrilProtocolInitializerBuilder::new()
-            .build(&100, &fake_data::protocol_parameters(), None, None)
-            .expect("build protocol initializer should not fail");
+        let protocol_initializer = MithrilProtocolInitializerBuilder::build(
+            &100,
+            &fake_data::protocol_parameters(),
+            None,
+            None,
+        )
+        .expect("build protocol initializer should not fail");
         signer.verification_key = key_encode_hex(protocol_initializer.verification_key()).unwrap();
         protocol_initializer_store
             .save_protocol_initializer(

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -134,16 +134,15 @@ impl SingleSigner for MithrilSingleSigner {
         signers_with_stake: &[SignerWithStake],
         protocol_initializer: &ProtocolInitializer,
     ) -> Result<Option<String>, SingleSignerError> {
-        let multi_signer = SignerBuilder::new(
+        let signer_builder = SignerBuilder::new(
             signers_with_stake,
             &protocol_initializer.get_protocol_parameters().into(),
         )
         .map_err(|error| {
             SingleSignerError::AggregateVerificationKeyComputationFailed(error.into())
-        })?
-        .build_multi_signer();
+        })?;
 
-        let encoded_avk = key_encode_hex(multi_signer.compute_aggregate_verification_key())
+        let encoded_avk = key_encode_hex(signer_builder.compute_aggregate_verification_key())
             .map_err(SingleSignerError::Codec)?;
 
         Ok(Some(encoded_avk))

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -4,30 +4,23 @@ use std::path::PathBuf;
 use thiserror::Error;
 
 use mithril_common::crypto_helper::{
-    key_decode_hex, key_encode_hex, KESPeriod, ProtocolClerk, ProtocolInitializer,
-    ProtocolInitializerError, ProtocolKeyRegistration, ProtocolPartyId, ProtocolRegistrationError,
-    ProtocolSigner, ProtocolStakeDistribution,
+    key_encode_hex, KESPeriod, ProtocolInitializer, ProtocolInitializerError,
 };
 use mithril_common::entities::{
     PartyId, ProtocolMessage, ProtocolParameters, SignerWithStake, SingleSignatures, Stake,
 };
+use mithril_common::protocol::SignerBuilder;
+use mithril_common::StdError;
 
 #[cfg(test)]
 use mockall::automock;
 
 /// This is responsible of creating new instances of ProtocolInitializer.
-#[derive(Default)]
 pub struct MithrilProtocolInitializerBuilder {}
 
 impl MithrilProtocolInitializerBuilder {
-    /// Create a new MithrilProtocolInitializerBuilder instance.
-    pub fn new() -> Self {
-        Self {}
-    }
-
     /// Create a ProtocolInitializer instance.
     pub fn build(
-        &self,
         stake: &Stake,
         protocol_parameters: &ProtocolParameters,
         kes_secret_key_path: Option<PathBuf>,
@@ -65,35 +58,27 @@ pub trait SingleSigner: Sync + Send {
     ) -> Result<Option<String>, SingleSignerError>;
 
     /// Get party id
-    fn get_party_id(&self) -> ProtocolPartyId;
+    fn get_party_id(&self) -> PartyId;
 }
 
 /// SingleSigner error structure.
-#[derive(Error, Debug, PartialEq, Eq)]
+#[derive(Error, Debug)]
 pub enum SingleSignerError {
-    /// This signer has not registered for this Epoch hence cannot participate to the signature.
-    #[error("the signer verification key is not registered in the stake distribution")]
-    UnregisteredVerificationKey(),
-
-    /// No stake is associated with this signer.
-    #[error("the signer party id is not registered in the stake distribution")]
-    UnregisteredPartyId(),
-
     /// Cryptographic Signer creation error.
     #[error("the protocol signer creation failed: `{0}`")]
     ProtocolSignerCreationFailure(String),
 
-    /// Could not fetch a protocol initializer for this Epoch.
-    #[error("the protocol initializer is missing")]
-    ProtocolInitializerMissing(),
-
-    /// Could not fetch a signer from a protocol initializer.
-    #[error("the protocol initializer is not registered")]
-    ProtocolInitializerNotRegistered(#[from] ProtocolRegistrationError),
-
     /// Encoding / Decoding error.
     #[error("codec error: '{0}'")]
     Codec(String),
+
+    /// Signature Error
+    #[error("Signature Error: {0:?}")]
+    SignatureFailed(StdError),
+
+    /// Avk computation Error
+    #[error("Aggregate verification key computation Error: {0:?}")]
+    AggregateVerificationKeyComputationFailed(StdError),
 }
 
 /// Implementation of the SingleSigner.
@@ -106,83 +91,6 @@ impl MithrilSingleSigner {
     pub fn new(party_id: PartyId) -> Self {
         Self { party_id }
     }
-
-    /// Create a protocol key registration.
-    fn create_protocol_key_registration(
-        &self,
-        signers_with_stake: &[SignerWithStake],
-    ) -> Result<ProtocolKeyRegistration, SingleSignerError> {
-        let signers = signers_with_stake
-            .iter()
-            .filter(|signer| !signer.verification_key.is_empty())
-            .collect::<Vec<&SignerWithStake>>();
-
-        if signers.is_empty() {
-            return Err(SingleSignerError::ProtocolSignerCreationFailure(
-                "no signer".to_string(),
-            ));
-        }
-
-        let stake_distribution = signers
-            .iter()
-            .map(|&s| s.into())
-            .collect::<ProtocolStakeDistribution>();
-        let mut key_reg = ProtocolKeyRegistration::init(&stake_distribution);
-        for s in signers {
-            let operational_certificate = match &s.operational_certificate {
-                Some(operational_certificate) => {
-                    key_decode_hex(operational_certificate).map_err(SingleSignerError::Codec)?
-                }
-                _ => None,
-            };
-            let verification_key =
-                key_decode_hex(&s.verification_key).map_err(SingleSignerError::Codec)?;
-            let kes_signature = match &s.verification_key_signature {
-                Some(verification_key_signature) => Some(
-                    key_decode_hex(verification_key_signature).map_err(SingleSignerError::Codec)?,
-                ),
-                _ => None,
-            };
-            let kes_period = s.kes_period;
-            key_reg
-                .register(
-                    Some(s.party_id.to_owned()),
-                    operational_certificate,
-                    kes_signature,
-                    kes_period,
-                    verification_key,
-                )
-                .map_err(|e| SingleSignerError::ProtocolSignerCreationFailure(e.to_string()))?;
-        }
-        Ok(key_reg)
-    }
-
-    /// Create a protocol signer.
-    fn create_protocol_signer(
-        &self,
-        signers_with_stake: &[SignerWithStake],
-        protocol_initializer: &ProtocolInitializer,
-    ) -> Result<ProtocolSigner, SingleSignerError> {
-        let key_reg = self.create_protocol_key_registration(signers_with_stake)?;
-        let closed_reg = key_reg.close();
-
-        Ok(protocol_initializer.to_owned().new_signer(closed_reg)?)
-    }
-
-    /// Create a cryptographic clerk.
-    fn create_protocol_clerk(
-        &self,
-        signers_with_stake: &[SignerWithStake],
-        protocol_initializer: &ProtocolInitializer,
-    ) -> Result<ProtocolClerk, SingleSignerError> {
-        let key_reg = self.create_protocol_key_registration(signers_with_stake)?;
-        let closed_reg = key_reg.close();
-
-        Ok(ProtocolClerk::from_registration(
-            &protocol_initializer.get_protocol_parameters(),
-            &closed_reg,
-        ))
-    }
 }
 
 impl SingleSigner for MithrilSingleSigner {
@@ -192,34 +100,32 @@ impl SingleSigner for MithrilSingleSigner {
         signers_with_stake: &[SignerWithStake],
         protocol_initializer: &ProtocolInitializer,
     ) -> Result<Option<SingleSignatures>, SingleSignerError> {
-        let protocol_signer =
-            self.create_protocol_signer(signers_with_stake, protocol_initializer)?;
-        let message = protocol_message.compute_hash().as_bytes().to_vec();
-
+        let builder = SignerBuilder::new(
+            signers_with_stake,
+            &protocol_initializer.get_protocol_parameters().into(),
+        )
+        .map_err(|e| SingleSignerError::ProtocolSignerCreationFailure(e.to_string()))?;
         info!("Signing protocol message"; "protocol_message" =>  #?protocol_message, "signed message" => protocol_message.compute_hash().encode_hex::<String>());
+        let signatures = builder
+            .restore_signer_from_initializer(self.party_id.clone(), protocol_initializer.clone())
+            .map_err(|e| SingleSignerError::ProtocolSignerCreationFailure(e.to_string()))?
+            .sign(protocol_message)
+            .map_err(|e| SingleSignerError::SignatureFailed(e.into()))?;
 
-        match protocol_signer.sign(&message) {
+        match &signatures {
             Some(signature) => {
                 trace!(
                     "Party #{}: lottery #{:?} won",
-                    self.party_id,
-                    &signature.indexes
+                    signature.party_id,
+                    &signature.won_indexes
                 );
-                let encoded_signature =
-                    key_encode_hex(&signature).map_err(SingleSignerError::Codec)?;
-                let won_indexes = signature.indexes;
-
-                Ok(Some(SingleSignatures::new(
-                    self.party_id.clone(),
-                    encoded_signature,
-                    won_indexes,
-                )))
             }
             None => {
                 warn!("no signature computed, all lotteries were lost");
-                Ok(None)
             }
-        }
+        };
+
+        Ok(signatures)
     }
 
     /// Compute aggregate verification key from stake distribution
@@ -228,20 +134,23 @@ impl SingleSigner for MithrilSingleSigner {
         signers_with_stake: &[SignerWithStake],
         protocol_initializer: &ProtocolInitializer,
     ) -> Result<Option<String>, SingleSignerError> {
-        match self.create_protocol_clerk(signers_with_stake, protocol_initializer) {
-            Ok(clerk) => Ok(Some(
-                key_encode_hex(clerk.compute_avk()).map_err(SingleSignerError::Codec)?,
-            )),
-            Err(SingleSignerError::ProtocolSignerCreationFailure(err)) => {
-                warn!("compute_aggregate_verification_key::protocol_signer_creation_failure"; "error" => err);
-                Ok(None)
-            }
-            Err(e) => Err(e),
-        }
+        let multi_signer = SignerBuilder::new(
+            signers_with_stake,
+            &protocol_initializer.get_protocol_parameters().into(),
+        )
+        .map_err(|error| {
+            SingleSignerError::AggregateVerificationKeyComputationFailed(error.into())
+        })?
+        .build_multi_signer();
+
+        let encoded_avk = key_encode_hex(multi_signer.compute_aggregate_verification_key())
+            .map_err(SingleSignerError::Codec)?;
+
+        Ok(Some(encoded_avk))
     }
 
     /// Get party id
-    fn get_party_id(&self) -> ProtocolPartyId {
+    fn get_party_id(&self) -> PartyId {
         self.party_id.clone()
     }
 }
@@ -251,7 +160,7 @@ mod tests {
     use super::*;
 
     use mithril_common::{
-        crypto_helper::{key_decode_hex, tests_setup::*, ProtocolClerk, ProtocolSingleSignature},
+        crypto_helper::{key_decode_hex, ProtocolClerk, ProtocolSingleSignature},
         entities::ProtocolMessagePartKey,
         test_utils::MithrilFixtureBuilder,
     };
@@ -259,12 +168,10 @@ mod tests {
     #[test]
     fn compute_single_signature_success() {
         let snapshot_digest = "digest".to_string();
-        let protocol_parameters = setup_protocol_parameters();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let signers_with_stake = fixture.signers_with_stake();
         let current_signer = &fixture.signers_fixture()[0];
-        let single_signer =
-            MithrilSingleSigner::new(current_signer.signer_with_stake.party_id.to_owned());
+        let single_signer = MithrilSingleSigner::new(current_signer.party_id());
         let clerk = ProtocolClerk::from_signer(&current_signer.protocol_signer);
         let avk = clerk.compute_avk();
         let mut protocol_message = ProtocolMessage::new();
@@ -284,7 +191,7 @@ mod tests {
         assert!(
             decoded_sig
                 .verify(
-                    &protocol_parameters,
+                    &fixture.protocol_parameters().into(),
                     &current_signer.protocol_signer.verification_key(),
                     &current_signer.protocol_signer.get_stake(),
                     &avk,


### PR DESCRIPTION
## Content
This PR introduce three new types in `mithril-common` in order to factorize crypto operation arround issuing single/multi signatures:

- `protocol::SingleSigner`: Issue single signatures
- `protocol::MultiSigner`: Aggregate single signatures, compute avk, and verify single signatures
- `protocol::SignerBuilder`: A builder for the two previous types, handle the key registration..

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #669 
