### PR TITLE
display cardano node version in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.41"
+version = "0.3.42"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.41"
+version = "0.3.42"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/commands/snapshot/show.rs
+++ b/mithril-client/src/commands/snapshot/show.rs
@@ -55,6 +55,14 @@ fn convert_to_field_items(snapshot_message: &SnapshotMessage) -> Vec<SnapshotFie
         ),
         SnapshotFieldItem::new("Digest".to_string(), snapshot_message.digest.to_string()),
         SnapshotFieldItem::new("Size".to_string(), format!("{}", snapshot_message.size)),
+        SnapshotFieldItem::new(
+            "Cardano node version".to_string(),
+            snapshot_message
+                .cardano_node_version
+                .as_ref()
+                .unwrap_or(&"NA".to_string())
+                .to_string(),
+        ),
     ];
     for (idx, location) in snapshot_message.locations.iter().enumerate() {
         field_items.push(SnapshotFieldItem::new(


### PR DESCRIPTION
## Content
This PR makes the Mithril Client to display the Cardano node version used to produced the given snapshot.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [X] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
None

## Issue(s)
Relates to #948 
