### PR TITLE
Fix certificate hashes re-computation in aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/runbook/recompute-certificates-hash/README.md
+++ b/docs/runbook/recompute-certificates-hash/README.md
@@ -5,12 +5,14 @@ Export the environment variables:
 ```bash
 export MITHRIL_VM=**MITHRIL_VM**
 export CARDANO_NETWORK=**CARDANO_NETWORK**
+export MITHRIL_DISTRIBUTION_LINUX_PKG=**MITHRIL_DISTRIBUTION_LINUX_PKG**
 ```
 
 Here is an exmaple for the `release-mainnet` network:
 ```bash
 export MITHRIL_VM=aggregator.release-mainnet.api.mithril.network
 export CARDANO_NETWORK=mainnet
+export MITHRIL_DISTRIBUTION_LINUX_PKG=https://github.com/input-output-hk/mithril/releases/download/2342.0/mithril-2342.0-linux-x64.tar.gz
 ```
 
 ## Make a backup of the aggregator database
@@ -30,29 +32,64 @@ And copy the SQLite database file `aggregator.sqlite3`:
 cp /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3 /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/aggregator.sqlite3.bak.$(date +%Y-%m-%d)
 ```
 
-And connect to the aggregator container:
+## Create a temp directory
+
+Create a temp directory:
 ```bash
-docker exec -it mithril-aggregator bash
+rm -rf /home/curry/temp
+mkdir -p /home/curry/temp/config
+cd /home/curry/temp
 ```
+
+And download the configuration file for tools:
+```bash
+wget https://raw.githubusercontent.com/input-output-hk/mithril/main/docs/runbook/recompute-certificates-hash/config/tools.json -O /home/curry/temp/config/tools.json
+```
+
+## Download the pre-compiled aggregator binary
+
+Download the mithril pre-compiled binaries package:
+```bash
+wget $MITHRIL_DISTRIBUTION_LINUX_PKG -O mithril-bin.tar.gz
+```
+
+Unpack the mithril aggregator binary:
+```bash
+tar xzf mithril-bin.tar.gz mithril-aggregator
+```
+
+Make mithril aggregator binary executable:
+```bash
+chmod u+x mithril-aggregator
+```
+
+Make sure you are running the expected version of the aggregator:
+```bash
+./mithril-aggregator --version
+```
+
+## Stop the aggregator
+
+Stop the aggregator container:
+```bash
+docker stop mithril-aggregator
+```
+
+## Run the migration
 
 Once connected to the aggregator container, recompute the certificates hashes:
 ```bash
-/app/bin/mithril-aggregator -vvvv tools recompute-certificates-hash
-```
-
-Then disconnect from the aggregator container:
-```bash
-exit
+DATA_STORES_DIRECTORY=/home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/stores/ ./mithril-aggregator --run-mode tools -vvv tools recompute-certificates-hash
 ```
 
 ## Restart the aggregator
 
 Restart the aggregator to make sure that the certificate chain is valid:
 ```bash
-docker restart mithril-aggregator
+docker start mithril-aggregator
 ```
 
-Make sure that the certificate chain is valid (wait for the state machiene to go into the state `READY`):
+Make sure that the certificate chain is valid (wait for the state machine to go into the `READY` state):
 ```bash
 docker logs -f --tail 1000 mithril-aggregator
 ```
@@ -60,6 +97,13 @@ docker logs -f --tail 1000 mithril-aggregator
 Then disconnect from the aggregator VM:
 ```bash
 exit
+```
+
+## Cleanup the temp directory
+
+Remove the temp directory:
+```bash
+rm -rf /home/curry/temp
 ```
 
 ## Rollback procedure

--- a/docs/runbook/recompute-certificates-hash/config/tools.json
+++ b/docs/runbook/recompute-certificates-hash/config/tools.json
@@ -1,0 +1,17 @@
+{
+    "cardano_cli_path": "-",
+    "cardano_node_socket_path": "-",
+    "network": "-",
+    "network_magic": 0,
+    "run_interval": 0,
+    "protocol_parameters": {
+        "k": 0,
+        "m": 0,
+        "phi_f": 0
+    },
+    "snapshot_store_type": "local",
+    "snapshot_uploader_type": "local",
+    "genesis_verification_key": "-",
+    "era_adapter_type": "bootstrap",
+    "cardano_node_version": "-"
+}

--- a/docs/runbook/terraform-lock/README.md
+++ b/docs/runbook/terraform-lock/README.md
@@ -20,6 +20,6 @@ Currently, the following [Mithril networks](https://mithril.network/doc/manual/d
 
 A user with administrator rights can simply remove the lock file:
 - In GCP [**Cloud Storage**](https://console.cloud.google.com/storage/browser)
-- In the terraform administration bucket that you have identified earlier, the file that needs to be removed is at path `**TERRAFORM_BACKEND_BUCKET**/terraform/mithril-**MITHRIL_NETWORK_IDENTIFIER**/.terraform.lock.hcl` (e.g. `mithril-terraform-prod/terraform/mithril-release-mainnet/terraform.lock.hcl`) 
+- In the terraform administration bucket that you have identified earlier, the file that needs to be removed is at path `**TERRAFORM_BACKEND_BUCKET**/terraform/mithril-**MITHRIL_NETWORK_IDENTIFIER**/default.tflock` (e.g. `mithril-terraform-prod/terraform/mithril-release-mainnet/terraform.lock.hcl`) 
 
 :warning: never delete/modify the `**TERRAFORM_BACKEND_BUCKET**/terraform/mithril-**MITHRIL_NETWORK_IDENTIFIER**/default.tfstate` file.

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.8"
+version = "0.4.9"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -48,7 +48,7 @@ zstd = { version = "0.13.0", features = ["zstdmt"] }
 httpmock = "0.6.8"
 mithril-common = { path = "../mithril-common", features = [
     "allow_skip_signer_certification",
-    "test_tools"
+    "test_tools",
 ] }
 mockall = "0.11.4"
 slog-term = "2.9.0"


### PR DESCRIPTION
## Content
This PR includes:
- a fix to the aggregator tool that re-computes certificates hashes (and allows some hashes to remain unchanged, e.g. for genesis certificate)
- an updated and more robust process for the re-computation of the hashes of the certificates
- a fix of a typo in the terraform lock runbook

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1343 
