### PR TITLE
Fix breaking change introduced with `mithril-client-cli` using `mithril-client` library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.5.9"
+version = "0.5.10"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
@@ -6,7 +6,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use mithril_client::ClientBuilder;
 use mithril_client_cli::configuration::ConfigParameters;
-use mithril_common::StdResult;
+use mithril_common::{test_utils::fake_keys, StdResult};
 
 /// Mithril stake distribution LIST command
 #[derive(Parser, Debug, Clone)]
@@ -23,9 +23,16 @@ impl MithrilStakeDistributionListCommand {
         let params = Arc::new(ConfigParameters::new(
             config.try_deserialize::<HashMap<String, String>>()?,
         ));
+        // TODO: This should not be done this way.
+        // Now that mithril-client-cli uses the mithril-client library, the genesis verification key is required for all commands
+        let fallback_genesis_verification_key =
+            fake_keys::genesis_verification_key()[0].to_string();
         let client = ClientBuilder::aggregator(
             &params.require("aggregator_endpoint")?,
-            &params.require("genesis_verification_key")?,
+            &params.get_or(
+                "genesis_verification_key",
+                &fallback_genesis_verification_key,
+            ),
         )
         .with_logger(logger())
         .build()?;

--- a/mithril-client-cli/src/commands/snapshot/list.rs
+++ b/mithril-client-cli/src/commands/snapshot/list.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Table};
 use config::{builder::DefaultState, ConfigBuilder};
+use mithril_common::test_utils::fake_keys;
 use slog_scope::logger;
 use std::{collections::HashMap, sync::Arc};
 
@@ -22,9 +23,16 @@ impl SnapshotListCommand {
         let params = Arc::new(ConfigParameters::new(
             config.try_deserialize::<HashMap<String, String>>()?,
         ));
+        // TODO: This should not be done this way.
+        // Now that mithril-client-cli uses the mithril-client library, the genesis verification key is required for all commands
+        let fallback_genesis_verification_key =
+            fake_keys::genesis_verification_key()[0].to_string();
         let client = ClientBuilder::aggregator(
             &params.require("aggregator_endpoint")?,
-            &params.require("genesis_verification_key")?,
+            &params.get_or(
+                "genesis_verification_key",
+                &fallback_genesis_verification_key,
+            ),
         )
         .with_logger(logger())
         .build()?;

--- a/mithril-client-cli/src/commands/snapshot/show.rs
+++ b/mithril-client-cli/src/commands/snapshot/show.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use mithril_client::ClientBuilder;
 use mithril_client_cli::{configuration::ConfigParameters, utils::ExpanderUtils};
-use mithril_common::StdResult;
+use mithril_common::{test_utils::fake_keys, StdResult};
 
 /// Clap command to show a given snapshot
 #[derive(Parser, Debug, Clone)]
@@ -29,9 +29,16 @@ impl SnapshotShowCommand {
         let params = Arc::new(ConfigParameters::new(
             config.try_deserialize::<HashMap<String, String>>()?,
         ));
+        // TODO: This should not be done this way.
+        // Now that mithril-client-cli uses the mithril-client library, the genesis verification key is required for all commands
+        let fallback_genesis_verification_key =
+            fake_keys::genesis_verification_key()[0].to_string();
         let client = ClientBuilder::aggregator(
             &params.require("aggregator_endpoint")?,
-            &params.require("genesis_verification_key")?,
+            &params.get_or(
+                "genesis_verification_key",
+                &fallback_genesis_verification_key,
+            ),
         )
         .with_logger(logger())
         .build()?;


### PR DESCRIPTION
## Content
This PR includes a fix on a breaking change introduced by the PR #1395.

Some commands of `mithril-client-cli` (`snapshot show`, `snapshot list` and `msd list`) don't need to a `genesis_verification_key` configured to be runned.

Now that `mithril-client-cli` uses the `mithril-client-cli` that needs a `genesis_verification_key` to build a `Client`, we have to provide a value, even for commands that don't need it.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested