### PR TITLE
Fix `mithril-client` dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3278,7 +3278,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3352,7 +3352,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.142"
+version = "0.2.143"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -39,7 +39,7 @@ zstd = { version = "0.13.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mithril-common = { path = "../mithril-common", version = "0.2", features = [
-    "full",
+    "fs",
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
@@ -54,7 +54,8 @@ wasm-bindgen-futures = "0.4.37"
 httpmock = "0.6.8"
 indicatif = { version = "0.17.7", features = ["tokio"] }
 mithril-common = { path = "../mithril-common", version = "0.2", features = [
-    "test_http_server",
+    "random",
+    "test_tools",
 ] }
 mockall = "0.11.4"
 slog-async = "2.8.0"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.5.10"
+version = "0.5.11"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.142"
+version = "0.2.143"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -1,12 +1,12 @@
 //! Tools to request metadata, like the current epoch or the stake distribution, from the Cardano
 
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", feature = "random"))]
 mod cli_observer;
 #[cfg(feature = "test_tools")]
 mod fake_observer;
 mod interface;
 mod model;
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", feature = "random"))]
 mod pallas_observer;
 
 #[cfg(test)]
@@ -15,7 +15,7 @@ mod test_cli_runner;
 #[cfg(test)]
 pub use cli_observer::CliRunner;
 
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", feature = "random"))]
 pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
 #[cfg(feature = "test_tools")]
 pub use fake_observer::FakeObserver;
@@ -25,5 +25,5 @@ pub use interface::{ChainObserver, ChainObserverError};
 pub use model::{
     ChainAddress, TxDatum, TxDatumBuilder, TxDatumError, TxDatumFieldTypeName, TxDatumFieldValue,
 };
-#[cfg(feature = "fs")]
+#[cfg(all(feature = "fs", feature = "random"))]
 pub use pallas_observer::PallasChainObserver;


### PR DESCRIPTION
## Content
This PR removes unused dependencies from the `mithril-common` crate when called in the `mithril-client` crate.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1390 
