### PR TITLE
StdResult and StdError as anyhow alias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,6 @@ dependencies = [
  "http",
  "jsonschema",
  "kes-summed-ed25519",
- "lazy_static",
  "mithril-stm",
  "mockall",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,7 @@ dependencies = [
 name = "mithril-aggregator"
 version = "0.3.67"
 dependencies = [
+ "anyhow",
  "async-trait",
  "chrono",
  "clap",
@@ -2142,6 +2143,7 @@ dependencies = [
 name = "mithril-client"
 version = "0.3.29"
 dependencies = [
+ "anyhow",
  "async-recursion",
  "async-trait",
  "chrono",
@@ -2250,6 +2252,7 @@ dependencies = [
 name = "mithril-signer"
 version = "0.2.65"
 dependencies = [
+ "anyhow",
  "async-trait",
  "clap",
  "config",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+anyhow = "1.0.71"
 async-trait = "0.1.52"
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.0", features = ["derive", "env", "cargo"] }

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -142,10 +142,11 @@ impl ArtifactBuilder<Beacon, Snapshot> for CardanoImmutableFilesFullArtifactBuil
 
 #[cfg(test)]
 mod tests {
+    use anyhow::anyhow;
     use std::path::Path;
+    use tempfile::NamedTempFile;
 
     use mithril_common::test_utils::fake_data;
-    use tempfile::NamedTempFile;
 
     use super::*;
 
@@ -253,7 +254,7 @@ mod tests {
         let mut snapshot_uploader = MockSnapshotUploader::new();
         snapshot_uploader
             .expect_upload_snapshot()
-            .return_once(|_| Err("an error".to_string()))
+            .return_once(|_| Err(anyhow!("an error")))
             .once();
 
         let cardano_immutable_files_full_artifact_builder =

--- a/mithril-aggregator/src/commands/mod.rs
+++ b/mithril-aggregator/src/commands/mod.rs
@@ -5,9 +5,10 @@ mod tools_command;
 
 use clap::{Parser, Subcommand};
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
+use mithril_common::StdResult;
 use slog::Level;
 use slog_scope::debug;
-use std::{error::Error, path::PathBuf};
+use std::path::PathBuf;
 
 use crate::DefaultConfiguration;
 
@@ -21,10 +22,7 @@ pub enum MainCommand {
 }
 
 impl MainCommand {
-    pub async fn execute(
-        &self,
-        config_builder: ConfigBuilder<DefaultState>,
-    ) -> Result<(), Box<dyn Error>> {
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
         match self {
             Self::Genesis(cmd) => cmd.execute(config_builder).await,
             Self::Era(cmd) => cmd.execute(config_builder).await,
@@ -84,7 +82,7 @@ impl Source for MainOpts {
 
 impl MainOpts {
     /// execute command
-    pub async fn execute(&self) -> Result<(), Box<dyn Error>> {
+    pub async fn execute(&self) -> StdResult<()> {
         let config_file_path = self
             .config_directory
             .join(format!("{}.json", self.run_mode));

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -2,13 +2,12 @@ use config::{ConfigError, Map, Source, Value, ValueKind};
 use mithril_common::crypto_helper::{key_encode_hex, ProtocolGenesisSigner};
 use mithril_common::era::adapters::EraReaderAdapterType;
 use serde::{Deserialize, Serialize};
-use std::error::Error;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
 
 use mithril_common::entities::{HexEncodedGenesisVerificationKey, ProtocolParameters};
-use mithril_common::CardanoNetwork;
+use mithril_common::{CardanoNetwork, StdResult};
 
 use crate::tools::GcpFileUploader;
 use crate::{LocalSnapshotUploader, RemoteSnapshotUploader, SnapshotUploader};
@@ -32,7 +31,7 @@ impl FromStr for ExecutionEnvironment {
             "production" => Ok(Self::Production),
             "test" => Ok(Self::Test),
             _ => Err(ConfigError::Message(format!(
-                "Unkown execution environement {s}"
+                "Unknown execution environment {s}"
             ))),
         }
     }
@@ -159,7 +158,7 @@ impl Configuration {
     }
 
     /// Create a snapshot uploader from configuration settings.
-    pub fn build_snapshot_uploader(&self) -> Result<Arc<dyn SnapshotUploader>, Box<dyn Error>> {
+    pub fn build_snapshot_uploader(&self) -> StdResult<Arc<dyn SnapshotUploader>> {
         match self.snapshot_uploader_type {
             SnapshotUploaderType::Gcp => {
                 let bucket = self.snapshot_bucket_name.to_owned().ok_or_else(|| {

--- a/mithril-aggregator/src/database/provider/signed_entity.rs
+++ b/mithril-aggregator/src/database/provider/signed_entity.rs
@@ -14,7 +14,7 @@ use mithril_common::{
         WhereCondition,
     },
     store::adapter::AdapterError,
-    StdError, StdResult,
+    StdResult,
 };
 
 #[cfg(test)]
@@ -138,20 +138,14 @@ impl<'client> SignedEntityRecordProvider<'client> {
         Self { client }
     }
 
-    fn condition_by_signed_entity_id(
-        &self,
-        signed_entity_id: &str,
-    ) -> Result<WhereCondition, StdError> {
+    fn condition_by_signed_entity_id(&self, signed_entity_id: &str) -> StdResult<WhereCondition> {
         Ok(WhereCondition::new(
             "signed_entity_id = ?*",
             vec![Value::String(signed_entity_id.to_owned())],
         ))
     }
 
-    fn condition_by_certificate_id(
-        &self,
-        certificate_id: &str,
-    ) -> Result<WhereCondition, StdError> {
+    fn condition_by_certificate_id(&self, certificate_id: &str) -> StdResult<WhereCondition> {
         Ok(WhereCondition::new(
             "certificate_id = ?*",
             vec![Value::String(certificate_id.to_owned())],
@@ -170,7 +164,7 @@ impl<'client> SignedEntityRecordProvider<'client> {
     fn condition_by_signed_entity_type(
         &self,
         signed_entity_type: &SignedEntityTypeDiscriminants,
-    ) -> Result<WhereCondition, StdError> {
+    ) -> StdResult<WhereCondition> {
         let signed_entity_type_id: i64 = signed_entity_type.index() as i64;
 
         Ok(WhereCondition::new(
@@ -183,7 +177,7 @@ impl<'client> SignedEntityRecordProvider<'client> {
     pub fn get_by_signed_entity_id(
         &self,
         signed_entity_id: &str,
-    ) -> Result<EntityCursor<SignedEntityRecord>, StdError> {
+    ) -> StdResult<EntityCursor<SignedEntityRecord>> {
         let filters = self.condition_by_signed_entity_id(signed_entity_id)?;
         let signed_entity_record = self.find(filters)?;
 
@@ -194,7 +188,7 @@ impl<'client> SignedEntityRecordProvider<'client> {
     pub fn get_by_certificate_id(
         &self,
         certificate_id: &str,
-    ) -> Result<EntityCursor<SignedEntityRecord>, StdError> {
+    ) -> StdResult<EntityCursor<SignedEntityRecord>> {
         let filters = self.condition_by_certificate_id(certificate_id)?;
         let signed_entity_record = self.find(filters)?;
 
@@ -205,7 +199,7 @@ impl<'client> SignedEntityRecordProvider<'client> {
     pub fn get_by_certificates_ids(
         &self,
         certificates_ids: &[&str],
-    ) -> Result<EntityCursor<SignedEntityRecord>, StdError> {
+    ) -> StdResult<EntityCursor<SignedEntityRecord>> {
         let filters = self.condition_by_certificates_ids(certificates_ids);
         let signed_entity_record = self.find(filters)?;
 
@@ -216,7 +210,7 @@ impl<'client> SignedEntityRecordProvider<'client> {
     pub fn get_by_signed_entity_type(
         &self,
         signed_entity_type: &SignedEntityTypeDiscriminants,
-    ) -> Result<EntityCursor<SignedEntityRecord>, StdError> {
+    ) -> StdResult<EntityCursor<SignedEntityRecord>> {
         let filters = self.condition_by_signed_entity_type(signed_entity_type)?;
         let signed_entity_record = self.find(filters)?;
 
@@ -224,7 +218,7 @@ impl<'client> SignedEntityRecordProvider<'client> {
     }
 
     /// Get all SignedEntityRecords.
-    pub fn get_all(&self) -> Result<EntityCursor<SignedEntityRecord>, StdError> {
+    pub fn get_all(&self) -> StdResult<EntityCursor<SignedEntityRecord>> {
         let filters = WhereCondition::default();
         let signed_entity_record = self.find(filters)?;
 
@@ -273,10 +267,7 @@ impl<'conn> InsertSignedEntityRecordProvider<'conn> {
         )
     }
 
-    fn persist(
-        &self,
-        signed_entity_record: SignedEntityRecord,
-    ) -> Result<SignedEntityRecord, StdError> {
+    fn persist(&self, signed_entity_record: SignedEntityRecord) -> StdResult<SignedEntityRecord> {
         let filters = self.get_insert_condition(signed_entity_record.clone());
 
         let entity = self.find(filters)?.next().unwrap_or_else(|| {
@@ -335,10 +326,7 @@ where signed_entity_id = ?*";
         Ok(WhereCondition::new(expression, parameters))
     }
 
-    fn persist(
-        &self,
-        signed_entity_record: &SignedEntityRecord,
-    ) -> Result<SignedEntityRecord, StdError> {
+    fn persist(&self, signed_entity_record: &SignedEntityRecord) -> StdResult<SignedEntityRecord> {
         let filters = self.get_update_condition(signed_entity_record)?;
         let mut cursor = self.find(filters)?;
 
@@ -559,7 +547,7 @@ mod tests {
     pub fn setup_signed_entity_db(
         connection: &Connection,
         signed_entity_records: Vec<SignedEntityRecord>,
-    ) -> Result<(), StdError> {
+    ) -> StdResult<()> {
         apply_all_migrations_to_db(connection)?;
         disable_foreign_key_support(connection)?;
 

--- a/mithril-aggregator/src/database/provider/signed_entity.rs
+++ b/mithril-aggregator/src/database/provider/signed_entity.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -434,7 +435,8 @@ impl SignedEntityStorer for SignedEntityStoreAdapter {
         let provider = SignedEntityRecordProvider::new(connection);
         let mut cursor = provider
             .get_by_signed_entity_id(signed_entity_id)
-            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
+            .with_context(|| format!("get signed entity by id failure, id: {signed_entity_id}"))
+            .map_err(AdapterError::GeneralError)?;
         let signed_entity = cursor.next();
 
         Ok(signed_entity)
@@ -448,7 +450,12 @@ impl SignedEntityStorer for SignedEntityStoreAdapter {
         let provider = SignedEntityRecordProvider::new(connection);
         let mut cursor = provider
             .get_by_certificate_id(certificate_id)
-            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
+            .with_context(|| {
+                format!(
+                    "get signed entity by certificate id failure, certificate_id: {certificate_id}"
+                )
+            })
+            .map_err(AdapterError::GeneralError)?;
         let signed_entity = cursor.next();
 
         Ok(signed_entity)
@@ -474,7 +481,10 @@ impl SignedEntityStorer for SignedEntityStoreAdapter {
         let provider = SignedEntityRecordProvider::new(connection);
         let cursor = provider
             .get_by_signed_entity_type(signed_entity_type_id)
-            .map_err(|e| AdapterError::GeneralError(format!("{e}")))?;
+            .with_context(|| {
+                format!("get last signed entity by type failure, type: {signed_entity_type_id:?}")
+            })
+            .map_err(AdapterError::GeneralError)?;
         let signed_entities: Vec<SignedEntityRecord> = cursor.take(total).collect();
 
         Ok(signed_entities)

--- a/mithril-aggregator/src/database/provider/single_signature.rs
+++ b/mithril-aggregator/src/database/provider/single_signature.rs
@@ -151,10 +151,7 @@ impl<'client> SingleSignatureRecordProvider<'client> {
         Self { client }
     }
 
-    fn condition_by_open_message_id(
-        &self,
-        open_message_id: &Uuid,
-    ) -> Result<WhereCondition, StdError> {
+    fn condition_by_open_message_id(&self, open_message_id: &Uuid) -> StdResult<WhereCondition> {
         Ok(WhereCondition::new(
             "open_message_id = ?*",
             vec![Value::String(open_message_id.to_string())],
@@ -162,7 +159,7 @@ impl<'client> SingleSignatureRecordProvider<'client> {
     }
 
     #[allow(dead_code)] // todo: Should we keep this ?
-    fn condition_by_signer_id(&self, signer_id: String) -> Result<WhereCondition, StdError> {
+    fn condition_by_signer_id(&self, signer_id: String) -> StdResult<WhereCondition> {
         Ok(WhereCondition::new(
             "signer_id = ?*",
             vec![Value::String(signer_id)],
@@ -173,7 +170,7 @@ impl<'client> SingleSignatureRecordProvider<'client> {
     fn condition_by_registration_epoch(
         &self,
         registration_epoch: &Epoch,
-    ) -> Result<WhereCondition, StdError> {
+    ) -> StdResult<WhereCondition> {
         let epoch: i64 = registration_epoch.try_into()?;
 
         Ok(WhereCondition::new(
@@ -186,7 +183,7 @@ impl<'client> SingleSignatureRecordProvider<'client> {
     pub fn get_by_open_message_id(
         &self,
         open_message_id: &Uuid,
-    ) -> Result<EntityCursor<SingleSignatureRecord>, StdError> {
+    ) -> StdResult<EntityCursor<SingleSignatureRecord>> {
         let filters = self.condition_by_open_message_id(open_message_id)?;
         let single_signature_record = self.find(filters)?;
 
@@ -194,7 +191,7 @@ impl<'client> SingleSignatureRecordProvider<'client> {
     }
 
     /// Get all SingleSignatureRecords.
-    pub fn get_all(&self) -> Result<EntityCursor<SingleSignatureRecord>, StdError> {
+    pub fn get_all(&self) -> StdResult<EntityCursor<SingleSignatureRecord>> {
         let filters = WhereCondition::default();
         let single_signature_record = self.find(filters)?;
 
@@ -249,7 +246,7 @@ impl<'conn> UpdateSingleSignatureRecordProvider<'conn> {
     fn persist(
         &self,
         single_signature_record: SingleSignatureRecord,
-    ) -> Result<SingleSignatureRecord, StdError> {
+    ) -> StdResult<SingleSignatureRecord> {
         let filters = self.get_update_condition(&single_signature_record);
 
         let entity = self.find(filters)?.next().unwrap_or_else(|| {
@@ -297,7 +294,7 @@ impl SingleSignatureRepository {
         &self,
         single_signature: &SingleSignatures,
         open_message: &OpenMessageRecord,
-    ) -> Result<SingleSignatureRecord, StdError> {
+    ) -> StdResult<SingleSignatureRecord> {
         let connection = self.connection.lock().await;
         let single_signature = SingleSignatureRecord::try_from_single_signatures(
             single_signature,

--- a/mithril-aggregator/src/database/provider/stake_pool.rs
+++ b/mithril-aggregator/src/database/provider/stake_pool.rs
@@ -1,10 +1,10 @@
 use anyhow::Context;
-use std::ops::Not;
-use std::sync::Arc;
-
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use sqlite::{Connection, Value};
+use std::ops::Not;
+use std::sync::Arc;
+use tokio::sync::Mutex;
 
 use mithril_common::{
     entities::{Epoch, PartyId, Stake, StakeDistribution},
@@ -13,10 +13,8 @@ use mithril_common::{
         WhereCondition,
     },
     store::{adapter::AdapterError, StakeStorer, StoreError},
+    StdResult,
 };
-
-use mithril_common::StdError;
-use tokio::sync::Mutex;
 
 /// Stake pool as read from Chain.
 #[derive(Debug, PartialEq)]
@@ -89,7 +87,7 @@ impl<'client> StakePoolProvider<'client> {
         Self { client }
     }
 
-    fn condition_by_epoch(&self, epoch: &Epoch) -> Result<WhereCondition, StdError> {
+    fn condition_by_epoch(&self, epoch: &Epoch) -> StdResult<WhereCondition> {
         Ok(WhereCondition::new(
             "epoch = ?*",
             vec![Value::Integer(epoch.try_into()?)],
@@ -97,7 +95,7 @@ impl<'client> StakePoolProvider<'client> {
     }
 
     /// Get StakePools for a given Epoch for given pool_ids.
-    pub fn get_by_epoch(&self, epoch: &Epoch) -> Result<EntityCursor<StakePool>, StdError> {
+    pub fn get_by_epoch(&self, epoch: &Epoch) -> StdResult<EntityCursor<StakePool>> {
         let filters = self.condition_by_epoch(epoch)?;
         let stake_pool = self.find(filters)?;
 
@@ -151,12 +149,7 @@ impl<'conn> InsertOrReplaceStakePoolProvider<'conn> {
         )
     }
 
-    fn persist(
-        &self,
-        stake_pool_id: &str,
-        epoch: Epoch,
-        stake: Stake,
-    ) -> Result<StakePool, StdError> {
+    fn persist(&self, stake_pool_id: &str, epoch: Epoch, stake: Stake) -> StdResult<StakePool> {
         let filters = self.get_insert_or_replace_condition(stake_pool_id, epoch, stake);
 
         let entity = self.find(filters)?
@@ -221,7 +214,7 @@ impl<'conn> DeleteStakePoolProvider<'conn> {
     }
 
     /// Prune the stake pools data older than the given epoch.
-    pub fn prune(&self, epoch_threshold: Epoch) -> Result<EntityCursor<StakePool>, StdError> {
+    pub fn prune(&self, epoch_threshold: Epoch) -> StdResult<EntityCursor<StakePool>> {
         let filters = self.get_prune_condition(epoch_threshold);
 
         self.find(filters)
@@ -314,7 +307,7 @@ mod tests {
     pub fn setup_stake_db(
         connection: &Connection,
         epoch_to_insert_settings: &[i64],
-    ) -> Result<(), StdError> {
+    ) -> StdResult<()> {
         apply_all_migrations_to_db(connection)?;
 
         let query = {

--- a/mithril-aggregator/src/database/provider/test_helper.rs
+++ b/mithril-aggregator/src/database/provider/test_helper.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use chrono::Utc;
 use mithril_common::test_utils::fake_keys;
 use mithril_common::{entities::Epoch, StdResult};
@@ -38,9 +39,7 @@ pub fn setup_single_signature_records(
 pub fn disable_foreign_key_support(connection: &Connection) -> StdResult<()> {
     connection
         .execute("pragma foreign_keys=false")
-        .map_err(|e| {
-            format!("SQLite initialization: could not enable FOREIGN KEY support. err: {e}")
-        })?;
+        .with_context(|| "SQLite initialization: could not enable FOREIGN KEY support.")?;
     Ok(())
 }
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -235,7 +235,7 @@ impl DependenciesBuilder {
                     "SQLite initialization: could not open connection with string '{}'.",
                     path.display()
                 ),
-                error: Some(Box::new(e)),
+                error: Some(e.into()),
             })?;
         // Check database migrations
         let mut db_checker = DatabaseVersionChecker::new(
@@ -672,7 +672,7 @@ impl DependenciesBuilder {
             .build(self.get_chain_observer().await?)
             .map_err(|e| DependenciesBuilderError::Initialization {
                 message: "Could not build EraReader as dependency.".to_string(),
-                error: Some(Box::new(e)),
+                error: Some(e.into()),
             })?,
             _ => Arc::new(EraReaderDummyAdapter::from_markers(vec![EraMarker::new(
                 &SupportedEra::dummy().to_string(),

--- a/mithril-aggregator/src/dependency_injection/error.rs
+++ b/mithril-aggregator/src/dependency_injection/error.rs
@@ -33,7 +33,7 @@ impl Display for DependenciesBuilderError {
         match self {
             Self::Initialization { message, error } => {
                 if let Some(nested) = error {
-                    write!(f, "Dependency initialization error: «{message}» with additional nested error: '{nested}'.")
+                    write!(f, "Dependency initialization error: «{message}» with additional nested error: '{nested:?}'.")
                 } else {
                     write!(f, "Dependency initialization error: «{message}».")
                 }

--- a/mithril-aggregator/src/event_store/event.rs
+++ b/mithril-aggregator/src/event_store/event.rs
@@ -1,14 +1,13 @@
-use std::{collections::HashMap, sync::Arc};
-
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
+use sqlite::Connection;
+use std::sync::Mutex;
+use std::{collections::HashMap, sync::Arc};
+
 use mithril_common::sqlite::{
     HydrationError, Projection, Provider, SourceAlias, SqLiteEntity, WhereCondition,
 };
-use sqlite::Connection;
-use std::sync::Mutex;
-
-use mithril_common::StdError;
+use mithril_common::StdResult;
 
 /// Event that is sent from a thread to be persisted.
 #[derive(Debug, Clone)]
@@ -155,7 +154,7 @@ impl EventPersister {
         Self { connection }
     }
 
-    fn get_persist_parameters(&self, message: EventMessage) -> Result<WhereCondition, StdError> {
+    fn get_persist_parameters(&self, message: EventMessage) -> StdResult<WhereCondition> {
         let filters = WhereCondition::new(
             "(source, action, content, created_at) values (?*, ?*, ?*, ?*)",
             vec![
@@ -174,7 +173,7 @@ impl EventPersister {
     }
 
     /// Save an EventMessage in the database.
-    pub fn persist(&self, message: EventMessage) -> Result<Event, StdError> {
+    pub fn persist(&self, message: EventMessage) -> StdResult<Event> {
         let connection = &*self.connection.lock().unwrap();
         let provider = EventPersisterProvider::new(connection);
         let log_message = message.clone();

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -128,6 +128,7 @@ mod handlers {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::anyhow;
     use mithril_common::test_utils::{apispec::APISpec, fake_data};
     use serde_json::Value::Null;
     use warp::{http::Method, test::request};
@@ -252,7 +253,7 @@ mod tests {
         let mut certifier_service = MockCertifierService::new();
         certifier_service
             .expect_get_latest_certificates()
-            .returning(|_| Err("an error".into()));
+            .returning(|_| Err(anyhow!("an error")));
         dependency_manager.certifier_service = Arc::new(certifier_service);
 
         let method = Method::GET.as_str();
@@ -331,7 +332,7 @@ mod tests {
         let mut certifier_service = MockCertifierService::new();
         certifier_service
             .expect_get_certificate_by_hash()
-            .returning(|_| Err("an error".into()));
+            .returning(|_| Err(anyhow!("an error")));
         dependency_manager.certifier_service = Arc::new(certifier_service);
 
         let method = Method::GET.as_str();

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -202,9 +202,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .return_once(move |_, _| {
-                Err(Box::new(CertifierServiceError::NotFound(
-                    signed_entity_type,
-                )))
+                Err(CertifierServiceError::NotFound(signed_entity_type).into())
             });
         let mut dependency_manager = initialize_dependencies().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
@@ -237,9 +235,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .return_once(move |_, _| {
-                Err(Box::new(CertifierServiceError::AlreadyCertified(
-                    signed_entity_type,
-                )))
+                Err(CertifierServiceError::AlreadyCertified(signed_entity_type).into())
             });
         let mut dependency_manager = initialize_dependencies().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
@@ -270,9 +266,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .return_once(move |_, _| {
-                Err(Box::new(ProtocolError::Core(
-                    "an error occurred".to_string(),
-                )))
+                Err(ProtocolError::Core("an error occurred".to_string()).into())
             });
         let mut dependency_manager = initialize_dependencies().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -194,6 +194,7 @@ mod handlers {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::anyhow;
     use mithril_common::entities::Epoch;
     use mithril_common::{
         crypto_helper::ProtocolRegistrationError,
@@ -477,7 +478,7 @@ mod tests {
         let mut mock_verification_key_store = MockVerificationKeyStorer::new();
         mock_verification_key_store
             .expect_get_stake_distribution_for_epoch()
-            .return_once(|_| Err(AdapterError::GeneralError("invalid query".to_string()).into()));
+            .return_once(|_| Err(AdapterError::GeneralError(anyhow!("invalid query")).into()));
         let mut dependency_manager = initialize_dependencies().await;
         dependency_manager.verification_key_store = Arc::new(mock_verification_key_store);
 

--- a/mithril-aggregator/src/main.rs
+++ b/mithril-aggregator/src/main.rs
@@ -2,6 +2,7 @@
 
 use clap::Parser;
 use mithril_aggregator::MainOpts;
+use mithril_common::StdResult;
 use slog::{Drain, Logger};
 use std::sync::Arc;
 
@@ -18,7 +19,7 @@ pub fn build_logger(args: &MainOpts) -> Logger {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), String> {
+async fn main() -> StdResult<()> {
     // Load args
     let args = MainOpts::parse();
     let _guard = slog_scope::set_global_logger(build_logger(&args));
@@ -26,5 +27,5 @@ async fn main() -> Result<(), String> {
     #[cfg(feature = "bundle_openssl")]
     openssl_probe::init_ssl_cert_env_vars();
 
-    args.execute().await.map_err(|e| e.to_string())
+    args.execute().await
 }

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -388,16 +388,16 @@ impl AggregatorRuntime {
 
 #[cfg(test)]
 mod tests {
-
     use crate::entities::OpenMessage;
-
-    use super::super::runner::MockAggregatorRunner;
-    use super::*;
+    use anyhow::anyhow;
+    use mockall::predicate;
 
     use mithril_common::entities::{Epoch, SignedEntityType};
     use mithril_common::era::UnsupportedEraError;
     use mithril_common::test_utils::fake_data;
-    use mockall::predicate;
+
+    use super::super::runner::MockAggregatorRunner;
+    use super::*;
 
     async fn init_runtime(
         init_state: Option<AggregatorState>,
@@ -441,7 +441,7 @@ mod tests {
         runner
             .expect_is_certificate_chain_valid()
             .once()
-            .returning(|_| Err("error".into()));
+            .returning(|_| Err(anyhow!("error")));
         runner
             .expect_update_era_checker()
             .with(predicate::eq(fake_data::beacon()))
@@ -722,7 +722,7 @@ mod tests {
         runner
             .expect_create_artifact()
             .once()
-            .returning(|_, _| Err("whatever".into()));
+            .returning(|_, _| Err(anyhow!("whatever")));
         let state = SigningState {
             current_beacon: fake_data::beacon(),
             open_message: OpenMessage::dummy(),

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -1,19 +1,19 @@
 //! Stake Pool manager for the Runners
 //!
 
+use async_trait::async_trait;
 use std::{
     fmt::Display,
     sync::{Arc, RwLock},
 };
+use tokio::sync::{Mutex, MutexGuard};
 
-use async_trait::async_trait;
 use mithril_common::{
     chain_observer::ChainObserver,
     entities::{Epoch, StakeDistribution},
     store::StakeStorer,
-    StdError,
+    StdError, StdResult,
 };
-use tokio::sync::{Mutex, MutexGuard};
 
 use crate::database::provider::StakePoolStore;
 
@@ -117,7 +117,7 @@ impl Default for UpdateToken {
 }
 
 impl UpdateToken {
-    pub fn update(&self, epoch: Epoch) -> Result<MutexGuard<()>, StdError> {
+    pub fn update(&self, epoch: Epoch) -> StdResult<MutexGuard<()>> {
         let update_semaphore = self.is_busy.try_lock().map_err(|_| {
             let last_updated_epoch = self.busy_on_epoch.read().unwrap();
 

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -203,7 +203,7 @@ impl StakeDistributionService for MithrilStakeDistributionService {
         let _mutex = self
             .update_token
             .update(current_epoch)
-            .map_err(|e| StakePoolDistributionServiceError::technical_subsystem(e))?;
+            .map_err(StakePoolDistributionServiceError::technical_subsystem)?;
         let stake_distribution = self
             .chain_observer
             .get_current_stake_distribution()

--- a/mithril-aggregator/src/services/ticker.rs
+++ b/mithril-aggregator/src/services/ticker.rs
@@ -10,11 +10,9 @@ use mithril_common::{
     chain_observer::ChainObserver,
     digesters::ImmutableFileObserver,
     entities::{Beacon, Epoch},
-    CardanoNetwork, StdError,
+    CardanoNetwork, StdResult,
 };
 use thiserror::Error;
-
-type StdResult<T> = Result<T, StdError>;
 
 #[derive(Debug, Error)]
 enum MithrilTickerError {

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -10,7 +10,7 @@ use mithril_common::{
     },
     entities::{Epoch, Signer, SignerWithStake, StakeDistribution},
     store::StoreError,
-    StdError,
+    StdResult,
 };
 
 use crate::VerificationKeyStorer;
@@ -113,14 +113,14 @@ pub trait SignerRegistrationRoundOpener: Sync + Send {
 #[async_trait]
 pub trait SignerRecorder: Sync + Send {
     /// Record signer_id
-    async fn record_signer_id(&self, signer_id: String) -> Result<(), StdError>;
+    async fn record_signer_id(&self, signer_id: String) -> StdResult<()>;
 
     /// Record pool ticker by id
     async fn record_signer_pool_ticker(
         &self,
         signer_id: String,
         pool_ticker: Option<String>,
-    ) -> Result<(), StdError>;
+    ) -> StdResult<()>;
 }
 
 /// Implementation of a [SignerRegisterer]

--- a/mithril-aggregator/src/snapshot_uploaders/dumb_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/dumb_snapshot_uploader.rs
@@ -1,5 +1,6 @@
+use anyhow::anyhow;
 use async_trait::async_trait;
-use std::{error::Error, path::Path, sync::RwLock};
+use std::{path::Path, sync::RwLock};
 
 use super::{SnapshotLocation, SnapshotUploader};
 
@@ -20,11 +21,11 @@ impl DumbSnapshotUploader {
     }
 
     /// Return the last upload that was triggered.
-    pub fn get_last_upload(&self) -> Result<Option<String>, Box<dyn Error + Sync + Send>> {
+    pub fn get_last_upload(&self) -> anyhow::Result<Option<String>> {
         let value = self
             .last_uploaded
             .read()
-            .map_err(|e| format!("Error while saving filepath location: {e}"))?;
+            .map_err(|e| anyhow!("Error while saving filepath location: {e}"))?;
 
         Ok(value.as_ref().map(|v| v.to_string()))
     }
@@ -39,11 +40,11 @@ impl Default for DumbSnapshotUploader {
 #[async_trait]
 impl SnapshotUploader for DumbSnapshotUploader {
     /// Upload a snapshot
-    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> Result<SnapshotLocation, String> {
+    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> anyhow::Result<SnapshotLocation> {
         let mut value = self
             .last_uploaded
             .write()
-            .map_err(|e| format!("Error while saving filepath location: {e}"))?;
+            .map_err(|e| anyhow!("Error while saving filepath location: {e}"))?;
 
         let location = snapshot_filepath.to_string_lossy().to_string();
         *value = Some(location.clone());

--- a/mithril-aggregator/src/snapshot_uploaders/dumb_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/dumb_snapshot_uploader.rs
@@ -1,5 +1,6 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
+use mithril_common::StdResult;
 use std::{path::Path, sync::RwLock};
 
 use super::{SnapshotLocation, SnapshotUploader};
@@ -21,7 +22,7 @@ impl DumbSnapshotUploader {
     }
 
     /// Return the last upload that was triggered.
-    pub fn get_last_upload(&self) -> anyhow::Result<Option<String>> {
+    pub fn get_last_upload(&self) -> StdResult<Option<String>> {
         let value = self
             .last_uploaded
             .read()
@@ -40,7 +41,7 @@ impl Default for DumbSnapshotUploader {
 #[async_trait]
 impl SnapshotUploader for DumbSnapshotUploader {
     /// Upload a snapshot
-    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> anyhow::Result<SnapshotLocation> {
+    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> StdResult<SnapshotLocation> {
         let mut value = self
             .last_uploaded
             .write()

--- a/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use mithril_common::StdResult;
 use slog_scope::debug;
 use std::path::{Path, PathBuf};
 
@@ -29,12 +30,12 @@ impl LocalSnapshotUploader {
 
 #[async_trait]
 impl SnapshotUploader for LocalSnapshotUploader {
-    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> anyhow::Result<SnapshotLocation> {
+    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> StdResult<SnapshotLocation> {
         let archive_name = snapshot_filepath.file_name().unwrap().to_str().unwrap();
         let target_path = &self.target_location.join(archive_name);
         tokio::fs::copy(snapshot_filepath, target_path)
             .await
-            .with_context(|| format!("Snapshot copy failure"))?;
+            .with_context(|| "Snapshot copy failure")?;
 
         let digest = tools::extract_digest_from_path(Path::new(archive_name));
         let location = format!(

--- a/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
@@ -1,9 +1,9 @@
-use crate::snapshot_uploaders::{SnapshotLocation, SnapshotUploader};
-use crate::tools::RemoteFileUploader;
-use std::path::Path;
-
 use async_trait::async_trait;
 use slog_scope::debug;
+use std::path::Path;
+
+use crate::snapshot_uploaders::{SnapshotLocation, SnapshotUploader};
+use crate::tools::RemoteFileUploader;
 
 /// GCPSnapshotUploader is a snapshot uploader working using Google Cloud Platform services
 pub struct RemoteSnapshotUploader {
@@ -24,7 +24,7 @@ impl RemoteSnapshotUploader {
 
 #[async_trait]
 impl SnapshotUploader for RemoteSnapshotUploader {
-    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> Result<SnapshotLocation, String> {
+    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> anyhow::Result<SnapshotLocation> {
         let archive_name = snapshot_filepath.file_name().unwrap().to_str().unwrap();
         let location = format!(
             "https://storage.googleapis.com/{}/{}",
@@ -42,22 +42,25 @@ mod tests {
     use super::RemoteSnapshotUploader;
     use crate::snapshot_uploaders::SnapshotUploader;
     use crate::tools::MockRemoteFileUploader;
+    use anyhow::anyhow;
     use std::path::Path;
 
     #[tokio::test]
     async fn test_upload_snapshot_ok() {
         let mut file_uploader = MockRemoteFileUploader::new();
-        file_uploader.expect_upload_file().return_const(Ok(()));
+        file_uploader.expect_upload_file().returning(|_| Ok(()));
         let snapshot_uploader =
             RemoteSnapshotUploader::new(Box::new(file_uploader), "cardano-testnet".to_string());
         let snapshot_filepath = Path::new("test/snapshot.xxx.tar.gz");
         let expected_location =
             "https://storage.googleapis.com/cardano-testnet/snapshot.xxx.tar.gz".to_string();
 
-        assert_eq!(
-            Ok(expected_location),
-            snapshot_uploader.upload_snapshot(snapshot_filepath).await
-        );
+        let location = snapshot_uploader
+            .upload_snapshot(snapshot_filepath)
+            .await
+            .expect("remote upload should not fail");
+
+        assert_eq!(expected_location, location);
     }
 
     #[tokio::test]
@@ -65,12 +68,15 @@ mod tests {
         let mut file_uploader = MockRemoteFileUploader::new();
         file_uploader
             .expect_upload_file()
-            .return_const(Err("unexpected error".to_string()));
+            .returning(|_| Err(anyhow!("unexpected error")));
         let snapshot_uploader =
             RemoteSnapshotUploader::new(Box::new(file_uploader), "".to_string());
         let snapshot_filepath = Path::new("test/snapshot.xxx.tar.gz");
 
-        let result = snapshot_uploader.upload_snapshot(snapshot_filepath).await;
-        assert_eq!(Err("unexpected error".to_string()), result);
+        let result = snapshot_uploader
+            .upload_snapshot(snapshot_filepath)
+            .await
+            .expect_err("remote upload should fail");
+        assert_eq!("unexpected error".to_string(), result.to_string());
     }
 }

--- a/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use mithril_common::StdResult;
 use slog_scope::debug;
 use std::path::Path;
 
@@ -24,7 +25,7 @@ impl RemoteSnapshotUploader {
 
 #[async_trait]
 impl SnapshotUploader for RemoteSnapshotUploader {
-    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> anyhow::Result<SnapshotLocation> {
+    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> StdResult<SnapshotLocation> {
         let archive_name = snapshot_filepath.file_name().unwrap().to_str().unwrap();
         let location = format!(
             "https://storage.googleapis.com/{}/{}",

--- a/mithril-aggregator/src/snapshot_uploaders/snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/snapshot_uploader.rs
@@ -11,5 +11,5 @@ pub type SnapshotLocation = String;
 #[async_trait]
 pub trait SnapshotUploader: Sync + Send {
     /// Upload a snapshot
-    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> Result<SnapshotLocation, String>;
+    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> anyhow::Result<SnapshotLocation>;
 }

--- a/mithril-aggregator/src/snapshot_uploaders/snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/snapshot_uploader.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use mithril_common::StdResult;
 use std::path::Path;
 
 #[cfg(test)]
@@ -11,5 +12,5 @@ pub type SnapshotLocation = String;
 #[async_trait]
 pub trait SnapshotUploader: Sync + Send {
     /// Upload a snapshot
-    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> anyhow::Result<SnapshotLocation>;
+    async fn upload_snapshot(&self, snapshot_filepath: &Path) -> StdResult<SnapshotLocation>;
 }

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -2,7 +2,6 @@ use flate2::Compression;
 use flate2::{read::GzDecoder, write::GzEncoder};
 use mithril_common::StdResult;
 use slog_scope::{info, warn};
-use std::error::Error as StdError;
 use std::fs::File;
 use std::io::{self, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
@@ -189,9 +188,7 @@ impl DumbSnapshotter {
     }
 
     /// Return the last fake snapshot produced.
-    pub fn get_last_snapshot(
-        &self,
-    ) -> Result<Option<OngoingSnapshot>, Box<dyn StdError + Sync + Send>> {
+    pub fn get_last_snapshot(&self) -> StdResult<Option<OngoingSnapshot>> {
         let value = self
             .last_snapshot
             .read()
@@ -285,7 +282,7 @@ mod tests {
 
         std::fs::create_dir_all(&pending_snapshot_directory).unwrap();
 
-        std::fs::File::create(pending_snapshot_directory.join("whatever.txt")).unwrap();
+        File::create(pending_snapshot_directory.join("whatever.txt")).unwrap();
 
         Arc::new(GzipSnapshotter::new(db_directory, pending_snapshot_directory.clone()).unwrap());
 
@@ -310,7 +307,7 @@ mod tests {
         );
 
         // this file should not be deleted by the archive creation
-        std::fs::File::create(pending_snapshot_directory.join("other-process.file")).unwrap();
+        File::create(pending_snapshot_directory.join("other-process.file")).unwrap();
 
         let _ = snapshotter
             .snapshot("whatever.tar.gz")

--- a/mithril-aggregator/src/tools/remote_file_uploader.rs
+++ b/mithril-aggregator/src/tools/remote_file_uploader.rs
@@ -4,6 +4,7 @@ use cloud_storage::{
     bucket::Entity, bucket_access_control::Role, object_access_control::NewObjectAccessControl,
     Client,
 };
+use mithril_common::StdResult;
 use slog_scope::info;
 use std::{env, path::Path};
 use tokio_util::{codec::BytesCodec, codec::FramedRead};
@@ -16,7 +17,7 @@ use mockall::automock;
 #[async_trait]
 pub trait RemoteFileUploader: Sync + Send {
     /// Upload a snapshot
-    async fn upload_file(&self, filepath: &Path) -> anyhow::Result<()>;
+    async fn upload_file(&self, filepath: &Path) -> StdResult<()>;
 }
 
 /// GcpFileUploader represents a Google Cloud Platform file uploader interactor
@@ -33,7 +34,7 @@ impl GcpFileUploader {
 
 #[async_trait]
 impl RemoteFileUploader for GcpFileUploader {
-    async fn upload_file(&self, filepath: &Path) -> anyhow::Result<()> {
+    async fn upload_file(&self, filepath: &Path) -> StdResult<()> {
         if env::var("GOOGLE_APPLICATION_CREDENTIALS_JSON").is_err() {
             return Err(anyhow!(
                 "Missing GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable".to_string()

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+anyhow = "1.0.71"
 async-recursion = "1.0.4"
 async-trait = "0.1.52"
 chrono = { version = "0.4.26", features = ["serde"] }

--- a/mithril-client/src/commands/mithril_stake_distribution/mod.rs
+++ b/mithril-client/src/commands/mithril_stake_distribution/mod.rs
@@ -2,12 +2,12 @@
 mod download;
 mod list;
 
-use clap::Subcommand;
-use config::{builder::DefaultState, ConfigBuilder};
-
 pub use download::*;
 pub use list::*;
-use mithril_common::StdError;
+
+use clap::Subcommand;
+use config::{builder::DefaultState, ConfigBuilder};
+use mithril_common::StdResult;
 
 /// Mithril Stake Distribution management (alias: msd)
 #[derive(Subcommand, Debug, Clone)]
@@ -23,10 +23,7 @@ pub enum MithrilStakeDistributionCommands {
 
 impl MithrilStakeDistributionCommands {
     /// Execute Mithril stake distribution command
-    pub async fn execute(
-        &self,
-        config_builder: ConfigBuilder<DefaultState>,
-    ) -> Result<(), StdError> {
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,
             Self::Download(cmd) => cmd.execute(config_builder).await,

--- a/mithril-client/src/commands/snapshot/mod.rs
+++ b/mithril-client/src/commands/snapshot/mod.rs
@@ -3,14 +3,13 @@ mod download;
 mod list;
 mod show;
 
-use clap::Subcommand;
-use config::{builder::DefaultState, ConfigBuilder};
-
-use mithril_common::StdError;
-
 pub use download::*;
 pub use list::*;
 pub use show::*;
+
+use clap::Subcommand;
+use config::{builder::DefaultState, ConfigBuilder};
+use mithril_common::StdResult;
 
 /// Snapshot management
 #[derive(Subcommand, Debug, Clone)]
@@ -30,10 +29,7 @@ pub enum SnapshotCommands {
 
 impl SnapshotCommands {
     /// Execute snapshot command
-    pub async fn execute(
-        &self,
-        config_builder: ConfigBuilder<DefaultState>,
-    ) -> Result<(), StdError> {
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,
             Self::Download(cmd) => cmd.execute(config_builder).await,

--- a/mithril-client/src/commands/snapshot/show.rs
+++ b/mithril-client/src/commands/snapshot/show.rs
@@ -1,9 +1,9 @@
-use std::sync::Arc;
-
 use clap::Parser;
 use cli_table::{print_stdout, WithTitle};
 use config::{builder::DefaultState, Config, ConfigBuilder};
-use mithril_common::{messages::SnapshotMessage, StdError};
+use std::sync::Arc;
+
+use mithril_common::{messages::SnapshotMessage, StdResult};
 
 use crate::{dependencies::DependenciesBuilder, SnapshotFieldItem};
 
@@ -22,10 +22,7 @@ pub struct SnapshotShowCommand {
 
 impl SnapshotShowCommand {
     /// Snapshot Show command
-    pub async fn execute(
-        &self,
-        config_builder: ConfigBuilder<DefaultState>,
-    ) -> Result<(), StdError> {
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
         let config: Config = config_builder.build()?;
         let mut dependencies_builder = DependenciesBuilder::new(Arc::new(config));
         let snapshot_service = dependencies_builder.get_snapshot_service().await?;

--- a/mithril-client/src/main.rs
+++ b/mithril-client/src/main.rs
@@ -127,5 +127,5 @@ async fn main() -> Result<(), String> {
 
     args.execute()
         .await
-        .map_err(|e| format!("An error occured: {e}"))
+        .map_err(|e| format!("An error occured: {e:?}"))
 }

--- a/mithril-client/src/main.rs
+++ b/mithril-client/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand};
 use config::builder::DefaultState;
 use config::{ConfigBuilder, Map, Source, Value, ValueKind};
 use mithril_client::commands::mithril_stake_distribution::MithrilStakeDistributionCommands;
-use mithril_common::StdError;
+use mithril_common::StdResult;
 use slog::{Drain, Level, Logger};
 use slog_scope::debug;
 use std::path::PathBuf;
@@ -43,7 +43,7 @@ pub struct Args {
 }
 
 impl Args {
-    pub async fn execute(&self) -> Result<(), StdError> {
+    pub async fn execute(&self) -> StdResult<()> {
         debug!("Run Mode: {}", self.run_mode);
         let filename = format!("{}/{}.json", self.config_directory.display(), self.run_mode);
         debug!("Reading configuration file '{}'.", filename);
@@ -105,10 +105,7 @@ enum ArtifactCommands {
 }
 
 impl ArtifactCommands {
-    pub async fn execute(
-        &self,
-        config_builder: ConfigBuilder<DefaultState>,
-    ) -> Result<(), StdError> {
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
         match self {
             Self::Snapshot(cmd) => cmd.execute(config_builder).await,
             Self::MithrilStakeDistribution(cmd) => cmd.execute(config_builder).await,
@@ -117,7 +114,7 @@ impl ArtifactCommands {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), String> {
+async fn main() -> StdResult<()> {
     // Load args
     let args = Args::parse();
     let _guard = slog_scope::set_global_logger(args.build_logger());
@@ -125,7 +122,5 @@ async fn main() -> Result<(), String> {
     #[cfg(feature = "bundle_openssl")]
     openssl_probe::init_ssl_cert_env_vars();
 
-    args.execute()
-        .await
-        .map_err(|e| format!("An error occured: {e:?}"))
+    args.execute().await
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -32,7 +32,6 @@ kes-summed-ed25519 = { version = "0.2.0", features = [
     "serde_enabled",
     "sk_clone_enabled",
 ] }
-lazy_static = "1.4.0"
 mockall = "0.11.0"
 nom = "7.1"
 rand-chacha-dalek-compat = { package = "rand_chacha", version = "0.2" }

--- a/mithril-common/src/beacon_provider.rs
+++ b/mithril-common/src/beacon_provider.rs
@@ -82,6 +82,7 @@ mod tests {
     use crate::chain_observer::{ChainAddress, ChainObserver, ChainObserverError, TxDatum};
     use crate::digesters::DumbImmutableFileObserver;
     use crate::entities::{Epoch, StakeDistribution};
+    use anyhow::anyhow;
 
     use super::*;
 
@@ -103,11 +104,9 @@ mod tests {
         async fn get_current_stake_distribution(
             &self,
         ) -> Result<Option<StakeDistribution>, ChainObserverError> {
-            Err(ChainObserverError::General(
+            Err(ChainObserverError::General(anyhow!(
                 "this should not be called in the BeaconProvider"
-                    .to_string()
-                    .into(),
-            ))
+            )))
         }
     }
 

--- a/mithril-common/src/chain_observer/interface.rs
+++ b/mithril-common/src/chain_observer/interface.rs
@@ -1,10 +1,10 @@
 use crate::{
     crypto_helper::{KESPeriod, OpCert},
     entities::*,
+    StdError,
 };
 use async_trait::async_trait;
 use mockall::automock;
-use std::error::Error as StdError;
 use thiserror::Error;
 
 use super::{ChainAddress, TxDatum};
@@ -13,12 +13,12 @@ use super::{ChainAddress, TxDatum};
 #[derive(Debug, Error)]
 pub enum ChainObserverError {
     /// Generic [ChainObserver] error.
-    #[error("general error {0}")]
-    General(Box<dyn StdError + Sync + Send>),
+    #[error("general error {0:?}")]
+    General(StdError),
 
     /// Error raised when the content could not be parsed.
-    #[error("could not parse content: {0}")]
-    InvalidContent(Box<dyn StdError + Sync + Send>),
+    #[error("could not parse content: {0:?}")]
+    InvalidContent(StdError),
 }
 
 /// Retrieve data from the cardano network

--- a/mithril-common/src/crypto_helper/types/protocol_key.rs
+++ b/mithril-common/src/crypto_helper/types/protocol_key.rs
@@ -1,9 +1,10 @@
-use anyhow::{anyhow, Context, Result as StdResult};
+use anyhow::{anyhow, Context};
 use serde::{de::DeserializeOwned, Deserialize, Serialize, Serializer};
 use std::any::type_name;
 use std::ops::Deref;
 
 use crate::crypto_helper::{key_decode_hex, key_encode_hex};
+use crate::StdResult;
 
 /// A ProtocolKey is a wrapped that add Serialization capabilities.
 ///

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -1,8 +1,9 @@
-use anyhow::{Context, Result as StdResult};
+use anyhow::Context;
 use hex::{FromHex, ToHex};
 use mithril_stm::stm::{StmAggrSig, StmSig, StmVerificationKeyPoP};
 
 use crate::crypto_helper::{ProtocolKey, ProtocolKeyCodec, D};
+use crate::StdResult;
 
 /// Wrapper of [MithrilStm:StmVerificationKeyPoP](type@StmVerificationKeyPoP) to add serialization
 /// utilities.

--- a/mithril-common/src/database/db_version.rs
+++ b/mithril-common/src/database/db_version.rs
@@ -1,15 +1,15 @@
+use anyhow::anyhow;
+use chrono::{DateTime, NaiveDateTime, Utc};
+use sqlite::{Connection, Row, Value};
 use std::{
     cmp::Ordering,
     fmt::{Debug, Display},
 };
 
-use chrono::{DateTime, NaiveDateTime, Utc};
-use sqlite::{Connection, Row, Value};
-
-use crate::sqlite::{
-    HydrationError, Projection, Provider, SourceAlias, SqLiteEntity, WhereCondition,
+use crate::{
+    sqlite::{HydrationError, Projection, Provider, SourceAlias, SqLiteEntity, WhereCondition},
+    StdError,
 };
-use crate::StdError;
 
 use super::DbVersion;
 
@@ -29,7 +29,7 @@ impl ApplicationNodeType {
         match node_type {
             "aggregator" => Ok(Self::Aggregator),
             "signer" => Ok(Self::Signer),
-            _ => Err(format!("unknown node type '{node_type}'").into()),
+            _ => Err(anyhow!("unknown node type '{node_type}'")),
         }
     }
 }
@@ -205,7 +205,7 @@ impl<'conn> DatabaseVersionUpdater<'conn> {
         let entity = self
             .find(filters)?
             .next()
-            .ok_or("No data returned after insertion")?;
+            .ok_or(anyhow!("No data returned after insertion"))?;
 
         Ok(entity)
     }

--- a/mithril-common/src/database/db_version.rs
+++ b/mithril-common/src/database/db_version.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     sqlite::{HydrationError, Projection, Provider, SourceAlias, SqLiteEntity, WhereCondition},
-    StdError,
+    StdResult,
 };
 
 use super::DbVersion;
@@ -25,7 +25,7 @@ pub enum ApplicationNodeType {
 
 impl ApplicationNodeType {
     /// [ApplicationNodeType] constructor.
-    pub fn new(node_type: &str) -> Result<Self, StdError> {
+    pub fn new(node_type: &str) -> StdResult<Self> {
         match node_type {
             "aggregator" => Ok(Self::Aggregator),
             "signer" => Ok(Self::Signer),
@@ -121,7 +121,7 @@ impl<'conn> DatabaseVersionProvider<'conn> {
     pub fn create_table_if_not_exists(
         &self,
         application_type: &ApplicationNodeType,
-    ) -> Result<(), StdError> {
+    ) -> StdResult<()> {
         let connection = self.get_connection();
         let sql = "select exists(select name from sqlite_master where type='table' and name='db_version') as table_exists";
         let table_exists = connection
@@ -148,7 +148,7 @@ insert into db_version (application_type, version, updated_at) values ('{applica
     pub fn get_application_version(
         &self,
         application_type: &ApplicationNodeType,
-    ) -> Result<Option<DatabaseVersion>, StdError> {
+    ) -> StdResult<Option<DatabaseVersion>> {
         let filters = WhereCondition::new(
             "application_type = ?*",
             vec![Value::String(format!("{application_type}"))],
@@ -193,7 +193,7 @@ impl<'conn> DatabaseVersionUpdater<'conn> {
     }
 
     /// Persist the given entity and return the projection of the saved entity.
-    pub fn save(&self, version: DatabaseVersion) -> Result<DatabaseVersion, StdError> {
+    pub fn save(&self, version: DatabaseVersion) -> StdResult<DatabaseVersion> {
         let filters = WhereCondition::new(
             "",
             vec![

--- a/mithril-common/src/database/version_checker.rs
+++ b/mithril-common/src/database/version_checker.rs
@@ -1,12 +1,9 @@
+use anyhow::anyhow;
 use chrono::Utc;
-use slog::{debug, error};
-use slog::{info, Logger};
+use slog::{debug, error, info, Logger};
 use sqlite::Connection;
+use std::{cmp::Ordering, collections::BTreeSet, ops::Deref, sync::Arc};
 use tokio::sync::Mutex;
-
-use std::ops::Deref;
-use std::sync::Arc;
-use std::{cmp::Ordering, collections::BTreeSet};
 
 use crate::StdError;
 
@@ -92,7 +89,7 @@ impl DatabaseVersionChecker {
                     migration_version,
                 );
 
-                Err("This software version is older than the database structure. Aborting launch to prevent possible data corruption.")?;
+                Err(anyhow!("This software version is older than the database structure. Aborting launch to prevent possible data corruption."))?;
             }
             Ordering::Equal => {
                 debug!(&self.logger, "database up to date");

--- a/mithril-common/src/digesters/cache/json_provider_builder.rs
+++ b/mithril-common/src/digesters/cache/json_provider_builder.rs
@@ -2,6 +2,7 @@ use crate::{
     digesters::cache::{ImmutableFileDigestCacheProvider, JsonImmutableFileDigestCacheProvider},
     StdError,
 };
+use anyhow::Context;
 use slog_scope::info;
 use std::path::Path;
 use tokio::fs;
@@ -43,21 +44,19 @@ impl<'a> JsonImmutableFileDigestCacheProviderBuilder<'a> {
         let cache_provider = JsonImmutableFileDigestCacheProvider::new(&cache_file);
 
         if self.ensure_dir_exist {
-            fs::create_dir_all(&self.cache_dir).await.map_err(|e| {
+            fs::create_dir_all(&self.cache_dir).await.with_context(|| {
                 format!(
-                    "Failure when creating cache directory `{}`: {}",
+                    "Failure when creating cache directory `{}`",
                     self.cache_dir.display(),
-                    e
                 )
             })?;
         }
 
         if self.reset_digests_cache {
-            cache_provider.reset().await.map_err(|e| {
+            cache_provider.reset().await.with_context(|| {
                 format!(
-                    "Failure when resetting digests cache file `{}`: {}",
+                    "Failure when resetting digests cache file `{}`",
                     cache_file.display(),
-                    e
                 )
             })?;
         }

--- a/mithril-common/src/digesters/cache/json_provider_builder.rs
+++ b/mithril-common/src/digesters/cache/json_provider_builder.rs
@@ -1,6 +1,6 @@
 use crate::{
     digesters::cache::{ImmutableFileDigestCacheProvider, JsonImmutableFileDigestCacheProvider},
-    StdError,
+    StdResult,
 };
 use anyhow::Context;
 use slog_scope::info;
@@ -39,7 +39,7 @@ impl<'a> JsonImmutableFileDigestCacheProviderBuilder<'a> {
     }
 
     /// Build a [JsonImmutableFileDigestCacheProvider] based on the parameters previously set.
-    pub async fn build(&self) -> Result<JsonImmutableFileDigestCacheProvider, StdError> {
+    pub async fn build(&self) -> StdResult<JsonImmutableFileDigestCacheProvider> {
         let cache_file = self.cache_dir.join(self.filename);
         let cache_provider = JsonImmutableFileDigestCacheProvider::new(&cache_file);
 

--- a/mithril-common/src/digesters/immutable_file_observer.rs
+++ b/mithril-common/src/digesters/immutable_file_observer.rs
@@ -1,7 +1,7 @@
 use crate::digesters::{ImmutableFile, ImmutableFileListingError};
 use crate::entities::ImmutableFileNumber;
+use crate::StdResult;
 use async_trait::async_trait;
-use std::error::Error;
 use std::ops::Add;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -87,8 +87,9 @@ impl DumbImmutableFileObserver {
         self
     }
 
-    /// Increase by one the stored [immutable file number][DumbImmutableFileObserver::shall_return].
-    pub async fn increase(&self) -> Result<u64, Box<dyn Error + Sync + Send>> {
+    /// Increase by one the stored [immutable file number][DumbImmutableFileObserver::shall_return],
+    /// return the updated value.
+    pub async fn increase(&self) -> StdResult<u64> {
         let new_number = self
             .shall_return
             .read()

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use strum_macros::{Display, EnumDiscriminants};
 
-use crate::{sqlite::HydrationError, StdError};
+use crate::{sqlite::HydrationError, StdResult};
 
 use super::{Beacon, Epoch};
 
@@ -89,7 +89,7 @@ impl SignedEntityType {
     }
 
     /// Return a JSON serialized value of the internal beacon
-    pub fn get_json_beacon(&self) -> Result<String, StdError> {
+    pub fn get_json_beacon(&self) -> StdResult<String> {
         let value = match self {
             Self::CardanoImmutableFilesFull(value) => serde_json::to_string(value)?,
             Self::CardanoStakeDistribution(value) | Self::MithrilStakeDistribution(value) => {

--- a/mithril-common/src/era/adapters/bootstrap.rs
+++ b/mithril-common/src/era/adapters/bootstrap.rs
@@ -1,8 +1,8 @@
 use async_trait::async_trait;
 
 use crate::entities::Epoch;
-
-use super::super::{EraMarker, EraReaderAdapter, SupportedEra};
+use crate::era::{EraMarker, EraReaderAdapter, SupportedEra};
+use crate::StdResult;
 
 /// The goal of the bootstrap adapter is to advertise for the first existing Era
 /// while it does not exist yet on any backend. This adapter is intended to be
@@ -11,7 +11,7 @@ pub struct BootstrapAdapter;
 
 #[async_trait]
 impl EraReaderAdapter for BootstrapAdapter {
-    async fn read(&self) -> Result<Vec<EraMarker>, Box<dyn std::error::Error + Sync + Send>> {
+    async fn read(&self) -> StdResult<Vec<EraMarker>> {
         Ok(vec![EraMarker::new(
             &SupportedEra::eras().first().unwrap().to_string(),
             Some(Epoch(1)),

--- a/mithril-common/src/era/adapters/cardano_chain.rs
+++ b/mithril-common/src/era/adapters/cardano_chain.rs
@@ -6,38 +6,36 @@ use crate::{
     },
     entities::HexEncodedEraMarkersSignature,
     era::{EraMarker, EraReaderAdapter},
+    StdError, StdResult,
 };
 use async_trait::async_trait;
 use hex::{FromHex, ToHex};
 use serde::{Deserialize, Serialize};
-use std::error::Error as StdError;
 use std::sync::Arc;
 use thiserror::Error;
-
-type GeneralError = Box<dyn StdError + Sync + Send>;
 
 /// [EraMarkersPayload] related errors.
 #[derive(Debug, Error)]
 pub enum EraMarkersPayloadError {
     /// Error raised when the message serialization fails
-    #[error("could not serialize message: {0}")]
-    SerializeMessage(GeneralError),
+    #[error("could not serialize message: {0:?}")]
+    SerializeMessage(StdError),
 
     /// Error raised when the signature deserialization fails
-    #[error("could not deserialize signature: {0}")]
-    DeserializeSignature(GeneralError),
+    #[error("could not deserialize signature: {0:?}")]
+    DeserializeSignature(StdError),
 
     /// Error raised when the signature is missing
     #[error("could not verify signature: signature is missing")]
     MissingSignature,
 
     /// Error raised when the signature is invalid
-    #[error("could not verify signature: {0}")]
-    VerifySignature(GeneralError),
+    #[error("could not verify signature: {0:?}")]
+    VerifySignature(StdError),
 
     /// Error raised when the signing the markers
-    #[error("could not create signature: {0}")]
-    CreateSignature(GeneralError),
+    #[error("could not create signature: {0:?}")]
+    CreateSignature(StdError),
 }
 
 /// Era markers payload
@@ -121,7 +119,7 @@ impl CardanoChainAdapter {
 
 #[async_trait]
 impl EraReaderAdapter for CardanoChainAdapter {
-    async fn read(&self) -> Result<Vec<EraMarker>, GeneralError> {
+    async fn read(&self) -> StdResult<Vec<EraMarker>> {
         let tx_datums = self
             .chain_observer
             .get_current_datums(&self.address)

--- a/mithril-common/src/era/adapters/dummy.rs
+++ b/mithril-common/src/era/adapters/dummy.rs
@@ -1,8 +1,8 @@
-use std::{error::Error, sync::RwLock};
-
 use async_trait::async_trait;
+use std::sync::RwLock;
 
-use super::super::{EraMarker, EraReaderAdapter};
+use crate::era::{EraMarker, EraReaderAdapter};
+use crate::StdResult;
 
 /// Dummy adapter is intended to be used in a test environment (end to end test)
 /// to simulate not yet activated Eras.
@@ -29,7 +29,7 @@ impl DummyAdapter {
 
 #[async_trait]
 impl EraReaderAdapter for DummyAdapter {
-    async fn read(&self) -> Result<Vec<EraMarker>, Box<dyn Error + Sync + Send>> {
+    async fn read(&self) -> StdResult<Vec<EraMarker>> {
         let markers = self.markers.read().unwrap();
 
         Ok((*markers.clone()).to_vec())

--- a/mithril-common/src/era/adapters/file.rs
+++ b/mithril-common/src/era/adapters/file.rs
@@ -1,8 +1,8 @@
-use std::{error::Error, fs, path::PathBuf};
-
 use async_trait::async_trait;
+use std::{fs, path::PathBuf};
 
-use super::super::{EraMarker, EraReaderAdapter};
+use crate::era::{EraMarker, EraReaderAdapter};
+use crate::StdResult;
 
 /// File adapter is intended to be used in a test environment
 /// to simulate eras transitions.
@@ -19,7 +19,7 @@ impl FileAdapter {
 
 #[async_trait]
 impl EraReaderAdapter for FileAdapter {
-    async fn read(&self) -> Result<Vec<EraMarker>, Box<dyn Error + Sync + Send>> {
+    async fn read(&self) -> StdResult<Vec<EraMarker>> {
         Ok(serde_json::from_str(&fs::read_to_string(
             &self.markers_file,
         )?)?)

--- a/mithril-common/src/era/era_reader.rs
+++ b/mithril-common/src/era/era_reader.rs
@@ -1,8 +1,10 @@
-use crate::entities::Epoch;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use std::{error::Error as StdError, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 use thiserror::Error;
+
+use crate::entities::Epoch;
+use crate::{StdError, StdResult};
 
 use super::{supported_era::UnsupportedEraError, SupportedEra};
 
@@ -30,7 +32,7 @@ impl EraMarker {
 #[async_trait]
 pub trait EraReaderAdapter: Sync + Send {
     /// Read era markers from the underlying adapter.
-    async fn read(&self) -> Result<Vec<EraMarker>, Box<dyn StdError + Sync + Send>>;
+    async fn read(&self) -> StdResult<Vec<EraMarker>>;
 }
 
 /// This is a response from the [EraReader]. It contains [EraMarker]s read from
@@ -106,7 +108,7 @@ pub enum EraReaderError {
         message: String,
 
         /// nested underlying adapter error
-        error: Box<dyn StdError + Sync + Send>,
+        error: StdError,
     },
 
     /// Data returned from the adapter are inconsistent or incomplete.

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -27,16 +27,14 @@ pub mod sqlite;
 pub mod store;
 pub mod test_utils;
 
-use std::error::Error;
-
 pub use beacon_provider::{BeaconProvider, BeaconProviderError, BeaconProviderImpl};
 pub use entities::{CardanoNetwork, MagicId};
 
 /// Generic error type
-pub type StdError = Box<dyn Error + Sync + Send>;
+pub type StdError = anyhow::Error;
 
 /// Generic result type
-pub type StdResult<T> = std::result::Result<T, StdError>;
+pub type StdResult<T> = anyhow::Result<T, StdError>;
 
 /// Mithril API protocol version header name
 pub const MITHRIL_API_VERSION_HEADER: &str = "mithril-api-version";

--- a/mithril-common/src/sqlite/provider.rs
+++ b/mithril-common/src/sqlite/provider.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use sqlite::Connection;
 
-use crate::StdError;
+use crate::StdResult;
 
 use super::{EntityCursor, SqLiteEntity, WhereCondition};
 
@@ -15,10 +15,7 @@ pub trait Provider<'conn> {
     fn get_connection(&'conn self) -> &'conn Connection;
 
     /// Perform the parametrized definition query.
-    fn find(
-        &'conn self,
-        filters: WhereCondition,
-    ) -> Result<EntityCursor<'conn, Self::Entity>, StdError> {
+    fn find(&'conn self, filters: WhereCondition) -> StdResult<EntityCursor<'conn, Self::Entity>> {
         let (condition, params) = filters.expand();
         let sql = self.get_definition(&condition);
         let cursor = self

--- a/mithril-common/src/sqlite/provider.rs
+++ b/mithril-common/src/sqlite/provider.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use sqlite::Connection;
 
 use crate::StdError;
@@ -23,7 +24,12 @@ pub trait Provider<'conn> {
         let cursor = self
             .get_connection()
             .prepare(&sql)
-            .map_err(|e| format!("error=`{e}, SQL=`{}`", &sql.replace('\n', " ").trim()))?
+            .with_context(|| {
+                format!(
+                    "Prepare query error: SQL=`{}`",
+                    &sql.replace('\n', " ").trim()
+                )
+            })?
             .into_iter()
             .bind(&params[..])?;
 

--- a/mithril-common/src/store/adapter/fail_adapter.rs
+++ b/mithril-common/src/store/adapter/fail_adapter.rs
@@ -1,4 +1,5 @@
 use super::{AdapterError, StoreAdapter};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use std::marker::PhantomData;
 
@@ -38,42 +39,42 @@ where
         _key: &Self::Key,
         _record: &Self::Record,
     ) -> Result<(), AdapterError> {
-        Err(AdapterError::GeneralError(
-            "Fail adapter always fails".to_string(),
-        ))
+        Err(AdapterError::GeneralError(anyhow!(
+            "Fail adapter always fails"
+        )))
     }
 
     async fn get_record(&self, _key: &Self::Key) -> Result<Option<Self::Record>, AdapterError> {
-        Err(AdapterError::GeneralError(
-            "Fail adapter always fails".to_string(),
-        ))
+        Err(AdapterError::GeneralError(anyhow!(
+            "Fail adapter always fails"
+        )))
     }
 
     async fn record_exists(&self, _key: &Self::Key) -> Result<bool, AdapterError> {
-        Err(AdapterError::GeneralError(
-            "Fail adapter always fails".to_string(),
-        ))
+        Err(AdapterError::GeneralError(anyhow!(
+            "Fail adapter always fails"
+        )))
     }
 
     async fn get_last_n_records(
         &self,
         _how_many: usize,
     ) -> Result<Vec<(Self::Key, Self::Record)>, AdapterError> {
-        Err(AdapterError::GeneralError(
-            "Fail adapter always fails".to_string(),
-        ))
+        Err(AdapterError::GeneralError(anyhow!(
+            "Fail adapter always fails"
+        )))
     }
 
     async fn remove(&mut self, _key: &Self::Key) -> Result<Option<Self::Record>, AdapterError> {
-        Err(AdapterError::GeneralError(
-            "Fail adapter always fails".to_string(),
-        ))
+        Err(AdapterError::GeneralError(anyhow!(
+            "Fail adapter always fails"
+        )))
     }
 
     async fn get_iter(&self) -> Result<Box<dyn Iterator<Item = Self::Record> + '_>, AdapterError> {
-        Err(AdapterError::GeneralError(
-            "Fail adapter always fails".to_string(),
-        ))
+        Err(AdapterError::GeneralError(anyhow!(
+            "Fail adapter always fails"
+        )))
     }
 }
 

--- a/mithril-common/src/store/adapter/memory_adapter.rs
+++ b/mithril-common/src/store/adapter/memory_adapter.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use async_trait::async_trait;
 use std::{collections::HashMap, hash::Hash};
 
@@ -25,9 +26,9 @@ where
 
         for (idx, elt) in data.into_iter() {
             if values.insert(idx.clone(), elt).is_some() {
-                return Err(AdapterError::InitializationError(
-                    "duplicate key found".into(),
-                ));
+                return Err(AdapterError::InitializationError(anyhow!(
+                    "duplicate key found"
+                )));
             }
             index.push(idx);
         }

--- a/mithril-common/src/store/adapter/sqlite_adapter.rs
+++ b/mithril-common/src/store/adapter/sqlite_adapter.rs
@@ -5,7 +5,7 @@ use sqlite::{Connection, State, Statement};
 use tokio::sync::Mutex;
 
 use crate::StdError;
-use lazy_static::__Deref;
+use std::ops::Deref;
 use std::{marker::PhantomData, sync::Arc, thread::sleep, time::Duration};
 
 use super::{AdapterError, StoreAdapter};

--- a/mithril-common/src/store/adapter/sqlite_adapter.rs
+++ b/mithril-common/src/store/adapter/sqlite_adapter.rs
@@ -1,12 +1,11 @@
+use anyhow::anyhow;
 use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use sha2::{Digest, Sha256};
 use sqlite::{Connection, State, Statement};
-use tokio::sync::Mutex;
-
-use crate::StdError;
 use std::ops::Deref;
 use std::{marker::PhantomData, sync::Arc, thread::sleep, time::Duration};
+use tokio::sync::Mutex;
 
 use super::{AdapterError, StoreAdapter};
 
@@ -88,7 +87,7 @@ where
     fn serialize_key(&self, key: &K) -> Result<String> {
         serde_json::to_string(&key).map_err(|e| {
             AdapterError::GeneralError(
-                StdError::new(e).context("SQLite adapter: Serde error while serializing store key"),
+                anyhow!(e).context("SQLite adapter: Serde error while serializing store key"),
             )
         })
     }
@@ -161,7 +160,7 @@ where
         );
         let value = serde_json::to_string(record).map_err(|e| {
             AdapterError::GeneralError(
-                StdError::new(e)
+                anyhow!(e)
                     .context("SQLite adapter error: could not serialize value before insertion"),
             )
         })?;
@@ -209,7 +208,7 @@ where
             .read::<i64, _>(0)
             .map_err(|e| {
                 AdapterError::GeneralError(
-                    StdError::new(e).context("There should be a result in this case !"),
+                    anyhow!(e).context("There should be a result in this case !"),
                 )
             })
             .map(|res| res == 1)

--- a/mithril-common/src/store/adapter/sqlite_adapter.rs
+++ b/mithril-common/src/store/adapter/sqlite_adapter.rs
@@ -4,6 +4,7 @@ use sha2::{Digest, Sha256};
 use sqlite::{Connection, State, Statement};
 use tokio::sync::Mutex;
 
+use crate::StdError;
 use lazy_static::__Deref;
 use std::{marker::PhantomData, sync::Arc, thread::sleep, time::Duration};
 
@@ -86,9 +87,9 @@ where
 
     fn serialize_key(&self, key: &K) -> Result<String> {
         serde_json::to_string(&key).map_err(|e| {
-            AdapterError::GeneralError(format!(
-                "SQLite adapter: Serde error while serializing store key: {e:?}"
-            ))
+            AdapterError::GeneralError(
+                StdError::new(e).context("SQLite adapter: Serde error while serializing store key"),
+            )
         })
     }
 
@@ -159,9 +160,10 @@ where
             self.table
         );
         let value = serde_json::to_string(record).map_err(|e| {
-            AdapterError::GeneralError(format!(
-                "SQLite adapter error: could not serialize value before insertion: {e:?}"
-            ))
+            AdapterError::GeneralError(
+                StdError::new(e)
+                    .context("SQLite adapter error: could not serialize value before insertion"),
+            )
         })?;
         let mut statement = connection
             .prepare(sql)
@@ -206,7 +208,9 @@ where
         statement
             .read::<i64, _>(0)
             .map_err(|e| {
-                AdapterError::GeneralError(format!("There should be a result in this case ! {e:?}"))
+                AdapterError::GeneralError(
+                    StdError::new(e).context("There should be a result in this case !"),
+                )
             })
             .map(|res| res == 1)
     }

--- a/mithril-common/src/store/adapter/store_adapter.rs
+++ b/mithril-common/src/store/adapter/store_adapter.rs
@@ -1,38 +1,37 @@
+use crate::StdError;
 use async_trait::async_trait;
 use thiserror::Error;
-
-type SubError = Box<dyn std::error::Error + Sync + Send>;
 
 /// [StoreAdapter] related errors
 #[derive(Debug, Error)]
 pub enum AdapterError {
     /// Generic [StoreAdapter] error.
-    #[error("something wrong happened: {0}")]
-    GeneralError(String),
+    #[error("something wrong happened: {0:?}")]
+    GeneralError(StdError),
 
     /// Error raised when the store initialization fails.
-    #[error("problem creating the repository: {0}")]
-    InitializationError(SubError),
+    #[error("problem creating the repository: {0:?}")]
+    InitializationError(StdError),
 
     /// Error raised when the opening of a IO stream fails.
-    #[error("problem opening the IO stream: {0}")]
-    OpeningStreamError(SubError),
+    #[error("problem opening the IO stream: {0:?}")]
+    OpeningStreamError(StdError),
 
     /// Error raised when the parsing of a IO stream fails.
-    #[error("problem parsing the IO stream: {0}")]
-    ParsingDataError(SubError),
+    #[error("problem parsing the IO stream: {0:?}")]
+    ParsingDataError(StdError),
 
     /// Error raised if a writting operation fails.
-    #[error("problem writing on the adapter: {0}")]
-    MutationError(SubError),
+    #[error("problem writing on the adapter: {0:?}")]
+    MutationError(StdError),
 
     /// Error while querying the subsystem.
-    #[error("problem when querying the adapter: {0}")]
-    QueryError(SubError),
+    #[error("problem when querying the adapter: {0:?}")]
+    QueryError(StdError),
 
     /// Type conversion cannot be performed by this adapter.
-    #[error("type conversion error, this adapter does not know how to handle this: {0}")]
-    TypeError(SubError),
+    #[error("type conversion error, this adapter does not know how to handle this: {0:?}")]
+    TypeError(StdError),
 }
 
 /// Represent a way to store Key/Value pair data.

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -10,6 +10,7 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
+anyhow = "1.0.71"
 async-trait = "0.1.52"
 clap = { version = "4.0", features = ["derive", "env"] }
 config = "0.13.1"

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -9,7 +9,7 @@ use mithril_common::{
         adapters::{EraReaderAdapterBuilder, EraReaderAdapterType},
         EraReaderAdapter,
     },
-    CardanoNetwork, StdError,
+    CardanoNetwork, StdResult,
 };
 
 const SQLITE_FILE: &str = "signer.sqlite3";
@@ -97,7 +97,7 @@ impl Configuration {
     pub fn build_era_reader_adapter(
         &self,
         chain_observer: Arc<dyn ChainObserver>,
-    ) -> Result<Arc<dyn EraReaderAdapter>, StdError> {
+    ) -> StdResult<Arc<dyn EraReaderAdapter>> {
         Ok(EraReaderAdapterBuilder::new(
             &self.era_reader_adapter_type,
             &self.era_reader_adapter_params,
@@ -127,7 +127,7 @@ impl Source for DefaultConfiguration {
         Box::new(self.clone())
     }
 
-    fn collect(&self) -> Result<Map<String, Value>, config::ConfigError> {
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
         let mut result = Map::new();
         let namespace = "default configuration".to_string();
         let myself = self.clone();

--- a/mithril-signer/src/runtime/error.rs
+++ b/mithril-signer/src/runtime/error.rs
@@ -1,6 +1,7 @@
-use std::{error::Error as StdError, fmt::Display};
+use std::fmt::Display;
 
 use mithril_common::entities::EpochError;
+use mithril_common::StdError;
 
 use crate::RunnerError;
 
@@ -15,7 +16,7 @@ pub enum RuntimeError {
         message: String,
 
         /// Eventual previous error message
-        nested_error: Option<Box<dyn StdError + Sync + Send>>,
+        nested_error: Option<StdError>,
     },
     /// Critical error means the runtime will exit and the software will return
     /// an error code.
@@ -24,7 +25,7 @@ pub enum RuntimeError {
         message: String,
 
         /// Eventual previous error message
-        nested_error: Option<Box<dyn StdError + Sync + Send>>,
+        nested_error: Option<StdError>,
     },
 }
 
@@ -41,7 +42,7 @@ impl RuntimeError {
     }
 }
 
-impl StdError for RuntimeError {}
+impl std::error::Error for RuntimeError {}
 
 impl Display for RuntimeError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -51,7 +52,7 @@ impl Display for RuntimeError {
                 nested_error,
             } => {
                 let nested = if let Some(error) = nested_error {
-                    format!("nested error = {error}")
+                    format!("nested error = {error:?}")
                 } else {
                     String::new()
                 };
@@ -65,7 +66,7 @@ impl Display for RuntimeError {
                 nested_error,
             } => {
                 let nested = if let Some(error) = nested_error {
-                    format!("nested error = {error}")
+                    format!("nested error = {error:?}")
                 } else {
                     String::new()
                 };

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -110,7 +110,7 @@ impl SingleSigner for MithrilSingleSigner {
             .restore_signer_from_initializer(self.party_id.clone(), protocol_initializer.clone())
             .map_err(|e| SingleSignerError::ProtocolSignerCreationFailure(e.to_string()))?
             .sign(protocol_message)
-            .map_err(|e| SingleSignerError::SignatureFailed(e.into()))?;
+            .map_err(SingleSignerError::SignatureFailed)?;
 
         match &signatures {
             Some(signature) => {
@@ -138,9 +138,7 @@ impl SingleSigner for MithrilSingleSigner {
             signers_with_stake,
             &protocol_initializer.get_protocol_parameters().into(),
         )
-        .map_err(|error| {
-            SingleSignerError::AggregateVerificationKeyComputationFailed(error.into())
-        })?;
+        .map_err(SingleSignerError::AggregateVerificationKeyComputationFailed)?;
 
         let encoded_avk = key_encode_hex(signer_builder.compute_aggregate_verification_key())
             .map_err(SingleSignerError::Codec)?;

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -1,33 +1,27 @@
 #![allow(dead_code)]
-use mithril_common::api_version::APIVersionProvider;
-use mithril_common::digesters::ImmutableFileObserver;
-use mithril_common::entities::SignerWithStake;
-use mithril_common::era::{
-    adapters::{EraReaderAdapterType, EraReaderDummyAdapter},
-    EraChecker, EraReader,
-};
-use mithril_common::era::{EraMarker, SupportedEra};
-use mithril_common::signable_builder::{
-    CardanoImmutableFilesFullSignableBuilder, MithrilSignableBuilderService,
-    MithrilStakeDistributionSignableBuilder,
-};
-use mithril_common::BeaconProvider;
 use slog::Drain;
 use slog_scope::debug;
-use std::error::Error as StdError;
-use std::fmt::Debug;
-use std::path::Path;
-use std::{path::PathBuf, sync::Arc, time::Duration};
+use std::{fmt::Debug, path::Path, path::PathBuf, sync::Arc, time::Duration};
 use thiserror::Error;
 
-use mithril_common::crypto_helper::tests_setup;
 use mithril_common::{
+    api_version::APIVersionProvider,
     chain_observer::FakeObserver,
-    digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
-    entities::{Beacon, Epoch},
+    crypto_helper::tests_setup,
+    digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
+    entities::{Beacon, Epoch, SignerWithStake},
+    era::{
+        adapters::{EraReaderAdapterType, EraReaderDummyAdapter},
+        EraChecker, EraMarker, EraReader, SupportedEra,
+    },
+    signable_builder::{
+        CardanoImmutableFilesFullSignableBuilder, MithrilSignableBuilderService,
+        MithrilStakeDistributionSignableBuilder,
+    },
     store::{adapter::MemoryAdapter, StakeStore, StakeStorer},
-    BeaconProviderImpl,
+    BeaconProvider, BeaconProviderImpl, StdError,
 };
+
 use mithril_signer::{
     AggregatorClient, Configuration, MithrilSingleSigner, ProtocolInitializerStore,
     ProtocolInitializerStorer, RuntimeError, SignerRunner, SignerServices, SignerState,
@@ -43,7 +37,7 @@ pub enum TestError {
     #[error("Assertion failed: {0}")]
     AssertFailed(String),
     #[error("Subsystem error: {0:?}")]
-    SubsystemError(#[from] Box<dyn StdError + Sync + Send>),
+    SubsystemError(#[from] StdError),
     #[error("Value error: {0}")]
     ValueError(String),
 }

--- a/mithril-test-lab/mithril-end-to-end/.gitignore
+++ b/mithril-test-lab/mithril-end-to-end/.gitignore
@@ -2,4 +2,5 @@ data/
 target/
 mithril-end-to-end
 load-aggregator
+!load-aggregator/
 .DS_Store


### PR DESCRIPTION
## Content
This heart of this PR is to change what `StdResult` and `StdError` are aliasing to, replacing std types with the one from [`anyhow`](https://crates.io/crates/anyhow):
```diff
 /// Generic error type
-pub type StdError = Box<dyn Error + Sync + Send>;
+pub type StdError = anyhow::Error;
 
 /// Generic result type
-pub type StdResult<T> = std::result::Result<T, StdError>;
+pub type StdResult<T> = anyhow::Result<T, StdError>;
```

Most of the other changes are related to adapting the code to `anyhow` results.

This PR also:
- Changes the return types of the main function of our three binaries (aggregator, signer, client) to the "new" `StdResult`.
This is an improvement since when main function yield an anyhow error, it is printed out nicely (including the backtrace, see [this rust playground](https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=8e28065ed46df9e67fa04563e5bcdda5)).
- It unify the usages of boxed errors, replacing most usage of local error/result types to a `StdError` or `StdResult`.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
The unused dependency to `lazy_static` from `mithril-common` was removed. It was only used to access the `.deref()` method something that the standard rust library already provide.

## Issue(s)
Relates to #798