### PR TITLE
Add subnote and git command for unstable release

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -85,6 +85,18 @@ runs:
         Compatible systems include, but are not limited to, \`Ubuntu 20.04+\` or \`Debian 11+\` (Bullseye)).
         EOF
 
+    - name: Fetch the latest version of the unstable tag
+      if: contains('unstable', inputs.version-name)
+      shell: bash
+      run: |
+        cat >> ./release-notes-addon.txt << EOF
+        
+        ## Fetch the latest version of the \`unstable\` tag
+        The \`unstable\` tag is updated with a new commit id when a new \`unstable\` release is published.
+        To fetch the latest version of the unstable tag, execute the command:
+        \`git tag -d unstable && git fetch origin tag unstable\`
+        EOF
+
     - name: Create and sign sha256 checksum
       shell: bash
       env:


### PR DESCRIPTION
## Content
This PR includes a new section in the note published with `unstable` releases.

This subnote explains how to fetch the latest version of the unstable tag from a local repository.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1235 
