### PR TITLE
Simplify certificate verifier usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.129"
+version = "0.2.130"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.3"
+version = "0.4.4"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -621,7 +621,10 @@ impl DependenciesBuilder {
     }
 
     async fn build_certificate_verifier(&mut self) -> Result<Arc<dyn CertificateVerifier>> {
-        let verifier = Arc::new(MithrilCertificateVerifier::new(self.get_logger().await?));
+        let verifier = Arc::new(MithrilCertificateVerifier::new(
+            self.get_logger().await?,
+            self.get_certificate_repository().await?,
+        ));
 
         Ok(verifier)
     }

--- a/mithril-aggregator/src/services/certifier.rs
+++ b/mithril-aggregator/src/services/certifier.rs
@@ -383,11 +383,7 @@ impl CertifierService for MithrilCertifierService {
         );
 
         self.certificate_verifier
-            .verify_certificate(
-                &certificate,
-                self.certificate_repository.clone(),
-                &self.genesis_verifier,
-            )
+            .verify_certificate(&certificate, &self.genesis_verifier.to_verification_key())
             .await
             .with_context(|| {
                 format!(
@@ -444,8 +440,7 @@ impl CertifierService for MithrilCertifierService {
             self.certificate_verifier
                 .verify_certificate_chain(
                     certificate.to_owned(),
-                    self.certificate_repository.clone(),
-                    &self.genesis_verifier,
+                    &self.genesis_verifier.to_verification_key(),
                 )
                 .await
                 .with_context(|| "CertificateVerifier can not verify certificate chain")?;
@@ -692,8 +687,7 @@ mod tests {
             .certificate_verifier
             .verify_certificate(
                 &certificate_created,
-                certifier_service.certificate_repository.clone(),
-                &certifier_service.genesis_verifier,
+                &certifier_service.genesis_verifier.to_verification_key(),
             )
             .await
             .unwrap();

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -182,7 +182,10 @@ impl GenesisTools {
             genesis_signature,
         )?;
         self.certificate_verifier
-            .verify_genesis_certificate(&genesis_certificate, &self.genesis_verifier)
+            .verify_genesis_certificate(
+                &genesis_certificate,
+                &self.genesis_verifier.to_verification_key(),
+            )
             .await?;
         self.certificate_repository
             .create_certificate(genesis_certificate.clone())
@@ -243,7 +246,10 @@ mod tests {
         let connection = Connection::open_with_full_mutex(":memory:").unwrap();
         apply_all_migrations_to_db(&connection).unwrap();
         let certificate_store = Arc::new(CertificateRepository::new(Arc::new(connection)));
-        let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(slog_scope::logger()));
+        let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(
+            slog_scope::logger(),
+            certificate_store.clone(),
+        ));
         let genesis_avk = create_fake_genesis_avk();
         let genesis_verifier = Arc::new(genesis_signer.create_genesis_verifier());
         let genesis_tools = GenesisTools::new(
@@ -295,7 +301,10 @@ mod tests {
 
         assert_eq!(1, last_certificates.len());
         certificate_verifier
-            .verify_genesis_certificate(&last_certificates[0], &genesis_verifier)
+            .verify_genesis_certificate(
+                &last_certificates[0],
+                &genesis_verifier.to_verification_key(),
+            )
             .await
             .expect(
                 "verify_genesis_certificate should successfully validate the genesis certificate",
@@ -317,7 +326,10 @@ mod tests {
 
         assert_eq!(1, last_certificates.len());
         certificate_verifier
-            .verify_genesis_certificate(&last_certificates[0], &genesis_verifier)
+            .verify_genesis_certificate(
+                &last_certificates[0],
+                &genesis_verifier.to_verification_key(),
+            )
             .await
             .expect(
                 "verify_genesis_certificate should successfully validate the genesis certificate",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.4.13"
+version = "0.4.14"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/dependencies/builder.rs
+++ b/mithril-client/src/dependencies/builder.rs
@@ -222,7 +222,10 @@ impl DependenciesBuilder {
     }
 
     async fn build_certificate_verifier(&mut self) -> StdResult<Arc<dyn CertificateVerifier>> {
-        let verifier = MithrilCertificateVerifier::new(self.get_logger().await?);
+        let verifier = MithrilCertificateVerifier::new(
+            self.get_logger().await?,
+            self.get_certificate_client().await?,
+        );
 
         Ok(Arc::new(verifier))
     }

--- a/mithril-client/src/services/mock.rs
+++ b/mithril-client/src/services/mock.rs
@@ -1,9 +1,8 @@
 use std::path::Path;
-use std::sync::Arc;
 
 use async_trait::async_trait;
-use mithril_common::certificate_chain::{CertificateRetriever, CertificateVerifier};
-use mithril_common::crypto_helper::ProtocolGenesisVerifier;
+use mithril_common::certificate_chain::CertificateVerifier;
+use mithril_common::crypto_helper::ProtocolGenesisVerificationKey;
 use mithril_common::digesters::{ImmutableDigester, ImmutableDigesterError};
 use mithril_common::entities::{Beacon, Certificate, ProtocolMessage};
 use mithril_common::StdResult;
@@ -30,21 +29,19 @@ mock! {
         async fn verify_genesis_certificate(
             &self,
             genesis_certificate: &Certificate,
-            genesis_verifier: &ProtocolGenesisVerifier,
+            genesis_verification_key: &ProtocolGenesisVerificationKey,
         ) -> StdResult<()>;
 
         async fn verify_certificate(
             &self,
             certificate: &Certificate,
-            certificate_retriever: Arc<dyn CertificateRetriever>,
-            genesis_verifier: &ProtocolGenesisVerifier,
+            genesis_verification_key: &ProtocolGenesisVerificationKey,
         ) -> StdResult<Option<Certificate>>;
 
         async fn verify_certificate_chain(
             &self,
             certificate: Certificate,
-            certificate_retriever: Arc<dyn CertificateRetriever>,
-            genesis_verifier: &ProtocolGenesisVerifier,
+            genesis_verification_key: &ProtocolGenesisVerificationKey,
         ) -> StdResult<()>;
 
         fn verify_protocol_message(

--- a/mithril-client/src/services/snapshot.rs
+++ b/mithril-client/src/services/snapshot.rs
@@ -161,11 +161,7 @@ impl MithrilClientSnapshotService {
             ProtocolGenesisVerifier::from_verification_key(genesis_verification_key);
 
         self.certificate_verifier
-            .verify_certificate_chain(
-                certificate.clone(),
-                self.certificate_client.clone(),
-                &genesis_verifier,
-            )
+            .verify_certificate_chain(certificate.clone(), &genesis_verifier.to_verification_key())
             .await?;
 
         Ok(())
@@ -458,7 +454,7 @@ mod tests {
         let mut certificate_verifier = MockCertificateVerifierImpl::new();
         certificate_verifier
             .expect_verify_certificate_chain()
-            .returning(|_, _, _| Ok(()))
+            .returning(|_, _| Ok(()))
             .times(1);
 
         let dumb_digester = DumbImmutableDigester::new("snapshot-digest-123", true);

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.129"
+version = "0.2.130"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -87,10 +87,16 @@ impl ProtocolGenesisVerifier {
         self.verification_key
     }
 
-    /// Verifies the signature of a message
+    /// Verifies the genesis signature of a message
+    pub fn verify(&self, message: &[u8], signature: &ProtocolGenesisSignature) -> StdResult<()> {
+        self.verification_key.verify(message, signature)
+    }
+}
+
+impl ProtocolGenesisVerificationKey {
+    /// Verifies the genesis signature of a message
     pub fn verify(&self, message: &[u8], signature: &ProtocolGenesisSignature) -> StdResult<()> {
         Ok(self
-            .verification_key
             .verify_strict(message, signature)
             .map_err(|e| ProtocolGenesisError(anyhow!(e)))?)
     }

--- a/mithril-common/src/test_utils/fake_keys.rs
+++ b/mithril-common/src/test_utils/fake_keys.rs
@@ -304,6 +304,18 @@ pub const fn signer_verification_key_signature<'a>() -> [&'a str; 2] {
     ]
 }
 
+/// A list of pre json hex encoded [ed25519_dalek::VerifyingKey](https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.VerifyingKey.html)
+pub const fn genesis_verification_key<'a>() -> [&'a str; 2] {
+    [
+        "5b33322c3235332c3138362c3230312c3137372c31312c3131372c3133352c3138372c3136372c3138312c3138\
+        382c32322c35392c3230362c3130352c3233312c3135302c3231352c33302c37382c3231322c37362c31362c323\
+        5322c3138302c37322c3133342c3133372c3234372c3136312c36385d",
+        "5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c\
+        3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3\
+        232392c322c3234392c3230352c3230352c33392c3233352c34345d",
+    ]
+}
+
 /// A list of pre json hex encoded [OpCert][crate::crypto_helper::OpCert]
 pub const fn operational_certificate<'a>() -> [&'a str; 2] {
     [
@@ -356,6 +368,7 @@ pub const fn aggregate_verification_key<'a>() -> [&'a str; 3] {
 #[cfg(test)]
 mod test {
     use super::*;
+    use ed25519_dalek::VerifyingKey;
     use kes_summed_ed25519::kes::Sum6KesSig;
     use mithril_stm::stm::{StmAggrSig, StmAggrVerificationKey, StmSig, StmVerificationKeyPoP};
     use serde::{de::DeserializeOwned, Serialize};
@@ -450,6 +463,11 @@ mod test {
         assert_can_deserialize_using_key_decode_hex::<Sum6KesSig>(
             &signer_verification_key_signature(),
         );
+    }
+
+    #[test]
+    fn assert_encoded_genesis_verification_key_are_still_matching_concrete_type() {
+        assert_can_deserialize_using_key_decode_hex::<VerifyingKey>(&genesis_verification_key());
     }
 
     #[test]


### PR DESCRIPTION
## Content

This PR simplify the usage of the `CertificateVerifier` by moving the `CertificateRetriever` from its methods parameters to its the implementation.

The goal is to allow to design a simple certificate verification api in the client.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1311
