### PR TITLE
Add a JSON message response on /aggregator endpoint calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.105"
+version = "0.3.106"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.105"
+version = "0.3.106"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -7,7 +7,7 @@ use crate::{
     SignerRegisterer, VerificationKeyStorer,
 };
 
-use mithril_common::BeaconProvider;
+use mithril_common::{api_version::APIVersionProvider, BeaconProvider};
 use std::convert::Infallible;
 use std::sync::Arc;
 use warp::Filter;
@@ -87,4 +87,11 @@ pub fn with_verification_key_store(
     dependency_manager: Arc<DependencyContainer>,
 ) -> impl Filter<Extract = (Arc<dyn VerificationKeyStorer>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.verification_key_store.clone())
+}
+
+/// With API version provider
+pub fn with_api_version_provider(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (Arc<APIVersionProvider>,), Error = Infallible> + Clone {
+    warp::any().map(move || dependency_manager.api_version_provider.clone())
 }

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -3,6 +3,7 @@ mod certificate_routes;
 mod epoch_routes;
 mod middlewares;
 mod reply;
+mod root_routes;
 pub mod router;
 mod signatures_routes;
 mod signer_routes;

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -1,0 +1,117 @@
+use crate::DependencyContainer;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use warp::Filter;
+
+use super::middlewares;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct RootRouteMessage {
+    pub open_api_version: String,
+    pub documentation_url: String,
+}
+
+pub fn routes(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    root(dependency_manager)
+}
+
+/// GET /
+fn root(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path::end()
+        .and(middlewares::with_api_version_provider(dependency_manager))
+        .and_then(handlers::root)
+}
+
+mod handlers {
+    use mithril_common::api_version::APIVersionProvider;
+    use reqwest::StatusCode;
+    use slog_scope::{debug, warn};
+
+    use crate::http_server::routes::{
+        reply::{self, json},
+        root_routes::RootRouteMessage,
+    };
+    use std::{convert::Infallible, sync::Arc};
+
+    /// Root
+    pub async fn root(
+        api_version_provider: Arc<APIVersionProvider>,
+    ) -> Result<impl warp::Reply, Infallible> {
+        debug!("⇄ HTTP SERVER: root");
+
+        match api_version_provider.compute_current_version() {
+            Ok(open_api_version) => Ok(json(
+                &RootRouteMessage {
+                    open_api_version: open_api_version.to_string(),
+                    documentation_url: env!("CARGO_PKG_HOMEPAGE").to_string(),
+                },
+                StatusCode::OK,
+            )),
+            Err(err) => {
+                warn!("root::error"; "error" => ?err);
+                Ok(reply::internal_server_error(err.to_string()))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::http_server::SERVER_BASE_PATH;
+    use crate::{initialize_dependencies, DependencyContainer};
+    use reqwest::StatusCode;
+    use std::sync::Arc;
+    use warp::http::Method;
+    use warp::test::request;
+    use warp::Filter;
+
+    use super::*;
+
+    fn setup_router(
+        dependency_manager: Arc<DependencyContainer>,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        let cors = warp::cors()
+            .allow_any_origin()
+            .allow_headers(vec!["content-type"])
+            .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
+
+        warp::any()
+            .and(warp::path(SERVER_BASE_PATH))
+            .and(routes(dependency_manager).with(cors))
+    }
+
+    #[tokio::test]
+    async fn test_root_route_ok() {
+        let method = Method::GET.as_str();
+        let path = "/";
+        let dependency_manager = initialize_dependencies().await;
+        let expected_open_api_version = dependency_manager
+            .api_version_provider
+            .clone()
+            .compute_current_version()
+            .unwrap()
+            .to_string();
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        let response_body: RootRouteMessage = serde_json::from_slice(response.body()).unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            response_body,
+            RootRouteMessage {
+                open_api_version: expected_open_api_version,
+                documentation_url: env!("CARGO_PKG_HOMEPAGE").to_string(),
+            }
+        );
+    }
+}


### PR DESCRIPTION
## Content
This PR includes an update of /aggregator/ endpoint behaviour.

Instead of returning a 404 status code error, it now sends a JSON message containing `open_api_version` and `documentation_url` with a status code 200.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1103 
