### PR TITLE
Client regressions in snapshot list and download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/snapshot/download.rs
+++ b/mithril-client-cli/src/commands/snapshot/download.rs
@@ -78,10 +78,17 @@ impl SnapshotDownloadCommand {
                 )
             })?;
 
+        let canonicalized_filepath = filepath.canonicalize().with_context(|| {
+            format!(
+                "Could not get canonicalized filepath of '{}'",
+                filepath.display()
+            )
+        })?;
+
         if self.json {
             println!(
                 r#"{{"db_directory": "{}"}}"#,
-                filepath.canonicalize()?.display()
+                canonicalized_filepath.display()
             );
         } else {
             println!(
@@ -97,7 +104,7 @@ docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind
                 &self.digest,
                 filepath.display(),
                 snapshot_entity.artifact.cardano_node_version,
-                filepath.display(),
+                canonicalized_filepath.display(),
                 snapshot_entity.artifact.beacon.network,
             );
         }

--- a/mithril-client-cli/src/commands/snapshot/list.rs
+++ b/mithril-client-cli/src/commands/snapshot/list.rs
@@ -47,7 +47,7 @@ impl SnapshotListCommand {
                         item.beacon.network.cell(),
                         item.digest.cell(),
                         item.size.cell(),
-                        item.locations.join(",").cell(),
+                        format!("{}", item.locations.len()).cell(),
                         item.created_at.to_string().cell(),
                     ]
                 })


### PR DESCRIPTION
## Content
This PR fixes the two regressions detected after the merge of the PR #1291.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
- Fix `snapshot list` command: displays the number of locations in the "Locations" column, as before:

![image](https://github.com/input-output-hk/mithril/assets/135982616/0e3a045a-3faa-46d7-adc6-6c716ac0d003)

- Fix `snapshot run` command: the absolute path is now provided in the docker command in the output after the execution of a `snapshot download` command.

![Screenshot 2023-10-27 at 17 25 26](https://github.com/input-output-hk/mithril/assets/135982616/c9e9ea98-49e1-4a72-ae3c-e39377c78e65)

## Issue(s)
Closes #1321 
