### PR TITLE
Add `release-mainnet` configuration in documentation and explorer

### DIFF
--- a/docs/root/networks-matrix.md
+++ b/docs/root/networks-matrix.md
@@ -9,10 +9,48 @@ import TabItem from '@theme/TabItem';
 
 Here is an updated list of all **Mithril networks**, including their configurations and current statuses:
 
-> Last update: 07/05/2023
+> Last update: 07/21/2023
 
 <Tabs>
-  <TabItem value="preview" label="Preview" default>
+  <TabItem value="mainnet" label="Mainnet" default>
+
+## `release-mainnet`
+
+| Information | -
+|------------|------------
+| **Mithril network** | `release-mainnet`
+| **Cardano network** | `mainnet` 
+| **Cardano magic id** |   `-`
+| **Supported** | Yes :heavy_check_mark:
+| **Status** | Beta 🟢
+| **Aggregator endpoint** | `https://aggregator.release-mainnet.api.mithril.network/aggregator` [:arrow_upper_right:](https://aggregator.release-mainnet.api.mithril.network/aggregator)  
+| **Genesis verification key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/genesis.vkey)  
+| **Era reader adapter type** | `cardano-chain`
+| **Era reader address** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/era.addr` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/era.addr)
+| **Era reader verification key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/era.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-mainnet/era.vkey)
+| **Build from** |  **Latest release** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/releases/latest) 
+
+  </TabItem>
+  <TabItem value="preprod" label="Preprod">
+
+## `release-preprod`
+
+| Information | -
+|------------|------------
+| **Mithril network** | `release-preprod` [:mag_right:](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.release-preprod.api.mithril.network%2Faggregator)
+| **Cardano network** | `preprod` 
+| **Cardano magic Id** |   `1`
+| **Supported** | Yes :heavy_check_mark:
+| **Status** | Release 🟢
+| **Aggregator endpoint** | `https://aggregator.release-preprod.api.mithril.network/aggregator` [:arrow_upper_right:](https://aggregator.release-preprod.api.mithril.network/aggregator)  
+| **Genesis verification key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey)  
+| **Era reader adapter type** | `cardano-chain`
+| **Era reader address** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.addr` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.addr)
+| **Era reader verification key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.vkey)
+| **Build from** |  **Latest release** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/releases/latest) 
+
+  </TabItem>
+  <TabItem value="preview" label="Preview">
 
 ## `pre-release-preview`
 
@@ -48,44 +86,6 @@ Here is an updated list of all **Mithril networks**, including their configurati
 | **Era reader address** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-preview/era.addr` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-preview/era.addr)
 | **Era reader verification key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-preview/era.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-preview/era.vkey)
 | **Build from** |  **Main branch** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/tree/main) 
-
-  </TabItem>
-  <TabItem value="preprod" label="Preprod">
-
-## `release-preprod`
-
-| Information | -
-|------------|------------
-| **Mithril network** | `release-preprod` [:mag_right:](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.release-preprod.api.mithril.network%2Faggregator)
-| **Cardano network** | `preprod` 
-| **Cardano magic Id** |   `1`
-| **Supported** | Yes :heavy_check_mark:
-| **Status** | Release 🟢
-| **Aggregator endpoint** | `https://aggregator.release-preprod.api.mithril.network/aggregator` [:arrow_upper_right:](https://aggregator.release-preprod.api.mithril.network/aggregator)  
-| **Genesis verification key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey)  
-| **Era reader adapter type** | `cardano-chain`
-| **Era reader address** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.addr` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.addr)
-| **Era reader verification key** | `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.vkey` [:arrow_upper_right:](https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/era.vkey)
-| **Build from** |  **Latest release** [:arrow_upper_right:](https://github.com/input-output-hk/mithril/releases/latest) 
-
-  </TabItem>
-  <TabItem value="mainnet" label="Mainnet">
-
-## `release-mainnet`
-
-| Information | -
-|------------|------------
-| **Mithril network** | `release-mainnet`
-| **Cardano network** | `mainnet` 
-| **Cardano magic Id** |   `-`
-| **Supported** | No :x:
-| **Status** | -
-| **Aggregator endpoint** | - 
-| **Genesis verification key** | -  
-| **Era reader adapter type** | -
-| **Era reader address** | -
-| **Era reader verification key** | -
-| **Build From** |  -
 
   </TabItem>
 </Tabs>

--- a/mithril-explorer/aggregators-list.js
+++ b/mithril-explorer/aggregators-list.js
@@ -1,5 +1,6 @@
 export default [
   "https://aggregator.release-preprod.api.mithril.network/aggregator",
+  "https://aggregator.release-mainnet.api.mithril.network/aggregator",
   "https://aggregator.pre-release-preview.api.mithril.network/aggregator",
   "https://aggregator.testing-preview.api.mithril.network/aggregator",
   "http://localhost:8080/aggregator"

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Content
This PR includes:
- The configuration for the `release-mainnet` network in the network configuration blocks of the documentation
- The configuration of the `release-mainnet` network in the explorer

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

## Issue(s)
Relates to #918
