### PR TITLE
Protocol key for genesis keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.71"
+version = "0.3.72"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.32"
+version = "0.3.33"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.94"
+version = "0.2.95"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.71"
+version = "0.3.72"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -1,8 +1,8 @@
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use clap::{Parser, Subcommand};
 use config::{builder::DefaultState, ConfigBuilder};
 use mithril_common::{
-    crypto_helper::{key_decode_hex, ProtocolGenesisSigner},
+    crypto_helper::{ProtocolGenesisSecretKey, ProtocolGenesisSigner},
     entities::HexEncodedGenesisSecretKey,
     StdResult,
 };
@@ -175,8 +175,8 @@ impl BootstrapGenesisSubCommand {
         let genesis_tools = GenesisTools::from_dependencies(dependencies)
             .await
             .with_context(|| "genesis-tools: initialization error")?;
-        let genesis_secret_key = key_decode_hex(&self.genesis_secret_key)
-            .map_err(|e| anyhow!(e).context("json hex decode of genesis secret key failure"))?;
+        let genesis_secret_key = ProtocolGenesisSecretKey::from_json_hex(&self.genesis_secret_key)
+            .with_context(|| "json hex decode of genesis secret key failure")?;
         let genesis_signer = ProtocolGenesisSigner::from_secret_key(genesis_secret_key);
         genesis_tools
             .bootstrap_test_genesis_certificate(genesis_signer)

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -1,5 +1,5 @@
 use config::{ConfigError, Map, Source, Value, ValueKind};
-use mithril_common::crypto_helper::{key_encode_hex, ProtocolGenesisSigner};
+use mithril_common::crypto_helper::ProtocolGenesisSigner;
 use mithril_common::era::adapters::EraReaderAdapterType;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -143,7 +143,7 @@ impl Configuration {
             db_directory: PathBuf::new(),
             snapshot_directory: PathBuf::new(),
             data_stores_directory: PathBuf::from(":memory:"),
-            genesis_verification_key: key_encode_hex(genesis_verification_key).unwrap(),
+            genesis_verification_key: genesis_verification_key.to_json_hex().unwrap(),
             reset_digests_cache: false,
             disable_digests_cache: false,
             store_retention_limit: None,

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -236,9 +236,9 @@ impl SignerRegisterer for MithrilSignerRegisterer {
         let party_id_save = key_registration.register(
             party_id_register.clone(),
             signer.operational_certificate.clone(),
-            signer.verification_key_signature.clone(),
+            signer.verification_key_signature,
             kes_period,
-            signer.verification_key.clone(),
+            signer.verification_key,
         )?;
         let mut signer_save = SignerWithStake::from_signer(
             signer.to_owned(),

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, Context};
 use std::{fs::File, io::prelude::*, io::Write, path::Path, sync::Arc};
 use tokio::sync::RwLock;
 
@@ -139,8 +139,10 @@ impl GenesisTools {
         let mut genesis_secret_key_serialized = String::new();
         genesis_secret_key_file.read_to_string(&mut genesis_secret_key_serialized)?;
 
-        let genesis_secret_key = key_decode_hex(genesis_secret_key_serialized.trim())
-            .map_err(|e| anyhow!(e).context("Genesis secret key decode error"))?;
+        let genesis_secret_key = genesis_secret_key_serialized
+            .trim()
+            .try_into()
+            .with_context(|| "Genesis secret key decode error")?;
         let genesis_signer = ProtocolGenesisSigner::from_secret_key(genesis_secret_key);
 
         let mut to_sign_payload_file = File::open(to_sign_payload_path).unwrap();

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.32"
+version = "0.3.33"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.94"
+version = "0.2.95"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/crypto_helper/conversions.rs
+++ b/mithril-common/src/crypto_helper/conversions.rs
@@ -69,8 +69,7 @@ pub mod tests {
             .with_signers(1)
             .build()
             .signers_with_stake()[0]
-            .verification_key
-            .clone();
+            .verification_key;
         let signer_with_stake_expected = &entities::SignerWithStake::new(
             "1".to_string(),
             verification_key,

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -110,7 +110,7 @@ impl ProtocolGenesisVerifier {
 
     /// ProtocolGenesisVerifier to ProtocolGenesisVerificationKey
     pub fn to_verification_key(&self) -> ProtocolGenesisVerificationKey {
-        self.verification_key.clone()
+        self.verification_key
     }
 
     /// Verifies the signature of a message

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -64,8 +64,7 @@ impl ProtocolGenesisSigner {
         &self,
         expanded_secret_key: &ExpandedSecretKey,
     ) -> ProtocolGenesisVerificationKey {
-        let verification_key: ProtocolGenesisVerificationKey = expanded_secret_key.into();
-        verification_key
+        ProtocolGenesisVerificationKey::new(expanded_secret_key.into())
     }
 
     /// Create a ProtocolGenesisVerifier
@@ -111,7 +110,7 @@ impl ProtocolGenesisVerifier {
 
     /// ProtocolGenesisVerifier to ProtocolGenesisVerificationKey
     pub fn to_verification_key(&self) -> ProtocolGenesisVerificationKey {
-        self.verification_key
+        self.verification_key.clone()
     }
 
     /// Verifies the signature of a message

--- a/mithril-common/src/crypto_helper/types/alias.rs
+++ b/mithril-common/src/crypto_helper/types/alias.rs
@@ -10,7 +10,6 @@ use mithril_stm::{
 };
 
 use blake2::{digest::consts::U32, Blake2b};
-use ed25519_dalek;
 
 /// A protocol version
 pub type ProtocolVersion<'a> = &'a str;
@@ -50,9 +49,6 @@ pub type ProtocolClosedKeyRegistration = ClosedKeyReg<D>;
 
 /// Alias of [MithrilStm:StmAggrVerificationKey](struct@mithril_stm::stm::StmAggrVerificationKey).
 pub type ProtocolAggregateVerificationKey = StmAggrVerificationKey<D>;
-
-/// Alias of [Ed25519:SecretKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SecretKey.html).
-pub type ProtocolGenesisSecretKey = ed25519_dalek::SecretKey;
 
 // Error alias
 /// Alias of a wrapper of [MithrilCommon:ProtocolRegistrationErrorWrapper](enum@ProtocolRegistrationErrorWrapper).

--- a/mithril-common/src/crypto_helper/types/alias.rs
+++ b/mithril-common/src/crypto_helper/types/alias.rs
@@ -51,9 +51,6 @@ pub type ProtocolClosedKeyRegistration = ClosedKeyReg<D>;
 /// Alias of [MithrilStm:StmAggrVerificationKey](struct@mithril_stm::stm::StmAggrVerificationKey).
 pub type ProtocolAggregateVerificationKey = StmAggrVerificationKey<D>;
 
-/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.PublicKey.html).
-pub type ProtocolGenesisVerificationKey = ed25519_dalek::PublicKey;
-
 /// Alias of [Ed25519:SecretKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SecretKey.html).
 pub type ProtocolGenesisSecretKey = ed25519_dalek::SecretKey;
 

--- a/mithril-common/src/crypto_helper/types/protocol_key.rs
+++ b/mithril-common/src/crypto_helper/types/protocol_key.rs
@@ -85,6 +85,8 @@ where
     }
 }
 
+impl<T> Copy for ProtocolKey<T> where T: Copy + Serialize + DeserializeOwned {}
+
 impl<T> Serialize for ProtocolKey<T>
 where
     T: ProtocolKeyCodec<T> + Serialize + DeserializeOwned,

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -26,6 +26,9 @@ pub type ProtocolGenesisSignature = ProtocolKey<ed25519_dalek::Signature>;
 /// Wrapper of [OpCert] to add serialization utilities.
 pub type ProtocolOpCert = ProtocolKey<OpCert>;
 
+/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.PublicKey.html).
+pub type ProtocolGenesisVerificationKey = ProtocolKey<ed25519_dalek::PublicKey>;
+
 impl ProtocolGenesisSignature {
     /// Create an instance from a bytes hex representation
     pub fn from_bytes_hex(hex_string: &str) -> StdResult<Self> {
@@ -70,6 +73,6 @@ impl ProtocolKeyCodec<ed25519_dalek::Signature> for ed25519_dalek::Signature {
 }
 
 impl_codec_and_type_conversions_for_protocol_key!(
-    json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert
+    json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert, ed25519_dalek::PublicKey
 );
 impl_codec_and_type_conversions_for_protocol_key!(no_default_codec => ed25519_dalek::Signature);

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -29,6 +29,9 @@ pub type ProtocolOpCert = ProtocolKey<OpCert>;
 /// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.PublicKey.html).
 pub type ProtocolGenesisVerificationKey = ProtocolKey<ed25519_dalek::PublicKey>;
 
+/// Alias of [Ed25519:SecretKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SecretKey.html).
+pub type ProtocolGenesisSecretKey = ProtocolKey<ed25519_dalek::SecretKey>;
+
 impl ProtocolGenesisSignature {
     /// Create an instance from a bytes hex representation
     pub fn from_bytes_hex(hex_string: &str) -> StdResult<Self> {
@@ -73,6 +76,6 @@ impl ProtocolKeyCodec<ed25519_dalek::Signature> for ed25519_dalek::Signature {
 }
 
 impl_codec_and_type_conversions_for_protocol_key!(
-    json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert, ed25519_dalek::PublicKey
+    json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert, ed25519_dalek::PublicKey, ed25519_dalek::SecretKey
 );
 impl_codec_and_type_conversions_for_protocol_key!(no_default_codec => ed25519_dalek::Signature);

--- a/mithril-common/src/entities/signer.rs
+++ b/mithril-common/src/entities/signer.rs
@@ -253,10 +253,8 @@ mod tests {
             .with_signers(1)
             .build()
             .signers_with_stake()[0]
-            .verification_key
-            .clone();
-        let signer_expected =
-            Signer::new("1".to_string(), verification_key.clone(), None, None, None);
+            .verification_key;
+        let signer_expected = Signer::new("1".to_string(), verification_key, None, None, None);
         let signer_with_stake =
             SignerWithStake::new("1".to_string(), verification_key, None, None, None, 100);
 
@@ -324,8 +322,7 @@ mod tests {
         }
         {
             let mut signer_different_verification_key = signer.clone();
-            signer_different_verification_key.verification_key =
-                signers[1].verification_key.clone();
+            signer_different_verification_key.verification_key = signers[1].verification_key;
 
             assert_ne!(
                 EXPECTED_HASH,

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -52,9 +52,9 @@ impl SignerBuilder {
                 .register(
                     Some(signer.party_id.to_owned()),
                     signer.operational_certificate.clone(),
-                    signer.verification_key_signature.clone(),
+                    signer.verification_key_signature,
                     signer.kes_period,
-                    signer.verification_key.clone(),
+                    signer.verification_key,
                 )
                 .with_context(|| {
                     format!("Registration failed for signer: '{}'", signer.party_id)

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -242,12 +242,12 @@ impl SignerFixture {
 
     /// Decode this signer verification key certificate
     pub fn verification_key(&self) -> ProtocolSignerVerificationKey {
-        self.signer_with_stake.verification_key.clone()
+        self.signer_with_stake.verification_key
     }
 
     /// Decode this signer verification key signature certificate if any
     pub fn verification_key_signature(&self) -> Option<ProtocolSignerVerificationKeySignature> {
-        self.signer_with_stake.verification_key_signature.clone()
+        self.signer_with_stake.verification_key_signature
     }
 
     /// Get the path to this signer kes secret key


### PR DESCRIPTION
## Content
This PR implements ProtocolKey type to handle serialization and deserialization of the Genesis Secret Key and Genesis Verification Key.
This was achieved following the methodology described in the issue https://github.com/input-output-hk/mithril/issues/668.

Copy trait was implemented for `ProtocolKey<T>`. So unnecessary clone() have been removed.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [X] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Relates to #668
