### PR TITLE
total_stake calculation corrected

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4106,9 +4106,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.39"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2ef2af84856a50c1d430afce2fdded0a4ec7eda868db86409b4543df0797f9"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -4292,9 +4292,9 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "88ad59a7560b41a70d191093a945f0b87bc1deeda46fb237479708a1d6b6cdfc"
 dependencies = [
  "getrandom",
  "rand",
@@ -4303,9 +4303,9 @@ dependencies = [
 
 [[package]]
 name = "uuid-macro-internal"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7e1ba1f333bd65ce3c9f27de592fcbc256dafe3af2717f56d7c87761fbaccf4"
+checksum = "3d8c6bba9b149ee82950daefc9623b32bb1dacbfb1890e352f6b887bd582adaf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4314,9 +4314,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+checksum = "4a72e1902dde2bd6441347de2b70b7f5d59bf157c6c62f0c44572607a1d55bbe"
 
 [[package]]
 name = "vcpkg"

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -1634,31 +1634,15 @@ mod tests {
                 _ => unreachable!(),
             }
         }
-    }
 
-    #[test]
-    fn debug_total_stake_calc(){
-        let nparties = 5;
-        let m = 12;
-        let k = 3;
-
-        let params = StmParameters { m, k, phi_f: 0.2 };
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-
-        let mut public_signers: Vec<(StmVerificationKey, Stake)> = Vec::with_capacity(nparties);
-        let mut initializers: Vec<StmInitializer> = Vec::with_capacity(nparties);
-
-        let stakes = (0..nparties)
-            .map(|_| 1 + (rng.next_u64() % 9999))
-            .collect::<Vec<_>>();
-
-        for stake in stakes {
-            let initializer = StmInitializer::setup(params, stake, &mut rng);
-            initializers.push(initializer.clone());
-            public_signers.push((initializer.verification_key().vk, initializer.stake));
+        #[test]
+        fn test_total_stake_core_verifier(nparties in 2_usize..30,
+                              m in 10_u64..20,
+                              k in 1_u64..5,) {
+            let params = StmParameters { m, k, phi_f: 0.2 };
+            let (_initializers, public_signers) = setup_equal_core_parties(params, nparties);
+            let core_verifier = CoreVerifier::setup(&public_signers);
+            assert_ne!(core_verifier.total_stake, 0, "Total stake is 0.");
         }
-
-        let core_verifier = CoreVerifier::setup(&public_signers);
-        println!("Total stake test: {}", core_verifier.total_stake);
     }
 }

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -902,7 +902,7 @@ impl CoreVerifier {
     ///     * Calculate the total stake of the eligible signers,
     ///     * Sort the eligible signers.
     pub fn setup(public_signers: &[(VerificationKey, Stake)]) -> Self {
-        let mut total_stake: Stake = 3;
+        let mut total_stake: Stake = 0;
         let mut unique_parties = HashSet::new();
         for signer in public_signers.iter() {
             let (res, overflow) = total_stake.overflowing_add(signer.1);

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -1642,7 +1642,7 @@ mod tests {
             let params = StmParameters { m, k, phi_f: 0.2 };
             let (_initializers, public_signers) = setup_equal_core_parties(params, nparties);
             let core_verifier = CoreVerifier::setup(&public_signers);
-            assert_ne!(core_verifier.total_stake, 0, "Total stake is 0.");
+            assert_eq!(nparties as u64, core_verifier.total_stake, "Total stake expected: {}, got: {}.", nparties, core_verifier.total_stake);
         }
     }
 }


### PR DESCRIPTION
## Content
<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->
This PR includes the fix for the wrong calculation of the total stake in the setup of a core verifier and a test for total stake calculation.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Issue(s)
<!-- The issue(s) this PR relates to or closes -->
Closes #1306 