### PR TITLE
Speedup node bootstrap after client download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.26"
+version = "0.3.27"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.26"
+version = "0.3.27"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR make the `snapshot download` command of the client append a empty file named 'clean' in the unpacked database.
This is a trick to tell the cardano node to skip the ledger check at startup (this file is usually added by the node itself on a clean shutdown).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Relates to #1131 
