### PR TITLE
Implement anyhow context in aggregator/signer_register

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.97"
+version = "0.3.98"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.97"
+version = "0.3.98"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -135,13 +135,6 @@ mod handlers {
                 );
                 Ok(reply::empty(StatusCode::CREATED))
             }
-            Err(SignerRegistrationError::Codec(err)) => {
-                warn!("register_signer::failed_signer_decoding"; "error" => ?err);
-                Ok(reply::bad_request(
-                    "failed_signer_decoding".to_string(),
-                    err,
-                ))
-            }
             Err(SignerRegistrationError::FailedSignerRegistration(err)) => {
                 warn!("register_signer::failed_signer_registration"; "error" => ?err);
                 Ok(reply::bad_request(
@@ -312,9 +305,9 @@ mod tests {
         mock_signer_registerer
             .expect_register_signer()
             .return_once(|_, _| {
-                Err(SignerRegistrationError::FailedSignerRegistration(
-                    ProtocolRegistrationError::OpCertInvalid,
-                ))
+                Err(SignerRegistrationError::FailedSignerRegistration(anyhow!(
+                    ProtocolRegistrationError::OpCertInvalid
+                )))
             });
         mock_signer_registerer
             .expect_get_current_round()

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -332,7 +332,6 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .signer_registration_round_opener
             .open_registration_round(registration_epoch, stakes)
             .await
-            .map_err(|e| e.into())
     }
 
     async fn close_signer_registration_round(&self) -> StdResult<()> {
@@ -342,7 +341,6 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .signer_registration_round_opener
             .close_registration_round()
             .await
-            .map_err(|e| e.into())
     }
 
     async fn update_protocol_parameters_in_multisigner(


### PR DESCRIPTION
## Content
This PR includes an update of mithril-aggregator `signer_register` with `anyhow` context.

`VerificationKeyStorer::Codec` has been removed as it is not used.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #798