### PR TITLE
Fix `dev-preview` network protocol parameters

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -35,9 +35,9 @@ jobs:
           mithril_api_domain: api.mithril.network
           mithril_protocol_parameters: |
             {
-              k     = 100
-              m     = 60
-              phi_f = 0.95
+              k     = 5
+              m     = 100
+              phi_f = 0.65
             }
           mithril_signers: |
             {


### PR DESCRIPTION
## Content
This PR includes a fix to the protocol parameters of the `dev-preview` network (previous would have never allowed siging).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1361 
