### PR TITLE
Fix missing aggregator configuration in `devnet`

### DIFF
--- a/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-mkfiles.sh
@@ -54,7 +54,8 @@ SECURITY_PARAM=2
 NODE_PORT_START=3000
 NODE_ADDR_PREFIX="172.16.238"
 NODE_ADDR_INCREMENT=10
-CARDANO_BINARY_URL="https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz"
+CARDANO_NODE_VERSION="8.1.2"
+CARDANO_BINARY_URL="https://github.com/input-output-hk/cardano-node/releases/download/${CARDANO_NODE_VERSION}/cardano-node-${CARDANO_NODE_VERSION}-linux.tar.gz"
 ALONZO_GENESIS_URL="https://book.world.dev.cardano.org/environments/private/alonzo-genesis.json"
 CONWAY_GENESIS_URL="https://book.world.dev.cardano.org/environments/private/conway-genesis.json"
 
@@ -968,8 +969,10 @@ cat >> docker-compose.yaml <<EOF
       - URL_SNAPSHOT_MANIFEST=
       - SNAPSHOT_STORE_TYPE=local
       - SNAPSHOT_UPLOADER_TYPE=local
+      - SNAPSHOT_COMPRESSION_ALGORITHM=zstandard
       - DATA_STORES_DIRECTORY=/data/mithril/aggregator/stores
       - CARDANO_NODE_SOCKET_PATH=/data/ipc/node.sock
+      - CARDANO_NODE_VERSION=${CARDANO_NODE_VERSION}
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
       - GENESIS_VERIFICATION_KEY=${GENESIS_VERIFICATION_KEY}
       - DB_DIRECTORY=/data/db
@@ -1005,6 +1008,7 @@ cat >> docker-compose.yaml <<EOF
       - SNAPSHOT_UPLOADER_TYPE=local
       - DATA_STORES_DIRECTORY=/data/mithril/aggregator/stores
       - CARDANO_NODE_SOCKET_PATH=/data/ipc/node.sock
+      - CARDANO_NODE_VERSION=${CARDANO_NODE_VERSION}
       - CARDANO_CLI_PATH=/app/bin/cardano-cli
       - GENESIS_VERIFICATION_KEY=${GENESIS_VERIFICATION_KEY}
       - GENESIS_SECRET_KEY=${GENESIS_SECRET_KEY}


### PR DESCRIPTION
## Content
This PR includes a fix to the aggregator configuration in the `devnet`:
- Added the required `CARDANO_NODE_VERSION` configuration
- Switched to `zstandard` compression with the optional `SNAPSHOT_COMPRESSION_ALGORITHM` configuration

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1272 
