### PR TITLE
Add anyhow in integration & e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.103"
+version = "0.3.104"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.119"
+version = "0.2.120"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.2.15"
+version = "0.2.16"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.103"
+version = "0.3.104"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -160,10 +160,8 @@ async fn certificate_chain() {
         "Checking that no signers are registered for the next epoch since they did not register"
     );
     let next_epoch_verification_keys = tester
-        .deps_builder
-        .get_verification_key_store()
-        .await
-        .unwrap()
+        .dependencies
+        .verification_key_store
         .get_verification_keys(new_epoch + 1)
         .await
         .expect("get_verification_keys should not fail");

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.119"
+version = "0.2.120"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/digesters/immutable_file_observer.rs
+++ b/mithril-common/src/digesters/immutable_file_observer.rs
@@ -95,9 +95,9 @@ impl DumbImmutableFileObserver {
     pub async fn increase(&self) -> StdResult<u64> {
         let new_number = self
             .shall_return
-            .read()
+            .write()
             .await
-            .unwrap() // I do not understand why ok_or_else does not work here, TODO: fix this
+            .ok_or_else(|| anyhow!(ImmutableFileObserverError::Missing()))?
             .add(1);
         self.shall_return(Some(new_number)).await;
 

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.2.15"
+version = "0.2.16"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
@@ -1,8 +1,9 @@
 use crate::{Aggregator, Devnet};
 use mithril_common::entities::ProtocolParameters;
+use mithril_common::StdResult;
 use slog_scope::info;
 
-pub async fn bootstrap_genesis_certificate(aggregator: &mut Aggregator) -> Result<(), String> {
+pub async fn bootstrap_genesis_certificate(aggregator: &mut Aggregator) -> StdResult<()> {
     info!("Bootstrap genesis certificate");
 
     info!("> stopping aggregator");
@@ -15,7 +16,7 @@ pub async fn bootstrap_genesis_certificate(aggregator: &mut Aggregator) -> Resul
     Ok(())
 }
 
-pub async fn delegate_stakes_to_pools(devnet: &Devnet) -> Result<(), String> {
+pub async fn delegate_stakes_to_pools(devnet: &Devnet) -> StdResult<()> {
     info!("Delegate stakes to the cardano pools");
 
     devnet.delegate_stakes().await?;
@@ -23,7 +24,7 @@ pub async fn delegate_stakes_to_pools(devnet: &Devnet) -> Result<(), String> {
     Ok(())
 }
 
-pub async fn update_protocol_parameters(aggregator: &mut Aggregator) -> Result<(), String> {
+pub async fn update_protocol_parameters(aggregator: &mut Aggregator) -> StdResult<()> {
     info!("Update protocol parameters");
 
     info!("> stopping aggregator");

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -1,7 +1,7 @@
 use crate::assertions;
 use crate::MithrilInfrastructure;
 use mithril_common::chain_observer::ChainObserver;
-use std::error::Error;
+use mithril_common::StdResult;
 
 pub struct Spec<'a> {
     pub infrastructure: &'a mut MithrilInfrastructure,
@@ -12,7 +12,7 @@ impl<'a> Spec<'a> {
         Self { infrastructure }
     }
 
-    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
+    pub async fn run(&mut self) -> StdResult<()> {
         let aggregator_endpoint = self.infrastructure.aggregator().endpoint();
         assertions::wait_for_enough_immutable(self.infrastructure.aggregator().db_directory())
             .await?;

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
+use mithril_common::StdResult;
 use mithril_end_to_end::{Devnet, MithrilInfrastructure, RunOnly, Spec};
 use slog::{Drain, Logger};
 use slog_scope::{error, info};
 use std::{
-    error::Error,
     fs,
     path::{Path, PathBuf},
     sync::Arc,
@@ -64,7 +64,7 @@ pub struct Args {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn Error>> {
+async fn main() -> StdResult<()> {
     let args = Args::parse();
     let _guard = slog_scope::set_global_logger(build_logger());
     let server_port = 8080;
@@ -102,7 +102,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    let runner: Result<(), Box<dyn Error>> = match run_only_mode {
+    let runner: StdResult<()> = match run_only_mode {
         true => {
             let mut run_only = RunOnly::new(&mut infrastructure);
             run_only.start().await
@@ -129,7 +129,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 }
 
-async fn run_until_cancelled(devnet: Devnet) -> Result<(), Box<dyn Error>> {
+async fn run_until_cancelled(devnet: Devnet) -> StdResult<()> {
     let cancellation_token = CancellationToken::new();
     let cloned_token = cancellation_token.clone();
 

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
@@ -2,6 +2,7 @@ use crate::devnet::PoolNode;
 use crate::utils::MithrilCommand;
 use crate::DEVNET_MAGIC_ID;
 use mithril_common::entities::PartyId;
+use mithril_common::StdResult;
 use std::collections::HashMap;
 use std::path::Path;
 use tokio::process::Child;
@@ -22,7 +23,7 @@ impl Signer {
         bin_dir: &Path,
         mithril_era: &str,
         enable_certification: bool,
-    ) -> Result<Self, String> {
+    ) -> StdResult<Self> {
         let party_id = pool_node.party_id()?;
         let magic_id = DEVNET_MAGIC_ID.to_string();
         let data_stores_path = format!("./stores/signer-{party_id}");
@@ -67,12 +68,12 @@ impl Signer {
         })
     }
 
-    pub fn start(&mut self) -> Result<(), String> {
+    pub fn start(&mut self) -> StdResult<()> {
         self.process = Some(self.command.start(&[])?);
         Ok(())
     }
 
-    pub async fn tail_logs(&self, number_of_line: u64) -> Result<(), String> {
+    pub async fn tail_logs(&self, number_of_line: u64) -> StdResult<()> {
         self.command
             .tail_logs(
                 Some(format!("mithril-signer-{}", self.party_id).as_str()),

--- a/mithril-test-lab/mithril-end-to-end/src/run_only.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/run_only.rs
@@ -1,7 +1,7 @@
 use crate::assertions;
 use crate::MithrilInfrastructure;
 use mithril_common::chain_observer::ChainObserver;
-use std::error::Error;
+use mithril_common::StdResult;
 
 pub struct RunOnly<'a> {
     pub infrastructure: &'a mut MithrilInfrastructure,
@@ -12,7 +12,7 @@ impl<'a> RunOnly<'a> {
         Self { infrastructure }
     }
 
-    pub async fn start(&mut self) -> Result<(), Box<dyn Error>> {
+    pub async fn start(&mut self) -> StdResult<()> {
         let aggregator_endpoint = self.infrastructure.aggregator().endpoint();
         assertions::wait_for_enough_immutable(self.infrastructure.aggregator().db_directory())
             .await?;

--- a/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+use mithril_common::StdResult;
 use std::path::Path;
 use tokio::process::Command;
 
@@ -5,7 +7,7 @@ use tokio::process::Command;
 ///
 /// For the sake of simplicity it use internally the tail command so be sure to have it on
 /// your system.
-pub async fn tail(file_path: &Path, number_of_line: u64) -> Result<String, String> {
+pub async fn tail(file_path: &Path, number_of_line: u64) -> StdResult<String> {
     let tail_result = Command::new("tail")
         .args(vec![
             "-n",
@@ -15,10 +17,9 @@ pub async fn tail(file_path: &Path, number_of_line: u64) -> Result<String, Strin
         .kill_on_drop(true)
         .output()
         .await
-        .map_err(|e| format!("Failed to tail file `{}`: {}", file_path.display(), e))?;
+        .with_context(|| format!("Failed to tail file `{}`", file_path.display()))?;
 
-    String::from_utf8(tail_result.stdout)
-        .map_err(|e| format!("Failed to parse tail output to utf8: {e}"))
+    String::from_utf8(tail_result.stdout).with_context(|| "Failed to parse tail output to utf8")
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Content

This PR upgrades aggregator integration tests & the end-to-end crate to use `anyhow` result & error.

Note: there was nothing to do for `mithril-signer` integration tests

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
This PR also simplify the aggregator integration tests by building all dependencies before start, removing the need to call the deps builder everytime one is needed (which need error handling).

## Issue(s)
Relates to #798
