### PR TITLE
Add min libc version to distribution release note

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -1,0 +1,77 @@
+name: prepare-distribution
+description: |
+  Package, add crates table, sign artifacts
+  
+  The artifacts for all supported environments must have been downloaded
+  in "package-{EnvName}-x64" subfolders before calling this action.
+inputs:
+  version-name:
+    description: Name of the version to package
+    required: true
+  download-url-base:
+    description: Base url where the released distribution will be downloadable
+    required: true
+  gpg-secret-key:
+    description: A GPG secret key to sign the distribution
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Package distribution (Linux-X64)
+      shell: bash
+      run: |
+        python3 ./.github/workflows/scripts/package-distribution.py \
+        --input package-Linux-X64/ \
+        --dest package/ \
+        --version "${{ inputs.version-name }}" \
+        --target "linux-x64"
+
+    - name: Package distribution (macOS-X64)
+      shell: bash
+      run: |
+        python3 ./.github/workflows/scripts/package-distribution.py \
+        --input package-macOS-X64/ \
+        --dest package/ \
+        --version "${{ inputs.version-name }}" \
+        --target "macos-x64"
+
+    - name: Package distribution (Windows-X64)
+      shell: bash
+      run: |
+        python3 ./.github/workflows/scripts/package-distribution.py \
+        --input package-Windows-X64/ \
+        --dest package/ \
+        --version "${{ inputs.version-name }}" \
+        --target "windows-x64"
+
+    - name: Prepare crates versions table
+      shell: bash
+      run: |
+        cat > ./release-notes-addon.txt << EOF
+
+        ## Crates Versions
+        |  Crate  |  Version  |
+        |---------- |-------------|
+        EOF
+
+        cargo metadata --quiet --no-deps | \
+          jq -r '.packages | sort_by(.name) | .[] | select([.name] | inside(["mithrildemo", "mithril-end-to-end"]) | not) | "| \(.name) | `\(.version)` |"' \
+          >> ./release-notes-addon.txt
+
+    - name: Create and sign sha256 checksum
+      shell: bash
+      env:
+        GPG_SECRET_KEY: ${{ inputs.gpg-secret-key }}
+      run: ./.github/workflows/scripts/sign-distribution.sh
+
+    - name: Create a procedure to verify the distribution
+      shell: bash
+      env:
+        GPG_SECRET_KEY: ${{ inputs.gpg-secret-key }}
+        PROCEDURE_FILE_PATH: ./release-notes-addon.txt
+        DOWNLOAD_URL_BASE: ${{ inputs.download-url-base }}
+      run: ./.github/workflows/scripts/verify-distribution.sh
+
+    - name: List packaged assets
+      shell: bash
+      run: ls -al ./package

--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -57,6 +57,16 @@ runs:
         cargo metadata --quiet --no-deps | \
           jq -r '.packages | sort_by(.name) | .[] | select([.name] | inside(["mithrildemo", "mithril-end-to-end"]) | not) | "| \(.name) | `\(.version)` |"' \
           >> ./release-notes-addon.txt
+        
+    - name: Add minimum supported libc version
+      shell: bash
+      run: |
+        cat > ./release-notes-addon.txt << EOF
+        ## Linux Requirements
+        The Linux binaries target `glibc`: to run them or install the `.deb` packages you must have `glibc`
+        version `2.31+` installed.
+        Compatible systems include, but are not limited to, `Ubuntu 20.04+` or `Debian 11+` (Bullseye)).
+        EOF
 
     - name: Create and sign sha256 checksum
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,7 +368,7 @@ jobs:
           path: ./package-Windows-X64
 
       - name: Prepare distribution package
-        uses: ./.github/workflows/actions/toolchain-and-cache
+        uses: ./.github/workflows/actions/prepare-distribution
         with:
           version-name: unstable-${{ steps.slug.outputs.sha8 }}
           download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,57 +367,12 @@ jobs:
           name: mithril-distribution-Windows-X64
           path: ./package-Windows-X64
 
-      - name: Package distribution (Linux-X64)
-        run: |
-          python3 ./.github/workflows/scripts/package-distribution.py \
-          --input package-Linux-X64/ \
-          --dest package/ \
-          --version "unstable-${{ steps.slug.outputs.sha8 }}" \
-          --target "linux-x64"
-
-      - name: Package distribution (macOS-X64)
-        run: |
-          python3 ./.github/workflows/scripts/package-distribution.py \
-          --input package-macOS-X64/ \
-          --dest package/ \
-          --version "unstable-${{ steps.slug.outputs.sha8 }}" \
-          --target "macos-x64"
-
-      - name: Package distribution (Windows-X64)
-        run: |
-          python3 ./.github/workflows/scripts/package-distribution.py \
-          --input package-Windows-X64/ \
-          --dest package/ \
-          --version "unstable-${{ steps.slug.outputs.sha8 }}" \
-          --target "windows-x64"
-
-      - name: Prepare crates versions table
-        run: |
-          cat > ./release-notes-addon.txt << EOF
-
-          ## Crates Versions
-          |  Crate  |  Version  |
-          |---------- |-------------|
-          EOF
-
-          cargo metadata --quiet --no-deps | \
-            jq -r '.packages | sort_by(.name) | .[] | select([.name] | inside(["mithrildemo", "mithril-end-to-end"]) | not) | "| \(.name) | `\(.version)` |"' \
-            >> ./release-notes-addon.txt
-
-      - name: Create and sign sha256 checksum
-        env:
-          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-        run: ./.github/workflows/scripts/sign-distribution.sh
-
-      - name: Create a procedure to verify the distribution
-        env:
-          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-          PROCEDURE_FILE_PATH: ./release-notes-addon.txt
-          DOWNLOAD_URL_BASE: ${{ github.server_url }}/${{ github.repository }}/releases/download/unstable
-        run: ./.github/workflows/scripts/verify-distribution.sh
-
-      - name: List packaged assets
-        run: ls -al ./package
+      - name: Prepare distribution package
+        uses: ./.github/workflows/actions/toolchain-and-cache
+        with:
+          version-name: unstable-${{ steps.slug.outputs.sha8 }}
+          download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/unstable
+          gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
 
       - name: Update unstable release
         uses: marvinpinto/action-automatic-releases@latest

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -57,7 +57,7 @@ jobs:
           echo ${{ github.ref_name }} >> ./package/VERSION
 
       - name: Prepare distribution package
-        uses: ./.github/workflows/actions/toolchain-and-cache
+        uses: ./.github/workflows/actions/prepare-distribution
         with:
           version-name: ${{ github.ref_name }}
           download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -52,61 +52,16 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
 
-      - name: Package distribution (Linux-X64)
-        run: |
-          python3 ./.github/workflows/scripts/package-distribution.py \
-          --input package-Linux-X64/ \
-          --dest package/ \
-          --version "${{ github.ref_name }}" \
-          --target "linux-x64"
-
-      - name: Package distribution (macOS-X64)
-        run: |
-          python3 ./.github/workflows/scripts/package-distribution.py \
-          --input package-macOS-X64/ \
-          --dest package/ \
-          --version "${{ github.ref_name }}" \
-          --target "macos-x64"
-
-      - name: Package distribution (Windows-X64)
-        run: |
-          python3 ./.github/workflows/scripts/package-distribution.py \
-          --input package-Windows-X64/ \
-          --dest package/ \
-          --version "${{ github.ref_name }}" \
-          --target "windows-x64"
-      
       - name: Append VERSION file
         run: |
           echo ${{ github.ref_name }} >> ./package/VERSION
-      
-      - name: Prepare crates versions table
-        run: |
-          cat > ./release-notes-addon.txt << EOF
 
-          ## Crates Versions
-          |  Crate  |  Version  |
-          |---------- |-------------|
-          EOF
-
-          cargo metadata --quiet --no-deps | \
-            jq -r '.packages | sort_by(.name) | .[] | select([.name] | inside(["mithrildemo", "mithril-end-to-end"]) | not) | "| \(.name) | `\(.version)` |"' \
-            >> ./release-notes-addon.txt
-
-      - name: Create and sign sha256 checksum
-        env:
-          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-        run: ./.github/workflows/scripts/sign-distribution.sh
-
-      - name: Create a procedure to verify the distribution
-        env:
-          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-          PROCEDURE_FILE_PATH: ./release-notes-addon.txt
-          DOWNLOAD_URL_BASE: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}
-        run: ./.github/workflows/scripts/verify-distribution.sh
-          
-      - name: List packaged assets
-        run: ls -al ./package
+      - name: Prepare distribution package
+        uses: ./.github/workflows/actions/toolchain-and-cache
+        with:
+          version-name: ${{ github.ref_name }}
+          download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}
+          gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
 
       - name: Create pre-release ${{ github.ref_name }}
         uses: marvinpinto/action-automatic-releases@latest


### PR DESCRIPTION
## Content

This PR add the minimum libc version to [the distribution release notes](https://github.com/input-output-hk/mithril/releases).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
This PR also factorize part of the distribution packaging step in a composite action.

## Issue(s)
Relates to #874
