### PR TITLE
Add network compatiblity table to autogenerated releases

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -14,6 +14,9 @@ inputs:
   gpg-secret-key:
     description: A GPG secret key to sign the distribution
     required: true
+  compatibility-table:
+    description: A json in which each key corresponds to a network and each value describes its compatibility
+    required: true
 runs:
   using: "composite"
   steps:
@@ -56,6 +59,20 @@ runs:
 
         cargo metadata --quiet --no-deps | \
           jq -r '.packages | sort_by(.name) | .[] | select([.name] | inside(["mithrildemo", "mithril-end-to-end"]) | not) | "| \(.name) | `\(.version)` |"' \
+          >> ./release-notes-addon.txt
+        
+    - name: Add compatibility table
+      shell: bash
+      run: |
+        cat >> ./release-notes-addon.txt << EOF
+
+        ## Networks Compatibility :warning:
+        |  Network  |  Compatible  |
+        |---------- |:-------------:|
+        EOF
+
+        echo "${{ inputs.compatibility-table }}" \
+          | jq -r 'keys_unsorted[] as $network | "| \($network) | \(.[$network]) |"' \
           >> ./release-notes-addon.txt
         
     - name: Add minimum supported libc version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,8 @@ jobs:
           version-name: unstable-${{ steps.slug.outputs.sha8 }}
           download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/unstable
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
-
+          compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "✔" }'
+      
       - name: Update unstable release
         uses: marvinpinto/action-automatic-releases@latest
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -62,6 +62,7 @@ jobs:
           version-name: ${{ github.ref_name }}
           download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
+          compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "✔" }'
 
       - name: Create pre-release ${{ github.ref_name }}
         uses: marvinpinto/action-automatic-releases@latest


### PR DESCRIPTION
## Content

This PR includes add network compatiblity table to autogenerated releases.

Example for unstable release:
> |  Network  |  Compatible  |
> |---------- |:-------------:|
> | `release-mainnet` | ⛔  |
> | `release-preprod` | ⛔  |
> | `pre-release-preview` | ✔   |
> | `testing-preview` | ✔   |

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1151 
