### PR TITLE
Fix dependency-review check when merging to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,6 +185,9 @@ jobs:
       
       - name: Dependency & Vulnerabilities Review
         uses: actions/dependency-review-action@v3
+        with:
+          base-ref: ${{ github.event.pull_request.base.sha || 'main' }}
+          head-ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
   run-test-lab:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Content
This PR fix the dependency review action when merging PR on the main branch by providing the arguments that this action ask when running on something else than a `pull_request` action trigger.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1037
