### PR TITLE
Use source attribute in wrapped errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.104"
+version = "0.3.105"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2194,7 +2194,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.120"
+version = "0.2.121"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.83"
+version = "0.2.84"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.104"
+version = "0.3.105"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -343,7 +343,7 @@ mod tests {
         mock_signer_registerer
             .expect_register_signer()
             .return_once(|_, _| {
-                Err(SignerRegistrationError::ChainObserver(
+                Err(SignerRegistrationError::FailedSignerRecorder(
                     "an error occurred".to_string(),
                 ))
             });

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -25,47 +25,47 @@ use mockall::automock;
 pub enum ProtocolError {
     /// Signer is already registered.
     #[error("signer already registered")]
-    ExistingSigner(),
+    ExistingSigner,
 
     /// Signer was not registered.
     #[error("signer did not register")]
-    UnregisteredParty(),
+    UnregisteredParty,
 
     /// Signer registration failed.
     #[error("signer registration failed")]
-    FailedSignerRegistration(StdError),
+    FailedSignerRegistration(#[source] StdError),
 
     /// Single signature already recorded.
     #[error("single signature already recorded")]
     ExistingSingleSignature(entities::PartyId),
 
     /// Mithril STM library returned an error.
-    #[error("core error: '{0}'")]
-    Core(StdError),
+    #[error("core error")]
+    Core(#[source] StdError),
 
     /// No message available.
     #[error("no message available")]
-    UnavailableMessage(),
+    UnavailableMessage,
 
     /// No protocol parameters available.
     #[error("no protocol parameters available")]
-    UnavailableProtocolParameters(),
+    UnavailableProtocolParameters,
 
     /// No clerk available.
     #[error("no clerk available")]
-    UnavailableClerk(),
+    UnavailableClerk,
 
     /// No beacon available.
     #[error("no beacon available")]
-    UnavailableBeacon(),
+    UnavailableBeacon,
 
     /// Store error.
-    #[error("store error: {0}")]
-    StoreError(StdError),
+    #[error("store error")]
+    StoreError(#[source] StdError),
 
     /// Beacon error.
-    #[error("beacon error: '{0}'")]
-    Beacon(StdError),
+    #[error("beacon error")]
+    Beacon(#[source] StdError),
 }
 
 /// MultiSigner is the cryptographic engine in charge of producing multi signatures from individual signatures
@@ -124,7 +124,7 @@ pub trait MultiSigner: Sync + Send {
         let protocol_parameters = self
             .get_protocol_parameters()
             .await?
-            .ok_or_else(ProtocolError::UnavailableProtocolParameters)?;
+            .ok_or(ProtocolError::UnavailableProtocolParameters)?;
         Ok(self
             .compute_aggregate_verification_key(&signers_with_stake, &protocol_parameters)
             .await?)
@@ -138,7 +138,7 @@ pub trait MultiSigner: Sync + Send {
         let protocol_parameters = self
             .get_next_protocol_parameters()
             .await?
-            .ok_or_else(ProtocolError::UnavailableProtocolParameters)?;
+            .ok_or(ProtocolError::UnavailableProtocolParameters)?;
         Ok(self
             .compute_aggregate_verification_key(&next_signers_with_stake, &protocol_parameters)
             .await?)
@@ -285,7 +285,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch
             .offset_to_signer_retrieval_epoch()
             .with_context(|| "Multi Signer can not offset to signer retrieveal epoch while retrivieving protocol parameters")
@@ -302,7 +302,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch
             .offset_to_protocol_parameters_recording_epoch();
 
@@ -322,7 +322,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch
             .offset_to_next_signer_retrieval_epoch();
         self.get_protocol_parameters_at_epoch(epoch).await
@@ -334,7 +334,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch
             .offset_to_signer_retrieval_epoch()
             .with_context(|| "Multi Signer can not offset to signer retrieveal epoch while retrieving stake distribution")
@@ -350,7 +350,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch
             .offset_to_next_signer_retrieval_epoch();
         self.get_stake_distribution_at_epoch(epoch).await
@@ -365,7 +365,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch
             .offset_to_recording_epoch();
         let stakes = StakeDistribution::from_iter(stakes.iter().cloned());
@@ -397,7 +397,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch;
         let epoch = epoch
             .offset_to_signer_retrieval_epoch()
@@ -439,7 +439,7 @@ impl MultiSigner for MultiSignerImpl {
         let epoch = self
             .current_beacon
             .as_ref()
-            .ok_or_else(ProtocolError::UnavailableBeacon)?
+            .ok_or(ProtocolError::UnavailableBeacon)?
             .epoch
             .offset_to_next_signer_retrieval_epoch();
         let signers = self
@@ -486,7 +486,7 @@ impl MultiSigner for MultiSignerImpl {
         let protocol_parameters = self
             .get_protocol_parameters()
             .await?
-            .ok_or_else(ProtocolError::UnavailableProtocolParameters)?;
+            .ok_or(ProtocolError::UnavailableProtocolParameters)?;
 
         let signers_with_stakes = self.get_signers_with_stake().await?;
 
@@ -508,7 +508,7 @@ impl MultiSigner for MultiSignerImpl {
         let protocol_parameters = self
             .get_protocol_parameters()
             .await?
-            .ok_or_else(ProtocolError::UnavailableProtocolParameters)?;
+            .ok_or(ProtocolError::UnavailableProtocolParameters)?;
 
         let signers_with_stakes = self.get_signers_with_stake().await?;
 

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -7,31 +7,34 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum RuntimeError {
     /// Errors that need the runtime to try again without changing its state.
-    #[error("An error occured: {message}. This runtime cycle will be skipped. Nested error: {nested_error:#?}.")]
+    #[error("An error occured: {message}. This runtime cycle will be skipped.")]
     KeepState {
         /// error message
         message: String,
 
         /// Eventual caught error
+        #[source]
         nested_error: Option<StdError>,
     },
     /// A Critical error means the Runtime stops and the software exits with an
     /// error code.
-    #[error("Critical error:'{message}'. Nested error: {nested_error:#?}.")]
+    #[error("Critical error:'{message}'.")]
     Critical {
         /// error message
         message: String,
 
         /// Eventual caught error
+        #[source]
         nested_error: Option<StdError>,
     },
     /// An error that needs to re-initialize the state machine.
-    #[error("An error occured: {message}. The state machine will be re-initialized. Nested error: {nested_error:#?}")]
+    #[error("An error occured: {message}. The state machine will be re-initialized.")]
     ReInit {
         /// error message
         message: String,
 
         /// Eventual caught error
+        #[source]
         nested_error: Option<StdError>,
     },
 }

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -32,6 +32,7 @@ pub enum SignerRegistrationError {
         received_epoch: Epoch,
     },
 
+    // todo: wrap ChainObserverError instead
     /// Chain observer error.
     #[error("chain observer error: '{0}'")]
     ChainObserver(String),
@@ -41,12 +42,12 @@ pub enum SignerRegistrationError {
     ExistingSigner(Box<SignerWithStake>),
 
     /// Store error.
-    #[error("store error: {0}")]
-    StoreError(StdError),
+    #[error("store error")]
+    StoreError(#[source] StdError),
 
     /// Signer registration failed.
     #[error("signer registration failed")]
-    FailedSignerRegistration(StdError),
+    FailedSignerRegistration(#[source] StdError),
 
     /// Signer recorder failed.
     #[error("signer recorder failed: '{0}'")]

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -13,6 +13,7 @@ use mithril_common::{
 
 use crate::VerificationKeyStorer;
 
+use mithril_common::chain_observer::ChainObserverError;
 #[cfg(test)]
 use mockall::automock;
 
@@ -32,10 +33,9 @@ pub enum SignerRegistrationError {
         received_epoch: Epoch,
     },
 
-    // todo: wrap ChainObserverError instead
     /// Chain observer error.
-    #[error("chain observer error: '{0}'")]
-    ChainObserver(String),
+    #[error("chain observer error")]
+    ChainObserver(#[from] ChainObserverError),
 
     /// Signer is already registered.
     #[error("signer already registered")]
@@ -230,8 +230,7 @@ impl SignerRegisterer for MithrilSignerRegisterer {
             Some(operational_certificate) => Some(
                 self.chain_observer
                     .get_current_kes_period(operational_certificate)
-                    .await
-                    .map_err(|e| SignerRegistrationError::ChainObserver(e.to_string()))?
+                    .await?
                     .unwrap_or_default()
                     - operational_certificate.start_kes_period as KESPeriod,
             ),

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.4.7"
+version = "0.4.8"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client/http_client.rs
+++ b/mithril-client/src/aggregator_client/http_client.rs
@@ -22,20 +22,20 @@ use crate::utils::{DownloadProgressReporter, SnapshotUnpacker};
 #[derive(Error, Debug)]
 pub enum AggregatorHTTPClientError {
     /// Error raised when querying the aggregator returned a 5XX error.
-    #[error("remote server technical error: '{0}'")]
-    RemoteServerTechnical(StdError),
+    #[error("remote server technical error")]
+    RemoteServerTechnical(#[source] StdError),
 
     /// Error raised when querying the aggregator returned a 4XX error.
-    #[error("remote server logical error: '{0}'")]
-    RemoteServerLogical(StdError),
+    #[error("remote server logical error")]
+    RemoteServerLogical(#[source] StdError),
 
     /// Error raised when the server API version mismatch the client API version.
-    #[error("API version mismatch: {0}")]
-    ApiVersionMismatch(StdError),
+    #[error("API version mismatch")]
+    ApiVersionMismatch(#[source] StdError),
 
     /// HTTP subsystem error
-    #[error("HTTP subsystem error: {0}")]
-    SubsystemError(StdError),
+    #[error("HTTP subsystem error")]
+    SubsystemError(#[source] StdError),
 }
 
 /// API that defines a client for the Aggregator

--- a/mithril-client/src/services/mithril_stake_distribution.rs
+++ b/mithril-client/src/services/mithril_stake_distribution.rs
@@ -39,13 +39,14 @@ pub enum MithrilStakeDistributionServiceError {
     CertificateNotFound(String),
 
     /// The configuration has invalid or missing parameters
-    #[error("Missing or invalid parameters: {0:?}")]
-    InvalidParameters(StdError),
+    #[error("Missing or invalid parameters")]
+    InvalidParameters(#[source] StdError),
 
     /// Could not find the given stake distribution
     #[error("Could not find stake distribution associated to hash '{0}'.")]
     CouldNotFindStakeDistribution(String),
 }
+
 /// Definition of the service responsible of Mithril Stake Distribution.
 #[async_trait]
 pub trait MithrilStakeDistributionService {

--- a/mithril-client/src/utils/unpacker.rs
+++ b/mithril-client/src/utils/unpacker.rs
@@ -41,16 +41,17 @@ pub enum SnapshotUnpackerError {
     UnpackDirectoryAlreadyExists(PathBuf),
 
     /// Cannot write in the given directory.
-    #[error("Unpack directory '{0}' is not writable. (underlying error: « {1} »).")]
-    UnpackDirectoryIsNotWritable(PathBuf, StdError),
+    #[error("Unpack directory '{0}' is not writable.")]
+    UnpackDirectoryIsNotWritable(PathBuf, #[source] StdError),
 
     /// Unpacking error
-    #[error("Could not unpack from streamed data snapshot to directory '{dirpath}'. Error: « {error:?} ».")]
+    #[error("Could not unpack from streamed data snapshot to directory '{dirpath}'")]
     UnpackFailed {
         /// Location where the archive is to be extracted.
         dirpath: PathBuf,
 
         /// Subsystem error
+        #[source]
         error: StdError,
     },
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.120"
+version = "0.2.121"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_retriever.rs
+++ b/mithril-common/src/certificate_chain/certificate_retriever.rs
@@ -11,7 +11,7 @@ use mockall::automock;
 /// [CertificateRetriever] related errors.
 #[derive(Debug, Error)]
 #[error("Error when retrieving certificate")]
-pub struct CertificateRetrieverError(pub StdError);
+pub struct CertificateRetrieverError(#[source] pub StdError);
 
 /// CertificateRetriever is in charge of retrieving a [Certificate] given its hash
 #[cfg_attr(test, automock)]

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -28,7 +28,7 @@ pub enum CertificateVerifierError {
     VerifyMultiSignature(String),
 
     /// Error raised when the Genesis Signature stored in a [Certificate] is invalid.
-    #[error("certificate genesis error: '{0}'")]
+    #[error("certificate genesis error")]
     CertificateGenesis(#[from] ProtocolGenesisError),
 
     /// Error raised when the hash stored in a [Certificate] doesn't match a recomputed hash.

--- a/mithril-common/src/chain_observer/interface.rs
+++ b/mithril-common/src/chain_observer/interface.rs
@@ -13,12 +13,12 @@ use super::{ChainAddress, TxDatum};
 #[derive(Debug, Error)]
 pub enum ChainObserverError {
     /// Generic [ChainObserver] error.
-    #[error("general error {0:?}")]
-    General(StdError),
+    #[error("general error")]
+    General(#[source] StdError),
 
     /// Error raised when the content could not be parsed.
-    #[error("could not parse content: {0:?}")]
-    InvalidContent(StdError),
+    #[error("could not parse content")]
+    InvalidContent(#[source] StdError),
 }
 
 /// Retrieve data from the cardano network

--- a/mithril-common/src/chain_observer/model.rs
+++ b/mithril-common/src/chain_observer/model.rs
@@ -14,12 +14,12 @@ pub type ChainAddress = String;
 #[derive(Debug, Error)]
 pub enum TxDatumError {
     /// Error raised when the content could not be parsed.
-    #[error("could not parse tx datum: {0:?}")]
-    InvalidContent(StdError),
+    #[error("could not parse tx datum")]
+    InvalidContent(#[source] StdError),
 
     /// Error raised when building the tx datum failed.
-    #[error("could not build tx datum: {0}")]
-    Build(serde_json::Error),
+    #[error("could not build tx datum")]
+    Build(#[source] serde_json::Error),
 }
 
 /// [TxDatum] represents transaction Datum.

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -36,8 +36,8 @@ pub struct Sum6KesBytes(#[serde(with = "As::<Bytes>")] pub [u8; 612]);
 
 /// Parse error
 #[derive(Error, Debug)]
-#[error("Codec parse error: `{0:?}`")]
-pub struct CodecParseError(StdError);
+#[error("Codec parse error")]
+pub struct CodecParseError(#[source] StdError);
 
 /// Fields for a shelley formatted file (holds for vkeys, skeys or certs)
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/mithril-common/src/crypto_helper/era.rs
+++ b/mithril-common/src/crypto_helper/era.rs
@@ -21,8 +21,8 @@ pub type EraMarkersVerifierSignature = ProtocolKey<ed25519_dalek::Signature>;
 /// [EraMarkersSigner] and [EraMarkersVerifier] related errors.
 pub enum EraMarkersVerifierError {
     /// Error raised when a Signature verification fail
-    #[error("era markers signature verification error: '{0}'")]
-    SignatureVerification(StdError),
+    #[error("era markers signature verification error")]
+    SignatureVerification(#[source] StdError),
 }
 
 /// A cryptographic signer that is responsible for signing the EraMarkers

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -11,8 +11,8 @@ use super::{ProtocolGenesisSecretKey, ProtocolGenesisSignature, ProtocolGenesisV
 
 #[derive(Error, Debug)]
 /// [ProtocolGenesisSigner] and [ProtocolGenesisVerifier] related errors.
-#[error("genesis signature verification error: '{0}'")]
-pub struct ProtocolGenesisError(StdError);
+#[error("genesis signature verification error")]
+pub struct ProtocolGenesisError(#[source] StdError);
 
 /// A protocol Genesis Signer that is responsible for signing the
 /// [Genesis Certificate](https://mithril.network/doc/mithril/mithril-protocol/certificates#the-certificate-chain-design)

--- a/mithril-common/src/digesters/cache/provider.rs
+++ b/mithril-common/src/digesters/cache/provider.rs
@@ -16,11 +16,11 @@ pub type CacheProviderResult<T> = Result<T, ImmutableDigesterCacheProviderError>
 #[derive(Error, Debug)]
 pub enum ImmutableDigesterCacheProviderError {
     /// Error raised by [ImmutableFileDigestCacheProvider::store].
-    #[error("Could not store immutable file digests cache: {0}")]
+    #[error("Could not store immutable file digests cache")]
     Store(#[from] ImmutableDigesterCacheStoreError),
 
     /// Error raised by [ImmutableFileDigestCacheProvider::get].
-    #[error("Could not read immutable file digests cache: {0}")]
+    #[error("Could not read immutable file digests cache")]
     Get(#[from] ImmutableDigesterCacheGetError),
 }
 
@@ -28,11 +28,11 @@ pub enum ImmutableDigesterCacheProviderError {
 #[derive(Error, Debug)]
 pub enum ImmutableDigesterCacheStoreError {
     /// Raised when an IO error is raised when storing a cache.
-    #[error("IO error when storing cache: {0}")]
+    #[error("IO error when storing cache")]
     Io(#[from] io::Error),
 
     /// Raised when json cache serialization fails.
-    #[error("IO error when serializing json cache: {0}")]
+    #[error("IO error when serializing json cache")]
     JsonSerialization(#[from] serde_json::Error),
 }
 
@@ -40,11 +40,11 @@ pub enum ImmutableDigesterCacheStoreError {
 #[derive(Error, Debug)]
 pub enum ImmutableDigesterCacheGetError {
     /// Raised when an IO error is raised when getting a cache.
-    #[error("IO error when getting cache: {0}")]
+    #[error("IO error when getting cache")]
     Io(#[from] io::Error),
 
     /// Raised when json cache deserialization fails.
-    #[error("IO error when deserializing json cache: {0}")]
+    #[error("IO error when deserializing json cache")]
     JsonDeserialization(#[from] serde_json::Error),
 }
 

--- a/mithril-common/src/digesters/immutable_digester.rs
+++ b/mithril-common/src/digesters/immutable_digester.rs
@@ -60,7 +60,7 @@ pub trait ImmutableDigester: Sync + Send {
 #[derive(Error, Debug)]
 pub enum ImmutableDigesterError {
     /// Error raised when the files listing failed.
-    #[error("Immutable files listing failed: {0}")]
+    #[error("Immutable files listing failed")]
     ListImmutablesError(#[from] ImmutableFileListingError),
 
     /// Error raised when there's less than the required number of completed immutables in
@@ -76,6 +76,6 @@ pub enum ImmutableDigesterError {
     },
 
     /// Error raised when the digest computation failed.
-    #[error("Digest computation failed: {0}")]
+    #[error("Digest computation failed")]
     DigestComputationError(#[from] io::Error),
 }

--- a/mithril-common/src/digesters/immutable_file.rs
+++ b/mithril-common/src/digesters/immutable_file.rs
@@ -48,7 +48,7 @@ pub enum ImmutableFileCreationError {
     },
 
     /// Raised when the immutable file number parsing, from the filename, fails.
-    #[error("Error while parsing immutable file number: {0}")]
+    #[error("Error while parsing immutable file number")]
     FileNumberParsing(#[from] ParseIntError),
 }
 
@@ -56,11 +56,11 @@ pub enum ImmutableFileCreationError {
 #[derive(Error, Debug)]
 pub enum ImmutableFileListingError {
     /// Raised when the metadata of a file could not be read.
-    #[error("metadata parsing failed: {0}")]
+    #[error("metadata parsing failed")]
     MetadataParsing(#[from] io::Error),
 
     /// Raised when [ImmutableFile::new] fails.
-    #[error("immutable file creation error: {0}")]
+    #[error("immutable file creation error")]
     ImmutableFileCreation(#[from] ImmutableFileCreationError),
 }
 

--- a/mithril-common/src/digesters/immutable_file_observer.rs
+++ b/mithril-common/src/digesters/immutable_file_observer.rs
@@ -26,8 +26,8 @@ pub enum ImmutableFileObserverError {
     Missing(),
 
     /// Raised when [immutable file listing][ImmutableFile::list_completed_in_dir] fails.
-    #[error("immutable file creation error: {0}")]
-    ImmutableFileListing(StdError),
+    #[error("immutable file creation error")]
+    ImmutableFileListing(#[source] StdError),
 }
 
 /// An [ImmutableFileObserver] using the filesystem.

--- a/mithril-common/src/era/adapters/builder.rs
+++ b/mithril-common/src/era/adapters/builder.rs
@@ -49,12 +49,12 @@ pub enum AdapterBuilderError {
     MissingParameters(),
 
     /// Parameters parse error.
-    #[error("era reader adapter parameters parse error: {0:?}")]
-    ParseParameters(serde_json::Error),
+    #[error("era reader adapter parameters parse error")]
+    ParseParameters(#[source] serde_json::Error),
 
     /// Parameters decode error.
-    #[error("era reader adapter parameters decode error: {0:?}")]
-    Decode(StdError),
+    #[error("era reader adapter parameters decode error")]
+    Decode(#[source] StdError),
 }
 
 /// Era adapter builder

--- a/mithril-common/src/era/adapters/cardano_chain.rs
+++ b/mithril-common/src/era/adapters/cardano_chain.rs
@@ -17,24 +17,24 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum EraMarkersPayloadError {
     /// Error raised when the message serialization fails
-    #[error("could not serialize message: {0:?}")]
-    SerializeMessage(StdError),
+    #[error("could not serialize message")]
+    SerializeMessage(#[source] StdError),
 
     /// Error raised when the signature deserialization fails
-    #[error("could not deserialize signature: {0:?}")]
-    DeserializeSignature(StdError),
+    #[error("could not deserialize signature")]
+    DeserializeSignature(#[source] StdError),
 
     /// Error raised when the signature is missing
     #[error("could not verify signature: signature is missing")]
     MissingSignature,
 
     /// Error raised when the signature is invalid
-    #[error("could not verify signature: {0:?}")]
-    VerifySignature(StdError),
+    #[error("could not verify signature")]
+    VerifySignature(#[source] StdError),
 
     /// Error raised when the signing the markers
-    #[error("could not create signature: {0:?}")]
-    CreateSignature(StdError),
+    #[error("could not create signature")]
+    CreateSignature(#[source] StdError),
 }
 
 /// Era markers payload

--- a/mithril-common/src/era/era_reader.rs
+++ b/mithril-common/src/era/era_reader.rs
@@ -103,12 +103,13 @@ pub struct EraReader {
 #[derive(Debug, Error)]
 pub enum EraReaderError {
     /// Underlying adapter fails to return data.
-    #[error("Adapter Error message: «{message}» caught error: {error:?}")]
+    #[error("Adapter Error message: «{message}»")]
     AdapterFailure {
         /// context message
         message: String,
 
         /// nested underlying adapter error
+        #[source]
         error: StdError,
     },
 

--- a/mithril-common/src/store/adapter/store_adapter.rs
+++ b/mithril-common/src/store/adapter/store_adapter.rs
@@ -6,24 +6,24 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum AdapterError {
     /// Generic [StoreAdapter] error.
-    #[error("something wrong happened: {0:?}")]
-    GeneralError(StdError),
+    #[error("something wrong happened")]
+    GeneralError(#[source] StdError),
 
     /// Error raised when the store initialization fails.
-    #[error("problem creating the repository: {0:?}")]
-    InitializationError(StdError),
+    #[error("problem creating the repository")]
+    InitializationError(#[source] StdError),
 
     /// Error raised when the opening of a IO stream fails.
-    #[error("problem opening the IO stream: {0:?}")]
-    OpeningStreamError(StdError),
+    #[error("problem opening the IO stream")]
+    OpeningStreamError(#[source] StdError),
 
     /// Error raised when the parsing of a IO stream fails.
-    #[error("problem parsing the IO stream: {0:?}")]
-    ParsingDataError(StdError),
+    #[error("problem parsing the IO stream")]
+    ParsingDataError(#[source] StdError),
 
     /// Error while querying the subsystem.
-    #[error("problem when querying the adapter: {0:?}")]
-    QueryError(StdError),
+    #[error("problem when querying the adapter")]
+    QueryError(#[source] StdError),
 }
 
 /// Represent a way to store Key/Value pair data.

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.83"
+version = "0.2.84"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/aggregator_client.rs
+++ b/mithril-signer/src/aggregator_client.rs
@@ -29,40 +29,40 @@ use crate::message_adapters::{
 #[derive(Error, Debug)]
 pub enum AggregatorClientError {
     /// The aggregator host has returned a technical error.
-    #[error("remote server technical error: '{0}'")]
-    RemoteServerTechnical(StdError),
+    #[error("remote server technical error")]
+    RemoteServerTechnical(#[source] StdError),
 
     /// The aggregator host responded it cannot fulfill our request.
-    #[error("remote server logical error: '{0}'")]
-    RemoteServerLogical(StdError),
+    #[error("remote server logical error")]
+    RemoteServerLogical(#[source] StdError),
 
     /// Could not reach aggregator.
-    #[error("remote server unreachable: '{0}'")]
-    RemoteServerUnreachable(StdError),
+    #[error("remote server unreachable")]
+    RemoteServerUnreachable(#[source] StdError),
 
     /// Could not parse response.
-    #[error("json parsing failed: '{0}'")]
-    JsonParseFailed(StdError),
+    #[error("json parsing failed")]
+    JsonParseFailed(#[source] StdError),
 
     /// Mostly network errors.
-    #[error("Input/Output error: {0}")]
+    #[error("Input/Output error")]
     IOError(#[from] io::Error),
 
     /// Incompatible API version error
-    #[error("HTTP API version mismatch: {0}")]
-    ApiVersionMismatch(StdError),
+    #[error("HTTP API version mismatch")]
+    ApiVersionMismatch(#[source] StdError),
 
     /// HTTP client creation error
-    #[error("HTTP client creation failed: {0}")]
-    HTTPClientCreation(StdError),
+    #[error("HTTP client creation failed")]
+    HTTPClientCreation(#[source] StdError),
 
     /// Proxy creation error
-    #[error("proxy creation failed: {0}")]
-    ProxyCreation(StdError),
+    #[error("proxy creation failed")]
+    ProxyCreation(#[source] StdError),
 
     /// Adapter error
-    #[error("adapter failed: {0}")]
-    Adapter(StdError),
+    #[error("adapter failed")]
+    Adapter(#[source] StdError),
 }
 
 #[cfg(test)]

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -1,5 +1,6 @@
 use slog_scope::{crit, debug, error, info};
-use std::{fmt::Display, thread::sleep, time::Duration};
+use std::{fmt::Display, time::Duration};
+use tokio::time::sleep;
 
 use mithril_common::{
     crypto_helper::ProtocolInitializerError,
@@ -127,7 +128,7 @@ impl StateMachine {
                 "… Cycle finished, Sleeping for {} ms",
                 self.state_sleep.as_millis()
             );
-            sleep(self.state_sleep);
+            sleep(self.state_sleep).await;
         }
     }
 

--- a/mithril-signer/src/single_signer.rs
+++ b/mithril-signer/src/single_signer.rs
@@ -64,16 +64,16 @@ pub trait SingleSigner: Sync + Send {
 #[derive(Error, Debug)]
 pub enum SingleSignerError {
     /// Cryptographic Signer creation error.
-    #[error("the protocol signer creation failed: `{0}`")]
-    ProtocolSignerCreationFailure(StdError),
+    #[error("the protocol signer creation failed")]
+    ProtocolSignerCreationFailure(#[source] StdError),
 
     /// Signature Error
-    #[error("Signature Error: {0:?}")]
-    SignatureFailed(StdError),
+    #[error("Signature Error")]
+    SignatureFailed(#[source] StdError),
 
     /// Avk computation Error
-    #[error("Aggregate verification key computation Error: {0:?}")]
-    AggregateVerificationKeyComputationFailed(StdError),
+    #[error("Aggregate verification key computation Error")]
+    AggregateVerificationKeyComputationFailed(#[source] StdError),
 }
 
 /// Implementation of the SingleSigner.


### PR DESCRIPTION
## Content

This PR add the `#[source]` attribute to all wrapped errors if it was missing (which was mostly the case), this allow us to remove the manual print of those wrapped error in the error message.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
This PR also contains two small fixes:
- Remove the indirection to a string for the `ChainObserver` variant of the `SignerRegistrationError`.
- Use `tokio::time::sleep` in the mithril-signer state machine, since the one from std block the whole thread and   doesn't yield execution back to the tokio executer.

## Issue(s)
Closes #1265
