### PR TITLE
Fix broken `.#hydraJobs.x86_64-linux.mithril-end-to-end`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,7 @@
           mithril-aggregator = buildPackage ./mithril-aggregator/Cargo.toml mithril.cargoArtifacts {};
           mithril-signer = buildPackage ./mithril-signer/Cargo.toml mithril.cargoArtifacts {};
           mithrildemo = buildPackage ./demo/protocol-demo/Cargo.toml mithril.cargoArtifacts {};
-          mithril-end-to-end = buildPackage ./mithril-test-lab/mithril-end-to-end/Cargo.toml mithril.cargoArtifacts {};
+          mithril-end-to-end = buildPackage ./mithril-test-lab/mithril-end-to-end/Cargo.toml null {};
         };
 
         devShells.default = pkgs.mkShell {


### PR DESCRIPTION
## Content
>
This PR includes a quick fix to error: **failed to create file `/build/source/target/release/load-aggregator.d`** that happened in Hydra and was reproducible with `nix build .#hydraJobs.x86_64-linux.mithril-end-to-end`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [x] Add dev blog post (if relevant)

## Comments

This PR does fix the issue, but I'm not sure to understand fully the implications of the change. So reviews are welcome! :)

## Issue(s)

N/A
