### PR TITLE
Add signers ticker automatic import process + `/signers/tickers` route to aggregator http server 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.107"
+version = "0.3.108"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.122"
+version = "0.2.123"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "rand_chacha",
  "rand_core 0.6.4",
  "rayon",
+ "reqwest",
  "semver",
  "serde",
  "serde_bytes",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.107"
+version = "0.3.108"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -134,11 +134,10 @@ impl ServeCommand {
             Ok(())
         });
 
-        // Create a [SignerTickersImporter] only if the `cexplorer_pools_url` is provided in the
-        // config.
+        // Create a SignersImporter only if the `cexplorer_pools_url` is provided in the config.
         if let Some(cexplorer_pools_url) = config.cexplorer_pools_url {
             match dependencies_builder
-                .create_signer_ticker_importer(&cexplorer_pools_url)
+                .create_signer_importer(&cexplorer_pools_url)
                 .await
             {
                 Ok(service) => {
@@ -148,8 +147,8 @@ impl ServeCommand {
                         tokio::time::sleep(Duration::from_secs(5)).await;
                         service
                             .run_forever(Duration::from_secs(
-                                // Signer Ticker Interval are in minutes
-                                config.signer_ticker_run_interval * 60,
+                                // Import interval are in minutes
+                                config.signer_importer_run_interval * 60,
                             ))
                             .await;
                         Ok(())
@@ -157,7 +156,7 @@ impl ServeCommand {
                 }
                 Err(error) => {
                     warn!(
-                        "Failed to build the `SignerTickersImporter` fetching url `{}`. Error: {:?}",
+                        "Failed to build the `SignersImporter`:\n url to import `{}`\n Error: {:?}",
                         cexplorer_pools_url, error
                     );
                 }

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -143,6 +143,9 @@ impl ServeCommand {
             {
                 Ok(service) => {
                     join_set.spawn(async move {
+                        // Wait 5s to let the other services the time to start before running
+                        // the first import.
+                        tokio::time::sleep(Duration::from_secs(5)).await;
                         service
                             .run_forever(Duration::from_secs(
                                 // Signer Ticker Interval are in minutes

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -121,6 +121,13 @@ pub struct Configuration {
     /// Specific parameters when [snapshot_compression_algorithm][Self::snapshot_compression_algorithm]
     /// is set to [zstandard][CompressionAlgorithm::Zstandard].
     pub zstandard_parameters: Option<ZstandardCompressionParameters>,
+
+    /// Url to CExplorer list of pools that will be pulled to import the pools as signer in
+    /// the database (including their pool ticker).
+    pub cexplorer_pools_url: Option<String>,
+
+    /// Time interval at which the [Self::cexplorer_pools_url] will be fetch (in minutes).
+    pub signer_ticker_run_interval: u64,
 }
 
 /// Uploader needed to copy the snapshot once computed.
@@ -188,6 +195,8 @@ impl Configuration {
             era_reader_adapter_params: None,
             snapshot_compression_algorithm: CompressionAlgorithm::Zstandard,
             zstandard_parameters: Some(ZstandardCompressionParameters::default()),
+            cexplorer_pools_url: None,
+            signer_ticker_run_interval: 1,
         }
     }
 
@@ -262,6 +271,9 @@ pub struct DefaultConfiguration {
 
     /// Use CDN domain to construct snapshot urls default setting (if snapshot_uploader_type is Gcp)
     pub snapshot_use_cdn_domain: String,
+
+    /// Signer ticker run interval default setting
+    pub signer_ticker_run_interval: u64,
 }
 
 impl Default for DefaultConfiguration {
@@ -279,6 +291,7 @@ impl Default for DefaultConfiguration {
             disable_digests_cache: "false".to_string(),
             snapshot_compression_algorithm: "zstandard".to_string(),
             snapshot_use_cdn_domain: "false".to_string(),
+            signer_ticker_run_interval: 720,
         }
     }
 }
@@ -368,6 +381,13 @@ impl Source for DefaultConfiguration {
             Value::new(
                 Some(&namespace),
                 ValueKind::from(myself.snapshot_use_cdn_domain),
+            ),
+        );
+        result.insert(
+            "signer_ticker_run_interval".to_string(),
+            Value::new(
+                Some(&namespace),
+                ValueKind::from(myself.signer_ticker_run_interval),
             ),
         );
 

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -122,12 +122,11 @@ pub struct Configuration {
     /// is set to [zstandard][CompressionAlgorithm::Zstandard].
     pub zstandard_parameters: Option<ZstandardCompressionParameters>,
 
-    /// Url to CExplorer list of pools that will be pulled to import the pools as signer in
-    /// the database (including their pool ticker).
+    /// Url to CExplorer list of pools to import as signer in the database.
     pub cexplorer_pools_url: Option<String>,
 
-    /// Time interval at which the [Self::cexplorer_pools_url] will be fetch (in minutes).
-    pub signer_ticker_run_interval: u64,
+    /// Time interval at which the signers in [Self::cexplorer_pools_url] will be imported (in minutes).
+    pub signer_importer_run_interval: u64,
 }
 
 /// Uploader needed to copy the snapshot once computed.
@@ -196,7 +195,7 @@ impl Configuration {
             snapshot_compression_algorithm: CompressionAlgorithm::Zstandard,
             zstandard_parameters: Some(ZstandardCompressionParameters::default()),
             cexplorer_pools_url: None,
-            signer_ticker_run_interval: 1,
+            signer_importer_run_interval: 1,
         }
     }
 
@@ -272,8 +271,8 @@ pub struct DefaultConfiguration {
     /// Use CDN domain to construct snapshot urls default setting (if snapshot_uploader_type is Gcp)
     pub snapshot_use_cdn_domain: String,
 
-    /// Signer ticker run interval default setting
-    pub signer_ticker_run_interval: u64,
+    /// Signer importer run interval default setting
+    pub signer_importer_run_interval: u64,
 }
 
 impl Default for DefaultConfiguration {
@@ -291,7 +290,7 @@ impl Default for DefaultConfiguration {
             disable_digests_cache: "false".to_string(),
             snapshot_compression_algorithm: "zstandard".to_string(),
             snapshot_use_cdn_domain: "false".to_string(),
-            signer_ticker_run_interval: 720,
+            signer_importer_run_interval: 720,
         }
     }
 }
@@ -384,10 +383,10 @@ impl Source for DefaultConfiguration {
             ),
         );
         result.insert(
-            "signer_ticker_run_interval".to_string(),
+            "signer_importer_run_interval".to_string(),
             Value::new(
                 Some(&namespace),
-                ValueKind::from(myself.signer_ticker_run_interval),
+                ValueKind::from(myself.signer_importer_run_interval),
             ),
         );
 

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -592,13 +592,13 @@ where signed_entity.signed_entity_type_id = 2;
         "#,
         ),
         // Migration 19
-        // Alter `signer` table to add `registered_at` field with base value copied from the
+        // Alter `signer` table to add `last_registered_at` field with base value copied from the
         // `created_at` field.
         SqlMigration::new(
             19,
             r#"
-alter table signer add column registered_at text null;
-update signer set registered_at = created_at; 
+alter table signer add column last_registered_at text null;
+update signer set last_registered_at = created_at; 
         "#,
         ),
     ]

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -591,5 +591,15 @@ update signed_entity
 where signed_entity.signed_entity_type_id = 2;
         "#,
         ),
+        // Migration 19
+        // Alter `signer` table to add `registered_at` field with base value copied from the
+        // `created_at` field.
+        SqlMigration::new(
+            19,
+            r#"
+alter table signer add column registered_at text null;
+update signer set registered_at = created_at; 
+        "#,
+        ),
     ]
 }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -56,10 +56,7 @@ use crate::{
         MithrilStakeDistributionService, MithrilTickerService, SignedEntityService,
         StakeDistributionService, TickerService,
     },
-    tools::{
-        CExplorerSignerTickerRetriever, GcpFileUploader, GenesisToolsDependency,
-        SignerTickersImporter,
-    },
+    tools::{CExplorerSignerRetriever, GcpFileUploader, GenesisToolsDependency, SignersImporter},
     AggregatorConfig, AggregatorRunner, AggregatorRuntime, CertificatePendingStore,
     CompressedArchiveSnapshotter, Configuration, DependencyContainer, DumbSnapshotUploader,
     DumbSnapshotter, LocalSnapshotUploader, MithrilSignerRegisterer, MultiSigner, MultiSignerImpl,
@@ -1097,18 +1094,16 @@ impl DependenciesBuilder {
         Ok(dependencies)
     }
 
-    /// Create a [SignerTickersImporter] instance.
-    pub async fn create_signer_ticker_importer(
+    /// Create a [SignersImporter] instance.
+    pub async fn create_signer_importer(
         &mut self,
         cexplorer_pools_url: &str,
-    ) -> Result<SignerTickersImporter> {
-        let retriever = CExplorerSignerTickerRetriever::new(
-            cexplorer_pools_url,
-            Some(Duration::from_secs(30)),
-        )?;
+    ) -> Result<SignersImporter> {
+        let retriever =
+            CExplorerSignerRetriever::new(cexplorer_pools_url, Some(Duration::from_secs(30)))?;
         let persister = self.get_signer_store().await?;
 
-        Ok(SignerTickersImporter::new(Arc::new(retriever), persister))
+        Ok(SignersImporter::new(Arc::new(retriever), persister))
     }
 
     /// Create [TickerService] instance.

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -285,9 +285,9 @@ impl DependencyContainer {
     async fn fill_verification_key_store(&self, target_epoch: Epoch, signers: &[SignerWithStake]) {
         for signer in signers {
             self.signer_recorder
-                .record_signer_id(signer.party_id.clone())
+                .record_signer_registration(signer.party_id.clone())
                 .await
-                .expect("record_signer_id should not fail");
+                .expect("record_signer_registration should not fail");
             self.verification_key_store
                 .save_verification_key(target_epoch, signer.clone())
                 .await

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -16,10 +16,9 @@ use mithril_common::{
     BeaconProvider,
 };
 
-use crate::database::provider::CertificateRepository;
 use crate::{
     configuration::*,
-    database::provider::{SignedEntityStorer, StakePoolStore},
+    database::provider::{CertificateRepository, SignedEntityStorer, SignerGetter, StakePoolStore},
     event_store::{EventMessage, TransmitterService},
     multi_signer::MultiSigner,
     services::{CertifierService, SignedEntityService, StakeDistributionService, TickerService},
@@ -123,6 +122,9 @@ pub struct DependencyContainer {
 
     /// Signed Entity storer
     pub signed_entity_storer: Arc<dyn SignedEntityStorer>,
+
+    /// Signer getter service
+    pub signer_getter: Arc<dyn SignerGetter>,
 }
 
 #[doc(hidden)]

--- a/mithril-aggregator/src/entities/mod.rs
+++ b/mithril-aggregator/src/entities/mod.rs
@@ -9,4 +9,4 @@ pub use open_message::OpenMessage;
 pub use signer_registration_message::{
     SignerRegistrationsListItemMessage, SignerRegistrationsMessage,
 };
-pub use signer_ticker_message::SignerTickerMessage;
+pub use signer_ticker_message::{SignerTickerListItemMessage, SignersTickersMessage};

--- a/mithril-aggregator/src/entities/mod.rs
+++ b/mithril-aggregator/src/entities/mod.rs
@@ -3,8 +3,10 @@
 //! This module provide domain entities for the services & state machine.
 mod open_message;
 mod signer_registration_message;
+mod signer_ticker_message;
 
 pub use open_message::OpenMessage;
 pub use signer_registration_message::{
     SignerRegistrationsListItemMessage, SignerRegistrationsMessage,
 };
+pub use signer_ticker_message::SignerTickerMessage;

--- a/mithril-aggregator/src/entities/signer_ticker_message.rs
+++ b/mithril-aggregator/src/entities/signer_ticker_message.rs
@@ -1,0 +1,16 @@
+use mithril_common::entities::PartyId;
+use serde::{Deserialize, Serialize};
+
+/// Message structure of a known signer
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SignerTickerMessage {
+    /// The signer party id
+    pub party_id: PartyId,
+
+    /// The signer pool ticker
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pool_ticker: Option<String>,
+
+    /// True if the signer have registered at least once
+    pub has_registered: bool,
+}

--- a/mithril-aggregator/src/entities/signer_ticker_message.rs
+++ b/mithril-aggregator/src/entities/signer_ticker_message.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 /// Message structure of a known signer
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct SignerTickerMessage {
+pub struct SignerTickerListItemMessage {
     /// The signer party id
     pub party_id: PartyId,
 
@@ -13,4 +13,14 @@ pub struct SignerTickerMessage {
 
     /// True if the signer have registered at least once
     pub has_registered: bool,
+}
+
+/// Message structure of signers known by the aggregator
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct SignersTickersMessage {
+    /// Cardano network of the aggregator
+    pub network: String,
+
+    /// Known signers
+    pub signers: Vec<SignerTickerListItemMessage>,
 }

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -7,6 +7,7 @@ use crate::{
     SignerRegisterer, VerificationKeyStorer,
 };
 
+use crate::database::provider::SignerGetter;
 use mithril_common::{api_version::APIVersionProvider, BeaconProvider};
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -38,6 +39,13 @@ pub fn with_signer_registerer(
     dependency_manager: Arc<DependencyContainer>,
 ) -> impl Filter<Extract = (Arc<dyn SignerRegisterer>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.signer_registerer.clone())
+}
+
+/// With signer getter middleware
+pub fn with_signer_getter(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (Arc<dyn SignerGetter>,), Error = Infallible> + Clone {
+    warp::any().map(move || dependency_manager.signer_getter.clone())
 }
 
 /// With config middleware

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -2,7 +2,7 @@ mod artifact_routes;
 mod certificate_routes;
 mod epoch_routes;
 mod middlewares;
-mod reply;
+pub(crate) mod reply;
 mod root_routes;
 pub mod router;
 mod signatures_routes;

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -213,7 +213,7 @@ mod handlers {
                     .map(|s| SignerTickerMessage {
                         party_id: s.signer_id,
                         pool_ticker: s.pool_ticker,
-                        has_registered: s.registered_at.is_some(),
+                        has_registered: s.last_registered_at.is_some(),
                     })
                     .collect();
                 Ok(reply::json(&message, StatusCode::OK))
@@ -548,14 +548,14 @@ mod tests {
                         pool_ticker: None,
                         created_at: Default::default(),
                         updated_at: Default::default(),
-                        registered_at: None,
+                        last_registered_at: None,
                     },
                     SignerRecord {
                         signer_id: "pool_with_ticker".to_string(),
                         pool_ticker: Some("pool_ticker".to_string()),
                         created_at: Default::default(),
                         updated_at: Default::default(),
-                        registered_at: None,
+                        last_registered_at: None,
                     },
                 ])
             })

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -58,6 +58,9 @@ pub use store::{
     CertificatePendingStore, ProtocolParametersStore, ProtocolParametersStorer,
     VerificationKeyStore, VerificationKeyStorer,
 };
+pub use tools::{
+    CExplorerSignerRetriever, SignersImporter, SignersImporterPersister, SignersImporterRetriever,
+};
 
 #[cfg(test)]
 pub use dependency_injection::tests::initialize_dependencies;

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
-use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -108,21 +107,8 @@ pub trait SignerRegistrationRoundOpener: Sync + Send {
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait SignerRecorder: Sync + Send {
-    /// Record signer_id
-    async fn record_signer_id(&self, signer_id: String) -> StdResult<()>;
-
-    /// Record pool ticker by id
-    async fn record_signer_pool_ticker(
-        &self,
-        signer_id: String,
-        pool_ticker: Option<String>,
-    ) -> StdResult<()>;
-
-    /// Record many pool ticker by id at once
-    async fn record_many_signers_pool_tickers(
-        &self,
-        pool_ticker_by_id: HashMap<String, Option<String>>,
-    ) -> StdResult<()>;
+    /// Record a signer registration
+    async fn record_signer_registration(&self, signer_id: String) -> StdResult<()>;
 }
 
 /// Implementation of a [SignerRegisterer]
@@ -268,7 +254,7 @@ impl SignerRegisterer for MithrilSignerRegisterer {
         signer_save.party_id = party_id_save.clone();
 
         self.signer_recorder
-            .record_signer_id(party_id_save)
+            .record_signer_registration(party_id_save)
             .await
             .map_err(|e| SignerRegistrationError::FailedSignerRecorder(e.to_string()))?;
 
@@ -323,7 +309,7 @@ mod tests {
         )));
         let mut signer_recorder = MockSignerRecorder::new();
         signer_recorder
-            .expect_record_signer_id()
+            .expect_record_signer_registration()
             .returning(|_| Ok(()))
             .once();
         let signer_registerer = MithrilSignerRegisterer::new(
@@ -368,7 +354,7 @@ mod tests {
         )));
         let mut signer_recorder = MockSignerRecorder::new();
         signer_recorder
-            .expect_record_signer_id()
+            .expect_record_signer_registration()
             .returning(|_| Ok(()))
             .once();
         let signer_registerer = MithrilSignerRegisterer::new(

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
@@ -115,6 +116,12 @@ pub trait SignerRecorder: Sync + Send {
         &self,
         signer_id: String,
         pool_ticker: Option<String>,
+    ) -> StdResult<()>;
+
+    /// Record many pool ticker by id at once
+    async fn record_many_signers_pool_tickers(
+        &self,
+        pool_ticker_by_id: HashMap<String, Option<String>>,
     ) -> StdResult<()>;
 }
 

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -3,6 +3,7 @@ mod digest_helpers;
 mod era;
 mod genesis;
 mod remote_file_uploader;
+mod signer_tickers_importer;
 
 pub use certificates_hash_migrator::CertificatesHashMigrator;
 pub use digest_helpers::extract_digest_from_path;

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -10,6 +10,10 @@ pub use digest_helpers::extract_digest_from_path;
 pub use era::EraTools;
 pub use genesis::{GenesisTools, GenesisToolsDependency};
 pub use remote_file_uploader::{GcpFileUploader, RemoteFileUploader};
+pub use signer_tickers_importer::{
+    CExplorerSignerTickerRetriever, SignerTickersImporter, SignerTickersPersister,
+    SignerTickersRetriever,
+};
 
 #[cfg(test)]
 pub use remote_file_uploader::MockRemoteFileUploader;

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -3,16 +3,15 @@ mod digest_helpers;
 mod era;
 mod genesis;
 mod remote_file_uploader;
-mod signer_tickers_importer;
+mod signer_importer;
 
 pub use certificates_hash_migrator::CertificatesHashMigrator;
 pub use digest_helpers::extract_digest_from_path;
 pub use era::EraTools;
 pub use genesis::{GenesisTools, GenesisToolsDependency};
 pub use remote_file_uploader::{GcpFileUploader, RemoteFileUploader};
-pub use signer_tickers_importer::{
-    CExplorerSignerTickerRetriever, SignerTickersImporter, SignerTickersPersister,
-    SignerTickersRetriever,
+pub use signer_importer::{
+    CExplorerSignerRetriever, SignersImporter, SignersImporterPersister, SignersImporterRetriever,
 };
 
 #[cfg(test)]

--- a/mithril-aggregator/src/tools/signer_tickers_importer.rs
+++ b/mithril-aggregator/src/tools/signer_tickers_importer.rs
@@ -87,9 +87,7 @@ impl SignerTickersPersister for SignerStore {
             "🔧 Signer Ticker Importer: persisting retrieved data in the database";
             "number_of_signer_to_insert" => signers.len()
         );
-        for (party_id, ticker) in signers {
-            self.record_signer_pool_ticker(party_id, ticker).await?;
-        }
+        self.record_many_signers_pool_tickers(signers).await?;
 
         Ok(())
     }

--- a/mithril-aggregator/src/tools/signer_tickers_importer.rs
+++ b/mithril-aggregator/src/tools/signer_tickers_importer.rs
@@ -1,12 +1,15 @@
-use crate::database::provider::SignerStore;
 use anyhow::Context;
 use async_trait::async_trait;
-use mithril_common::StdResult;
+use mithril_common::{entities::PartyId, StdResult};
+use reqwest::Url;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::ops::Not;
 use std::sync::Arc;
 
+use crate::database::provider::SignerStore;
 use crate::SignerRecorder;
-use mithril_common::entities::PartyId;
+
 #[cfg(test)]
 use mockall::automock;
 
@@ -41,49 +44,101 @@ impl SignerTickersImporter {
 #[async_trait]
 pub trait SignerTickersRetriever {
     /// Retrieve the signers list.
-    async fn retrieve(&self) -> StdResult<HashMap<PartyId, PoolTicker>>;
+    async fn retrieve(&self) -> StdResult<HashMap<PartyId, Option<PoolTicker>>>;
 }
 
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait SignerTickersPersister {
     /// Persist the given list of signers.
-    async fn persist(&self, signers: HashMap<PartyId, PoolTicker>) -> StdResult<()>;
+    async fn persist(&self, signers: HashMap<PartyId, Option<PoolTicker>>) -> StdResult<()>;
 }
 
 #[async_trait]
 impl SignerTickersPersister for SignerStore {
-    async fn persist(&self, signers: HashMap<PartyId, PoolTicker>) -> StdResult<()> {
+    async fn persist(&self, signers: HashMap<PartyId, Option<PoolTicker>>) -> StdResult<()> {
         for (party_id, ticker) in signers {
-            self.record_signer_pool_ticker(party_id, Some(ticker))
-                .await?;
+            self.record_signer_pool_ticker(party_id, ticker).await?;
         }
 
         Ok(())
     }
 }
 
-#[derive(Debug, Copy, Clone)]
-struct SPOItem {
-    pool_id: &'static str,
-    name: &'static str,
+/// A [SignerTickersRetriever] fetching signers data from CExplorer.
+pub struct CExplorerSignerTickerRetriever {
+    /// Url from which a SPO list using the CExplorer format will be fetch.
+    source_url: Url,
 }
 
-#[derive(Debug, Clone)]
+impl CExplorerSignerTickerRetriever {
+    /// Create a new [CExplorerSignerTickerRetriever] that will fetch data from the given url.
+    pub(crate) fn new(source_url: Url) -> Self {
+        Self { source_url }
+    }
+}
+
+#[async_trait]
+impl SignerTickersRetriever for CExplorerSignerTickerRetriever {
+    async fn retrieve(&self) -> StdResult<HashMap<PartyId, Option<PoolTicker>>> {
+        let spo_list = reqwest::get(self.source_url.to_owned())
+            .await
+            .with_context(|| "Retrieving of CExplorer SPO list failed")?
+            .json::<SPOList>()
+            .await
+            .with_context(|| "Failed to deserialize retrieved SPO list from CExplorer")?;
+
+        Ok(spo_list
+            .data
+            .into_iter()
+            .map(|item| item.extract())
+            .collect())
+    }
+}
+
+/// *Internal type* that map a CExplorer SPO list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct SPOList {
     data: Vec<SPOItem>,
 }
 
+/// *Internal type* that map a CExplorer SPO item inside its data list.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct SPOItem {
+    pool_id: String,
+    name: String,
+}
+
+impl SPOItem {
+    const EMPTY_NAME: &'static str = "[] ";
+
+    fn is_name_empty(&self) -> bool {
+        self.name.is_empty() || self.name == Self::EMPTY_NAME
+    }
+
+    /// Consume this item to convert it to a result ready to be yield by a
+    /// [SignerTickersRetriever::retrieve] implementation.
+    fn extract(self) -> (PartyId, Option<PoolTicker>) {
+        let is_name_empty = self.is_name_empty();
+        let (pool_id, name) = (self.pool_id, self.name);
+
+        (pool_id, is_name_empty.not().then_some(name))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use mithril_common::test_utils::test_http_server::test_http_server;
     use mithril_common::StdResult;
     use sqlite::Connection;
     use std::sync::Arc;
     use tokio::sync::Mutex;
+    use warp::Filter;
 
     use crate::database::provider::{
         apply_all_migrations_to_db, disable_foreign_key_support, SignerStore,
     };
+    use crate::http_server::routes::reply;
     use crate::SignerRecorder;
 
     use super::*;
@@ -148,6 +203,79 @@ mod tests {
         Ok(signers)
     }
 
+    #[test]
+    fn item_with_empty_name_yield_empty_pool_ticker() {
+        for name in ["", SPOItem::EMPTY_NAME] {
+            let item = SPOItem {
+                pool_id: "whatever".to_string(),
+                name: name.to_string(),
+            };
+            assert!(item.is_name_empty());
+            assert_eq!(("whatever".to_string(), None), item.extract());
+        }
+    }
+
+    #[tokio::test]
+    async fn retriever_should_return_deduplicated_data_and_handle_empty_name() {
+        let cexplorer_spo_list = r#"{
+            "data": [
+                {"pool_id": "pool1", "name": ""},
+                {"pool_id": "pool2", "name": "[] "},
+                {"pool_id": "pool3", "name": "whatever"},
+                {"pool_id": "pool3", "name": "whatever2"}
+            ]
+        }"#;
+        let routes = warp::path("list").map(move || cexplorer_spo_list);
+        let server = test_http_server(routes);
+
+        let retriever = CExplorerSignerTickerRetriever::new(
+            Url::parse(&format!("{}/list", server.url())).unwrap(),
+        );
+        let result = retriever
+            .retrieve()
+            .await
+            .expect("Retriever should not fail");
+
+        assert_eq!(
+            result,
+            HashMap::from([
+                ("pool1".to_string(), None),
+                ("pool2".to_string(), None),
+                ("pool3".to_string(), Some("whatever2".to_string())),
+            ])
+        );
+    }
+
+    #[tokio::test]
+    async fn retriever_doesnt_crash_if_remote_url_is_not_responding() {
+        let routes =
+            warp::path("list").map(|| reply::internal_server_error("whatever".to_string()));
+        let server = test_http_server(routes);
+
+        let retriever = CExplorerSignerTickerRetriever::new(
+            Url::parse(&format!("{}/list", server.url())).unwrap(),
+        );
+        retriever
+            .retrieve()
+            .await
+            .expect_err("An error should have been raised");
+    }
+
+    #[tokio::test]
+    async fn retriever_yield_error_when_json_is_malformed() {
+        let cexplorer_spo_list = r#"{ "data": [ {"pool_" ] }"#;
+        let routes = warp::path("list").map(move || cexplorer_spo_list);
+        let server = test_http_server(routes);
+
+        let retriever = CExplorerSignerTickerRetriever::new(
+            Url::parse(&format!("{}/list", server.url())).unwrap(),
+        );
+        retriever
+            .retrieve()
+            .await
+            .expect_err("An error should have been raised");
+    }
+
     #[tokio::test]
     async fn imported_list_of_one_signer_with_ticker() {
         let connection = Arc::new(Mutex::new(connection_without_foreign_key_support()));
@@ -159,7 +287,34 @@ mod tests {
         retriever.expect_retrieve().returning(|| {
             Ok(HashMap::from([(
                 "pool7809lhh2dhf48ezp7dy8j7450z026hch1w7c2j0px43jmu9l3wc".to_string(),
-                "[Pool name test]".to_string(),
+                Some("[Pool name test]".to_string()),
+            )]))
+        });
+
+        let importer = SignerTickersImporter::new(
+            Arc::new(retriever),
+            Arc::new(SignerStore::new(connection.clone())),
+        );
+        importer
+            .run()
+            .await
+            .expect("running importer should not fail");
+
+        let result = get_all_signers(connection).await.unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn imported_list_of_one_signer_without_ticker() {
+        let connection = Arc::new(Mutex::new(connection_without_foreign_key_support()));
+        let expected = vec![TestSigner::without_ticker(
+            "pool7809lhh2dhf48ezp7dy8j7450z026hch1w7c2j0px43jmu9l3wc",
+        )];
+        let mut retriever = MockSignerTickersRetriever::new();
+        retriever.expect_retrieve().returning(|| {
+            Ok(HashMap::from([(
+                "pool7809lhh2dhf48ezp7dy8j7450z026hch1w7c2j0px43jmu9l3wc".to_string(),
+                None,
             )]))
         });
 

--- a/mithril-aggregator/src/tools/signer_tickers_importer.rs
+++ b/mithril-aggregator/src/tools/signer_tickers_importer.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use crate::database::provider::SignerStore;
-use crate::SignerRecorder;
 
 #[cfg(test)]
 use mockall::automock;
@@ -87,7 +86,7 @@ impl SignerTickersPersister for SignerStore {
             "🔧 Signer Ticker Importer: persisting retrieved data in the database";
             "number_of_signer_to_insert" => signers.len()
         );
-        self.record_many_signers_pool_tickers(signers).await?;
+        self.import_many_signers(signers).await?;
 
         Ok(())
     }
@@ -192,7 +191,6 @@ mod tests {
         apply_all_migrations_to_db, disable_foreign_key_support, SignerStore,
     };
     use crate::http_server::routes::reply;
-    use crate::SignerRecorder;
 
     use super::*;
 
@@ -234,7 +232,7 @@ mod tests {
 
         for signer in test_signers {
             store
-                .record_signer_pool_ticker(signer.pool_id.clone(), signer.ticker.clone())
+                .import_signer(signer.pool_id.clone(), signer.ticker.clone())
                 .await?;
         }
 

--- a/mithril-aggregator/src/tools/signer_tickers_importer.rs
+++ b/mithril-aggregator/src/tools/signer_tickers_importer.rs
@@ -1,0 +1,178 @@
+use crate::database::provider::SignerStore;
+use anyhow::Context;
+use async_trait::async_trait;
+use mithril_common::StdResult;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::SignerRecorder;
+use mithril_common::entities::PartyId;
+#[cfg(test)]
+use mockall::automock;
+
+pub type PoolTicker = String;
+
+/// Tool that can import a list of Signer including their Pool Tickers
+pub struct SignerTickersImporter {
+    retriever: Arc<dyn SignerTickersRetriever>,
+    persister: Arc<dyn SignerTickersPersister>,
+}
+
+impl SignerTickersImporter {
+    /// [SignerTickersImporter] factory
+    pub fn new(
+        retriever: Arc<dyn SignerTickersRetriever>,
+        persister: Arc<dyn SignerTickersPersister>,
+    ) -> Self {
+        Self {
+            retriever,
+            persister,
+        }
+    }
+
+    /// Import and persist the signers
+    pub async fn run(&self) -> StdResult<()> {
+        let items = self.retriever.retrieve().await.with_context(|| "todo")?;
+        self.persister.persist(items).await.with_context(|| "todo")
+    }
+}
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait SignerTickersRetriever {
+    /// Retrieve the signers list.
+    async fn retrieve(&self) -> StdResult<HashMap<PartyId, PoolTicker>>;
+}
+
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait SignerTickersPersister {
+    /// Persist the given list of signers.
+    async fn persist(&self, signers: HashMap<PartyId, PoolTicker>) -> StdResult<()>;
+}
+
+#[async_trait]
+impl SignerTickersPersister for SignerStore {
+    async fn persist(&self, signers: HashMap<PartyId, PoolTicker>) -> StdResult<()> {
+        for (party_id, ticker) in signers {
+            self.record_signer_pool_ticker(party_id, Some(ticker))
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+struct SPOItem {
+    pool_id: &'static str,
+    name: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct SPOList {
+    data: Vec<SPOItem>,
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::StdResult;
+    use sqlite::Connection;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    use crate::database::provider::{
+        apply_all_migrations_to_db, disable_foreign_key_support, SignerStore,
+    };
+    use crate::SignerRecorder;
+
+    use super::*;
+
+    #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq)]
+    struct TestSigner {
+        pool_id: String,
+        ticker: Option<String>,
+    }
+
+    impl TestSigner {
+        fn with_ticker(pool_id: &str, ticker: &str) -> Self {
+            Self {
+                pool_id: pool_id.to_string(),
+                ticker: Some(ticker.to_string()),
+            }
+        }
+
+        fn without_ticker(pool_id: &str) -> Self {
+            Self {
+                pool_id: pool_id.to_string(),
+                ticker: None,
+            }
+        }
+    }
+
+    fn connection_without_foreign_key_support() -> Connection {
+        let connection = Connection::open(":memory:").unwrap();
+        apply_all_migrations_to_db(&connection).unwrap();
+        disable_foreign_key_support(&connection).unwrap();
+
+        connection
+    }
+
+    async fn fill_signer_db(
+        connection: Arc<Mutex<Connection>>,
+        test_signers: &[TestSigner],
+    ) -> StdResult<()> {
+        let store = SignerStore::new(connection);
+
+        for signer in test_signers {
+            store
+                .record_signer_pool_ticker(signer.pool_id.clone(), signer.ticker.clone())
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn get_all_signers(connection: Arc<Mutex<Connection>>) -> StdResult<Vec<TestSigner>> {
+        let store = SignerStore::new(connection);
+
+        let signers = store
+            .get_all()
+            .await?
+            .into_iter()
+            .map(|s| TestSigner {
+                pool_id: s.signer_id,
+                ticker: s.pool_ticker,
+            })
+            .collect();
+        Ok(signers)
+    }
+
+    #[tokio::test]
+    async fn imported_list_of_one_signer_with_ticker() {
+        let connection = Arc::new(Mutex::new(connection_without_foreign_key_support()));
+        let expected = vec![TestSigner::with_ticker(
+            "pool7809lhh2dhf48ezp7dy8j7450z026hch1w7c2j0px43jmu9l3wc",
+            "[Pool name test]",
+        )];
+        let mut retriever = MockSignerTickersRetriever::new();
+        retriever.expect_retrieve().returning(|| {
+            Ok(HashMap::from([(
+                "pool7809lhh2dhf48ezp7dy8j7450z026hch1w7c2j0px43jmu9l3wc".to_string(),
+                "[Pool name test]".to_string(),
+            )]))
+        });
+
+        let importer = SignerTickersImporter::new(
+            Arc::new(retriever),
+            Arc::new(SignerStore::new(connection.clone())),
+        );
+        importer
+            .run()
+            .await
+            .expect("running importer should not fail");
+
+        let result = get_all_signers(connection).await.unwrap();
+        assert_eq!(result, expected);
+    }
+}

--- a/mithril-aggregator/src/tools/signer_tickers_importer.rs
+++ b/mithril-aggregator/src/tools/signer_tickers_importer.rs
@@ -188,7 +188,7 @@ mod tests {
     use warp::Filter;
 
     use crate::database::provider::{
-        apply_all_migrations_to_db, disable_foreign_key_support, SignerStore,
+        apply_all_migrations_to_db, disable_foreign_key_support, SignerGetter, SignerStore,
     };
     use crate::http_server::routes::reply;
 

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -70,6 +70,7 @@ mithril-stm = { path = "../mithril-stm", default-features = false, features = [
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
+reqwest = { version = "0.11.22", features = ["json"] }
 slog-async = "2.8.0"
 slog-scope = "4.4.0"
 slog-term = "2.9.0"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.122"
+version = "0.2.123"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -11,6 +11,7 @@ pub mod fake_data;
 pub mod fake_keys;
 mod fixture_builder;
 mod mithril_fixture;
+pub mod test_http_server;
 
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};
 pub use mithril_fixture::{MithrilFixture, SignerFixture};

--- a/mithril-common/src/test_utils/test_http_server.rs
+++ b/mithril-common/src/test_utils/test_http_server.rs
@@ -1,0 +1,160 @@
+//! Define a HttpServer for test that can be configured using warp filters.
+
+// Base code from the httpserver in reqwest tests:
+// https://github.com/seanmonstar/reqwest/blob/master/tests/support/server.rs
+
+use std::{net::SocketAddr, sync::mpsc as std_mpsc, thread, time::Duration};
+use tokio::{runtime, sync::oneshot};
+use warp::{Filter, Reply};
+
+/// A HTTP server for test
+pub struct TestHttpServer {
+    address: SocketAddr,
+    panic_rx: std_mpsc::Receiver<()>,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl TestHttpServer {
+    /// Get the test server address
+    pub fn address(&self) -> SocketAddr {
+        self.address
+    }
+
+    /// Get the server url
+    pub fn url(&self) -> String {
+        format!("http://{}", self.address)
+    }
+}
+
+impl Drop for TestHttpServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+
+        if !::std::thread::panicking() {
+            self.panic_rx
+                .recv_timeout(Duration::from_secs(3))
+                .expect("test server should not panic");
+        }
+    }
+}
+
+/// Spawn a [TestHttpServer] using the given warp filters
+pub fn test_http_server<F>(filters: F) -> TestHttpServer
+where
+    F: Filter + Clone + Send + Sync + 'static,
+    F::Extract: Reply,
+{
+    //Spawn new runtime in thread to prevent reactor execution context conflict
+    thread::spawn(move || {
+        let rt = runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("new rt");
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let (address, server) = rt.block_on(async move {
+            warp::serve(filters).bind_with_graceful_shutdown(([127, 0, 0, 1], 0), async {
+                shutdown_rx.await.ok();
+            })
+        });
+
+        let (panic_tx, panic_rx) = std_mpsc::channel();
+        let thread_name = format!(
+            "test({})-support-server",
+            thread::current().name().unwrap_or("<unknown>")
+        );
+        thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || {
+                rt.block_on(server);
+                let _ = panic_tx.send(());
+            })
+            .expect("thread spawn");
+
+        TestHttpServer {
+            address,
+            panic_rx,
+            shutdown_tx: Some(shutdown_tx),
+        }
+    })
+    .join()
+    .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::StatusCode;
+    use serde::Deserialize;
+
+    #[tokio::test]
+    async fn test_server_simple_http() {
+        let expected: &'static str = "Hello Mithril !";
+        let routes = warp::any().map(move || expected);
+        let server = test_http_server(routes);
+
+        let result = reqwest::get(server.url())
+            .await
+            .expect("should run")
+            .text()
+            .await
+            .unwrap();
+
+        assert_eq!(result, expected)
+    }
+
+    #[tokio::test]
+    async fn test_server_simple_json() {
+        #[derive(Debug, Eq, PartialEq, Deserialize)]
+        struct Test {
+            content: String,
+        }
+
+        let routes = warp::any().map(move || r#"{"content":"Hello Mithril !"}"#);
+        let server = test_http_server(routes);
+
+        let result = reqwest::get(server.url())
+            .await
+            .expect("should run")
+            .json::<Test>()
+            .await
+            .unwrap();
+
+        assert_eq!(
+            result,
+            Test {
+                content: "Hello Mithril !".to_string()
+            }
+        )
+    }
+
+    #[tokio::test]
+    async fn test_server_specific_route() {
+        let expected: &'static str = "Hello Mithril !";
+        let routes = warp::path("hello").map(move || expected);
+        let server = test_http_server(routes);
+
+        let result = reqwest::get(format!("{}/hello", server.url()))
+            .await
+            .expect("should run")
+            .text()
+            .await
+            .unwrap();
+
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn test_server_unbind_route_yield_404() {
+        let expected: &'static str = "Hello Mithril !";
+        let routes = warp::path("hello").map(move || expected);
+        let server = test_http_server(routes);
+
+        let result = reqwest::get(format!("{}/unbind", server.url()))
+            .await
+            .expect("should run");
+
+        assert_eq!(result.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -287,7 +287,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/SignerRegistrationsMessage"
         "404":
-          description: Registed Signers not found
+          description: Registered Signers not found
         "412":
           description: API version mismatch
         default:
@@ -296,7 +296,30 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  
+
+  /signers/tickers:
+    get:
+      summary: Get the signers known by the aggregator
+      description: |
+        Returns the signers party id and, if available, their pool ticker
+      responses:
+        "200":
+          description: Signers found
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SignerTickerMessage"
+        "412":
+          description: API version mismatch
+        default:
+          description: Signers retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /register-signer:
     post:
       summary: Registers signer
@@ -662,6 +685,30 @@ components:
         party_id:
           description: The unique identifier of the signer
           type: string
+
+    SignerTickerMessage:
+      description: represents a known signer with its pool ticker
+      type: object
+      additionalProperties: true
+      required:
+        - party_id
+        - has_registered
+      properties:
+        party_id:
+          description: The unique identifier of the signer
+          type: string
+        pool_ticker:
+          description: The signer pool ticker
+          type: string
+        has_registered:
+          description: The signer has registered at least once
+          type: boolean
+      example:
+        {
+          "party_id": "pool1234567890",
+          "pool_ticker": "[Pool_Name]",
+          "has_registered": true
+        }
 
     RegisterSingleSignatureMessage:
       description: |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.11
+  version: 0.1.12
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -308,9 +308,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/SignerTickerMessage"
+                $ref: "#/components/schemas/SignersTickersMessage"
         "412":
           description: API version mismatch
         default:
@@ -661,8 +659,8 @@ components:
           $ref: "#/components/schemas/Epoch"
         registrations:
           type: array
-          items: 
-            $ref: "#/components/schemas/SignerRegistrationsListItemMessage" 
+          items:
+            $ref: "#/components/schemas/SignerRegistrationsListItemMessage"
       example:
         {
           "registered_at": 420,
@@ -686,7 +684,38 @@ components:
           description: The unique identifier of the signer
           type: string
 
-    SignerTickerMessage:
+    SignersTickersMessage:
+      description: represents the list of signers known by the aggregator
+      type: object
+      required:
+        - network
+        - signers
+      properties:
+        network:
+          description: Cardano network of the aggregator
+          type: string
+          format: bytes
+        signers:
+          description: Known signers
+          items:
+            $ref: "#/components/schemas/SignerTickerListItemMessage"
+      example:
+        {
+          "network": "mainnet",
+          "signers": [
+            {
+              "party_id": "pool1234567890",
+              "pool_ticker": "[Pool_Name]",
+              "has_registered": true
+            },
+            {
+              "party_id": "pool0987654321",
+              "has_registered": false
+            }
+          ]
+        }
+
+    SignerTickerListItemMessage:
       description: represents a known signer with its pool ticker
       type: object
       additionalProperties: true


### PR DESCRIPTION
## Content

This PR add to the aggregator:
- The `SignerImporter` services and traits (to define how it retrieves its data and how it persist them)
- Run this service in an infinite loop within a thread when using the serve commands (if an source url is defined, else the thread won't be spawned)
- Add a new route: `/signers/tickers` that expose a simplified view of the `signer` table.
- Add a new field in the `signer` table: `last_registered_at`, since we will now import signers into that table from external source and not create them anymore only at registration.

This PR also add a `TestHttpServer` that allow test to define a http server, configured using warp routes as it's done in the aggregator.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

## Issue(s)
Relates to #1185
