### PR TITLE
Enhance Mithril nodes `devnet` Docker images

### DIFF
--- a/mithril-aggregator/Dockerfile.ci
+++ b/mithril-aggregator/Dockerfile.ci
@@ -1,7 +1,8 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-aggregator executable has been built
 # on a debian-compatible x86-64 environment
-FROM debian:11-slim
+ARG DOCKER_IMAGE_FROM=debian:11-slim
+FROM $DOCKER_IMAGE_FROM
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-aggregator/Makefile
+++ b/mithril-aggregator/Makefile
@@ -6,7 +6,7 @@ all: test build
 
 build:
 	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable
+	${CARGO} build --release --features portable,bundle_openssl
 	cp ../target/release/mithril-aggregator .
 
 run: build
@@ -31,6 +31,9 @@ doc:
 
 docker-build:
 	cd ../ && docker build -t mithril/mithril-aggregator -f mithril-aggregator/Dockerfile .
+
+docker-build-ci: build
+	cd ../ && docker build -t mithril/mithril-aggregator -f mithril-aggregator/Dockerfile.ci --build-arg DOCKER_IMAGE_FROM .
 
 docker-run:
 	docker run --rm -p 8080:8080 --name='mithril-aggregator' mithril/mithril-aggregator serve

--- a/mithril-client-cli/Dockerfile.ci
+++ b/mithril-client-cli/Dockerfile.ci
@@ -1,7 +1,8 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-client executable has been built
 # on a debian-compatible x86-64 environment
-FROM debian:11-slim
+ARG DOCKER_IMAGE_FROM=debian:11-slim
+FROM $DOCKER_IMAGE_FROM
 
 # Create appuser
 RUN adduser --disabled-password appuser

--- a/mithril-client-cli/Makefile
+++ b/mithril-client-cli/Makefile
@@ -11,7 +11,7 @@ all: test build
 
 build:
 	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable,build-binary
+	${CARGO} build --release --features portable,build-binary,bundle_openssl
 	cp ../target/release/mithril-client .
 
 run: build
@@ -39,6 +39,9 @@ doc:
 
 docker-build:
 	cd ../ && docker build -t mithril/mithril-client -f mithril-client-cli/Dockerfile .
+
+docker-build-ci: build
+	cd ../ && docker build -t mithril/mithril-client -f mithril-client-cli/Dockerfile.ci --build-arg DOCKER_IMAGE_FROM .
 
 docker-run:
 	docker run --rm --name='mithril-client' mithril/mithril-client

--- a/mithril-signer/Dockerfile.ci
+++ b/mithril-signer/Dockerfile.ci
@@ -1,7 +1,8 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-signer executable has been built
 # on a debian-compatible x86-64 environment
-FROM debian:11-slim
+ARG DOCKER_IMAGE_FROM=debian:11-slim
+FROM $DOCKER_IMAGE_FROM
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser

--- a/mithril-signer/Makefile
+++ b/mithril-signer/Makefile
@@ -6,7 +6,7 @@ all: test build
 
 build:
 	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable
+	${CARGO} build --release --features portable,bundle_openssl
 	cp ../target/release/mithril-signer .
 
 run: build
@@ -31,6 +31,9 @@ doc:
 
 docker-build:
 	cd ../ && docker build -t mithril/mithril-signer -f mithril-signer/Dockerfile .
+
+docker-build-ci: build
+	cd ../ && docker build -t mithril/mithril-signer -f mithril-signer/Dockerfile.ci --build-arg DOCKER_IMAGE_FROM .
 
 docker-run:
 	docker run --rm --name='mithril-signer' mithril/mithril-signer

--- a/mithril-test-lab/mithril-devnet/README.md
+++ b/mithril-test-lab/mithril-devnet/README.md
@@ -46,6 +46,21 @@ NODES=cardano ./devnet-run.sh
 # Run devnet with Mithril nodes only
 NODES=mithril ./devnet-run.sh
 
+# Build Mithril Docker images available options
+## from locally built binaries (fast build times, enabled by default)
+./devnet-run.sh
+### or
+MITHRIL_NODE_DOCKER_BUILD_TYPE=ci ./devnet-run.sh
+
+## from locally built binaries with a custom slim image used as Docker image source 
+### This configuration depends on the version of 'glibc' on your computer
+### 'debian:12-slim': default value, works on Ubuntu 22.04
+### 'debian:11-slim': works on Ubuntu 20.04
+MITHRIL_NODE_DOCKER_CI_IMAGE_FROM=debian:11-slim MITHRIL_NODE_DOCKER_BUILD_TYPE=ci ./devnet-run.sh
+
+## from rust builder in Docker (slower build times, always works)
+MITHRIL_NODE_DOCKER_BUILD_TYPE=legacy ./devnet-run.sh
+
 # Logs devnet
 ./devnet-log.sh
 

--- a/mithril-test-lab/mithril-devnet/devnet-run.sh
+++ b/mithril-test-lab/mithril-devnet/devnet-run.sh
@@ -34,8 +34,6 @@ echo ">> Cardano BFT nodes: ${NUM_BFT_NODES}"
 echo ">> Cardano SPO nodes: ${NUM_POOL_NODES}"
 echo ">> Cardano Slot Length: ${SLOT_LENGTH}s"
 echo ">> Cardano Epoch Length: ${EPOCH_LENGTH}s"
-echo ">> Info: Mithril Aggregator will be attached to the first Cardano BFT node"
-echo ">> Info: Mithril Signers will be attached to each Cardano SPO node"
 rm -rf ${ROOT} && ./devnet-mkfiles.sh ${ROOT} ${NUM_BFT_NODES} ${NUM_POOL_NODES} ${SLOT_LENGTH} ${EPOCH_LENGTH}> /dev/null
 echo
 
@@ -54,6 +52,8 @@ fi
 
 # Start devnet Mithril nodes
 if [ "${NODES}" = "mithril" ] || [ "${NODES}" = "*" ]; then 
+    echo ">> Info: Mithril Aggregator will be attached to the first Cardano BFT node"
+    echo ">> Info: Mithril Signers will be attached to each Cardano SPO node"
     echo "====================================================================="
     echo " Start Mithril nodes"
     echo "====================================================================="


### PR DESCRIPTION
## Content
This PR includes:
- Building Docker images by default with the CI images (pre-compiled binaries)
- Added the possibility to use a different slim image in the CI images
- Implemented the possibility to use the "legacy" rust builder in the Docker file

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)

## Issue(s)
Closes #1272 
