### PR TITLE
Adapt `mithril-client` and `mithril-common` to compile in WASM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,24 @@ jobs:
           binaries-build-args: ${{ matrix.binaries-build-args }}
           libraries-build-args: ${{ matrix.libraries-build-args }}
           common-build-args: ${{ matrix.common-build-args }}
-  
+
+  build-wasm:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain, tools, and restore cache
+        uses: ./.github/workflows/actions/toolchain-and-cache
+        with:
+          cache-version: ${{ secrets.CACHE_VERSION }}-wasm
+          cargo-tools: wasm-pack
+
+      - name: Cargo build 'mithril-client' - WASM package
+        shell: bash
+        run: |
+          wasm-pack build mithril-client --release
+
   test:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
         with:
-          binaries-build-args: --bin mithril-aggregator --bin mithril-signer --bin mithril-client --bin mithril-relay --features bundle_openssl
+          binaries-build-args: --bin mithril-aggregator --bin mithril-signer --bin mithril-client --bin mithril-relay --features bundle_openssl,full
           libraries-build-args: --package mithril-stm --package mithril-client --features full
 
       - name: Build Debian packages

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3214,7 +3214,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3254,7 +3254,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.5.8"
+version = "0.5.9"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3271,6 +3271,7 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "slog",
  "slog-async",
@@ -3281,12 +3282,14 @@ dependencies = [
  "tokio",
  "uuid",
  "warp",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
  "zstd",
 ]
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3325,7 +3328,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.141"
+version = "0.2.142"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3373,7 +3376,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3398,7 +3401,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -3421,7 +3424,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.95"
+version = "0.2.96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4930,6 +4933,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17ba92964781421b6cef36bf0d7da26d201e96d84e1b10e7ae6ed416e516906d"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,6 +3263,7 @@ dependencies = [
  "flate2",
  "flume",
  "futures",
+ "getrandom",
  "httpmock",
  "indicatif",
  "mithril-common",

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
             // args);
 
         mithril-stm = buildPackage ./mithril-stm/Cargo.toml null {};
-        mithril-common = buildPackage ./mithril-common/Cargo.toml mithril-stm.cargoArtifacts {};
+        mithril-common = buildPackage ./mithril-common/Cargo.toml mithril-stm.cargoArtifacts { cargoExtraArgs = "-p mithril-common --features full"; };
         mithril = buildPackage null mithril-common.cargoArtifacts {
           doCheck = false;
         };
@@ -103,7 +103,7 @@
         packages = {
           default = mithril;
           inherit mithril mithril-stm mithril-common;
-          mithril-client = buildPackage ./mithril-client/Cargo.toml mithril.cargoArtifacts {};
+          mithril-client = buildPackage ./mithril-client/Cargo.toml mithril.cargoArtifacts { cargoExtraArgs = "-p mithril-client --features full"; };
           mithril-client-cli = buildPackage ./mithril-client-cli/Cargo.toml mithril.cargoArtifacts {};
           mithril-aggregator = buildPackage ./mithril-aggregator/Cargo.toml mithril.cargoArtifacts {};
           mithril-signer = buildPackage ./mithril-signer/Cargo.toml mithril.cargoArtifacts {};

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -18,7 +18,7 @@ cloud-storage = "0.11.1"
 config = "0.13.3"
 flate2 = "1.0.27"
 hex = "0.4.3"
-mithril-common = { path = "../mithril-common" }
+mithril-common = { path = "../mithril-common", features = ["full"] }
 openssl = { version = "0.10.57", features = ["vendored"], optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 reqwest = { version = "0.11.22", features = ["json"] }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.16"
+version = "0.4.17"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -37,7 +37,7 @@ futures = "0.3.28"
 hex = "0.4.3"
 human_bytes = { version = "0.4.3", features = ["fast"] }
 indicatif = { version = "0.17.7", features = ["tokio"] }
-mithril-common = { path = "../mithril-common" }
+mithril-common = { path = "../mithril-common", features = ["full"] }
 openssl = { version = "0.10.57", features = ["vendored"], optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 reqwest = { version = "0.11.22", features = ["json", "stream"] }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.5.7"
+version = "0.5.8"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -31,9 +31,6 @@ chrono = { version = "0.4.31", features = ["serde"] }
 flate2 = { version = "1.0.27", optional = true }
 flume = { version = "0.11.0", optional = true }
 futures = "0.3.28"
-mithril-common = { path = "../mithril-common", version = "0.2", features = [
-    "full",
-] }
 reqwest = { version = "0.11.22", features = ["json", "stream"] }
 semver = "1.0.19"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -44,6 +41,17 @@ thiserror = "1.0.49"
 tokio = { version = "1.32.0", features = ["sync"] }
 uuid = { version = "1.5.0", features = ["v4"] }
 zstd = { version = "0.13.0", optional = true }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+mithril-common = { path = "../mithril-common", version = "0.2", features = [
+    "full",
+] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+mithril-common = { path = "../mithril-common", version = "0.2" }
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4.37"
+serde-wasm-bindgen = "0.6.0"
 
 [dev-dependencies]
 httpmock = "0.6.8"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.5.8"
+version = "0.5.9"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -31,7 +31,9 @@ chrono = { version = "0.4.31", features = ["serde"] }
 flate2 = { version = "1.0.27", optional = true }
 flume = { version = "0.11.0", optional = true }
 futures = "0.3.28"
-mithril-common = { path = "../mithril-common", version = "0.2" }
+mithril-common = { path = "../mithril-common", version = "0.2", features = [
+    "full",
+] }
 reqwest = { version = "0.11.22", features = ["json", "stream"] }
 semver = "1.0.19"
 serde = { version = "1.0.188", features = ["derive"] }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -53,6 +53,7 @@ wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.37"
 serde-wasm-bindgen = "0.6.0"
 getrandom = { version = "0.2", features = ["js"] }
+reqwest = { version = "0.11.22", features = ["json", "stream"] }
 
 [dev-dependencies]
 httpmock = "0.6.8"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -48,12 +48,12 @@ mithril-common = { path = "../mithril-common", version = "0.2", features = [
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 mithril-common = { path = "../mithril-common", version = "0.2" }
+reqwest = { version = "0.11.22", features = ["json", "stream"] }
+serde-wasm-bindgen = "0.6.0"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.37"
-serde-wasm-bindgen = "0.6.0"
-getrandom = { version = "0.2", features = ["js"] }
-reqwest = { version = "0.11.22", features = ["json", "stream"] }
 
 [dev-dependencies]
 httpmock = "0.6.8"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -52,11 +52,12 @@ mithril-common = { path = "../mithril-common", version = "0.2" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4.37"
 serde-wasm-bindgen = "0.6.0"
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 httpmock = "0.6.8"
 indicatif = { version = "0.17.7", features = ["tokio"] }
-mithril-common = { path = "../mithril-common", version = "0.2.133", features = [
+mithril-common = { path = "../mithril-common", version = "0.2", features = [
     "test_http_server",
 ] }
 mockall = "0.11.4"
@@ -68,9 +69,11 @@ warp = "0.3"
 
 [features]
 # Include nothing by default
-# TODO: rollback to default = []
-default = ["full"]
+default = []
+
+# Full feature set
 full = ["fs"]
+
 # Enable file system releated functionnality, right now that mean ony snapshot download
 fs = ["flate2", "flume", "tar", "tokio/rt", "zstd"]
 portable = ["mithril-common/portable"]

--- a/mithril-client/Makefile
+++ b/mithril-client/Makefile
@@ -26,3 +26,6 @@ clean:
 
 doc:
 	${CARGO} doc --no-deps --open --features full
+
+build-wasm:
+	wasm-pack build --release

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -93,7 +93,8 @@ impl AggregatorRequest {
 }
 
 /// API that defines a client for the Aggregator
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait AggregatorClient: Sync + Send {
     /// Get the content back from the Aggregator
     async fn get_content(
@@ -165,7 +166,8 @@ impl AggregatorHTTPClient {
     }
 
     /// Perform a HTTP GET request on the Aggregator and return the given JSON
-    #[async_recursion]
+    #[cfg_attr(target_arch = "wasm32", async_recursion(?Send))]
+    #[cfg_attr(not(target_arch = "wasm32"), async_recursion)]
     async fn get(&self, url: Url) -> Result<Response, AggregatorClientError> {
         debug!(self.logger, "GET url='{url}'.");
         let request_builder = self.http_client.get(url.clone());
@@ -236,7 +238,8 @@ impl AggregatorHTTPClient {
 }
 
 #[cfg_attr(test, automock)]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl AggregatorClient for AggregatorHTTPClient {
     async fn get_content(
         &self,

--- a/mithril-client/src/certificate_client.rs
+++ b/mithril-client/src/certificate_client.rs
@@ -87,7 +87,8 @@ pub struct CertificateClient {
 
 /// API that defines how to validate certificates.
 #[cfg_attr(test, automock)]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CertificateVerifier: Sync + Send {
     /// Validate the chain starting with the given certificate.
     async fn verify_chain(&self, certificate: &MithrilCertificate) -> MithrilResult<()>;
@@ -223,7 +224,8 @@ impl MithrilCertificateVerifier {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CertificateVerifier for MithrilCertificateVerifier {
     async fn verify_chain(&self, certificate: &MithrilCertificate) -> MithrilResult<()> {
         // Todo: move most of this code in the `mithril_common` verifier by defining
@@ -266,7 +268,8 @@ impl CertificateVerifier for MithrilCertificateVerifier {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CertificateRetriever for InternalCertificateRetriever {
     async fn get_certificate_details(
         &self,

--- a/mithril-client/src/feedback.rs
+++ b/mithril-client/src/feedback.rs
@@ -157,7 +157,8 @@ impl FeedbackSender {
 }
 
 /// A receiver of [MithrilEvent].
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait FeedbackReceiver: Sync + Send {
     /// Callback called by a [FeedbackSender] when it needs to send an [event][MithrilEvent].
     async fn handle_event(&self, event: MithrilEvent);
@@ -175,7 +176,8 @@ impl SlogFeedbackReceiver {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl FeedbackReceiver for SlogFeedbackReceiver {
     async fn handle_event(&self, event: MithrilEvent) {
         match event {
@@ -271,7 +273,8 @@ impl Default for StackFeedbackReceiver {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl FeedbackReceiver for StackFeedbackReceiver {
     async fn handle_event(&self, event: MithrilEvent) {
         let mut events = self.stacked_events.write().unwrap();

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -72,9 +72,9 @@ pub mod feedback;
 mod message;
 pub mod mithril_stake_distribution_client;
 pub mod snapshot_client;
-cfg_fs! {
-    pub mod snapshot_downloader;
-}
+#[cfg(feature = "fs")]
+pub mod snapshot_downloader;
+
 mod type_alias;
 mod utils;
 

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -50,7 +50,7 @@ slog = "2.7.0"
 sqlite = { version = "0.31.1", features = ["bundled"], optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.49"
-tokio = { version = "1.32.0", features = ["fs", "io-util", "rt", "sync"] }
+tokio = { version = "1.32.0", features = ["io-util", "rt", "sync"] }
 typetag = "0.2.13"
 walkdir = "2.4.0"
 warp = { version = "0.3.6", optional = true }
@@ -88,14 +88,15 @@ serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 
 [features]
-default = ["database"]
-full = ["database", "process", "test_tools"]
+default = []
+full = ["database", "fs", "process", "test_tools"]
 
 allow_skip_signer_certification = []
 # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 portable = ["mithril-stm/portable"]
 database = ["sqlite"]
 process = ["tokio/process"]
+fs = ["tokio/fs"]
 
 # Enable all tests tools
 test_tools = ["apispec", "test_http_server"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.141"
+version = "0.2.142"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -47,26 +47,26 @@ serde_with = "3.3.0"
 serde_yaml = "0.9.25"
 sha2 = "0.10.8"
 slog = "2.7.0"
-sqlite = { version = "0.31.1", features = ["bundled"] }
+sqlite = { version = "0.31.1", features = ["bundled"], optional = true }
 strum = { version = "0.25.0", features = ["derive"] }
 thiserror = "1.0.49"
-tokio = { version = "1.32.0", features = [
-    "fs",
-    "io-util",
-    "process",
-    "rt",
-    "sync",
-] }
+tokio = { version = "1.32.0", features = ["fs", "io-util", "rt", "sync"] }
 typetag = "0.2.13"
 walkdir = "2.4.0"
 warp = { version = "0.3.6", optional = true }
 
-[target.'cfg(not(windows))'.dependencies]
-# non-windows: use default rug backend
+[target.'cfg(target_family = "unix")'.dependencies]
+# only unix supports the default rug backend
 mithril-stm = { path = "../mithril-stm", version = "0.3" }
 
 [target.'cfg(windows)'.dependencies]
 # Windows doesn't support rug backend, fallback to num-integer
+mithril-stm = { path = "../mithril-stm", version = "0.3", default-features = false, features = [
+    "num-integer-backend",
+] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+# WASM doesn't support rug backend, fallback to num-integer
 mithril-stm = { path = "../mithril-stm", version = "0.3", default-features = false, features = [
     "num-integer-backend",
 ] }
@@ -88,12 +88,14 @@ serde_json = "1.0.107"
 serde_yaml = "0.9.25"
 
 [features]
-default = []
-full = []
+default = ["database"]
+full = ["database", "process", "test_tools"]
 
 allow_skip_signer_certification = []
 # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 portable = ["mithril-stm/portable"]
+database = ["sqlite"]
+process = ["tokio/process"]
 
 # Enable all tests tools
 test_tools = ["apispec", "test_http_server"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -34,7 +34,7 @@ kes-summed-ed25519 = { version = "0.2.1", features = [
     "sk_clone_enabled",
 ] }
 nom = "7.1.3"
-pallas-network = "0.20.0"
+pallas-network = { version = "0.20.0", optional = true }
 rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 rayon = "1.8.0"
@@ -94,7 +94,7 @@ default = []
 full = ["random", "database", "fs", "test_tools"]
 random = ["rand_core/getrandom"]
 database = ["sqlite"]
-fs = ["tokio/fs", "tokio/process"]
+fs = ["tokio/fs", "tokio/process", "pallas-network"]
 
 # Portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 portable = ["mithril-stm/portable"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -36,7 +36,7 @@ kes-summed-ed25519 = { version = "0.2.1", features = [
 nom = "7.1.3"
 pallas-network = "0.20.0"
 rand_chacha = "0.3.1"
-rand_core = { version = "0.6.4", features = ["getrandom"] }
+rand_core = "0.6.4"
 rayon = "1.8.0"
 semver = "1.0.19"
 serde = { version = "1.0.188", features = ["derive"] }
@@ -89,17 +89,25 @@ serde_yaml = "0.9.25"
 
 [features]
 default = []
-full = ["database", "fs", "process", "test_tools"]
 
-allow_skip_signer_certification = []
-# portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
-portable = ["mithril-stm/portable"]
+# Full feature set
+full = ["random", "database", "fs", "test_tools"]
+random = ["rand_core/getrandom"]
 database = ["sqlite"]
-process = ["tokio/process"]
-fs = ["tokio/fs"]
+fs = ["tokio/fs", "tokio/process"]
 
+# Portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
+portable = ["mithril-stm/portable"]
+
+# Disable signer certification, to be used only for tests
+allow_skip_signer_certification = []
 # Enable all tests tools
 test_tools = ["apispec", "test_http_server"]
 # Enable tools to helps validate conformity to an OpenAPI specification
 apispec = ["glob", "http", "jsonschema", "warp"]
 test_http_server = ["warp"]
+
+[package.metadata.docs.rs]
+all-features = true
+# enable unstable features in the documentation
+rustdoc-args = ["--cfg", "docsrs"]

--- a/mithril-common/Makefile
+++ b/mithril-common/Makefile
@@ -6,10 +6,10 @@ all: test build
 
 build:
 	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable
+	${CARGO} build --release --features portable,full
 
 test:
-	${CARGO} test
+	${CARGO} test --features full
 
 check:
 	${CARGO} check --release --all-features --all-targets
@@ -17,4 +17,4 @@ check:
 	${CARGO} fmt --check
 
 doc:
-	${CARGO} doc --no-deps --open
+	${CARGO} doc --no-deps --open --features full

--- a/mithril-common/src/certificate_chain/certificate_retriever.rs
+++ b/mithril-common/src/certificate_chain/certificate_retriever.rs
@@ -15,7 +15,8 @@ pub struct CertificateRetrieverError(#[source] pub StdError);
 
 /// CertificateRetriever is in charge of retrieving a [Certificate] given its hash
 #[cfg_attr(test, automock)]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CertificateRetriever: Sync + Send {
     /// Get [Certificate] details
     async fn get_certificate_details(

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -60,7 +60,8 @@ pub enum CertificateVerifierError {
 /// CertificateVerifier is the cryptographic engine in charge of verifying multi signatures and
 /// [certificates](Certificate)
 #[cfg_attr(test, automock)]
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 pub trait CertificateVerifier: Send + Sync {
     /// Verify Genesis certificate
     async fn verify_genesis_certificate(
@@ -232,7 +233,8 @@ impl MithrilCertificateVerifier {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
 impl CertificateVerifier for MithrilCertificateVerifier {
     /// Verify Genesis certificate
     async fn verify_genesis_certificate(

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -1,7 +1,8 @@
 //! Tools to request metadata, like the current epoch or the stake distribution, from the Cardano
 
-#[cfg(feature = "process")]
+#[cfg(feature = "fs")]
 mod cli_observer;
+#[cfg(feature = "test_tools")]
 mod fake_observer;
 mod interface;
 mod model;
@@ -13,8 +14,9 @@ mod test_cli_runner;
 #[cfg(test)]
 pub use cli_observer::CliRunner;
 
-#[cfg(feature = "process")]
+#[cfg(feature = "fs")]
 pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
+#[cfg(feature = "test_tools")]
 pub use fake_observer::FakeObserver;
 #[cfg(test)]
 pub use interface::MockChainObserver;

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -1,5 +1,6 @@
 //! Tools to request metadata, like the current epoch or the stake distribution, from the Cardano
 
+#[cfg(feature = "process")]
 mod cli_observer;
 mod fake_observer;
 mod interface;
@@ -12,6 +13,7 @@ mod test_cli_runner;
 #[cfg(test)]
 pub use cli_observer::CliRunner;
 
+#[cfg(feature = "process")]
 pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
 pub use fake_observer::FakeObserver;
 #[cfg(test)]

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -6,6 +6,7 @@ mod cli_observer;
 mod fake_observer;
 mod interface;
 mod model;
+#[cfg(feature = "fs")]
 mod pallas_observer;
 
 #[cfg(test)]
@@ -24,4 +25,5 @@ pub use interface::{ChainObserver, ChainObserverError};
 pub use model::{
     ChainAddress, TxDatum, TxDatumBuilder, TxDatumError, TxDatumFieldTypeName, TxDatumFieldValue,
 };
+#[cfg(feature = "fs")]
 pub use pallas_observer::PallasChainObserver;

--- a/mithril-common/src/crypto_helper/cardano/mod.rs
+++ b/mithril-common/src/crypto_helper/cardano/mod.rs
@@ -1,9 +1,11 @@
 mod codec;
+#[cfg(feature = "random")]
 mod cold_key;
 mod key_certification;
 mod opcert;
 
 pub use codec::*;
+#[cfg(feature = "random")]
 pub use cold_key::*;
 pub use key_certification::*;
 pub use opcert::*;

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -1,7 +1,9 @@
 use crate::{StdError, StdResult};
 use anyhow::anyhow;
 use ed25519_dalek::{Signer, SigningKey};
-use rand_chacha::rand_core::{self, CryptoRng, RngCore, SeedableRng};
+#[cfg(feature = "random")]
+use rand_chacha::rand_core;
+use rand_chacha::rand_core::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
 use std::{fs::File, io::Write, path::Path};
@@ -38,10 +40,12 @@ impl ProtocolGenesisSigner {
         Self::create_test_genesis_signer(rng)
     }
 
-    /// [ProtocolGenesisSigner] non deterministic
-    pub fn create_non_deterministic_genesis_signer() -> Self {
-        let rng = rand_core::OsRng;
-        Self::create_test_genesis_signer(rng)
+    cfg_random! {
+        /// [ProtocolGenesisSigner] non deterministic
+        pub fn create_non_deterministic_genesis_signer() -> Self {
+            let rng = rand_core::OsRng;
+            Self::create_test_genesis_signer(rng)
+        }
     }
 
     /// [ProtocolGenesisSigner] from [ProtocolGenesisSecretKey]
@@ -131,19 +135,21 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_generate_test_non_deterministic_genesis_keypair() {
-        let genesis_signer = ProtocolGenesisSigner::create_non_deterministic_genesis_signer();
-        let genesis_verifier = genesis_signer.create_genesis_verifier();
+    cfg_random! {
+        #[test]
+        fn test_generate_test_non_deterministic_genesis_keypair() {
+            let genesis_signer = ProtocolGenesisSigner::create_non_deterministic_genesis_signer();
+            let genesis_verifier = genesis_signer.create_genesis_verifier();
 
-        println!(
-            "Non Deterministic Genesis Verification Key={}",
-            genesis_verifier.verification_key.to_json_hex().unwrap()
-        );
-        println!(
-            "Non Deterministic Genesis Secret Key=={}",
-            genesis_signer.secret_key.to_json_hex().unwrap()
-        );
+            println!(
+                "Non Deterministic Genesis Verification Key={}",
+                genesis_verifier.verification_key.to_json_hex().unwrap()
+            );
+            println!(
+                "Non Deterministic Genesis Secret Key=={}",
+                genesis_signer.secret_key.to_json_hex().unwrap()
+            );
+        }
     }
 
     #[test]

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -5,12 +5,16 @@ mod codec;
 mod conversions;
 mod era;
 mod genesis;
+#[cfg(feature = "test_tools")]
 pub mod tests_setup;
 mod types;
 
+#[cfg(feature = "random")]
+pub use cardano::ColdKeyGenerator;
+
 pub use cardano::{
-    ColdKeyGenerator, KESPeriod, OpCert, ProtocolInitializerErrorWrapper,
-    ProtocolRegistrationErrorWrapper, SerDeShelleyFileFormat, Sum6KesBytes,
+    KESPeriod, OpCert, ProtocolInitializerErrorWrapper, ProtocolRegistrationErrorWrapper,
+    SerDeShelleyFileFormat, Sum6KesBytes,
 };
 pub use codec::*;
 pub use era::{

--- a/mithril-common/src/digesters/cache/json_provider.rs
+++ b/mithril-common/src/digesters/cache/json_provider.rs
@@ -13,6 +13,7 @@ use std::{
     collections::BTreeMap,
     path::{Path, PathBuf},
 };
+#[cfg(feature = "fs")]
 use tokio::{
     fs,
     fs::File,

--- a/mithril-common/src/digesters/cache/json_provider_builder.rs
+++ b/mithril-common/src/digesters/cache/json_provider_builder.rs
@@ -5,6 +5,7 @@ use crate::{
 use anyhow::Context;
 use slog::{info, Logger};
 use std::path::Path;
+#[cfg(feature = "fs")]
 use tokio::fs;
 
 /// A [JsonImmutableFileDigestCacheProvider] builder.

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -1,7 +1,10 @@
+use crate::StdResult;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumDiscriminants};
 
-use crate::{sqlite::HydrationError, StdResult};
+cfg_database! {
+    use crate::{sqlite::HydrationError};
+}
 
 use super::{Beacon, Epoch};
 
@@ -46,37 +49,40 @@ impl SignedEntityType {
             Self::CardanoStakeDistribution(e) | Self::MithrilStakeDistribution(e) => *e,
         }
     }
-    /// Create an instance from data coming from the database
-    pub fn hydrate(signed_entity_type_id: usize, beacon_str: &str) -> Result<Self, HydrationError> {
-        let myself = match signed_entity_type_id {
-            ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION => {
-                let epoch: Epoch = serde_json::from_str(beacon_str).map_err(|e| {
-                    HydrationError::InvalidData(format!(
-                        "Invalid Epoch JSON representation '{beacon_str}. Error: {e}'."
-                    ))
-                })?;
-                Self::MithrilStakeDistribution(epoch)
-            }
-            ENTITY_TYPE_CARDANO_STAKE_DISTRIBUTION => {
-                let epoch: Epoch = serde_json::from_str(beacon_str).map_err(|e| {
-                    HydrationError::InvalidData(format!(
-                        "Invalid Epoch JSON representation '{beacon_str}. Error: {e}'."
-                    ))
-                })?;
-                Self::CardanoStakeDistribution(epoch)
-            }
-            ENTITY_TYPE_CARDANO_IMMUTABLE_FILES_FULL => {
-                let beacon: Beacon = serde_json::from_str(beacon_str).map_err(|e| {
-                    HydrationError::InvalidData(format!(
-                        "Invalid Beacon JSON in open_message.beacon: '{beacon_str}'. Error: {e}"
-                    ))
-                })?;
-                Self::CardanoImmutableFilesFull(beacon)
-            }
-            index => panic!("Invalid entity_type_id {index}."),
-        };
 
-        Ok(myself)
+    cfg_database! {
+        /// Create an instance from data coming from the database
+        pub fn hydrate(signed_entity_type_id: usize, beacon_str: &str) -> Result<Self, HydrationError> {
+            let myself = match signed_entity_type_id {
+                ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION => {
+                    let epoch: Epoch = serde_json::from_str(beacon_str).map_err(|e| {
+                        HydrationError::InvalidData(format!(
+                            "Invalid Epoch JSON representation '{beacon_str}. Error: {e}'."
+                        ))
+                    })?;
+                    Self::MithrilStakeDistribution(epoch)
+                }
+                ENTITY_TYPE_CARDANO_STAKE_DISTRIBUTION => {
+                    let epoch: Epoch = serde_json::from_str(beacon_str).map_err(|e| {
+                        HydrationError::InvalidData(format!(
+                            "Invalid Epoch JSON representation '{beacon_str}. Error: {e}'."
+                        ))
+                    })?;
+                    Self::CardanoStakeDistribution(epoch)
+                }
+                ENTITY_TYPE_CARDANO_IMMUTABLE_FILES_FULL => {
+                    let beacon: Beacon = serde_json::from_str(beacon_str).map_err(|e| {
+                        HydrationError::InvalidData(format!(
+                            "Invalid Beacon JSON in open_message.beacon: '{beacon_str}'. Error: {e}"
+                        ))
+                    })?;
+                    Self::CardanoImmutableFilesFull(beacon)
+                }
+                index => panic!("Invalid entity_type_id {index}."),
+            };
+
+            Ok(myself)
+        }
     }
 
     /// Get the database value from enum's instance

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -20,11 +20,21 @@ macro_rules! cfg_database {
     }
 }
 
-macro_rules! cfg_fs {
+macro_rules! cfg_random {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "fs")]
-            #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
+            #[cfg(feature = "random")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "random")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_test_tools {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "test_tools")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "test_tools")))]
             $item
         )*
     }
@@ -53,6 +63,7 @@ pub mod sqlite;
 #[cfg(feature = "database")]
 pub mod store;
 
+#[cfg(feature = "test_tools")]
 pub mod test_utils;
 
 #[cfg(feature = "fs")]

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -10,12 +10,36 @@
 //! - A [certificate chain] used to validate the Certificate Chain created by an aggregator
 //! - The [entities] used by, and exchanged between, the aggregator, signers and client.
 
+macro_rules! cfg_database {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "database")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "database")))]
+            $item
+        )*
+    }
+}
+
+macro_rules! cfg_fs {
+    ($($item:item)*) => {
+        $(
+            #[cfg(feature = "fs")]
+            #[cfg_attr(docsrs, doc(cfg(feature = "fs")))]
+            $item
+        )*
+    }
+}
+
 pub mod api_version;
+#[cfg(feature = "fs")]
 mod beacon_provider;
+
 pub mod certificate_chain;
 pub mod chain_observer;
 pub mod crypto_helper;
+#[cfg(feature = "database")]
 pub mod database;
+#[cfg(feature = "fs")]
 pub mod digesters;
 pub mod entities;
 #[macro_use]
@@ -23,11 +47,17 @@ pub mod era;
 pub mod messages;
 pub mod protocol;
 pub mod signable_builder;
+
+#[cfg(feature = "database")]
 pub mod sqlite;
+#[cfg(feature = "database")]
 pub mod store;
+
 pub mod test_utils;
 
+#[cfg(feature = "fs")]
 pub use beacon_provider::{BeaconProvider, BeaconProviderImpl};
+
 pub use entities::{CardanoNetwork, MagicId};
 
 /// Generic error type

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -2,11 +2,13 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
+#[cfg(feature = "test_tools")]
+use crate::entities::ProtocolMessagePartKey;
 use crate::entities::{
     Beacon, Certificate, CertificateMetadata, CertificateSignature, ProtocolMessage,
-    ProtocolMessagePartKey,
 };
 use crate::messages::CertificateMetadataMessagePart;
+#[cfg(feature = "test_tools")]
 use crate::test_utils::fake_keys;
 use crate::StdError;
 
@@ -55,27 +57,29 @@ pub struct CertificateMessage {
 }
 
 impl CertificateMessage {
-    /// Return a dummy test entity (test-only).
-    pub fn dummy() -> Self {
-        let mut protocol_message = ProtocolMessage::new();
-        protocol_message.set_message_part(
-            ProtocolMessagePartKey::SnapshotDigest,
-            "snapshot-digest-123".to_string(),
-        );
-        protocol_message.set_message_part(
-            ProtocolMessagePartKey::NextAggregateVerificationKey,
-            fake_keys::aggregate_verification_key()[1].to_owned(),
-        );
-        Self {
-            hash: "hash".to_string(),
-            previous_hash: "previous_hash".to_string(),
-            beacon: Beacon::new("testnet".to_string(), 10, 100),
-            metadata: CertificateMetadataMessagePart::dummy(),
-            protocol_message: protocol_message.clone(),
-            signed_message: "signed_message".to_string(),
-            aggregate_verification_key: fake_keys::aggregate_verification_key()[0].to_owned(),
-            multi_signature: fake_keys::multi_signature()[0].to_owned(),
-            genesis_signature: String::new(),
+    cfg_test_tools! {
+        /// Return a dummy test entity (test-only).
+        pub fn dummy() -> Self {
+            let mut protocol_message = ProtocolMessage::new();
+            protocol_message.set_message_part(
+                ProtocolMessagePartKey::SnapshotDigest,
+                "snapshot-digest-123".to_string(),
+            );
+            protocol_message.set_message_part(
+                ProtocolMessagePartKey::NextAggregateVerificationKey,
+                fake_keys::aggregate_verification_key()[1].to_owned(),
+            );
+            Self {
+                hash: "hash".to_string(),
+                previous_hash: "previous_hash".to_string(),
+                beacon: Beacon::new("testnet".to_string(), 10, 100),
+                metadata: CertificateMetadataMessagePart::dummy(),
+                protocol_message: protocol_message.clone(),
+                signed_message: "signed_message".to_string(),
+                aggregate_verification_key: fake_keys::aggregate_verification_key()[0].to_owned(),
+                multi_signature: fake_keys::multi_signature()[0].to_owned(),
+                genesis_signature: String::new(),
+            }
         }
     }
 

--- a/mithril-common/src/messages/certificate_pending.rs
+++ b/mithril-common/src/messages/certificate_pending.rs
@@ -29,23 +29,25 @@ pub struct CertificatePendingMessage {
 }
 
 impl CertificatePendingMessage {
-    /// Provide a dummy instance for test.
-    pub fn dummy() -> Self {
-        Self {
-            beacon: Beacon::default(),
-            signed_entity_type: SignedEntityType::dummy(),
-            protocol_parameters: ProtocolParameters {
-                k: 5,
-                m: 100,
-                phi_f: 0.65,
-            },
-            next_protocol_parameters: ProtocolParameters {
-                k: 50,
-                m: 1000,
-                phi_f: 0.65,
-            },
-            signers: [SignerMessagePart::dummy()].to_vec(),
-            next_signers: [SignerMessagePart::dummy()].to_vec(),
+    cfg_test_tools! {
+        /// Provide a dummy instance for test.
+        pub fn dummy() -> Self {
+            Self {
+                beacon: Beacon::default(),
+                signed_entity_type: SignedEntityType::dummy(),
+                protocol_parameters: ProtocolParameters {
+                    k: 5,
+                    m: 100,
+                    phi_f: 0.65,
+                },
+                next_protocol_parameters: ProtocolParameters {
+                    k: 50,
+                    m: 1000,
+                    phi_f: 0.65,
+                },
+                signers: [SignerMessagePart::dummy()].to_vec(),
+                next_signers: [SignerMessagePart::dummy()].to_vec(),
+            }
         }
     }
 }

--- a/mithril-common/src/messages/message_parts/signer.rs
+++ b/mithril-common/src/messages/message_parts/signer.rs
@@ -1,10 +1,11 @@
+#[cfg(feature = "test_tools")]
+use crate::test_utils::fake_keys;
 use crate::{
     crypto_helper::{KESPeriod, ProtocolOpCert, ProtocolSignerVerificationKeySignature},
     entities::{
         HexEncodedOpCert, HexEncodedVerificationKey, HexEncodedVerificationKeySignature, PartyId,
         SignerWithStake, Stake,
     },
-    test_utils::fake_keys,
     StdResult,
 };
 use anyhow::Context;
@@ -46,17 +47,19 @@ pub struct SignerWithStakeMessagePart {
 }
 
 impl SignerWithStakeMessagePart {
-    /// Return a dummy test entity (test-only).
-    pub fn dummy() -> Self {
-        Self {
-            party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
-            verification_key: fake_keys::signer_verification_key()[0].to_string(),
-            verification_key_signature: Some(
-                fake_keys::signer_verification_key_signature()[0].to_string(),
-            ),
-            operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
-            kes_period: Some(6),
-            stake: 234,
+    cfg_test_tools! {
+        /// Return a dummy test entity (test-only).
+        pub fn dummy() -> Self {
+            Self {
+                party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
+                verification_key: fake_keys::signer_verification_key()[0].to_string(),
+                verification_key_signature: Some(
+                    fake_keys::signer_verification_key_signature()[0].to_string(),
+                ),
+                operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
+                kes_period: Some(6),
+                stake: 234,
+            }
         }
     }
 
@@ -175,16 +178,18 @@ pub struct SignerMessagePart {
 }
 
 impl SignerMessagePart {
-    /// Return a dummy test entity (test-only).
-    pub fn dummy() -> Self {
-        Self {
-            party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
-            verification_key: fake_keys::signer_verification_key()[0].to_string(),
-            verification_key_signature: Some(
-                fake_keys::signer_verification_key_signature()[0].to_string(),
-            ),
-            operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
-            kes_period: Some(6),
+    cfg_test_tools! {
+        /// Return a dummy test entity (test-only).
+        pub fn dummy() -> Self {
+            Self {
+                party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
+                verification_key: fake_keys::signer_verification_key()[0].to_string(),
+                verification_key_signature: Some(
+                    fake_keys::signer_verification_key_signature()[0].to_string(),
+                ),
+                operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
+                kes_period: Some(6),
+            }
         }
     }
 }

--- a/mithril-common/src/messages/mithril_stake_distribution.rs
+++ b/mithril-common/src/messages/mithril_stake_distribution.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::entities::Epoch;
 use crate::entities::ProtocolParameters;
+#[cfg(feature = "test_tools")]
 use crate::test_utils::fake_data;
 
 use super::SignerWithStakeMessagePart;
@@ -31,17 +32,19 @@ pub struct MithrilStakeDistributionMessage {
 }
 
 impl MithrilStakeDistributionMessage {
-    /// Return a dummy test entity (test-only).
-    pub fn dummy() -> Self {
-        Self {
-            epoch: Epoch(1),
-            signers_with_stake: vec![SignerWithStakeMessagePart::dummy()],
-            hash: "hash-123".to_string(),
-            certificate_hash: "cert-hash-123".to_string(),
-            created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
-                .unwrap()
-                .with_timezone(&Utc),
-            protocol_parameters: fake_data::protocol_parameters(),
+    cfg_test_tools! {
+        /// Return a dummy test entity (test-only).
+        pub fn dummy() -> Self {
+            Self {
+                epoch: Epoch(1),
+                signers_with_stake: vec![SignerWithStakeMessagePart::dummy()],
+                hash: "hash-123".to_string(),
+                certificate_hash: "cert-hash-123".to_string(),
+                created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+                protocol_parameters: fake_data::protocol_parameters(),
+            }
         }
     }
 }

--- a/mithril-common/src/messages/register_signature.rs
+++ b/mithril-common/src/messages/register_signature.rs
@@ -1,10 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
-use crate::{
-    entities::{HexEncodedSingleSignature, LotteryIndex, PartyId, SignedEntityType},
-    test_utils::fake_keys,
-};
+use crate::entities::{HexEncodedSingleSignature, LotteryIndex, PartyId, SignedEntityType};
+#[cfg(feature = "test_tools")]
+use crate::test_utils::fake_keys;
 
 era_deprecate!("make signed_entity_type of RegisterSignatureMessage not optional");
 /// Message structure to register single signature.
@@ -26,13 +25,15 @@ pub struct RegisterSignatureMessage {
 }
 
 impl RegisterSignatureMessage {
-    /// Return a dummy test entity (test-only).
-    pub fn dummy() -> Self {
-        Self {
-            signed_entity_type: Some(SignedEntityType::dummy()),
-            party_id: "party_id".to_string(),
-            signature: fake_keys::single_signature()[0].to_string(),
-            won_indexes: vec![1, 3],
+    cfg_test_tools! {
+        /// Return a dummy test entity (test-only).
+        pub fn dummy() -> Self {
+            Self {
+                signed_entity_type: Some(SignedEntityType::dummy()),
+                party_id: "party_id".to_string(),
+                signature: fake_keys::single_signature()[0].to_string(),
+                won_indexes: vec![1, 3],
+            }
         }
     }
 }

--- a/mithril-common/src/messages/register_signer.rs
+++ b/mithril-common/src/messages/register_signer.rs
@@ -1,13 +1,14 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
+#[cfg(feature = "test_tools")]
+use crate::test_utils::fake_keys;
 use crate::{
     crypto_helper::KESPeriod,
     entities::{
         Epoch, HexEncodedOpCert, HexEncodedVerificationKey, HexEncodedVerificationKeySignature,
         PartyId,
     },
-    test_utils::fake_keys,
 };
 
 era_deprecate!("make epoch of RegisterSignerMessage not optional");
@@ -47,17 +48,19 @@ pub struct RegisterSignerMessage {
 }
 
 impl RegisterSignerMessage {
-    /// Return a dummy test entity (test-only).
-    pub fn dummy() -> Self {
-        Self {
-            epoch: Some(Epoch(1)),
-            party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
-            verification_key: fake_keys::signer_verification_key()[0].to_string(),
-            verification_key_signature: Some(
-                fake_keys::signer_verification_key_signature()[0].to_string(),
-            ),
-            operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
-            kes_period: Some(6),
+    cfg_test_tools! {
+        /// Return a dummy test entity (test-only).
+        pub fn dummy() -> Self {
+            Self {
+                epoch: Some(Epoch(1)),
+                party_id: "pool1m8crhnqj5k2kyszf5j2scshupystyxc887zdfrpzh6ty6eun4fx".to_string(),
+                verification_key: fake_keys::signer_verification_key()[0].to_string(),
+                verification_key_signature: Some(
+                    fake_keys::signer_verification_key_signature()[0].to_string(),
+                ),
+                operational_certificate: Some(fake_keys::operational_certificate()[0].to_string()),
+                kes_period: Some(6),
+            }
         }
     }
 }

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -123,17 +123,19 @@ impl SignerBuilder {
         ))
     }
 
-    /// Build non deterministic [SingleSigner] and [ProtocolInitializer] based on the registered parties.
-    pub fn build_single_signer(
-        &self,
-        signer_with_stake: SignerWithStake,
-        kes_secret_key_path: Option<&Path>,
-    ) -> StdResult<(SingleSigner, ProtocolInitializer)> {
-        self.build_single_signer_with_rng(
-            signer_with_stake,
-            kes_secret_key_path,
-            &mut rand_core::OsRng,
-        )
+    cfg_random! {
+        /// Build non deterministic [SingleSigner] and [ProtocolInitializer] based on the registered parties.
+        pub fn build_single_signer(
+            &self,
+            signer_with_stake: SignerWithStake,
+            kes_secret_key_path: Option<&Path>,
+        ) -> StdResult<(SingleSigner, ProtocolInitializer)> {
+            self.build_single_signer_with_rng(
+                signer_with_stake,
+                kes_secret_key_path,
+                &mut rand_core::OsRng,
+            )
+        }
     }
 
     /// Build deterministic [SingleSigner] and [ProtocolInitializer] based on the registered parties.

--- a/mithril-common/src/signable_builder/mod.rs
+++ b/mithril-common/src/signable_builder/mod.rs
@@ -1,10 +1,12 @@
 //! The module used for building signables
 
+#[cfg(feature = "fs")]
 mod cardano_immutable_full_signable_builder;
 mod interface;
 mod mithril_stake_distribution;
 mod signable_builder_service;
 
+#[cfg(feature = "fs")]
 pub use cardano_immutable_full_signable_builder::*;
 pub use interface::*;
 pub use mithril_stake_distribution::*;

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -27,7 +27,7 @@ libp2p = { version = "0.53", features = [
     "tcp",
     "yamux",
 ] }
-mithril-common = { path = "../mithril-common", features = ["test_http_server"] }
+mithril-common = { path = "../mithril-common", features = ["full"] }
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.4"
+version = "0.1.5"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1.73"
 clap = { version = "4.4.6", features = ["derive", "env"] }
 config = "0.13.3"
 hex = "0.4.3"
-mithril-common = { path = "../mithril-common" }
+mithril-common = { path = "../mithril-common", features = ["full"] }
 openssl = { version = "0.10.57", features = ["vendored"], optional = true }
 openssl-probe = { version = "0.1.5", optional = true }
 rand_chacha = "0.3.1"

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.95"
+version = "0.2.96"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -22,7 +22,7 @@ clap = { version = "4.4.6", features = ["derive"] }
 glob = "0.3.1"
 hex = "0.4.3"
 indicatif = { version = "0.17.7", features = ["tokio"] }
-mithril-common = { path = "../../mithril-common" }
+mithril-common = { path = "../../mithril-common", features = ["full"] }
 reqwest = { version = "0.11.22", features = ["json"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.2.26"
+version = "0.2.27"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes the adaptation of the `mithril-common` and `mithril-client` libraries in order to build them in WASM.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1336 
