### PR TITLE
Get rid of string error comparison in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.101"
+version = "0.3.103"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.118"
+version = "0.2.119"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2331,7 +2331,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.102"
+version = "0.3.103"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -78,7 +78,6 @@ impl MultiSigner {
                 &avk,
                 message.compute_hash().as_bytes(),
             )
-            .map_err(|e| anyhow!(e))
             .with_context(|| {
                 format!(
                     "Invalid signature for party: '{}'",
@@ -92,6 +91,8 @@ impl MultiSigner {
 
 #[cfg(test)]
 mod test {
+    use mithril_stm::StmSignatureError;
+
     use crate::{
         entities::{ProtocolMessagePartKey, ProtocolParameters},
         protocol::SignerBuilder,
@@ -192,11 +193,10 @@ mod test {
                 "Verify single signature should fail if the signer isn't in the registered parties",
             );
 
-        assert!(
-            error.to_string().contains("Invalid signature for party"),
-            "Expected invalid signature of party error, got: {error}, cause: {}",
-            error.root_cause()
-        )
+        match error.downcast_ref::<StmSignatureError>() {
+            Some(StmSignatureError::SignatureInvalid(_)) => (),
+            _ => panic!("Expected an SignatureInvalid error, got: {error:?}"),
+        }
     }
 
     #[test]
@@ -219,11 +219,10 @@ mod test {
             .verify_single_signature(&ProtocolMessage::default(), &single_signature)
             .expect_err("Verify single signature should fail");
 
-        assert!(
-            error.to_string().contains("Invalid signature for party"),
-            "Expected invalid signature of party error, got: {error}, cause: {}",
-            error.root_cause()
-        )
+        match error.downcast_ref::<StmSignatureError>() {
+            Some(StmSignatureError::SignatureInvalid(_)) => (),
+            _ => panic!("Expected an SignatureInvalid error, got: {error:?}"),
+        }
     }
 
     #[test]

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.3"
+version = "0.3.4"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/src/error.rs
+++ b/mithril-stm/src/error.rs
@@ -78,8 +78,9 @@ pub enum StmAggregateSignatureError<D: Digest + FixedOutput> {
     #[error("Batch verification of STM aggregate signatures failed")]
     BatchInvalid,
 
+    /// `CoreVerifier` check failed
     #[error("Core verification error: {0}")]
-    CoreVerificationError(CoreVerifierError),
+    CoreVerificationError(#[source] CoreVerifierError),
 }
 
 /// Errors which can be output by `CoreVerifier`.
@@ -99,7 +100,7 @@ pub enum CoreVerifierError {
 
     /// One of the aggregated signatures is invalid
     #[error("Individual signature is invalid: {0}")]
-    IndividualSignatureInvalid(StmSignatureError),
+    IndividualSignatureInvalid(#[source] StmSignatureError),
 }
 
 /// Error types for aggregation.

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -10,7 +10,10 @@ pub mod key_reg;
 mod merkle_tree;
 pub mod stm;
 
-pub use crate::error::{AggregationError, CoreVerifierError, RegisterError};
+pub use crate::error::{
+    AggregationError, CoreVerifierError, RegisterError, StmAggregateSignatureError,
+    StmSignatureError,
+};
 
 #[cfg(feature = "benchmark-internals")]
 pub mod multi_sig;


### PR DESCRIPTION
## Content
This PR includes an update of `multi_signer` and `signer_builder` in aggregator.

`error.to_string().contains()` were removed from tests and replaced by asserts on existing error types.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #798
