### PR TITLE
Refactor Dockerfile.ci to slim containers

### DIFF
--- a/mithril-aggregator/Dockerfile.ci
+++ b/mithril-aggregator/Dockerfile.ci
@@ -3,24 +3,27 @@
 # on a debian-compatible x86-64 environment
 FROM debian:11-slim
 
-# Args
-ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz
-
-# Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
-
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser
 
-# Copy the executable
-COPY mithril-aggregator/mithril-aggregator /app/bin/mithril-aggregator
-COPY mithril-aggregator/config /app/config
+# Precreate workdir
+RUN mkdir -p /app/bin
+
+# Upgrade
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz $CARDANO_BIN_URL
-RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
-RUN /app/bin/cardano-cli --version
-RUN rm -f cardano-bin.tar.gz
+ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz $CARDANO_BIN_URL \
+    && tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin \
+    && /app/bin/cardano-cli --version \
+    && rm -f cardano-bin.tar.gz
+
+# Copy the executable
+COPY mithril-aggregator/mithril-aggregator /app/bin/mithril-aggregator
+
+# Copy the config files
+COPY mithril-aggregator/config /app/config
 
 #Workdir
 WORKDIR /app/

--- a/mithril-client/Dockerfile.ci
+++ b/mithril-client/Dockerfile.ci
@@ -3,14 +3,19 @@
 # on a debian-compatible x86-64 environment
 FROM debian:11-slim
 
-# Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
-
 # Create appuser
 RUN adduser --disabled-password appuser
 
+# Precreate workdir
+RUN mkdir -p /app/bin
+
+# Upgrade
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Copy the executable
 COPY mithril-client/mithril-client /app/bin/mithril-client
+
+# Copy the config files
 COPY mithril-client/config /app/config
 
 # Workdir

--- a/mithril-signer/Dockerfile.ci
+++ b/mithril-signer/Dockerfile.ci
@@ -3,24 +3,27 @@
 # on a debian-compatible x86-64 environment
 FROM debian:11-slim
 
-# Args
-ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz
-
-# Upgrade
-RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && rm -rf /var/lib/apt/lists/*
-
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser
 
-# Copy the executable
-COPY mithril-signer/mithril-signer /app/bin/mithril-signer
-COPY mithril-signer/config /app/config
+# Precreate workdir
+RUN mkdir -p /app/bin
+
+# Upgrade
+RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install cardano-cli
-RUN wget -nv -O cardano-bin.tar.gz $CARDANO_BIN_URL
-RUN tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin
-RUN /app/bin/cardano-cli --version
-RUN rm -f cardano-bin.tar.gz
+ARG CARDANO_BIN_URL=https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz
+RUN wget -nv -O cardano-bin.tar.gz $CARDANO_BIN_URL \
+    && tar xzf cardano-bin.tar.gz ./cardano-cli && mv cardano-cli /app/bin \
+    && /app/bin/cardano-cli --version \
+    && rm -f cardano-bin.tar.gz
+
+# Copy the executable
+COPY mithril-signer/mithril-signer /app/bin/mithril-signer
+
+# Copy the config files
+COPY mithril-signer/config /app/config
 
 # Workdir
 WORKDIR /app/


### PR DESCRIPTION
## Content
Refactors the Dockerfile and Dockerfile.ci to use release binaries. 

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [X] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
* Reduces the size of existing containers. 
* Does not implement a BuildX cache to leverage identical image layers from previous CI runs.

## Issue(s)
Relates to #1272
