### PR TITLE
Fix certificate chain hashes recomputation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/runbook/recompute-certificates-hash/README.md
+++ b/docs/runbook/recompute-certificates-hash/README.md
@@ -27,7 +27,7 @@ export CARDANO_NETWORK=**CARDANO_NETWORK**
 
 And copy the SQLite database file `aggregator.sqlite3`:
 ```bash
-cp /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3 cp /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3.bak.$(date +%Y-%m-%d)
+cp /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3 /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3.bak.$(date +%Y-%m-%d)
 ```
 
 And connect to the aggregator container:
@@ -37,7 +37,7 @@ docker exec -it mithril-aggregator bash
 
 Once connected to the aggregator container, recompute the certificates hashes:
 ```bash
-/app/bin/mithril-aggregator -vvv tools recompute-certificates-hash
+/app/bin/mithril-aggregator -vvvv tools recompute-certificates-hash
 ```
 
 Then disconnect from the aggregator container:
@@ -73,7 +73,7 @@ docker stop mithril-aggregator
 
 Then, restore the backed up database:
 ```bash
-cp /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3.sqlite3.bak.$(date +%Y-%m-%d) cp /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator
+cp /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3.bak.$(date +%Y-%m-%d) /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator/aggregator.sqlite3
 ```
 
 Then, start the aggregator:

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.5"
+version = "0.4.6"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a fix of the certificate chain hashes recomputation:
- Avoid reaching the SQLite limit of variables in a query by chunking the inserts
- Minor fixes in the associated runbook

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
