### PR TITLE
Fix `mithril-common` publication on crates.io

### DIFF
--- a/.github/workflows/actions/publish-crate-package/action.yml
+++ b/.github/workflows/actions/publish-crate-package/action.yml
@@ -36,21 +36,27 @@ runs:
         echo "should_deploy=false" >> $GITHUB_OUTPUT
       fi
 
+  - name: Copy OpenAPI specs files
+    shell: bash
+    run: |
+      echo "Copy OpenAPI specs files"
+      cp openapi*.yaml ./${{ inputs.package}}
+
   - name: Cargo publish dry run
     shell: bash
     run: |
       echo "Cargo publish '${{ inputs.package }}' package (dry run)"
-      cargo publish -p ${{ inputs.package }} --dry-run --no-verify ${{ inputs.publish_args }} 
+      cargo publish -p ${{ inputs.package }} --dry-run --no-verify --allow-dirty ${{ inputs.publish_args }} 
 
   - name: Cargo package list
     shell: bash
     run: |
       echo "Cargo package list '${{ inputs.package }}' package"
-      cargo package -p ${{ inputs.package }} --list
+      cargo package -p ${{ inputs.package }} --list --allow-dirty
 
   - name: Cargo publish
     if: inputs.dry_run == 'false' && steps.check_version.outputs.should_deploy == 'true'
     shell: bash
     run: |
       echo "Cargo publish '${{ inputs.package }}' package"
-      cargo publish -p ${{ inputs.package }} --token ${{ inputs.api_token }} --no-verify ${{ inputs.publish_args }}
+      cargo publish -p ${{ inputs.package }} --token ${{ inputs.api_token }} --no-verify --allow-dirty ${{ inputs.publish_args }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.136"
+version = "0.2.138"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -7,7 +7,7 @@ edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
-include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
+include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore", "openapi.yaml"]
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.136"
+version = "0.2.138"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/build.rs
+++ b/mithril-common/build.rs
@@ -19,6 +19,9 @@ fn read_version_from_open_api_spec_file(spec_file_path: PathBuf) -> OpenAPIVersi
 
 fn list_all_open_api_spec_files() -> Vec<PathBuf> {
     let mut open_api_spec_files = Vec::new();
+    for entry in glob("./openapi*.yaml").unwrap() {
+        open_api_spec_files.push(entry.unwrap())
+    }
     for entry in glob("../openapi*.yaml").unwrap() {
         open_api_spec_files.push(entry.unwrap())
     }
@@ -51,7 +54,7 @@ fn main() {
 /// Open API file name
 pub type OpenAPIFileName = String;
 
-/// Open PAI raw version
+/// Open API raw version
 pub type OpenAPIVersionRaw = String;
 
 /// Build Open API versions mapping


### PR DESCRIPTION
## Content
This PR includes a fix to the process to publish `mithril-common` on crates.io: the OpenAPI specs file must be published with the package on crates.io so that the build script that computes available API versions.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

