### PR TITLE
Add anyhow context for api_version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.101"
+version = "0.2.102"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.101"
+version = "0.2.102"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes an update of `api_version` error handling.

`compute_current_version` errors are now return with a `anyhow` context.

`APIVersionProviderError` was removed as it's no longer used.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Relates to #798 
