### PR TITLE
Add goodbye message for signer node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.90"
+version = "0.2.91"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.90"
+version = "0.2.91"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/main.rs
+++ b/mithril-signer/src/main.rs
@@ -1,10 +1,14 @@
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use clap::Parser;
 use slog::{o, Drain, Level, Logger};
-use slog_scope::debug;
+use slog_scope::{crit, debug};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::{
+    signal::unix::{signal, SignalKind},
+    task::JoinSet,
+};
 
 use mithril_common::StdResult;
 use mithril_signer::{
@@ -111,11 +115,49 @@ async fn main() -> StdResult<()> {
         .with_context(|| "services initialization error")?;
 
     debug!("Started"; "run_mode" => &args.run_mode, "config" => format!("{config:?}"));
-    let mut state_machine = StateMachine::new(
+    let state_machine = StateMachine::new(
         SignerState::Init,
         Box::new(SignerRunner::new(config.clone(), services)),
         Duration::from_millis(config.run_interval),
     );
 
-    state_machine.run().await.map_err(|e| e.into())
+    let mut join_set = JoinSet::new();
+    join_set.spawn(async move {
+        state_machine
+            .run()
+            .await
+            .map_err(|e| anyhow!(e))
+            .map(|_| None)
+    });
+
+    join_set.spawn(async {
+        tokio::signal::ctrl_c()
+            .await
+            .map_err(|e| anyhow!(e))
+            .map(|_| Some("Received Ctrl+C".to_string()))
+    });
+
+    join_set.spawn(async move {
+        let mut sigterm = signal(SignalKind::terminate()).expect("Failed to create SIGTERM signal");
+        sigterm
+            .recv()
+            .await
+            .ok_or(anyhow!("Failed to receive SIGTERM"))
+            .map(|_| Some("Received SIGTERM".to_string()))
+    });
+
+    let shutdown_reason = match join_set.join_next().await {
+        Some(Err(e)) => {
+            crit!("A critical error occurred: {e:?}");
+            None
+        }
+        Some(Ok(res)) => res?,
+        None => None,
+    };
+
+    join_set.shutdown().await;
+
+    debug!("Stopping"; "shutdown_reason" => shutdown_reason);
+
+    Ok(())
 }

--- a/mithril-signer/src/main.rs
+++ b/mithril-signer/src/main.rs
@@ -146,6 +146,15 @@ async fn main() -> StdResult<()> {
             .map(|_| Some("Received SIGTERM".to_string()))
     });
 
+    join_set.spawn(async move {
+        let mut sigterm = signal(SignalKind::quit()).expect("Failed to create SIGQUIT signal");
+        sigterm
+            .recv()
+            .await
+            .ok_or(anyhow!("Failed to receive SIGQUIT"))
+            .map(|_| Some("Received SIGQUIT".to_string()))
+    });
+
     let shutdown_reason = match join_set.join_next().await {
         Some(Err(e)) => {
             crit!("A critical error occurred: {e:?}");

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -23,7 +23,7 @@ use super::signer_services::SignerServices;
 
 /// This trait is mainly intended for mocking.
 #[async_trait]
-pub trait Runner {
+pub trait Runner: Send + Sync {
     /// Fetch the current epoch settings if any.
     async fn get_epoch_settings(&self) -> StdResult<Option<EpochSettings>>;
 

--- a/mithril-signer/tests/era_switch.rs
+++ b/mithril-signer/tests/era_switch.rs
@@ -21,7 +21,7 @@ async fn era_fail_at_startup() {
 
     tester
         .comment("TEST: state machine fails starting when current Era is not supported.")
-        .is_init().unwrap()
+        .is_init().await.unwrap()
         .cycle_unregistered().await
         .expect_err("The state machine must fail at startup.");
 
@@ -31,7 +31,7 @@ async fn era_fail_at_startup() {
             EraMarker::new(&SupportedEra::dummy().to_string(), Some(Epoch(0))),
             EraMarker::new("unsupported", Some(Epoch(4))),
             ])
-        .is_init().unwrap()
+        .is_init().await.unwrap()
         .cycle_unregistered().await.unwrap()
         .check_era_checker_last_updated_at(Epoch(1)).await.unwrap()
         .comment("Init Era checking went well, now let's go to usual business…")

--- a/mithril-signer/tests/state_machine.rs
+++ b/mithril-signer/tests/state_machine.rs
@@ -17,7 +17,7 @@ async fn test_create_single_signature() {
 
     tester
         .comment("state machine starts in Init and transit to Unregistered state.")
-        .is_init().unwrap()
+        .is_init().await.unwrap()
         .cycle_unregistered().await.unwrap()
         .cycle_unregistered().await.unwrap()
         .check_era_checker_last_updated_at(Epoch(1)).await.unwrap()

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -213,9 +213,9 @@ impl StateMachineTester {
     }
 
     /// Is the state machine in `Init` state?
-    pub fn is_init(&mut self) -> Result<&mut Self> {
+    pub async fn is_init(&mut self) -> Result<&mut Self> {
         self.assert(
-            self.state_machine.get_state().is_init(),
+            self.state_machine.get_state().await.is_init(),
             "state machine shall be in Init state".to_string(),
         )
     }
@@ -224,10 +224,10 @@ impl StateMachineTester {
     pub async fn cycle_registered(&mut self) -> Result<&mut Self> {
         self.cycle().await?;
         self.assert(
-            self.state_machine.get_state().is_registered(),
+            self.state_machine.get_state().await.is_registered(),
             format!(
                 "state machine is in {} state (Registered was expected)",
-                self.state_machine.get_state()
+                self.state_machine.get_state().await
             ),
         )
     }
@@ -237,10 +237,10 @@ impl StateMachineTester {
         self.cycle().await?;
 
         self.assert(
-            self.state_machine.get_state().is_signed(),
+            self.state_machine.get_state().await.is_signed(),
             format!(
                 "state machine is in {} state (Signed was expected)",
-                self.state_machine.get_state()
+                self.state_machine.get_state().await
             ),
         )
     }
@@ -250,10 +250,10 @@ impl StateMachineTester {
         self.cycle().await?;
 
         self.assert(
-            self.state_machine.get_state().is_unregistered(),
+            self.state_machine.get_state().await.is_unregistered(),
             format!(
                 "state machine is in {} state (Unregistered was expected)",
-                self.state_machine.get_state()
+                self.state_machine.get_state().await
             ),
         )
     }


### PR DESCRIPTION
## Content
This PR includes an update of the `mithril-signer` node. There is now a goodbye message when the node terminates with no error.

This mechanism handles SIGTERM, SIGQUIT signals and Ctrl+C interrupts.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1312 
