### PR TITLE
Fix verbosity log levels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           mkdir artifacts
 
       - name: Test
-        run: ./mithril-end-to-end --bin-directory ./bin --work-directory=./artifacts --devnet-scripts-directory=./mithril-test-lab/mithril-devnet --mithril-era=${{ matrix.era }} ${{ matrix.extra_args }}
+        run: ./mithril-end-to-end -vvv --bin-directory ./bin --work-directory=./artifacts --devnet-scripts-directory=./mithril-test-lab/mithril-devnet --mithril-era=${{ matrix.era }} ${{ matrix.extra_args }}
 
       - name: Upload E2E Tests Artifacts
         if:  ${{ failure() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3267,7 +3267,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3354,7 +3354,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.2.24"
+version = "0.2.25"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3379,7 +3379,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.92"
+version = "0.2.93"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.13"
+version = "0.4.14"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/mod.rs
+++ b/mithril-aggregator/src/commands/mod.rs
@@ -101,9 +101,10 @@ impl MainOpts {
     /// get log level from parameters
     pub fn log_level(&self) -> Level {
         match self.verbose {
-            0 => Level::Warning,
-            1 => Level::Info,
-            2 => Level::Debug,
+            0 => Level::Error,
+            1 => Level::Warning,
+            2 => Level::Info,
+            3 => Level::Debug,
             _ => Level::Trace,
         }
     }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.5.5"
+version = "0.5.6"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -60,9 +60,10 @@ impl Args {
 
     fn log_level(&self) -> Level {
         match self.verbose {
-            0 => Level::Warning,
-            1 => Level::Info,
-            2 => Level::Debug,
+            0 => Level::Error,
+            1 => Level::Warning,
+            2 => Level::Info,
+            3 => Level::Debug,
             _ => Level::Trace,
         }
     }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.2"
+version = "0.1.3"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/src/main.rs
+++ b/mithril-relay/src/main.rs
@@ -47,9 +47,10 @@ impl Args {
 
     fn log_level(&self) -> Level {
         match self.verbose {
-            0 => Level::Warning,
-            1 => Level::Info,
-            2 => Level::Debug,
+            0 => Level::Error,
+            1 => Level::Warning,
+            2 => Level::Info,
+            3 => Level::Debug,
             _ => Level::Trace,
         }
     }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.92"
+version = "0.2.93"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/main.rs
+++ b/mithril-signer/src/main.rs
@@ -58,9 +58,10 @@ pub struct Args {
 impl Args {
     fn log_level(&self) -> Level {
         match self.verbose {
-            0 => Level::Warning,
-            1 => Level::Info,
-            2 => Level::Debug,
+            0 => Level::Error,
+            1 => Level::Warning,
+            2 => Level::Info,
+            3 => Level::Debug,
             _ => Level::Trace,
         }
     }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.2.24"
+version = "0.2.25"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/README.md
+++ b/mithril-test-lab/mithril-end-to-end/README.md
@@ -31,7 +31,7 @@ make build
 ./mithril-end-to-end --help
 
 # Run
-./mithril-end-to-end --db-directory db/ --bin-directory ../../target/release
+./mithril-end-to-end -vvv --db-directory db/ --bin-directory ../../target/release
 ```
 
 To run `mithril-end-to-end` command, you must first compile the Mithril nodes:
@@ -83,7 +83,7 @@ cp $HOME/.local/bin/cardano-cli mithril-test-lab/mithril-devnet/cardano-cli
 - Use the `--skip-cardano-bin-download` option to run the end to end test:
 
 ```bash
-./mithril-end-to-end --db-directory db/ --bin-directory ../../target/release --skip-cardano-bin-download
+./mithril-end-to-end -vvv --db-directory db/ --bin-directory ../../target/release --skip-cardano-bin-download
 ```
 
 ## Build and run an aggregator stress test

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/entities.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/entities.rs
@@ -50,9 +50,10 @@ impl MainOpts {
     /// get log level from parameters
     pub fn log_level(&self) -> Level {
         match self.verbose {
-            0 => Level::Warning,
-            1 => Level::Info,
-            2 => Level::Debug,
+            0 => Level::Error,
+            1 => Level::Warning,
+            2 => Level::Info,
+            3 => Level::Debug,
             _ => Level::Trace,
         }
     }


### PR DESCRIPTION
## Content
This PR includes a fix for log levels problems that was raised in the issue #1325.

This consists of: 
- correctly adjust verbosity according to verbosity level (`-v`, `-vv`, `-vvv`)
- display `critical` level logs when parameter is absent

Changes have been implemented into:
- `mithril-client-cli`
- `mithril-aggregator`
- `mithril-signer`
- `mithril-relay`
- `mithril-test-lab` (`mithril-end-to-end` & `stress-test`)
 
## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Log level management has been added to the `mithril-end-to-end`, as it wasn't already included.

## Issue(s)
Closes #1325 
