### PR TITLE
Implement manual crates publication workflow

### DIFF
--- a/.github/workflows/manual-publish-crates.yml
+++ b/.github/workflows/manual-publish-crates.yml
@@ -1,0 +1,44 @@
+name: Manually publish crates
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Dry run will not publish to crates.io registry
+        required: true
+        type: boolean
+        default: true
+
+jobs:
+  publish-crate:
+    strategy:
+      fail-fast: true
+      max-parallel: 1
+      matrix:
+        package: [ mithril-stm, mithril-common, mithril-client ]
+        include:
+        - package: mithril-stm
+          api_token_secret_name: CRATES_IO_API_TOKEN
+        - package: mithril-common
+          api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_COMMON
+        - package: mithril-client
+          api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_CLIENT
+          
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+        
+      - name: Publish package to crates.io
+        uses: ./.github/workflows/actions/publish-crate-package
+        with:
+          #dry_run: ${{ inputs.dry_run }}
+          dry_run: "true"
+          package: ${{ matrix.package }}
+          api_token: test123
+          #api_token: ${{ secrets[matrix.api_token_secret_name] }}

--- a/.github/workflows/test-deploy-network.yml
+++ b/.github/workflows/test-deploy-network.yml
@@ -1,4 +1,4 @@
-name: Test network deploy
+name: Test network deployment
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-docker-distribution.yml
+++ b/.github/workflows/test-docker-distribution.yml
@@ -1,4 +1,4 @@
-name: Docker images test
+name: Test Docker images
 
 on:
   workflow_dispatch:

--- a/.github/workflows/test-docker-distribution.yml
+++ b/.github/workflows/test-docker-distribution.yml
@@ -1,95 +1,44 @@
-name: Test Docker images
+name: Manually publish crates
 
 on:
   workflow_dispatch:
     inputs:
-      distribution_code:
-        description: |
-          Specific code to identify the new distribution. The distribution package will be named with the following nomenclature: `test-{{distribution_code}}-{{sha}}`
-        required: true
-        type: string
-      commit_sha:
-        description: |
-          SHA of the commit on which the mithril binaries should be obtained, a "ci.yml" workflow must have run
-          on it otherwise no binary would be available leading to the failure of this workflow.
-        required: true
-        type: string
-      cardano_bin_url:
-        description: The url of the archive of the Cardano binaries
-        required: true
-        type: string
-        default: https://github.com/input-output-hk/cardano-node/releases/download/8.1.2/cardano-node-8.1.2-linux.tar.gz
       dry_run:
-        description: Dry run will not push the Docker images to the registry
+        description: Dry run will not publish to crates.io registry
         required: true
         type: boolean
         default: true
 
 jobs:
-  build-push-docker:
-    runs-on: ubuntu-22.04
+  publish-crate:
     strategy:
-      fail-fast: false
+      fail-fast: true
+      max-parallel: 1
       matrix:
-        project: [ mithril-aggregator, mithril-client-cli, mithril-signer, mithril-relay ]
-
+        package: [ mithril-stm, mithril-common, mithril-client ]
         include:
-          - project: mithril-client-cli
-            package: mithril-client
-    
-    permissions:
-      contents: read
-      packages: write 
-
-    env:
-      REGISTRY: ghcr.io
-      PACKAGE: ${{ github.repository_owner }}/${{ matrix.package != '' && matrix.package || matrix.project }}
-      DOCKER_FILE: ./${{ matrix.project }}/Dockerfile.ci
-      CONTEXT: .
-      GITHUB_REF: ${{ github.ref}}
-
+        - package: mithril-stm
+          api_token_secret_name: CRATES_IO_API_TOKEN
+        - package: mithril-common
+          api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_COMMON
+        - package: mithril-client
+          api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_CLIENT
+          
+    runs-on: ubuntu-22.04
     steps:
-      - name: Checkout repository
+      - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Get short SHA
-        id: slug
-        run: echo "sha8=$(echo ${{ inputs.commit_sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
-
-      - name: Checkout commit
-        run: |
-          git checkout ${{ inputs.commit_sha }}
-
-      - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v2
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
-          name: mithril-distribution-Linux-X64
-          path: ${{ matrix.project }}
-          commit: ${{ inputs.commit_sha }}
-          workflow: ci.yml
-          workflow_conclusion: completed
-
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
+          toolchain: stable
+        
+      - name: Publish package to crates.io
+        uses: ./.github/workflows/actions/publish-crate-package
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
-          tags: |
-            test
-            type=raw,value=test-${{ inputs.distribution_code }}-${{ steps.slug.outputs.sha8 }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: ${{ env.CONTEXT }}
-          file: ${{ env.DOCKER_FILE }}
-          build-args: CARDANO_BIN_URL=${{ inputs.cardano_bin_url }}
-          push: ${{ inputs.dry_run == false }}
-          tags: ${{ steps.meta.outputs.tags }}
+          #dry_run: ${{ inputs.dry_run }}
+          dry_run: "true"
+          package: ${{ matrix.package }}
+          api_token: test123
+          #api_token: ${{ secrets[matrix.api_token_secret_name] }}

--- a/docs/runbook/test-deploy-network/README.md
+++ b/docs/runbook/test-deploy-network/README.md
@@ -6,7 +6,7 @@ From time to time, we may need to deploy manually on a test Mithril network a te
 
 ## Run the associated 'Test network deploy' GitHub Actions workflow
 
-Go to the page of the workflow with your browser: [Docker image test](https://github.com/input-output-hk/mithril/actions/workflows/test-deploy.yml)
+Go to the page of the workflow with your browser: [Docker image test](https://github.com/input-output-hk/mithril/actions/workflows/test-deploy-network.yml)
 
 Then, click on the **Run workflow** button:
 

--- a/docs/runbook/test-docker-distribution/README.md
+++ b/docs/runbook/test-docker-distribution/README.md
@@ -7,7 +7,7 @@ This is a convenient way for testing early releases of the Cardano node. This is
 
 ## Run the associated 'Docker images test' GitHub Actions workflow
 
-Go to the page of the workflow with your browser: [Docker image test](https://github.com/input-output-hk/mithril/actions/workflows/test-docker.yml)
+Go to the page of the workflow with your browser: [Docker image test](https://github.com/input-output-hk/mithril/actions/workflows/test-docker-distribution.yml)
 
 Then, click on the **Run workflow** button:
 


### PR DESCRIPTION
## Content
This PR includes:
- Renaming of `Test network deployment` workflow
- Renaming of `Test Docker images` workflow
- Implementing `Manually publish crates` workflow

## Pre-submit checklist

- Branch
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update documentation 

## Issue(s)
Closes #1380 
