### PR TITLE
Add snapshot archive verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2102,7 +2102,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.66"
+version = "0.3.67"
 dependencies = [
  "async-trait",
  "chrono",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.66"
+version = "0.3.67"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -120,7 +120,7 @@ impl SignedEntityService for MithrilSignedEntityService {
             "certificate_hash" => &certificate.hash
         );
 
-        let mut remaining_retries = 3;
+        let mut remaining_retries = 2;
         let artifact = loop {
             remaining_retries -= 1;
 


### PR DESCRIPTION
## Content
This PR includes a fix for the aggregator producing from time to time corrupted archives: the created snapshot archive is verified before being published. This is a quick term fix, and a new implementation of the snapshot production will be done shortly.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1137 
