### PR TITLE
Fix latest digest usage in documentation

### DIFF
--- a/docs/website/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client.md
@@ -201,7 +201,7 @@ export MITHRIL_IMAGE_ID=**YOUR_MITHRIL_IMAGE_ID**
 export NETWORK=**YOUR_CARDANO_NETWORK**
 export AGGREGATOR_ENDPOINT=**YOUR_AGGREGATOR_ENDPOINT**
 export GENESIS_VERIFICATION_KEY=$(wget -q -O - **YOUR_GENESIS_VERIFICATION_KEY**)
-export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=latest
 ```
 
 Here is an example configuration for the `release-preprod` network and the `latest` stable Docker image:
@@ -211,7 +211,7 @@ export MITHRIL_IMAGE_ID=latest
 export NETWORK=preprod
 export AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator
 export GENESIS_VERIFICATION_KEY=$(wget -q -O - https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey)
-export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=latest
 ```
 
 Proceed by creating a shell function for the Mithril client:

--- a/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
@@ -222,7 +222,7 @@ export GENESIS_VERIFICATION_KEY=$(wget -q -O - **YOUR_GENESIS_VERIFICATION_KEY**
 
 # Digest of the latest produced snapshot for convenience of the demo
 # You can also modify this variable and set it to the value of the digest of a snapshot that you can retrieve at step 2
-export SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=latest
 ```
 
 ### Step 2: Select a snapshot

--- a/docs/website/root/manual/getting-started/run-mithril-devnet.md
+++ b/docs/website/root/manual/getting-started/run-mithril-devnet.md
@@ -428,14 +428,14 @@ tail -n 22 ./node-pool2/node.log
 
 ```bash
 # Cardano network
-NETWORK=devnet
+export NETWORK=devnet
 
 # Aggregator API endpoint URL
-AGGREGATOR_ENDPOINT=http://localhost:8080/aggregator
+export AGGREGATOR_ENDPOINT=http://localhost:8080/aggregator
 
 # Digest of the latest produced snapshot for convenience of the demo
 # You can also modify this variable and set it to the value of the digest of a snapshot that you can retrieve at step 2
-SNAPSHOT_DIGEST=$(curl -sL $AGGREGATOR_ENDPOINT/artifact/snapshots | jq -r '.[0].digest')
+export SNAPSHOT_DIGEST=latest
 ```
 
 You can pick an online test aggregator directly from the [Mithril Explorer](https://mithril.network/explorer).


### PR DESCRIPTION
## Content
This PR includes a fix of the documentation to use the new `latest` value in the client command instead of computing it manually

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

