### PR TITLE
Aggregator keyreg bottleneck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.3.111"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2257,7 +2257,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.126"
+version = "0.2.127"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.2.20"
+version = "0.2.21"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.3.111"
+version = "0.4.0"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/artifact_builder/mithril_stake_distribution.rs
@@ -55,6 +55,7 @@ mod tests {
             Epoch(1),
             &protocol_parameters,
             &protocol_parameters,
+            &protocol_parameters,
             &signers_with_stake,
             &signers_with_stake,
         );

--- a/mithril-aggregator/src/database/provider/signer_registration.rs
+++ b/mithril-aggregator/src/database/provider/signer_registration.rs
@@ -9,7 +9,7 @@ use mithril_common::{
     crypto_helper::KESPeriod,
     entities::{
         Epoch, HexEncodedOpCert, HexEncodedVerificationKey, HexEncodedVerificationKeySignature,
-        PartyId, Signer, SignerWithStake, Stake, StakeDistribution,
+        PartyId, Signer, SignerWithStake, Stake,
     },
     sqlite::{
         EntityCursor, HydrationError, Projection, Provider, SourceAlias, SqLiteEntity,
@@ -492,27 +492,6 @@ impl VerificationKeyStorer for SignerRegistrationStore {
             .collect::<Vec<_>>();
 
         Ok(())
-    }
-
-    async fn get_stake_distribution_for_epoch(
-        &self,
-        epoch: Epoch,
-    ) -> StdResult<Option<StakeDistribution>> {
-        let connection = &*self.connection.lock().await;
-        let provider = SignerRegistrationRecordProvider::new(connection);
-        let cursor = provider
-            .get_by_epoch(&epoch)
-            .with_context(|| format!("get stake distribution failure, epoch: {epoch}"))
-            .map_err(AdapterError::GeneralError)?;
-
-        let stake_distribution = StakeDistribution::from_iter(
-            cursor.map(|r| (r.signer_id, r.stake.unwrap_or_default())),
-        );
-
-        match stake_distribution.is_empty() {
-            true => Ok(None),
-            false => Ok(Some(stake_distribution)),
-        }
     }
 }
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1114,7 +1114,7 @@ impl DependenciesBuilder {
             certificate_verifier: self.get_certificate_verifier().await?,
             genesis_verifier: self.get_genesis_verifier().await?,
             protocol_parameters_store: self.get_protocol_parameters_store().await?,
-            multi_signer: self.get_multi_signer().await?,
+            verification_key_store: self.get_verification_key_store().await?,
         };
 
         Ok(dependencies)

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -342,7 +342,6 @@ impl DependenciesBuilder {
     async fn build_multi_signer(&mut self) -> Result<Arc<RwLock<dyn MultiSigner>>> {
         let multi_signer = MultiSignerImpl::new(
             self.get_verification_key_store().await?,
-            self.get_stake_store().await?,
             self.get_protocol_parameters_store().await?,
             self.get_epoch_service().await?,
         );
@@ -939,12 +938,10 @@ impl DependenciesBuilder {
     }
 
     async fn build_epoch_service(&mut self) -> Result<EpochServiceWrapper> {
-        let stake_distribution_service = self.get_stake_distribution_service().await?;
         let verification_key_store = self.get_verification_key_store().await?;
         let protocol_parameters_store = self.get_protocol_parameters_store().await?;
 
         let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
-            stake_distribution_service,
             protocol_parameters_store,
             verification_key_store,
         )));

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -906,9 +906,9 @@ impl DependenciesBuilder {
 
     async fn build_signed_entity_service(&mut self) -> Result<Arc<dyn SignedEntityService>> {
         let signed_entity_storer = self.build_signed_entity_storer().await?;
-        let multi_signer = self.get_multi_signer().await?;
+        let epoch_service = self.get_epoch_service().await?;
         let mithril_stake_distribution_artifact_builder =
-            Arc::new(MithrilStakeDistributionArtifactBuilder::new(multi_signer));
+            Arc::new(MithrilStakeDistributionArtifactBuilder::new(epoch_service));
         let snapshotter = self.build_snapshotter().await?;
         let snapshot_uploader = self.build_snapshot_uploader().await?;
         let cardano_node_version = Version::parse(&self.configuration.cardano_node_version)
@@ -1172,6 +1172,7 @@ impl DependenciesBuilder {
         let genesis_verifier = self.get_genesis_verifier().await?;
         let multi_signer = self.get_multi_signer().await?;
         let ticker_service = self.get_ticker_service().await?;
+        let epoch_service = self.get_epoch_service().await?;
         let logger = self.get_logger().await?;
 
         Ok(Arc::new(MithrilCertifierService::new(
@@ -1182,6 +1183,7 @@ impl DependenciesBuilder {
             genesis_verifier,
             multi_signer,
             ticker_service,
+            epoch_service,
             logger,
         )))
     }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -941,6 +941,7 @@ impl DependenciesBuilder {
         let protocol_parameters_store = self.get_protocol_parameters_store().await?;
 
         let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
+            self.configuration.protocol_parameters.clone(),
             protocol_parameters_store,
             verification_key_store,
         )));

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1142,6 +1142,7 @@ impl DependenciesBuilder {
         let certificate_verifier = self.get_certificate_verifier().await?;
         let genesis_verifier = self.get_genesis_verifier().await?;
         let multi_signer = self.get_multi_signer().await?;
+        let ticker_service = self.get_ticker_service().await?;
         let logger = self.get_logger().await?;
 
         Ok(Arc::new(MithrilCertifierService::new(
@@ -1151,6 +1152,7 @@ impl DependenciesBuilder {
             certificate_verifier,
             genesis_verifier,
             multi_signer,
+            ticker_service,
             logger,
         )))
     }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -344,6 +344,7 @@ impl DependenciesBuilder {
             self.get_verification_key_store().await?,
             self.get_stake_store().await?,
             self.get_protocol_parameters_store().await?,
+            self.get_epoch_service().await?,
         );
 
         Ok(Arc::new(RwLock::new(multi_signer)))

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -340,10 +340,7 @@ impl DependenciesBuilder {
     }
 
     async fn build_multi_signer(&mut self) -> Result<Arc<RwLock<dyn MultiSigner>>> {
-        let multi_signer = MultiSignerImpl::new(
-            self.get_protocol_parameters_store().await?,
-            self.get_epoch_service().await?,
-        );
+        let multi_signer = MultiSignerImpl::new(self.get_epoch_service().await?);
 
         Ok(Arc::new(RwLock::new(multi_signer)))
     }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -341,7 +341,6 @@ impl DependenciesBuilder {
 
     async fn build_multi_signer(&mut self) -> Result<Arc<RwLock<dyn MultiSigner>>> {
         let multi_signer = MultiSignerImpl::new(
-            self.get_verification_key_store().await?,
             self.get_protocol_parameters_store().await?,
             self.get_epoch_service().await?,
         );

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -230,7 +230,7 @@ impl DependencyContainer {
             let mut multi_signer = self.multi_signer.write().await;
 
             multi_signer
-                .update_current_beacon(last_beacon)
+                .update_current_epoch(last_beacon.epoch)
                 .await
                 .expect("setting the beacon should not fail");
             multi_signer

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -16,6 +16,7 @@ use mithril_common::{
     BeaconProvider,
 };
 
+use crate::services::EpochService;
 use crate::{
     configuration::*,
     database::provider::{CertificateRepository, SignedEntityStorer, SignerGetter, StakePoolStore},
@@ -28,8 +29,11 @@ use crate::{
     SignerRegistrationRoundOpener, Snapshotter, VerificationKeyStorer,
 };
 
-/// MultiSignerWrapper wraps a MultiSigner
+/// MultiSignerWrapper wraps a [MultiSigner]
 pub type MultiSignerWrapper = Arc<RwLock<dyn MultiSigner>>;
+
+/// EpochServiceWrapper wraps a [EpochService]
+pub type EpochServiceWrapper = Arc<RwLock<dyn EpochService>>;
 
 /// DependencyManager handles the dependencies
 pub struct DependencyContainer {
@@ -116,6 +120,9 @@ pub struct DependencyContainer {
 
     /// Certifier Service
     pub certifier_service: Arc<dyn CertifierService>,
+
+    /// Epoch service
+    pub epoch_service: EpochServiceWrapper,
 
     /// Ticker Service
     pub ticker_service: Arc<dyn TickerService>,

--- a/mithril-aggregator/src/entities/signer_registration_message.rs
+++ b/mithril-aggregator/src/entities/signer_registration_message.rs
@@ -1,4 +1,4 @@
-use mithril_common::entities::{Epoch, PartyId, Stake, StakeDistribution};
+use mithril_common::entities::{Epoch, PartyId, SignerWithStake, Stake};
 use serde::{Deserialize, Serialize};
 
 /// Message structure of signer registrations for an epoch.
@@ -25,11 +25,14 @@ pub struct SignerRegistrationsListItemMessage {
 }
 
 impl SignerRegistrationsMessage {
-    /// Build a [SignerRegistrationsMessage] from a [stake distribution][StakeDistribution].
-    pub fn new(registered_at: Epoch, stake_distribution: StakeDistribution) -> Self {
-        let registrations: Vec<SignerRegistrationsListItemMessage> = stake_distribution
+    /// Build a [SignerRegistrationsMessage] from a list of signers with stake.
+    pub fn new(registered_at: Epoch, signers_with_stake: Vec<SignerWithStake>) -> Self {
+        let registrations: Vec<SignerRegistrationsListItemMessage> = signers_with_stake
             .into_iter()
-            .map(|(party_id, stake)| SignerRegistrationsListItemMessage { party_id, stake })
+            .map(|signer| SignerRegistrationsListItemMessage {
+                party_id: signer.party_id,
+                stake: signer.stake,
+            })
             .collect();
 
         Self {

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -62,7 +62,7 @@ pub mod handlers {
             }
             Err(err) => {
                 warn!("list_artifacts_mithril_stake_distribution"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }
@@ -88,7 +88,7 @@ pub mod handlers {
             }
             Err(err) => {
                 warn!("get_mithril_stake_distribution_details::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -119,7 +119,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("list_artifacts_snapshot"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }
@@ -144,7 +144,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("snapshot_details::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }
@@ -220,7 +220,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("snapshot_download::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -73,7 +73,7 @@ mod handlers {
             Ok(None) => Ok(reply::empty(StatusCode::NO_CONTENT)),
             Err(err) => {
                 warn!("certificate_pending::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }
@@ -94,7 +94,7 @@ mod handlers {
             )),
             Err(err) => {
                 warn!("certificate_certificates::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }
@@ -120,7 +120,7 @@ mod handlers {
             Ok(None) => Ok(reply::empty(StatusCode::NOT_FOUND)),
             Err(err) => {
                 warn!("certificate_certificate_hash::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -40,19 +40,19 @@ mod handlers {
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("⇄ HTTP SERVER: epoch_settings");
 
-        match multi_signer.read().await.get_current_beacon().await {
-            Some(beacon) => {
+        match multi_signer.read().await.get_current_epoch().await {
+            Some(epoch) => {
                 match (
                     protocol_parameters_store
-                        .get_protocol_parameters(beacon.epoch)
+                        .get_protocol_parameters(epoch)
                         .await,
                     protocol_parameters_store
-                        .get_protocol_parameters(beacon.epoch.next())
+                        .get_protocol_parameters(epoch.next())
                         .await,
                 ) {
                     (Ok(Some(protocol_parameters)), Ok(Some(next_protocol_parameters))) => {
                         let epoch_settings = EpochSettings {
-                            epoch: beacon.epoch,
+                            epoch,
                             protocol_parameters,
                             next_protocol_parameters,
                         };

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -38,8 +38,8 @@ mod handlers {
 
         match (
             epoch_service.epoch_of_current_data(),
-            epoch_service.current_protocol_parameters(),
             epoch_service.next_protocol_parameters(),
+            epoch_service.upcoming_protocol_parameters(),
         ) {
             (Ok(epoch), Ok(protocol_parameters), Ok(next_protocol_parameters)) => {
                 let epoch_settings = EpochSettings {

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -52,7 +52,7 @@ mod handlers {
             }
             (Err(err), _, _) | (_, Err(err), _) | (_, _, Err(err)) => {
                 warn!("epoch_settings::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -1,13 +1,12 @@
 use crate::{
-    dependency_injection::MultiSignerWrapper,
+    database::provider::SignerGetter,
+    dependency_injection::EpochServiceWrapper,
     event_store::{EventMessage, TransmitterService},
-    services::CertifierService,
-    services::{SignedEntityService, TickerService},
-    CertificatePendingStore, Configuration, DependencyContainer, ProtocolParametersStorer,
-    SignerRegisterer, VerificationKeyStorer,
+    services::{CertifierService, SignedEntityService, TickerService},
+    CertificatePendingStore, Configuration, DependencyContainer, SignerRegisterer,
+    VerificationKeyStorer,
 };
 
-use crate::database::provider::SignerGetter;
 use mithril_common::{api_version::APIVersionProvider, BeaconProvider};
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -18,20 +17,6 @@ pub(crate) fn with_certificate_pending_store(
     dependency_manager: Arc<DependencyContainer>,
 ) -> impl Filter<Extract = (Arc<CertificatePendingStore>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.certificate_pending_store.clone())
-}
-
-/// With protocol parameters store
-pub(crate) fn with_protocol_parameters_store(
-    dependency_manager: Arc<DependencyContainer>,
-) -> impl Filter<Extract = (Arc<dyn ProtocolParametersStorer>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.protocol_parameters_store.clone())
-}
-
-/// With multi signer middleware
-pub fn with_multi_signer(
-    dependency_manager: Arc<DependencyContainer>,
-) -> impl Filter<Extract = (MultiSignerWrapper,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.multi_signer.clone())
 }
 
 /// With signer registerer middleware
@@ -81,6 +66,13 @@ pub fn with_ticker_service(
     dependency_manager: Arc<DependencyContainer>,
 ) -> impl Filter<Extract = (Arc<dyn TickerService>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.ticker_service.clone())
+}
+
+/// With epoch service middleware
+pub fn with_epoch_service(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (EpochServiceWrapper,), Error = Infallible> + Clone {
+    warp::any().map(move || dependency_manager.epoch_service.clone())
 }
 
 /// With signed entity service

--- a/mithril-aggregator/src/http_server/routes/reply.rs
+++ b/mithril-aggregator/src/http_server/routes/reply.rs
@@ -23,3 +23,7 @@ pub fn bad_request(label: String, message: String) -> Box<dyn warp::Reply> {
 pub fn internal_server_error<T: Into<InternalServerError>>(message: T) -> Box<dyn warp::Reply> {
     json(&message.into(), StatusCode::INTERNAL_SERVER_ERROR)
 }
+
+pub fn service_unavailable<T: Into<InternalServerError>>(message: T) -> Box<dyn warp::Reply> {
+    json(&message.into(), StatusCode::SERVICE_UNAVAILABLE)
+}

--- a/mithril-aggregator/src/http_server/routes/reply.rs
+++ b/mithril-aggregator/src/http_server/routes/reply.rs
@@ -20,9 +20,6 @@ pub fn bad_request(label: String, message: String) -> Box<dyn warp::Reply> {
     json(&ClientError::new(label, message), StatusCode::BAD_REQUEST)
 }
 
-pub fn internal_server_error(message: String) -> Box<dyn warp::Reply> {
-    json(
-        &InternalServerError::new(message),
-        StatusCode::INTERNAL_SERVER_ERROR,
-    )
+pub fn internal_server_error<T: Into<InternalServerError>>(message: T) -> Box<dyn warp::Reply> {
+    json(&message.into(), StatusCode::INTERNAL_SERVER_ERROR)
 }

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -53,7 +53,7 @@ mod handlers {
             )),
             Err(err) => {
                 warn!("root::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -115,7 +115,6 @@ mod tests {
         http_server::SERVER_BASE_PATH,
         initialize_dependencies,
         services::{CertifierServiceError, MockCertifierService},
-        ProtocolError,
     };
 
     use super::*;
@@ -267,7 +266,7 @@ mod tests {
         let mut mock_certifier_service = MockCertifierService::new();
         mock_certifier_service
             .expect_register_single_signature()
-            .return_once(move |_, _| Err(ProtocolError::Core(anyhow!("an error occurred")).into()));
+            .return_once(move |_, _| Err(anyhow!("an error occurred")));
         let mut dependency_manager = initialize_dependencies().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
 

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -86,7 +86,7 @@ mod handlers {
                         }
                         Some(_) | None => {
                             warn!("register_signatures::error"; "error" => ?err);
-                            Ok(reply::internal_server_error(err.to_string()))
+                            Ok(reply::internal_server_error(err))
                         }
                     },
                     Ok(()) => Ok(reply::empty(StatusCode::CREATED)),
@@ -94,7 +94,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("register_signatures::cant_retrieve_signed_entity_type"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -201,7 +201,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("registered_signers::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }
@@ -230,7 +230,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("registered_signers::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::internal_server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -34,7 +34,7 @@ pub use crate::configuration::{
     Configuration, DefaultConfiguration, ExecutionEnvironment, SnapshotUploaderType,
     ZstandardCompressionParameters,
 };
-pub use crate::multi_signer::{MultiSigner, MultiSignerImpl, ProtocolError};
+pub use crate::multi_signer::{MultiSigner, MultiSignerImpl};
 pub use commands::MainOpts;
 pub use dependency_injection::DependencyContainer;
 pub use message_adapters::{

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -72,10 +72,6 @@ impl From<StdError> for RuntimeError {
 // TODO: Are these errors still relevant, do we need to remove them?
 #[allow(clippy::enum_variant_names)]
 pub enum RunnerError {
-    /// No stake distribution found
-    #[error("Missing stake distribution: '{0}'.")]
-    MissingStakeDistribution(String),
-
     /// Missing protocol parameters
     #[error("Missing protocol parameters: '{0}'.")]
     MissingProtocolParameters(String),

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -65,14 +65,3 @@ impl From<StdError> for RuntimeError {
         }
     }
 }
-
-/// Errors returned when the runner cannot fulfil its missions with no subsystem
-/// to fail.
-#[derive(Debug, Error)]
-// TODO: Are these errors still relevant, do we need to remove them?
-#[allow(clippy::enum_variant_names)]
-pub enum RunnerError {
-    /// Missing protocol parameters
-    #[error("Missing protocol parameters: '{0}'.")]
-    MissingProtocolParameters(String),
-}

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -59,9 +59,6 @@ pub trait AggregatorRunnerTrait: Sync + Send {
     /// Check if a certificate chain is valid.
     async fn is_certificate_chain_valid(&self, beacon: &Beacon) -> StdResult<()>;
 
-    /// Update the multisigner with the given beacon.
-    async fn update_beacon(&self, new_beacon: &Beacon) -> StdResult<()>;
-
     /// Read the stake distribution from the blockchain and store it.
     async fn update_stake_distribution(&self, new_beacon: &Beacon) -> StdResult<()>;
 
@@ -70,10 +67,6 @@ pub trait AggregatorRunnerTrait: Sync + Send {
 
     /// Close the signer registration round of an epoch.
     async fn close_signer_registration_round(&self) -> StdResult<()>;
-
-    /// Update the multisigner with the protocol parameters from configuration.
-    async fn update_protocol_parameters_in_multisigner(&self, new_beacon: &Beacon)
-        -> StdResult<()>;
 
     /// Compute the protocol message
     async fn compute_protocol_message(
@@ -247,18 +240,6 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         Ok(())
     }
 
-    // TODO: is this still useful?
-    async fn update_beacon(&self, new_beacon: &Beacon) -> StdResult<()> {
-        debug!("RUNNER: update beacon"; "beacon" => #?new_beacon);
-        self.dependencies
-            .multi_signer
-            .write()
-            .await
-            .update_current_epoch(new_beacon.epoch)
-            .await?;
-        Ok(())
-    }
-
     async fn update_stake_distribution(&self, new_beacon: &Beacon) -> StdResult<()> {
         debug!("RUNNER: update stake distribution"; "beacon" => #?new_beacon);
         self.dependencies
@@ -292,31 +273,6 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .signer_registration_round_opener
             .close_registration_round()
             .await
-    }
-
-    async fn update_protocol_parameters_in_multisigner(
-        &self,
-        new_beacon: &Beacon,
-    ) -> StdResult<()> {
-        debug!("RUNNER: update protocol parameters"; "beacon" => #?new_beacon);
-        let protocol_parameters = self.dependencies.config.protocol_parameters.clone();
-
-        self.update_beacon(new_beacon)
-            .await
-            .with_context(|| format!("AggregatorRunner can not update beacon: '{new_beacon}'"))?;
-        self.dependencies
-            .multi_signer
-            .write()
-            .await
-            .update_protocol_parameters(&protocol_parameters.clone().into())
-            .await
-            .map_err(|e| anyhow!(e))
-            .with_context(|| {
-                format!(
-                    "Multi Signer can not update protocol parameters: '{:?}'",
-                    &protocol_parameters
-                )
-            })
     }
 
     async fn compute_protocol_message(
@@ -569,11 +525,7 @@ pub mod tests {
         )
         .await;
 
-        let runner = AggregatorRunner::new(Arc::new(deps));
-        let beacon = runner.get_beacon_from_chain().await.unwrap();
-        runner.update_beacon(&beacon).await.unwrap();
-
-        runner
+        AggregatorRunner::new(Arc::new(deps))
     }
 
     #[tokio::test]
@@ -595,26 +547,6 @@ pub mod tests {
         // Retrieves the expected beacon
         let res = runner.get_beacon_from_chain().await;
         assert_eq!(expected_beacon, res.unwrap());
-    }
-
-    #[tokio::test]
-    async fn test_update_beacon() {
-        let deps = initialize_dependencies().await;
-        let deps = Arc::new(deps);
-        let runner = AggregatorRunner::new(deps.clone());
-        let beacon = runner.get_beacon_from_chain().await.unwrap();
-        let res = runner.update_beacon(&beacon).await;
-
-        assert!(res.is_ok());
-        let stored_epoch = deps
-            .multi_signer
-            .read()
-            .await
-            .get_current_epoch()
-            .await
-            .unwrap();
-
-        assert_eq!(beacon.epoch, stored_epoch);
     }
 
     #[tokio::test]
@@ -721,38 +653,6 @@ pub mod tests {
 
         let saved_current_round = signer_registration_round_opener.get_current_round().await;
         assert!(saved_current_round.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_update_protocol_parameters_in_multisigner() {
-        let deps = initialize_dependencies().await;
-        let deps = Arc::new(deps);
-        let runner = AggregatorRunner::new(deps.clone());
-        let beacon = runner.get_beacon_from_chain().await.unwrap();
-        runner
-            .update_beacon(&beacon)
-            .await
-            .expect("setting the beacon should not fail");
-        runner
-            .update_protocol_parameters_in_multisigner(&beacon)
-            .await
-            .expect("updating protocol parameters should not return an error");
-
-        let current_protocol_parameters = deps.config.protocol_parameters.clone();
-
-        let saved_protocol_parameters = deps
-            .protocol_parameters_store
-            .get_protocol_parameters(beacon.epoch.offset_to_protocol_parameters_recording_epoch())
-            .await
-            .unwrap()
-            .unwrap_or_else(|| {
-                panic!(
-                    "should have protocol parameters for the epoch {:?}",
-                    beacon.epoch
-                )
-            });
-
-        assert_eq!(current_protocol_parameters, saved_protocol_parameters);
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -564,6 +564,7 @@ pub mod tests {
             &[
                 current_epoch.offset_to_signer_retrieval_epoch().unwrap(),
                 current_epoch,
+                current_epoch.next(),
             ],
         )
         .await;

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -93,10 +93,10 @@ pub trait AggregatorRunnerTrait: Sync + Send {
         pending_certificate: CertificatePending,
     ) -> StdResult<()>;
 
-    /// Drop the multisigner's actual pending certificate.
+    /// Drop the actual pending certificate in the store.
     async fn drop_pending_certificate(&self) -> StdResult<Option<CertificatePending>>;
 
-    /// Create multi-signature.
+    /// Tell the certifier to try to create a new certificate.
     async fn create_certificate(
         &self,
         signed_entity_type: &SignedEntityType,
@@ -133,7 +133,7 @@ pub struct AggregatorRunner {
 }
 
 impl AggregatorRunner {
-    /// Create a new instance of the Aggrergator Runner.
+    /// Create a new instance of the Aggregator Runner.
     pub fn new(dependencies: Arc<DependencyContainer>) -> Self {
         Self { dependencies }
     }
@@ -310,7 +310,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         beacon: Beacon,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<CertificatePending> {
-        debug!("RUNNER: create new pending certificate from multisigner");
+        debug!("RUNNER: create new pending certificate");
         let epoch_service = self.dependencies.epoch_service.read().await;
 
         let signers = epoch_service.current_signers_with_stake()?;
@@ -368,7 +368,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<Certificate>> {
-        debug!("RUNNER: create multi-signature");
+        debug!("RUNNER: create_certificate");
 
         self.dependencies
             .certifier_service

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -5,7 +5,7 @@ use std::{path::Path, path::PathBuf, sync::Arc};
 
 use mithril_common::entities::{
     Beacon, Certificate, CertificatePending, Epoch, ProtocolMessage, ProtocolMessagePartKey,
-    SignedEntityType,
+    SignedEntityType, Signer,
 };
 use mithril_common::store::StakeStorer;
 use mithril_common::{CardanoNetwork, StdResult};
@@ -331,8 +331,8 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             signed_entity_type.to_owned(),
             protocol_parameters.clone(),
             next_protocol_parameters.clone(),
-            signers.clone().into_iter().map(|s| s.into()).collect(),
-            next_signers.clone().into_iter().map(|s| s.into()).collect(),
+            Signer::vec_from(signers.clone()),
+            Signer::vec_from(next_signers.clone()),
         );
 
         Ok(pending_certificate)
@@ -488,7 +488,8 @@ pub mod tests {
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
         entities::{
-            Beacon, CertificatePending, ProtocolMessage, SignedEntityType, StakeDistribution,
+            Beacon, CertificatePending, ProtocolMessage, SignedEntityType, Signer,
+            StakeDistribution,
         },
         signable_builder::SignableBuilderService,
         store::StakeStorer,
@@ -692,8 +693,8 @@ pub mod tests {
             signed_entity_type,
             protocol_parameters.clone(),
             protocol_parameters,
-            current_signers.into_iter().map(|s| s.into()).collect(),
-            next_signers.into_iter().map(|s| s.into()).collect(),
+            Signer::vec_from(current_signers),
+            Signer::vec_from(next_signers),
         );
         expected.signers.sort_by_key(|s| s.party_id.clone());
         expected.next_signers.sort_by_key(|s| s.party_id.clone());

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -280,9 +280,7 @@ impl AggregatorRuntime {
                 .update_era_checker(&new_beacon)
                 .await
                 .map_err(|e| RuntimeError::critical("transiting IDLE → READY", Some(e)))?;
-            self.runner
-                .certifier_inform_new_epoch(&new_beacon.epoch)
-                .await?;
+            self.runner.inform_new_epoch(new_beacon.epoch).await?;
             self.runner.update_stake_distribution(&new_beacon).await?;
             self.runner
                 .open_signer_registration_round(&new_beacon)
@@ -458,7 +456,7 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
-            .expect_certifier_inform_new_epoch()
+            .expect_inform_new_epoch()
             .with(predicate::eq(fake_data::beacon().epoch))
             .once()
             .returning(|_| Ok(()));
@@ -522,7 +520,7 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
-            .expect_certifier_inform_new_epoch()
+            .expect_inform_new_epoch()
             .with(predicate::eq(fake_data::beacon().epoch))
             .once()
             .returning(|_| Ok(()));

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -199,7 +199,7 @@ impl AggregatorRuntime {
                     });
                 } else if let Some(open_message) = self
                     .runner
-                    .get_current_non_certified_open_message()
+                    .get_current_non_certified_open_message(&chain_beacon)
                     .await.with_context(|| "AggregatorRuntime can not get the current non certified open message")?
                 {
                     // transition READY > SIGNING
@@ -566,7 +566,7 @@ mod tests {
         runner
             .expect_get_current_non_certified_open_message()
             .once()
-            .returning(|| Ok(None));
+            .returning(|_| Ok(None));
         let mut runtime = init_runtime(
             Some(AggregatorState::Ready(ReadyState {
                 current_beacon: beacon.clone(),
@@ -595,7 +595,7 @@ mod tests {
         runner
             .expect_get_current_non_certified_open_message()
             .once()
-            .returning(|| {
+            .returning(|_| {
                 let open_message = OpenMessage {
                     is_certified: false,
                     ..OpenMessage::dummy()

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -280,7 +280,7 @@ impl AggregatorRuntime {
                 .update_era_checker(&new_beacon)
                 .await
                 .map_err(|e| RuntimeError::critical("transiting IDLE → READY", Some(e)))?;
-            self.runner.inform_new_epoch(new_beacon.epoch).await?;
+            self.runner.new_epoch_cleanup(new_beacon.epoch).await?;
             self.runner.update_stake_distribution(&new_beacon).await?;
             self.runner
                 .open_signer_registration_round(&new_beacon)
@@ -288,6 +288,7 @@ impl AggregatorRuntime {
             self.runner
                 .update_protocol_parameters_in_multisigner(&new_beacon)
                 .await?;
+            self.runner.inform_new_epoch(new_beacon.epoch).await?;
         }
 
         self.runner
@@ -456,6 +457,11 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
+            .expect_new_epoch_cleanup()
+            .with(predicate::eq(fake_data::beacon().epoch))
+            .once()
+            .returning(|_| Ok(()));
+        runner
             .expect_inform_new_epoch()
             .with(predicate::eq(fake_data::beacon().epoch))
             .once()
@@ -517,6 +523,11 @@ mod tests {
         runner
             .expect_update_era_checker()
             .with(predicate::eq(fake_data::beacon()))
+            .once()
+            .returning(|_| Ok(()));
+        runner
+            .expect_new_epoch_cleanup()
+            .with(predicate::eq(fake_data::beacon().epoch))
             .once()
             .returning(|_| Ok(()));
         runner

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -379,10 +379,7 @@ impl AggregatorRuntime {
 
         let certificate_pending = self
             .runner
-            .create_new_pending_certificate_from_multisigner(
-                new_beacon.clone(),
-                &open_message.signed_entity_type,
-            )
+            .create_new_pending_certificate(new_beacon.clone(), &open_message.signed_entity_type)
             .await?;
         self.runner
             .save_pending_certificate(certificate_pending.clone())
@@ -630,7 +627,7 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
-            .expect_create_new_pending_certificate_from_multisigner()
+            .expect_create_new_pending_certificate()
             .once()
             .returning(|_, _| Ok(fake_data::certificate_pending()));
         runner

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -114,7 +114,7 @@ impl AggregatorRuntime {
                         message: _,
                         nested_error: _,
                     } => {
-                        crit!("state machine: a critical error occurred: {e}");
+                        crit!("state machine: a critical error occurred: {e:?}");
 
                         return Err(e);
                     }
@@ -126,7 +126,7 @@ impl AggregatorRuntime {
                             "KeepState Error: {message}. Nested error: «{}».",
                             nested_error
                                 .as_ref()
-                                .map(|e| format!("{e}"))
+                                .map(|e| format!("{e:?}"))
                                 .unwrap_or("None".into())
                         );
                     }
@@ -138,7 +138,7 @@ impl AggregatorRuntime {
                             "ReInit Error: {message}. Nested error: «{}».",
                             nested_error
                                 .as_ref()
-                                .map(|e| format!("{e}"))
+                                .map(|e| format!("{e:?}"))
                                 .unwrap_or("None".into())
                         );
                         self.state = AggregatorState::Idle(IdleState {

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -283,6 +283,7 @@ impl AggregatorRuntime {
             self.runner
                 .open_signer_registration_round(&new_beacon)
                 .await?;
+            self.runner.update_protocol_parameters().await?;
             self.runner.precompute_epoch_data().await?;
         }
 
@@ -443,6 +444,10 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
+            .expect_update_protocol_parameters()
+            .once()
+            .returning(|| Ok(()));
+        runner
             .expect_precompute_epoch_data()
             .once()
             .returning(|| Ok(()));
@@ -500,6 +505,10 @@ mod tests {
             .with(predicate::eq(fake_data::beacon().epoch))
             .once()
             .returning(|_| Ok(()));
+        runner
+            .expect_update_protocol_parameters()
+            .once()
+            .returning(|| Ok(()));
         runner
             .expect_precompute_epoch_data()
             .once()

--- a/mithril-aggregator/src/services/certifier.rs
+++ b/mithril-aggregator/src/services/certifier.rs
@@ -498,7 +498,7 @@ mod tests {
         }
     }
 
-    /// Note: If current_epoch is provided the [EpochService] [EpochService::]
+    /// Note: If current_epoch is provided the [EpochService] will be automatically initialized
     async fn setup_certifier_service(
         fixture: &MithrilFixture,
         epochs_with_signers: &[Epoch],
@@ -516,15 +516,11 @@ mod tests {
             .await;
 
         if let Some(epoch) = current_epoch {
-            dependency_builder
-                .get_epoch_service()
-                .await
-                .unwrap()
-                .write()
-                .await
-                .inform_epoch(epoch)
-                .await
-                .unwrap();
+            let epoch_service = dependency_builder.get_epoch_service().await.unwrap();
+            let mut epoch_service = epoch_service.write().await;
+
+            epoch_service.inform_epoch(epoch).await.unwrap();
+            epoch_service.precompute_epoch_data().await.unwrap();
         }
 
         MithrilCertifierService::from_deps(dependency_builder).await

--- a/mithril-aggregator/src/services/certifier.rs
+++ b/mithril-aggregator/src/services/certifier.rs
@@ -651,13 +651,6 @@ mod tests {
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
         let certifier_service =
             setup_certifier_service(&fixture, &epochs_with_signers, Some(beacon.epoch)).await;
-        certifier_service
-            .multi_signer
-            .write()
-            .await
-            .update_current_epoch(beacon.epoch)
-            .await
-            .unwrap();
 
         certifier_service
             .create_open_message(&signed_entity_type, &protocol_message)

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use slog_scope::debug;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -17,9 +18,15 @@ pub enum EpochServiceError {
     #[error("Epoch service could not obtain {1} for epoch {0}")]
     UnavailableData(Epoch, String),
 
-    /// Raised when service had not collected data at least once.
-    #[error("Epoch service was not initialized, you can call inform_epoch to initialize it")]
+    /// Raised when service has not collected data at least once.
+    #[error("Epoch service was not initialized, the function `inform_epoch` must be called first")]
     NotYetInitialized,
+
+    /// Raised when service has not computed data for its current epoch.
+    #[error(
+        "No data computed for epoch {0}, the function `precompute_epoch_data` must be called first"
+    )]
+    NotYetComputed(Epoch),
 }
 
 /// Service that aggregates all data that don't change in a given epoch.
@@ -28,6 +35,16 @@ pub trait EpochService: Sync + Send {
     /// Inform the service a new epoch has been detected, telling it to update its
     /// internal state for the new epoch.
     async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()>;
+
+    /// Insert future protocol parameters in the store based on this service current epoch.
+    ///
+    /// Note: must be called after `inform_epoch`.
+    async fn update_protocol_parameters(&mut self) -> StdResult<()>;
+
+    /// Inform the service that it can precompute data for its current epoch.
+    ///
+    /// Note: must be called after `inform_epoch`.
+    async fn precompute_epoch_data(&mut self) -> StdResult<()>;
 
     /// Get the current epoch for which the data stored in this service are computed.
     fn epoch_of_current_data(&self) -> StdResult<Epoch>;
@@ -54,21 +71,24 @@ pub trait EpochService: Sync + Send {
     fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner>;
 }
 
-/// Struct that aggregates all data that don't change in a given epoch.
 struct EpochData {
     epoch: Epoch,
     protocol_parameters: ProtocolParameters,
     next_protocol_parameters: ProtocolParameters,
-    aggregate_verification_key: ProtocolAggregateVerificationKey,
-    next_aggregate_verification_key: ProtocolAggregateVerificationKey,
     signers: Vec<SignerWithStake>,
     next_signers: Vec<SignerWithStake>,
+}
+
+struct ComputedEpochData {
+    aggregate_verification_key: ProtocolAggregateVerificationKey,
+    next_aggregate_verification_key: ProtocolAggregateVerificationKey,
     protocol_multi_signer: ProtocolMultiSigner,
 }
 
 /// Implementation of the [epoch service][EpochService].
 pub struct MithrilEpochService {
-    current_epoch_data: Option<EpochData>,
+    epoch_data: Option<EpochData>,
+    computed_epoch_data: Option<ComputedEpochData>,
     protocol_parameters_store: Arc<dyn ProtocolParametersStorer>,
     verification_key_store: Arc<dyn VerificationKeyStorer>,
 }
@@ -80,7 +100,8 @@ impl MithrilEpochService {
         verification_key_store: Arc<dyn VerificationKeyStorer>,
     ) -> Self {
         Self {
-            current_epoch_data: None,
+            epoch_data: None,
+            computed_epoch_data: None,
             protocol_parameters_store,
             verification_key_store,
         }
@@ -94,24 +115,31 @@ impl MithrilEpochService {
             .verification_key_store
             .get_signers(signer_retrieval_epoch)
             .await?
-            .ok_or(EpochServiceError::UnavailableData(
-                signer_retrieval_epoch,
-                "signers verification keys".to_string(),
-            ))?;
+            .unwrap_or_default();
 
         Ok(signers)
     }
 
     fn unwrap_data(&self) -> Result<&EpochData, EpochServiceError> {
-        self.current_epoch_data
+        self.epoch_data
             .as_ref()
             .ok_or(EpochServiceError::NotYetInitialized)
+    }
+
+    fn unwrap_computed_data(&self) -> Result<&ComputedEpochData, EpochServiceError> {
+        let epoch = self.unwrap_data()?.epoch;
+
+        self.computed_epoch_data
+            .as_ref()
+            .ok_or(EpochServiceError::NotYetComputed(epoch))
     }
 }
 
 #[async_trait]
 impl EpochService for MithrilEpochService {
     async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()> {
+        debug!("EpochService::inform_epoch(epoch: {epoch:?})");
+
         let signer_retrieval_epoch =
             epoch.offset_to_signer_retrieval_epoch().with_context(|| {
                 format!("EpochService could not compute signer retrieval epoch from epoch: {epoch}")
@@ -143,25 +171,38 @@ impl EpochService for MithrilEpochService {
             .get_signers_with_stake_at_epoch(next_signer_retrieval_epoch)
             .await?;
 
-        let protocol_multi_signer =
-            SignerBuilder::new(&current_signers, &current_protocol_parameters)
-                .with_context(|| "Epoch service failed to build protocol multi signer")?
-                .build_multi_signer();
-
-        let next_protocol_multi_signer =
-            SignerBuilder::new(&next_signers, &next_protocol_parameters)
-                .with_context(|| "Epoch service failed to build next protocol multi signer")?
-                .build_multi_signer();
-
-        self.current_epoch_data = Some(EpochData {
+        self.epoch_data = Some(EpochData {
             epoch,
             protocol_parameters: current_protocol_parameters,
             next_protocol_parameters,
+            signers: current_signers,
+            next_signers,
+        });
+        self.computed_epoch_data = None;
+
+        Ok(())
+    }
+
+    async fn precompute_epoch_data(&mut self) -> StdResult<()> {
+        debug!("EpochService::precompute_epoch_data");
+
+        let data = self.unwrap_data().with_context(|| {
+            "can't precompute epoch data if inform_epoch has not been called first"
+        })?;
+
+        let protocol_multi_signer = SignerBuilder::new(&data.signers, &data.protocol_parameters)
+            .with_context(|| "Epoch service failed to build protocol multi signer")?
+            .build_multi_signer();
+
+        let next_protocol_multi_signer =
+            SignerBuilder::new(&data.next_signers, &data.next_protocol_parameters)
+                .with_context(|| "Epoch service failed to build next protocol multi signer")?
+                .build_multi_signer();
+
+        self.computed_epoch_data = Some(ComputedEpochData {
             aggregate_verification_key: protocol_multi_signer.compute_aggregate_verification_key(),
             next_aggregate_verification_key: next_protocol_multi_signer
                 .compute_aggregate_verification_key(),
-            signers: current_signers,
-            next_signers,
             protocol_multi_signer,
         });
 
@@ -181,11 +222,11 @@ impl EpochService for MithrilEpochService {
     }
 
     fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
-        Ok(&self.unwrap_data()?.aggregate_verification_key)
+        Ok(&self.unwrap_computed_data()?.aggregate_verification_key)
     }
 
     fn next_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
-        Ok(&self.unwrap_data()?.next_aggregate_verification_key)
+        Ok(&self.unwrap_computed_data()?.next_aggregate_verification_key)
     }
 
     fn current_signers_with_stake(&self) -> StdResult<&Vec<SignerWithStake>> {
@@ -197,14 +238,16 @@ impl EpochService for MithrilEpochService {
     }
 
     fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner> {
-        Ok(&self.unwrap_data()?.protocol_multi_signer)
+        Ok(&self.unwrap_computed_data()?.protocol_multi_signer)
     }
 }
 
 #[cfg(test)]
 pub struct FakeEpochService {
     epoch_data: Option<EpochData>,
+    computed_epoch_data: Option<ComputedEpochData>,
     inform_epoch_error: Option<()>,
+    precompute_epoch_data_error: Option<()>,
 }
 
 #[cfg(test)]
@@ -232,15 +275,18 @@ impl FakeEpochService {
                 epoch,
                 protocol_parameters: protocol_parameters.clone(),
                 next_protocol_parameters: next_protocol_parameters.clone(),
+                signers: signers.to_vec(),
+                next_signers: next_signers.to_vec(),
+            }),
+            computed_epoch_data: Some(ComputedEpochData {
                 aggregate_verification_key: protocol_multi_signer
                     .compute_aggregate_verification_key(),
                 next_aggregate_verification_key: next_protocol_multi_signer
                     .compute_aggregate_verification_key(),
-                signers: signers.to_vec(),
-                next_signers: next_signers.to_vec(),
                 protocol_multi_signer,
             }),
             inform_epoch_error: None,
+            precompute_epoch_data_error: None,
         }
     }
 
@@ -262,7 +308,9 @@ impl FakeEpochService {
     pub fn without_data() -> Self {
         Self {
             epoch_data: None,
+            computed_epoch_data: None,
             inform_epoch_error: None,
+            precompute_epoch_data_error: None,
         }
     }
 
@@ -270,10 +318,22 @@ impl FakeEpochService {
         self.inform_epoch_error = Some(());
     }
 
+    pub fn enable_precompute_epoch_data_error(&mut self) {
+        self.precompute_epoch_data_error = Some(());
+    }
+
     fn unwrap_data(&self) -> Result<&EpochData, EpochServiceError> {
         self.epoch_data
             .as_ref()
             .ok_or(EpochServiceError::NotYetInitialized)
+    }
+
+    fn unwrap_computed_data(&self) -> Result<&ComputedEpochData, EpochServiceError> {
+        let epoch = self.unwrap_data()?.epoch;
+
+        self.computed_epoch_data
+            .as_ref()
+            .ok_or(EpochServiceError::NotYetComputed(epoch))
     }
 }
 
@@ -283,7 +343,14 @@ impl EpochService for FakeEpochService {
     async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()> {
         match self.inform_epoch_error {
             None => Ok(()),
-            Some(_) => anyhow::bail!("Inform epoch fake error, given epoch: {epoch}"),
+            Some(_) => anyhow::bail!("inform_epoch fake error, given epoch: {epoch}"),
+        }
+    }
+
+    async fn precompute_epoch_data(&mut self) -> StdResult<()> {
+        match self.precompute_epoch_data_error {
+            None => Ok(()),
+            Some(_) => anyhow::bail!("precompute_epoch_data fake error"),
         }
     }
 
@@ -300,11 +367,11 @@ impl EpochService for FakeEpochService {
     }
 
     fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
-        Ok(&self.unwrap_data()?.aggregate_verification_key)
+        Ok(&self.unwrap_computed_data()?.aggregate_verification_key)
     }
 
     fn next_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
-        Ok(&self.unwrap_data()?.next_aggregate_verification_key)
+        Ok(&self.unwrap_computed_data()?.next_aggregate_verification_key)
     }
 
     fn current_signers_with_stake(&self) -> StdResult<&Vec<SignerWithStake>> {
@@ -316,7 +383,7 @@ impl EpochService for FakeEpochService {
     }
 
     fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner> {
-        Ok(&self.unwrap_data()?.protocol_multi_signer)
+        Ok(&self.unwrap_computed_data()?.protocol_multi_signer)
     }
 }
 
@@ -324,7 +391,7 @@ impl EpochService for FakeEpochService {
 mod tests {
     use mithril_common::entities::PartyId;
     use mithril_common::store::adapter::MemoryAdapter;
-    use mithril_common::test_utils::MithrilFixtureBuilder;
+    use mithril_common::test_utils::{MithrilFixture, MithrilFixtureBuilder};
     use std::collections::{BTreeSet, HashMap};
 
     use crate::{ProtocolParametersStore, VerificationKeyStore};
@@ -336,20 +403,22 @@ mod tests {
         epoch: Epoch,
         protocol_parameters: ProtocolParameters,
         next_protocol_parameters: ProtocolParameters,
-        aggregate_verification_key: ProtocolAggregateVerificationKey,
-        next_aggregate_verification_key: ProtocolAggregateVerificationKey,
         signers: BTreeSet<SignerWithStake>,
         next_signers: BTreeSet<SignerWithStake>,
     }
 
+    #[derive(Debug, Clone, PartialEq)]
+    struct ExpectedComputedEpochData {
+        aggregate_verification_key: ProtocolAggregateVerificationKey,
+        next_aggregate_verification_key: ProtocolAggregateVerificationKey,
+    }
+
     impl ExpectedEpochData {
         async fn from_service(service: &MithrilEpochService) -> StdResult<Self> {
-            Ok(ExpectedEpochData {
+            Ok(Self {
                 epoch: service.epoch_of_current_data()?,
                 protocol_parameters: service.current_protocol_parameters()?.clone(),
                 next_protocol_parameters: service.next_protocol_parameters()?.clone(),
-                aggregate_verification_key: service.current_aggregate_verification_key()?.clone(),
-                next_aggregate_verification_key: service.next_aggregate_verification_key()?.clone(),
                 signers: service
                     .current_signers_with_stake()?
                     .clone()
@@ -364,6 +433,15 @@ mod tests {
         }
     }
 
+    impl ExpectedComputedEpochData {
+        async fn from_service(service: &MithrilEpochService) -> StdResult<Self> {
+            Ok(Self {
+                aggregate_verification_key: service.current_aggregate_verification_key()?.clone(),
+                next_aggregate_verification_key: service.next_aggregate_verification_key()?.clone(),
+            })
+        }
+    }
+
     fn map_signers_for_vkey_store(
         signers: &[SignerWithStake],
     ) -> HashMap<PartyId, SignerWithStake> {
@@ -374,33 +452,25 @@ mod tests {
             .collect()
     }
 
-    #[tokio::test]
-    async fn informs_epoch_get_data_from_its_dependencies() {
-        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-        let fixture2 = MithrilFixtureBuilder::default()
-            .with_protocol_parameters(ProtocolParameters::new(8, 80, 0.80))
-            .with_signers(5)
-            .build();
-
-        let epoch = Epoch(5);
+    async fn build_service(
+        epoch: Epoch,
+        current_epoch_fixture: &MithrilFixture,
+        next_epoch_fixture: &MithrilFixture,
+    ) -> MithrilEpochService {
         let signer_retrieval_epoch = epoch.offset_to_signer_retrieval_epoch().unwrap();
         let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
-
-        let expected = ExpectedEpochData {
-            epoch,
-            protocol_parameters: fixture.protocol_parameters(),
-            next_protocol_parameters: fixture2.protocol_parameters(),
-            aggregate_verification_key: fixture.compute_avk(),
-            next_aggregate_verification_key: fixture2.compute_avk(),
-            signers: fixture.signers_with_stake().into_iter().collect(),
-            next_signers: fixture2.signers_with_stake().into_iter().collect(),
-        };
 
         let protocol_parameters_store = ProtocolParametersStore::new(
             Box::new(
                 MemoryAdapter::new(Some(vec![
-                    (signer_retrieval_epoch, fixture.protocol_parameters()),
-                    (next_signer_retrieval_epoch, fixture2.protocol_parameters()),
+                    (
+                        signer_retrieval_epoch,
+                        current_epoch_fixture.protocol_parameters(),
+                    ),
+                    (
+                        next_signer_retrieval_epoch,
+                        next_epoch_fixture.protocol_parameters(),
+                    ),
                 ]))
                 .unwrap(),
             ),
@@ -410,27 +480,198 @@ mod tests {
             MemoryAdapter::new(Some(vec![
                 (
                     signer_retrieval_epoch,
-                    map_signers_for_vkey_store(&fixture.signers_with_stake()),
+                    map_signers_for_vkey_store(&current_epoch_fixture.signers_with_stake()),
                 ),
                 (
                     next_signer_retrieval_epoch,
-                    map_signers_for_vkey_store(&fixture2.signers_with_stake()),
+                    map_signers_for_vkey_store(&next_epoch_fixture.signers_with_stake()),
                 ),
             ]))
             .unwrap(),
         ));
 
-        let mut service =
-            MithrilEpochService::new(Arc::new(protocol_parameters_store), Arc::new(vkey_store));
+        MithrilEpochService::new(Arc::new(protocol_parameters_store), Arc::new(vkey_store))
+    }
+
+    #[tokio::test]
+    async fn inform_epoch_get_data_from_its_dependencies() {
+        let current_epoch_fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let next_epoch_fixture = MithrilFixtureBuilder::default()
+            .with_protocol_parameters(ProtocolParameters::new(8, 80, 0.80))
+            .with_signers(5)
+            .build();
+
+        let epoch = Epoch(5);
+        let mut service = build_service(epoch, &current_epoch_fixture, &next_epoch_fixture).await;
 
         service
             .inform_epoch(epoch)
             .await
             .expect("inform_epoch should not fail");
+
         let data = ExpectedEpochData::from_service(&service)
             .await
             .expect("extracting data from service should not fail");
 
-        assert_eq!(expected, data);
+        assert_eq!(
+            data,
+            ExpectedEpochData {
+                epoch,
+                protocol_parameters: current_epoch_fixture.protocol_parameters(),
+                next_protocol_parameters: next_epoch_fixture.protocol_parameters(),
+                signers: current_epoch_fixture
+                    .signers_with_stake()
+                    .into_iter()
+                    .collect(),
+                next_signers: next_epoch_fixture
+                    .signers_with_stake()
+                    .into_iter()
+                    .collect(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn compute_data_with_data_from_inform_epoch() {
+        let current_epoch_fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let next_epoch_fixture = MithrilFixtureBuilder::default()
+            .with_protocol_parameters(ProtocolParameters::new(8, 80, 0.80))
+            .with_signers(5)
+            .build();
+
+        let epoch = Epoch(5);
+        let mut service = build_service(epoch, &current_epoch_fixture, &next_epoch_fixture).await;
+
+        service
+            .inform_epoch(epoch)
+            .await
+            .expect("inform_epoch should not fail");
+        service
+            .precompute_epoch_data()
+            .await
+            .expect("precompute_epoch_data should not fail");
+
+        let data = ExpectedComputedEpochData::from_service(&service)
+            .await
+            .expect("extracting data from service should not fail");
+
+        assert_eq!(
+            data,
+            ExpectedComputedEpochData {
+                aggregate_verification_key: current_epoch_fixture.compute_avk(),
+                next_aggregate_verification_key: next_epoch_fixture.compute_avk(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn inform_epoch_reset_computed_data() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let avk = fixture.compute_avk();
+        let epoch = Epoch(4);
+        let mut service = build_service(epoch, &fixture, &fixture).await;
+        service.computed_epoch_data = Some(ComputedEpochData {
+            aggregate_verification_key: avk.clone(),
+            next_aggregate_verification_key: avk.clone(),
+            protocol_multi_signer: SignerBuilder::new(
+                &fixture.signers_with_stake(),
+                &fixture.protocol_parameters(),
+            )
+            .unwrap()
+            .build_multi_signer(),
+        });
+
+        service
+            .inform_epoch(epoch)
+            .await
+            .expect("inform_epoch should not fail");
+
+        assert!(service.computed_epoch_data.is_none());
+    }
+
+    #[tokio::test]
+    async fn cant_get_data_if_inform_epoch_has_not_been_called() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let service = build_service(Epoch(4), &fixture, &fixture).await;
+
+        for (name, res) in [
+            (
+                "epoch_of_current_data",
+                service.epoch_of_current_data().err(),
+            ),
+            (
+                "current_protocol_parameters",
+                service.current_protocol_parameters().err(),
+            ),
+            (
+                "next_protocol_parameters",
+                service.next_protocol_parameters().err(),
+            ),
+            (
+                "current_signers_with_stake",
+                service.current_signers_with_stake().err(),
+            ),
+            (
+                "next_signers_with_stake",
+                service.next_signers_with_stake().err(),
+            ),
+            (
+                "current_aggregate_verification_key",
+                service.current_aggregate_verification_key().err(),
+            ),
+            (
+                "next_aggregate_verification_key",
+                service.next_aggregate_verification_key().err(),
+            ),
+            (
+                "protocol_multi_signer",
+                service.protocol_multi_signer().err(),
+            ),
+        ] {
+            let error =
+                res.unwrap_or_else(|| panic!("getting {name} should have returned an error"));
+
+            match error.downcast_ref::<EpochServiceError>() {
+                Some(EpochServiceError::NotYetInitialized) => (),
+                _ => panic!("Expected an NotYetInitialized error, got: {error:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn can_only_get_non_computed_data_if_inform_epoch_has_been_called_but_not_precompute_epoch_data(
+    ) {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let mut service = build_service(Epoch(4), &fixture, &fixture).await;
+        service.inform_epoch(Epoch(4)).await.unwrap();
+
+        assert!(service.epoch_of_current_data().is_ok());
+        assert!(service.current_protocol_parameters().is_ok());
+        assert!(service.next_protocol_parameters().is_ok());
+        assert!(service.current_signers_with_stake().is_ok());
+        assert!(service.next_signers_with_stake().is_ok());
+
+        for (name, res) in [
+            (
+                "current_aggregate_verification_key",
+                service.current_aggregate_verification_key().err(),
+            ),
+            (
+                "next_aggregate_verification_key",
+                service.next_aggregate_verification_key().err(),
+            ),
+            (
+                "protocol_multi_signer",
+                service.protocol_multi_signer().err(),
+            ),
+        ] {
+            let error =
+                res.unwrap_or_else(|| panic!("getting {name} should have returned an error"));
+
+            match error.downcast_ref::<EpochServiceError>() {
+                Some(EpochServiceError::NotYetComputed(Epoch(4))) => (),
+                _ => panic!("Expected an NotYetComputed error for epoch 4, got: {error:?}"),
+            }
+        }
     }
 }

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -1,0 +1,358 @@
+use anyhow::Context;
+use async_trait::async_trait;
+use std::sync::Arc;
+use thiserror::Error;
+
+use mithril_common::crypto_helper::ProtocolAggregateVerificationKey;
+use mithril_common::entities::{Epoch, ProtocolParameters, SignerWithStake};
+use mithril_common::protocol::{MultiSigner as ProtocolMultiSigner, SignerBuilder};
+use mithril_common::StdResult;
+
+use crate::services::StakeDistributionService;
+use crate::{ProtocolParametersStorer, VerificationKeyStorer};
+
+/// Errors dedicated to the CertifierService.
+#[derive(Debug, Error)]
+pub enum EpochServiceError {
+    /// One of the data that is held for an epoch duration by the service was not available.
+    #[error("Epoch service could not obtain {1} for epoch {0}")]
+    UnavailableData(Epoch, String),
+
+    /// Raised when service had not collected data at least once.
+    #[error("Epoch service was not initialized, you can call inform_epoch to initialize it")]
+    NotYetInitialized,
+}
+
+/// Service that aggregates all data that don't change in a given epoch.
+#[async_trait]
+pub trait EpochService: Sync + Send {
+    /// Inform the service a new epoch has been detected, telling it to update its
+    /// internal state for the new epoch.
+    async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()>;
+
+    /// Get the current epoch for which the data stored in this service are computed.
+    fn epoch_of_current_data(&self) -> StdResult<Epoch>;
+
+    /// Get protocol parameters for current epoch
+    fn current_protocol_parameters(&self) -> StdResult<&ProtocolParameters>;
+
+    /// Get next protocol parameters for next epoch
+    fn next_protocol_parameters(&self) -> StdResult<&ProtocolParameters>;
+
+    /// Get aggregate verification key for current epoch
+    fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey>;
+
+    /// Get next aggregate verification key for next epoch
+    fn next_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey>;
+
+    /// Get signers with stake for the current epoch
+    fn current_signers_with_stake(&self) -> StdResult<&Vec<SignerWithStake>>;
+
+    /// Get signers with stake for the next epoch
+    fn next_signers_with_stake(&self) -> StdResult<&Vec<SignerWithStake>>;
+
+    /// Get the [protocol multi signer][ProtocolMultiSigner] for the current epoch
+    fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner>;
+}
+
+/// Struct that aggregates all data that don't change in a given epoch.
+struct EpochData {
+    epoch: Epoch,
+    protocol_parameters: ProtocolParameters,
+    next_protocol_parameters: ProtocolParameters,
+    aggregate_verification_key: ProtocolAggregateVerificationKey,
+    next_aggregate_verification_key: ProtocolAggregateVerificationKey,
+    signers: Vec<SignerWithStake>,
+    next_signers: Vec<SignerWithStake>,
+    protocol_multi_signer: ProtocolMultiSigner,
+}
+
+/// Implementation of the [epoch service][EpochService].
+pub struct MithrilEpochService {
+    current_epoch_data: Option<EpochData>,
+    stake_distribution_service: Arc<dyn StakeDistributionService>,
+    protocol_parameters_store: Arc<dyn ProtocolParametersStorer>,
+    verification_key_store: Arc<dyn VerificationKeyStorer>,
+}
+
+impl MithrilEpochService {
+    /// Create a new service instance
+    pub fn new(
+        stake_distribution_service: Arc<dyn StakeDistributionService>,
+        protocol_parameters_store: Arc<dyn ProtocolParametersStorer>,
+        verification_key_store: Arc<dyn VerificationKeyStorer>,
+    ) -> Self {
+        Self {
+            current_epoch_data: None,
+            stake_distribution_service,
+            protocol_parameters_store,
+            verification_key_store,
+        }
+    }
+
+    // todo: this should be entirely retrieved from one source instead of two.
+    async fn get_signers_with_stake_at_epoch(
+        &self,
+        signer_retrieval_epoch: Epoch,
+    ) -> StdResult<Vec<SignerWithStake>> {
+        let stake_distribution = self
+            .stake_distribution_service
+            .get_stake_distribution(signer_retrieval_epoch)
+            .await
+            .with_context(|| {
+                format!("Epoch service could not obtains stake distribution for epoch: {signer_retrieval_epoch}")
+            })?;
+        let mut signers = self
+            .verification_key_store
+            .get_verification_keys(signer_retrieval_epoch)
+            .await?
+            .ok_or(EpochServiceError::UnavailableData(
+                signer_retrieval_epoch,
+                "signers verification keys".to_string(),
+            ))?;
+
+        Ok(stake_distribution
+            .into_iter()
+            .filter_map(|(party_id, stake)| {
+                signers.remove(&party_id).map(|signer| {
+                    SignerWithStake::new(
+                        party_id,
+                        signer.verification_key,
+                        signer.verification_key_signature,
+                        signer.operational_certificate,
+                        signer.kes_period,
+                        stake,
+                    )
+                })
+            })
+            .collect())
+    }
+
+    fn unwrap_data(&self) -> Result<&EpochData, EpochServiceError> {
+        self.current_epoch_data
+            .as_ref()
+            .ok_or(EpochServiceError::NotYetInitialized)
+    }
+}
+
+#[async_trait]
+impl EpochService for MithrilEpochService {
+    async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()> {
+        let signer_retrieval_epoch =
+            epoch.offset_to_signer_retrieval_epoch().with_context(|| {
+                format!("EpochService could not compute signer retrieval epoch from epoch: {epoch}")
+            })?;
+        let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
+        let current_protocol_parameters = self
+            .protocol_parameters_store
+            .get_protocol_parameters(signer_retrieval_epoch)
+            .await
+            .with_context(|| "Epoch service failed to obtains current protocol parameters")?
+            .ok_or(EpochServiceError::UnavailableData(
+                signer_retrieval_epoch,
+                "protocol parameters".to_string(),
+            ))?;
+        let next_protocol_parameters = self
+            .protocol_parameters_store
+            .get_protocol_parameters(next_signer_retrieval_epoch)
+            .await
+            .with_context(|| "Epoch service failed to obtains next protocol parameters")?
+            .ok_or(EpochServiceError::UnavailableData(
+                signer_retrieval_epoch,
+                "protocol parameters".to_string(),
+            ))?;
+
+        let current_signers = self
+            .get_signers_with_stake_at_epoch(signer_retrieval_epoch)
+            .await?;
+        let next_signers = self
+            .get_signers_with_stake_at_epoch(next_signer_retrieval_epoch)
+            .await?;
+
+        let protocol_multi_signer =
+            SignerBuilder::new(&current_signers, &current_protocol_parameters)
+                .with_context(|| "Epoch service failed to build protocol multi signer")?
+                .build_multi_signer();
+
+        let next_protocol_multi_signer =
+            SignerBuilder::new(&next_signers, &next_protocol_parameters)
+                .with_context(|| "Epoch service failed to build next protocol multi signer")?
+                .build_multi_signer();
+
+        self.current_epoch_data = Some(EpochData {
+            epoch,
+            protocol_parameters: current_protocol_parameters,
+            next_protocol_parameters,
+            aggregate_verification_key: protocol_multi_signer.compute_aggregate_verification_key(),
+            next_aggregate_verification_key: next_protocol_multi_signer
+                .compute_aggregate_verification_key(),
+            signers: current_signers,
+            next_signers,
+            protocol_multi_signer,
+        });
+
+        Ok(())
+    }
+
+    fn epoch_of_current_data(&self) -> StdResult<Epoch> {
+        Ok(self.unwrap_data()?.epoch)
+    }
+
+    fn current_protocol_parameters(&self) -> StdResult<&ProtocolParameters> {
+        Ok(&self.unwrap_data()?.protocol_parameters)
+    }
+
+    fn next_protocol_parameters(&self) -> StdResult<&ProtocolParameters> {
+        Ok(&self.unwrap_data()?.next_protocol_parameters)
+    }
+
+    fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
+        Ok(&self.unwrap_data()?.aggregate_verification_key)
+    }
+
+    fn next_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
+        Ok(&self.unwrap_data()?.next_aggregate_verification_key)
+    }
+
+    fn current_signers_with_stake(&self) -> StdResult<&Vec<SignerWithStake>> {
+        Ok(&self.unwrap_data()?.signers)
+    }
+
+    fn next_signers_with_stake(&self) -> StdResult<&Vec<SignerWithStake>> {
+        Ok(&self.unwrap_data()?.next_signers)
+    }
+
+    fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner> {
+        Ok(&self.unwrap_data()?.protocol_multi_signer)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::entities::PartyId;
+    use mithril_common::store::adapter::MemoryAdapter;
+    use mithril_common::test_utils::MithrilFixtureBuilder;
+    use mockall::predicate::eq;
+    use std::collections::{BTreeSet, HashMap};
+
+    use crate::services::MockStakeDistributionService;
+    use crate::{ProtocolParametersStore, VerificationKeyStore};
+
+    use super::*;
+
+    #[derive(Debug, Clone, PartialEq)]
+    struct ExpectedEpochData {
+        epoch: Epoch,
+        protocol_parameters: ProtocolParameters,
+        next_protocol_parameters: ProtocolParameters,
+        aggregate_verification_key: ProtocolAggregateVerificationKey,
+        next_aggregate_verification_key: ProtocolAggregateVerificationKey,
+        signers: BTreeSet<SignerWithStake>,
+        next_signers: BTreeSet<SignerWithStake>,
+    }
+
+    impl ExpectedEpochData {
+        async fn from_service(service: &MithrilEpochService) -> StdResult<Self> {
+            Ok(ExpectedEpochData {
+                epoch: service.epoch_of_current_data()?,
+                protocol_parameters: service.current_protocol_parameters()?.clone(),
+                next_protocol_parameters: service.next_protocol_parameters()?.clone(),
+                aggregate_verification_key: service.current_aggregate_verification_key()?.clone(),
+                next_aggregate_verification_key: service.next_aggregate_verification_key()?.clone(),
+                signers: service
+                    .current_signers_with_stake()?
+                    .clone()
+                    .into_iter()
+                    .collect(),
+                next_signers: service
+                    .next_signers_with_stake()?
+                    .clone()
+                    .into_iter()
+                    .collect(),
+            })
+        }
+    }
+
+    fn map_signers_for_vkey_store(
+        signers: &[SignerWithStake],
+    ) -> HashMap<PartyId, SignerWithStake> {
+        signers
+            .iter()
+            .cloned()
+            .map(|s| (s.party_id.to_owned(), s))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn informs_epoch_get_data_from_its_dependencies() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let fixture2 = MithrilFixtureBuilder::default()
+            .with_protocol_parameters(ProtocolParameters::new(8, 80, 0.80))
+            .with_signers(5)
+            .build();
+
+        let epoch = Epoch(5);
+        let signer_retrieval_epoch = epoch.offset_to_signer_retrieval_epoch().unwrap();
+        let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
+
+        let expected = ExpectedEpochData {
+            epoch,
+            protocol_parameters: fixture.protocol_parameters(),
+            next_protocol_parameters: fixture2.protocol_parameters(),
+            aggregate_verification_key: fixture.compute_avk(),
+            next_aggregate_verification_key: fixture2.compute_avk(),
+            signers: fixture.signers_with_stake().into_iter().collect(),
+            next_signers: fixture2.signers_with_stake().into_iter().collect(),
+        };
+
+        let protocol_parameters_store = ProtocolParametersStore::new(
+            Box::new(
+                MemoryAdapter::new(Some(vec![
+                    (signer_retrieval_epoch, fixture.protocol_parameters()),
+                    (next_signer_retrieval_epoch, fixture2.protocol_parameters()),
+                ]))
+                .unwrap(),
+            ),
+            None,
+        );
+        let vkey_store = VerificationKeyStore::new(Box::new(
+            MemoryAdapter::new(Some(vec![
+                (
+                    signer_retrieval_epoch,
+                    map_signers_for_vkey_store(&fixture.signers_with_stake()),
+                ),
+                (
+                    next_signer_retrieval_epoch,
+                    map_signers_for_vkey_store(&fixture2.signers_with_stake()),
+                ),
+            ]))
+            .unwrap(),
+        ));
+
+        let mut stake_service = MockStakeDistributionService::new();
+        stake_service
+            .expect_get_stake_distribution()
+            .with(eq(signer_retrieval_epoch))
+            .returning(move |_| Ok(fixture.stake_distribution()));
+        stake_service
+            .expect_get_stake_distribution()
+            .with(eq(next_signer_retrieval_epoch))
+            .returning(move |_| Ok(fixture2.stake_distribution()));
+
+        let mut service = MithrilEpochService::new(
+            Arc::new(stake_service),
+            Arc::new(protocol_parameters_store),
+            Arc::new(vkey_store),
+        );
+
+        service
+            .inform_epoch(epoch)
+            .await
+            .expect("inform_epoch should not fail");
+        let data = ExpectedEpochData::from_service(&service)
+            .await
+            .expect("extracting data from service should not fail");
+
+        assert_eq!(expected, data);
+    }
+}

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -244,6 +244,19 @@ impl FakeEpochService {
         }
     }
 
+    pub fn from_fixture(
+        epoch: Epoch,
+        fixture: &mithril_common::test_utils::MithrilFixture,
+    ) -> Self {
+        Self::with_data(
+            epoch,
+            &fixture.protocol_parameters(),
+            &fixture.protocol_parameters(),
+            &fixture.signers_with_stake(),
+            &fixture.signers_with_stake(),
+        )
+    }
+
     /// Note: using this will make all 'get' method from [EpochService] trait
     /// return a [EpochServiceError::NotYetInitialized] error.
     pub fn without_data() -> Self {

--- a/mithril-aggregator/src/services/mod.rs
+++ b/mithril-aggregator/src/services/mod.rs
@@ -10,11 +10,13 @@
 //! Each service is defined by a public API (a trait) that is used in the controllers (runtimes).
 
 mod certifier;
+mod epoch_service;
 mod signed_entity;
 mod stake_distribution;
 mod ticker;
 
 pub use certifier::*;
+pub use epoch_service::*;
 pub use signed_entity::*;
 pub use stake_distribution::*;
 pub use ticker::*;

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -17,6 +17,9 @@ use mithril_common::{
 
 use crate::database::provider::StakePoolStore;
 
+#[cfg(test)]
+use mockall::automock;
+
 /// Errors related to the [StakeDistributionService].
 #[derive(Debug)]
 pub enum StakePoolDistributionServiceError {
@@ -86,6 +89,7 @@ impl Display for StakePoolDistributionServiceError {
 impl std::error::Error for StakePoolDistributionServiceError {}
 
 /// Responsible of synchronizing with Cardano stake distribution.
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait StakeDistributionService: Sync + Send {
     /// Return the stake distribution fot the given epoch.

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -21,7 +21,7 @@ use mockall::automock;
 #[derive(Error, Debug)]
 pub enum SignerRegistrationError {
     /// No signer registration round opened yet
-    #[error("a signer registration round has not yet to be opened")]
+    #[error("a signer registration round is not opened yet, please try again later")]
     RegistrationRoundNotYetOpened,
 
     /// Registration round for unexpected epoch

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -27,11 +27,14 @@ pub trait VerificationKeyStorer: Sync + Send {
         signer: SignerWithStake,
     ) -> StdResult<Option<SignerWithStake>>;
 
-    /// Returns a HashMap of [Signer] indexed by [PartyId] for the given `Beacon`.
+    /// Returns a HashMap of [Signer] indexed by [PartyId] for the given `epoch`.
     async fn get_verification_keys(
         &self,
         epoch: Epoch,
     ) -> StdResult<Option<HashMap<PartyId, Signer>>>;
+
+    /// Returns the list of signers for the given `epoch`.
+    async fn get_signers(&self, epoch: Epoch) -> StdResult<Option<Vec<SignerWithStake>>>;
 
     /// Prune all verification keys that are at or below the given epoch.
     async fn prune_verification_keys(&self, max_epoch_to_prune: Epoch) -> StdResult<()>;
@@ -93,6 +96,18 @@ impl VerificationKeyStorer for VerificationKeyStore {
         Ok(record.map(|h| h.into_iter().map(|(k, v)| (k, v.into())).collect()))
     }
 
+    async fn get_signers(&self, epoch: Epoch) -> StdResult<Option<Vec<SignerWithStake>>> {
+        let record = self
+            .adapter
+            .read()
+            .await
+            .get_record(&epoch)
+            .await
+            .with_context(|| format!("Could not get signers for epoch {epoch}."))?;
+
+        Ok(record.map(|h| h.into_values().collect()))
+    }
+
     async fn prune_verification_keys(&self, max_epoch_to_prune: Epoch) -> StdResult<()> {
         let mut adapter = self.adapter.write().await;
 
@@ -150,6 +165,11 @@ macro_rules! test_verification_key_storer {
             }
 
             #[tokio::test]
+            async fn get_signers_for_empty_epoch() {
+                test_suite::get_signers_for_empty_epoch(&$store_builder).await;
+            }
+
+            #[tokio::test]
             async fn get_stake_distribution_for_empty_epoch() {
                 test_suite::get_stake_distribution_for_empty_epoch(&$store_builder).await;
             }
@@ -157,6 +177,11 @@ macro_rules! test_verification_key_storer {
             #[tokio::test]
             async fn get_verification_keys_for_existing_epoch() {
                 test_suite::get_verification_keys_for_existing_epoch(&$store_builder).await;
+            }
+
+            #[tokio::test]
+            async fn get_signers_for_existing_epoch() {
+                test_suite::get_signers_for_existing_epoch(&$store_builder).await;
             }
 
             #[tokio::test]
@@ -180,7 +205,7 @@ pub(crate) use test_verification_key_storer;
 pub mod test_suite {
     use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake, StakeDistribution};
     use mithril_common::test_utils::fake_keys;
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::{BTreeMap, BTreeSet, HashMap};
     use std::sync::Arc;
 
     use crate::VerificationKeyStorer;
@@ -282,6 +307,14 @@ pub mod test_suite {
         assert!(res.is_none());
     }
 
+    pub async fn get_signers_for_empty_epoch(store_builder: &StoreBuilder) {
+        let signers = build_signers(2, 1);
+        let store = store_builder(signers);
+        let res = store.get_signers(Epoch(0)).await.unwrap();
+
+        assert!(res.is_none());
+    }
+
     pub async fn get_stake_distribution_for_empty_epoch(store_builder: &StoreBuilder) {
         let signers = build_signers(2, 1);
         let store = store_builder(signers);
@@ -309,6 +342,24 @@ pub mod test_suite {
             .await
             .unwrap()
             .map(|x| BTreeMap::from_iter(x.into_iter()));
+
+        assert_eq!(expected_signers, res);
+    }
+
+    pub async fn get_signers_for_existing_epoch(store_builder: &StoreBuilder) {
+        let signers = build_signers(2, 2);
+        let store = store_builder(signers.clone());
+
+        let expected_signers: Option<BTreeSet<SignerWithStake>> = signers
+            .into_iter()
+            .filter(|(e, _)| e == 1)
+            .map(|(_, signers)| BTreeSet::from_iter(signers.into_values()))
+            .next();
+        let res = store
+            .get_signers(Epoch(1))
+            .await
+            .unwrap()
+            .map(|x| BTreeSet::from_iter(x.into_iter()));
 
         assert_eq!(expected_signers, res);
     }

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -67,7 +67,7 @@ impl GenesisTools {
         let mut multi_signer = dependencies.multi_signer.write().await;
         let beacon_provider = dependencies.beacon_provider.clone();
         let beacon = beacon_provider.get_current_beacon().await?;
-        multi_signer.update_current_beacon(beacon.clone()).await?;
+        multi_signer.update_current_epoch(beacon.epoch).await?;
 
         let genesis_verifier = dependencies.genesis_verifier.clone();
         let certificate_verifier = dependencies.certificate_verifier.clone();

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context};
 use std::{fs::File, io::prelude::*, io::Write, path::Path, sync::Arc};
-use tokio::sync::RwLock;
 
 use mithril_common::{
     certificate_chain::{CertificateGenesisProducer, CertificateVerifier},
@@ -9,15 +8,16 @@ use mithril_common::{
         ProtocolGenesisVerifier,
     },
     entities::{Beacon, ProtocolParameters},
+    protocol::SignerBuilder,
     BeaconProvider, StdResult,
 };
 
 use crate::database::provider::CertificateRepository;
-use crate::{MultiSigner, ProtocolParametersStorer};
+use crate::{ProtocolParametersStorer, VerificationKeyStorer};
 
 pub struct GenesisToolsDependency {
-    /// Multi-signer service.
-    pub multi_signer: Arc<RwLock<dyn MultiSigner>>,
+    /// Verification key store
+    pub verification_key_store: Arc<dyn VerificationKeyStorer>,
 
     /// Beacon provider service.
     pub beacon_provider: Arc<dyn BeaconProvider>,
@@ -64,24 +64,39 @@ impl GenesisTools {
     }
 
     pub async fn from_dependencies(dependencies: GenesisToolsDependency) -> StdResult<Self> {
-        let mut multi_signer = dependencies.multi_signer.write().await;
         let beacon_provider = dependencies.beacon_provider.clone();
         let beacon = beacon_provider.get_current_beacon().await?;
-        multi_signer.update_current_epoch(beacon.epoch).await?;
 
         let genesis_verifier = dependencies.genesis_verifier.clone();
         let certificate_verifier = dependencies.certificate_verifier.clone();
         let certificate_repository = dependencies.certificate_repository.clone();
         let protocol_parameters_store = dependencies.protocol_parameters_store.clone();
 
+        let protocol_params_epoch = beacon.epoch.offset_to_signer_retrieval_epoch()?;
         let protocol_parameters = protocol_parameters_store
+            .get_protocol_parameters(protocol_params_epoch)
+            .await?
+            .ok_or_else(|| {
+                anyhow!("Missing protocol parameters for epoch {protocol_params_epoch}")
+            })?;
+
+        let genesis_avk_epoch = beacon.epoch.offset_to_next_signer_retrieval_epoch();
+        let genesis_avk_protocol_parameters = protocol_parameters_store
             .get_protocol_parameters(beacon.epoch.offset_to_signer_retrieval_epoch()?)
             .await?
-            .ok_or_else(|| anyhow!("Missing protocol parameters"))?;
+            .ok_or_else(|| anyhow!("Missing protocol parameters for epoch {genesis_avk_epoch}"))?;
+        let genesis_signers = dependencies
+            .verification_key_store
+            .get_signers(genesis_avk_epoch)
+            .await?
+            .ok_or_else(|| anyhow!("Missing signers for epoch {genesis_avk_epoch}"))?;
 
-        let genesis_avk = multi_signer
-            .compute_next_stake_distribution_aggregate_verification_key()
-            .await?;
+        let protocol_multi_signer =
+            SignerBuilder::new(&genesis_signers, &genesis_avk_protocol_parameters)
+                .with_context(|| "Could not build a multi signer to compute the genesis avk")?
+                .build_multi_signer();
+
+        let genesis_avk = protocol_multi_signer.compute_aggregate_verification_key();
 
         Ok(Self::new(
             protocol_parameters,

--- a/mithril-aggregator/src/tools/signer_importer.rs
+++ b/mithril-aggregator/src/tools/signer_importer.rs
@@ -302,9 +302,8 @@ mod tests {
 
     #[tokio::test]
     async fn retriever_handle_http_data_fetching_error() {
-        let server = test_http_server(
-            warp::path("list").map(|| reply::internal_server_error("whatever".to_string())),
-        );
+        let server =
+            test_http_server(warp::path("list").map(|| reply::internal_server_error("whatever")));
 
         let retriever =
             CExplorerSignerRetriever::new(format!("{}/list", server.url()), None).unwrap();

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.126"
+version = "0.2.127"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/entities/http_server_error.rs
+++ b/mithril-common/src/entities/http_server_error.rs
@@ -1,3 +1,4 @@
+use crate::StdError;
 use serde::{Deserialize, Serialize};
 
 /// Representation of a Internal Server Error raised by an http server
@@ -11,6 +12,24 @@ impl InternalServerError {
     /// InternalServerError factory
     pub fn new(message: String) -> InternalServerError {
         InternalServerError { message }
+    }
+}
+
+impl From<String> for InternalServerError {
+    fn from(message: String) -> Self {
+        InternalServerError::new(message)
+    }
+}
+
+impl From<&str> for InternalServerError {
+    fn from(message: &str) -> Self {
+        InternalServerError::new(message.to_string())
+    }
+}
+
+impl From<StdError> for InternalServerError {
+    fn from(error: StdError) -> Self {
+        InternalServerError::new(format!("{error:?}"))
     }
 }
 

--- a/mithril-common/src/entities/signer.rs
+++ b/mithril-common/src/entities/signer.rs
@@ -60,6 +60,11 @@ impl Signer {
         }
     }
 
+    /// Convert the given values to a vec of signers.
+    pub fn vec_from<T: Into<Signer>>(from: Vec<T>) -> Vec<Self> {
+        from.into_iter().map(|f| f.into()).collect()
+    }
+
     /// Computes the hash of Signer
     pub fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.2.20"
+version = "0.2.21"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/bin/load-aggregator/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/bin/load-aggregator/main.rs
@@ -165,9 +165,16 @@ async fn main_scenario(
 
     info!(">> Send the Signer Key Registrations payloads");
     parameters.reporter.start("signers registration");
+    fake_signer::try_register_signer_until_registration_round_is_open(
+        &parameters.aggregator,
+        &parameters.signers_fixture.signers()[0],
+        current_epoch + 1,
+        Duration::from_secs(60),
+    )
+    .await?;
     let errors = fake_signer::register_signers_to_aggregator(
         &parameters.aggregator,
-        &parameters.signers_fixture.signers(),
+        &parameters.signers_fixture.signers()[1..],
         current_epoch + 1,
     )
     .await?;

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_client.rs
@@ -120,8 +120,10 @@ pub async fn clients_scenario(endpoint: String, num_clients: usize) -> StdResult
     info!(">> Run clients scenario with {num_clients} clients");
 
     let mut join_set: JoinSet<StdResult<()>> = JoinSet::new();
+    // todo: redraw this progress bar but in a MultiProgressBar, drawing it as is create
+    // a blinking progress bar in the cli since we are doing other operation at the same time.
     let progress_bar =
-        ProgressBar::with_draw_target(Some(num_clients as u64), ProgressDrawTarget::stdout());
+        ProgressBar::with_draw_target(Some(num_clients as u64), ProgressDrawTarget::hidden());
 
     let http_client = Arc::new(reqwest::Client::new());
     for _client_index in 0..num_clients {

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_client.rs
@@ -8,7 +8,7 @@ use mithril_common::{
     StdResult,
 };
 use reqwest::StatusCode;
-use slog_scope::{info, warn};
+use slog_scope::warn;
 use thiserror::Error;
 use tokio::task::JoinSet;
 
@@ -117,8 +117,6 @@ pub async fn download_certificate_chain(
 }
 
 pub async fn clients_scenario(endpoint: String, num_clients: usize) -> StdResult<usize> {
-    info!(">> Run clients scenario with {num_clients} clients");
-
     let mut join_set: JoinSet<StdResult<()>> = JoinSet::new();
     // todo: redraw this progress bar but in a MultiProgressBar, drawing it as is create
     // a blinking progress bar in the cli since we are doing other operation at the same time.

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
@@ -1,6 +1,8 @@
+use async_recursion::async_recursion;
 use indicatif::{ProgressBar, ProgressDrawTarget};
-use reqwest::StatusCode;
-use slog_scope::warn;
+use reqwest::{RequestBuilder, StatusCode};
+use slog_scope::{debug, info, warn};
+use std::time::Duration;
 use thiserror::Error;
 use tokio::task::JoinSet;
 
@@ -30,6 +32,73 @@ pub enum LoadError {
     },
 }
 
+#[async_recursion]
+async fn send_signer_registration_request(
+    party_id: PartyId,
+    http_request: RequestBuilder,
+    try_register_until_registration_round_is_open: bool,
+) -> StdResult<()> {
+    let response = http_request.try_clone().unwrap().send().await.unwrap();
+
+    match response.status() {
+        StatusCode::CREATED => Ok(()),
+        StatusCode::SERVICE_UNAVAILABLE if try_register_until_registration_round_is_open => {
+            let error_message = response.text().await.unwrap();
+            debug!(
+                "Error 503 (SERVICE_UNAVAILABLE) for First signer registration, waiting 250ms before trying again";
+                "error_message" => &error_message
+            );
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            send_signer_registration_request(party_id, http_request, true).await
+        }
+        status => Err(LoadError::SignerRegistrationError {
+            expected_http_code: 201,
+            got_http_code: status.as_u16() as u32,
+            party_id,
+            error_message: response.text().await.unwrap(),
+        }
+        .into()),
+    }
+}
+
+pub async fn try_register_signer_until_registration_round_is_open(
+    aggregator: &Aggregator,
+    signer: &Signer,
+    epoch: Epoch,
+    timeout: Duration,
+) -> StdResult<()> {
+    let mut register_message =
+        payload_builder::generate_register_signer_message(&[signer.clone()], epoch);
+    let register_message = register_message.swap_remove(0);
+    let party_id = register_message.party_id.clone();
+
+    let http_request = reqwest::Client::new()
+        .post(format!("{}/register-signer", aggregator.endpoint()))
+        .json(&register_message);
+
+    spin_while_waiting!(
+        {
+            match send_signer_registration_request(register_message.party_id, http_request, true)
+                .await
+            {
+                Ok(_) => {
+                    info!("Signer registration succeeded, sending the other registrations...");
+                }
+                Err(err) => {
+                    warn!("Signer Registration error for first signer caught, other registrations will be skipped: {err:?}");
+                }
+            }
+
+            Ok(())
+        },
+        timeout,
+        format!(
+            "Trying to register signer '{party_id}' until the registration round is opened ...",
+        ),
+        format!("Aggregator failed to register signer '{party_id}' after {timeout:?}'",)
+    )
+}
+
 pub async fn register_signers_to_aggregator(
     aggregator: &Aggregator,
     signers: &[Signer],
@@ -44,29 +113,16 @@ pub async fn register_signers_to_aggregator(
     );
 
     let http_client = reqwest::Client::new();
+    let register_url = format!("{}/register-signer", aggregator.endpoint());
+    let mut errors = 0;
 
     for register in register_messages {
-        let endpoint = aggregator.endpoint();
-        let http_request = http_client
-            .post(format!("{}/register-signer", endpoint))
-            .json(&register);
+        let http_request = http_client.post(&register_url).json(&register);
 
         join_set.spawn(async move {
-            let response = http_request.send().await.unwrap();
-
-            match response.status() {
-                StatusCode::CREATED => Ok(()),
-                status => Err(LoadError::SignerRegistrationError {
-                    expected_http_code: 201,
-                    got_http_code: status.as_u16() as u32,
-                    party_id: register.party_id,
-                    error_message: response.text().await.unwrap(),
-                }
-                .into()),
-            }
+            send_signer_registration_request(register.party_id, http_request, false).await
         });
     }
-    let mut errors = 0;
 
     while let Some(res) = join_set.join_next().await {
         let res = res.expect("Tokio task join failed!");
@@ -77,6 +133,8 @@ pub async fn register_signers_to_aggregator(
             errors += 1;
         }
     }
+
+    progress_bar.finish();
 
     Ok(errors)
 }
@@ -129,6 +187,8 @@ pub async fn register_signatures_to_aggregator(
             errors += 1;
         }
     }
+
+    progress_bar.finish();
 
     Ok(errors)
 }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
@@ -166,6 +166,8 @@ pub async fn register_signatures_to_aggregator(
 
             match response.status() {
                 StatusCode::CREATED => Ok(()),
+                // Certificate already certified
+                StatusCode::GONE => Ok(()),
                 status => Err(LoadError::SignaturesRegistrationError {
                     expected_http_code: 201,
                     got_http_code: status.as_u16() as u32,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -341,6 +341,12 @@ paths:
                 $ref: "#/components/schemas/Error"
         "412":
           description: API version mismatch
+        "503":
+          description: signer registration is unavailable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           description: signer registration error
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.12
+  version: 0.1.13
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content
This PR refactor how the aggregator works with its multi-signer:
- Instead of calling the multi signer to do computation _(like the avk)_ or get data (the signers and protocol parameters) those are moved to a new service, `EpochService` that compute only once for a given epoch.
- The state machine is responsible to tell the `EpochService` to update it's data.
- Since all those data are what needed to compute a `ProtocolMultiSigner`, the `EpochService` precompute one. Creating a `ProtocolMultiSigner` multiple times was the source of  the bottleneck raised in #1187.
- Also the future protocol parameters insertion, previously handled by the multi-signer, is moved to this new service.

This allow to remove all states in the aggregator multi-signer, now it only have two methods: `verify_single_signature` and, `create_multi_signature`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
- It came to light that the `StakeDistributionService` was unused, since it was handled by the multi-signer before was the opportunity to use it instead.
- Some works have also be done on the errors logging and reporting via the aggregator http server (most of the stack traces were ignored).
- A confusion have been lifted by replacing the `get_stake_distribution_for_epoch` method of the `VerificationKeyStorer` by a new `get_signers` method. The `VerificationKeyStorer` doesn't work on the whole stake distribution so this method was misleading (it returned the list of registered signers for a given epoch using the `StakeDistribution` as return type).


## Performances improvements

There's an approximately `x33` improvements on signatures registration:

### Context
Each test consist of running `cargo run --bin load-aggregator  -- -vvv --num-signers 500 --num-clients 0`.
The tests run on a computer with:
* Ubuntu 22.04.3 LTS
* 11th Gen Intel® Core™ i7-11800H @ 2.30GHz × 16 threads
* 32Gb of RAM

### Before
Run on the tip of the main branch as of now (commit [#ac51892](https://github.com/input-output-hk/mithril/commit/ac51892b33a8027ba77e63d9d91f74eb41fa1a2e)).
```
signers clients phase   duration/ms
500     0       stress bootstrap - without clients      107457
500     0       signers registration - without clients  28016
500     0       signatures registration - without clients       357224
500     0       signatures registration - without clients       359440
500     0       signers registration - without clients  29349
500     0       signatures registration - without clients       361011
500     0       signatures registration - without clients       339555
```

### After
```
signers clients phase   duration/ms
500     0       stress bootstrap - without clients      104512
500     0       signers registration - without clients  30779
500     0       signatures registration - without clients       10123
500     0       signatures registration - without clients       10101
500     0       signers registration - without clients  30256
500     0       signatures registration - without clients       10279
500     0       signatures registration - without clients       10071
```

## Issue(s)
Closes #1187
 