### PR TITLE
Upgrade ed25519-dalek to v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2282,7 +2282,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.99"
+version = "0.2.100"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414dcefbc63d77c526a76b3afcf6fbb9b5e2791c19c3aa2297733208750c6e53"
 
 [[package]]
+name = "base64ct"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
 name = "basic-cookies"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +723,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,6 +935,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f711ade317dd348950a9910f81c5947e3d8907ebd2b83f76203ff1807e6a2bc2"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest 0.10.7",
+ "fiat-crypto",
+ "platforms",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fdaf97f4804dcebfa5862639bc9ce4121e82140bec2a987ac5140294865b5b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -955,6 +995,16 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.29",
+]
+
+[[package]]
+name = "der"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+dependencies = [
+ "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -1065,7 +1115,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
  "serde",
- "signature",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f6d271ca33075c88028be6f04d502853d63a5ece419d269c15315d4fc1cf1d"
+dependencies = [
+ "pkcs8",
+ "serde",
+ "signature 2.1.0",
 ]
 
 [[package]]
@@ -1074,12 +1135,26 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c762bae6dcaf24c4c84667b8579785430908723d5c889f469d76a41d59cc7a9d"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 3.2.0",
+ "ed25519 1.5.3",
  "rand 0.7.3",
  "serde",
  "serde_bytes",
  "sha2 0.9.9",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7277392b266383ef8396db7fdeb1e77b6c52fed775f5df15bb24f35b72156980"
+dependencies = [
+ "curve25519-dalek 4.0.0",
+ "ed25519 2.2.2",
+ "rand_core 0.6.4",
+ "serde",
+ "sha2 0.10.7",
  "zeroize",
 ]
 
@@ -1179,6 +1254,12 @@ name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e825f6987101665dea6ec934c09ec6d721de7bc1bf92248e1d5810c8cd636b77"
 
 [[package]]
 name = "filetime"
@@ -1930,7 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "091ace8c9cd5555e89df0cecf77e09aa658907fbc4a316d350a4344cafdb8c4b"
 dependencies = [
  "blake2 0.9.2",
- "ed25519-dalek",
+ "ed25519-dalek 1.0.1",
  "rand_core 0.5.1",
  "serde",
  "serde_with 2.3.3",
@@ -2210,7 +2291,7 @@ dependencies = [
  "chrono",
  "criterion",
  "digest 0.10.7",
- "ed25519-dalek",
+ "ed25519-dalek 2.0.0",
  "fixed",
  "glob",
  "hex",
@@ -2220,7 +2301,6 @@ dependencies = [
  "mithril-stm",
  "mockall",
  "nom",
- "rand_chacha 0.2.2",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "rayon",
@@ -2798,10 +2878,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "platforms"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4503fa043bf02cee09a9582e9554b4c6403b2ef55e4612e96561d294419429f8"
 
 [[package]]
 name = "plotters"
@@ -3198,6 +3294,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,6 +3624,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "signature"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+
+[[package]]
 name = "similar"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3666,6 +3777,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
  "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -22,7 +22,7 @@ bech32 = "0.9.1"
 blake2 = "0.10.6"
 chrono = { version = "0.4.26", features = ["serde"] }
 digest = "0.10.7"
-ed25519-dalek = { version = "1.0.1", features = ["serde"] }
+ed25519-dalek = { version = "2.0.0", features = ["rand_core", "serde"] }
 fixed = "1.23.1"
 glob = "0.3.1"
 hex = "0.4.3"
@@ -34,7 +34,6 @@ kes-summed-ed25519 = { version = "0.2.0", features = [
 ] }
 mockall = "0.11.4"
 nom = "7.1.3"
-rand-chacha-dalek-compat = { package = "rand_chacha", version = "0.2" }
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 rayon = "1.7.0"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.99"
+version = "0.2.100"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/crypto_helper/cardano/cold_key.rs
+++ b/mithril-common/src/crypto_helper/cardano/cold_key.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::SigningKey as ColdKeypair;
+use ed25519_dalek::SigningKey as ColdSecretKey;
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 
@@ -7,9 +7,9 @@ use rand_core::SeedableRng;
 pub struct ColdKeyGenerator();
 
 impl ColdKeyGenerator {
-    pub(crate) fn create_deterministic_keypair(seed: [u8; 32]) -> ColdKeypair {
+    pub(crate) fn create_deterministic_keypair(seed: [u8; 32]) -> ColdSecretKey {
         let mut rng = ChaCha20Rng::from_seed(seed);
-        ColdKeypair::generate(&mut rng)
+        ColdSecretKey::generate(&mut rng)
     }
 }
 

--- a/mithril-common/src/crypto_helper/cardano/cold_key.rs
+++ b/mithril-common/src/crypto_helper/cardano/cold_key.rs
@@ -1,6 +1,6 @@
-use ed25519_dalek::Keypair as ColdKeypair;
-use rand_chacha_dalek_compat::rand_core::SeedableRng;
-use rand_chacha_dalek_compat::ChaCha20Rng;
+use ed25519_dalek::SigningKey as ColdKeypair;
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
 
 /// A cold key generator / test only
 #[derive(Debug)]

--- a/mithril-common/src/crypto_helper/cardano/opcert.rs
+++ b/mithril-common/src/crypto_helper/cardano/opcert.rs
@@ -23,7 +23,7 @@ pub enum OpCertError {
     PoolAddressEncoding,
 }
 
-/// Raw Fields of the operational certificates (without incluiding the cold VK)
+/// Raw Fields of the operational certificates (without including the cold VK)
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 struct RawFields(
     #[serde(with = "serde_bytes")] Vec<u8>,

--- a/mithril-common/src/crypto_helper/era.rs
+++ b/mithril-common/src/crypto_helper/era.rs
@@ -6,13 +6,13 @@ use thiserror::Error;
 
 use super::ProtocolKey;
 
-/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.VerifyingKey.html).
+/// Wrapper of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.VerifyingKey.html).
 pub type EraMarkersVerifierVerificationKey = ProtocolKey<ed25519_dalek::VerifyingKey>;
 
-/// Alias of [Ed25519:SigningKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html).
+/// Wrapper of [Ed25519:SigningKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html).
 pub type EraMarkersVerifierSecretKey = ProtocolKey<ed25519_dalek::SigningKey>;
 
-/// Alias of [Ed25519:Signature](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.Signature.html).
+/// Wrapper of [Ed25519:Signature](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.Signature.html).
 pub type EraMarkersVerifierSignature = ProtocolKey<ed25519_dalek::Signature>;
 
 #[derive(Error, Debug)]
@@ -30,7 +30,7 @@ pub struct EraMarkersSigner {
 }
 
 impl EraMarkersSigner {
-    /// EraMarkersSigner factory
+    /// [EraMarkersSigner] factory
     pub fn create_test_signer<R>(mut rng: R) -> Self
     where
         R: CryptoRng + RngCore,
@@ -39,29 +39,29 @@ impl EraMarkersSigner {
         Self::from_secret_key(secret_key.into())
     }
 
-    /// EraMarkersSigner deterministic
+    /// [EraMarkersSigner] deterministic
     pub fn create_deterministic_signer() -> Self {
         let rng = ChaCha20Rng::from_seed([0u8; 32]);
         Self::create_test_signer(rng)
     }
 
-    /// EraMarkersSigner non deterministic
+    /// [EraMarkersSigner] non deterministic
     pub fn create_non_deterministic_signer() -> Self {
         let rng = rand_core::OsRng;
         Self::create_test_signer(rng)
     }
 
-    /// EraMarkersSigner from EraMarkersVerifierSecretKey
+    /// [EraMarkersSigner] from [EraMarkersVerifierSecretKey]
     pub fn from_secret_key(secret_key: EraMarkersVerifierSecretKey) -> Self {
         Self { secret_key }
     }
 
-    /// Create a EraMarkersVerifier
+    /// Create a [EraMarkersVerifier]
     pub fn create_verifier(&self) -> EraMarkersVerifier {
         EraMarkersVerifier::from_verification_key(self.secret_key.verifying_key().into())
     }
 
-    /// Signs a message and returns a EraMarkersVerifierSignature
+    /// Signs a message and returns a [EraMarkersVerifierSignature]
     pub fn sign(&self, message: &[u8]) -> EraMarkersVerifierSignature {
         self.secret_key.sign(message).into()
     }
@@ -74,12 +74,12 @@ pub struct EraMarkersVerifier {
 }
 
 impl EraMarkersVerifier {
-    /// EraMarkersVerifier from EraMarkersVerifierVerificationKey
+    /// [EraMarkersVerifier] from [EraMarkersVerifierVerificationKey]
     pub fn from_verification_key(verification_key: EraMarkersVerifierVerificationKey) -> Self {
         Self { verification_key }
     }
 
-    /// EraMarkersVerifier to EraMarkersVerifierVerificationKey
+    /// [EraMarkersVerifier] to [EraMarkersVerifierVerificationKey]
     pub fn to_verification_key(&self) -> EraMarkersVerifierVerificationKey {
         self.verification_key
     }

--- a/mithril-common/src/crypto_helper/era.rs
+++ b/mithril-common/src/crypto_helper/era.rs
@@ -1,16 +1,16 @@
-use ed25519_dalek::{ExpandedSecretKey, SignatureError};
-use rand_chacha_dalek_compat::rand_core::{self, CryptoRng, RngCore, SeedableRng};
-use rand_chacha_dalek_compat::ChaCha20Rng;
+use ed25519_dalek::{SignatureError, Signer, SigningKey};
+use rand_chacha::rand_core::{self, CryptoRng, RngCore, SeedableRng};
+use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::ProtocolKey;
 
-/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.PublicKey.html).
-pub type EraMarkersVerifierVerificationKey = ProtocolKey<ed25519_dalek::PublicKey>;
+/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.VerifyingKey.html).
+pub type EraMarkersVerifierVerificationKey = ProtocolKey<ed25519_dalek::VerifyingKey>;
 
-/// Alias of [Ed25519:SecretKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SecretKey.html).
-pub type EraMarkersVerifierSecretKey = ProtocolKey<ed25519_dalek::SecretKey>;
+/// Alias of [Ed25519:SigningKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html).
+pub type EraMarkersVerifierSecretKey = ProtocolKey<ed25519_dalek::SigningKey>;
 
 /// Alias of [Ed25519:Signature](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.Signature.html).
 pub type EraMarkersVerifierSignature = ProtocolKey<ed25519_dalek::Signature>;
@@ -35,7 +35,7 @@ impl EraMarkersSigner {
     where
         R: CryptoRng + RngCore,
     {
-        let secret_key = ed25519_dalek::SecretKey::generate(&mut rng);
+        let secret_key = SigningKey::generate(&mut rng);
         Self::from_secret_key(secret_key.into())
     }
 
@@ -56,31 +56,14 @@ impl EraMarkersSigner {
         Self { secret_key }
     }
 
-    /// Create a an expanded secret key
-    fn create_expanded_secret_key(&self) -> ExpandedSecretKey {
-        ExpandedSecretKey::from(&*self.secret_key)
-    }
-
-    /// Create a EraMarkersVerifierVerificationKey
-    fn create_verification_key(
-        &self,
-        expanded_secret_key: &ExpandedSecretKey,
-    ) -> EraMarkersVerifierVerificationKey {
-        EraMarkersVerifierVerificationKey::new(expanded_secret_key.into())
-    }
-
     /// Create a EraMarkersVerifier
     pub fn create_verifier(&self) -> EraMarkersVerifier {
-        let expanded_secret_key = self.create_expanded_secret_key();
-        let verification_key = self.create_verification_key(&expanded_secret_key);
-        EraMarkersVerifier::from_verification_key(verification_key)
+        EraMarkersVerifier::from_verification_key(self.secret_key.verifying_key().into())
     }
 
     /// Signs a message and returns a EraMarkersVerifierSignature
     pub fn sign(&self, message: &[u8]) -> EraMarkersVerifierSignature {
-        let expanded_secret_key = self.create_expanded_secret_key();
-        let verification_key = self.create_verification_key(&expanded_secret_key);
-        expanded_secret_key.sign(message, &verification_key).into()
+        self.secret_key.sign(message).into()
     }
 }
 
@@ -139,7 +122,7 @@ mod tests {
         let verifier = signer.create_verifier();
         let signer_2 = EraMarkersSigner::create_deterministic_signer();
         let verifier_2 = signer.create_verifier();
-        assert_eq!(signer.secret_key.as_bytes(), signer_2.secret_key.as_bytes());
+        assert_eq!(signer.secret_key.to_bytes(), signer_2.secret_key.to_bytes());
         assert_eq!(
             verifier.verification_key.as_bytes(),
             verifier_2.verification_key.as_bytes()

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -25,7 +25,7 @@ pub struct ProtocolGenesisSigner {
 }
 
 impl ProtocolGenesisSigner {
-    /// ProtocolGenesisSigner factory
+    /// [ProtocolGenesisSigner] factory
     pub fn create_test_genesis_signer<R>(mut rng: R) -> Self
     where
         R: CryptoRng + RngCore,
@@ -34,29 +34,29 @@ impl ProtocolGenesisSigner {
         Self::from_secret_key(secret_key.into())
     }
 
-    /// ProtocolGenesisSigner deterministic
+    /// [ProtocolGenesisSigner] deterministic
     pub fn create_deterministic_genesis_signer() -> Self {
         let rng = ChaCha20Rng::from_seed([0u8; 32]);
         Self::create_test_genesis_signer(rng)
     }
 
-    /// ProtocolGenesisSigner non deterministic
+    /// [ProtocolGenesisSigner] non deterministic
     pub fn create_non_deterministic_genesis_signer() -> Self {
         let rng = rand_core::OsRng;
         Self::create_test_genesis_signer(rng)
     }
 
-    /// ProtocolGenesisSigner from ProtocolGenesisSecretKey
+    /// [ProtocolGenesisSigner] from [ProtocolGenesisSecretKey]
     pub fn from_secret_key(secret_key: ProtocolGenesisSecretKey) -> Self {
         Self { secret_key }
     }
 
-    /// Create a ProtocolGenesisVerifier
+    /// Create a [ProtocolGenesisVerifier]
     pub fn create_genesis_verifier(&self) -> ProtocolGenesisVerifier {
         ProtocolGenesisVerifier::from_verification_key(self.secret_key.verifying_key().into())
     }
 
-    /// Signs a message and returns a ProtocolGenesisSignature
+    /// Signs a message and returns a [ProtocolGenesisSignature]
     pub fn sign(&self, message: &[u8]) -> ProtocolGenesisSignature {
         self.secret_key.sign(message).into()
     }
@@ -79,12 +79,12 @@ pub struct ProtocolGenesisVerifier {
 }
 
 impl ProtocolGenesisVerifier {
-    /// ProtocolGenesisVerifier from ProtocolGenesisVerificationKey
+    /// [ProtocolGenesisVerifier] from [ProtocolGenesisVerificationKey]
     pub fn from_verification_key(verification_key: ProtocolGenesisVerificationKey) -> Self {
         Self { verification_key }
     }
 
-    /// ProtocolGenesisVerifier to ProtocolGenesisVerificationKey
+    /// [ProtocolGenesisVerifier] to [ProtocolGenesisVerificationKey]
     pub fn to_verification_key(&self) -> ProtocolGenesisVerificationKey {
         self.verification_key
     }

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -26,13 +26,13 @@ pub type ProtocolGenesisSignature = ProtocolKey<ed25519_dalek::Signature>;
 /// Wrapper of [OpCert] to add serialization utilities.
 pub type ProtocolOpCert = ProtocolKey<OpCert>;
 
-/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.VerifyingKey.html).
+/// Wrapper of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.VerifyingKey.html).
 pub type ProtocolGenesisVerificationKey = ProtocolKey<ed25519_dalek::VerifyingKey>;
 
-/// Alias of [Ed25519:SigningKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html).
+/// Wrapper of [Ed25519:SigningKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html).
 pub type ProtocolGenesisSecretKey = ProtocolKey<ed25519_dalek::SigningKey>;
 
-/// Alias of [MithrilStm:StmAggrVerificationKey](struct@mithril_stm::stm::StmAggrVerificationKey).
+/// Wrapper of [MithrilStm:StmAggrVerificationKey](struct@StmAggrVerificationKey).
 pub type ProtocolAggregateVerificationKey = ProtocolKey<StmAggrVerificationKey<D>>;
 
 impl ProtocolGenesisSignature {

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -26,11 +26,11 @@ pub type ProtocolGenesisSignature = ProtocolKey<ed25519_dalek::Signature>;
 /// Wrapper of [OpCert] to add serialization utilities.
 pub type ProtocolOpCert = ProtocolKey<OpCert>;
 
-/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.PublicKey.html).
-pub type ProtocolGenesisVerificationKey = ProtocolKey<ed25519_dalek::PublicKey>;
+/// Alias of [Ed25519:PublicKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.VerifyingKey.html).
+pub type ProtocolGenesisVerificationKey = ProtocolKey<ed25519_dalek::VerifyingKey>;
 
-/// Alias of [Ed25519:SecretKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SecretKey.html).
-pub type ProtocolGenesisSecretKey = ProtocolKey<ed25519_dalek::SecretKey>;
+/// Alias of [Ed25519:SigningKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html).
+pub type ProtocolGenesisSecretKey = ProtocolKey<ed25519_dalek::SigningKey>;
 
 /// Alias of [MithrilStm:StmAggrVerificationKey](struct@mithril_stm::stm::StmAggrVerificationKey).
 pub type ProtocolAggregateVerificationKey = ProtocolKey<StmAggrVerificationKey<D>>;
@@ -48,7 +48,7 @@ impl ProtocolGenesisSignature {
 
     /// Create an instance from a bytes representation
     pub fn from_bytes(bytes: &[u8]) -> StdResult<Self> {
-        let key = ed25519_dalek::Signature::from_bytes(bytes).with_context(|| {
+        let key = ed25519_dalek::Signature::from_slice(bytes).with_context(|| {
             "Could not deserialize a ProtocolGenesisSignature from bytes hex string:\
             invalid bytes"
                 .to_string()
@@ -80,6 +80,6 @@ impl ProtocolKeyCodec<ed25519_dalek::Signature> for ed25519_dalek::Signature {
 
 impl_codec_and_type_conversions_for_protocol_key!(
     json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert,
-        ed25519_dalek::PublicKey, ed25519_dalek::SecretKey, StmAggrVerificationKey<D>
+        ed25519_dalek::VerifyingKey, ed25519_dalek::SigningKey, StmAggrVerificationKey<D>
 );
 impl_codec_and_type_conversions_for_protocol_key!(no_default_codec => ed25519_dalek::Signature);


### PR DESCRIPTION
## Content
This PR upgrades Mithril common `ed25519-dalek` dependency from version `1.0.1` to `2.0.0`, adapting to the new api where needed.

This will solve the following dependabot issue: https://github.com/input-output-hk/mithril/security/dependabot/55

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Should we rename types to match their updated wrapped inner type ? ie:  `ProtocolGenesisSecretKey` refer to a `ProtocolKey<ed25519_dalek::SigningKey>` and could be renamed to `ProtocolGenesisSigningKey`.

## Issue(s)
Closes #1155 