### PR TITLE
#948 add get_version in chain observer

### DIFF
--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -46,6 +46,9 @@ pub struct Configuration {
     /// Cardano CLI tool path
     pub cardano_cli_path: PathBuf,
 
+    /// Cardano node binary path
+    pub cardano_node_path: PathBuf,
+
     /// Path of the socket used by the Cardano CLI tool
     /// to communicate with the Cardano node
     pub cardano_node_socket_path: PathBuf,
@@ -127,6 +130,7 @@ impl Configuration {
         Self {
             environment: ExecutionEnvironment::Test,
             cardano_cli_path: PathBuf::new(),
+            cardano_node_path: PathBuf::new(),
             cardano_node_socket_path: PathBuf::new(),
             network_magic: Some(42),
             network: "devnet".to_string(),

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -462,6 +462,7 @@ impl DependenciesBuilder {
     async fn build_cardano_cli_runner(&mut self) -> Result<Box<CardanoCliRunner>> {
         let cli_runner = CardanoCliRunner::new(
             self.configuration.cardano_cli_path.clone(),
+            self.configuration.cardano_node_path.clone(),
             self.configuration.cardano_node_socket_path.clone(),
             self.configuration.get_network()?,
         );

--- a/mithril-signer/src/aggregator_client.rs
+++ b/mithril-signer/src/aggregator_client.rs
@@ -412,6 +412,7 @@ mod tests {
         let server = MockServer::start();
         let config = Configuration {
             cardano_cli_path: PathBuf::new().join("cardano-cli"),
+            cardano_node_path: PathBuf::new().join("cardano-node"),
             cardano_node_socket_path: PathBuf::new().join("whatever"),
             network_magic: Some(42),
             network: "testnet".to_string(),

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -20,6 +20,9 @@ pub struct Configuration {
     /// Cardano CLI tool path
     pub cardano_cli_path: PathBuf,
 
+    /// Cardano node binary path
+    pub cardano_node_path: PathBuf,
+
     /// Path of the socket used by the Cardano CLI tool
     /// to communicate with the Cardano node
     pub cardano_node_socket_path: PathBuf,

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -553,6 +553,7 @@ mod tests {
             aggregator_endpoint: "http://0.0.0.0:3000".to_string(),
             relay_endpoint: None,
             cardano_cli_path: PathBuf::new(),
+            cardano_node_path: PathBuf::new(),
             cardano_node_socket_path: PathBuf::new(),
             db_directory: PathBuf::new(),
             network: "whatever".to_string(),

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -60,6 +60,7 @@ impl<'a> ProductionServiceBuilder<'a> {
                 Ok(Arc::new(CardanoCliChainObserver::new(Box::new(
                     CardanoCliRunner::new(
                         config.cardano_cli_path.clone(),
+                        config.cardano_node_path.clone(),
                         config.cardano_node_socket_path.clone(),
                         config.get_network()?,
                     ),
@@ -322,6 +323,7 @@ mod tests {
         let stores_dir = get_test_dir().join("stores");
         let config = Configuration {
             cardano_cli_path: PathBuf::new(),
+            cardano_node_path: PathBuf::new(),
             cardano_node_socket_path: PathBuf::new(),
             network_magic: None,
             network: "preview".to_string(),

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -80,6 +80,7 @@ impl StateMachineTester {
             aggregator_endpoint: "http://0.0.0.0:8000".to_string(),
             relay_endpoint: None,
             cardano_cli_path: PathBuf::new(),
+            cardano_node_path: PathBuf::new(),
             cardano_node_socket_path: PathBuf::new(),
             db_directory: PathBuf::new(),
             network: "devnet".to_string(),

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -127,6 +127,10 @@ impl Devnet {
         self.artifacts_dir.join("cardano-cli")
     }
 
+    pub fn cardano_node_path(&self) -> PathBuf {
+        self.artifacts_dir.join("cardano-node")
+    }
+
     pub fn topology(&self) -> DevnetTopology {
         let bft_nodes = (1..=self.number_of_bft_nodes)
             .map(|n| BftNode {

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -71,6 +71,7 @@ impl MithrilInfrastructure {
         let cardano_chain_observer = Arc::new(CardanoCliChainObserver::new(Box::new(
             CardanoCliRunner::new(
                 devnet.cardano_cli_path(),
+                devnet.cardano_node_path(),
                 bft_node.socket_path.clone(),
                 CardanoNetwork::DevNet(DEVNET_MAGIC_ID),
             ),


### PR DESCRIPTION
## Content
This PR includes a Cardano node version command reader to get node's version.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Relates to #948 
