### PR TITLE
Enhance end to end readme and fix `work_directory` default value on MacOS

### DIFF
--- a/mithril-test-lab/mithril-end-to-end/README.md
+++ b/mithril-test-lab/mithril-end-to-end/README.md
@@ -34,7 +34,39 @@ make build
 ./mithril-end-to-end --db-directory db/ --bin-directory ../../target/release
 ```
 
+To run `mithril-end-to-end` command, you must first compile the Mithril nodes:
+
+```bash
+cargo build --release
+```
+
 ### Note for MacOS users
+
+#### `sed` compatibility
+
+Mithril end to end test uses `sed` command which is not compatible with MacOS.
+
+To deal easily with this issue, you can install `gnu-sed` and use it as `sed`.
+
+Here is an example of the installation of `gnu-sed` with Homebrew:
+
+```bash
+brew install gnu-sed
+```
+
+The shell output should display the instruction below, that you must follow:
+
+```bash
+GNU "sed" has been installed as "gsed".
+If you need to use it as "sed", you can add a "gnubin" directory
+to your PATH from your bashrc like:
+
+     PATH="$HOMEBREW_PREFIX/opt/gnu-sed/libexec/gnubin:$PATH"
+```
+
+Once saved, you need to reload your shell profile. Execute source $HOME/.bashrc or source $HOME/.zshrc (depending on the shell application you use).
+
+#### Use your own cardano binaries
 
 The cardano binaries downloaded to run the test suite are only built for Linux.
 

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -19,6 +19,8 @@ pub struct Args {
     /// will be located.
     ///
     /// Optional: if not set it will default to `{system_temp_folder}/mithril-end-to-end`
+    /// Exception for MacOS: default is `./mithril-end-to-end` as the length of the temporary directory's path
+    /// is too long. It causes the maximum path size of the node.sock file to be exceeded.
     #[clap(long)]
     work_directory: Option<PathBuf>,
 
@@ -74,6 +76,9 @@ async fn main() -> StdResult<()> {
             path.canonicalize().unwrap()
         }
         None => {
+            #[cfg(target_os = "macos")]
+            let work_dir = PathBuf::from("./mithril_end_to_end");
+            #[cfg(not(target_os = "macos"))]
             let work_dir = std::env::temp_dir().join("mithril_end_to_end");
             create_workdir_if_not_exist_clean_otherwise(&work_dir);
             work_dir.canonicalize().unwrap()


### PR DESCRIPTION
## Content
This PR includes updates of `mithril-end-to-end` related to the the feedback in the PR #1331.

The modifications are linked to issues with the run of the end to end with MacOS: 
- Enhancement of the Readme file to solve the `sed` issue
- Replacement of the default value of `work_directory` as its value was too long

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)