### PR TITLE
Add timeout on signer node HTTP requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3402,7 +3402,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.93"
+version = "0.2.94"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.93"
+version = "0.2.94"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -24,3 +24,6 @@ pub use message_adapters::{
 pub use protocol_initializer_store::{ProtocolInitializerStore, ProtocolInitializerStorer};
 pub use runtime::*;
 pub use single_signer::*;
+
+/// HTTP request timeout duration in milliseconds
+const HTTP_REQUEST_TIMEOUT_DURATION: u64 = 30000;

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use sqlite::{Connection, ConnectionWithFullMutex};
-use std::{fs, sync::Arc};
+use std::{fs, sync::Arc, time::Duration};
 
 use mithril_common::{
     api_version::APIVersionProvider,
@@ -27,6 +27,7 @@ use mithril_common::{
 use crate::{
     aggregator_client::AggregatorClient, single_signer::SingleSigner, AggregatorHTTPClient,
     Configuration, MithrilSingleSigner, ProtocolInitializerStore, ProtocolInitializerStorer,
+    HTTP_REQUEST_TIMEOUT_DURATION,
 };
 
 type StakeStoreService = Arc<StakeStore>;
@@ -229,6 +230,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             self.config.aggregator_endpoint.clone(),
             self.config.relay_endpoint.clone(),
             api_version_provider.clone(),
+            Some(Duration::from_millis(HTTP_REQUEST_TIMEOUT_DURATION)),
         ));
 
         let cardano_immutable_snapshot_builder =


### PR DESCRIPTION
## Content
This PR includes an update to the `AggregatorHTTPClient` in the signer node which adds a 15 seconds timeout for HTTP requests.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1312 
