### PR TITLE
Implement anyhow context for adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2216,7 +2216,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.83"
+version = "0.3.84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.43"
+version = "0.3.44"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.106"
+version = "0.2.107"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2364,7 +2364,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.74"
+version = "0.2.75"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.83"
+version = "0.3.84"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/message_adapters/from_register_signature.rs
+++ b/mithril-aggregator/src/message_adapters/from_register_signature.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use mithril_common::{
     entities::SingleSignatures,
     messages::{RegisterSignatureMessage, TryFromMessageAdapter},
@@ -14,7 +15,12 @@ impl TryFromMessageAdapter<RegisterSignatureMessage, SingleSignatures>
     ) -> StdResult<SingleSignatures> {
         let signatures = SingleSignatures {
             party_id: register_single_signature_message.party_id,
-            signature: register_single_signature_message.signature.try_into()?,
+            signature: register_single_signature_message
+                .signature
+                .try_into()
+                .with_context(|| {
+                    "'FromRegisterSingleSignatureAdapter' can not convert the single signature"
+                })?,
             won_indexes: register_single_signature_message.won_indexes,
         };
 

--- a/mithril-aggregator/src/message_adapters/from_register_signer.rs
+++ b/mithril-aggregator/src/message_adapters/from_register_signer.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use mithril_common::{
     entities::Signer,
     messages::{RegisterSignerMessage, TryFromMessageAdapter},
@@ -12,13 +13,26 @@ impl TryFromMessageAdapter<RegisterSignerMessage, Signer> for FromRegisterSigner
     fn try_adapt(register_signer_message: RegisterSignerMessage) -> StdResult<Signer> {
         Ok(Signer {
             party_id: register_signer_message.party_id,
-            verification_key: register_signer_message.verification_key.try_into()?,
+            verification_key: register_signer_message
+                .verification_key
+                .try_into()
+                .with_context(|| {
+                    "'FromRegisterSignerAdapter' can not convert the verification key"
+                })?,
             verification_key_signature: match register_signer_message.verification_key_signature {
-                Some(verification_key_signature) => Some(verification_key_signature.try_into()?),
+                Some(verification_key_signature) => {
+                    Some(verification_key_signature.try_into().with_context(|| {
+                        "'FromRegisterSignerAdapter' can not convert the verification key signature"
+                    })?)
+                }
                 _ => None,
             },
             operational_certificate: match register_signer_message.operational_certificate {
-                Some(operational_certificate) => Some(operational_certificate.try_into()?),
+                Some(operational_certificate) => {
+                    Some(operational_certificate.try_into().with_context(|| {
+                        "'FromRegisterSignerAdapter' can not convert the operational certificate"
+                    })?)
+                }
                 _ => None,
             },
             kes_period: register_signer_message.kes_period,

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.43"
+version = "0.3.44"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/message_adapters/from_mithril_stake_distribution_message.rs
+++ b/mithril-client/src/message_adapters/from_mithril_stake_distribution_message.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use mithril_common::{
     entities::{MithrilStakeDistribution, SignedEntity, SignedEntityType},
     messages::{
@@ -18,7 +19,10 @@ impl TryFromMessageAdapter<MithrilStakeDistributionMessage, SignedEntity<Mithril
             epoch: from.epoch,
             signers_with_stake: SignerWithStakeMessagePart::try_into_signers(
                 from.signers_with_stake,
-            )?,
+            )
+            .with_context(|| {
+                "'FromMithrilStakeDistributionMessageAdapter' can not convert the list of signers"
+            })?,
             hash: from.hash,
             protocol_parameters: from.protocol_parameters,
         };

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.106"
+version = "0.2.107"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/messages/interface.rs
+++ b/mithril-common/src/messages/interface.rs
@@ -22,3 +22,9 @@ where
     /// Adapt message to entity
     fn adapt(from: U) -> V;
 }
+
+/// TryTo message adapter trait
+pub trait TryToMessageAdapter<U, V> {
+    /// Adapt message to entity
+    fn try_adapt(from: U) -> StdResult<V>;
+}

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.74"
+version = "0.2.75"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/message_adapters/to_register_signer_message.rs
+++ b/mithril-signer/src/message_adapters/to_register_signer_message.rs
@@ -1,26 +1,46 @@
+use anyhow::Context;
 use mithril_common::{
     entities::{Epoch, Signer},
-    messages::{RegisterSignerMessage, ToMessageAdapter},
+    messages::{RegisterSignerMessage, TryToMessageAdapter},
+    StdResult,
 };
 
 /// Adapter to create [RegisterSignerMessage] from [Signer] instance.
 pub struct ToRegisterSignerMessageAdapter;
 
-impl ToMessageAdapter<(Epoch, Signer), RegisterSignerMessage> for ToRegisterSignerMessageAdapter {
+impl TryToMessageAdapter<(Epoch, Signer), RegisterSignerMessage>
+    for ToRegisterSignerMessageAdapter
+{
     /// Method to trigger the conversion.
-    fn adapt((epoch, signer): (Epoch, Signer)) -> RegisterSignerMessage {
-        RegisterSignerMessage {
+    fn try_adapt((epoch, signer): (Epoch, Signer)) -> StdResult<RegisterSignerMessage> {
+        let message = RegisterSignerMessage {
             epoch: Some(epoch),
             party_id: signer.party_id,
-            verification_key: signer.verification_key.try_into().unwrap(),
-            verification_key_signature: signer
-                .verification_key_signature
-                .map(|k| k.try_into().unwrap()),
-            operational_certificate: signer
-                .operational_certificate
-                .map(|o| o.try_into().unwrap()),
+            verification_key: signer.verification_key.try_into().with_context(|| {
+                format!(
+                    "'ToRegisterSignerMessageAdapter' can not convert the verification key: '{:?}'",
+                    signer.verification_key
+                )
+            })?,
+            verification_key_signature: match signer.verification_key_signature {
+                Some(k) => Some(k.try_into().with_context(|| {
+                    format!(
+                        "'ToRegisterSignerMessageAdapter' can not convert the verification key signature: '{:?}'",
+                        signer.verification_key_signature
+                    )
+                })?),
+                None => None,
+            },
+            operational_certificate: match signer.operational_certificate {
+                Some(o) => Some(o.try_into().with_context(|| {
+                    "'ToRegisterSignerMessageAdapter' can not convert the operational certificate"
+                })?),
+                None => None,
+            },
             kes_period: signer.kes_period,
-        }
+        };
+
+        Ok(message)
     }
 }
 
@@ -35,7 +55,7 @@ mod tests {
         let epoch = Epoch(1);
         let mut signer = fake_data::signers(1)[0].to_owned();
         signer.party_id = "0".to_string();
-        let message = ToRegisterSignerMessageAdapter::adapt((epoch, signer));
+        let message = ToRegisterSignerMessageAdapter::try_adapt((epoch, signer)).unwrap();
 
         assert_eq!("0".to_string(), message.party_id);
     }


### PR DESCRIPTION
## Content
This PR includes an update of `adapters` modules in order to implement `anyhow` context.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
- At the moment, `AggregatorClientError::Adapter` has been added to return the context of adapters errors. This was done to avoid modifying the Signer initial error handling.
- Message adapters in the Aggregator side have not been modified as this requires more in-depth work. HTTP routes currently return `Infallible`.

## Issue(s)
Relates to #798 
