### PR TITLE
Upgrade client version to `0.4.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.3.45"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.3.45"
+version = "0.4.0"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes an upgrade of the client version to `0.4.0`. This makes clear that the previous version is no more fully compatible with the aggregator running the new `zstandard` compression format.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1219 
