### PR TITLE
Protocol key for AVK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.72"
+version = "0.3.73"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.33"
+version = "0.3.34"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2189,7 +2189,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.95"
+version = "0.2.96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.69"
+version = "0.2.70"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.72"
+version = "0.3.73"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/provider/certificate.rs
+++ b/mithril-aggregator/src/database/provider/certificate.rs
@@ -113,7 +113,7 @@ impl From<Certificate> for CertificateRecord {
             parent_certificate_id,
             message: other.signed_message,
             signature,
-            aggregate_verification_key: other.aggregate_verification_key,
+            aggregate_verification_key: other.aggregate_verification_key.to_json_hex().unwrap(),
             epoch: other.beacon.epoch,
             beacon: other.beacon,
             protocol_version: other.metadata.protocol_version,
@@ -153,7 +153,7 @@ impl From<CertificateRecord> for Certificate {
             metadata: certificate_metadata,
             signed_message: other.protocol_message.compute_hash(),
             protocol_message: other.protocol_message,
-            aggregate_verification_key: other.aggregate_verification_key,
+            aggregate_verification_key: other.aggregate_verification_key.try_into().unwrap(),
             signature,
         }
     }

--- a/mithril-aggregator/src/database/provider/certificate.rs
+++ b/mithril-aggregator/src/database/provider/certificate.rs
@@ -82,7 +82,7 @@ impl CertificateRecord {
             parent_certificate_id: Some(parent_id.to_string()),
             message: "message".to_string(),
             signature: fake_keys::multi_signature()[0].to_owned(),
-            aggregate_verification_key: "avk".to_string(),
+            aggregate_verification_key: fake_keys::aggregate_verification_key()[0].to_owned(),
             epoch: beacon.epoch,
             beacon,
             protocol_version: "protocol_version".to_string(),

--- a/mithril-aggregator/src/message_adapters/to_certificate_list_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_list_message.rs
@@ -27,7 +27,10 @@ impl ToMessageAdapter<Vec<Certificate>, CertificateListMessage>
                 },
                 protocol_message: certificate.protocol_message,
                 signed_message: certificate.signed_message,
-                aggregate_verification_key: certificate.aggregate_verification_key,
+                aggregate_verification_key: certificate
+                    .aggregate_verification_key
+                    .to_json_hex()
+                    .unwrap(),
             })
             .collect()
     }
@@ -58,7 +61,10 @@ mod tests {
             },
             protocol_message: certificate.protocol_message,
             signed_message: certificate.signed_message,
-            aggregate_verification_key: certificate.aggregate_verification_key,
+            aggregate_verification_key: certificate
+                .aggregate_verification_key
+                .to_json_hex()
+                .unwrap(),
         }];
 
         assert_eq!(certificate_list_message_expected, certificate_list_message);

--- a/mithril-aggregator/src/message_adapters/to_certificate_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_message.rs
@@ -34,7 +34,10 @@ impl ToMessageAdapter<Certificate, CertificateMessage> for ToCertificateMessageA
             metadata,
             protocol_message: certificate.protocol_message,
             signed_message: certificate.signed_message,
-            aggregate_verification_key: certificate.aggregate_verification_key,
+            aggregate_verification_key: certificate
+                .aggregate_verification_key
+                .to_json_hex()
+                .unwrap(),
             multi_signature,
             genesis_signature,
         }

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -5,13 +5,13 @@ use thiserror::Error;
 
 use mithril_common::{
     crypto_helper::{
-        key_encode_hex, ProtocolAggregateVerificationKey, ProtocolAggregationError,
-        ProtocolMultiSignature, ProtocolParameters, ProtocolRegistrationError,
-        ProtocolStakeDistribution,
+        ProtocolAggregateVerificationKey, ProtocolAggregationError, ProtocolMultiSignature,
+        ProtocolParameters, ProtocolRegistrationError, ProtocolStakeDistribution,
     },
     entities::{self, Epoch, SignerWithStake, StakeDistribution},
     protocol::{MultiSigner as ProtocolMultiSigner, SignerBuilder},
     store::{StakeStorer, StoreError},
+    StdError,
 };
 
 use crate::{entities::OpenMessage, store::VerificationKeyStorer, ProtocolParametersStorer};
@@ -39,8 +39,8 @@ pub enum ProtocolError {
     ExistingSingleSignature(entities::PartyId),
 
     /// Codec error.
-    #[error("codec error: '{0}'")]
-    Codec(String),
+    #[error("codec error: '{0:?}'")]
+    Codec(StdError),
 
     /// Mithril STM library returned an error.
     #[error("core error: '{0}'")]
@@ -131,7 +131,7 @@ pub trait MultiSigner: Sync + Send {
         let avk = self
             .compute_aggregate_verification_key(&signers_with_stake, &protocol_parameters)
             .await?;
-        Ok(key_encode_hex(avk).map_err(ProtocolError::Codec)?)
+        Ok(avk.to_json_hex().map_err(ProtocolError::Codec)?)
     }
 
     /// Compute next stake distribution aggregate verification key
@@ -146,7 +146,7 @@ pub trait MultiSigner: Sync + Send {
         let next_avk = self
             .compute_aggregate_verification_key(&next_signers_with_stake, &protocol_parameters)
             .await?;
-        Ok(key_encode_hex(next_avk).map_err(ProtocolError::Codec)?)
+        Ok(next_avk.to_json_hex().map_err(ProtocolError::Codec)?)
     }
 
     /// Get signers

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use async_trait::async_trait;
 use slog_scope::{debug, info, warn};
 use std::{path::Path, path::PathBuf, sync::Arc};
@@ -369,7 +370,9 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             ProtocolMessagePartKey::NextAggregateVerificationKey,
             multi_signer
                 .compute_next_stake_distribution_aggregate_verification_key()
-                .await?,
+                .await?
+                .to_json_hex()
+                .with_context(|| "convert next avk to json hex failure")?,
         );
 
         Ok(protocol_message)

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -342,7 +342,7 @@ mod test {
         let expected = vec![
             (
                 dummy_genesis(
-                    "b9263d7c2e94f6a62802b6521b30967e7e7a7fdccf02026dc70a0ffbc46da393",
+                    "98b44c52ac3c82adcbc5aea27a0c99cbba716048dddaf401b27acded80f1abcd",
                     1,
                     1,
                 ),
@@ -350,8 +350,8 @@ mod test {
             ),
             (
                 dummy_certificate(
-                    "5d73905d314abc86451a399d4f1820201d4c20076d8fb0e4b277ffe5f5e4dc07",
-                    "b9263d7c2e94f6a62802b6521b30967e7e7a7fdccf02026dc70a0ffbc46da393",
+                    "0b7c12daffe63ca93a9cded424e300361a5234ab8c52b3e7029ff9dfbd8a16bd",
+                    "98b44c52ac3c82adcbc5aea27a0c99cbba716048dddaf401b27acded80f1abcd",
                     1,
                     2,
                 ),
@@ -359,7 +359,7 @@ mod test {
                     signed_entity_id: "signed_entity_id".to_string(),
                     signed_entity_type: MithrilStakeDistribution(Epoch(1)),
                     certificate_id:
-                        "5d73905d314abc86451a399d4f1820201d4c20076d8fb0e4b277ffe5f5e4dc07"
+                        "0b7c12daffe63ca93a9cded424e300361a5234ab8c52b3e7029ff9dfbd8a16bd"
                             .to_string(),
                     artifact: "".to_string(),
                     created_at: Default::default(),
@@ -367,8 +367,8 @@ mod test {
             ),
             (
                 dummy_certificate(
-                    "583803ea5050f781de38c25d8773628ccf5c6fd737b4d984db2d41444bfdbf39",
-                    "5d73905d314abc86451a399d4f1820201d4c20076d8fb0e4b277ffe5f5e4dc07",
+                    "0aa74b928d3eade6548b22349435a12e9591f0c34c9ca2b0abfbeeefbb1acb37",
+                    "0b7c12daffe63ca93a9cded424e300361a5234ab8c52b3e7029ff9dfbd8a16bd",
                     2,
                     3,
                 ),
@@ -376,7 +376,7 @@ mod test {
                     signed_entity_id: "signed_entity_id".to_string(),
                     signed_entity_type: MithrilStakeDistribution(Epoch(2)),
                     certificate_id:
-                        "583803ea5050f781de38c25d8773628ccf5c6fd737b4d984db2d41444bfdbf39"
+                        "0aa74b928d3eade6548b22349435a12e9591f0c34c9ca2b0abfbeeefbb1acb37"
                             .to_string(),
                     artifact: "".to_string(),
                     created_at: Default::default(),

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -5,8 +5,8 @@ use tokio::sync::RwLock;
 use mithril_common::{
     certificate_chain::{CertificateGenesisProducer, CertificateVerifier},
     crypto_helper::{
-        key_decode_hex, ProtocolAggregateVerificationKey, ProtocolGenesisSignature,
-        ProtocolGenesisSigner, ProtocolGenesisVerifier,
+        ProtocolAggregateVerificationKey, ProtocolGenesisSignature, ProtocolGenesisSigner,
+        ProtocolGenesisVerifier,
     },
     entities::{Beacon, ProtocolParameters},
     BeaconProvider, StdResult,
@@ -82,8 +82,8 @@ impl GenesisTools {
         let genesis_avk = multi_signer
             .compute_next_stake_distribution_aggregate_verification_key()
             .await?;
-        let genesis_avk: ProtocolAggregateVerificationKey = key_decode_hex(&genesis_avk)
-            .map_err(|e| anyhow!(e).context("Aggregate verification key decode error"))?;
+        let genesis_avk = ProtocolAggregateVerificationKey::from_json_hex(&genesis_avk)
+            .with_context(|| "Aggregate verification key decode error")?;
 
         Ok(Self::new(
             protocol_parameters,
@@ -211,7 +211,7 @@ mod tests {
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let first_signer = fixture.signers_fixture()[0].clone().protocol_signer;
         let clerk = ProtocolClerk::from_signer(&first_signer);
-        clerk.compute_avk()
+        clerk.compute_avk().into()
     }
 
     fn build_tools(

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -82,8 +82,6 @@ impl GenesisTools {
         let genesis_avk = multi_signer
             .compute_next_stake_distribution_aggregate_verification_key()
             .await?;
-        let genesis_avk = ProtocolAggregateVerificationKey::from_json_hex(&genesis_avk)
-            .with_context(|| "Aggregate verification key decode error")?;
 
         Ok(Self::new(
             protocol_parameters,

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -416,7 +416,7 @@ impl RuntimeTester {
         let expected_certificate = match signed_entity_record {
             None if certificate.is_genesis() => ExpectedCertificate::new_genesis(
                 certificate.beacon,
-                certificate.aggregate_verification_key,
+                certificate.aggregate_verification_key.try_into().unwrap(),
             ),
             None => {
                 panic!("A certificate should always have a SignedEntity if it's not a genesis certificate");
@@ -429,7 +429,7 @@ impl RuntimeTester {
                 ExpectedCertificate::new(
                     certificate.beacon,
                     &certificate.metadata.signers,
-                    certificate.aggregate_verification_key,
+                    certificate.aggregate_verification_key.try_into().unwrap(),
                     record.signed_entity_type,
                     previous_cert_identifier,
                 )

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.33"
+version = "0.3.34"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client/certificate_client.rs
+++ b/mithril-client/src/aggregator_client/certificate_client.rs
@@ -108,7 +108,10 @@ mod tests {
                     },
                     protocol_message: certificate.protocol_message.clone(),
                     signed_message: certificate.signed_message.clone(),
-                    aggregate_verification_key: certificate.aggregate_verification_key.clone(),
+                    aggregate_verification_key: certificate
+                        .aggregate_verification_key
+                        .try_into()
+                        .unwrap(),
                     multi_signature,
                     genesis_signature,
                 };

--- a/mithril-client/src/message_adapters/from_certificate_message_adapter.rs
+++ b/mithril-client/src/message_adapters/from_certificate_message_adapter.rs
@@ -27,7 +27,9 @@ impl TryFromMessageAdapter<CertificateMessage, Certificate> for FromCertificateM
             metadata,
             protocol_message: certificate_message.protocol_message,
             signed_message: certificate_message.signed_message,
-            aggregate_verification_key: certificate_message.aggregate_verification_key,
+            aggregate_verification_key: certificate_message
+                .aggregate_verification_key
+                .try_into()?,
             signature: if certificate_message.genesis_signature.is_empty() {
                 CertificateSignature::MultiSignature(
                     certificate_message.multi_signature.try_into()?,

--- a/mithril-client/src/services/mithril_stake_distribution.rs
+++ b/mithril-client/src/services/mithril_stake_distribution.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use async_trait::async_trait;
 use std::{
     path::{Path, PathBuf},
@@ -9,8 +9,7 @@ use thiserror::Error;
 use mithril_common::{
     certificate_chain::CertificateVerifier,
     crypto_helper::{
-        key_encode_hex, ProtocolAggregateVerificationKey, ProtocolGenesisVerificationKey,
-        ProtocolGenesisVerifier,
+        ProtocolAggregateVerificationKey, ProtocolGenesisVerificationKey, ProtocolGenesisVerifier,
     },
     entities::{MithrilStakeDistribution, ProtocolMessagePartKey},
     messages::MithrilStakeDistributionListItemMessage,
@@ -156,12 +155,11 @@ impl MithrilStakeDistributionService for AppMithrilStakeDistributionService {
             )
             .await?;
 
-        let avk = key_encode_hex(
-            self.compute_avk_from_mithril_stake_distribution(&stake_distribution_entity.artifact)
-                .await?,
-        )
-        .map_err(|e| anyhow!(e))
-        .with_context(|| "Encoding avk error")?;
+        let avk = self
+            .compute_avk_from_mithril_stake_distribution(&stake_distribution_entity.artifact)
+            .await?
+            .to_json_hex()
+            .with_context(|| "Encoding avk error")?;
 
         let mut protocol_message = certificate.protocol_message.clone();
         protocol_message

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.95"
+version = "0.2.96"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -88,9 +88,6 @@ impl CertificateGenesisProducer {
         );
         let previous_hash = "".to_string();
         let genesis_protocol_message = Self::create_genesis_protocol_message(&genesis_avk)?;
-        let genesis_avk = genesis_avk
-            .to_json_hex()
-            .map_err(CertificateGenesisProducerError::Codec)?;
         Ok(Certificate::new(
             previous_hash,
             beacon,

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -7,21 +7,22 @@ use thiserror::Error;
 
 use crate::{
     crypto_helper::{
-        key_encode_hex, ProtocolAggregateVerificationKey, ProtocolGenesisSignature,
-        ProtocolGenesisSigner, PROTOCOL_VERSION,
+        ProtocolAggregateVerificationKey, ProtocolGenesisSignature, ProtocolGenesisSigner,
+        PROTOCOL_VERSION,
     },
     entities::{
         Beacon, Certificate, CertificateMetadata, CertificateSignature, ProtocolMessage,
         ProtocolMessagePartKey, ProtocolParameters,
     },
+    StdError,
 };
 
 /// [CertificateGenesisProducer] related errors.
 #[derive(Error, Debug)]
 pub enum CertificateGenesisProducerError {
     /// Error raised when a Codec error occurs
-    #[error("codec error: '{0}'")]
-    Codec(String),
+    #[error("codec error: '{0:?}'")]
+    Codec(StdError),
 
     /// Error raised when there is no genesis signer available
     #[error("missing genesis signer error")]
@@ -44,8 +45,9 @@ impl CertificateGenesisProducer {
     pub fn create_genesis_protocol_message(
         genesis_avk: &ProtocolAggregateVerificationKey,
     ) -> Result<ProtocolMessage, CertificateGenesisProducerError> {
-        let genesis_avk =
-            key_encode_hex(genesis_avk).map_err(CertificateGenesisProducerError::Codec)?;
+        let genesis_avk = genesis_avk
+            .to_json_hex()
+            .map_err(CertificateGenesisProducerError::Codec)?;
         let mut protocol_message = ProtocolMessage::new();
         protocol_message.set_message_part(
             ProtocolMessagePartKey::NextAggregateVerificationKey,
@@ -86,8 +88,9 @@ impl CertificateGenesisProducer {
         );
         let previous_hash = "".to_string();
         let genesis_protocol_message = Self::create_genesis_protocol_message(&genesis_avk)?;
-        let genesis_avk =
-            key_encode_hex(&genesis_avk).map_err(CertificateGenesisProducerError::Codec)?;
+        let genesis_avk = genesis_avk
+            .to_json_hex()
+            .map_err(CertificateGenesisProducerError::Codec)?;
         Ok(Certificate::new(
             previous_hash,
             beacon,

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -1,5 +1,6 @@
 //! A module used to validate the Certificate Chain created by an aggregator
 //!
+use anyhow::Context;
 use async_trait::async_trait;
 use hex::ToHex;
 use slog::{debug, Logger};
@@ -144,7 +145,7 @@ impl MithrilCertificateVerifier {
         &self,
         message: &[u8],
         multi_signature: &ProtocolMultiSignature,
-        aggregate_verification_key: &str,
+        aggregate_verification_key: &ProtocolAggregateVerificationKey,
         protocol_parameters: &ProtocolParameters,
     ) -> Result<(), CertificateVerifierError> {
         debug!(
@@ -152,14 +153,11 @@ impl MithrilCertificateVerifier {
             "Verify multi signature for {:?}",
             message.encode_hex::<String>()
         );
-        let aggregate_verification_key =
-            ProtocolAggregateVerificationKey::from_json_hex(aggregate_verification_key)
-                .map_err(CertificateVerifierError::Codec)?;
 
         multi_signature
             .verify(
                 message,
-                &aggregate_verification_key,
+                aggregate_verification_key,
                 &protocol_parameters.to_owned().into(),
             )
             .map_err(|e| CertificateVerifierError::VerifyMultiSignature(e.to_string()))
@@ -181,21 +179,44 @@ impl MithrilCertificateVerifier {
         let previous_certificate = certificate_retriever
             .get_certificate_details(&certificate.previous_hash)
             .await?;
-        let valid_certificate_has_different_epoch_as_previous =
-            |next_aggregate_verification_key: &String| -> bool {
-                next_aggregate_verification_key == &certificate.aggregate_verification_key
-                    && previous_certificate.beacon.epoch != certificate.beacon.epoch
-            };
-        let valid_certificate_has_same_epoch_as_previous = || -> bool {
-            previous_certificate.aggregate_verification_key
-                == certificate.aggregate_verification_key
-                && previous_certificate.beacon.epoch == certificate.beacon.epoch
-        };
+
         if previous_certificate.hash != certificate.previous_hash {
             return Err(CertificateVerifierError::CertificateChainPreviousHashUnmatch);
         }
 
-        match &previous_certificate
+        let current_certificate_avk: String = certificate
+            .aggregate_verification_key
+            .to_json_hex()
+            .with_context(|| {
+                format!(
+                    "avk to string conversion error for certificate: `{}`",
+                    certificate.hash
+                )
+            })
+            .map_err(CertificateVerifierError::Codec)?;
+
+        let previous_certificate_avk: String = previous_certificate
+            .aggregate_verification_key
+            .to_json_hex()
+            .with_context(|| {
+                format!(
+                    "avk to string conversion error for previous certificate: `{}`",
+                    certificate.hash
+                )
+            })
+            .map_err(CertificateVerifierError::Codec)?;
+
+        let valid_certificate_has_different_epoch_as_previous =
+            |next_aggregate_verification_key: &str| -> bool {
+                next_aggregate_verification_key == current_certificate_avk
+                    && previous_certificate.beacon.epoch != certificate.beacon.epoch
+            };
+        let valid_certificate_has_same_epoch_as_previous = || -> bool {
+            previous_certificate_avk == current_certificate_avk
+                && previous_certificate.beacon.epoch == certificate.beacon.epoch
+        };
+
+        match previous_certificate
             .protocol_message
             .get_message_part(&ProtocolMessagePartKey::NextAggregateVerificationKey)
         {
@@ -336,7 +357,7 @@ mod tests {
                 .verify_multi_signature(
                     &message_tampered,
                     &multi_signature,
-                    &aggregate_verification_key.to_json_hex().unwrap(),
+                    &aggregate_verification_key,
                     &fixture.protocol_parameters(),
                 )
                 .is_err(),
@@ -346,7 +367,7 @@ mod tests {
             .verify_multi_signature(
                 &message_hash,
                 &multi_signature,
-                &aggregate_verification_key.to_json_hex().unwrap(),
+                &aggregate_verification_key,
                 &fixture.protocol_parameters(),
             )
             .expect("multi signature verification should have succeeded");

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -1,5 +1,5 @@
 //! Test data builders for Mithril STM types, for testing purpose.
-use super::{genesis::*, key_encode_hex, types::*, OpCert, SerDeShelleyFileFormat};
+use super::{genesis::*, types::*, OpCert, SerDeShelleyFileFormat};
 use crate::{
     certificate_chain::CertificateGenesisProducer,
     entities::{
@@ -11,9 +11,7 @@ use crate::{
 
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
-use std::{cmp::min, fs, sync::Arc};
-
-use std::{collections::HashMap, path::PathBuf};
+use std::{cmp::min, collections::HashMap, fs, path::PathBuf, sync::Arc};
 
 /// Create or retrieve a temporary directory for storing cryptographic material for a signer, use this for tests only.
 pub fn setup_temp_directory_for_signer(
@@ -204,10 +202,10 @@ pub fn setup_certificate_chain(
     };
     let avk_for_signers = |signers: &[SignerFixture]| -> ProtocolAggregateVerificationKey {
         let clerk = clerk_for_signers(signers);
-        clerk.compute_avk()
+        clerk.compute_avk().into()
     };
     let avk_encode =
-        |avk: &ProtocolAggregateVerificationKey| -> String { key_encode_hex(avk).unwrap() };
+        |avk: &ProtocolAggregateVerificationKey| -> String { avk.to_json_hex().unwrap() };
     epochs.pop();
     let certificates = epochs
         .into_iter()

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -204,8 +204,6 @@ pub fn setup_certificate_chain(
         let clerk = clerk_for_signers(signers);
         clerk.compute_avk().into()
     };
-    let avk_encode =
-        |avk: &ProtocolAggregateVerificationKey| -> String { avk.to_json_hex().unwrap() };
     epochs.pop();
     let certificates = epochs
         .into_iter()
@@ -226,9 +224,9 @@ pub fn setup_certificate_chain(
                 .set_message_part(ProtocolMessagePartKey::SnapshotDigest, digest);
             fake_certificate.protocol_message.set_message_part(
                 ProtocolMessagePartKey::NextAggregateVerificationKey,
-                avk_encode(&next_avk),
+                next_avk.to_json_hex().unwrap(),
             );
-            fake_certificate.aggregate_verification_key = avk_encode(&avk);
+            fake_certificate.aggregate_verification_key = avk;
             fake_certificate.signed_message = fake_certificate.protocol_message.compute_hash();
             fake_certificate.previous_hash = "".to_string();
             match i {

--- a/mithril-common/src/crypto_helper/types/alias.rs
+++ b/mithril-common/src/crypto_helper/types/alias.rs
@@ -5,7 +5,7 @@ use crate::crypto_helper::cardano::{
 
 use mithril_stm::{
     key_reg::ClosedKeyReg,
-    stm::{Index, Stake, StmAggrVerificationKey, StmClerk, StmParameters, StmSigner},
+    stm::{Index, Stake, StmClerk, StmParameters, StmSigner},
     AggregationError,
 };
 
@@ -46,9 +46,6 @@ pub type ProtocolKeyRegistration = KeyRegWrapper;
 
 /// Alias of a wrapper of [MithrilStm:ClosedKeyReg](struct@mithril_stm::key_reg::KeyReg).
 pub type ProtocolClosedKeyRegistration = ClosedKeyReg<D>;
-
-/// Alias of [MithrilStm:StmAggrVerificationKey](struct@mithril_stm::stm::StmAggrVerificationKey).
-pub type ProtocolAggregateVerificationKey = StmAggrVerificationKey<D>;
 
 // Error alias
 /// Alias of a wrapper of [MithrilCommon:ProtocolRegistrationErrorWrapper](enum@ProtocolRegistrationErrorWrapper).

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use hex::{FromHex, ToHex};
 use kes_summed_ed25519::kes::Sum6KesSig;
-use mithril_stm::stm::{StmAggrSig, StmSig, StmVerificationKeyPoP};
+use mithril_stm::stm::{StmAggrSig, StmAggrVerificationKey, StmSig, StmVerificationKeyPoP};
 
 use crate::crypto_helper::{OpCert, ProtocolKey, ProtocolKeyCodec, D};
 use crate::StdResult;
@@ -31,6 +31,9 @@ pub type ProtocolGenesisVerificationKey = ProtocolKey<ed25519_dalek::PublicKey>;
 
 /// Alias of [Ed25519:SecretKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SecretKey.html).
 pub type ProtocolGenesisSecretKey = ProtocolKey<ed25519_dalek::SecretKey>;
+
+/// Alias of [MithrilStm:StmAggrVerificationKey](struct@mithril_stm::stm::StmAggrVerificationKey).
+pub type ProtocolAggregateVerificationKey = ProtocolKey<StmAggrVerificationKey<D>>;
 
 impl ProtocolGenesisSignature {
     /// Create an instance from a bytes hex representation
@@ -76,6 +79,7 @@ impl ProtocolKeyCodec<ed25519_dalek::Signature> for ed25519_dalek::Signature {
 }
 
 impl_codec_and_type_conversions_for_protocol_key!(
-    json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert, ed25519_dalek::PublicKey, ed25519_dalek::SecretKey
+    json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert,
+        ed25519_dalek::PublicKey, ed25519_dalek::SecretKey, StmAggrVerificationKey<D>
 );
 impl_codec_and_type_conversions_for_protocol_key!(no_default_codec => ed25519_dalek::Signature);

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -200,7 +200,7 @@ mod tests {
         );
         protocol_message.set_message_part(
             ProtocolMessagePartKey::NextAggregateVerificationKey,
-            "next-avk-123".to_string(),
+            fake_keys::aggregate_verification_key()[1].to_owned(),
         );
 
         protocol_message
@@ -209,7 +209,7 @@ mod tests {
     #[test]
     fn test_certificate_compute_hash() {
         const HASH_EXPECTED: &str =
-            "255d59cef74aae5bc2e83e87612dea41309551dde0c770d46bf6607971bb9765";
+            "af0965134ef5b2c2a33005cf401c58ca882dead8efda358540dac0575098b54e";
 
         let initiated_at = DateTime::parse_from_rfc3339("2024-02-12T13:11:47.0123043Z")
             .unwrap()
@@ -227,7 +227,7 @@ mod tests {
                 get_signers_with_stake(),
             ),
             get_protocol_message(),
-            "aggregate_verification_key".to_string(),
+            fake_keys::aggregate_verification_key()[0].to_owned(),
             CertificateSignature::MultiSignature(
                 fake_keys::multi_signature()[0].try_into().unwrap(),
             ),
@@ -272,7 +272,9 @@ mod tests {
                     let mut protocol_message_modified = certificate.protocol_message.clone();
                     protocol_message_modified.set_message_part(
                         ProtocolMessagePartKey::NextAggregateVerificationKey,
-                        "next-avk-456".to_string(),
+                        fake_keys::aggregate_verification_key()[2]
+                            .try_into()
+                            .unwrap(),
                     );
 
                     protocol_message_modified
@@ -285,7 +287,9 @@ mod tests {
         assert_ne!(
             HASH_EXPECTED,
             Certificate {
-                aggregate_verification_key: "aggregate_verification_key-modified".to_string(),
+                aggregate_verification_key: fake_keys::aggregate_verification_key()[2]
+                    .try_into()
+                    .unwrap(),
                 ..certificate.clone()
             }
             .compute_hash(),
@@ -306,7 +310,7 @@ mod tests {
     #[test]
     fn test_genesis_certificate_compute_hash() {
         const HASH_EXPECTED: &str =
-            "bbb265e74082896873d3fbe568e4b0118ddcf9a63b4f4b369b92773439e80159";
+            "e8cc8885ef7a76f35216a6ef603ab0387dcacb892e0a33df9de9f5bf98cf203b";
 
         let initiated_at = DateTime::parse_from_rfc3339("2024-02-12T13:11:47.0123043Z")
             .unwrap()
@@ -324,7 +328,7 @@ mod tests {
                 get_signers_with_stake(),
             ),
             get_protocol_message(),
-            "aggregate_verification_key".to_string(),
+            fake_keys::aggregate_verification_key()[1].to_owned(),
             CertificateSignature::GenesisSignature(
                 fake_keys::genesis_signature()[0].try_into().unwrap(),
             ),

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -59,7 +59,7 @@ impl CertificateMessage {
         );
         protocol_message.set_message_part(
             ProtocolMessagePartKey::NextAggregateVerificationKey,
-            "next-avk-123".to_string(),
+            fake_keys::aggregate_verification_key()[1].to_owned(),
         );
         Self {
             hash: "hash".to_string(),
@@ -68,7 +68,7 @@ impl CertificateMessage {
             metadata: CertificateMetadataMessagePart::dummy(),
             protocol_message: protocol_message.clone(),
             signed_message: "signed_message".to_string(),
-            aggregate_verification_key: "aggregate_verification_key".to_string(),
+            aggregate_verification_key: fake_keys::aggregate_verification_key()[0].to_owned(),
             multi_signature: fake_keys::multi_signature()[0].to_owned(),
             genesis_signature: String::new(),
         }

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -44,7 +44,7 @@ impl MultiSigner {
 
     /// Compute aggregate verification key from stake distribution
     pub fn compute_aggregate_verification_key(&self) -> ProtocolAggregateVerificationKey {
-        self.protocol_clerk.compute_avk()
+        self.protocol_clerk.compute_avk().into()
     }
 
     /// Verify a single signature

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -4,11 +4,10 @@ use rand_core::{CryptoRng, RngCore, SeedableRng};
 use std::path::Path;
 use thiserror::Error;
 
-use crate::crypto_helper::ProtocolAggregateVerificationKey;
 use crate::{
     crypto_helper::{
-        ProtocolClerk, ProtocolClosedKeyRegistration, ProtocolInitializer, ProtocolKeyRegistration,
-        ProtocolStakeDistribution,
+        ProtocolAggregateVerificationKey, ProtocolClerk, ProtocolClosedKeyRegistration,
+        ProtocolInitializer, ProtocolKeyRegistration, ProtocolStakeDistribution,
     },
     entities::{PartyId, ProtocolParameters, SignerWithStake},
     protocol::MultiSigner,
@@ -84,7 +83,7 @@ impl SignerBuilder {
         let clerk =
             ProtocolClerk::from_registration(&stm_parameters, &self.closed_key_registration);
 
-        clerk.compute_avk()
+        clerk.compute_avk().into()
     }
 
     fn build_single_signer_with_rng<R: RngCore + CryptoRng>(

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -134,7 +134,9 @@ pub fn certificate(certificate_hash: String) -> entities::Certificate {
 
     // Certificate
     let previous_hash = format!("{certificate_hash}0");
-    let aggregate_verification_key = fake_keys::aggregate_verification_key()[1].to_owned();
+    let aggregate_verification_key = fake_keys::aggregate_verification_key()[1]
+        .try_into()
+        .unwrap();
     let multi_signature = fake_keys::multi_signature()[0].try_into().unwrap();
 
     entities::Certificate {

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -123,7 +123,7 @@ pub fn certificate(certificate_hash: String) -> entities::Certificate {
     );
 
     // Protocol message
-    let next_aggregate_verification_key = "next-avk-123".to_string();
+    let next_aggregate_verification_key = fake_keys::aggregate_verification_key()[2].to_owned();
     let mut protocol_message = ProtocolMessage::new();
     let snapshot_digest = format!("1{}", beacon.immutable_file_number).repeat(20);
     protocol_message.set_message_part(ProtocolMessagePartKey::SnapshotDigest, snapshot_digest);
@@ -134,7 +134,7 @@ pub fn certificate(certificate_hash: String) -> entities::Certificate {
 
     // Certificate
     let previous_hash = format!("{certificate_hash}0");
-    let aggregate_verification_key = format!("AVK{}", beacon.immutable_file_number).repeat(5);
+    let aggregate_verification_key = fake_keys::aggregate_verification_key()[1].to_owned();
     let multi_signature = fake_keys::multi_signature()[0].try_into().unwrap();
 
     entities::Certificate {

--- a/mithril-common/src/test_utils/fake_keys.rs
+++ b/mithril-common/src/test_utils/fake_keys.rs
@@ -332,11 +332,32 @@ pub const fn operational_certificate<'a>() -> [&'a str; 2] {
     ]
 }
 
+/// A list of pre json hex encoded [MithrilStm:StmAggrVerificationKey](struct@mithril_stm::stm::StmAggrVerificationKey)
+pub const fn aggregate_verification_key<'a>() -> [&'a str; 3] {
+    [
+        "7b226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b3134302c31332c3135352c3134312c3136332c\
+        372c38362c3232372c34372c31392c3138302c3132372c3139362c3130382c3137312c3135382c3134302c37372\
+        c3137352c3135392c3133362c3139332c3130382c34322c3134322c3234342c38352c3131362c3235322c313536\
+        2c3233352c35305d2c226e725f6c6561766573223a312c22686173686572223a6e756c6c7d2c22746f74616c5f7\
+        374616b65223a313030393439373433323536397d",
+        "7b226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b37332c37342c3232392c3235302c3132322c32\
+        32362c38392c33372c3233312c3234352c3130362c3138332c3132372c332c39392c3137372c3231372c36352c3\
+        135322c3133352c33322c36372c3232332c33352c3134312c35312c342c3132352c3230332c33382c3139362c32\
+        31325d2c226e725f6c6561766573223a32342c22686173686572223a6e756c6c7d2c22746f74616c5f7374616b6\
+        5223a35323337353137363336353838327d",
+        "7b226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b39382c3234312c3132322c37382c3230322c33\
+        2c3230322c37322c36372c3231352c3139302c3135322c3130332c3135392c39372c35352c32362c3232312c313\
+        7372c38352c3233392c3132372c39322c35332c3131332c3235322c39302c39372c39352c3133342c3233342c36\
+        375d2c226e725f6c6561766573223a36342c22686173686572223a6e756c6c7d2c22746f74616c5f7374616b652\
+        23a313236393036323837373536363033367d",
+    ]
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use kes_summed_ed25519::kes::Sum6KesSig;
-    use mithril_stm::stm::{StmAggrSig, StmSig, StmVerificationKeyPoP};
+    use mithril_stm::stm::{StmAggrSig, StmAggrVerificationKey, StmSig, StmVerificationKeyPoP};
     use serde::{de::DeserializeOwned, Serialize};
     use std::any::type_name;
 
@@ -432,5 +453,12 @@ mod test {
     #[test]
     fn assert_encoded_operational_certificate_are_still_matching_concrete_type() {
         assert_can_deserialize_using_key_decode_hex::<OpCert>(&operational_certificate());
+    }
+
+    #[test]
+    fn assert_encoded_aggregate_verification_key_are_still_matching_concrete_type() {
+        assert_can_deserialize_using_key_decode_hex::<StmAggrVerificationKey<D>>(
+            &aggregate_verification_key(),
+        );
     }
 }

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -9,8 +9,8 @@ use std::{
 use crate::{
     certificate_chain::CertificateGenesisProducer,
     crypto_helper::{
-        key_encode_hex, ProtocolAggregateVerificationKey, ProtocolGenesisSigner,
-        ProtocolInitializer, ProtocolOpCert, ProtocolSigner, ProtocolSignerVerificationKey,
+        ProtocolAggregateVerificationKey, ProtocolGenesisSigner, ProtocolInitializer,
+        ProtocolOpCert, ProtocolSigner, ProtocolSignerVerificationKey,
         ProtocolSignerVerificationKeySignature, ProtocolStakeDistribution,
     },
     entities::{
@@ -154,7 +154,7 @@ impl MithrilFixture {
     /// Compute the Aggregate Verification Key for this fixture and returns it has a [HexEncodedAgregateVerificationKey].
     pub fn compute_and_encode_avk(&self) -> HexEncodedAgregateVerificationKey {
         let avk = self.compute_avk();
-        key_encode_hex(avk).unwrap()
+        avk.to_json_hex().unwrap()
     }
 
     /// Create a genesis certificate using the fixture signers for the given beacon

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.69"
+version = "0.2.70"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -3,9 +3,7 @@ use slog_scope::{info, trace, warn};
 use std::path::PathBuf;
 use thiserror::Error;
 
-use mithril_common::crypto_helper::{
-    key_encode_hex, KESPeriod, ProtocolInitializer, ProtocolInitializerError,
-};
+use mithril_common::crypto_helper::{KESPeriod, ProtocolInitializer, ProtocolInitializerError};
 use mithril_common::entities::{
     PartyId, ProtocolMessage, ProtocolParameters, SignerWithStake, SingleSignatures, Stake,
 };
@@ -69,8 +67,8 @@ pub enum SingleSignerError {
     ProtocolSignerCreationFailure(String),
 
     /// Encoding / Decoding error.
-    #[error("codec error: '{0}'")]
-    Codec(String),
+    #[error("codec error: '{0:?}'")]
+    Codec(StdError),
 
     /// Signature Error
     #[error("Signature Error: {0:?}")]
@@ -140,7 +138,9 @@ impl SingleSigner for MithrilSingleSigner {
         )
         .map_err(SingleSignerError::AggregateVerificationKeyComputationFailed)?;
 
-        let encoded_avk = key_encode_hex(signer_builder.compute_aggregate_verification_key())
+        let encoded_avk = signer_builder
+            .compute_aggregate_verification_key()
+            .to_json_hex()
             .map_err(SingleSignerError::Codec)?;
 
         Ok(Some(encoded_avk))


### PR DESCRIPTION
## Content

This PR update from a string to a `ProtocolKey` most usages of aggregate verification key.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
The `ProtocolMessage` `NextAggregateVerificationKey` was not updated since in order to do so we need to redesign the protocol message api to be able to handle other types than just strings.

## Issue(s)

Relates to #668
