### PR TITLE
Fix disk space warning not displayed in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2164,7 +2164,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.37"
+version = "0.3.38"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.37"
+version = "0.3.38"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a fix that prevented the display of the warning message when the available space on the disk might not be sufficient. The message was displayed only if verbose output (`-v`) was specified.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1160 
