### PR TITLE
Bundle openssl with released binaries

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -8,14 +8,19 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Add commit short sha to Cargo.tomls version
+    - name: Get label to append to crate versions
+      id: label
       shell: bash
+      run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+    
+    - name: Add commit short sha to Cargo.tomls version
+      shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: |
         pip3 install toml
-        python3 ./.github/workflows/scripts/edit-cargo-toml-version.py -l $(echo ${{ github.sha }} | cut -c1-7)
+        python3 ./.github/workflows/scripts/edit-cargo-toml-version.py -l "${{ steps.label.outputs.short_sha }}"
 
     - name: Cargo build - Distribution
-      shell: bash
+      shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: cargo build --release ${{ inputs.build-args }}
         
     - name: Publish Mithril Distribution (${{ runner.os }}-${{ runner.arch }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
+        with:
+          build-args: --features bundle_openssl
 
       - name: Build Debian packages
         shell: bash
@@ -95,7 +97,7 @@ jobs:
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
         with:
-          build-args: ${{ matrix.build-args }}
+          build-args: --features bundle_openssl ${{ matrix.build-args }}
   
   test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,11 @@ jobs:
         shell: bash
         run: |
           cargo nextest run --profile ci ${{ matrix.test-args }}
-          # Rename junit file to include runner info
+          
+      - name: Rename junit file to include runner info
+        shell: bash
+        if: success() || failure()
+        run: |
           mv target/nextest/ci/tests-result.junit.xml test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}.xml
 
       - name: Upload Tests Results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.54"
+version = "0.3.55"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "async-recursion",
  "async-trait",
@@ -2238,7 +2238,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.62"
+version = "0.2.63"
 dependencies = [
  "async-trait",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,6 +2108,8 @@ dependencies = [
  "httpmock",
  "mithril-common",
  "mockall",
+ "openssl",
+ "openssl-probe",
  "reqwest",
  "semver",
  "serde",
@@ -2150,6 +2152,8 @@ dependencies = [
  "indicatif",
  "mithril-common",
  "mockall",
+ "openssl",
+ "openssl-probe",
  "reqwest",
  "semver",
  "serde",
@@ -2243,6 +2247,8 @@ dependencies = [
  "httpmock",
  "mithril-common",
  "mockall",
+ "openssl",
+ "openssl-probe",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "reqwest",
@@ -2562,6 +2568,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.26.0+1.1.1u"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2569,6 +2584,7 @@ checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -18,6 +18,8 @@ config = "0.13.1"
 flate2 = "1.0.23"
 hex = "0.4.3"
 mithril-common = { path = "../mithril-common" }
+openssl = { version = "*", features = ["vendored"], optional = true }
+openssl-probe = { version = "0.1.5", optional = true }
 reqwest = { version = "0.11", features = ["json"] }
 semver = "1.0.16"
 serde = { version = "1.0", features = ["derive"] }
@@ -46,3 +48,4 @@ tempfile = "3.3.0"
 
 [features]
 portable = ["mithril-common/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
+bundle_openssl = ["dep:openssl", "dep:openssl-probe"]

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.54"
+version = "0.3.55"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/main.rs
+++ b/mithril-aggregator/src/main.rs
@@ -23,5 +23,8 @@ async fn main() -> Result<(), String> {
     let args = MainOpts::parse();
     let _guard = slog_scope::set_global_logger(build_logger(&args));
 
+    #[cfg(feature = "bundle_openssl")]
+    openssl_probe::init_ssl_cert_env_vars();
+
     args.execute().await.map_err(|e| e.to_string())
 }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -24,6 +24,8 @@ hex = "0.4.3"
 human_bytes = { version = "0.4.2", features = ["fast"] }
 indicatif = { version = "0.17.5", features = ["tokio"] }
 mithril-common = { path = "../mithril-common" }
+openssl = { version = "*", features = ["vendored"], optional = true }
+openssl-probe = { version = "0.1.5", optional = true }
 reqwest = { version = "0.11", features = ["json", "stream"] }
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -43,3 +45,4 @@ mockall = "0.11.0"
 
 [features]
 portable = ["mithril-common/portable"]
+bundle_openssl = ["dep:openssl", "dep:openssl-probe"]

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.21"
+version = "0.3.22"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/main.rs
+++ b/mithril-client/src/main.rs
@@ -122,6 +122,9 @@ async fn main() -> Result<(), String> {
     let args = Args::parse();
     let _guard = slog_scope::set_global_logger(args.build_logger());
 
+    #[cfg(feature = "bundle_openssl")]
+    openssl_probe::init_ssl_cert_env_vars();
+
     args.execute()
         .await
         .map_err(|e| format!("An error occured: {e}"))

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -78,4 +78,3 @@ serde_yaml = "0.9.10"
 default = []
 portable = ["mithril-stm/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 allow_skip_signer_certification = []
-

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -15,6 +15,8 @@ clap = { version = "4.0", features = ["derive", "env"] }
 config = "0.13.1"
 hex = "0.4.3"
 mithril-common = { path = "../mithril-common" }
+openssl = { version = "*", features = ["vendored"], optional = true }
+openssl-probe = { version = "0.1.5", optional = true }
 rand_chacha = "0.3.1"
 rand_core   = "0.6.3"
 reqwest = { version = "0.11", features = ["json", "stream"] }
@@ -36,3 +38,4 @@ slog-term = "2.9.0"
 
 [features]
 portable = ["mithril-common/portable"] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
+bundle_openssl = ["dep:openssl", "dep:openssl-probe"]

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.62"
+version = "0.2.63"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/main.rs
+++ b/mithril-signer/src/main.rs
@@ -77,6 +77,9 @@ async fn main() -> Result<(), String> {
     let args = Args::parse();
     let _guard = slog_scope::set_global_logger(build_logger(args.log_level()));
 
+    #[cfg(feature = "bundle_openssl")]
+    openssl_probe::init_ssl_cert_env_vars();
+
     debug!("Starting"; "node_version" => env!("CARGO_PKG_VERSION"));
 
     // Load config


### PR DESCRIPTION
## Content
This PR add a the `bundle_openssl` feature to our main binaries (client, aggregator, signer).
This feature enable the `vendored` feature of the [openssl crate](https://crates.io/crates/openssl) in order to compile and statically link a copy of OpenSSL.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Enabling the [`vendorded` feature](https://docs.rs/openssl/latest/openssl/index.html#vendored) as the following side effects:
- the bundled openssl loose the capacity to automatically find the system root certificates, we must find them manually using [`openssl_probe` crate](https://crates.io/crates/openssl-probe).
- to build OpenSSL the build process requires the following dependencies: a C compiler, perl (and perl-core), and make

## Issue(s)
Relates to #1073
