### PR TITLE
Simplify logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.70"
+version = "0.3.71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.93"
+version = "0.2.94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2236,7 +2236,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.68"
+version = "0.2.69"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.70"
+version = "0.3.71"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/provider/certificate.rs
+++ b/mithril-aggregator/src/database/provider/certificate.rs
@@ -410,7 +410,7 @@ protocol_message, signers, initiated_at, sealed_at)";
 
         let entity = self.find(filters)?.next().unwrap_or_else(|| {
             panic!(
-                "No entity returned by the persister, certificate_record = {certificate_record:?}"
+                "No entity returned by the persister, certificate_record = {certificate_record:#?}"
             )
         });
 

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -29,7 +29,7 @@ mod handlers {
         messages::{RegisterSignatureMessage, TryFromMessageAdapter},
     };
 
-    use slog_scope::{debug, warn};
+    use slog_scope::{debug, trace, warn};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -47,6 +47,7 @@ mod handlers {
         ticker_service: Arc<dyn TickerService>,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("⇄ HTTP SERVER: register_signatures/{:?}", message);
+        trace!("⇄ HTTP SERVER: register_signatures"; "complete_message" => #?message );
 
         let signed_entity_type = match message.signed_entity_type.clone() {
             Some(signed_entity_type) => Ok(signed_entity_type),

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -49,7 +49,7 @@ mod handlers {
     use mithril_common::entities::Epoch;
     use mithril_common::messages::{RegisterSignerMessage, TryFromMessageAdapter};
     use mithril_common::BeaconProvider;
-    use slog_scope::{debug, warn};
+    use slog_scope::{debug, trace, warn};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -65,6 +65,10 @@ mod handlers {
         debug!(
             "⇄ HTTP SERVER: register_signer/{:?}",
             register_signer_message
+        );
+        trace!(
+            "⇄ HTTP SERVER: register_signer";
+            "complete_message" => #?register_signer_message
         );
 
         let registration_epoch = match register_signer_message.epoch {

--- a/mithril-aggregator/src/message_adapters/to_certificate_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_message.rs
@@ -1,6 +1,7 @@
 use mithril_common::entities::{Certificate, CertificateSignature};
 use mithril_common::messages::{
-    CertificateMessage, CertificateMetadataMessage, SignerWithStakeMessagePart, ToMessageAdapter,
+    CertificateMessage, CertificateMetadataMessagePart, SignerWithStakeMessagePart,
+    ToMessageAdapter,
 };
 
 /// Adapter to convert [Certificate] to [CertificateMessage] instances
@@ -9,7 +10,7 @@ pub struct ToCertificateMessageAdapter;
 impl ToMessageAdapter<Certificate, CertificateMessage> for ToCertificateMessageAdapter {
     /// Method to trigger the conversion
     fn adapt(certificate: Certificate) -> CertificateMessage {
-        let metadata = CertificateMetadataMessage {
+        let metadata = CertificateMetadataMessagePart {
             protocol_version: certificate.metadata.protocol_version,
             protocol_parameters: certificate.metadata.protocol_parameters,
             initiated_at: certificate.metadata.initiated_at,

--- a/mithril-aggregator/src/message_adapters/to_certificate_pending_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_pending_message.rs
@@ -1,6 +1,6 @@
 use mithril_common::{
     entities::{CertificatePending, Signer},
-    messages::{CertificatePendingMessage, SignerMessage, ToMessageAdapter},
+    messages::{CertificatePendingMessage, SignerMessagePart, ToMessageAdapter},
 };
 
 /// Adapter to turn [CertificatePending] instances into [CertificatePendingMessage].
@@ -23,10 +23,10 @@ impl ToMessageAdapter<CertificatePending, CertificatePendingMessage>
 }
 
 impl ToCertificatePendingMessageAdapter {
-    fn adapt_signers(signers: Vec<Signer>) -> Vec<SignerMessage> {
+    fn adapt_signers(signers: Vec<Signer>) -> Vec<SignerMessagePart> {
         signers
             .into_iter()
-            .map(|signer| SignerMessage {
+            .map(|signer| SignerMessagePart {
                 party_id: signer.party_id,
                 verification_key: signer.verification_key.try_into().unwrap(),
                 verification_key_signature: signer

--- a/mithril-aggregator/src/services/certifier.rs
+++ b/mithril-aggregator/src/services/certifier.rs
@@ -17,7 +17,7 @@ use mithril_common::{
     StdResult,
 };
 use slog::Logger;
-use slog_scope::{debug, error, info, warn};
+use slog_scope::{debug, error, info, trace, warn};
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -206,6 +206,8 @@ impl CertifierService for MithrilCertifierService {
         signature: &SingleSignatures,
     ) -> StdResult<()> {
         debug!("CertifierService::register_single_signature(signed_entity_type: {signed_entity_type:?}, single_signatures: {signature:?}");
+        trace!("CertifierService::register_single_signature"; "complete_single_signatures" => #?signature);
+
         let open_message = self
             .get_open_message_record(signed_entity_type)
             .await?

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.31"
+version = "0.3.32"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client/certificate_client.rs
+++ b/mithril-client/src/aggregator_client/certificate_client.rs
@@ -67,7 +67,7 @@ impl CertificateRetriever for CertificateClient {
 #[cfg(test)]
 mod tests {
     use mithril_common::entities::CertificateSignature;
-    use mithril_common::messages::{CertificateMetadataMessage, SignerWithStakeMessagePart};
+    use mithril_common::messages::{CertificateMetadataMessagePart, SignerWithStakeMessagePart};
     use mithril_common::test_utils::fake_data;
 
     use crate::aggregator_client::MockAggregatorHTTPClient;
@@ -97,7 +97,7 @@ mod tests {
                     hash: certificate_hash.clone(),
                     previous_hash: previous_hash.clone(),
                     beacon: certificate.beacon.clone(),
-                    metadata: CertificateMetadataMessage {
+                    metadata: CertificateMetadataMessagePart {
                         protocol_version: certificate.metadata.protocol_version.clone(),
                         protocol_parameters: certificate.metadata.protocol_parameters.clone(),
                         initiated_at: certificate.metadata.initiated_at,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.93"
+version = "0.2.94"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -3,6 +3,7 @@ use crate::entities::{
     Beacon, CertificateMetadata, HexEncodedAgregateVerificationKey, ProtocolMessage,
 };
 use std::cmp::Ordering;
+use std::fmt::{Debug, Formatter};
 
 use sha2::{Digest, Sha256};
 
@@ -19,7 +20,7 @@ pub enum CertificateSignature {
 }
 
 /// Certificate represents a Mithril certificate embedding a Mithril STM multisignature
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct Certificate {
     /// Hash of the current certificate
     /// Computed from the other fields of the certificate
@@ -129,6 +130,34 @@ impl PartialOrd for Certificate {
             // Beacons may be not comparable (most likely because the network isn't the same) in
             // that case we can still order per hash
             None => self.hash.partial_cmp(&other.hash),
+        }
+    }
+}
+
+impl Debug for Certificate {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("Certificate");
+        debug
+            .field("hash", &self.hash)
+            .field("previous_hash", &self.previous_hash)
+            .field("beacon", &format_args!("{:?}", self.beacon))
+            .field("metadata", &format_args!("{:?}", self.metadata))
+            .field(
+                "protocol_message",
+                &format_args!("{:?}", self.protocol_message),
+            )
+            .field("signed_message", &self.signed_message);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "aggregate_verification_key",
+                    &format_args!("{:?}", self.aggregate_verification_key),
+                )
+                .field("signature", &format_args!("{:?}", self.signature))
+                .finish(),
+            false => debug.finish_non_exhaustive(),
         }
     }
 }

--- a/mithril-common/src/entities/signer.rs
+++ b/mithril-common/src/entities/signer.rs
@@ -5,12 +5,13 @@ use crate::{
     },
     entities::{PartyId, Stake},
 };
+use std::fmt::{Debug, Formatter};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 /// Signer represents a signing participant in the network
-#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
+#[derive(Clone, Eq, Serialize, Deserialize)]
 pub struct Signer {
     /// The unique identifier of the signer
     // TODO: Should be removed once the signer certification is fully deployed
@@ -75,6 +76,33 @@ impl Signer {
     }
 }
 
+impl Debug for Signer {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("Signer");
+        debug.field("party_id", &self.party_id);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "verification_key",
+                    &format_args!("{:?}", self.verification_key),
+                )
+                .field(
+                    "verification_key_signature",
+                    &format_args!("{:?}", self.verification_key_signature),
+                )
+                .field(
+                    "operational_certificate",
+                    &format_args!("{:?}", self.operational_certificate),
+                )
+                .field("kes_period", &format_args!("{:?}", self.kes_period))
+                .finish(),
+            false => debug.finish_non_exhaustive(),
+        }
+    }
+}
+
 impl From<SignerWithStake> for Signer {
     fn from(other: SignerWithStake) -> Self {
         Signer::new(
@@ -88,7 +116,7 @@ impl From<SignerWithStake> for Signer {
 }
 
 /// Signer represents a signing party in the network (including its stakes)
-#[derive(Clone, Debug, Eq, Serialize, Deserialize)]
+#[derive(Clone, Eq, Serialize, Deserialize)]
 pub struct SignerWithStake {
     /// The unique identifier of the signer
     // TODO: Should be removed once the signer certification is fully deployed
@@ -181,6 +209,35 @@ impl SignerWithStake {
         }
         hasher.update(self.stake.to_be_bytes());
         hex::encode(hasher.finalize())
+    }
+}
+
+impl Debug for SignerWithStake {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("SignerWithStake");
+        debug
+            .field("party_id", &self.party_id)
+            .field("stake", &self.stake);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "verification_key",
+                    &format_args!("{:?}", self.verification_key),
+                )
+                .field(
+                    "verification_key_signature",
+                    &format_args!("{:?}", self.verification_key_signature),
+                )
+                .field(
+                    "operational_certificate",
+                    &format_args!("{:?}", self.operational_certificate),
+                )
+                .field("kes_period", &format_args!("{:?}", self.kes_period))
+                .finish(),
+            false => debug.finish_non_exhaustive(),
+        }
     }
 }
 

--- a/mithril-common/src/entities/single_signatures.rs
+++ b/mithril-common/src/entities/single_signatures.rs
@@ -1,5 +1,6 @@
 use mithril_stm::stm::StmSig;
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 
 use crate::{
     crypto_helper::ProtocolSingleSignature,
@@ -8,7 +9,7 @@ use crate::{
 
 /// SingleSignatures represent single signatures originating from a participant in the network
 /// for a digest at won lottery indexes
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct SingleSignatures {
     /// The unique identifier of the signer
     pub party_id: PartyId,
@@ -38,6 +39,23 @@ impl SingleSignatures {
     /// Convert this [SingleSignatures] to its corresponding [MithrilStm Signature][StmSig].
     pub fn to_protocol_signature(&self) -> StmSig {
         self.signature.clone().into()
+    }
+}
+
+impl Debug for SingleSignatures {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let is_pretty_printing = f.alternate();
+        let mut debug = f.debug_struct("SingleSignatures");
+        debug
+            .field("party_id", &self.party_id)
+            .field("won_indexes", &format_args!("{:?}", self.won_indexes));
+
+        match is_pretty_printing {
+            true => debug
+                .field("signature", &format_args!("{:?}", self.signature))
+                .finish(),
+            false => debug.finish_non_exhaustive(),
+        }
     }
 }
 

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -1,11 +1,12 @@
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 
 use crate::entities::{Beacon, ProtocolMessage, ProtocolMessagePartKey};
 use crate::messages::CertificateMetadataMessagePart;
 use crate::test_utils::fake_keys;
 
 /// Message structure of a certificate
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct CertificateMessage {
     /// Hash of the current certificate
     /// Computed from the other fields of the certificate
@@ -70,6 +71,35 @@ impl CertificateMessage {
             aggregate_verification_key: "aggregate_verification_key".to_string(),
             multi_signature: fake_keys::multi_signature()[0].to_owned(),
             genesis_signature: String::new(),
+        }
+    }
+}
+
+impl Debug for CertificateMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("Certificate");
+        debug
+            .field("hash", &self.hash)
+            .field("previous_hash", &self.previous_hash)
+            .field("beacon", &format_args!("{:?}", self.beacon))
+            .field("metadata", &format_args!("{:?}", self.metadata))
+            .field(
+                "protocol_message",
+                &format_args!("{:?}", self.protocol_message),
+            )
+            .field("signed_message", &self.signed_message);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "aggregate_verification_key",
+                    &self.aggregate_verification_key,
+                )
+                .field("multi_signature", &self.multi_signature)
+                .field("genesis_signature", &self.genesis_signature)
+                .finish(),
+            false => debug.finish_non_exhaustive(),
         }
     }
 }

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -1,10 +1,8 @@
-use crate::{
-    entities::{Beacon, ProtocolMessage, ProtocolMessagePartKey},
-    messages::certificate_metadata::CertificateMetadataMessage,
-};
-
-use crate::test_utils::fake_keys;
 use serde::{Deserialize, Serialize};
+
+use crate::entities::{Beacon, ProtocolMessage, ProtocolMessagePartKey};
+use crate::messages::CertificateMetadataMessagePart;
+use crate::test_utils::fake_keys;
 
 /// Message structure of a certificate
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -26,7 +24,7 @@ pub struct CertificateMessage {
 
     /// Certificate metadata
     /// aka METADATA(p,n)
-    pub metadata: CertificateMetadataMessage,
+    pub metadata: CertificateMetadataMessagePart,
 
     /// Structured message that is used to created the signed message
     /// aka MSG(p,n) U AVK(n-1)
@@ -66,7 +64,7 @@ impl CertificateMessage {
             hash: "hash".to_string(),
             previous_hash: "previous_hash".to_string(),
             beacon: Beacon::new("testnet".to_string(), 10, 100),
-            metadata: CertificateMetadataMessage::dummy(),
+            metadata: CertificateMetadataMessagePart::dummy(),
             protocol_message: protocol_message.clone(),
             signed_message: "signed_message".to_string(),
             aggregate_verification_key: "aggregate_verification_key".to_string(),
@@ -96,7 +94,7 @@ mod tests {
             hash: "hash".to_string(),
             previous_hash: "previous_hash".to_string(),
             beacon: Beacon::new("testnet".to_string(), 10, 100),
-            metadata: CertificateMetadataMessage {
+            metadata: CertificateMetadataMessagePart {
                 protocol_version: "0.1.0".to_string(),
                 protocol_parameters: ProtocolParameters::new(1000, 100, 0.123),
                 initiated_at: DateTime::parse_from_rfc3339("2024-02-12T13:11:47Z")

--- a/mithril-common/src/messages/certificate_list.rs
+++ b/mithril-common/src/messages/certificate_list.rs
@@ -1,11 +1,10 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 
-use crate::entities::Beacon;
-use crate::entities::ProtocolMessage;
-use crate::entities::ProtocolMessagePartKey;
-use crate::entities::ProtocolParameters;
-use crate::entities::ProtocolVersion;
+use crate::entities::{
+    Beacon, ProtocolMessage, ProtocolMessagePartKey, ProtocolParameters, ProtocolVersion,
+};
 
 /// Message structure of a certificate list
 pub type CertificateListMessage = Vec<CertificateListItemMessage>;
@@ -40,7 +39,7 @@ pub struct CertificateListItemMessageMetadata {
 }
 
 /// Message structure of a certificate list item
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Default, Serialize, Deserialize)]
 pub struct CertificateListItemMessage {
     /// Hash of the current certificate
     /// Computed from the other fields of the certificate
@@ -105,6 +104,33 @@ impl CertificateListItemMessage {
             protocol_message: protocol_message.clone(),
             signed_message: "signed_message".to_string(),
             aggregate_verification_key: "aggregate_verification_key".to_string(),
+        }
+    }
+}
+
+impl Debug for CertificateListItemMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("Certificate");
+        debug
+            .field("hash", &self.hash)
+            .field("previous_hash", &self.previous_hash)
+            .field("beacon", &format_args!("{:?}", self.beacon))
+            .field("metadata", &format_args!("{:?}", self.metadata))
+            .field(
+                "protocol_message",
+                &format_args!("{:?}", self.protocol_message),
+            )
+            .field("signed_message", &self.signed_message);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "aggregate_verification_key",
+                    &self.aggregate_verification_key,
+                )
+                .finish(),
+            false => debug.finish_non_exhaustive(),
         }
     }
 }

--- a/mithril-common/src/messages/certificate_pending.rs
+++ b/mithril-common/src/messages/certificate_pending.rs
@@ -1,13 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{
-    crypto_helper::KESPeriod,
-    entities::{
-        Beacon, HexEncodedOpCert, HexEncodedVerificationKey, HexEncodedVerificationKeySignature,
-        PartyId, ProtocolParameters, SignedEntityType,
-    },
-    test_utils::fake_keys,
-};
+use crate::entities::{Beacon, ProtocolParameters, SignedEntityType};
+use crate::messages::SignerMessagePart;
 
 /// Structure to transport [crate::entities::CertificatePending] data.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -28,10 +22,10 @@ pub struct CertificatePendingMessage {
     pub next_protocol_parameters: ProtocolParameters,
 
     /// Current Signers
-    pub signers: Vec<SignerMessage>,
+    pub signers: Vec<SignerMessagePart>,
 
     /// Signers that will be able to sign on the next epoch
-    pub next_signers: Vec<SignerMessage>,
+    pub next_signers: Vec<SignerMessagePart>,
 }
 
 impl CertificatePendingMessage {
@@ -50,55 +44,8 @@ impl CertificatePendingMessage {
                 m: 1000,
                 phi_f: 0.65,
             },
-            signers: [SignerMessage::dummy()].to_vec(),
-            next_signers: [SignerMessage::dummy()].to_vec(),
-        }
-    }
-}
-
-// todo: move to message_parts
-/// Signer Message
-#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct SignerMessage {
-    /// The unique identifier of the signer
-    // TODO: Should be removed once the signer certification is fully deployed
-    pub party_id: PartyId,
-
-    /// The public key used to authenticate signer signature
-    pub verification_key: HexEncodedVerificationKey,
-
-    /// The encoded signer 'Mithril verification key' signature (signed by the
-    /// Cardano node KES secret key).
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub verification_key_signature: Option<HexEncodedVerificationKeySignature>,
-
-    /// The encoded operational certificate of stake pool operator attached to
-    /// the signer node.
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub operational_certificate: Option<HexEncodedOpCert>,
-
-    /// The KES period used to compute the verification key signature
-    // TODO: This KES period should not be used as is and should probably be
-    //       within an allowed range of KES periods for the epoch.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub kes_period: Option<KESPeriod>,
-}
-
-impl SignerMessage {
-    /// Return a dummy test entity (test-only).
-    pub fn dummy() -> Self {
-        Self {
-            party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
-            verification_key: fake_keys::signer_verification_key()[0].to_string(),
-            verification_key_signature: Some(
-                fake_keys::signer_verification_key_signature()[0].to_string(),
-            ),
-            operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
-            kes_period: Some(6),
+            signers: [SignerMessagePart::dummy()].to_vec(),
+            next_signers: [SignerMessagePart::dummy()].to_vec(),
         }
     }
 }
@@ -129,7 +76,7 @@ mod tests {
                 phi_f: 0.65,
             },
             signers: vec![
-                SignerMessage {
+                SignerMessagePart {
                     party_id: "123".to_string(),
                     verification_key: "7b22766b223a5b3134332c3136312c3235352c34382c37382c35372c3230342c3232302c32352c3232312c3136342c3235322c3234382c31342c35362c3132362c3138362c3133352c3232382c3138382c3134352c3138312c35322c3230302c39372c39392c3231332c34362c302c3139392c3139332c38392c3138372c38382c32392c3133352c3137332c3234342c38362c33362c38332c35342c36372c3136342c362c3133372c39342c37322c362c3130352c3132382c3132382c39332c34382c3137362c31312c342c3234362c3133382c34382c3138302c3133332c39302c3134322c3139322c32342c3139332c3131312c3134322c33312c37362c3131312c3131302c3233342c3135332c39302c3230382c3139322c33312c3132342c39352c3130322c34392c3135382c39392c35322c3232302c3136352c39342c3235312c36382c36392c3132312c31362c3232342c3139345d2c22706f70223a5b3136382c35302c3233332c3139332c31352c3133362c36352c37322c3132332c3134382c3132392c3137362c33382c3139382c3230392c34372c32382c3230342c3137362c3134342c35372c3235312c34322c32382c36362c37362c38392c39372c3135382c36332c35342c3139382c3139342c3137362c3133352c3232312c31342c3138352c3139372c3232352c3230322c39382c3234332c37342c3233332c3232352c3134332c3135312c3134372c3137372c3137302c3131372c36362c3136352c36362c36322c33332c3231362c3233322c37352c36382c3131342c3139352c32322c3130302c36352c34342c3139382c342c3136362c3130322c3233332c3235332c3234302c35392c3137352c36302c3131372c3134322c3131342c3134302c3132322c31372c38372c3131302c3138372c312c31372c31302c3139352c3135342c31332c3234392c38362c35342c3232365d7d".to_string(),
                     verification_key_signature: None,
@@ -138,7 +85,7 @@ mod tests {
                 }
             ],
             next_signers: vec![
-                SignerMessage {
+                SignerMessagePart {
                     party_id: "123".to_string(),
                     verification_key: "7b22766b223a5b3134332c3136312c3235352c34382c37382c35372c3230342c3232302c32352c3232312c3136342c3235322c3234382c31342c35362c3132362c3138362c3133352c3232382c3138382c3134352c3138312c35322c3230302c39372c39392c3231332c34362c302c3139392c3139332c38392c3138372c38382c32392c3133352c3137332c3234342c38362c33362c38332c35342c36372c3136342c362c3133372c39342c37322c362c3130352c3132382c3132382c39332c34382c3137362c31312c342c3234362c3133382c34382c3138302c3133332c39302c3134322c3139322c32342c3139332c3131312c3134322c33312c37362c3131312c3131302c3233342c3135332c39302c3230382c3139322c33312c3132342c39352c3130322c34392c3135382c39392c35322c3232302c3136352c39342c3235312c36382c36392c3132312c31362c3232342c3139345d2c22706f70223a5b3136382c35302c3233332c3139332c31352c3133362c36352c37322c3132332c3134382c3132392c3137362c33382c3139382c3230392c34372c32382c3230342c3137362c3134342c35372c3235312c34322c32382c36362c37362c38392c39372c3135382c36332c35342c3139382c3139342c3137362c3133352c3232312c31342c3138352c3139372c3232352c3230322c39382c3234332c37342c3233332c3232352c3134332c3135312c3134372c3137372c3137302c3131372c36362c3136352c36362c36322c33332c3231362c3233322c37352c36382c3131342c3139352c32322c3130302c36352c34342c3139382c342c3136362c3130322c3233332c3235332c3234302c35392c3137352c36302c3131372c3134322c3131342c3134302c3132322c31372c38372c3131302c3138372c312c31372c31302c3139352c3135342c31332c3234392c38362c35342c3232365d7d".to_string(),
                     verification_key_signature: None,

--- a/mithril-common/src/messages/message_parts/certificate_metadata.rs
+++ b/mithril-common/src/messages/message_parts/certificate_metadata.rs
@@ -8,10 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use super::SignerWithStakeMessagePart;
 
-// todo: move to message_parts
 /// CertificateMetadata represents the metadata associated to a Certificate
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-pub struct CertificateMetadataMessage {
+pub struct CertificateMetadataMessagePart {
     /// Protocol Version (semver)
     /// Useful to achieve backward compatibility of the certificates (including of the multi signature)
     /// part of METADATA(p,n)
@@ -38,7 +37,7 @@ pub struct CertificateMetadataMessage {
     pub signers: Vec<SignerWithStakeMessagePart>,
 }
 
-impl CertificateMetadataMessage {
+impl CertificateMetadataMessagePart {
     /// CertificateMetadata factory
     pub fn dummy() -> Self {
         let initiated_at = DateTime::parse_from_rfc3339("2024-02-12T13:11:47Z")
@@ -76,8 +75,8 @@ impl CertificateMetadataMessage {
 mod tests {
     use super::*;
 
-    fn golden_message() -> CertificateMetadataMessage {
-        CertificateMetadataMessage {
+    fn golden_message() -> CertificateMetadataMessagePart {
+        CertificateMetadataMessagePart {
             protocol_version: "0.1.0".to_string(),
             protocol_parameters: ProtocolParameters::new(1000, 100, 0.123),
             initiated_at: DateTime::parse_from_rfc3339("2024-02-12T13:11:47Z")
@@ -132,7 +131,7 @@ mod tests {
                 }
             ]
         }"#;
-        let message: CertificateMetadataMessage = serde_json::from_str(json).expect(
+        let message: CertificateMetadataMessagePart = serde_json::from_str(json).expect(
             "This JSON is expected to be successfully parsed into a CertificateMetadataMessage instance.",
         );
 

--- a/mithril-common/src/messages/message_parts/mod.rs
+++ b/mithril-common/src/messages/message_parts/mod.rs
@@ -1,3 +1,5 @@
+mod certificate_metadata;
 mod signer;
 
-pub use signer::SignerWithStakeMessagePart;
+pub use certificate_metadata::CertificateMetadataMessagePart;
+pub use signer::{SignerMessagePart, SignerWithStakeMessagePart};

--- a/mithril-common/src/messages/message_parts/signer.rs
+++ b/mithril-common/src/messages/message_parts/signer.rs
@@ -8,9 +8,10 @@ use crate::{
     StdResult,
 };
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 
 /// Signer with Stake Message
-#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SignerWithStakeMessagePart {
     /// The unique identifier of the signer
     // TODO: Should be removed once the signer certification is fully deployed
@@ -108,8 +109,35 @@ impl From<SignerWithStake> for SignerWithStakeMessagePart {
     }
 }
 
+impl Debug for SignerMessagePart {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("Signer");
+        debug.field("party_id", &self.party_id);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "verification_key",
+                    &format_args!("{:?}", self.verification_key),
+                )
+                .field(
+                    "verification_key_signature",
+                    &format_args!("{:?}", self.verification_key_signature),
+                )
+                .field(
+                    "operational_certificate",
+                    &format_args!("{:?}", self.operational_certificate),
+                )
+                .field("kes_period", &format_args!("{:?}", self.kes_period))
+                .finish(),
+            false => debug.finish_non_exhaustive(),
+        }
+    }
+}
+
 /// Signer Message
-#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SignerMessagePart {
     /// The unique identifier of the signer
     // TODO: Should be removed once the signer certification is fully deployed
@@ -150,6 +178,35 @@ impl SignerMessagePart {
             ),
             operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
             kes_period: Some(6),
+        }
+    }
+}
+
+impl Debug for SignerWithStakeMessagePart {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("Signer");
+        debug
+            .field("party_id", &self.party_id)
+            .field("stake", &self.stake);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "verification_key",
+                    &format_args!("{:?}", self.verification_key),
+                )
+                .field(
+                    "verification_key_signature",
+                    &format_args!("{:?}", self.verification_key_signature),
+                )
+                .field(
+                    "operational_certificate",
+                    &format_args!("{:?}", self.operational_certificate),
+                )
+                .field("kes_period", &format_args!("{:?}", self.kes_period))
+                .finish(),
+            false => debug.finish_non_exhaustive(),
         }
     }
 }

--- a/mithril-common/src/messages/message_parts/signer.rs
+++ b/mithril-common/src/messages/message_parts/signer.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Signer Message
+/// Signer with Stake Message
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SignerWithStakeMessagePart {
     /// The unique identifier of the signer
@@ -104,6 +104,52 @@ impl From<SignerWithStake> for SignerWithStakeMessagePart {
                 .map(|op_cert| (op_cert.try_into().unwrap())),
             kes_period: value.kes_period,
             stake: value.stake,
+        }
+    }
+}
+
+/// Signer Message
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SignerMessagePart {
+    /// The unique identifier of the signer
+    // TODO: Should be removed once the signer certification is fully deployed
+    pub party_id: PartyId,
+
+    /// The public key used to authenticate signer signature
+    pub verification_key: HexEncodedVerificationKey,
+
+    /// The encoded signer 'Mithril verification key' signature (signed by the
+    /// Cardano node KES secret key).
+    // TODO: Option should be removed once the signer certification is fully
+    //       deployed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verification_key_signature: Option<HexEncodedVerificationKeySignature>,
+
+    /// The encoded operational certificate of stake pool operator attached to
+    /// the signer node.
+    // TODO: Option should be removed once the signer certification is fully
+    //       deployed.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operational_certificate: Option<HexEncodedOpCert>,
+
+    /// The KES period used to compute the verification key signature
+    // TODO: This KES period should not be used as is and should probably be
+    //       within an allowed range of KES periods for the epoch.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kes_period: Option<KESPeriod>,
+}
+
+impl SignerMessagePart {
+    /// Return a dummy test entity (test-only).
+    pub fn dummy() -> Self {
+        Self {
+            party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
+            verification_key: fake_keys::signer_verification_key()[0].to_string(),
+            verification_key_signature: Some(
+                fake_keys::signer_verification_key_signature()[0].to_string(),
+            ),
+            operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
+            kes_period: Some(6),
         }
     }
 }

--- a/mithril-common/src/messages/mod.rs
+++ b/mithril-common/src/messages/mod.rs
@@ -2,7 +2,6 @@
 //! This module aims at providing shared structures for API communications.
 mod certificate;
 mod certificate_list;
-mod certificate_metadata;
 mod certificate_pending;
 mod epoch_settings;
 mod interface;
@@ -18,8 +17,7 @@ pub use certificate::CertificateMessage;
 pub use certificate_list::{
     CertificateListItemMessage, CertificateListItemMessageMetadata, CertificateListMessage,
 };
-pub use certificate_metadata::CertificateMetadataMessage;
-pub use certificate_pending::{CertificatePendingMessage, SignerMessage};
+pub use certificate_pending::CertificatePendingMessage;
 pub use epoch_settings::EpochSettingsMessage;
 pub use interface::*;
 pub use message_parts::*;

--- a/mithril-common/src/messages/register_signature.rs
+++ b/mithril-common/src/messages/register_signature.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 
 use crate::{
     entities::{HexEncodedSingleSignature, LotteryIndex, PartyId, SignedEntityType},
@@ -7,7 +8,7 @@ use crate::{
 
 era_deprecate!("make signed_entity_type of RegisterSignatureMessage not optional");
 /// Message structure to register single signature.
-#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct RegisterSignatureMessage {
     /// Signed entity type
     #[serde(rename = "entity_type")]
@@ -32,6 +33,25 @@ impl RegisterSignatureMessage {
             party_id: "party_id".to_string(),
             signature: fake_keys::single_signature()[0].to_string(),
             won_indexes: vec![1, 3],
+        }
+    }
+}
+
+impl Debug for RegisterSignatureMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let is_pretty_printing = f.alternate();
+        let mut debug = f.debug_struct("SingleSignatures");
+        debug
+            .field(
+                "signed_entity_type",
+                &format_args!("{:?}", self.signed_entity_type),
+            )
+            .field("party_id", &self.party_id)
+            .field("won_indexes", &format_args!("{:?}", self.won_indexes));
+
+        match is_pretty_printing {
+            true => debug.field("signature", &self.signature).finish(),
+            false => debug.finish_non_exhaustive(),
         }
     }
 }

--- a/mithril-common/src/messages/register_signer.rs
+++ b/mithril-common/src/messages/register_signer.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::fmt::{Debug, Formatter};
 
 use crate::{
     crypto_helper::KESPeriod,
@@ -11,7 +12,7 @@ use crate::{
 
 era_deprecate!("make epoch of RegisterSignerMessage not optional");
 /// Register Signer Message
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegisterSignerMessage {
     /// Epoch at which registration is sent
     /// #[serde(skip_serializing_if = "Option::is_none")]
@@ -57,6 +58,33 @@ impl RegisterSignerMessage {
             ),
             operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
             kes_period: Some(6),
+        }
+    }
+}
+
+impl Debug for RegisterSignerMessage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let should_be_exhaustive = f.alternate();
+        let mut debug = f.debug_struct("Signer");
+        debug.field("party_id", &self.party_id);
+
+        match should_be_exhaustive {
+            true => debug
+                .field(
+                    "verification_key",
+                    &format_args!("{:?}", self.verification_key),
+                )
+                .field(
+                    "verification_key_signature",
+                    &format_args!("{:?}", self.verification_key_signature),
+                )
+                .field(
+                    "operational_certificate",
+                    &format_args!("{:?}", self.operational_certificate),
+                )
+                .field("kes_period", &format_args!("{:?}", self.kes_period))
+                .finish(),
+            false => debug.finish_non_exhaustive(),
         }
     }
 }

--- a/mithril-common/src/test_utils/apispec.rs
+++ b/mithril-common/src/test_utils/apispec.rs
@@ -195,7 +195,7 @@ mod tests {
 
     use super::*;
     use crate::entities;
-    use crate::messages::{CertificatePendingMessage, SignerMessage};
+    use crate::messages::{CertificatePendingMessage, SignerMessagePart};
     use crate::test_utils::fake_data;
 
     #[test]
@@ -217,7 +217,7 @@ mod tests {
         assert!(APISpec::from_file(&APISpec::get_defaut_spec_file())
             .method(Method::POST.as_str())
             .path("/register-signer")
-            .validate_request(&SignerMessage::dummy())
+            .validate_request(&SignerMessagePart::dummy())
             .unwrap()
             .validate_response(&Response::<Bytes>::new(Bytes::new()))
             .is_err());

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.68"
+version = "0.2.69"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/message_adapters/from_pending_certificate_message.rs
+++ b/mithril-signer/src/message_adapters/from_pending_certificate_message.rs
@@ -3,14 +3,14 @@ use mithril_common::{
         ProtocolOpCert, ProtocolSignerVerificationKey, ProtocolSignerVerificationKeySignature,
     },
     entities::{CertificatePending, Signer},
-    messages::{CertificatePendingMessage, SignerMessage, TryFromMessageAdapter},
+    messages::{CertificatePendingMessage, SignerMessagePart, TryFromMessageAdapter},
     StdResult,
 };
 
 /// Adapter to turn [CertificatePendingMessage] instances into [CertificatePending].
 pub struct FromPendingCertificateMessageAdapter;
 
-fn to_signers(messages: &[SignerMessage]) -> StdResult<Vec<Signer>> {
+fn to_signers(messages: &[SignerMessagePart]) -> StdResult<Vec<Signer>> {
     let mut signers: Vec<Signer> = Vec::new();
 
     for msg in messages {
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn adapt_signers() {
         let mut message = CertificatePendingMessage::dummy();
-        message.signers = vec![SignerMessage::dummy(), SignerMessage::dummy()];
+        message.signers = vec![SignerMessagePart::dummy(), SignerMessagePart::dummy()];
         let certificate_pending = FromPendingCertificateMessageAdapter::try_adapt(message).unwrap();
 
         assert_eq!(2, certificate_pending.signers.len());

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.2.5"
+version = "0.2.6"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/check.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/check.rs
@@ -178,7 +178,7 @@ pub async fn assert_is_creating_certificate_with_enough_signers(
         }
     }) {
         AttemptResult::Ok(certificate) => {
-            info!("Aggregator produced a certificate"; "certificate" => #?certificate);
+            info!("Aggregator produced a certificate"; "certificate" => ?certificate);
             if certificate.metadata.signers.len() == total_signers_expected {
                 info!(
                     "Certificate is signed by expected number of signers: {} >= {} ",

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
@@ -50,7 +50,7 @@ pub async fn wait_for_epoch_settings(
                         .json::<EpochSettingsMessage>()
                         .await
                         .map_err(|e| format!("Invalid EpochSettings body : {e}"))?;
-                    info!("Aggregator ready"; "epoch_settings"  => #?epoch_settings);
+                    info!("Aggregator ready"; "epoch_settings"  => ?epoch_settings);
                     Ok(Some(epoch_settings))
                 }
                 s if s.is_server_error() => {


### PR DESCRIPTION
## Content

This PR changes implementation of the `Debug` trait from the automatic derive to manual for entities that use protocol keys or messages that use encoded keys. 

This makes the logs far more readable in exchange for not printing anymore those keys.

The keys can still be print by using a `#` / pretty print (or "alternate" mode) when logging.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Here's a pretty printed (real logs are on one line) before/after for the pending certificate log in the signer node:

### Before (truncated)
```
{
    "msg": " ⋅ Epoch has NOT changed but there is a pending certificate",
    "v": 0,
    "name": "slog-rs",
    "level": 30,
    "time": "2023-08-18T15:41:23.51891215Z",
    "hostname": "hostname",
    "pid": 892261,
    "pending_certificate": ""                                                                  
    CertificatePending {                                                                      
         beacon: Beacon {                                                                     
             network: "devnet",                                                               
             epoch: Epoch(6),                                                                 
             immutable_file_number: 9
        },                                                                                    
         signed_entity_type: MithrilStakeDistribution(Epoch(6)),                              
         protocol_parameters: ProtocolParameters {                                            
             k: 75,                                                                           
             m: 100,                                                                          
             phi_f: 0.95
        },                                                                                    
         next_protocol_parameters: ProtocolParameters {                                       
             k: 75,                                                                           
             m: 100,                                                                          
             phi_f: 0.95
        },                                                                                    
         signers: [                                                                           
            Signer {                                                                          
                 party_id: "pool17avvxxx30lmlh2n0zr3jc8exr0l0xcqqvum2tq9hj7amyadetn2",
                 verification_key: ProtocolKey {                                      
                     key: VerificationKeyPoP {                                        
                         vk: VerificationKey(PublicKey {                              
                                 point: blst_p2_affine {                              
                                     x: blst_fp2 {                                    
                                         fp: [                                        
                                            blst_fp {                                 
                                                 l: [                                 
                                                    15148569776549986134,             
                                                     2532660603485073893,             
                                                     10895492147431038496,            
                                                     15795909649679296934,            
                                                     6331102933914107134,             
                                                     1302122428126900701              
                                                ]                                     
                                            },                                        
                                             blst_fp {                                
                                                 l: [                                 
                                                    6446450567675719693,              
                                                     10155793262592011222,            
                                                     6358610156623793561,             
                                                     5970214565366383771,             
                                                     11593351669759234350,            
                                                     1456828862602068027              
                                                ]                                     
                                            }                                         
                                        ]                                             
                                    },                                                
                                     y: blst_fp2 {                                    
                                         fp: [                                        
                                            blst_fp {                                 
                                                 l: [                                 
                                                    9051931019042719695,              
                                                     6956447469825680176,             
                                                     6067750131055977754,             
                                                     4080863463760220615,             
                                                     15118383309077154739,            
                                                     1485994447500642830              
                                                ]                                     
                                            },                                        
                                             blst_fp {                                
                                                 l: [                                 
                                                    12028712266655523832,             
                                                     12572167197460985390,            
                                                     232535247483731350,              
                                                     3794627573772514830,             
                                                     10090622327978383303,            
                                                     1395530751138861046              
                                                ]                                     
                                            }                                         
                                        ]                                             
                                    }                                                 
                                }                                                     
                            }                                                         
                        ),                                                            
                         pop: ProofOfPossession {                                     
                             k1: Signature {                                          
                                 point: blst_p1_affine {                              
                                     x: blst_fp {                                     
                {...}
            },
            {...}
        ],
         next_signers: [{...}]
    }
""
}
```

### After
```
{
    "msg": " ⋅ Epoch has NOT changed but there is a pending certificate",
    "v": 0,
    "name": "slog-rs",
    "level": 30,
    "time": "2023-08-18T15:41:23.51891215Z",
    "hostname": "hostname",
    "pid": 892261,
    "pending_certificate": ""                                                                  
    CertificatePending {                                                                      
         beacon: Beacon {                                                                     
             network: "devnet",                                                               
             epoch: Epoch(6),                                                                 
             immutable_file_number: 9
        },                                                                                    
         signed_entity_type: MithrilStakeDistribution(Epoch(6)),                              
         protocol_parameters: ProtocolParameters {                                            
             k: 75,                                                                           
             m: 100,                                                                          
             phi_f: 0.95
        },                                                                                    
         next_protocol_parameters: ProtocolParameters {                                       
             k: 75,                                                                           
             m: 100,                                                                          
             phi_f: 0.95
        },                                                                                    
         signers: [                                                                           
            Signer {                                                                          
                 party_id: "pool1068ul873dplv4vncnvfvcqhl5xfucepztztzj6fg0730cashy84",        
                 ..
            },                                                                                
             Signer {                                                                         
                 party_id: "pool1j2tysspr3apqtujyz9a78snsykhuh5v2qq9mwt3lycjcksm4d63",
                 ..
            }
        ],
         next_signers: [                                                                      
            Signer {                                                                          
                 party_id: "pool1068ul873dplv4vncnvfvcqhl5xfucepztztzj6fg0730cashy84",        
                 ..
            },                                                                                
             Signer {                                                                         
                 party_id: "pool1j2tysspr3apqtujyz9a78snsykhuh5v2qq9mwt3lycjcksm4d63",        
                 ..
            }
        ]
    }
""
}
```

## Issue(s)

Closes #1106
