### PR TITLE
Regression on signer registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.92"
+version = "0.2.93"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.92"
+version = "0.2.93"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content
This PR fix a regression made by https://github.com/input-output-hk/mithril/pull/1164.

After merging this PR the persist of the signer `ProtocolInitializer`, created with the registration to the aggregator, failed with the following error:
```
An error occured, runtime state kept.
message =
    'Could not register to aggregator in 'unregistered → registered' phase for epoch Epoch(297).'.
nested error =
    Store adapter raised an error: problem parsing the IO stream:
    invalid type: map, expected a string at line 1 column 925\n\n
        Caused by:\n    problem parsing the IO stream: invalid type: map, expected a string at line 1 column 925
``` 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Relates to #668, fix regression from #1164
