### PR TITLE
Simplify epoch type by implementing Deref & TryInto<i64>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.63"
+version = "0.3.64"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.86"
+version = "0.2.87"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.63"
+version = "0.3.64"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -58,7 +58,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
             })?;
         let snapshot_name = format!(
             "{}-e{}-i{}.{}.tar.gz",
-            beacon.network, beacon.epoch.0, beacon.immutable_file_number, snapshot_digest
+            beacon.network, *beacon.epoch, beacon.immutable_file_number, snapshot_digest
         );
         // spawn a separate thread to prevent blocking
         let ongoing_snapshot =
@@ -237,7 +237,7 @@ mod tests {
             Path::new(
                 format!(
                     "{}-e{}-i{}.{}.tar.gz",
-                    beacon.network, beacon.epoch.0, beacon.immutable_file_number, "test+digest"
+                    beacon.network, *beacon.epoch, beacon.immutable_file_number, "test+digest"
                 )
                 .as_str()
             ),

--- a/mithril-aggregator/src/database/provider/certificate.rs
+++ b/mithril-aggregator/src/database/provider/certificate.rs
@@ -296,11 +296,9 @@ impl<'client> CertificateRecordProvider<'client> {
     }
 
     fn condition_by_epoch(&self, epoch: &Epoch) -> StdResult<WhereCondition> {
-        let epoch: i64 = i64::try_from(epoch.0)?;
-
         Ok(WhereCondition::new(
             "epoch = ?*",
-            vec![Value::Integer(epoch)],
+            vec![Value::Integer(epoch.try_into()?)],
         ))
     }
 
@@ -385,7 +383,7 @@ protocol_message, signers, initiated_at, sealed_at)";
                     Value::String(certificate_record.message.to_owned()),
                     Value::String(certificate_record.signature.to_owned()),
                     Value::String(certificate_record.aggregate_verification_key.to_owned()),
-                    Value::Integer(i64::try_from(certificate_record.epoch.0).unwrap()),
+                    Value::Integer(certificate_record.epoch.try_into().unwrap()),
                     Value::String(serde_json::to_string(&certificate_record.beacon).unwrap()),
                     Value::String(certificate_record.protocol_version.to_owned()),
                     Value::String(
@@ -456,7 +454,7 @@ impl<'conn> MasterCertificateProvider<'conn> {
     }
 
     pub fn get_master_certificate_condition(&self, epoch: Epoch) -> WhereCondition {
-        let epoch_i64: i64 = epoch.0.try_into().unwrap();
+        let epoch_i64: i64 = epoch.try_into().unwrap();
         WhereCondition::new(
             "certificate.epoch between ?* and ?*",
             vec![Value::Integer(epoch_i64 - 1), Value::Integer(epoch_i64)],
@@ -685,7 +683,7 @@ mod tests {
                     (3, certificate_record.message.into()),
                     (4, certificate_record.signature.into()),
                     (5, certificate_record.aggregate_verification_key.into()),
-                    (6, i64::try_from(certificate_record.epoch.0).unwrap().into()),
+                    (6, Value::Integer(*certificate_record.epoch as i64)),
                     (
                         7,
                         serde_json::to_string(&certificate_record.beacon)
@@ -878,7 +876,7 @@ mod tests {
                 Value::String(certificate_record.message),
                 Value::String(certificate_record.signature),
                 Value::String(certificate_record.aggregate_verification_key),
-                Value::Integer(i64::try_from(certificate_record.epoch.0).unwrap()),
+                Value::Integer(*certificate_record.epoch as i64),
                 Value::String(serde_json::to_string(&certificate_record.beacon).unwrap()),
                 Value::String(certificate_record.protocol_version),
                 Value::String(
@@ -925,7 +923,7 @@ protocol_message, signers, initiated_at, sealed_at) values \
                         Value::String(certificate_record.message),
                         Value::String(certificate_record.signature),
                         Value::String(certificate_record.aggregate_verification_key),
-                        Value::Integer(i64::try_from(certificate_record.epoch.0).unwrap()),
+                        Value::Integer(*certificate_record.epoch as i64),
                         Value::String(serde_json::to_string(&certificate_record.beacon).unwrap()),
                         Value::String(certificate_record.protocol_version),
                         Value::String(

--- a/mithril-aggregator/src/database/provider/epoch_setting.rs
+++ b/mithril-aggregator/src/database/provider/epoch_setting.rs
@@ -82,7 +82,7 @@ impl<'client> EpochSettingProvider<'client> {
     }
 
     fn condition_by_epoch(&self, epoch: &Epoch) -> Result<WhereCondition, StdError> {
-        let epoch_setting_id: i64 = i64::try_from(epoch.0)?;
+        let epoch_setting_id: i64 = epoch.try_into()?;
 
         Ok(WhereCondition::new(
             "epoch_setting_id = ?*",
@@ -140,7 +140,7 @@ impl<'conn> UpdateEpochSettingProvider<'conn> {
         epoch: Epoch,
         protocol_parameters: ProtocolParameters,
     ) -> WhereCondition {
-        let epoch_setting_id = i64::try_from(epoch.0).unwrap();
+        let epoch_setting_id: i64 = epoch.try_into().unwrap();
 
         WhereCondition::new(
             "(epoch_setting_id, protocol_parameters) values (?1, ?2)",
@@ -214,7 +214,7 @@ impl<'conn> DeleteEpochSettingProvider<'conn> {
 
     /// Create the SQL condition to delete a record given the Epoch.
     fn get_delete_condition_by_epoch(&self, epoch: Epoch) -> WhereCondition {
-        let epoch_setting_id_value = Value::Integer(i64::try_from(epoch.0).unwrap());
+        let epoch_setting_id_value = Value::Integer(epoch.try_into().unwrap());
 
         WhereCondition::new("epoch_setting_id = ?*", vec![epoch_setting_id_value])
     }
@@ -228,7 +228,7 @@ impl<'conn> DeleteEpochSettingProvider<'conn> {
 
     /// Create the SQL condition to prune data older than the given Epoch.
     fn get_prune_condition(&self, epoch_threshold: Epoch) -> WhereCondition {
-        let epoch_setting_id_value = Value::Integer(i64::try_from(epoch_threshold.0).unwrap());
+        let epoch_setting_id_value = Value::Integer(epoch_threshold.try_into().unwrap());
 
         WhereCondition::new("epoch_setting_id < ?*", vec![epoch_setting_id_value])
     }

--- a/mithril-aggregator/src/database/provider/open_message.rs
+++ b/mithril-aggregator/src/database/provider/open_message.rs
@@ -164,10 +164,7 @@ impl<'client> OpenMessageProvider<'client> {
     }
 
     fn get_epoch_condition(&self, epoch: Epoch) -> WhereCondition {
-        WhereCondition::new(
-            "epoch_setting_id = ?*",
-            vec![Value::Integer(epoch.0 as i64)],
-        )
+        WhereCondition::new("epoch_setting_id = ?*", vec![Value::Integer(*epoch as i64)])
     }
 
     fn get_signed_entity_type_condition(
@@ -231,7 +228,7 @@ impl<'client> InsertOpenMessageProvider<'client> {
         let beacon_str = signed_entity_type.get_json_beacon()?;
         let parameters = vec![
             Value::String(Uuid::new_v4().to_string()),
-            Value::Integer(epoch.0 as i64),
+            Value::Integer(epoch.try_into()?),
             Value::String(beacon_str),
             Value::Integer(signed_entity_type.index() as i64),
             Value::String(serde_json::to_string(protocol_message)?),
@@ -271,7 +268,7 @@ signed_entity_type_id = ?*, protocol_message = ?*, is_certified = ?* \
 where open_message_id = ?*";
         let beacon_str = open_message.signed_entity_type.get_json_beacon()?;
         let parameters = vec![
-            Value::Integer(open_message.epoch.0 as i64),
+            Value::Integer(open_message.epoch.try_into()?),
             Value::String(beacon_str),
             Value::Integer(open_message.signed_entity_type.index() as i64),
             Value::String(serde_json::to_string(&open_message.protocol_message)?),
@@ -308,10 +305,7 @@ impl<'client> DeleteOpenMessageProvider<'client> {
     }
 
     fn get_epoch_condition(&self, epoch: Epoch) -> WhereCondition {
-        WhereCondition::new(
-            "epoch_setting_id < ?*",
-            vec![Value::Integer(epoch.0 as i64)],
-        )
+        WhereCondition::new("epoch_setting_id < ?*", vec![Value::Integer(*epoch as i64)])
     }
 }
 
@@ -434,10 +428,7 @@ impl<'client> OpenMessageWithSingleSignaturesProvider<'client> {
     }
 
     fn get_epoch_condition(&self, epoch: Epoch) -> WhereCondition {
-        WhereCondition::new(
-            "epoch_setting_id = ?*",
-            vec![Value::Integer(epoch.0 as i64)],
-        )
+        WhereCondition::new("epoch_setting_id = ?*", vec![Value::Integer(*epoch as i64)])
     }
 
     fn get_signed_entity_type_condition(
@@ -448,7 +439,6 @@ impl<'client> OpenMessageWithSingleSignaturesProvider<'client> {
             "signed_entity_type_id = ?* and beacon = ?*",
             vec![
                 Value::Integer(signed_entity_type.index() as i64),
-                // TODO!: Remove this ugly unwrap, should this method returns a result ?
                 Value::String(signed_entity_type.get_json_beacon().unwrap()),
             ],
         )
@@ -807,7 +797,7 @@ else json_group_array( \
         );
         assert_eq!(
             vec![
-                Value::Integer(open_message.epoch.0 as i64),
+                Value::Integer(*open_message.epoch as i64),
                 Value::String(open_message.signed_entity_type.get_json_beacon().unwrap()),
                 Value::Integer(open_message.signed_entity_type.index() as i64),
                 Value::String(serde_json::to_string(&open_message.protocol_message).unwrap()),

--- a/mithril-aggregator/src/database/provider/signer_registration.rs
+++ b/mithril-aggregator/src/database/provider/signer_registration.rs
@@ -194,7 +194,7 @@ impl<'client> SignerRegistrationRecordProvider<'client> {
     }
 
     fn condition_by_epoch(&self, epoch: &Epoch) -> Result<WhereCondition, StdError> {
-        let epoch: i64 = i64::try_from(epoch.0)?;
+        let epoch: i64 = epoch.try_into()?;
 
         Ok(WhereCondition::new(
             "epoch_setting_id = ?*",
@@ -270,7 +270,7 @@ impl<'conn> InsertOrReplaceSignerRegistrationRecordProvider<'conn> {
             vec![
                 Value::String(signer_registration_record.signer_id),
                 Value::Integer(
-                    i64::try_from(signer_registration_record.epoch_setting_id.0).unwrap(),
+                    signer_registration_record.epoch_setting_id.try_into().unwrap(),
                 ),
                 Value::String(signer_registration_record.verification_key),
                 signer_registration_record
@@ -361,7 +361,7 @@ impl<'conn> DeleteSignerRegistrationRecordProvider<'conn> {
 
     /// Create the SQL condition to delete a record given the Epoch.
     fn get_delete_condition_by_epoch(&self, epoch: Epoch) -> WhereCondition {
-        let epoch_threshold = Value::Integer(i64::try_from(epoch.0).unwrap());
+        let epoch_threshold = Value::Integer(epoch.try_into().unwrap());
 
         WhereCondition::new("epoch_setting_id = ?*", vec![epoch_threshold])
     }
@@ -375,7 +375,7 @@ impl<'conn> DeleteSignerRegistrationRecordProvider<'conn> {
 
     /// Create the SQL condition to prune data older than the given Epoch.
     fn get_prune_condition(&self, epoch_threshold: Epoch) -> WhereCondition {
-        let epoch_threshold = Value::Integer(i64::try_from(epoch_threshold.0).unwrap());
+        let epoch_threshold = Value::Integer(epoch_threshold.try_into().unwrap());
 
         WhereCondition::new("epoch_setting_id < ?*", vec![epoch_threshold])
     }
@@ -512,9 +512,7 @@ mod tests {
                         (1, signer_registration_record.signer_id.into()),
                         (
                             2,
-                            i64::try_from(signer_registration_record.epoch_setting_id.0)
-                                .unwrap()
-                                .into(),
+                            Value::Integer(*signer_registration_record.epoch_setting_id as i64),
                         ),
                         (3, signer_registration_record.verification_key.into()),
                         (
@@ -632,9 +630,7 @@ mod tests {
         assert_eq!(
             vec![
                 Value::String(signer_registration_record.signer_id),
-                Value::Integer(
-                    i64::try_from(signer_registration_record.epoch_setting_id.0).unwrap(),
-                ),
+                Value::Integer(*signer_registration_record.epoch_setting_id as i64),
                 Value::String(signer_registration_record.verification_key),
                 signer_registration_record
                     .verification_key_signature

--- a/mithril-aggregator/src/database/provider/single_signature.rs
+++ b/mithril-aggregator/src/database/provider/single_signature.rs
@@ -174,7 +174,7 @@ impl<'client> SingleSignatureRecordProvider<'client> {
         &self,
         registration_epoch: &Epoch,
     ) -> Result<WhereCondition, StdError> {
-        let epoch: i64 = i64::try_from(registration_epoch.0)?;
+        let epoch: i64 = registration_epoch.try_into()?;
 
         Ok(WhereCondition::new(
             "registration_epoch_setting_id = ?*",
@@ -237,7 +237,7 @@ impl<'conn> UpdateSingleSignatureRecordProvider<'conn> {
                 Value::String(single_signature_record.open_message_id.to_string()),
                 Value::String(single_signature_record.signer_id.to_owned()),
                 Value::Integer(
-                    i64::try_from(single_signature_record.registration_epoch_setting_id.0).unwrap(),
+                    single_signature_record.registration_epoch_setting_id.try_into().unwrap(),
                 ),
                 Value::String(serde_json::to_string(&single_signature_record.lottery_indexes).unwrap()),
                 Value::String(single_signature_record.signature.to_owned()),
@@ -413,7 +413,7 @@ mod tests {
             vec![
                 Value::String(single_signature_record.open_message_id.to_string()),
                 Value::String(single_signature_record.signer_id),
-                Value::Integer(single_signature_record.registration_epoch_setting_id.0 as i64),
+                Value::Integer(*single_signature_record.registration_epoch_setting_id as i64),
                 Value::String(
                     serde_json::to_string(&single_signature_record.lottery_indexes).unwrap()
                 ),

--- a/mithril-aggregator/src/database/provider/stake_pool.rs
+++ b/mithril-aggregator/src/database/provider/stake_pool.rs
@@ -89,11 +89,9 @@ impl<'client> StakePoolProvider<'client> {
     }
 
     fn condition_by_epoch(&self, epoch: &Epoch) -> Result<WhereCondition, StdError> {
-        let epoch: i64 = i64::try_from(epoch.0)?;
-
         Ok(WhereCondition::new(
             "epoch = ?*",
-            vec![Value::Integer(epoch)],
+            vec![Value::Integer(epoch.try_into()?)],
         ))
     }
 
@@ -138,7 +136,7 @@ impl<'conn> InsertOrReplaceStakePoolProvider<'conn> {
         epoch: Epoch,
         stake: Stake,
     ) -> WhereCondition {
-        let epoch = i64::try_from(epoch.0).unwrap();
+        let epoch = epoch.try_into().unwrap();
         let stake = i64::try_from(stake).unwrap();
 
         WhereCondition::new(
@@ -215,9 +213,10 @@ impl<'conn> DeleteStakePoolProvider<'conn> {
 
     /// Create the SQL condition to prune data older than the given Epoch.
     fn get_prune_condition(&self, epoch_threshold: Epoch) -> WhereCondition {
-        let epoch_value = Value::Integer(i64::try_from(epoch_threshold.0).unwrap());
-
-        WhereCondition::new("epoch < ?*", vec![epoch_value])
+        WhereCondition::new(
+            "epoch < ?*",
+            vec![Value::Integer(epoch_threshold.try_into().unwrap())],
+        )
     }
 
     /// Prune the stake pools data older than the given epoch.

--- a/mithril-aggregator/src/database/provider/test_helper.rs
+++ b/mithril-aggregator/src/database/provider/test_helper.rs
@@ -82,9 +82,7 @@ pub fn insert_single_signatures_in_db(
                 (2, single_signature_record.signer_id.into()),
                 (
                     3,
-                    i64::try_from(single_signature_record.registration_epoch_setting_id.0)
-                        .unwrap()
-                        .into(),
+                    Value::Integer(*single_signature_record.registration_epoch_setting_id as i64),
                 ),
                 (
                     4,

--- a/mithril-aggregator/src/services/ticker.rs
+++ b/mithril-aggregator/src/services/ticker.rs
@@ -76,7 +76,7 @@ impl TickerService for MithrilTickerService {
 
         Ok(Beacon::new(
             self.network.to_string(),
-            epoch.0,
+            *epoch,
             immutable_file_number,
         ))
     }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.86"
+version = "0.2.87"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -201,7 +201,7 @@ pub fn setup_certificate_chain(
                 epoch,
                 MithrilFixtureBuilder::default()
                     .with_protocol_parameters(protocol_parameters.into())
-                    .with_signers(min(2 + epoch.0 as usize, 5))
+                    .with_signers(min(2 + *epoch as usize, 5))
                     .build(),
             )
         })

--- a/mithril-common/src/entities/beacon.rs
+++ b/mithril-common/src/entities/beacon.rs
@@ -108,7 +108,7 @@ impl Beacon {
     pub fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.network.as_bytes());
-        hasher.update(self.epoch.0.to_be_bytes());
+        hasher.update(self.epoch.to_be_bytes());
         hasher.update(self.immutable_file_number.to_be_bytes());
         hex::encode(hasher.finalize())
     }

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use std::num::TryFromIntError;
+use std::ops::{Deref, DerefMut};
 use std::{
     fmt::{Display, Formatter},
     ops::{Add, AddAssign, Sub, SubAssign},
@@ -71,6 +73,20 @@ impl Epoch {
     /// Check if there is a gap with another Epoch.
     pub fn has_gap_with(&self, other: &Epoch) -> bool {
         self.0.abs_diff(other.0) > 1
+    }
+}
+
+impl Deref for Epoch {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Epoch {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -161,6 +177,22 @@ impl Display for Epoch {
 }
 
 impl SignableBeacon for Epoch {}
+
+impl TryInto<i64> for Epoch {
+    type Error = TryFromIntError;
+
+    fn try_into(self) -> Result<i64, Self::Error> {
+        self.0.try_into()
+    }
+}
+
+impl TryInto<i64> for &Epoch {
+    type Error = TryFromIntError;
+
+    fn try_into(self) -> Result<i64, Self::Error> {
+        self.0.try_into()
+    }
+}
 
 /// EpochError is an error triggerred by an [Epoch]
 #[derive(Error, Debug)]

--- a/mithril-common/src/entities/mithril_stake_distribution.rs
+++ b/mithril-common/src/entities/mithril_stake_distribution.rs
@@ -47,7 +47,7 @@ impl MithrilStakeDistribution {
     /// Mithril Stake Distribution is defined by the epoch and signers
     fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();
-        hasher.update(self.epoch.0.to_be_bytes());
+        hasher.update(self.epoch.to_be_bytes());
 
         for signer_with_stake in &self.signers_with_stake {
             hasher.update(signer_with_stake.compute_hash().as_bytes());


### PR DESCRIPTION
## Content

This PR simplify the usage of the epoch types by removing the need to access the inner `u64` (with the `epoch.0` syntax) by implementing the `Deref` & `TryInto<i64>` traits .

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #YYY ?
