### PR TITLE
Fix github action contains expression

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -86,7 +86,7 @@ runs:
         EOF
 
     - name: Fetch the latest version of the unstable tag
-      if: contains('unstable', inputs.version-name)
+      if: contains(inputs.version-name, 'unstable')
       shell: bash
       run: |
         cat >> ./release-notes-addon.txt << EOF


### PR DESCRIPTION
## Content
This PR includes a fix to PR #1334.
The `contains` expression in "Fetch the latest version of the unstable tag" part was not used correctly.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1235 
