### PR TITLE
Fix verify archive in aggregator Snapshotter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.75"
+version = "0.3.76"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a fix to the archive verification in the aggregator `Snapshotter`: it now verifies that it can unpack all the archive without requiring extra space on disk.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1160
