### PR TITLE
Upgrade Rust `1.73.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2161,7 +2161,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.108"
+version = "0.3.109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2201,7 +2201,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.123"
+version = "0.2.124"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.108"
+version = "0.3.109"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -75,14 +75,14 @@ impl AggregatorRuntime {
     ) -> Result<Self, RuntimeError> {
         info!("initializing runtime");
 
-        let state = if init_state.is_none() {
+        let state = if let Some(init_state) = init_state {
+            trace!("got initial state from caller");
+            init_state
+        } else {
             trace!("idle state, no current beacon");
             AggregatorState::Idle(IdleState {
                 current_beacon: None,
             })
-        } else {
-            trace!("got initial state from caller");
-            init_state.unwrap()
         };
 
         Ok::<Self, RuntimeError>(Self {

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.4.9"
+version = "0.4.10"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client/certificate_client.rs
+++ b/mithril-client/src/aggregator_client/certificate_client.rs
@@ -32,7 +32,7 @@ impl CertificateClient {
         let response = self.http_client.get_content(&url).await;
 
         match response {
-            Err(e) if matches!(e, AggregatorHTTPClientError::RemoteServerLogical(_)) => Ok(None),
+            Err(AggregatorHTTPClientError::RemoteServerLogical(_)) => Ok(None),
             Err(e) => Err(e.into()),
             Ok(response) => {
                 let message =

--- a/mithril-client/src/aggregator_client/mithril_stake_distribution_client.rs
+++ b/mithril-client/src/aggregator_client/mithril_stake_distribution_client.rs
@@ -50,7 +50,7 @@ impl MithrilStakeDistributionClient {
 
                 Ok(Some(stake_distribution_entity))
             }
-            Err(e) if matches!(e, AggregatorHTTPClientError::RemoteServerLogical(_)) => Ok(None),
+            Err(AggregatorHTTPClientError::RemoteServerLogical(_)) => Ok(None),
             Err(e) => Err(e.into()),
         }
     }

--- a/mithril-client/src/services/snapshot.rs
+++ b/mithril-client/src/services/snapshot.rs
@@ -194,9 +194,7 @@ impl SnapshotService for MithrilClientSnapshotService {
             .show(&self.expand_eventual_snapshot_alias(digest).await?)
             .await
             .map_err(|e| match &e.downcast_ref::<AggregatorHTTPClientError>() {
-                Some(error)
-                    if matches!(error, &&AggregatorHTTPClientError::RemoteServerLogical(_)) =>
-                {
+                Some(AggregatorHTTPClientError::RemoteServerLogical(_)) => {
                     SnapshotServiceError::SnapshotNotFound(digest.to_owned()).into()
                 }
                 _ => e,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.123"
+version = "0.2.124"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/database/version_checker.rs
+++ b/mithril-common/src/database/version_checker.rs
@@ -154,7 +154,7 @@ impl SqlMigration {
 
 impl PartialOrd for SqlMigration {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.version.partial_cmp(&other.version)
+        Some(self.version.cmp(&other.version))
     }
 }
 

--- a/mithril-common/src/database/version_checker.rs
+++ b/mithril-common/src/database/version_checker.rs
@@ -154,13 +154,13 @@ impl SqlMigration {
 
 impl PartialOrd for SqlMigration {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.version.cmp(&other.version))
+        Some(self.cmp(other))
     }
 }
 
 impl Ord for SqlMigration {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.partial_cmp(other).unwrap()
+        self.version.cmp(&other.version)
     }
 }
 

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -130,7 +130,7 @@ impl PartialOrd for Certificate {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // Order by beacon first then per hash
         match self.beacon.partial_cmp(&other.beacon) {
-            Some(ordering) if ordering == Ordering::Equal => self.hash.partial_cmp(&other.hash),
+            Some(Ordering::Equal) => self.hash.partial_cmp(&other.hash),
             Some(other) => Some(other),
             // Beacons may be not comparable (most likely because the network isn't the same) in
             // that case we can still order per hash

--- a/mithril-common/src/entities/signer.rs
+++ b/mithril-common/src/entities/signer.rs
@@ -152,7 +152,7 @@ impl PartialEq for SignerWithStake {
 
 impl PartialOrd for SignerWithStake {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.party_id.cmp(&other.party_id))
+        Some(self.cmp(other))
     }
 }
 

--- a/mithril-common/src/entities/signer.rs
+++ b/mithril-common/src/entities/signer.rs
@@ -152,7 +152,7 @@ impl PartialEq for SignerWithStake {
 
 impl PartialOrd for SignerWithStake {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.party_id.partial_cmp(&other.party_id)
+        Some(self.party_id.cmp(&other.party_id))
     }
 }
 


### PR DESCRIPTION
## Content
This PR includes fixes for new clippy warnings with Rust `1.73.0` release.

Some ordering traits have been re-implemented according to the clippy rule: https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_partial_ord_impl_on_ord_type

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
