### PR TITLE
Call Aggregator API to verify Signer registration

### DIFF
--- a/docs/website/root/manual/getting-started/run-signer-node.md
+++ b/docs/website/root/manual/getting-started/run-signer-node.md
@@ -640,7 +640,7 @@ chmod +x verify_signer_registration.sh
 
 Finally, execute the script:
 ```bash
-SIGNER_LOGS_PATH=**YOUR_SIGNER_LOGS_PATH** ./verify_signer_registration.sh
+PARTY_ID=**YOUR_PARTY_ID** AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT** ./verify_signer_registration.sh
 ```
 
 :::tip
@@ -660,7 +660,7 @@ If your signer is registered, you should see this message:
 
 Otherwise, you should see this error message:
 ```bash
->> Oops, your signer node is not registered. Check your configuration.
+>> Oops, your signer node is not registered. Party ID not found among the signers registered at epoch 430.
 ```
 
 ### Verify your signer contributes with individual signatures

--- a/docs/website/static/scripts/verify_signer_registration.sh
+++ b/docs/website/static/scripts/verify_signer_registration.sh
@@ -2,13 +2,16 @@
 
 set -e
 
-if [ -z "$SIGNER_LOGS_PATH" ]; then
-    echo ">> ERROR: Required environment variable SIGNER_LOGS_PATH is not set."
+if [ -z "$AGGREGATOR_ENDPOINT" ] || [ -z "$PARTY_ID" ]; then
+    echo ">> ERROR: Required environment variables AGGREGATOR_ENDPOINT and/or PARTY_ID are not set."
     exit 1
 fi
 
-if grep -q "STATE MACHINE: new cycle: Registered" "$SIGNER_LOGS_PATH"; then
+CURRENT_EPOCH=$(curl -s "$AGGREGATOR_ENDPOINT/epoch-settings" -H 'accept: application/json' | jq -r '.epoch')
+SIGNERS_REGISTERED_RESPONSE=$(curl -s "$AGGREGATOR_ENDPOINT/signers/registered/$CURRENT_EPOCH" -H 'accept: application/json')
+
+if echo "$SIGNERS_REGISTERED_RESPONSE" | grep -q "$PARTY_ID"; then
     echo ">> Congrats, your signer node is registered!"
 else
-    echo ">> Oops, your signer node is not registered. Check your configuration."
+    echo ">> Oops, your signer node is not registered. Party ID not found among the signers registered at epoch ${CURRENT_EPOCH}."
 fi

--- a/docs/website/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
+++ b/docs/website/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
@@ -640,7 +640,7 @@ chmod +x verify_signer_registration.sh
 
 Finally, execute the script:
 ```bash
-SIGNER_LOGS_PATH=**YOUR_SIGNER_LOGS_PATH** ./verify_signer_registration.sh
+PARTY_ID=**YOUR_PARTY_ID** AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT** ./verify_signer_registration.sh
 ```
 
 :::tip
@@ -660,7 +660,7 @@ If your signer is registered, you should see this message:
 
 Otherwise, you should see this error message:
 ```bash
->> Oops, your signer node is not registered. Check your configuration.
+>> Oops, your signer node is not registered. Party ID not found among the signers registered at epoch 430.
 ```
 
 ### Verify your signer contributes with individual signatures


### PR DESCRIPTION
## Content
This PR includes an update of `verify_signer_registration` script.
It now calls `/epoch-settings` and`/signers/registered/` to find out whether or not the signer is registered at the current epoch.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Run a Mithril signer as an SPO guide was updated for both versions (current & next).

## Issue(s)
Closes #1152 
