### PR TITLE
Fix crates.io release credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,6 +174,10 @@ jobs:
         include:
         - package: mithril-stm
           api_token_secret_name: CRATES_IO_API_TOKEN
+        - package: mithril-common
+          api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_COMMON
+        - package: mithril-client
+          api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_CLIENT
           
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Content
This PR includes for missing credentials for crates.io publication in the `release.yml` workflow.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
