### PR TITLE
Registered signers page to explorer

### DIFF
--- a/mithril-explorer/Makefile
+++ b/mithril-explorer/Makefile
@@ -7,6 +7,12 @@ install: yarn.lock
 
 build: yarn.lock
 	yarn && yarn run build
+	# Fix to allow refresh & direct linking to the navigation page on static hosting such as Github Pages
+	# this is because the nextJs router is only active for the home page at start.
+	# A 'cleaner' way to do that must exist.
+	mkdir out/registrations
+	cp out/registrations.html out/registrations/index.html
+	cp out/registrations.txt out/registrations/index.txt
 
 serve: build
 	yarn run start

--- a/mithril-explorer/Makefile
+++ b/mithril-explorer/Makefile
@@ -41,9 +41,11 @@ upgrade: clean install
 		@reduxjs/toolkit@latest \
 		bootstrap@latest \
 		bootstrap-icons@latest \
+		chart.js@latest \
 		next@latest \
 		react@latest \
 		react-bootstrap@latest \
+		react-chartjs-2@latest \
 		react-dom@latest \
 		react-redux@latest \
 		@testing-library/jest-dom@latest \

--- a/mithril-explorer/__tests__/stakeFormat.test.js
+++ b/mithril-explorer/__tests__/stakeFormat.test.js
@@ -1,0 +1,62 @@
+import {formatStake} from "../src/utils";
+
+const toLovelace = (ada) => ada * 1000000;
+
+describe('Stake formatting', () => {
+  it('formatting a string returns NaN', () => {
+    expect(formatStake("string")).toEqual("NaN₳");
+  });
+  
+  it.each([
+    [0.13214, "0.13₳"],
+    [0.9182, "0.92₳"],
+    [10.1398, "10.14₳"],
+    [923.170, "923.17₳"],
+  ])('formatting Ada limit fraction to digits to 2 with rounding', (ada, expected) => {
+    expect(formatStake(toLovelace(ada))).toEqual(expected);
+  });
+  
+  it.each([
+    [100, "100₳"],
+    [289.239, "289.24₳"],
+    [583.999, "584₳"],
+    [999.99, "999.99₳"],
+  ])('formatting less than 1K Ada does not add power suffix', (ada, expected) => {
+    expect(formatStake(toLovelace(ada))).toEqual(expected);
+  });
+  
+  it.each([
+    [1000, "1K₳"],
+    [23289.239, "23.29K₳"],
+    [583999.999, "584K₳"],
+    [999990, "999.99K₳"],
+  ])('formatting between 1K and 1M Ada add the `K` suffix', (ada, expected) => {
+    expect(formatStake(toLovelace(ada))).toEqual(expected);
+  });
+  
+  it.each([
+    [1000000, "1M₳"],
+    [23289000.239, "23.29M₳"],
+    [583999000.999, "584M₳"],
+    [999990000, "999.99M₳"],
+  ])('formatting between 1M and 1B Ada add the `M` suffix', (ada, expected) => {
+    expect(formatStake(toLovelace(ada))).toEqual(expected);
+  });
+  
+  it.each([
+    [1000000000, "1B₳"],
+    [23289000000.239, "23.29B₳"],
+    [583999000000.999, "584B₳"],
+    [9999990000000, "9,999.99B₳"],
+  ])('formatting more than 1B Ada add the `B` suffix', (ada, expected) => {
+    expect(formatStake(toLovelace(ada))).toEqual(expected);
+  });
+
+  it.each([
+    [999.999, "1K₳"],
+    [999999.999, "1M₳"],
+    [999999999.999, "1B₳"],
+  ])('Handle rounding up to next power suffix', (ada, expected) => {
+    expect(formatStake(toLovelace(ada))).toEqual(expected);
+  });
+});

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -26,10 +26,10 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
-    "eslint": "^8.46.0",
+    "eslint": "^8.47.0",
     "eslint-config-next": "^13.4.13",
     "jest": "^29.6.2",
     "jest-environment-jsdom": "^29.6.2",
-    "next-router-mock": "^0.9.7"
+    "next-router-mock": "^0.9.8"
   }
 }

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -15,9 +15,11 @@
     "@reduxjs/toolkit": "^1.9.5",
     "bootstrap": "^5.3.1",
     "bootstrap-icons": "^1.10.5",
+    "chart.js": "^4.3.3",
     "next": "^13.4.13",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",
+    "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
     "react-redux": "^8.1.2"
   },

--- a/mithril-explorer/src/app/layout.js
+++ b/mithril-explorer/src/app/layout.js
@@ -7,6 +7,7 @@ import styles from "./explorer.module.css";
 import './global.css'
 import 'bootstrap/dist/css/bootstrap.min.css';
 import 'bootstrap-icons/font/bootstrap-icons.css';
+import Link from "next/link";
 
 export const metadata = {
   title: 'Mithril Explorer',
@@ -23,7 +24,9 @@ export default function RootLayout({children}) {
       <div className={styles.container}>
         <main className={styles.main}>
           <h1 className={styles.title}>
-            <Image src="/explorer/logo.png" alt="Mithril Logo" width={55} height={55}/> Mithril Explorer
+            <Link href="/" className="link-underline-opacity-0 link-body-emphasis ">
+              <Image src="/explorer/logo.png" alt="Mithril Logo" width={55} height={55}/> Mithril Explorer
+            </Link>
           </h1>
           {children}
         </main>

--- a/mithril-explorer/src/app/page.js
+++ b/mithril-explorer/src/app/page.js
@@ -9,6 +9,7 @@ import EpochSettings from "../components/EpochSettings";
 import PendingCertificate from '../components/PendingCertificate';
 import SnapshotsList from '../components/Artifacts/SnapshotsList';
 import MithrilStakeDistributionsList from "../components/Artifacts/MithrilStakeDistributionsList";
+import {aggregatorSearchParam} from "../constants";
 import {selectAggregator, selectedAggregator as currentlySelectedAggregator} from "../store/settingsSlice";
 
 // Disable SSR for the following components since they use data from the store that are not
@@ -20,19 +21,19 @@ export default function Explorer() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const dispatch = useDispatch();
-  
+
   // Used to avoid infinite loop between the update of the url query and the navigation handling.
   const [isUpdatingAggregatorInUrl, setIsUpdatingAggregatorInUrl] = useState(false);
   const selectedAggregator = useSelector(currentlySelectedAggregator);
 
   // Update the aggregator in the url query
   useEffect(() => {
-    const aggregatorInUrl = searchParams.get('aggregator');
+    const aggregatorInUrl = searchParams.get(aggregatorSearchParam);
 
     if (selectedAggregator !== aggregatorInUrl) {
       const params = new URLSearchParams();
       params.set("aggregator", selectedAggregator);
-     
+
       setIsUpdatingAggregatorInUrl(true);
       router.push("?" + params.toString(), undefined, {shallow: true});
     }

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -15,6 +15,7 @@ export default function Registrations() {
   const [aggregator, setAggregator] = useState(undefined);
   const [registrationEpoch, setRegistrationEpoch] = useState(undefined);
   const [signingEpoch, setSigningEpoch] = useState(undefined);
+  const [currentEpoch, setCurrentEpoch] = useState(undefined);
   const [registrations, setRegistrations] = useState([]);
 
   useEffect(() => {
@@ -41,6 +42,14 @@ export default function Registrations() {
           setSigningEpoch(undefined);
           setRegistrations([]);
           console.error("Fetch registrations error:", error);
+        });
+
+      fetch(`${aggregator}/epoch-settings`)
+        .then(response => response.status === 200 ? response.json() : {})
+        .then(data => setCurrentEpoch(data?.epoch))
+        .catch(error => {
+          setCurrentEpoch(undefined);
+          console.error("Fetch current epoch in epoch-settings error:", error);
         });
     } else {
       setCurrentError(error);
@@ -76,6 +85,7 @@ export default function Registrations() {
   }, [aggregator, router]);
 
   const navigateToPrevious = () => navigateTo(registrationEpoch - 1);
+  const navigateToCurrent = () => navigateTo(currentEpoch);
   const navigateToNext = () => navigateTo(registrationEpoch + 1);
 
   return (
@@ -112,8 +122,16 @@ export default function Registrations() {
             </Col>
             <Col className="d-flex align-content-center justify-content-center">
               <ButtonGroup xs={12} sm="auto" vertical>
-                <Button onClick={navigateToPrevious}>Previous Epoch ({registrationEpoch - 1})</Button>
-                <Button onClick={navigateToNext}>Next Epoch ({registrationEpoch + 1})</Button>
+                <Button onClick={navigateToPrevious}>
+                  Previous Epoch ({registrationEpoch - 1})
+                </Button>
+                <Button onClick={navigateToCurrent}
+                        disabled={currentEpoch === undefined || currentEpoch === registrationEpoch}>
+                  Current Epoch ({currentEpoch})
+                </Button>
+                <Button onClick={navigateToNext}>
+                  Next Epoch ({registrationEpoch + 1})
+                </Button>
               </ButtonGroup>
             </Col>
           </Row>

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -2,9 +2,11 @@
 
 import {useSearchParams} from "next/navigation";
 import {useEffect, useState} from "react";
+import {Alert, Col, Row, Stack, Table} from "react-bootstrap";
+import VerifiedBadge from "../../components/VerifiedBadge";
 import {aggregatorSearchParam} from "../../constants";
 import {checkUrl} from "../../utils";
-import {Alert, Stack} from "react-bootstrap";
+import RawJsonButton from "../../components/RawJsonButton";
 
 export default function Registrations() {
   const searchParams = useSearchParams();
@@ -35,6 +37,7 @@ export default function Registrations() {
           setRegistrations(data.registrations);
         })
         .catch(error => {
+          setSigningEpoch(undefined);
           setRegistrations([]);
           console.error("Fetch registrations error:", error);
         });
@@ -42,7 +45,7 @@ export default function Registrations() {
       setCurrentError(error);
     }
   }, [searchParams]);
- 
+
   function getErrorDescription() {
     let description = "";
 
@@ -64,14 +67,73 @@ export default function Registrations() {
   }
 
   return (
-    <Stack>
+    <Stack gap={3}>
+      <h2>
+        Registrations {' '}
+        {currentError === undefined &&
+          <RawJsonButton
+            href={`${aggregator}/signers/registered/${registrationEpoch}`}
+            variant="outline-light"
+            size="sm"/>
+        }
+      </h2>
       {currentError === undefined
-        ? <code>{JSON.stringify(registrations)}</code>
-        :
-        <Alert variant="danger">
-          <Alert.Heading>Oh snap! You got an error!</Alert.Heading>
-          <p>{getErrorDescription()}</p>
-        </Alert>
+        ? registrations === undefined || registrations.length === 0
+          ? <div>No Signers registered for this epoch</div>
+          : <>
+            <Stack direction="horizontal" gap={3}>
+              <Table>
+                <tbody>
+                <tr>
+                  <td><strong>Aggregator:</strong></td>
+                  <td>{aggregator}</td>
+                </tr>
+                <tr>
+                  <td><strong>Registration epoch:</strong></td>
+                  <td>{registrationEpoch}</td>
+                </tr>
+                <tr>
+                  <td><strong>Will be signing at epoch:</strong></td>
+                  <td>{signingEpoch}</td>
+                </tr>
+                </tbody>
+              </Table>
+            </Stack>
+            <Row>
+              <Col xs={12} sm={5}>
+                <Stack gap={3}>
+                  <div></div>
+                  <div></div>
+                </Stack>
+              </Col>
+              <Col xs={12} sm={7}>
+                <Table responsive striped>
+                  <thead>
+                  <tr>
+                    <th>#</th>
+                    <th>Party id</th>
+                    <th>Stake</th>
+                  </tr>
+                  </thead>
+                  <tbody>
+                  {registrations.map((signer, index) =>
+                    <tr key={signer.party_id}>
+                      <td>{index}</td>
+                      <td><VerifiedBadge tooltip="Verified Signer"/>{' '}{signer.party_id}</td>
+                      <td>{signer.stake}</td>
+                    </tr>
+                  )}
+                  </tbody>
+                </Table>
+              </Col>
+            </Row>
+          </>
+        : <>
+          <Alert variant="danger">
+            <Alert.Heading>Oh snap! You got an error!</Alert.Heading>
+            <p>{getErrorDescription()}</p>
+          </Alert>
+        </>
       }
     </Stack>
   );

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -2,14 +2,15 @@
 
 import {useSearchParams} from "next/navigation";
 import {useCallback, useEffect, useState} from "react";
-import {checkUrl, setChartJsDefaults} from "../../utils";
+import {checkUrl, setChartJsDefaults, toAda} from "../../utils";
 import {Alert, ButtonGroup, Col, Row, Spinner, Stack, Table} from "react-bootstrap";
 import {ArcElement, BarElement, CategoryScale, Chart, Legend, LinearScale, Title, Tooltip} from 'chart.js';
 import {Bar, Pie} from "react-chartjs-2";
-import VerifiedBadge from "../../components/VerifiedBadge";
 import {aggregatorSearchParam} from "../../constants";
 import LinkButton from "../../components/LinkButton";
+import Stake from "../../components/Stake";
 import RawJsonButton from "../../components/RawJsonButton";
+import VerifiedBadge from "../../components/VerifiedBadge";
 
 Chart.register(
   ArcElement,
@@ -115,7 +116,6 @@ export default function Registrations() {
 
   function computeSignersWeigth(registrationsList) {
     const registrations = registrationsList ?? [];
-    const toAda = (lovelace) => lovelace / 1000000;
 
     return {
       labels: registrations.map((r) => r.party_id),
@@ -240,7 +240,7 @@ export default function Registrations() {
                 <tr>
                   <th>#</th>
                   <th>Party id</th>
-                  <th>Stake</th>
+                  <th style={{textAlign: "end"}}>Stake</th>
                 </tr>
                 </thead>
                 <tbody>
@@ -248,7 +248,7 @@ export default function Registrations() {
                   <tr key={signer.party_id}>
                     <td>{index}</td>
                     <td><VerifiedBadge tooltip="Verified Signer"/>{' '}{signer.party_id}</td>
-                    <td>{signer.stake}</td>
+                    <td style={{textAlign: "end"}}><Stake lovelace={signer.stake}/></td>
                   </tr>
                 )}
                 </tbody>

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -1,0 +1,52 @@
+"use client";
+
+import {useSearchParams} from "next/navigation";
+import {useEffect, useState} from "react";
+import {aggregatorSearchParam} from "../../constants";
+import {checkUrl} from "../../utils";
+import {Alert} from "react-bootstrap";
+
+export default function Registrations() {
+  const searchParams = useSearchParams();
+  const [currentError, setCurrentError] = useState(undefined);
+  const [aggregator, setAggregator] = useState(undefined);
+  const [registrationEpoch, setRegistrationEpoch] = useState(undefined);
+  const [signingEpoch, setSigningEpoch] = useState(undefined);
+  const [registrations, setRegistrations] = useState([]);
+
+  useEffect(() => {
+    const aggregator = searchParams.get(aggregatorSearchParam);
+    const epoch = searchParams.get('epoch');
+    setAggregator(aggregator);
+    setRegistrationEpoch(epoch);
+
+    if (checkUrl(aggregator)) {
+      fetch(`${aggregator}/signers/registered/${epoch}`)
+        .then(response => response.status === 200 ? response.json() : {})
+        .then(data => {
+          setSigningEpoch(data.signing_at);
+          setRegistrations(data.registrations);
+        })
+        .catch(error => {
+          setRegistrations([]);
+          console.error("Fetch registrations error:", error);
+        });
+
+    } else {
+      setCurrentError("The aggregator endpoint isn't a valid url.");
+    }
+  }, [searchParams]);
+
+  return (
+    <>
+      {currentError === undefined
+        ? <code>{JSON.stringify(registrations)}</code>
+        :
+        <Alert variant="danger">
+          <Alert.Heading>Oh snap! You got an error!</Alert.Heading>
+          <p>{currentError}</p>
+        </Alert>
+      }
+    </>
+  );
+}

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -1,15 +1,15 @@
 "use client";
 
-import {useRouter, useSearchParams} from "next/navigation";
+import {useSearchParams} from "next/navigation";
 import {useCallback, useEffect, useState} from "react";
-import {Alert, Button, ButtonGroup, Col, Row, Spinner, Stack, Table} from "react-bootstrap";
+import {Alert, ButtonGroup, Col, Row, Spinner, Stack, Table} from "react-bootstrap";
 import VerifiedBadge from "../../components/VerifiedBadge";
 import {aggregatorSearchParam} from "../../constants";
 import {checkUrl} from "../../utils";
+import LinkButton from "../../components/LinkButton";
 import RawJsonButton from "../../components/RawJsonButton";
 
 export default function Registrations() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const [isLoading, setIsLoading] = useState(true);
   const [currentError, setCurrentError] = useState(undefined);
@@ -89,17 +89,17 @@ export default function Registrations() {
     }
   }
 
-  const navigateTo = useCallback((epoch) => {
+  const navigateToUrl = useCallback((epoch) => {
     const params = new URLSearchParams();
     params.set("aggregator", aggregator);
     params.set("epoch", epoch);
 
-    router.push(`/registrations?${params.toString()}`)
+    return `/registrations?${params.toString()}`;
   }, [aggregator, router]);
 
-  const navigateToPrevious = () => navigateTo(registrationEpoch - 1);
-  const navigateToCurrent = () => navigateTo(currentEpoch);
-  const navigateToNext = () => navigateTo(registrationEpoch + 1);
+  const navigateToPreviousUrl = navigateToUrl(registrationEpoch - 1);
+  const navigateToCurrentUrl = navigateToUrl(currentEpoch);
+  const navigateToNextUrl = navigateToUrl(registrationEpoch + 1);
 
   return (
     <Stack gap={3}>
@@ -115,38 +115,41 @@ export default function Registrations() {
       {currentError === undefined
         ? <>
           <Row>
-            <Col xs={12} sm={10}>
-              <Table>
-                <tbody>
-                <tr>
-                  <td><strong>Aggregator:</strong></td>
-                  <td>{aggregator}</td>
-                </tr>
-                <tr>
-                  <td><strong>Registration epoch:</strong></td>
-                  <td>{registrationEpoch}</td>
-                </tr>
-                <tr>
-                  <td><strong>Signing at epoch:</strong></td>
-                  <td>{signingEpoch}</td>
-                </tr>
-                </tbody>
-              </Table>
-            </Col>
-            <Col className="d-flex align-content-center justify-content-center">
-              <ButtonGroup xs={12} sm="auto" vertical>
-                <Button onClick={navigateToPrevious}>
-                  Previous Epoch ({registrationEpoch - 1})
-                </Button>
-                <Button onClick={navigateToCurrent}
-                        disabled={currentEpoch === undefined || currentEpoch === registrationEpoch}>
-                  Current Epoch ({currentEpoch})
-                </Button>
-                <Button onClick={navigateToNext} disabled={currentEpoch <= registrationEpoch}>
-                  Next Epoch ({registrationEpoch + 1})
-                </Button>
-              </ButtonGroup>
-            </Col>
+            <Table>
+              <tbody>
+              <tr>
+                <td><strong>Aggregator:</strong></td>
+                <td>{aggregator}</td>
+              </tr>
+              <tr>
+                <td><strong>Registration epoch:</strong></td>
+                <td>{registrationEpoch}</td>
+              </tr>
+              <tr>
+                <td><strong>Signing at epoch:</strong></td>
+                <td>{signingEpoch}</td>
+              </tr>
+              </tbody>
+            </Table>
+          </Row>
+          <Row>
+            <div>
+              {Number.isInteger(registrationEpoch) &&
+                <ButtonGroup>
+                  <LinkButton href={navigateToPreviousUrl}>
+                    Previous Epoch ({registrationEpoch - 1})
+                  </LinkButton>
+                  <LinkButton href={navigateToCurrentUrl}
+                              disabled={currentEpoch === undefined || currentEpoch === registrationEpoch}>
+                    Current Epoch ({currentEpoch})
+                  </LinkButton>
+                  <LinkButton href={navigateToNextUrl}
+                              disabled={currentEpoch <= registrationEpoch}>
+                    Next Epoch ({registrationEpoch + 1})
+                  </LinkButton>
+                </ButtonGroup>
+              }
+            </div>
           </Row>
           {isLoading
             ? <Spinner animation="grow"/>
@@ -158,12 +161,6 @@ export default function Registrations() {
               </Alert>
               :
               <Row>
-                <Col xs={12} sm={12} md={5}>
-                  <Stack gap={3}>
-                    <div></div>
-                    <div></div>
-                  </Stack>
-                </Col>
                 <Col xs={12} sm={12} md={7}>
                   <Table responsive striped>
                     <thead>
@@ -183,6 +180,12 @@ export default function Registrations() {
                     )}
                     </tbody>
                   </Table>
+                </Col>
+                <Col xs={12} sm={12} md={5}>
+                  <Stack gap={3}>
+                    <div></div>
+                    <div></div>
+                  </Stack>
                 </Col>
               </Row>
           }

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -2,7 +2,7 @@
 
 import {useRouter, useSearchParams} from "next/navigation";
 import {useCallback, useEffect, useState} from "react";
-import {Alert, Button, ButtonGroup, Col, Row, Stack, Table} from "react-bootstrap";
+import {Alert, Button, ButtonGroup, Col, Row, Spinner, Stack, Table} from "react-bootstrap";
 import VerifiedBadge from "../../components/VerifiedBadge";
 import {aggregatorSearchParam} from "../../constants";
 import {checkUrl} from "../../utils";
@@ -11,6 +11,7 @@ import RawJsonButton from "../../components/RawJsonButton";
 export default function Registrations() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const [isLoading, setIsLoading] = useState(true);
   const [currentError, setCurrentError] = useState(undefined);
   const [aggregator, setAggregator] = useState(undefined);
   const [registrationEpoch, setRegistrationEpoch] = useState(undefined);
@@ -37,10 +38,12 @@ export default function Registrations() {
         .then(data => {
           setSigningEpoch(data.signing_at);
           setRegistrations(data.registrations);
+          setIsLoading(false);
         })
         .catch(error => {
           setSigningEpoch(undefined);
           setRegistrations([]);
+          setIsLoading(false);
           console.error("Fetch registrations error:", error);
         });
 
@@ -75,7 +78,7 @@ export default function Registrations() {
 
     return description;
   }
-  
+
   function getNoRegistrationsMessage() {
     if (currentEpoch === registrationEpoch) {
       return "The aggregator did not receive registrations yet for the current epoch.";
@@ -145,41 +148,43 @@ export default function Registrations() {
               </ButtonGroup>
             </Col>
           </Row>
-          {registrations === undefined || registrations.length === 0
-            ?
-            <Alert variant="info">
-              <Alert.Heading>No registrations for epoch {registrationEpoch}</Alert.Heading>
-              <p>{getNoRegistrationsMessage()}</p>
-            </Alert>
-            :
-            <Row>
-              <Col xs={12} sm={12} md={5}>
-                <Stack gap={3}>
-                  <div></div>
-                  <div></div>
-                </Stack>
-              </Col>
-              <Col xs={12} sm={12} md={7}>
-                <Table responsive striped>
-                  <thead>
-                  <tr>
-                    <th>#</th>
-                    <th>Party id</th>
-                    <th>Stake</th>
-                  </tr>
-                  </thead>
-                  <tbody>
-                  {registrations.map((signer, index) =>
-                    <tr key={signer.party_id}>
-                      <td>{index}</td>
-                      <td><VerifiedBadge tooltip="Verified Signer"/>{' '}{signer.party_id}</td>
-                      <td>{signer.stake}</td>
+          {isLoading
+            ? <Spinner animation="grow"/>
+            : registrations === undefined || registrations.length === 0
+              ?
+              <Alert variant="info">
+                <Alert.Heading>No registrations for epoch {registrationEpoch}</Alert.Heading>
+                <p>{getNoRegistrationsMessage()}</p>
+              </Alert>
+              :
+              <Row>
+                <Col xs={12} sm={12} md={5}>
+                  <Stack gap={3}>
+                    <div></div>
+                    <div></div>
+                  </Stack>
+                </Col>
+                <Col xs={12} sm={12} md={7}>
+                  <Table responsive striped>
+                    <thead>
+                    <tr>
+                      <th>#</th>
+                      <th>Party id</th>
+                      <th>Stake</th>
                     </tr>
-                  )}
-                  </tbody>
-                </Table>
-              </Col>
-            </Row>
+                    </thead>
+                    <tbody>
+                    {registrations.map((signer, index) =>
+                      <tr key={signer.party_id}>
+                        <td>{index}</td>
+                        <td><VerifiedBadge tooltip="Verified Signer"/>{' '}{signer.party_id}</td>
+                        <td>{signer.stake}</td>
+                      </tr>
+                    )}
+                    </tbody>
+                  </Table>
+                </Col>
+              </Row>
           }
         </>
         : <>

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -75,6 +75,16 @@ export default function Registrations() {
 
     return description;
   }
+  
+  function getNoRegistrationsMessage() {
+    if (currentEpoch === registrationEpoch) {
+      return "The aggregator did not receive registrations yet for the current epoch.";
+    } else if (currentEpoch < registrationEpoch) {
+      return "The epoch is in the future";
+    } else {
+      return "The aggregator may have pruned old registrations or wasn't running at this epoch.";
+    }
+  }
 
   const navigateTo = useCallback((epoch) => {
     const params = new URLSearchParams();
@@ -129,7 +139,7 @@ export default function Registrations() {
                         disabled={currentEpoch === undefined || currentEpoch === registrationEpoch}>
                   Current Epoch ({currentEpoch})
                 </Button>
-                <Button onClick={navigateToNext}>
+                <Button onClick={navigateToNext} disabled={currentEpoch <= registrationEpoch}>
                   Next Epoch ({registrationEpoch + 1})
                 </Button>
               </ButtonGroup>
@@ -139,14 +149,7 @@ export default function Registrations() {
             ?
             <Alert variant="info">
               <Alert.Heading>No registrations for epoch {registrationEpoch}</Alert.Heading>
-              <div>
-                Either:
-                <ul>
-                  <li>It's the current epoch and the aggregator did not receive registrations yet.</li>
-                  <li>the epoch is in the future.</li>
-                  <li>the epoch is in the past and the aggregator have pruned old registrations.</li>
-                </ul>
-              </div>
+              <p>{getNoRegistrationsMessage()}</p>
             </Alert>
             :
             <Row>

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -195,11 +195,15 @@ export default function Registrations() {
           </tr>
           <tr>
             <td><strong>Signing at epoch:</strong></td>
-            <td>{signingEpoch}</td>
+            <td>{signingEpoch ?? '?'}</td>
           </tr>
           <tr>
             <td><strong>Number of signers:</strong></td>
             <td>{registrations?.length ?? 0}</td>
+          </tr>
+          <tr>
+            <td><strong>Total stakes:</strong></td>
+            <td><Stake lovelace={registrations?.reduce((acc, reg) => acc + reg.stake, 0) ?? 0}/></td>
           </tr>
           </tbody>
         </Table>

--- a/mithril-explorer/src/app/registrations/page.js
+++ b/mithril-explorer/src/app/registrations/page.js
@@ -59,26 +59,6 @@ export default function Registrations() {
     }
   }, [searchParams]);
 
-  function getErrorDescription() {
-    let description = "";
-
-    if (currentError) {
-      switch (currentError) {
-        case 'invalidEpoch':
-          description = "The given epoch isn't an integer, please correct it and try again.";
-          break;
-        case 'invalidAggregatorUrl':
-          description = "The given aggregator isn't a valid url, please correct it and try again.";
-          break;
-        default:
-          description = "Something went wrong";
-          break;
-      }
-    }
-
-    return description;
-  }
-
   function getNoRegistrationsMessage() {
     if (currentEpoch === registrationEpoch) {
       return "The aggregator did not receive registrations yet for the current epoch.";
@@ -101,101 +81,114 @@ export default function Registrations() {
   const navigateToCurrentUrl = navigateToUrl(currentEpoch);
   const navigateToNextUrl = navigateToUrl(registrationEpoch + 1);
 
+  if (currentError !== undefined) {
+    let errorDescription = "";
+    switch (currentError) {
+      case 'invalidEpoch':
+        errorDescription = "The given epoch isn't an integer, please correct it and try again.";
+        break;
+      case 'invalidAggregatorUrl':
+        errorDescription = "The given aggregator isn't a valid url, please correct it and try again.";
+        break;
+      default:
+        errorDescription = "Something went wrong";
+        break;
+    }
+
+    return (
+      <Stack gap={3}>
+        <h2>Registrations</h2>
+        <Alert variant="danger">
+          <Alert.Heading>Oh snap! You got an error!</Alert.Heading>
+          <p>{errorDescription}</p>
+        </Alert>
+      </Stack>
+    );
+  }
+
   return (
     <Stack gap={3}>
       <h2>
         Registrations {' '}
-        {currentError === undefined &&
-          <RawJsonButton
-            href={`${aggregator}/signers/registered/${registrationEpoch}`}
-            variant="outline-light"
-            size="sm"/>
-        }
+        <RawJsonButton
+          href={`${aggregator}/signers/registered/${registrationEpoch}`}
+          variant="outline-light"
+          size="sm"/>
       </h2>
-      {currentError === undefined
-        ? <>
-          <Row>
-            <Table>
-              <tbody>
-              <tr>
-                <td><strong>Aggregator:</strong></td>
-                <td>{aggregator}</td>
-              </tr>
-              <tr>
-                <td><strong>Registration epoch:</strong></td>
-                <td>{registrationEpoch}</td>
-              </tr>
-              <tr>
-                <td><strong>Signing at epoch:</strong></td>
-                <td>{signingEpoch}</td>
-              </tr>
-              </tbody>
-            </Table>
-          </Row>
-          <Row>
-            <div>
-              {Number.isInteger(registrationEpoch) &&
-                <ButtonGroup>
-                  <LinkButton href={navigateToPreviousUrl}>
-                    Previous Epoch ({registrationEpoch - 1})
-                  </LinkButton>
-                  <LinkButton href={navigateToCurrentUrl}
-                              disabled={currentEpoch === undefined || currentEpoch === registrationEpoch}>
-                    Current Epoch ({currentEpoch})
-                  </LinkButton>
-                  <LinkButton href={navigateToNextUrl}
-                              disabled={currentEpoch <= registrationEpoch}>
-                    Next Epoch ({registrationEpoch + 1})
-                  </LinkButton>
-                </ButtonGroup>
-              }
-            </div>
-          </Row>
-          {isLoading
-            ? <Spinner animation="grow"/>
-            : registrations === undefined || registrations.length === 0
-              ?
-              <Alert variant="info">
-                <Alert.Heading>No registrations for epoch {registrationEpoch}</Alert.Heading>
-                <p>{getNoRegistrationsMessage()}</p>
-              </Alert>
-              :
-              <Row>
-                <Col xs={12} sm={12} md={7}>
-                  <Table responsive striped>
-                    <thead>
-                    <tr>
-                      <th>#</th>
-                      <th>Party id</th>
-                      <th>Stake</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    {registrations.map((signer, index) =>
-                      <tr key={signer.party_id}>
-                        <td>{index}</td>
-                        <td><VerifiedBadge tooltip="Verified Signer"/>{' '}{signer.party_id}</td>
-                        <td>{signer.stake}</td>
-                      </tr>
-                    )}
-                    </tbody>
-                  </Table>
-                </Col>
-                <Col xs={12} sm={12} md={5}>
-                  <Stack gap={3}>
-                    <div></div>
-                    <div></div>
-                  </Stack>
-                </Col>
-              </Row>
+      <Row>
+        <Table>
+          <tbody>
+          <tr>
+            <td><strong>Aggregator:</strong></td>
+            <td>{aggregator}</td>
+          </tr>
+          <tr>
+            <td><strong>Registration epoch:</strong></td>
+            <td>{registrationEpoch}</td>
+          </tr>
+          <tr>
+            <td><strong>Signing at epoch:</strong></td>
+            <td>{signingEpoch}</td>
+          </tr>
+          </tbody>
+        </Table>
+      </Row>
+      <Row>
+        <div>
+          {Number.isInteger(registrationEpoch) &&
+            <ButtonGroup>
+              <LinkButton href={navigateToPreviousUrl}>
+                Previous Epoch ({registrationEpoch - 1})
+              </LinkButton>
+              <LinkButton href={navigateToCurrentUrl}
+                          disabled={currentEpoch === undefined || currentEpoch === registrationEpoch}>
+                Current Epoch ({currentEpoch})
+              </LinkButton>
+              <LinkButton href={navigateToNextUrl}
+                          disabled={currentEpoch <= registrationEpoch}>
+                Next Epoch ({registrationEpoch + 1})
+              </LinkButton>
+            </ButtonGroup>
           }
-        </>
-        : <>
-          <Alert variant="danger">
-            <Alert.Heading>Oh snap! You got an error!</Alert.Heading>
-            <p>{getErrorDescription()}</p>
+        </div>
+      </Row>
+      {isLoading
+        ? <Spinner animation="grow"/>
+        : registrations === undefined || registrations.length === 0
+          ?
+          <Alert variant="info">
+            <Alert.Heading>No registrations for epoch {registrationEpoch}</Alert.Heading>
+            <p>{getNoRegistrationsMessage()}</p>
           </Alert>
-        </>
+          :
+          <Row>
+            <Col xs={12} sm={12} md={7}>
+              <Table responsive striped>
+                <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Party id</th>
+                  <th>Stake</th>
+                </tr>
+                </thead>
+                <tbody>
+                {registrations.map((signer, index) =>
+                  <tr key={signer.party_id}>
+                    <td>{index}</td>
+                    <td><VerifiedBadge tooltip="Verified Signer"/>{' '}{signer.party_id}</td>
+                    <td>{signer.stake}</td>
+                  </tr>
+                )}
+                </tbody>
+              </Table>
+            </Col>
+            <Col xs={12} sm={12} md={5}>
+              <Stack gap={3}>
+                <div></div>
+                <div></div>
+              </Stack>
+            </Col>
+          </Row>
       }
     </Stack>
   );

--- a/mithril-explorer/src/components/CertificateModal/index.js
+++ b/mithril-explorer/src/components/CertificateModal/index.js
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {Badge, Button, Col, Container, ListGroup, Modal, Row, Table} from "react-bootstrap";
 import {useSelector} from "react-redux";
 import RawJsonButton from "../RawJsonButton";
+import Stake from "../Stake";
 import VerifiedBadge from '../VerifiedBadge';
 import ProtocolParameters from "../ProtocolParameters";
 import {selectedAggregator} from "../../store/settingsSlice";
@@ -81,7 +82,7 @@ export default function CertificateModal(props) {
                         <tr>
                           <th></th>
                           <th>Party id</th>
-                          <th>Stake</th>
+                          <th style={{textAlign: "end"}}>Stake</th>
                         </tr>
                         </thead>
                         <tbody>
@@ -93,7 +94,7 @@ export default function CertificateModal(props) {
                               }
                             </td>
                             <td>{signer.party_id}</td>
-                            <td>{signer.stake}</td>
+                            <td style={{textAlign: "end"}}><Stake lovelace={signer.stake}/></td>
                           </tr>
                         )}
                         </tbody>

--- a/mithril-explorer/src/components/EpochSettings/index.js
+++ b/mithril-explorer/src/components/EpochSettings/index.js
@@ -1,6 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Card, ListGroup} from "react-bootstrap";
-import Link from "next/link";
+import LinkButton from "../LinkButton";
 import RawJsonButton from "../RawJsonButton";
 import {useSelector} from "react-redux";
 import ProtocolParameters from "../ProtocolParameters";
@@ -60,18 +60,20 @@ export default function EpochSettings(props) {
         <Card.Body>
           <Card.Title>Current Epoch</Card.Title>
           <ListGroup variant="flush">
-            <ListGroup.Item>
-              {epochSettings.epoch}{' '}
-              {registrationPageUrl &&
-                <Link href={registrationPageUrl}>Registrations</Link>
-              }
-            </ListGroup.Item>
+            <ListGroup.Item>{epochSettings.epoch}</ListGroup.Item>
           </ListGroup>
           <Card.Title>Protocol Parameters</Card.Title>
           <ProtocolParameters protocolParameters={epochSettings.protocol}/>
           <Card.Title>Next Protocol Parameters</Card.Title>
           <ProtocolParameters protocolParameters={epochSettings.next_protocol}/>
         </Card.Body>
+        {registrationPageUrl &&
+          <Card.Footer className="text-center">
+            <LinkButton href={registrationPageUrl}>
+              Registered Signers
+            </LinkButton>
+          </Card.Footer>
+        }
       </Card>
     </div>
   );

--- a/mithril-explorer/src/components/LinkButton.js
+++ b/mithril-explorer/src/components/LinkButton.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import Link from "next/link";
+
+export default function RawJsonButton({href, children, className, disabled, ...props}) {
+  if (disabled === true) {
+    className = `${className} disabled`;
+  } else {
+    disabled = false;
+  }
+
+  return (
+    <Link href={href}
+          aria-disabled={disabled}
+          className={`btn btn-primary link-underline-opacity-0 link-light ${className}`}
+          {...props}>
+      {children}
+    </Link>
+  );
+}

--- a/mithril-explorer/src/components/Stake.js
+++ b/mithril-explorer/src/components/Stake.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import {OverlayTrigger, Tooltip} from "react-bootstrap";
+import {formatCurrency, formatStake, toAda} from "../utils";
+
+export default function Stake({lovelace}) {
+  return (
+    <OverlayTrigger overlay={<Tooltip>{formatCurrency(toAda(lovelace), 20)}₳</Tooltip>}>
+      <span>{formatStake(lovelace)}</span>
+    </OverlayTrigger>
+  );
+}

--- a/mithril-explorer/src/constants.js
+++ b/mithril-explorer/src/constants.js
@@ -1,0 +1,1 @@
+export const aggregatorSearchParam = 'aggregator';

--- a/mithril-explorer/src/store/provider.js
+++ b/mithril-explorer/src/store/provider.js
@@ -1,5 +1,6 @@
 "use client";
 
+import {aggregatorSearchParam} from "../constants";
 import {saveToLocalStorage, storeBuilder} from "./store";
 import {Provider} from "react-redux";
 import {useSearchParams} from "next/navigation";
@@ -7,7 +8,7 @@ import {useState} from "react";
 
 export function Providers({children}) {
   const searchParams = useSearchParams();
-  const initialAggregator = searchParams.get('aggregator');
+  const initialAggregator = searchParams.get(aggregatorSearchParam);
   const [store, initializeStore] = useState(storeBuilder(initialAggregator));
 
   store.subscribe(() => saveToLocalStorage(store.getState()));

--- a/mithril-explorer/src/store/store.js
+++ b/mithril-explorer/src/store/store.js
@@ -47,7 +47,7 @@ function getSettings(defaultSettings, initialAggregator) {
       availableAggregators: aggregators,
     };
   }
-  
+
   return settings;
 }
 

--- a/mithril-explorer/src/utils.js
+++ b/mithril-explorer/src/utils.js
@@ -7,6 +7,42 @@ function checkUrl(url) {
   }
 }
 
+function setChartJsDefaults(chartJs) {
+  const backgroundColor =
+    [
+      'rgba(255, 99, 132, 0.2)',
+      'rgba(255, 159, 64, 0.2)',
+      'rgba(255, 205, 86, 0.2)',
+      'rgba(75, 192, 192, 0.2)',
+      'rgba(54, 162, 235, 0.2)',
+      'rgba(153, 102, 255, 0.2)',
+      'rgba(201, 203, 207, 0.2)'
+    ]
+  const borderColor = [
+    'rgb(255, 99, 132)',
+    'rgb(255, 159, 64)',
+    'rgb(255, 205, 86)',
+    'rgb(75, 192, 192)',
+    'rgb(54, 162, 235)',
+    'rgb(153, 102, 255)',
+    'rgb(201, 203, 207)'
+  ];
+
+  // Global - hide charts title
+  chartJs.defaults.plugins.legend.display = false;
+
+  // Pie chart
+  chartJs.defaults.elements.arc.backgroundColor = backgroundColor;
+  chartJs.defaults.elements.arc.borderColor = borderColor;
+  chartJs.defaults.elements.arc.borderWidth = 1;
+
+  // Bar chart
+  chartJs.defaults.elements.bar.backgroundColor = backgroundColor;
+  chartJs.defaults.elements.bar.borderColor = borderColor;
+  chartJs.defaults.elements.bar.borderWidth = 1;
+}
+
 module.exports = {
-  checkUrl
+  checkUrl,
+  setChartJsDefaults,
 }

--- a/mithril-explorer/src/utils.js
+++ b/mithril-explorer/src/utils.js
@@ -7,6 +7,32 @@ function checkUrl(url) {
   }
 }
 
+const toAda = (lovelace) => lovelace / 1000000;
+
+const formatCurrency = (number, maximumFractionDigits = 2) => number.toLocaleString(undefined, {
+  maximumFractionDigits: maximumFractionDigits,
+});
+
+function formatStake(lovelace) {
+  // Credits to Jasser Mark Arioste for the original idea:
+  // https://reacthustle.com/blog/how-to-convert-number-to-kmb-format-in-javascript
+  const thresholds = [
+    {suffix: 'B', value: 1e9},
+    {suffix: 'M', value: 1e6},
+    {suffix: 'K', value: 1e3},
+    {suffix: '', value: 1},
+  ];
+  const ada = toAda(lovelace);
+  // Note: subtracting 0.001 to handle cases like `999,999₳` rounding up to `1,000₳` after string format.
+  const threshold = thresholds.find((t) => Math.abs(ada) >= (t.value - 0.001));
+
+  if (threshold) {
+    return `${formatCurrency(ada / threshold.value)}${threshold.suffix}₳`;
+  }
+
+  return `${formatCurrency(ada)}₳`;
+}
+
 function setChartJsDefaults(chartJs) {
   const backgroundColor =
     [
@@ -44,5 +70,8 @@ function setChartJsDefaults(chartJs) {
 
 module.exports = {
   checkUrl,
+  formatStake,
   setChartJsDefaults,
+  toAda,
+  formatCurrency,
 }

--- a/mithril-explorer/yarn.lock
+++ b/mithril-explorer/yarn.lock
@@ -605,6 +605,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.2.tgz#5acd38242e8bde4f9986e7913c8fdf49d3aa199f"
+  integrity sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw==
+
 "@next/env@13.4.13":
   version "13.4.13"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-13.4.13.tgz#50250cec7626904b93a4a934933d6a747763259d"
@@ -1439,6 +1444,13 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+chart.js@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.3.3.tgz#dcd98afadf9fcfa5219e72ace5912092ea48fd36"
+  integrity sha512-aTk7pBw+x6sQYhon/NR3ikfUJuym/LdgpTlgZRe2PaEhjUMKBKyNaFCMVRAyTEWYFNO7qRu7iQVqOw/OqzxZxQ==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 ci-info@^3.2.0:
   version "3.8.0"
@@ -3870,6 +3882,11 @@ react-bootstrap@^2.8.0:
     react-transition-group "^4.4.5"
     uncontrollable "^7.2.1"
     warning "^4.0.3"
+
+react-chartjs-2@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-5.2.0.tgz#43c1e3549071c00a1a083ecbd26c1ad34d385f5d"
+  integrity sha512-98iN5aguJyVSxp5U3CblRLH67J8gkfyGNbiK3c+l1QI/G4irHMPQw44aEPmjVag+YKTyQ260NcF82GTQ3bdscA==
 
 react-dom@^18.2.0:
   version "18.2.0"

--- a/mithril-explorer/yarn.lock
+++ b/mithril-explorer/yarn.lock
@@ -326,10 +326,10 @@
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.6.2.tgz#1816b5f6948029c5eaacb0703b850ee0cb37d8f8"
   integrity sha512-pPTNuaAG3QMH+buKyBIGJs3g/S5y0caxw0ygM3YyE6yJFySwiGGSzA+mM3KJ8QQvzeLh3blwgSonkFjgQdxzMw==
 
-"@eslint/eslintrc@^2.1.1":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.1.tgz#18d635e24ad35f7276e8a49d135c7d3ca6a46f93"
-  integrity sha512-9t7ZA7NGGK8ckelF0PQCfcxIUzs1Md5rrO6U/c+FIQNanea5UZC0wqKXH4vHBccmu4ZJgZ2idtPeW7+Q2npOEA==
+"@eslint/eslintrc@^2.1.2":
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-2.1.2.tgz#c6936b4b328c64496692f76944e755738be62396"
+  integrity sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==
   dependencies:
     ajv "^6.12.4"
     debug "^4.3.2"
@@ -341,10 +341,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@^8.46.0":
-  version "8.46.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.46.0.tgz#3f7802972e8b6fe3f88ed1aabc74ec596c456db6"
-  integrity sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA==
+"@eslint/js@^8.47.0":
+  version "8.47.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.47.0.tgz#5478fdf443ff8158f9de171c704ae45308696c7d"
+  integrity sha512-P6omY1zv5MItm93kLM8s2vr1HICJH8v0dvddDhysbIuZ+vcjOHg5Zbkf1mTkcmi2JA9oBG2anOkRnW8WJTS8Og==
 
 "@humanwhocodes/config-array@^0.11.10":
   version "0.11.10"
@@ -688,27 +688,15 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pkgr/utils@^2.3.1":
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/@pkgr/utils/-/utils-2.4.2.tgz#9e638bbe9a6a6f165580dc943f138fd3309a2cbc"
-  integrity sha512-POgTXhjrTfbTV63DiFXav4lBHiICLKKwDeaKn9Nphwj7WH6m0hMMCaJkMyRWjgtPFyRKRVoMXXjczsTQRDEhYw==
-  dependencies:
-    cross-spawn "^7.0.3"
-    fast-glob "^3.3.0"
-    is-glob "^4.0.3"
-    open "^9.1.0"
-    picocolors "^1.0.0"
-    tslib "^2.6.0"
-
 "@popperjs/core@^2.11.6", "@popperjs/core@^2.11.8":
   version "2.11.8"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.8.tgz#6b79032e760a0899cd4204710beede972a3a185f"
   integrity sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==
 
 "@react-aria/ssr@^3.5.0":
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.7.0.tgz#7eda2964ab792dc1c3a1fdacbf5bfb185590e9a5"
-  integrity sha512-bfufjg4ESE5giN+Fxj1XIzS5f/YIhqcGc+Ve+vUUKU8xZ8t/Xtjlv8F3kjqDBQdk//n3mluFY7xG1wQVB9rMLQ==
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/@react-aria/ssr/-/ssr-3.7.1.tgz#11d0fac17e50028459aad325c2d093dbb2960f68"
+  integrity sha512-ovVPSD1WlRpZHt7GI9DqJrWG3OIYS+NXQ9y5HIewMJpSe+jPQmMQfyRmgX4EnvmxSlp0u04Wg/7oItcoSIb/RA==
   dependencies:
     "@swc/helpers" "^0.5.0"
 
@@ -913,9 +901,9 @@
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
 "@types/node@*":
-  version "20.4.8"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.8.tgz#b5dda19adaa473a9bf0ab5cbd8f30ec7d43f5c85"
-  integrity sha512-0mHckf6D2DiIAzh8fM8f3HQCvMKDpK94YQ0DSVkfWTG9BZleYIWudw9cJxX8oCk9bM+vAkDyujDV6dmKHbvQpg==
+  version "20.4.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.9.tgz#c7164e0f8d3f12dfae336af0b1f7fdec8c6b204f"
+  integrity sha512-8e2HYcg7ohnTUbHk8focoklEQYvemQmu9M/f43DZVx43kHn0tE3BY/6gSDxS7k0SprtS0NHvj+L80cGLnoOUcQ==
 
 "@types/prop-types@*":
   version "15.7.5"
@@ -937,9 +925,9 @@
     "@types/react" "*"
 
 "@types/react@*", "@types/react@>=16.9.11":
-  version "18.2.19"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.19.tgz#f77cb2c8307368e624d464a25b9675fa35f95a8b"
-  integrity sha512-e2S8wmY1ePfM517PqCG80CcE48Xs5k0pwJzuDZsfE8IZRRBfOMCF+XqnFxu6mWtyivum1MQm4aco+WIt6Coimw==
+  version "18.2.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.20.tgz#1605557a83df5c8a2cc4eeb743b3dfc0eb6aaeb2"
+  integrity sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -1314,11 +1302,6 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-big-integer@^1.6.44:
-  version "1.6.51"
-  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
-  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
-
 bootstrap-icons@^1.10.5:
   version "1.10.5"
   resolved "https://registry.yarnpkg.com/bootstrap-icons/-/bootstrap-icons-1.10.5.tgz#5a1bbb1bb2212397d416587db1d422cc9501847c"
@@ -1328,13 +1311,6 @@ bootstrap@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.1.tgz#8ca07040ad15d7f75891d1504cf14c5dedfb1cfe"
   integrity sha512-jzwza3Yagduci2x0rr9MeFSORjcHpt0lRZukZPZQJT1Dth5qzV7XcgGqYzi39KGAVYR8QEDVoO0ubFKOxzMG+g==
-
-bplist-parser@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/bplist-parser/-/bplist-parser-0.2.0.tgz#43a9d183e5bf9d545200ceac3e712f79ebbe8d0e"
-  integrity sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==
-  dependencies:
-    big-integer "^1.6.44"
 
 brace-expansion@^1.1.7:
   version "1.1.11"
@@ -1372,13 +1348,6 @@ buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
-
-bundle-name@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-3.0.0.tgz#ba59bcc9ac785fb67ccdbf104a2bf60c099f0e1a"
-  integrity sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==
-  dependencies:
-    run-applescript "^5.0.0"
 
 busboy@1.6.0:
   version "1.6.0"
@@ -1645,29 +1614,6 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
-default-browser-id@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-3.0.0.tgz#bee7bbbef1f4e75d31f98f4d3f1556a14cea790c"
-  integrity sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==
-  dependencies:
-    bplist-parser "^0.2.0"
-    untildify "^4.0.0"
-
-default-browser@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-4.0.0.tgz#53c9894f8810bf86696de117a6ce9085a3cbc7da"
-  integrity sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==
-  dependencies:
-    bundle-name "^3.0.0"
-    default-browser-id "^3.0.0"
-    execa "^7.1.1"
-    titleize "^3.0.0"
-
-define-lazy-prop@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
-  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
-
 define-properties@^1.1.3, define-properties@^1.1.4, define-properties@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.2.0.tgz#52988570670c9eacedd8064f4a990f2405849bd5"
@@ -1738,9 +1684,9 @@ domexception@^4.0.0:
     webidl-conversions "^7.0.0"
 
 electron-to-chromium@^1.4.477:
-  version "1.4.488"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.488.tgz#442b1855f8c84fb1ed79f518985c65db94f64cc9"
-  integrity sha512-Dv4sTjiW7t/UWGL+H8ZkgIjtUAVZDgb/PwGWvMsCT7jipzUV/u5skbLXPFKb6iV0tiddVi/bcS2/kUrczeWgIQ==
+  version "1.4.490"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.490.tgz#d99286f6e915667fa18ea4554def1aa60eb4d5f1"
+  integrity sha512-6s7NVJz+sATdYnIwhdshx/N/9O6rvMxmhVoDSDFdj6iA45gHR8EQje70+RYsF4GeB+k0IeNSBnP7yG9ZXJFr7A==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -1918,18 +1864,17 @@ eslint-import-resolver-node@^0.3.6, eslint-import-resolver-node@^0.3.7:
     resolve "^1.22.4"
 
 eslint-import-resolver-typescript@^3.5.2:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.5.tgz#0a9034ae7ed94b254a360fbea89187b60ea7456d"
-  integrity sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.0.tgz#36f93e1eb65a635e688e16cae4bead54552e3bbd"
+  integrity sha512-QTHR9ddNnn35RTxlaEnx2gCxqFlF2SEN0SE2d17SqwyM7YOSI2GHWRYp5BiRkObTUNYPupC/3Fq2a0PpT+EKpg==
   dependencies:
     debug "^4.3.4"
     enhanced-resolve "^5.12.0"
     eslint-module-utils "^2.7.4"
+    fast-glob "^3.3.1"
     get-tsconfig "^4.5.0"
-    globby "^13.1.3"
     is-core-module "^2.11.0"
     is-glob "^4.0.3"
-    synckit "^0.8.5"
 
 eslint-module-utils@^2.7.4, eslint-module-utils@^2.8.0:
   version "2.8.0"
@@ -2018,20 +1963,20 @@ eslint-scope@^7.2.2:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.2:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.2.tgz#8c2095440eca8c933bedcadf16fefa44dbe9ba5f"
-  integrity sha512-8drBzUEyZ2llkpCA67iYrgEssKDUu68V8ChqqOfFupIaG/LCVPUT+CoGJpT77zJprs4T/W7p07LP7zAIMuweVw==
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.46.0:
-  version "8.46.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.46.0.tgz#a06a0ff6974e53e643acc42d1dcf2e7f797b3552"
-  integrity sha512-cIO74PvbW0qU8e0mIvk5IV3ToWdCq5FYG6gWPHHkx6gNdjlbAYvtfHmlCMXxjcoVaIdwy/IAt3+mDkZkfvb2Dg==
+eslint@^8.47.0:
+  version "8.47.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.47.0.tgz#c95f9b935463fb4fad7005e626c7621052e90806"
+  integrity sha512-spUQWrdPt+pRVP1TTJLmfRNJJHHZryFmptzcafwSvHsceV81djHOdnEeDmkdotZyLNjDhrOasNK8nikkoG1O8Q==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.6.1"
-    "@eslint/eslintrc" "^2.1.1"
-    "@eslint/js" "^8.46.0"
+    "@eslint/eslintrc" "^2.1.2"
+    "@eslint/js" "^8.47.0"
     "@humanwhocodes/config-array" "^0.11.10"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
@@ -2042,7 +1987,7 @@ eslint@^8.46.0:
     doctrine "^3.0.0"
     escape-string-regexp "^4.0.0"
     eslint-scope "^7.2.2"
-    eslint-visitor-keys "^3.4.2"
+    eslint-visitor-keys "^3.4.3"
     espree "^9.6.1"
     esquery "^1.4.2"
     esutils "^2.0.2"
@@ -2119,21 +2064,6 @@ execa@^5.0.0:
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
 
-execa@^7.1.1:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-7.2.0.tgz#657e75ba984f42a70f38928cedc87d6f2d4fe4e9"
-  integrity sha512-UduyVP7TLB5IcAQl+OzLyLcS/l32W/GLg+AhHJ+ow40FOk2U3SAllPwR44v4vmdFwIWqpdwxxpQbF1n5ta9seA==
-  dependencies:
-    cross-spawn "^7.0.3"
-    get-stream "^6.0.1"
-    human-signals "^4.3.0"
-    is-stream "^3.0.0"
-    merge-stream "^2.0.0"
-    npm-run-path "^5.1.0"
-    onetime "^6.0.0"
-    signal-exit "^3.0.7"
-    strip-final-newline "^3.0.0"
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -2156,7 +2086,7 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-glob@^3.2.9, fast-glob@^3.3.0:
+fast-glob@^3.2.9, fast-glob@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
   integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
@@ -2305,7 +2235,7 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-stream@^6.0.0, get-stream@^6.0.1:
+get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
@@ -2319,9 +2249,9 @@ get-symbol-description@^1.0.0:
     get-intrinsic "^1.1.1"
 
 get-tsconfig@^4.5.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.6.2.tgz#831879a5e6c2aa24fe79b60340e2233a1e0f472e"
-  integrity sha512-E5XrT4CbbXcXWy+1jChlZmrmCwd5KGx502kDCXJJ7y898TtWW9FwoG5HfOLVRKmlmDGkWN2HM9Ho+/Y8F0sJDg==
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.7.0.tgz#06ce112a1463e93196aa90320c35df5039147e34"
+  integrity sha512-pmjiZ7xtB8URYm74PlGJozDNyhvsVLUcpBa8DZBG3bWHwaHa9bPiRpiSfovw+fjhwONSCWKRyk+JQHEGZmMrzw==
   dependencies:
     resolve-pkg-maps "^1.0.0"
 
@@ -2374,9 +2304,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.19.0:
-  version "13.20.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.20.0.tgz#ea276a1e508ffd4f1612888f9d1bad1e2717bf82"
-  integrity sha512-Qg5QtVkCy/kv3FUSlu4ukeZDVf9ee0iXLAUYX13gbR17bnejFTzr4iS9bY7kwCf1NztRNm1t91fjOiyx4CSwPQ==
+  version "13.21.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.21.0.tgz#163aae12f34ef502f5153cfbdd3600f36c63c571"
+  integrity sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==
   dependencies:
     type-fest "^0.20.2"
 
@@ -2398,17 +2328,6 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
-
-globby@^13.1.3:
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
-  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
-  dependencies:
-    dir-glob "^3.0.1"
-    fast-glob "^3.3.0"
-    ignore "^5.2.4"
-    merge2 "^1.4.1"
-    slash "^4.0.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -2514,11 +2433,6 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
-human-signals@^4.3.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-4.3.1.tgz#ab7f811e851fca97ffbd2c1fe9a958964de321b2"
-  integrity sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==
-
 iconv-lite@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
@@ -2526,7 +2440,7 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ignore@^5.2.0, ignore@^5.2.4:
+ignore@^5.2.0:
   version "5.2.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
   integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
@@ -2647,16 +2561,6 @@ is-date-object@^1.0.1, is-date-object@^1.0.5:
   dependencies:
     has-tostringtag "^1.0.0"
 
-is-docker@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
-  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
-
-is-docker@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
-  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
-
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -2678,13 +2582,6 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
-
-is-inside-container@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
-  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
-  dependencies:
-    is-docker "^3.0.0"
 
 is-map@^2.0.1, is-map@^2.0.2:
   version "2.0.2"
@@ -2743,11 +2640,6 @@ is-stream@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
   integrity sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==
 
-is-stream@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
-  integrity sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==
-
 is-string@^1.0.5, is-string@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.7.tgz#0dd12bf2006f255bb58f695110eff7491eebc0fd"
@@ -2788,13 +2680,6 @@ is-weakset@^2.0.1:
   dependencies:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
-
-is-wsl@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
-  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
-  dependencies:
-    is-docker "^2.0.0"
 
 isarray@^2.0.5:
   version "2.0.5"
@@ -3448,11 +3333,6 @@ mimic-fn@^2.1.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
 
-mimic-fn@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-4.0.0.tgz#60a90550d5cb0b239cca65d893b1a53b29871ecc"
-  integrity sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==
-
 min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
@@ -3490,10 +3370,10 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-next-router-mock@^0.9.7:
-  version "0.9.7"
-  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.7.tgz#828e699fba6862e3a3defdb67803c3200a5ab699"
-  integrity sha512-y5ioLCIsdkJKwcoPnrUyocNEJT22RK4wKSg6LO0Q2XkBBvkYprEWy5FiCZt+CA8+qpfxpBlNca76F+glEohbRA==
+next-router-mock@^0.9.8:
+  version "0.9.8"
+  resolved "https://registry.yarnpkg.com/next-router-mock/-/next-router-mock-0.9.8.tgz#83f82bcd57baee46fc8653ea2f6a5c17177b4c8d"
+  integrity sha512-u9yzuLTYuBzarv1wfN2z+aC3iSr5nmvMIRnMXNq4c+Alyf4iXKOTnKG3dW1w6h3JW+qNRhTJV37weMsARALZpw==
 
 next@^13.4.13:
   version "13.4.13"
@@ -3540,13 +3420,6 @@ npm-run-path@^4.0.1:
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
   dependencies:
     path-key "^3.0.0"
-
-npm-run-path@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-5.1.0.tgz#bc62f7f3f6952d9894bd08944ba011a6ee7b7e00"
-  integrity sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==
-  dependencies:
-    path-key "^4.0.0"
 
 nwsapi@^2.2.2:
   version "2.2.7"
@@ -3645,23 +3518,6 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-onetime@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-6.0.0.tgz#7c24c18ed1fd2e9bca4bd26806a33613c77d34b4"
-  integrity sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==
-  dependencies:
-    mimic-fn "^4.0.0"
-
-open@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/open/-/open-9.1.0.tgz#684934359c90ad25742f5a26151970ff8c6c80b6"
-  integrity sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==
-  dependencies:
-    default-browser "^4.0.0"
-    define-lazy-prop "^3.0.0"
-    is-inside-container "^1.0.0"
-    is-wsl "^2.2.0"
-
 optionator@^0.9.3:
   version "0.9.3"
   resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.9.3.tgz#007397d44ed1872fdc6ed31360190f81814e2c64"
@@ -3745,11 +3601,6 @@ path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-3.1.1.tgz#581f6ade658cbba65a0d3380de7753295054f375"
   integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
-
-path-key@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/path-key/-/path-key-4.0.0.tgz#295588dc3aee64154f877adb9d780b81c554bf18"
-  integrity sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==
 
 path-parse@^1.0.7:
   version "1.0.7"
@@ -4051,13 +3902,6 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
-run-applescript@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-5.0.0.tgz#e11e1c932e055d5c6b40d98374e0268d9b11899c"
-  integrity sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==
-  dependencies:
-    execa "^5.0.0"
-
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/run-parallel/-/run-parallel-1.2.0.tgz#66d1368da7bdf921eb9d95bd1a9229e7f21a43ee"
@@ -4150,11 +3994,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-slash@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-4.0.0.tgz#2422372176c4c6c5addb5e2ada885af984b396a7"
-  integrity sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==
 
 source-map-js@^1.0.2:
   version "1.0.2"
@@ -4278,11 +4117,6 @@ strip-final-newline@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-2.0.0.tgz#89b852fb2fcbe936f6f4b3187afb0a12c1ab58ad"
   integrity sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
 
-strip-final-newline@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/strip-final-newline/-/strip-final-newline-3.0.0.tgz#52894c313fbff318835280aed60ff71ebf12b8fd"
-  integrity sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==
-
 strip-indent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-3.0.0.tgz#c32e1cee940b6b3432c771bc2c54bcce73cd3001"
@@ -4333,14 +4167,6 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-synckit@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/synckit/-/synckit-0.8.5.tgz#b7f4358f9bb559437f9f167eb6bc46b3c9818fa3"
-  integrity sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==
-  dependencies:
-    "@pkgr/utils" "^2.3.1"
-    tslib "^2.5.0"
-
 tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -4359,11 +4185,6 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
-
-titleize@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/titleize/-/titleize-3.0.0.tgz#71c12eb7fdd2558aa8a44b0be83b8a76694acd53"
-  integrity sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -4414,7 +4235,7 @@ tsconfig-paths@^3.14.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.4.0, tslib@^2.5.0, tslib@^2.6.0:
+tslib@^2.4.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.1.tgz#fd8c9a0ff42590b25703c0acb3de3d3f4ede0410"
   integrity sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==
@@ -4509,11 +4330,6 @@ universalify@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
   integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
-
-untildify@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
-  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 update-browserslist-db@^1.0.11:
   version "1.0.11"


### PR DESCRIPTION
## Content
This PR add a new pages to the explorer: Registrations. This pages can be navigated to by using a button at the bottom of the epoch settings card.
It display the registered signers for a given epoch, their stakes, two charts (breakdown of the stakes and the signers weigth) and allow to navigate to the registration of the previous, current or next epoch.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1097
