### PR TITLE
Add signers registered route to aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.65"
+version = "0.3.66"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2175,7 +2175,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.88"
+version = "0.2.89"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.65"
+version = "0.3.66"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/entities/mod.rs
+++ b/mithril-aggregator/src/entities/mod.rs
@@ -2,5 +2,9 @@
 //!
 //! This module provide domain entities for the services & state machine.
 mod open_message;
+mod signer_registration_message;
 
 pub use open_message::OpenMessage;
+pub use signer_registration_message::{
+    SignerRegistrationsListItemMessage, SignerRegistrationsMessage,
+};

--- a/mithril-aggregator/src/entities/signer_registration_message.rs
+++ b/mithril-aggregator/src/entities/signer_registration_message.rs
@@ -1,0 +1,41 @@
+use mithril_common::entities::{Epoch, PartyId, Stake, StakeDistribution};
+use serde::{Deserialize, Serialize};
+
+/// Message structure of signer registrations for an epoch.
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SignerRegistrationsMessage {
+    /// The epoch at which the registration was sent.
+    pub registered_at: Epoch,
+
+    /// The epoch at which the registration was able to send signatures.
+    pub signing_at: Epoch,
+
+    /// The signer registrations
+    pub registrations: Vec<SignerRegistrationsListItemMessage>,
+}
+
+/// Message structure of a signer registration
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SignerRegistrationsListItemMessage {
+    /// The registered signer party id
+    pub party_id: PartyId,
+
+    /// The registered signer stake
+    pub stake: Stake,
+}
+
+impl SignerRegistrationsMessage {
+    /// Build a [SignerRegistrationsMessage] from a [stake distribution][StakeDistribution].
+    pub fn new(registered_at: Epoch, stake_distribution: StakeDistribution) -> Self {
+        let registrations: Vec<SignerRegistrationsListItemMessage> = stake_distribution
+            .into_iter()
+            .map(|(party_id, stake)| SignerRegistrationsListItemMessage { party_id, stake })
+            .collect();
+
+        Self {
+            registered_at,
+            signing_at: registered_at.offset_to_signer_signing_offset(),
+            registrations,
+        }
+    }
+}

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -4,7 +4,7 @@ use crate::{
     services::CertifierService,
     services::{SignedEntityService, TickerService},
     CertificatePendingStore, Configuration, DependencyContainer, ProtocolParametersStorer,
-    SignerRegisterer,
+    SignerRegisterer, VerificationKeyStorer,
 };
 
 use mithril_common::BeaconProvider;
@@ -80,4 +80,11 @@ pub fn with_signed_entity_service(
     dependency_manager: Arc<DependencyContainer>,
 ) -> impl Filter<Extract = (Arc<dyn SignedEntityService>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.signed_entity_service.clone())
+}
+
+/// With verification key store
+pub fn with_verification_key_store(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (Arc<dyn VerificationKeyStorer>,), Error = Infallible> + Clone {
+    warp::any().map(move || dependency_manager.verification_key_store.clone())
 }

--- a/mithril-aggregator/src/store/mod.rs
+++ b/mithril-aggregator/src/store/mod.rs
@@ -10,3 +10,5 @@ pub use verification_key_store::{VerificationKeyStore, VerificationKeyStorer};
 pub use verification_key_store::test_suite as verification_key_store_test_suite;
 #[cfg(test)]
 pub(crate) use verification_key_store::test_verification_key_storer;
+#[cfg(test)]
+pub use verification_key_store::MockVerificationKeyStorer;

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -5,12 +5,16 @@ use tokio::sync::RwLock;
 use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake, StakeDistribution};
 use mithril_common::store::{adapter::StoreAdapter, StoreError};
 
+#[cfg(test)]
+use mockall::automock;
+
 type Adapter = Box<dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, SignerWithStake>>>;
 
 /// Store and get signers verification keys for given epoch.
 ///
 /// Important note: This store works on the **recording** epoch, the epoch at which the signers
 /// are signed into a certificate so they can sign single signatures at the next epoch.
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait VerificationKeyStorer: Sync + Send {
     /// Save the verification key, for the given [Signer] for the given [Epoch], returns the

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -2,12 +2,15 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use tokio::sync::RwLock;
 
-use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake};
+use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake, StakeDistribution};
 use mithril_common::store::{adapter::StoreAdapter, StoreError};
 
 type Adapter = Box<dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, SignerWithStake>>>;
 
 /// Store and get signers verification keys for given epoch.
+///
+/// Important note: This store works on the **recording** epoch, the epoch at which the signers
+/// are signed into a certificate so they can sign single signatures at the next epoch.
 #[async_trait]
 pub trait VerificationKeyStorer: Sync + Send {
     /// Save the verification key, for the given [Signer] for the given [Epoch], returns the
@@ -26,6 +29,12 @@ pub trait VerificationKeyStorer: Sync + Send {
 
     /// Prune all verification keys that are at or below the given epoch.
     async fn prune_verification_keys(&self, max_epoch_to_prune: Epoch) -> Result<(), StoreError>;
+
+    /// Return the parties that are stored at the given epoch.
+    async fn get_stake_distribution_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<StakeDistribution>, StoreError>;
 }
 
 /// Store for the `VerificationKey`.
@@ -85,6 +94,19 @@ impl VerificationKeyStorer for VerificationKeyStore {
 
         Ok(())
     }
+
+    async fn get_stake_distribution_for_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<StakeDistribution>, StoreError> {
+        let record = self.adapter.read().await.get_record(&epoch).await?;
+        Ok(record.map(|r| {
+            StakeDistribution::from_iter(
+                r.into_iter()
+                    .map(|(party_id, signer)| (party_id, signer.stake)),
+            )
+        }))
+    }
 }
 
 /// Macro that generate tests that a [VerificationKeyStorer] must pass
@@ -111,8 +133,18 @@ macro_rules! test_verification_key_storer {
             }
 
             #[tokio::test]
+            async fn get_stake_distribution_for_empty_epoch() {
+                test_suite::get_stake_distribution_for_empty_epoch(&$store_builder).await;
+            }
+
+            #[tokio::test]
             async fn get_verification_keys_for_existing_epoch() {
                 test_suite::get_verification_keys_for_existing_epoch(&$store_builder).await;
+            }
+
+            #[tokio::test]
+            async fn get_stake_distribution_for_existing_epoch() {
+                test_suite::get_stake_distribution_for_existing_epoch(&$store_builder).await;
             }
 
             #[tokio::test]
@@ -129,7 +161,7 @@ pub(crate) use test_verification_key_storer;
 #[macro_use]
 #[cfg(test)]
 pub mod test_suite {
-    use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake};
+    use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake, StakeDistribution};
     use mithril_common::test_utils::fake_keys;
     use std::collections::{BTreeMap, HashMap};
     use std::sync::Arc;
@@ -233,6 +265,17 @@ pub mod test_suite {
         assert!(res.is_none());
     }
 
+    pub async fn get_stake_distribution_for_empty_epoch(store_builder: &StoreBuilder) {
+        let signers = build_signers(2, 1);
+        let store = store_builder(signers);
+        let res = store
+            .get_stake_distribution_for_epoch(Epoch(0))
+            .await
+            .unwrap();
+
+        assert!(res.is_none());
+    }
+
     pub async fn get_verification_keys_for_existing_epoch(store_builder: &StoreBuilder) {
         let signers = build_signers(2, 2);
         let store = store_builder(signers.clone());
@@ -251,6 +294,26 @@ pub mod test_suite {
             .map(|x| BTreeMap::from_iter(x.into_iter()));
 
         assert_eq!(expected_signers, res);
+    }
+
+    pub async fn get_stake_distribution_for_existing_epoch(store_builder: &StoreBuilder) {
+        let signers = build_signers(2, 2);
+        let store = store_builder(signers.clone());
+
+        let expected: Option<StakeDistribution> = signers
+            .into_iter()
+            .filter(|(e, _)| e == 1)
+            .map(|(_, signers)| {
+                StakeDistribution::from_iter(signers.into_iter().map(|(p, s)| (p, s.stake)))
+            })
+            .next();
+        let res = store
+            .get_stake_distribution_for_epoch(Epoch(1))
+            .await
+            .unwrap()
+            .map(|x| BTreeMap::from_iter(x.into_iter()));
+
+        assert_eq!(expected, res);
     }
 
     pub async fn can_prune_keys_from_given_epoch_retention_limit(store_builder: &StoreBuilder) {

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.88"
+version = "0.2.89"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -29,6 +29,10 @@ impl Epoch {
     /// The epoch offset used for aggregator protocol parameters recording.
     pub const PROTOCOL_PARAMETERS_RECORDING_OFFSET: u64 = 2;
 
+    /// The epoch offset used to retrieve, given the epoch at which a signer registered, the epoch
+    /// at which the signer can send single signatures.
+    pub const SIGNER_SIGNING_OFFSET: u64 = 2;
+
     /// Computes a new Epoch by applying an epoch offset.
     ///
     /// Will fail if the computed epoch is negative.
@@ -58,6 +62,11 @@ impl Epoch {
     /// Apply the [protocol parameters recording offset][Self::PROTOCOL_PARAMETERS_RECORDING_OFFSET] to this epoch
     pub fn offset_to_protocol_parameters_recording_epoch(&self) -> Self {
         *self + Self::PROTOCOL_PARAMETERS_RECORDING_OFFSET
+    }
+
+    /// Apply the [signer signing offset][Self::SIGNER_SIGNING_OFFSET] to this epoch
+    pub fn offset_to_signer_signing_offset(&self) -> Self {
+        *self + Self::SIGNER_SIGNING_OFFSET
     }
 
     /// Computes the next Epoch

--- a/mithril-common/src/test_utils/apispec.rs
+++ b/mithril-common/src/test_utils/apispec.rs
@@ -33,10 +33,10 @@ impl<'a> APISpec<'a> {
                 .path(path)
                 .content_type(content_type)
                 .validate_request(request_body)
-                .map_err(|e| panic!("OpenAPI invalid request in {spec_file}, reason: {e}"))
+                .map_err(|e| panic!("OpenAPI invalid request in {spec_file}, reason: {e}\nresponse: {response:#?}"))
                 .unwrap()
                 .validate_response(response)
-                .map_err(|e| panic!("OpenAPI invalid response in {spec_file}, reason: {e}"))
+                .map_err(|e| panic!("OpenAPI invalid response in {spec_file}, reason: {e}\nresponse: {response:#?}"))
                 .unwrap();
         }
     }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -7,6 +7,7 @@ documentation = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+default-run = "mithril-end-to-end"
 
 [[bin]]
 name = "load-aggregator"

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.2.0"
+version = "0.2.1"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.8
+  version: 0.1.9
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -45,6 +45,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  
   /certificate-pending:
     get:
       summary: Get current pending certificate information
@@ -71,6 +72,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /certificates:
     get:
       summary: Get most recent certificates
@@ -91,6 +93,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /certificate/{certificate_hash}:
     get:
       summary: Get certificate by hash
@@ -122,6 +125,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /artifact/snapshots:
     get:
       summary: Get most recent snapshots
@@ -142,6 +146,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /artifact/snapshot/{digest}:
     get:
       summary: Get snapshot information
@@ -173,6 +178,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /artifact/snapshot/{digest}/download:
     get:
       summary: Download the snapshot
@@ -205,6 +211,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /artifact/mithril-stake-distributions:
     get:
       summary: Get most recent Mithril stake distributions
@@ -225,6 +232,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /artifact/mithril-stake-distribution/{hash}:
     get:
       summary: Get Mithril stake distribution information
@@ -256,6 +264,39 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+  
+  /signers/registered/{epoch}:
+    get:
+      summary: Get registered signers for an epoch
+      description: |
+        Returns the signers that registered at a given Epoch
+      parameters:
+        - name: epoch
+          in: path
+          description: Cardano Epoch at which the signer registrations are registered
+          required: true
+          schema:
+            type: integer
+            format: int64
+          example: 419
+      responses:
+        "200":
+          description: Registered Signers found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SignerRegistrationsMessage"
+        "404":
+          description: Registed Signers not found
+        "412":
+          description: API version mismatch
+        default:
+          description: Registered Signers retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  
   /register-signer:
     post:
       summary: Registers signer
@@ -285,6 +326,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
   /register-signatures:
     post:
       summary: Registers signatures
@@ -318,8 +360,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+
 components:
   schemas:
+    Epoch:
+      description: Cardano chain epoch number
+      type: integer
+      format: int64
+    
     EpochSettingsMessage:
       description: Epoch settings
       type: object
@@ -330,9 +378,7 @@ components:
         - next_protocol
       properties:
         epoch:
-          description: Cardano chain epoch number
-          type: integer
-          format: int64
+          $ref: "#/components/schemas/Epoch"
         protocol:
           $ref: "#/components/schemas/ProtocolParameters"
         next_protocol:
@@ -379,9 +425,7 @@ components:
           description: Cardano network
           type: string
         epoch:
-          description: Cardano chain epoch number
-          type: integer
-          format: int64
+          $ref: "#/components/schemas/Epoch"
         immutable_file_number:
           description: Number of the last immutable file that should be included the snapshot
           type: integer
@@ -525,9 +569,7 @@ components:
       additionalProperties: true
       properties:
         epoch:
-          description: Cardano chain epoch number
-          type: integer
-          format: int64
+          $ref: "#/components/schemas/Epoch"
       allOf:
         - $ref: "#/components/schemas/Signer"
       example:
@@ -555,6 +597,43 @@ components:
           "kes_period": 123,
           "stake": 1234
         }
+      
+    SignerRegistrationsMessage:
+      description: |
+        This message holds the registered signers at a given epoch.
+      type: object
+      additionalProperties: false
+      properties:
+        registered_at:
+          $ref: "#/components/schemas/Epoch"
+        signing_at:
+          $ref: "#/components/schemas/Epoch"
+        registrations:
+          type: array
+          items: 
+            $ref: "#/components/schemas/SignerRegistrationsListItemMessage" 
+      example:
+        {
+          "registered_at": 420,
+          "signing_at": 422,
+          "registrations": [
+            {
+              "party_id": "1234567890",
+              "stake": 1234
+            }
+          ]
+        }
+    
+    SignerRegistrationsListItemMessage:
+      description: represents an item of a SignerRegistrationsMessage registration
+      type: object
+      additionalProperties: true
+      allOf:
+        - $ref: "#/components/schemas/Stake"
+      properties:
+        party_id:
+          description: The unique identifier of the signer
+          type: string
 
     RegisterSingleSignatureMessage:
       description: |
@@ -731,7 +810,6 @@ components:
         metadata:
           $ref: "#/components/schemas/CertificateListItemMessageMetadata"
         protocol_message:
-          description: Protocol message
           $ref: "#/components/schemas/ProtocolMessage"
         signed_message:
           description: Hash of the protocol message that is signed by the signer participants
@@ -856,7 +934,6 @@ components:
         metadata:
           $ref: "#/components/schemas/CertificateMetadata"
         protocol_message:
-          description: Protocol message
           $ref: "#/components/schemas/ProtocolMessage"
         signed_message:
           description: Hash of the protocol message that is signed by the signer participants
@@ -1045,9 +1122,7 @@ components:
           - created_at
         properties:
           epoch:
-            description: Cardano chain epoch number
-            type: integer
-            format: int64
+            $ref: "#/components/schemas/Epoch"
           hash:
             description: Hash of the Mithril stake distribution
             type: string
@@ -1080,9 +1155,7 @@ components:
         - protocol_parameters
       properties:
         epoch:
-          description: Cardano chain epoch number
-          type: integer
-          format: int64
+          $ref: "#/components/schemas/Epoch"
         hash:
           description: Hash of the Mithril stake distribution
           type: string


### PR DESCRIPTION
## Content
This PR add a new route to the aggregator, `/signers/registered/{epoch}`, that allow to retrieve the signer registration for a given epoch.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1097
