### PR TITLE
Client snapshot download progress with json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2153,7 +2153,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.34"
+version = "0.3.35"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.34"
+version = "0.3.35"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client/snapshot_client.rs
+++ b/mithril-client/src/aggregator_client/snapshot_client.rs
@@ -1,20 +1,20 @@
 //! This module contains a struct to exchange snapshot information with the Aggregator
 
+use slog_scope::warn;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
+use thiserror::Error;
 
-use indicatif::ProgressBar;
 use mithril_common::{
     entities::Snapshot,
     messages::{SnapshotListItemMessage, SnapshotListMessage, SnapshotMessage},
     StdResult,
 };
-use slog_scope::warn;
-use thiserror::Error;
 
-use super::AggregatorClient;
+use crate::aggregator_client::AggregatorClient;
+use crate::utils::DownloadProgressReporter;
 
 /// Error for the Snapshot client
 #[derive(Error, Debug)]
@@ -64,7 +64,7 @@ impl SnapshotClient {
         &self,
         snapshot: &Snapshot,
         download_dir: &Path,
-        progress_bar: ProgressBar,
+        progress_reporter: DownloadProgressReporter,
     ) -> StdResult<PathBuf> {
         let filepath = PathBuf::new()
             .join(download_dir)
@@ -74,7 +74,7 @@ impl SnapshotClient {
             if self.http_client.probe(url).await.is_ok() {
                 match self
                     .http_client
-                    .download(url, &filepath, progress_bar)
+                    .download(url, &filepath, progress_reporter)
                     .await
                 {
                     Ok(()) => return Ok(filepath),

--- a/mithril-client/src/commands/snapshot/download.rs
+++ b/mithril-client/src/commands/snapshot/download.rs
@@ -1,11 +1,12 @@
-use std::{path::PathBuf, sync::Arc};
-
 use clap::Parser;
 use config::{builder::DefaultState, Config, ConfigBuilder};
-use indicatif::ProgressDrawTarget;
+use std::{path::PathBuf, sync::Arc};
+
 use mithril_common::{messages::FromMessageAdapter, StdResult};
 
-use crate::{dependencies::DependenciesBuilder, FromSnapshotMessageAdapter};
+use crate::{
+    dependencies::DependenciesBuilder, utils::ProgressOutputType, FromSnapshotMessageAdapter,
+};
 
 /// Clap command to download the snapshot and verify the certificate.
 #[derive(Parser, Debug, Clone)]
@@ -36,17 +37,17 @@ impl SnapshotDownloadCommand {
         let snapshot_service = dependencies_builder.get_snapshot_service().await?;
         let snapshot_entity =
             FromSnapshotMessageAdapter::adapt(snapshot_service.show(&self.digest).await?);
-        let progress_target = if self.json {
-            ProgressDrawTarget::hidden()
+        let progress_output_type = if self.json {
+            ProgressOutputType::JsonReporter
         } else {
-            ProgressDrawTarget::stdout()
+            ProgressOutputType::TTY
         };
         let filepath = snapshot_service
             .download(
                 &snapshot_entity,
                 &self.download_dir,
                 &config.get_string("genesis_verification_key")?,
-                progress_target,
+                progress_output_type,
             )
             .await?;
 

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -1,6 +1,8 @@
 //! Utilities module
 //! This module contains tools needed mostly in services layers.
 
+mod progress_reporter;
 mod unpacker;
 
+pub use progress_reporter::*;
 pub use unpacker::*;

--- a/mithril-client/src/utils/progress_reporter.rs
+++ b/mithril-client/src/utils/progress_reporter.rs
@@ -1,0 +1,83 @@
+use indicatif::{ProgressBar, ProgressDrawTarget};
+use slog_scope::warn;
+use std::{
+    sync::RwLock,
+    time::{Duration, Instant},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+/// Output type of a [ProgressReporter]
+pub enum ProgressOutputType {
+    /// Output to json
+    JsonReporter,
+    /// Output to tty
+    TTY,
+    /// No output
+    Hidden,
+}
+
+impl From<ProgressOutputType> for ProgressDrawTarget {
+    fn from(value: ProgressOutputType) -> Self {
+        match value {
+            ProgressOutputType::JsonReporter => ProgressDrawTarget::hidden(),
+            ProgressOutputType::TTY => ProgressDrawTarget::stdout(),
+            ProgressOutputType::Hidden => ProgressDrawTarget::hidden(),
+        }
+    }
+}
+
+/// Wrapper of a indicatif [ProgressBar] to allow reporting to json.
+pub struct DownloadProgressReporter {
+    progress_bar: ProgressBar,
+    output_type: ProgressOutputType,
+    last_json_report_instant: RwLock<Option<Instant>>,
+}
+
+impl DownloadProgressReporter {
+    /// Instanciate a new progress reporter
+    pub fn new(progress_bar: ProgressBar, output_type: ProgressOutputType) -> Self {
+        Self {
+            progress_bar,
+            output_type,
+            last_json_report_instant: RwLock::new(None),
+        }
+    }
+
+    /// Report the current progress
+    pub fn report(&self, actual_position: u64) {
+        self.progress_bar.set_position(actual_position);
+
+        if let ProgressOutputType::JsonReporter = self.output_type {
+            let should_report = match self.get_remaining_time_since_last_json_report() {
+                Some(remaining_time) => remaining_time > Duration::from_millis(333),
+                None => true,
+            };
+
+            if should_report {
+                println!(
+                    r#"{{ "bytesDownloaded": {}, "bytesTotal": {}, "secondsLeft": {}.{}, "secondsElapsed": {}.{} }}"#,
+                    self.progress_bar.position(),
+                    self.progress_bar.length().unwrap_or(0),
+                    self.progress_bar.eta().as_secs(),
+                    self.progress_bar.eta().subsec_millis(),
+                    self.progress_bar.elapsed().as_secs(),
+                    self.progress_bar.elapsed().subsec_millis(),
+                );
+
+                match self.last_json_report_instant.write() {
+                    Ok(mut instant) => *instant = Some(Instant::now()),
+                    Err(error) => {
+                        warn!("failed to update last json report instant, error: {error:?}")
+                    }
+                };
+            }
+        };
+    }
+
+    fn get_remaining_time_since_last_json_report(&self) -> Option<Duration> {
+        match self.last_json_report_instant.read() {
+            Ok(instant) => (*instant).map(|instant| instant.elapsed()),
+            Err(_) => None,
+        }
+    }
+}


### PR DESCRIPTION
## Content

This PR enhance **mithril-client** command `snapshot download` json output (`--json` parameter).
Instead of reporting nothing until the command finish using `--json` will now print:

- The current step of the process, ie:
```json
{"step_num": 1, "total_steps": 7, "message": "Checking local disk info…"}                                                                                                    
{"step_num": 2, "total_steps": 7, "message": "Fetching the certificate's information…"}                                                                                      
{"step_num": 3, "total_steps": 7, "message": "Verifying the certificate chain…"}                                                                                             
{"step_num": 4, "total_steps": 7, "message": "Downloading the snapshot…"}
```
- The current progress when in downloading (approximately every 333ms), ie:
```json
{ "bytesDownloaded": 2067507114, "bytesTotal": 2438424190, "secondsLeft": 10.408, "secondsElapsed": 58.296 }
{ "bytesDownloaded": 2079647658, "bytesTotal": 2438424190, "secondsLeft": 10.65, "secondsElapsed": 58.629 }
{ "bytesDownloaded": 2091788202, "bytesTotal": 2438424190, "secondsLeft": 9.723, "secondsElapsed": 58.962 }
{ "bytesDownloaded": 2103928746, "bytesTotal": 2438424190, "secondsLeft": 9.380, "secondsElapsed": 59.296 }
{ "bytesDownloaded": 2116069290, "bytesTotal": 2438424190, "secondsLeft": 9.37, "secondsElapsed": 59.629 }
{ "bytesDownloaded": 2128209834, "bytesTotal": 2438424190, "secondsLeft": 8.694, "secondsElapsed": 59.962 }
{ "bytesDownloaded": 2138122154, "bytesTotal": 2438424190, "secondsLeft": 8.414, "secondsElapsed": 60.295 }
{ "bytesDownloaded": 2147870634, "bytesTotal": 2438424190, "secondsLeft": 8.146, "secondsElapsed": 60.629 }
```

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1095