### PR TITLE
Rust version 1.72.0 : fix cargo clippy warning & update dependencies

### DIFF
--- a/mithril-common/src/sqlite/provider.rs
+++ b/mithril-common/src/sqlite/provider.rs
@@ -233,7 +233,7 @@ returning {projection}
     #[test]
     fn test_upsertion() {
         let provider = TestEntityUpdateProvider::new(init_database());
-        let params = vec![
+        let params = [
             Value::String("row 1".to_string()),
             Value::Float(1.234),
             Value::Integer(0),


### PR DESCRIPTION
## Content
This PR includes a modification related to a new Clippy lint: "Useless Vec".

Rust 1.72.0 : https://rust-lang.github.io/rust-clippy/master/index.html#/useless_vec
Clippy lint "Useless Vec": https://rust-lang.github.io/rust-clippy/master/index.html#/useless_vec

Dependancies were also updated in this PR.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
