### PR TITLE
Rename GPG public key in releases

### DIFF
--- a/.github/workflows/scripts/sign-distribution.sh
+++ b/.github/workflows/scripts/sign-distribution.sh
@@ -18,7 +18,7 @@ main() {
     chmod 700 gpghome
     echo "$GPG_SECRET_KEY" | gpg --homedir gpghome --batch --import
     gpg --homedir gpghome --list-secret-keys
-    gpg --homedir gpghome --export --armor mithril@iohk.io > ./package/gpg-public.key
+    gpg --homedir gpghome --export --armor mithril@iohk.io > ./package/public-key.gpg
     cd ./package
     find . -type f -print | grep -v CHECKSUM | sort -n | xargs -I '{}' sha256sum '{}' > ./CHECKSUM
     gpg --homedir ../gpghome --clear-sign ./CHECKSUM

--- a/.github/workflows/scripts/verify-distribution.sh
+++ b/.github/workflows/scripts/verify-distribution.sh
@@ -51,10 +51,10 @@ You must see:
 \`\`\`
 ./***YOUR_ASSET_FILE***: OK
 \`\`\`
-* **Step 5**: Download the public key file from this link [gpg-public.key](${DOWNLOAD_URL_BASE}/gpg-public.key) and save it in the same folder as the asset
+* **Step 5**: Download the public key file from this link [public-key.gpg](${DOWNLOAD_URL_BASE}/public-key.gpg) and save it in the same folder as the asset
 * **Step 6**: Then import the GPG public key:
 \`\`\`
-gpg --import ./gpg-public.key
+gpg --import ./public-key.gpg
 \`\`\`
 You must see something like:
 \`\`\`
@@ -64,7 +64,7 @@ gpg:               imported: 1
 \`\`\`
 * **Step 7**: Then verify the GPG signature of the checksum file:
 \`\`\`
-gpg --verify ./gpg-public.key ./CHECKSUM.asc
+gpg --verify ./public-key.gpg ./CHECKSUM.asc
 \`\`\`
 You must see something like:
 \`\`\`


### PR DESCRIPTION
## Content
This PR includes the renaming of the GPG public key in the releases from `gpg-public.key` to `public-key.gpg`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1292 
