### PR TITLE
Mithril-client-lib: Gate snapshot download & message computation behind a feature

### DIFF
--- a/.github/workflows/actions/publish-crate-package/action.yml
+++ b/.github/workflows/actions/publish-crate-package/action.yml
@@ -11,6 +11,9 @@ inputs:
   api_token: 
     description: crates.io API token.
     required: false
+  publish_args:
+    description: Additional arguments that will be passed to 'cargo publish'
+    required: false
 
 runs:
   using: "composite"
@@ -36,18 +39,18 @@ runs:
   - name: Cargo publish dry run
     shell: bash
     run: |
-      echo "Cargo publish '${{ inputs.package}}' package (dry run)"
-      cargo publish -p ${{ inputs.package}} --dry-run --no-verify
+      echo "Cargo publish '${{ inputs.package }}' package (dry run)"
+      cargo publish -p ${{ inputs.package }} --dry-run --no-verify ${{ inputs.publish_args }} 
 
   - name: Cargo package list
     shell: bash
     run: |
-      echo "Cargo package list '${{ inputs.package}}' package"
-      cargo package -p ${{ inputs.package}} --list
+      echo "Cargo package list '${{ inputs.package }}' package"
+      cargo package -p ${{ inputs.package }} --list
 
   - name: Cargo publish
     if: inputs.dry_run == 'false' && steps.check_version.outputs.should_deploy == 'true'
     shell: bash
     run: |
-      echo "Cargo publish '${{ inputs.package}}' package"
-      cargo publish -p ${{ inputs.package}} --token ${{ inputs.api_token }} --no-verify
+      echo "Cargo publish '${{ inputs.package }}' package"
+      cargo publish -p ${{ inputs.package }} --token ${{ inputs.api_token }} --no-verify ${{ inputs.publish_args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
         with:
           binaries-build-args: --bin mithril-aggregator --bin mithril-signer --bin mithril-client --bin mithril-relay --features bundle_openssl
-          libraries-build-args: --package mithril-stm --package mithril-client
+          libraries-build-args: --package mithril-stm --package mithril-client --features full
 
       - name: Build Debian packages
         shell: bash
@@ -87,12 +87,12 @@ jobs:
         # Only build client on windows & mac
         - os: macos-12
           binaries-build-args: --bin mithril-client --features bundle_openssl
-          libraries-build-args: --package mithril-stm --package mithril-client
+          libraries-build-args: --package mithril-stm --package mithril-client --features full
         - os: windows-latest
           # Use `--bins --package <package>` instead of `--bin <package>`, otherwise the 'windows' compatibility
           # hack in mithril common cargo.toml doesn't apply (we have no idea why).
           binaries-build-args: --bins --package mithril-client-cli --features bundle_openssl
-          libraries-build-args: --package mithril-stm --package mithril-client --no-default-features --features num-integer-backend
+          libraries-build-args: --package mithril-stm --package mithril-client --no-default-features --features num-integer-backend,full
     runs-on: ${{ matrix.os }}
     
     steps:
@@ -119,12 +119,12 @@ jobs:
         
         include:
           - os: ubuntu-22.04
-            test-args: --features portable --workspace
+            test-args: --features portable,full --workspace
           # Only test client on windows & mac (since its the only binaries supported for those os for now)
           - os: macos-12
-            test-args: --package mithril-client --package mithril-client-cli
+            test-args: --package mithril-client --package mithril-client-cli --features full
           - os: windows-latest
-            test-args: --package mithril-client --package mithril-client-cli
+            test-args: --package mithril-client --package mithril-client-cli --features full
     
     runs-on: ${{ matrix.os }}
     

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,8 @@ jobs:
       - name: Generate cargo doc
         run: |
           cargo doc --no-deps -p mithril-stm -p mithril-common -p mithril-aggregator \
-                    -p mithril-signer -p mithril-client -p mithril-client-cli --message-format=json \
+                    -p mithril-signer -p mithril-client -p mithril-client-cli \
+                    --all-features --message-format=json \
                     | clippy-sarif | tee rust-cargo-doc-results.sarif | sarif-fmt
           
           # Update tool sarif metadata from "clippy" to "cargo-doc" (since it's set this way by clippy-sarif)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client-library.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client-library.md
@@ -117,7 +117,7 @@ Snapshot download and certificate chain validation can take quite some time even
 An example of implementation with the crate [indicatif](https://crates.io/crates/indicatif) is available in the [Mithril repository](https://github.com/input-output-hk/mithril/tree/main/mithril-client/examples/snapshot_list_get_show_download_verify.rs). To run it, execute the following command:
 
 ```bash
-cargo run --example snapshot_list_get_show_download_verify 
+cargo run --example snapshot_list_get_show_download_verify --features fs
 ```
 
 :::

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -58,7 +58,8 @@ warp = "0.3"
 
 [features]
 # Include nothing by default
-default = []
+# TODO: rollback to default = []
+default = ["full"]
 full = ["fs"]
 # Enable file system releated functionnality, right now that mean ony snapshot download
 fs = ["flate2", "flume", "tar", "tokio/rt", "zstd"]

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -13,13 +13,23 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]
 
+[[example]]
+name = "snapshot_list_get_show_download_verify"
+path = "examples/snapshot_list_get_show_download_verify.rs"
+required-features = ["fs"]
+
+[[test]]
+name = "snapshot_list_get_show_download_verify"
+path = "tests/snapshot_list_get_show_download_verify.rs"
+required-features = ["fs"]
+
 [dependencies]
 anyhow = "1.0.75"
 async-recursion = "1.0.5"
 async-trait = "0.1.73"
 chrono = { version = "0.4.31", features = ["serde"] }
-flate2 = "1.0.27"
-flume = "0.11.0"
+flate2 = { version = "1.0.27", optional = true }
+flume = { version = "0.11.0", optional = true }
 futures = "0.3.28"
 mithril-common = { path = "../mithril-common", version = "0.2" }
 reqwest = { version = "0.11.22", features = ["json", "stream"] }
@@ -27,11 +37,11 @@ semver = "1.0.19"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 slog = "2.7.0"
-tar = "0.4.40"
+tar = { version = "0.4.40", optional = true }
 thiserror = "1.0.49"
 tokio = { version = "1.32.0", features = ["sync"] }
 uuid = { version = "1.5.0", features = ["v4"] }
-zstd = "0.13.0"
+zstd = { version = "0.13.0", optional = true }
 
 [dev-dependencies]
 httpmock = "0.6.8"
@@ -47,4 +57,14 @@ tokio = { version = "1.32.0", features = ["macros", "rt"] }
 warp = "0.3"
 
 [features]
+# Include nothing by default
+default = []
+full = ["fs"]
+# Enable file system releated functionnality, right now that mean ony snapshot download
+fs = ["flate2", "flume", "tar", "tokio/rt", "zstd"]
 portable = ["mithril-common/portable"]
+
+[package.metadata.docs.rs]
+all-features = true
+# enable unstable features in the documentation
+rustdoc-args = ["--cfg", "docsrs"]

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.5.6"
+version = "0.5.7"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Makefile
+++ b/mithril-client/Makefile
@@ -11,10 +11,10 @@ all: test build
 
 build:
 	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable
+	${CARGO} build --release --features portable,full
 
 test:
-	${CARGO} test
+	${CARGO} test --features full
 
 check:
 	${CARGO} check --release --all-features --all-targets
@@ -25,4 +25,4 @@ clean:
 	${CARGO} clean
 
 doc:
-	${CARGO} doc --no-deps --open
+	${CARGO} doc --no-deps --open --features full

--- a/mithril-client/src/client.rs
+++ b/mithril-client/src/client.rs
@@ -5,6 +5,7 @@ use crate::certificate_client::{
 use crate::feedback::{FeedbackReceiver, FeedbackSender};
 use crate::mithril_stake_distribution_client::MithrilStakeDistributionClient;
 use crate::snapshot_client::SnapshotClient;
+#[cfg(feature = "fs")]
 use crate::snapshot_downloader::{HttpSnapshotDownloader, SnapshotDownloader};
 use crate::MithrilResult;
 use anyhow::{anyhow, Context};
@@ -45,6 +46,7 @@ pub struct ClientBuilder {
     genesis_verification_key: String,
     aggregator_client: Option<Arc<dyn AggregatorClient>>,
     certificate_verifier: Option<Arc<dyn CertificateVerifier>>,
+    #[cfg(feature = "fs")]
     snapshot_downloader: Option<Arc<dyn SnapshotDownloader>>,
     logger: Option<Logger>,
     feedback_receivers: Vec<Arc<dyn FeedbackReceiver>>,
@@ -59,6 +61,7 @@ impl ClientBuilder {
             genesis_verification_key: genesis_verification_key.to_string(),
             aggregator_client: None,
             certificate_verifier: None,
+            #[cfg(feature = "fs")]
             snapshot_downloader: None,
             logger: None,
             feedback_receivers: vec![],
@@ -75,6 +78,7 @@ impl ClientBuilder {
             genesis_verification_key: genesis_verification_key.to_string(),
             aggregator_client: None,
             certificate_verifier: None,
+            #[cfg(feature = "fs")]
             snapshot_downloader: None,
             logger: None,
             feedback_receivers: vec![],
@@ -115,6 +119,7 @@ impl ClientBuilder {
             Some(client) => client,
         };
 
+        #[cfg(feature = "fs")]
         let snapshot_downloader = match self.snapshot_downloader {
             None => Arc::new(
                 HttpSnapshotDownloader::new(feedback_sender.clone(), logger.clone())
@@ -146,6 +151,7 @@ impl ClientBuilder {
         ));
         let snapshot_client = Arc::new(SnapshotClient::new(
             aggregator_client,
+            #[cfg(feature = "fs")]
             snapshot_downloader,
             feedback_sender,
             logger,
@@ -176,6 +182,7 @@ impl ClientBuilder {
         self
     }
 
+    cfg_fs! {
     /// Set the [SnapshotDownloader] that will be used to download snapshots.
     pub fn with_snapshot_downloader(
         mut self,
@@ -183,6 +190,7 @@ impl ClientBuilder {
     ) -> ClientBuilder {
         self.snapshot_downloader = Some(snapshot_downloader);
         self
+    }
     }
 
     /// Set the [Logger] to use.

--- a/mithril-client/src/client.rs
+++ b/mithril-client/src/client.rs
@@ -153,7 +153,9 @@ impl ClientBuilder {
             aggregator_client,
             #[cfg(feature = "fs")]
             snapshot_downloader,
+            #[cfg(feature = "fs")]
             feedback_sender,
+            #[cfg(feature = "fs")]
             logger,
         ));
 

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Define all the tooling necessary to manipulate Mithril certified types from a
 //! [Mithril Aggregator](https://mithril.network/rust-doc/mithril_aggregator/index.html).
@@ -18,6 +19,8 @@
 //! # Example
 //!
 //! Below is an example describing the usage of most of the library's functions together:
+//!
+//! **Note:** _Snapshot download and the compute snapshot message functions are available using crate feature_ **fs**.
 //!
 //! ```no_run
 //! # async fn run() -> mithril_client::MithrilResult<()> {
@@ -52,6 +55,16 @@
 //! # }
 //! ```
 
+macro_rules! cfg_fs {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "fs")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
+            $item
+        )*
+    }
+}
+
 pub mod aggregator_client;
 pub mod certificate_client;
 mod client;
@@ -59,7 +72,9 @@ pub mod feedback;
 mod message;
 pub mod mithril_stake_distribution_client;
 pub mod snapshot_client;
-pub mod snapshot_downloader;
+cfg_fs! {
+    pub mod snapshot_downloader;
+}
 mod type_alias;
 mod utils;
 

--- a/mithril-client/src/message.rs
+++ b/mithril-client/src/message.rs
@@ -25,6 +25,20 @@ impl MessageBuilder {
         }
     }
 
+    /// Set the [Logger] to use.
+    pub fn with_logger(mut self, logger: Logger) -> Self {
+        self.logger = logger;
+        self
+    }
+
+    cfg_fs! {
+    fn get_immutable_digester(&self) -> Arc<dyn ImmutableDigester> {
+        match self.immutable_digester.as_ref() {
+            None => Arc::new(CardanoImmutableDigester::new(None, self.logger.clone())),
+            Some(digester) => digester.clone(),
+        }
+    }
+
     /// Set the [ImmutableDigester] to be used for the message computation for snapshot.
     ///
     /// If not set a default implementation will be used.
@@ -34,19 +48,6 @@ impl MessageBuilder {
     ) -> Self {
         self.immutable_digester = Some(immutable_digester);
         self
-    }
-
-    /// Set the [Logger] to use.
-    pub fn with_logger(mut self, logger: Logger) -> Self {
-        self.logger = logger;
-        self
-    }
-
-    fn get_immutable_digester(&self) -> Arc<dyn ImmutableDigester> {
-        match self.immutable_digester.as_ref() {
-            None => Arc::new(CardanoImmutableDigester::new(None, self.logger.clone())),
-            Some(digester) => digester.clone(),
-        }
     }
 
     /// Compute message for a snapshot (based on the directory where it was unpacked).
@@ -73,6 +74,7 @@ impl MessageBuilder {
         message.set_message_part(ProtocolMessagePartKey::SnapshotDigest, digest);
 
         Ok(message)
+    }
     }
 
     /// Compute message for a Mithril stake distribution.

--- a/mithril-client/src/message.rs
+++ b/mithril-client/src/message.rs
@@ -1,16 +1,22 @@
 use anyhow::Context;
+#[cfg(feature = "fs")]
 use mithril_common::digesters::{CardanoImmutableDigester, ImmutableDigester};
 use mithril_common::entities::{ProtocolMessage, ProtocolMessagePartKey};
 use mithril_common::messages::SignerWithStakeMessagePart;
 use mithril_common::protocol::SignerBuilder;
 use slog::{o, Logger};
+#[cfg(feature = "fs")]
 use std::path::Path;
+#[cfg(feature = "fs")]
 use std::sync::Arc;
 
-use crate::{MithrilCertificate, MithrilResult, MithrilStakeDistribution};
+#[cfg(feature = "fs")]
+use crate::MithrilCertificate;
+use crate::{MithrilResult, MithrilStakeDistribution};
 
 /// A [MessageBuilder] can be used to compute the message of Mithril artifacts.
 pub struct MessageBuilder {
+    #[cfg(feature = "fs")]
     immutable_digester: Option<Arc<dyn ImmutableDigester>>,
     logger: Logger,
 }
@@ -20,6 +26,7 @@ impl MessageBuilder {
     pub fn new() -> MessageBuilder {
         let logger = Logger::root(slog::Discard, o!());
         Self {
+            #[cfg(feature = "fs")]
             immutable_digester: None,
             logger,
         }

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -64,11 +64,13 @@
 //! ```
 
 use anyhow::Context;
+#[cfg(feature = "fs")]
 use slog::Logger;
 use std::sync::Arc;
 use thiserror::Error;
 
 use crate::aggregator_client::{AggregatorClient, AggregatorClientError, AggregatorRequest};
+#[cfg(feature = "fs")]
 use crate::feedback::FeedbackSender;
 #[cfg(feature = "fs")]
 use crate::snapshot_downloader::SnapshotDownloader;
@@ -93,7 +95,9 @@ pub struct SnapshotClient {
     aggregator_client: Arc<dyn AggregatorClient>,
     #[cfg(feature = "fs")]
     snapshot_downloader: Arc<dyn SnapshotDownloader>,
+    #[cfg(feature = "fs")]
     feedback_sender: FeedbackSender,
+    #[cfg(feature = "fs")]
     logger: Logger,
 }
 
@@ -102,14 +106,16 @@ impl SnapshotClient {
     pub fn new(
         aggregator_client: Arc<dyn AggregatorClient>,
         #[cfg(feature = "fs")] snapshot_downloader: Arc<dyn SnapshotDownloader>,
-        feedback_sender: FeedbackSender,
-        logger: Logger,
+        #[cfg(feature = "fs")] feedback_sender: FeedbackSender,
+        #[cfg(feature = "fs")] logger: Logger,
     ) -> Self {
         Self {
             aggregator_client,
             #[cfg(feature = "fs")]
             snapshot_downloader,
+            #[cfg(feature = "fs")]
             feedback_sender,
+            #[cfg(feature = "fs")]
             logger,
         }
     }

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -40,6 +40,7 @@
 //! ```
 //!
 //! # Download a snapshot
+//! **Note:** _Available on crate feature_ **fs** _only._
 //!
 //! To download and simultaneously unpack the tarball of a snapshots using the [ClientBuilder][crate::client::ClientBuilder].
 //!
@@ -63,12 +64,13 @@
 //! ```
 
 use anyhow::Context;
-use slog::{warn, Logger};
-use std::{path::Path, sync::Arc};
+use slog::Logger;
+use std::sync::Arc;
 use thiserror::Error;
 
 use crate::aggregator_client::{AggregatorClient, AggregatorClientError, AggregatorRequest};
-use crate::feedback::{FeedbackSender, MithrilEvent};
+use crate::feedback::FeedbackSender;
+#[cfg(feature = "fs")]
 use crate::snapshot_downloader::SnapshotDownloader;
 use crate::{MithrilResult, Snapshot, SnapshotListItem};
 
@@ -89,6 +91,7 @@ pub enum SnapshotClientError {
 /// Aggregator client for the snapshot artifact
 pub struct SnapshotClient {
     aggregator_client: Arc<dyn AggregatorClient>,
+    #[cfg(feature = "fs")]
     snapshot_downloader: Arc<dyn SnapshotDownloader>,
     feedback_sender: FeedbackSender,
     logger: Logger,
@@ -98,12 +101,13 @@ impl SnapshotClient {
     /// Constructs a new `SnapshotClient`.
     pub fn new(
         aggregator_client: Arc<dyn AggregatorClient>,
-        snapshot_downloader: Arc<dyn SnapshotDownloader>,
+        #[cfg(feature = "fs")] snapshot_downloader: Arc<dyn SnapshotDownloader>,
         feedback_sender: FeedbackSender,
         logger: Logger,
     ) -> Self {
         Self {
             aggregator_client,
+            #[cfg(feature = "fs")]
             snapshot_downloader,
             feedback_sender,
             logger,
@@ -143,6 +147,7 @@ impl SnapshotClient {
         }
     }
 
+    cfg_fs! {
     /// Download and unpack the given snapshot to the given directory
     ///
     /// **NOTE**: The directory should already exist, and the user running the binary
@@ -150,8 +155,10 @@ impl SnapshotClient {
     pub async fn download_unpack(
         &self,
         snapshot: &Snapshot,
-        target_dir: &Path,
+        target_dir: &std::path::Path,
     ) -> MithrilResult<()> {
+        use crate::feedback::MithrilEvent;
+
         for location in snapshot.locations.as_slice() {
             if self.snapshot_downloader.probe(location).await.is_ok() {
                 let download_id = MithrilEvent::new_snapshot_download_id();
@@ -182,7 +189,7 @@ impl SnapshotClient {
                         Ok(())
                     }
                     Err(e) => {
-                        warn!(
+                        slog::warn!(
                             self.logger,
                             "Failed downloading snapshot from '{location}' Error: {e}."
                         );
@@ -200,14 +207,18 @@ impl SnapshotClient {
         }
         .into())
     }
+    }
 }
 
-#[cfg(test)]
-mod tests {
+#[cfg(all(test, feature = "fs"))]
+mod tests_download {
     use crate::{
-        aggregator_client::MockAggregatorHTTPClient, feedback::StackFeedbackReceiver,
-        snapshot_downloader::MockHttpSnapshotDownloader, test_utils,
+        aggregator_client::MockAggregatorHTTPClient,
+        feedback::{MithrilEvent, StackFeedbackReceiver},
+        snapshot_downloader::MockHttpSnapshotDownloader,
+        test_utils,
     };
+    use std::path::Path;
 
     use super::*;
 

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -1,8 +1,10 @@
 //! Utilities module
 //! This module contains tools needed mostly for the snapshot download and unpack.
 
-mod stream_reader;
-mod unpacker;
+cfg_fs! {
+    mod stream_reader;
+    mod unpacker;
 
-pub use stream_reader::*;
-pub use unpacker::*;
+    pub use stream_reader::*;
+    pub use unpacker::*;
+}


### PR DESCRIPTION
## Content

This PR gates the snapshot download and snapshot message computation of the mithril-client library behind a `fs` feature. 

This feature is disabled by default because it simpler to enable a feature than to disable a default feature.

The doc is updated to add "Available on **crate feature fs** only" labels, ie:
![image](https://github.com/input-output-hk/mithril/assets/790521/31a18cd0-56e6-4d39-b88a-61b5fde44050)

But for those labels to show we need to trick cargo since [this features is still unstable](https://doc.rust-lang.org/unstable-book/language-features/doc-cfg.html).
For that we took inspiration from tokio, a major crate that use this feature, cf their [main toml](https://github.com/tokio-rs/tokio/blob/master/tokio/Cargo.toml#L157) (for how to trick doc rs to add a rustc flag that will be used to enable the feature) and their [dedicated doc macros](https://github.com/tokio-rs/tokio/blob/master/tokio-util/src/cfg.rs).

To test the the labels locally you need to:
1.  remove the `cfg_attr(docsrs` conditions from the `lib.rs`
2. switch to the unstable rust (`rustup default nightly`)
3. build and open the doc: `cargo doc --no-deps -p mithril-client --open --all-features`

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
CI scripts had to be adapted to use the feature to trigger the tests and to include the gated functions in the doc.

## Issue(s)
Relates to #1311
