### PR TITLE
Fix crates versions not shown in release notes

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -61,7 +61,8 @@ runs:
     - name: Add minimum supported libc version
       shell: bash
       run: |
-        cat > ./release-notes-addon.txt << EOF
+        cat >> ./release-notes-addon.txt << EOF
+        
         ## Linux Requirements
         The Linux binaries target \`glibc\`: to run them or install the \`.deb\` packages you must have \`glibc\` version \`2.31+\` installed.
         Compatible systems include, but are not limited to, \`Ubuntu 20.04+\` or \`Debian 11+\` (Bullseye)).


### PR DESCRIPTION
## Content
This PR includes a fi xto the release notes generation that did not show the `crates versions` section.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

