### PR TITLE
Enhance Run a Mithril Signer as an SPO guide

### DIFF
--- a/docs/root/manual/getting-started/SPO-on-boarding-guide.md
+++ b/docs/root/manual/getting-started/SPO-on-boarding-guide.md
@@ -39,8 +39,8 @@ To participate in the Pioneer Program, you will need to:
 - Run an active SPO on the Cardano `preview` network for at least one epoch or one day. 
 - Set up a **Mithril Signer** node on the `pre-release-preview` Mithril network by following the [**Run a Mithril Signer node (SPO)**](run-signer-node.md) guide.
 - You can choose between the **Naive** (easier to set up) or the **Production** deployment models.
-- Wait for two epochs (or two days) before your **Mithril Signer** is eligible to contribute.
-- Verify that your **Pool Id** is listed in some of the produced certificates using the [**Mithril Explorer**](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.pre-release-preview.api.mithril.network%2Faggregator).
+- Wait for two epochs (or two days) before your **Mithril Signer** is eligible to contribute. Check that your **Mithril Signer** is registered by the Aggregator following [**Verify your signer is registered**](./run-signer-node.md#verify-your-signer-is-registered) steps.
+- Verify that your **Pool Id** is listed in some of the produced certificates using the [**Mithril Explorer**](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.pre-release-preview.api.mithril.network%2Faggregator) or following [**Verify your signer contributes with individual signatures**](./run-signer-node.md#verify-your-signer-contributes-with-individual-signatures) steps.
 - :warning: Follow our [**#moria**](https://discord.gg/5kaErDKDRq) Discord channel or our [**GitHub repository**](https://github.com/input-output-hk/mithril/releases?q=pre) for new pre-releases to install.
 - If you have any technical issues or would like to provide feedback, feel free to ask questions on the [**#moria**](https://discord.gg/5kaErDKDRq) Discord channel.
 
@@ -58,8 +58,8 @@ To get ready for `mainnet`, you need to:
 - Be an active SPO on the Cardano `preprod` network for at least one epoch or five days.
 - Set up a **Mithril Signer** node on Mithril's `release-preprod` network by following the [**Run a Mithril Signer node (SPO)**](run-signer-node.md) guide.
 - You **must** run the **Production** deployment model.
-- Wait for two epochs (or ten days) before your **Mithril Signer** is eligible to contribute.
-- Verify that your **Pool Id** is listed in some of the produced certificates using the [**Mithril Explorer**](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.release-preprod.api.mithril.network%2Faggregator).
+- Wait for two epochs (or ten days) before your **Mithril Signer** is eligible to contribute. Check that your **Mithril Signer** is registered by the Aggregator following [**Verify your signer is registered**](./run-signer-node.md#verify-your-signer-is-registered) steps.
+- Verify that your **Pool Id** is listed in some of the produced certificates using the [**Mithril Explorer**](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.release-preprod.api.mithril.network%2Faggregator) or following [**Verify your signer contributes with individual signatures**](./run-signer-node.md#verify-your-signer-contributes-with-individual-signatures) steps.
 - :warning: Follow our [**#moria**](https://discord.gg/5kaErDKDRq) Discord channel or our [**GitHub repository**](https://github.com/input-output-hk/mithril/releases/latest) for new releases to install.
 - If you have any technical issues or would like to provide feedback, feel free to ask questions on the [**#moria**](https://discord.gg/5kaErDKDRq) Discord channel.
 
@@ -77,8 +77,8 @@ To run **Mithril** on `mainnet`, you need to:
 - Be an active SPO on Cardano `mainnet` for at least one epoch or five days.
 - Set up a **Mithril Signer** node on Mithril's `release-mainnet` network by following the [**Run a Mithril Signer node (SPO)**](run-signer-node.md) guide.
 - You **must** run the **Production** deployment model.
-- Wait for two epochs (or ten days) before your **Mithril Signer** is eligible to contribute.
-- Verify that your **Pool Id** is listed in some of the produced certificates using the [**Mithril Explorer**](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.release-mainnet.api.mithril.network%2Faggregator).
+- Wait for two epochs (or ten days) before your **Mithril Signer** is eligible to contribute. Check that your **Mithril Signer** is registered by the Aggregator following [**Verify your signer is registered**](./run-signer-node.md#verify-your-signer-is-registered) steps.
+- Verify that your **Pool Id** is listed in some of the produced certificates using the [**Mithril Explorer**](https://mithril.network/explorer?aggregator=https%3A%2F%2Faggregator.release-mainnet.api.mithril.network%2Faggregator) or following [**Verify your signer contributes with individual signatures**](./run-signer-node.md#verify-your-signer-contributes-with-individual-signatures) steps.
 - :warning: Follow our [**#moria**](https://discord.gg/5kaErDKDRq) Discord channel or our [**GitHub repository**](https://github.com/input-output-hk/mithril/releases/latest) for new releases to install.
 - If you have any technical issues or would like to provide feedback, feel free to ask questions on the [**#moria**](https://discord.gg/5kaErDKDRq) Discord channel.
 

--- a/docs/root/manual/getting-started/run-signer-node.md
+++ b/docs/root/manual/getting-started/run-signer-node.md
@@ -29,6 +29,12 @@ In this guide, you will learn how to set up a **Mithril Signer** within the stak
 
 :::
 
+:::info
+
+In the current setup, you don't need to install a Mithril Aggregator.
+
+:::
+
 :::caution
 
 The **production** deployment model is currently in the beta version.
@@ -231,6 +237,24 @@ Replace this value with the correct user. We assume that the user used to run th
   * `RELAY_ENDPOINT=http://192.168.1.50:3128` **(optional)**: this is the endpoint of the **Mithril relay**, which is required for **production** deployment only. For **naive** deployment, do not set this variable in your environment file.
 :::
 
+:::tip
+
+Here is an **example** set of values for **release-preprod** that will be used in this guide in the **tip** boxes to illustrate some commands:  
+
+* ****YOUR_KES_SECRET_KEY_PATH****: `/cardano/keys/kes.skey`
+* ****YOUR_OPERATIONAL_CERTIFICATE_PATH****: `/cardano/keys/node.cert`
+* ****YOUR_CARDANO_NETWORK****: `preprod`
+* ****YOUR_AGGREGATOR_ENDPOINT****: `https://aggregator.release-preprod.api.mithril.network/aggregator`
+* ****YOUR_ERA_READER_ADAPTER_TYPE****: `cardano-chain`
+* ****YOUR_ERA_READER_ADAPTER_PARAMS****: `{"address": "addr_test1qpkyv2ws0deszm67t840sdnruqgr492n80g3y96xw3p2ksk6suj5musy6w8lsg3yjd09cnpgctc2qh386rtxphxt248qr0npnx", "verification_key": "5b35352c3232382c3134342c38372c3133382c3133362c34382c382c31342c3138372c38352c3134382c39372c3233322c3235352c3232392c33382c3234342c3234372c3230342c3139382c31332c33312c3232322c32352c3136342c35322c3130322c39312c3132302c3230382c3134375d"}`
+* ****YOUR_RELAY_ENDPOINT****: `192.168.1.50`
+* ****YOUR_RELAY_LISTENING_PORT****: `3128`
+* ****YOUR_BLOCK_PRODUCER_INTERNAL_IP****: `192.168.1.75`
+* ****YOUR_SIGNER_LOGS_PATH****: `/var/log/syslog`
+* ****YOUR_PARTY_ID****: `pool1hp72sauk0g0yqm4dzllz0pz6j93gewhllkzphn4hykkfmne43y`
+
+:::
+
 First, create an environment file that will be used by the service:
 
 - for **production** deployment:
@@ -252,6 +276,30 @@ RELAY_ENDPOINT=**YOUR_RELAY_ENDPOINT**
 EOF'
 ```
 
+:::tip
+
+Here is an example of the aforementioned command created with the example set for `release-preprod`:
+
+```bash
+sudo bash -c 'cat > /opt/mithril/mithril-signer.env << EOF
+KES_SECRET_KEY_PATH=/cardano/keys/kes.skey
+OPERATIONAL_CERTIFICATE_PATH=/cardano/keys/node.cert
+NETWORK=preprod
+AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator
+RUN_INTERVAL=60000
+DB_DIRECTORY=/cardano/db
+CARDANO_NODE_SOCKET_PATH=/cardano/ipc/node.socket
+CARDANO_CLI_PATH=/app/bin/cardano-cli
+DATA_STORES_DIRECTORY=/opt/mithril/stores
+STORE_RETENTION_LIMIT=5
+ERA_READER_ADAPTER_TYPE=cardano-chain
+ERA_READER_ADAPTER_PARAMS={"address": "addr_test1qpkyv2ws0deszm67t840sdnruqgr492n80g3y96xw3p2ksk6suj5musy6w8lsg3yjd09cnpgctc2qh386rtxphxt248qr0npnx", "verification_key": "5b35352c3232382c3134342c38372c3133382c3133362c34382c382c31342c3138372c38352c3134382c39372c3233322c3235352c3232392c33382c3234342c3234372c3230342c3139382c31332c33312c3232322c32352c3136342c35322c3130322c39312c3132302c3230382c3134375d"}
+RELAY_ENDPOINT=http://192.168.1.50:3128
+EOF'
+```
+
+:::
+
 - for **naive** deployment:
 ```bash
 sudo bash -c 'cat > /opt/mithril/mithril-signer.env << EOF
@@ -269,6 +317,29 @@ ERA_READER_ADAPTER_TYPE=**YOUR_ERA_READER_ADAPTER_TYPE**
 ERA_READER_ADAPTER_PARAMS=**YOUR_ERA_READER_ADAPTER_PARAMS**
 EOF'
 ```
+
+:::tip
+
+Here is an example of the aforementioned command created with the example set for `release-preprod`:
+
+```bash
+sudo bash -c 'cat > /opt/mithril/mithril-signer.env << EOF
+KES_SECRET_KEY_PATH=/cardano/keys/kes.skey
+OPERATIONAL_CERTIFICATE_PATH=/cardano/keys/node.cert
+NETWORK=preprod
+AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator
+RUN_INTERVAL=60000
+DB_DIRECTORY=/cardano/db
+CARDANO_NODE_SOCKET_PATH=/cardano/ipc/node.socket
+CARDANO_CLI_PATH=/app/bin/cardano-cli
+DATA_STORES_DIRECTORY=/opt/mithril/stores
+STORE_RETENTION_LIMIT=5
+ERA_READER_ADAPTER_TYPE=cardano-chain
+ERA_READER_ADAPTER_PARAMS={"address": "addr_test1qpkyv2ws0deszm67t840sdnruqgr492n80g3y96xw3p2ksk6suj5musy6w8lsg3yjd09cnpgctc2qh386rtxphxt248qr0npnx", "verification_key": "5b35352c3232382c3134342c38372c3133382c3133362c34382c382c31342c3138372c38352c3134382c39372c3233322c3235352c3232392c33382c3234342c3234372c3230342c3139382c31332c33312c3232322c32352c3136342c35322c3130322c39312c3132302c3230382c3134375d"}
+EOF'
+```
+
+:::
 
 Then, create a `/etc/systemd/system/mithril-signer.service` description file for the service:
 
@@ -404,6 +475,63 @@ http_access deny all
 EOF'
 ```
 
+:::tip
+
+Here is an example of the aforementioned command created with the example set for `release-preprod`:
+
+```bash
+sudo bash -c 'cat > /etc/squid/squid.conf << EOF
+# Listening port (port 3128 is recommended)
+http_port 3128
+
+# ACL for internal IP of your block producer node
+acl relay_internal_ip src 192.168.1.75
+
+# ACL for aggregator endpoint
+acl aggregator_domain dstdomain .mithril.network
+
+# ACL for SSL port only
+acl SSL_port port 443
+
+# Allowed traffic
+http_access allow relay_internal_ip aggregator_domain SSL_port
+
+# Do not disclose block producer internal IP
+forwarded_for delete
+
+# Turn off via header
+via off
+ 
+# Deny request for original source of a request
+follow_x_forwarded_for deny all
+ 
+# Anonymize request headers
+request_header_access Authorization allow all
+request_header_access Proxy-Authorization allow all
+request_header_access Cache-Control allow all
+request_header_access Content-Length allow all
+request_header_access Content-Type allow all
+request_header_access Date allow all
+request_header_access Host allow all
+request_header_access If-Modified-Since allow all
+request_header_access Pragma allow all
+request_header_access Accept allow all
+request_header_access Accept-Charset allow all
+request_header_access Accept-Encoding allow all
+request_header_access Accept-Language allow all
+request_header_access Connection allow all
+request_header_access All deny all
+
+# Disable cache
+cache deny all
+
+# Deny everything else
+http_access deny all
+EOF'
+```
+
+:::
+
 With this configuration, the proxy will:
 - accept incoming traffic originating from the internal IP of the block-producing machine
 - accept incoming traffic directed to the listening port of the proxy
@@ -429,6 +557,16 @@ Finally, monitor service logs:
 tail /var/log/syslog
 ```
 
+:::info
+
+Here is the command to see squid access logs:
+
+```bash
+tail /var/log/squid/access.log
+```
+
+:::
+
 ### Firewall configuration
 
 :::info
@@ -446,6 +584,16 @@ Assuming you are using [`Uncomplicated Firewall`](https://en.wikipedia.org/wiki/
 sudo ufw allow from **YOUR_BLOCK_PRODUCER_INTERNAL_IP** to any port **YOUR_RELAY_LISTENING_PORT** proto tcp
 ```
 
+:::tip
+
+Here is an example of the aforementioned command created with the example set for `release-preprod`:
+
+```bash
+sudo ufw allow from 192.168.1.75 to any port 3128 proto tcp
+```
+
+:::
+
 Assuming you are using [`Iptables`](https://en.wikipedia.org/wiki/Iptables) (`1.8.7+`), the command to open that traffic is:
 
 ```bash
@@ -454,6 +602,18 @@ sudo iptables -L -v
 sudo service netfilter-persistent save
 ```
 
+:::tip
+
+Here is an example of the aforementioned command created with the example set for `release-preprod`:
+
+```bash
+sudo iptables -A INPUT -s 192.168.1.75 -p tcp --dport 3128 -j ACCEPT
+sudo iptables -L -v
+sudo service netfilter-persistent save
+```
+
+:::
+
 ## Verify the Mithril Signer deployment
 
 :::tip
@@ -461,3 +621,85 @@ There is a delay of `2` epochs between the registration of the signer node and i
 
 Once this delay has passed, you should be able to observe your `PoolId` listed in some of the certificates accessible on the [`Mithril Explorer`](https://mithril.network/explorer).
 :::
+
+### Verify your signer is registered
+
+After installing the Mithril Signer, you can verify that your node is registered by checking your Mithril Signer node logs.  
+
+First, download the script into the desired directory:
+
+```bash
+wget https://mithril.network/doc/scripts/verify_signer_registration.sh
+```
+
+Make the script executable:
+
+```bash
+chmod +x verify_signer_registration.sh
+```
+
+Finally, execute the script:
+```bash
+SIGNER_LOGS_PATH=**YOUR_SIGNER_LOGS_PATH** ./verify_signer_registration.sh
+```
+
+:::tip
+
+Here is an example command:
+
+```bash
+SIGNER_LOGS_PATH=/var/log/syslog ./verify_signer_registration.sh
+```
+
+:::
+
+If your signer is registered, you should see this message:
+```bash
+>> Congrats, your signer node is registered!
+```
+
+Otherwise, you should see this error message:
+```bash
+>> Oops, your signer node is not registered. Check your configuration.
+```
+
+### Verify your signer contributes with individual signatures
+
+After waiting for two epochs, you will be able to verify that your signer is contributing with individual signatures.
+
+First, download the script into the desired directory:
+
+```bash
+wget https://mithril.network/doc/scripts/verify_signer_signature.sh
+```
+
+Make the script executable:
+
+```bash
+chmod +x verify_signer_signature.sh
+```
+
+Finally, execute the script:
+```bash
+PARTY_ID=**YOUR_PARTY_ID** AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT** ./verify_signer_signature.sh
+```
+
+:::tip
+
+Here is an example of the aforementioned command created with the example set for `release-preprod`:
+
+```bash
+PARTY_ID=pool1hp72sauk0g0yqm4dzllz0pz6j93gewhllkzphn4hykkfmne43y AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator ./verify_signer_signature.sh
+```
+
+:::
+
+If your signer is contributing, you should see this message:
+```bash
+>> Congrats, you have signed this certificate: https://aggregator.release-preprod.api.mithril.network/aggregator/certificate/el3p289b03a223244285b2ls10839846ae7a69f1e8362824a383f376f93f723f !
+```
+
+Otherwise, you should see this error message:
+```bash
+>> Oops, your party id was not found in the last 20 certificates. Please try again later.
+```

--- a/docs/static/scripts/verify_signer_registration.sh
+++ b/docs/static/scripts/verify_signer_registration.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$SIGNER_LOGS_PATH" ]; then
+    echo ">> ERROR: Required environment variable SIGNER_LOGS_PATH is not set."
+    exit 1
+fi
+
+if grep -q "STATE MACHINE: new cycle: Registered" "$SIGNER_LOGS_PATH"; then
+    echo ">> Congrats, your signer node is registered!"
+else
+    echo ">> Oops, your signer node is not registered. Check your configuration."
+fi

--- a/docs/static/scripts/verify_signer_signature.sh
+++ b/docs/static/scripts/verify_signer_signature.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$AGGREGATOR_ENDPOINT" ] || [ -z "$PARTY_ID" ]; then
+    echo ">> ERROR: Required environment variables AGGREGATOR_ENDPOINT and/or PARTY_ID are not set."
+    exit 1
+fi
+
+CERTIFICATES_RESPONSE=$(curl -s "$AGGREGATOR_ENDPOINT/certificates" -H 'accept: application/json')
+CERTIFICATES_COUNT=$(echo "$CERTIFICATES_RESPONSE" | jq '. | length')
+
+echo "$CERTIFICATES_RESPONSE" | jq -r '.[] | .hash' | while read -r HASH; do
+    RESPONSE=$(curl -s "$AGGREGATOR_ENDPOINT/certificate/$HASH" -H 'accept: application/json')
+    SIGNER_COUNT=$(echo "$RESPONSE" | jq '.metadata.signers | length')
+    for (( i=0; i < SIGNER_COUNT; i++ )); do
+        PARTY_ID_RESPONSE=$(echo "$RESPONSE" | jq -r ".metadata.signers[$i].party_id")
+        if [[ "$PARTY_ID_RESPONSE" == "$PARTY_ID" ]]; then
+            echo ">> Congrats, you have signed this certificate: $AGGREGATOR_ENDPOINT/certificate/$HASH !"
+            exit 1
+        fi
+    done
+done
+
+echo ">> Oops, your party id was not found in the last ${CERTIFICATES_COUNT} certificates. Please try again later."


### PR DESCRIPTION
## Content
This PR includes improvements of the guide "Run a Mithril Signer as an SPO". Examples have been added with the appropriate values for `release-preprod` network.

Two scripts have also been created to verify that the signer node is correctly configured and to check that it's correctly signing certificates. They are located in `/docs/static/scripts/` directory.
A description of how to run them have been added at the end of the guide.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Closes #1055 
