### PR TITLE
Fix client CLI Docker package name in CI/CD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,6 +296,10 @@ jobs:
       fail-fast: false
       matrix:
         project: [ mithril-aggregator, mithril-client-cli, mithril-signer ]
+
+        include:
+          - project: mithril-client-cli
+            package: mithril-client
     
     permissions:
       contents: read
@@ -304,7 +308,7 @@ jobs:
     env:
       PUSH_PACKAGES: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.ref)) }}
       REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/${{ matrix.project }}
+      PACKAGE: ${{ github.repository_owner }}/${{ matrix.package != '' && matrix.package || matrix.project }}
       DOCKER_FILE: ./${{ matrix.project }}/Dockerfile.ci
       CONTEXT: .
 
@@ -323,7 +327,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
             unstable
             type=raw,value=${{ github.base_ref || github.ref_name }}-{{sha}}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -88,6 +88,10 @@ jobs:
       fail-fast: false
       matrix:
         project: [ mithril-aggregator, mithril-client-cli, mithril-signer ]
+
+        include:
+          - project: mithril-client-cli
+            package: mithril-client
     
     permissions:
       contents: read
@@ -95,7 +99,7 @@ jobs:
 
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/${{ matrix.project }}
+      PACKAGE: ${{ github.repository_owner }}/${{ matrix.package != '' && matrix.package || matrix.project }}
       DOCKER_FILE: ./${{ matrix.project }}/Dockerfile.ci
       CONTEXT: .
       GITHUB_REF: ${{ github.ref}}
@@ -115,7 +119,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
             pre-release
             type=raw,value=${{ github.ref_name }}-{{sha}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         project: [ mithril-aggregator, mithril-client-cli, mithril-signer ]
+
+        include:
+          - project: mithril-client-cli
+            package: mithril-client
     
     permissions:
       contents: read
@@ -18,7 +22,7 @@ jobs:
 
     env:
       REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/${{ matrix.project }}
+      PACKAGE: ${{ github.repository_owner }}/${{ matrix.package != '' && matrix.package || matrix.project }}
       DOCKER_FILE: ./${{ matrix.project }}/Dockerfile.ci
       CONTEXT: .
       GITHUB_REF: ${{ github.ref}}
@@ -38,7 +42,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
             latest
             type=raw,value=${{ github.ref_name }}-{{sha}}


### PR DESCRIPTION
## Content
This PR includes a fix for handling a custom **Docker package name** for the `mithril-client-cli` in the CI/CD workflows.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1322 
