### PR TITLE
Fix `mithril-stm` WASM build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2356,7 +2356,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -1,27 +1,44 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.0 (10-08-2023)
+## 0.3.7 (10-10-2023)
+
 ### Added
+
+- Implemented a build script that automatically detects that WASM is not targeted, and automatically activates the feature `batch-verify-aggregates` (which enables batch verification of signatures).
+
+## 0.3.0 (10-08-2023)
+
+### Added
+
 - Added `Coreverifier` struct and its functionalities to cover signature procedure for a full node.
 - Adapted existing functionality to inherit from a more generic structure `Coreverifier`.
 - Added tests for core verification.
 
 ## 0.2.5 (15-03-2023)
+
 ### Added
+
 - Included helper functions for unsafe code
 - Added tests for batch verification
+
 ## 0.2.1 (04-01-2023)
+
 ### Added
+
 - Batch verification for `StmAggrSig`.
 
 ## 0.2.0 (16-12-2022)
+
 ### Changed
+
 - Adapted the `Signature` struct, so that it does not contain the verification key and
-  the stake, as these values are not required. 
+  the stake, as these values are not required.
 
 ## 0.1.0 (05-12-2022)
+
 Initial release.

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.6"
+version = "0.3.7"
 edition = { workspace = true }
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-stm/build.rs
+++ b/mithril-stm/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let target_no_batch_verify_aggregates =
+        target_arch.eq("wasm32") || env::var("STM_TEST_NO_BATCH_VERIFY_AGGREGATES").is_ok();
+
+    if !target_no_batch_verify_aggregates {
+        println!("cargo:rustc-cfg=feature=\"batch-verify-aggregates\"");
+    }
+}

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -404,6 +404,7 @@ impl Signature {
     }
 
     /// Batch verify several sets of signatures with their corresponding verification keys.
+    #[cfg(feature = "batch-verify-aggregates")]
     pub fn batch_verify_aggregates(
         msgs: &[Vec<u8>],
         vks: &[VerificationKey],

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -789,6 +789,7 @@ impl<D: Clone + Digest + FixedOutput + Send + Sync> StmAggrSig<D> {
     }
 
     /// Batch verify a set of signatures, with different messages and avks.
+    #[cfg(feature = "batch-verify-aggregates")]
     pub fn batch_verify(
         stm_signatures: &[Self],
         msgs: &[Vec<u8>],


### PR DESCRIPTION
## Content
This PR fixes the compilation of the `mithril-stm` library when targeting WASM: 
- The batch signature verification provided by `blst` is not available with WASM
- A build script detects a if WASM is targeted and applies the feature `batch-verify-aggregates` if this is not the case
- The `batch_verify` function is available if the `batch-verify-aggregates` feature is activated

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1254 
