### PR TITLE
Simplify common deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2289,7 +2289,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.132"
+version = "0.2.133"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2360,7 +2360,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.88"
+version = "0.2.89"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -48,7 +48,7 @@ zstd = { version = "0.13.0", features = ["zstdmt"] }
 httpmock = "0.6.8"
 mithril-common = { path = "../mithril-common", features = [
     "allow_skip_signer_certification",
-    "apispec"
+    "test_tools"
 ] }
 mockall = "0.11.4"
 slog-term = "2.9.0"

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.7"
+version = "0.4.8"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -48,6 +48,7 @@ zstd = { version = "0.13.0", features = ["zstdmt"] }
 httpmock = "0.6.8"
 mithril-common = { path = "../mithril-common", features = [
     "allow_skip_signer_certification",
+    "apispec"
 ] }
 mockall = "0.11.4"
 slog-term = "2.9.0"

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -534,6 +534,7 @@ impl DependenciesBuilder {
             &self.configuration.data_stores_directory,
             &format!("immutables_digests_{}.json", self.configuration.network),
         )
+        .with_logger(self.get_logger().await?)
         .should_reset_digests_cache(self.configuration.reset_digests_cache)
         .build()
         .await?;

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -228,7 +228,7 @@ impl StakeDistributionService for MithrilStakeDistributionService {
 #[cfg(test)]
 mod tests {
     use crate::dependency_injection::DependenciesBuilder;
-    use mithril_common::chain_observer::MockChainObserver;
+    use crate::tools::mocks::MockChainObserver;
 
     use super::*;
 

--- a/mithril-aggregator/src/services/ticker.rs
+++ b/mithril-aggregator/src/services/ticker.rs
@@ -91,7 +91,8 @@ impl TickerService for MithrilTickerService {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::{chain_observer::MockChainObserver, digesters::DumbImmutableFileObserver};
+    use crate::tools::mocks::MockChainObserver;
+    use mithril_common::digesters::DumbImmutableFileObserver;
 
     use super::*;
 

--- a/mithril-aggregator/src/tools/mocks.rs
+++ b/mithril-aggregator/src/tools/mocks.rs
@@ -1,0 +1,28 @@
+use async_trait::async_trait;
+use mithril_common::chain_observer::{ChainAddress, ChainObserver, ChainObserverError, TxDatum};
+use mithril_common::crypto_helper::{KESPeriod, OpCert};
+use mithril_common::entities::{Epoch, StakeDistribution};
+use mockall::mock;
+
+mock! {
+    pub ChainObserver {}
+
+    #[async_trait]
+    impl ChainObserver for ChainObserver {
+        async fn get_current_datums(
+            &self,
+            address: &ChainAddress,
+        ) -> Result<Vec<TxDatum>, ChainObserverError>;
+
+        async fn get_current_epoch(&self) -> Result<Option<Epoch>, ChainObserverError>;
+
+        async fn get_current_stake_distribution(
+            &self,
+        ) -> Result<Option<StakeDistribution>, ChainObserverError>;
+
+        async fn get_current_kes_period(
+            &self,
+            opcert: &OpCert,
+        ) -> Result<Option<KESPeriod>, ChainObserverError>;
+    }
+}

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -2,6 +2,8 @@ mod certificates_hash_migrator;
 mod digest_helpers;
 mod era;
 mod genesis;
+#[cfg(test)]
+pub mod mocks;
 mod remote_file_uploader;
 mod signer_importer;
 

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -58,7 +58,7 @@ zstd = "0.13.0"
 
 [dev-dependencies]
 httpmock = "0.6.8"
-mithril-common = { path = "../mithril-common" }
+mithril-common = { path = "../mithril-common", features = ["test_http_server"] }
 mockall = "0.11.4"
 warp = "0.3"
 

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.5.3"
+version = "0.5.4"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.5.3"
+version = "0.5.4"
 description = "Mithril Client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -35,6 +35,7 @@ zstd = "0.13.0"
 [dev-dependencies]
 httpmock = "0.6.8"
 indicatif = { version = "0.17.7", features = ["tokio"] }
+mithril-common = { path = "../mithril-common", features = ["test_http_server"] }
 mockall = "0.11.4"
 slog-async = "2.8.0"
 slog-scope = "4.4.0"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -56,7 +56,7 @@ thiserror = "1.0.49"
 tokio = { version = "1.32.0", features = ["full"] }
 typetag = "0.2.13"
 walkdir = "2.4.0"
-warp = "0.3.6"
+warp = { version = "0.3.6", optional = true }
 
 [target.'cfg(not(windows))'.dependencies]
 # non-windows: use default rug backend
@@ -83,9 +83,15 @@ serde_yaml = "0.9.25"
 
 [features]
 default = []
+
+allow_skip_signer_certification = []
+# portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 portable = [
     "mithril-stm/portable",
-] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
-allow_skip_signer_certification = []
+]
+
+# Enable all tests tools
+test_tools = ["apispec", "test_http_server"]
 # Enable tools to helps validate conformity to an OpenAPI specification
-apispec = ["glob", "http", "jsonschema"]
+apispec = ["glob", "http", "jsonschema", "warp"]
+test_http_server = ["warp"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -44,11 +44,7 @@ serde_json = "1.0.107"
 serde_with = "3.3.0"
 serde_yaml = "0.9.25"
 sha2 = "0.10.8"
-slog = { version = "2.7.0", features = [
-    "max_level_trace",
-    "release_max_level_debug",
-] }
-slog-scope = "4.4.0"
+slog = "2.7.0"
 sqlite = { version = "0.31.1", features = ["bundled"] }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.49"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.132"
+version = "0.2.133"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -34,7 +34,7 @@ kes-summed-ed25519 = { version = "0.2.1", features = [
 ] }
 nom = "7.1.3"
 rand_chacha = "0.3.1"
-rand_core = "0.6.4"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 rayon = "1.8.0"
 semver = "1.0.19"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -24,10 +24,10 @@ chrono = { version = "0.4.31", features = ["serde"] }
 digest = "0.10.7"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core", "serde"] }
 fixed = "1.24.0"
-glob = "0.3.1"
+glob = { version = "0.3.1", optional = true }
 hex = "0.4.3"
-http = "0.2.9"
-jsonschema = "0.17.1"
+http = { version = "0.2.9", optional = true }
+jsonschema = { version = "0.17.1", optional = true }
 kes-summed-ed25519 = { version = "0.2.1", features = [
     "serde_enabled",
     "sk_clone_enabled",
@@ -87,3 +87,5 @@ portable = [
     "mithril-stm/portable",
 ] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 allow_skip_signer_certification = []
+# Enable tools to helps validate conformity to an OpenAPI specification
+apispec = ["glob", "http", "jsonschema"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -52,7 +52,7 @@ slog-scope = "4.4.0"
 sqlite = { version = "0.31.1", features = ["bundled"] }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.49"
-tokio = { version = "1.32.0", features = ["full"] }
+tokio = { version = "1.32.0", features = ["fs", "io-util", "process", "rt", "sync"] }
 typetag = "0.2.13"
 walkdir = "2.4.0"
 warp = { version = "0.3.6", optional = true }
@@ -74,6 +74,7 @@ reqwest = { version = "0.11.22", features = ["json"] }
 slog-async = "2.8.0"
 slog-scope = "4.4.0"
 slog-term = "2.9.0"
+tokio = { version = "1.32.0", features = ["macros", "time"] }
 
 [build-dependencies]
 glob = "0.3.1"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -32,7 +32,6 @@ kes-summed-ed25519 = { version = "0.2.1", features = [
     "serde_enabled",
     "sk_clone_enabled",
 ] }
-mockall = "0.11.4"
 nom = "7.1.3"
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
@@ -70,6 +69,7 @@ mithril-stm = { path = "../mithril-stm", default-features = false, features = [
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
+mockall = "0.11.4"
 reqwest = { version = "0.11.22", features = ["json"] }
 slog-async = "2.8.0"
 slog-scope = "4.4.0"

--- a/mithril-common/src/chain_observer/interface.rs
+++ b/mithril-common/src/chain_observer/interface.rs
@@ -4,8 +4,10 @@ use crate::{
     StdError,
 };
 use async_trait::async_trait;
-use mockall::automock;
 use thiserror::Error;
+
+#[cfg(test)]
+use mockall::automock;
 
 use super::{ChainAddress, TxDatum};
 
@@ -22,10 +24,10 @@ pub enum ChainObserverError {
 }
 
 /// Retrieve data from the cardano network
-#[automock]
+#[cfg_attr(test, automock)]
 #[async_trait]
 pub trait ChainObserver: Sync + Send {
-    /// Retrieve the datums associated to and address
+    /// Retrieve the datums associated to an address
     async fn get_current_datums(
         &self,
         address: &ChainAddress,

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -7,7 +7,9 @@ mod model;
 
 pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
 pub use fake_observer::FakeObserver;
-pub use interface::{ChainObserver, ChainObserverError, MockChainObserver};
+#[cfg(test)]
+pub use interface::MockChainObserver;
+pub use interface::{ChainObserver, ChainObserverError};
 pub use model::{
     ChainAddress, TxDatum, TxDatumBuilder, TxDatumError, TxDatumFieldTypeName, TxDatumFieldValue,
 };

--- a/mithril-common/src/digesters/cache/json_provider_builder.rs
+++ b/mithril-common/src/digesters/cache/json_provider_builder.rs
@@ -3,7 +3,7 @@ use crate::{
     StdResult,
 };
 use anyhow::Context;
-use slog_scope::info;
+use slog::{info, Logger};
 use std::path::Path;
 use tokio::fs;
 
@@ -13,6 +13,7 @@ pub struct JsonImmutableFileDigestCacheProviderBuilder<'a> {
     filename: &'a str,
     ensure_dir_exist: bool,
     reset_digests_cache: bool,
+    logger: Logger,
 }
 
 impl<'a> JsonImmutableFileDigestCacheProviderBuilder<'a> {
@@ -23,6 +24,7 @@ impl<'a> JsonImmutableFileDigestCacheProviderBuilder<'a> {
             filename,
             ensure_dir_exist: false,
             reset_digests_cache: false,
+            logger: Logger::root(slog::Discard, slog::o!()),
         }
     }
 
@@ -35,6 +37,12 @@ impl<'a> JsonImmutableFileDigestCacheProviderBuilder<'a> {
     /// Set if existing cached values in the provider must be reset.
     pub fn should_reset_digests_cache(&mut self, should_reset: bool) -> &mut Self {
         self.reset_digests_cache = should_reset;
+        self
+    }
+
+    /// Set the [Logger] to use.
+    pub fn with_logger(&mut self, logger: Logger) -> &mut Self {
+        self.logger = logger;
         self
     }
 
@@ -62,6 +70,7 @@ impl<'a> JsonImmutableFileDigestCacheProviderBuilder<'a> {
         }
 
         info!(
+            self.logger,
             "Storing/Getting immutables digests cache from: {}",
             cache_file.display()
         );

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -12,6 +12,7 @@ pub mod fake_data;
 pub mod fake_keys;
 mod fixture_builder;
 mod mithril_fixture;
+#[cfg(feature = "test_http_server")]
 pub mod test_http_server;
 
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -6,6 +6,7 @@
 //! * A builder of [MithrilFixture] to generate signers alongside a stake distribution
 //!
 
+#[cfg(feature = "apispec")]
 pub mod apispec;
 pub mod fake_data;
 pub mod fake_keys;

--- a/mithril-common/src/test_utils/test_http_server.rs
+++ b/mithril-common/src/test_utils/test_http_server.rs
@@ -85,7 +85,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::StatusCode;
+    use reqwest::StatusCode;
     use serde::Deserialize;
 
     #[tokio::test]

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.88"
+version = "0.2.89"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -130,6 +130,7 @@ impl<'a> ProductionServiceBuilder<'a> {
             &format!("immutables_digests_{}.json", self.config.network),
         )
         .should_reset_digests_cache(self.config.reset_digests_cache)
+        .with_logger(slog_scope::logger())
         .build()
         .await?;
 


### PR DESCRIPTION
## Content
This PR reworks `mithril-common` dependencies:
- Move the `APISpec` and the `TestHttpServer` behind features, allowing to make several common dependencies optional (`glob`, `http`, `jsonschema` and `warp`).
- Remove mockall from the dependencies (now used only internally as a dev-dependency).
- Limit tokio features to just what's actually used: from `full` to `fs`, `io-util`, `process`, `rt`, and `sync` for main dependencies + `macros` and `time` for dev-dependencies.
- Remove `slog-scope`: as it's should only be used for binaries, libraries should be able to set their logger freely.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Less dependency tree for common will simplify wasm adaptation for the client-lib.
