### PR TITLE
Upgrade Rust `1.71.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.52"
+version = "0.3.53"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.19"
+version = "0.3.20"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.78"
+version = "0.2.79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2234,7 +2234,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.60"
+version = "0.2.61"
 dependencies = [
  "async-trait",
  "clap",
@@ -2260,7 +2260,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.2.18"
+version = "0.2.19"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.52"
+version = "0.3.53"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -129,7 +129,7 @@ impl CertificatesHashMigrator {
             .await?;
 
         debug!("🔧 Certificate Hash Migrator: updating signed entities certificate_ids to new computed hash");
-        for mut signed_entity_record in records_to_migrate.iter_mut() {
+        for signed_entity_record in records_to_migrate.iter_mut() {
             let new_certificate_hash =
                 old_and_new_certificate_hashes
                     .get(&signed_entity_record.certificate_id)

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.19"
+version = "0.3.20"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/services/snapshot.rs
+++ b/mithril-client/src/services/snapshot.rs
@@ -209,7 +209,7 @@ impl SnapshotService for MithrilClientSnapshotService {
         let unpack_dir = pathdir.join("db");
         let progress_bar = MultiProgress::with_draw_target(progress_target);
         progress_bar.println("1/7 - Checking local disk info…")?;
-        let unpacker = SnapshotUnpacker::default();
+        let unpacker = SnapshotUnpacker;
 
         if let Err(e) = unpacker.check_prerequisites(&unpack_dir, snapshot_entity.artifact.size) {
             self.check_disk_space_error(e)?;

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.78"
+version = "0.2.79"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -132,7 +132,7 @@ impl<'a> TryFrom<&'a mut Sum6KesBytes> for Sum6Kes<'a> {
     }
 }
 
-#[cfg(all(test))]
+#[cfg(test)]
 mod test {
     use super::*;
 

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -291,7 +291,7 @@ impl KeyRegWrapper {
     }
 }
 
-#[cfg(all(test))]
+#[cfg(test)]
 mod test {
 
     use super::*;

--- a/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
+++ b/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
@@ -83,7 +83,7 @@ mod tests {
     }
     #[tokio::test]
     async fn compute_signable() {
-        let digester = ImmutableDigesterImpl::default();
+        let digester = ImmutableDigesterImpl;
         let signable_builder = CardanoImmutableFilesFullSignableBuilder::new(
             Arc::new(digester),
             Path::new(""),

--- a/mithril-common/src/store/adapter/memory_adapter.rs
+++ b/mithril-common/src/store/adapter/memory_adapter.rs
@@ -102,8 +102,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Borrow;
-
     use super::*;
 
     fn init_adapter(nb: u64) -> MemoryAdapter<u64, String> {
@@ -232,7 +230,7 @@ mod tests {
     async fn check_get_last_n_modified_records() {
         let mut adapter = init_adapter(3);
         adapter
-            .store_record(&1, "updated record".to_string().borrow())
+            .store_record(&1, &"updated record".to_string())
             .await
             .unwrap();
         let values = adapter.get_last_n_records(2).await.unwrap();

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.60"
+version = "0.2.61"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -723,7 +723,7 @@ mod tests {
         let runner = init_runner(Some(services), None).await;
         let mut pending_certificate = fake_data::certificate_pending();
         let epoch = pending_certificate.beacon.epoch;
-        let mut signer = &mut pending_certificate.signers[0];
+        let signer = &mut pending_certificate.signers[0];
 
         let protocol_initializer = MithrilProtocolInitializerBuilder::build(
             &100,

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "mithril-stm"
-version = "0.2.18"
+version = "0.2.19"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/src/merkle_tree.rs
+++ b/mithril-stm/src/merkle_tree.rs
@@ -416,7 +416,7 @@ impl<D: Digest + FixedOutput> MerkleTree<D> {
             nodes,
             n,
             leaf_off: num_nodes - n,
-            hasher: PhantomData::default(),
+            hasher: PhantomData,
         }
     }
 
@@ -583,7 +583,7 @@ impl<D: Digest + FixedOutput> MerkleTree<D> {
             nodes,
             leaf_off: num_nodes - n,
             n,
-            hasher: PhantomData::default(),
+            hasher: PhantomData,
         })
     }
 }
@@ -725,7 +725,7 @@ mod tests {
                             .map(|x|  Blake2b::<U32>::digest(x).to_vec())
                             .collect(),
                 index,
-                hasher: PhantomData::<Blake2b<U32>>::default()
+                hasher: PhantomData::<Blake2b<U32>>
                 };
             assert!(t.to_commitment().check(&values[0], &path).is_err());
         }
@@ -744,7 +744,7 @@ mod tests {
                             .map(|x|  Blake2b::<U32>::digest(x).to_vec())
                             .collect(),
                 indices,
-                hasher: PhantomData::<Blake2b<U32>>::default()
+                hasher: PhantomData::<Blake2b<U32>>
                 };
             assert!(t.to_commitment_batch_compat().check(&batch_values, &path).is_err());
         }


### PR DESCRIPTION
## Content
This PR includes fixes for new clippy warnings with Rust `1.71.0` release.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
