### PR TITLE
Add Mithril networks status page in website footer

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -188,6 +188,10 @@ const config = {
             title: 'More',
             items: [
               {
+                label: 'Mithril Networks Status',
+                href: 'https://mithril.cronitorstatus.com/'
+              },
+              {
                 label: 'Logbook',
                 href: 'https://github.com/input-output-hk/mithril/wiki/Logbook'
               },

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-doc",
-  "version": "0.1.24",
+  "version": "0.1.25",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
## Content
This PR adds a footer link to the [Mithril networks status page](https://mithril.cronitorstatus.com/) on the website.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

## Issue(s)
Relates to #1277