### PR TITLE
Better unpack error in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2140,7 +2140,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "async-recursion",
  "async-trait",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.27"
+version = "0.3.28"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/utils/unpacker.rs
+++ b/mithril-client/src/utils/unpacker.rs
@@ -49,7 +49,7 @@ pub enum SnapshotUnpackerError {
     UnpackDirectoryIsNotWritable(PathBuf, StdError),
 
     /// Unpacking error
-    #[error("Could not unpack '{filepath}' in directory '{dirpath}'. Error: « {error} ».")]
+    #[error("Could not unpack '{filepath}' in directory '{dirpath}'. Error: « {error:#?} ».")]
     UnpackFailed {
         /// Location of the packed archive.
         filepath: PathBuf,


### PR DESCRIPTION
## Content
This PR includes a fix to get a full subsystem error displayed when the unpack of the archive fails

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1147 
