### PR TITLE
Add `sign` sub-command in aggregator `genesis` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.57"
+version = "0.3.58"
 dependencies = [
  "async-trait",
  "chrono",

--- a/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/root/manual/developer-docs/nodes/mithril-aggregator.md
@@ -190,6 +190,8 @@ SUBCOMMANDS:
     import       Import payload signed with genesis secret key and create & import a genesis certificate
 ```
 
+### bootstrap sub-command (test-only)
+
 Run 'genesis bootstrap' command in release with default configuration, **only in test mode**.
 This allows the Mithril Aggregator node to bootstrap a `Genesis Certificate`. After this operation, the Mithril Aggregator will be able to produce new snapshots and certificates.
 
@@ -203,27 +205,28 @@ Or with a specific `Genesis Secret Key`, **only in test mode**.
 ./mithril-aggregator genesis bootstrap --genesis-secret-key **YOUR_SECRET_KEY*
 ```
 
-Run 'genesis export' command in release with default configuration.
+### export sub-command
+
+Run 'genesis export' command in release.
 This allows the Mithril Aggregator node to export the `Genesis Payload` that needs to be signed (and later reimported) of the `Genesis Certificate`. The signature of the `Genesis Payload` must be done manually with the owner of the `Genesis Secret Key`.
-
-```bash
-./mithril-aggregator genesis export
-```
-
-Or with a custom export path (to override the default value `./mithril-genesis-payload.txt`)
 
 ```bash
 ./mithril-aggregator genesis export --target-path **YOUR_TARGET_PATH**
 ```
 
-Run 'genesis import' command in release with default configuration.
-This allows the Mithril Aggregator node to import the signed payload of the `Genesis Certificate` and create it in the store. After this operation, the Mithril Aggregator will be able to produce new snapshots and certificates.
+### sign sub-command
+
+Run 'genesis sign' command in release.
+This allows the Mithril Aggregator node to sign the `Genesis Payload` that needs to be reimported. The signature of the `Genesis Payload` must be done manually by the owner of the `Genesis Secret Key`.
 
 ```bash
-./mithril-aggregator genesis import
+./mithril-aggregator genesis sign --to-sign-payload-path **TO_SIGN_PAYLOAD_PATH** --target-signed-payload-path **TARGET_SIGNED_PAYLOAD_PATH** --genesis-secret-key-path **GENESIS_SECRET_KEY_PATH**
 ```
 
-Or with a custom export path (to override the default value `./mithril-genesis-signed-payload.txt`)
+### import sub-command
+
+Run 'genesis import' command in release.
+This allows the Mithril Aggregator node to import the signed payload of the `Genesis Certificate` and create it in the store. After this operation, the Mithril Aggregator will be able to produce new snapshots and certificates.
 
 ```bash
 ./mithril-aggregator genesis import --signed-payload-path **YOUR_SIGNED_PAYLOAD_PATH**
@@ -397,6 +400,7 @@ Here are the subcommands available:
 | **serve** | Aggregator runs its HTTP server in nominal mode and orchestrates multi signatures production |
 | **help** | Print this message or the help of the given subcommand(s) |
 | **genesis export** | Export genesis payload to sign with genesis secret key |
+| **genesis sign** | Sign genesis payload with genesis secret key |
 | **genesis import** | Import genesis signature (payload signed with genesis secret key) and create & import a genesis certificate in the store |
 | **genesis bootstrap** | Bootstrap a genesis certificate (test only usage) |
 | **era list** | List the supported eras |
@@ -450,17 +454,25 @@ General parameters:
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
 | `genesis_secret_key` | - | - | `GENESIS_SECRET_KEY` | Genesis secret key, :warning: for test only | - | - | - |
 
+`genesis export` command:
+
+| Parameter | Command Line (long) |  Command Line (short) | Environment Variable | Description | Default Value | Example | Mandatory |
+|-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
+| `target_path` | `--target-path` | - | - | Path of the file to export the payload to. | - | - | - | - |
+
 `genesis import` command:
 
 | Parameter | Command Line (long) |  Command Line (short) | Environment Variable | Description | Default Value | Example | Mandatory |
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
 | `signed_payload_path` | `--signed-payload-path` | - | - | Path of the payload to import. | - | - | - | - |
 
-`genesis export` command:
+`genesis sign` command:
 
 | Parameter | Command Line (long) |  Command Line (short) | Environment Variable | Description | Default Value | Example | Mandatory |
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
-| `target_path` | `--target-path` | - | - | Path of the file to export the payload to. | - | - | - | - |
+| `to_sign_payload_path` | `--to-sign-payload-path` | - | - | Path of the payload to sign. | - | - | - | - |
+| `target_signed_payload_path` | `--target-signed-payload-path` | - | - | Path of the signed payload to export. | - | - | - | - |
+| `genesis_secret_key_path` | `--genesis-secret-key-path` | - | - | Path of the Genesis secret key. | - | - | - |
 
 `era list` command:
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.57"
+version = "0.3.58"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -146,33 +146,22 @@ pub struct SignGenesisSubCommand {
 impl SignGenesisSubCommand {
     pub async fn execute(
         &self,
-        config_builder: ConfigBuilder<DefaultState>,
+        _config_builder: ConfigBuilder<DefaultState>,
     ) -> Result<(), Box<dyn Error>> {
-        let config: Configuration = config_builder
-            .build()
-            .map_err(|e| format!("configuration build error: {e}"))?
-            .try_deserialize()
-            .map_err(|e| format!("configuration deserialize error: {e}"))?;
-        debug!("SIGN GENESIS command"; "config" => format!("{config:?}"));
+        debug!("SIGN GENESIS command");
         println!(
             "Genesis sign payload from {} to {}",
             self.to_sign_payload_path.to_string_lossy(),
             self.target_signed_payload_path.to_string_lossy()
         );
-        let mut dependencies_builder = DependenciesBuilder::new(config.clone());
-        let dependencies = dependencies_builder.create_genesis_container().await?;
 
-        let genesis_tools = GenesisTools::from_dependencies(dependencies)
-            .await
-            .map_err(|err| format!("genesis-tools: initialization error: {err}"))?;
-        genesis_tools
-            .sign_genesis_certificate(
-                &self.to_sign_payload_path,
-                &self.target_signed_payload_path,
-                &self.genesis_secret_key_path,
-            )
-            .await
-            .map_err(|err| format!("genesis-tools: sign error: {err}"))?;
+        GenesisTools::sign_genesis_certificate(
+            &self.to_sign_payload_path,
+            &self.target_signed_payload_path,
+            &self.genesis_secret_key_path,
+        )
+        .await
+        .map_err(|err| format!("genesis-tools: sign error: {err}"))?;
 
         Ok(())
     }

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -127,6 +127,33 @@ impl GenesisTools {
             .await
     }
 
+    /// Sign the genesis certificate
+    pub async fn sign_genesis_certificate(
+        &self,
+        to_sign_payload_path: &Path,
+        target_signed_payload_path: &Path,
+        genesis_secret_key_path: &Path,
+    ) -> StdResult<()> {
+        let mut genesis_secret_key_file = File::open(genesis_secret_key_path).unwrap();
+        let mut genesis_secret_key_serialized = String::new();
+        genesis_secret_key_file.read_to_string(&mut genesis_secret_key_serialized)?;
+
+        let genesis_secret_key = key_decode_hex(&genesis_secret_key_serialized)?;
+        let genesis_signer = ProtocolGenesisSigner::from_secret_key(genesis_secret_key);
+
+        let mut to_sign_payload_file = File::open(to_sign_payload_path).unwrap();
+        let mut to_sign_payload_buffer = Vec::new();
+        to_sign_payload_file.read_to_end(&mut to_sign_payload_buffer)?;
+
+        let genesis_signature = genesis_signer.sign(&to_sign_payload_buffer);
+        let signed_payload = genesis_signature.to_bytes();
+
+        let mut target_signed_payload_file = File::create(target_signed_payload_path)?;
+        target_signed_payload_file.write_all(&signed_payload)?;
+
+        Ok(())
+    }
+
     async fn create_and_save_genesis_certificate(
         &self,
         genesis_signature: ProtocolGenesisSignature,
@@ -152,7 +179,7 @@ mod tests {
     use crate::database::provider::apply_all_migrations_to_db;
     use mithril_common::{
         certificate_chain::MithrilCertificateVerifier,
-        crypto_helper::{ProtocolClerk, ProtocolGenesisSigner},
+        crypto_helper::{key_encode_hex, ProtocolClerk, ProtocolGenesisSigner},
         test_utils::{fake_data, MithrilFixtureBuilder},
     };
     use sqlite::Connection;
@@ -162,7 +189,10 @@ mod tests {
     use super::*;
 
     fn get_temp_dir(dir_name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join("mithril_test").join(dir_name);
+        let dir = std::env::temp_dir()
+            .join("mithril_test")
+            .join("genesis")
+            .join(dir_name);
 
         if dir.exists() {
             let _ = fs::remove_dir_all(&dir);
@@ -178,20 +208,6 @@ mod tests {
         let first_signer = fixture.signers_fixture()[0].clone().protocol_signer;
         let clerk = ProtocolClerk::from_signer(&first_signer);
         clerk.compute_avk()
-    }
-
-    fn sign_avk_payload(
-        payload_path: &Path,
-        target_path: &Path,
-        genesis_signer: &ProtocolGenesisSigner,
-    ) -> StdResult<()> {
-        let mut payload_file = File::open(payload_path).unwrap();
-        let mut payload_buffer = Vec::new();
-        payload_file.read_to_end(&mut payload_buffer)?;
-        let payload_signed = genesis_signer.sign(&payload_buffer).to_bytes();
-        let mut target_file = File::create(target_path)?;
-        target_file.write_all(&payload_signed)?;
-        Ok(())
     }
 
     fn build_tools(
@@ -229,17 +245,32 @@ mod tests {
     #[tokio::test]
     async fn export_sign_then_import_genesis_payload() {
         let test_dir = get_temp_dir("export_payload_to_sign");
-        let path = test_dir.join("payload.txt");
+        let payload_path = test_dir.join("payload.txt");
         let signed_payload_path = test_dir.join("payload-signed.txt");
+        let genesis_secret_key_path = test_dir.join("genesis.sk");
         let genesis_signer = ProtocolGenesisSigner::create_deterministic_genesis_signer();
         let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
             build_tools(&genesis_signer);
+        let mut genesis_secret_key_file = File::create(&genesis_secret_key_path).unwrap();
+        genesis_secret_key_file
+            .write_all(
+                key_encode_hex(genesis_signer.secret_key.as_bytes())
+                    .unwrap()
+                    .as_bytes(),
+            )
+            .unwrap();
 
         genesis_tools
-            .export_payload_to_sign(&path)
+            .export_payload_to_sign(&payload_path)
             .expect("export_payload_to_sign should not fail");
-        sign_avk_payload(&path, &signed_payload_path, &genesis_signer)
-            .expect("sign avk payload should not fail");
+        genesis_tools
+            .sign_genesis_certificate(
+                &payload_path,
+                &signed_payload_path,
+                &genesis_secret_key_path,
+            )
+            .await
+            .expect("sign_genesis_certificate should not fail");
         genesis_tools
             .import_payload_signature(&signed_payload_path)
             .await

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -179,7 +179,7 @@ mod tests {
     use crate::database::provider::apply_all_migrations_to_db;
     use mithril_common::{
         certificate_chain::MithrilCertificateVerifier,
-        crypto_helper::{key_encode_hex, ProtocolClerk, ProtocolGenesisSigner},
+        crypto_helper::{ProtocolClerk, ProtocolGenesisSigner},
         test_utils::{fake_data, MithrilFixtureBuilder},
     };
     use sqlite::Connection;
@@ -251,15 +251,10 @@ mod tests {
         let genesis_signer = ProtocolGenesisSigner::create_deterministic_genesis_signer();
         let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
             build_tools(&genesis_signer);
-        let mut genesis_secret_key_file = File::create(&genesis_secret_key_path).unwrap();
-        genesis_secret_key_file
-            .write_all(
-                key_encode_hex(genesis_signer.secret_key.as_bytes())
-                    .unwrap()
-                    .as_bytes(),
-            )
-            .unwrap();
 
+        genesis_signer
+            .export_to_file(&genesis_secret_key_path)
+            .expect("exporting the secret key should not fail");
         genesis_tools
             .export_payload_to_sign(&payload_path)
             .expect("export_payload_to_sign should not fail");

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -129,7 +129,6 @@ impl GenesisTools {
 
     /// Sign the genesis certificate
     pub async fn sign_genesis_certificate(
-        &self,
         to_sign_payload_path: &Path,
         target_signed_payload_path: &Path,
         genesis_secret_key_path: &Path,
@@ -138,7 +137,7 @@ impl GenesisTools {
         let mut genesis_secret_key_serialized = String::new();
         genesis_secret_key_file.read_to_string(&mut genesis_secret_key_serialized)?;
 
-        let genesis_secret_key = key_decode_hex(&genesis_secret_key_serialized)?;
+        let genesis_secret_key = key_decode_hex(&genesis_secret_key_serialized.trim().to_string())?;
         let genesis_signer = ProtocolGenesisSigner::from_secret_key(genesis_secret_key);
 
         let mut to_sign_payload_file = File::open(to_sign_payload_path).unwrap();
@@ -258,14 +257,13 @@ mod tests {
         genesis_tools
             .export_payload_to_sign(&payload_path)
             .expect("export_payload_to_sign should not fail");
-        genesis_tools
-            .sign_genesis_certificate(
-                &payload_path,
-                &signed_payload_path,
-                &genesis_secret_key_path,
-            )
-            .await
-            .expect("sign_genesis_certificate should not fail");
+        GenesisTools::sign_genesis_certificate(
+            &payload_path,
+            &signed_payload_path,
+            &genesis_secret_key_path,
+        )
+        .await
+        .expect("sign_genesis_certificate should not fail");
         genesis_tools
             .import_payload_signature(&signed_payload_path)
             .await

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -1,10 +1,15 @@
+use crate::StdResult;
 use ed25519_dalek::{ExpandedSecretKey, SignatureError};
 use rand_chacha_dalek_compat::rand_core::{self, CryptoRng, RngCore, SeedableRng};
 use rand_chacha_dalek_compat::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
+use std::{fs::File, io::Write, path::Path};
 use thiserror::Error;
 
-use super::{ProtocolGenesisSecretKey, ProtocolGenesisSignature, ProtocolGenesisVerificationKey};
+use super::{
+    key_encode_hex, ProtocolGenesisSecretKey, ProtocolGenesisSignature,
+    ProtocolGenesisVerificationKey,
+};
 
 #[derive(Error, Debug)]
 /// [ProtocolGenesisSigner] and [ProtocolGenesisVerifier] related errors.
@@ -19,7 +24,7 @@ pub enum ProtocolGenesisError {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProtocolGenesisSigner {
     /// Protocol Genesis secret key
-    pub secret_key: ProtocolGenesisSecretKey,
+    pub(crate) secret_key: ProtocolGenesisSecretKey,
 }
 
 impl ProtocolGenesisSigner {
@@ -75,6 +80,19 @@ impl ProtocolGenesisSigner {
         let expanded_secret_key = self.create_expanded_secret_key();
         let verification_key = self.create_verification_key(&expanded_secret_key);
         expanded_secret_key.sign(message, &verification_key)
+    }
+
+    /// Export the secret key from the genesis verifier to a file. TEST ONLY
+    #[doc(hidden)]
+    pub fn export_to_file(&self, secret_key_path: &Path) -> StdResult<()> {
+        let mut genesis_secret_key_file = File::create(secret_key_path)?;
+        genesis_secret_key_file.write_all(
+            key_encode_hex(self.secret_key.as_bytes())
+                .unwrap()
+                .as_bytes(),
+        )?;
+
+        Ok(())
     }
 }
 

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -18,7 +18,8 @@ pub enum ProtocolGenesisError {
 /// [Genesis Certificate](https://mithril.network/doc/mithril/mithril-protocol/certificates#the-certificate-chain-design)
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ProtocolGenesisSigner {
-    pub(crate) secret_key: ProtocolGenesisSecretKey,
+    /// Protocol Genesis secret key
+    pub secret_key: ProtocolGenesisSecretKey,
 }
 
 impl ProtocolGenesisSigner {


### PR DESCRIPTION
## Content
This PR includes a new `sign` sub-command in the `genesis` command.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

## Issue(s)
Closes #1081 
