### PR TITLE
Add `full` feature to `mithril-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.140"
+version = "0.2.141"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -89,6 +89,7 @@ serde_yaml = "0.9.25"
 
 [features]
 default = []
+full = []
 
 allow_skip_signer_certification = []
 # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.140"
+version = "0.2.141"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR adds the `full` feature to `mithril-common` so that it does not break the CI with publication to crates.io checks.

> [!NOTE]
> The `full` feature does nothing at the moment, and will be activated in PR #1368 

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1336
