### PR TITLE
Replace `git switch` with `git checkout` in docs

### DIFF
--- a/docs/website/root/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-aggregator.md
@@ -58,7 +58,7 @@ Switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory:

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client.md
@@ -61,7 +61,7 @@ Switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory: 

--- a/docs/website/root/manual/developer-docs/nodes/mithril-signer.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-signer.md
@@ -60,7 +60,7 @@ Switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory:

--- a/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
@@ -65,7 +65,7 @@ To build the Mithril client binary, switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory:

--- a/docs/website/root/manual/getting-started/run-signer-node.md
+++ b/docs/website/root/manual/getting-started/run-signer-node.md
@@ -120,7 +120,7 @@ First, switch to build a branch/tag:
 ```bash
 # **YOUR_BUILD_BRANCH_OR_TAG** depends on the Mithril network you target, 
 # please refer to the **Build from** column of the above **Mithril networks** table
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Then, change the directory:

--- a/docs/website/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/website/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-aggregator.md
@@ -58,7 +58,7 @@ Switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory:

--- a/docs/website/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/website/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-client.md
@@ -61,7 +61,7 @@ Switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory: 

--- a/docs/website/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-signer.md
+++ b/docs/website/versioned_docs/version-maintained/manual/developer-docs/nodes/mithril-signer.md
@@ -60,7 +60,7 @@ Switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory:

--- a/docs/website/versioned_docs/version-maintained/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/website/versioned_docs/version-maintained/manual/getting-started/bootstrap-cardano-node.md
@@ -65,7 +65,7 @@ To build the Mithril client binary, switch to the desired branch/tag:
 ```bash
 # Replace **YOUR_BUILD_BRANCH_OR_TAG** with the appropriate branch or tag name
 # Please refer to the **Build from** column of the **Mithril networks** table above
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Change the directory:

--- a/docs/website/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
+++ b/docs/website/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
@@ -120,7 +120,7 @@ First, switch to build a branch/tag:
 ```bash
 # **YOUR_BUILD_BRANCH_OR_TAG** depends on the Mithril network you target, 
 # please refer to the **Build from** column of the above **Mithril networks** table
-git switch **YOUR_BUILD_BRANCH_OR_TAG**
+git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
 Then, change the directory:


### PR DESCRIPTION
## Content
This PR includes a fix in Mithril documentation. 
`git switch` command was replaced by `git checkout` in guides to handle checking out tags.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Commands were updated for both versions (current & next).

## Issue(s)
Closes #1174 
