### PR TITLE
Enhance machine readable logs in client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
+ "slog-bunyan",
  "slog-scope",
  "slog-term",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,7 +3280,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client.md
@@ -137,6 +137,10 @@ Options:
           Directory where configuration file is located [default: ./config]
       --aggregator-endpoint <AGGREGATOR_ENDPOINT>
           Override configuration Aggregator endpoint URL
+      --log-format-json
+          Enable JSON output for logs displayed according to verbosity level
+      --log-output <LOG_OUTPUT>
+          Redirect the logs to a file
   -h, --help
           Print help
   -V, --version
@@ -296,13 +300,21 @@ Here is a list of the available parameters:
 | `network` | - | - | `NETWORK` | Cardano network | - | `testnet` or `mainnet` or `devnet` | :heavy_check_mark: |
 | `aggregator_endpoint` | `--aggregator-endpoint` | - | `AGGREGATOR_ENDPOINT` | Aggregator node endpoint | - | `https://aggregator.pre-release-preview.api.mithril.network/aggregator` | :heavy_check_mark: |
 | `genesis_verification_key` | - | - | `GENESIS_VERIFICATION_KEY` | Genesis verification key | - | - | :heavy_check_mark: |
-| `json_output` | `--json` | `-j` | - | Enable JSON output | no | - | - |
+| `log_format_json` | `--log-format-json` | - | - | Enable JSON output for logs | - | - | - |
+| `log_output` | `--log-output` | `-o` | - | Redirect the logs to a file | - | `./mithril-client.log` | - |
 
 `snapshot show` command:
 
 | Parameter | Command line (long) |  Command line (short) | Environment variable | Description | Default value | Example | Mandatory |
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
 | `digest` | `--digest` | - | `DIGEST` | Snapshot digest or `latest` for the latest digest | - | - | :heavy_check_mark: |
+| `json` | `--json` | - | - | Enable JSON output for command results | - | - | - |
+
+`snapshot list` command:
+
+| Parameter | Command line (long) |  Command line (short) | Environment variable | Description | Default value | Example | Mandatory |
+|-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
+| `json` | `--json` | - | - | Enable JSON output for command results | - | - | - |
 
 `snapshot download` command:
 
@@ -310,6 +322,13 @@ Here is a list of the available parameters:
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
 | `digest` | `--digest` | - | `DIGEST` | Snapshot digest or `latest` for the latest digest | - | - | :heavy_check_mark: |
 | `download_dir` | `--download-dir` | - | - | Directory where the snapshot will be downloaded | . | - | - |
+| `json` | `--json` | - | - | Enable JSON output for progress logs | - | - | - |
+
+`mithril-stake-distribution list` command:
+
+| Parameter | Command line (long) |  Command line (short) | Environment variable | Description | Default value | Example | Mandatory |
+|-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
+| `json` | `--json` | - | - | Enable JSON output for command results | - | - | - |
 
 `mithril-stake-distribution download` command:
 

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.5.11"
+version = "0.5.12"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -46,6 +46,7 @@ slog = { version = "2.7.0", features = [
     "release_max_level_debug",
 ] }
 slog-async = "2.8.0"
+slog-bunyan = "2.4.0"
 slog-scope = "4.4.0"
 slog-term = "2.9.0"
 thiserror = "1.0.49"

--- a/mithril-client-cli/src/commands/snapshot/download.rs
+++ b/mithril-client-cli/src/commands/snapshot/download.rs
@@ -1,4 +1,5 @@
 use anyhow::{anyhow, Context};
+use chrono::Utc;
 use clap::Parser;
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
 use slog_scope::{debug, logger, warn};
@@ -183,7 +184,8 @@ impl SnapshotDownloadCommand {
 
         if self.json {
             println!(
-                r#"{{"db_directory": "{}"}}"#,
+                r#"{{"timestamp": "{}", "db_directory": "{}"}}"#,
+                Utc::now().to_rfc3339(),
                 canonicalized_filepath.display()
             );
         } else {

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -2,19 +2,41 @@
 
 mod commands;
 
-use std::path::PathBuf;
-use std::sync::Arc;
-
+use anyhow::Context;
 use clap::{Parser, Subcommand};
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
-use slog::{Drain, Level, Logger};
+use slog::{Drain, Fuse, Level, Logger};
+use slog_async::Async;
 use slog_scope::debug;
+use slog_term::Decorator;
+use std::io::Write;
+use std::sync::Arc;
+use std::{fs::File, path::PathBuf};
 
 use mithril_client_cli::common::StdResult;
 
 use commands::{
     mithril_stake_distribution::MithrilStakeDistributionCommands, snapshot::SnapshotCommands,
 };
+
+enum LogOutputType {
+    Stdout,
+    File(String),
+}
+
+impl LogOutputType {
+    fn get_writer(&self) -> StdResult<Box<dyn Write + Send>> {
+        let writer: Box<dyn Write + Send> = match self {
+            LogOutputType::Stdout => Box::new(std::io::stdout()),
+            LogOutputType::File(filepath) => Box::new(
+                File::create(filepath)
+                    .with_context(|| format!("Can not create output log file: {}", filepath))?,
+            ),
+        };
+
+        Ok(writer)
+    }
+}
 
 #[derive(Parser, Debug, Clone)]
 #[clap(name = "mithril-client")]
@@ -47,6 +69,10 @@ pub struct Args {
     /// Enable JSON output for logs displayed according to verbosity level
     #[clap(long)]
     log_format_json: bool,
+
+    /// Redirect the logs to a file
+    #[clap(long, alias("o"))]
+    log_output: Option<String>,
 }
 
 impl Args {
@@ -72,24 +98,38 @@ impl Args {
         }
     }
 
-    fn build_logger(&self) -> Logger {
+    fn get_log_output_type(&self) -> LogOutputType {
+        if let Some(output_filepath) = &self.log_output {
+            LogOutputType::File(output_filepath.to_string())
+        } else {
+            LogOutputType::Stdout
+        }
+    }
+
+    fn wrap_drain<D: Decorator + Send + 'static>(&self, decorator: D) -> Fuse<Async> {
+        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+        let drain = slog::LevelFilter::new(drain, self.log_level()).fuse();
+
+        slog_async::Async::new(drain).build().fuse()
+    }
+
+    fn build_logger(&self) -> StdResult<Logger> {
+        let log_output_type = self.get_log_output_type();
+        let writer = log_output_type.get_writer()?;
+
         let drain = if self.log_format_json {
-            let drain = slog_bunyan::new(std::io::stdout())
-                .set_pretty(false)
-                .build()
-                .fuse();
+            let drain = slog_bunyan::new(writer).set_pretty(false).build().fuse();
             let drain = slog::LevelFilter::new(drain, self.log_level()).fuse();
 
             slog_async::Async::new(drain).build().fuse()
         } else {
-            let decorator = slog_term::TermDecorator::new().build();
-            let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-            let drain = slog::LevelFilter::new(drain, self.log_level()).fuse();
-
-            slog_async::Async::new(drain).build().fuse()
+            match log_output_type {
+                LogOutputType::Stdout => self.wrap_drain(slog_term::TermDecorator::new().build()),
+                LogOutputType::File(_) => self.wrap_drain(slog_term::PlainDecorator::new(writer)),
+            }
         };
 
-        Logger::root(Arc::new(drain), slog::o!())
+        Ok(Logger::root(Arc::new(drain), slog::o!()))
     }
 }
 
@@ -135,7 +175,7 @@ impl ArtifactCommands {
 async fn main() -> StdResult<()> {
     // Load args
     let args = Args::parse();
-    let _guard = slog_scope::set_global_logger(args.build_logger());
+    let _guard = slog_scope::set_global_logger(args.build_logger()?);
 
     #[cfg(feature = "bundle_openssl")]
     openssl_probe::init_ssl_cert_env_vars();

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget};
 use mithril_common::StdResult;
 use slog_scope::warn;
@@ -49,8 +50,9 @@ impl ProgressPrinter {
     pub fn report_step(&self, step_number: u16, text: &str) -> StdResult<()> {
         match self.output_type {
             ProgressOutputType::JsonReporter => println!(
-                r#"{{"step_num": {step_number}, "total_steps": {}, "message": "{text}"}}"#,
-                self.number_of_steps
+                r#"{{"timestamp": "{timestamp}", "step_num": {step_number}, "total_steps": {number_of_steps}, "message": "{text}"}}"#,
+                timestamp = Utc::now().to_rfc3339(),
+                number_of_steps = self.number_of_steps,
             ),
             ProgressOutputType::TTY => self
                 .multi_progress
@@ -99,7 +101,8 @@ impl DownloadProgressReporter {
 
             if should_report {
                 println!(
-                    r#"{{ "bytes_downloaded": {}, "bytes_total": {}, "seconds_left": {}.{}, "seconds_elapsed": {}.{} }}"#,
+                    r#"{{ "timestamp": "{}", "bytes_downloaded": {}, "bytes_total": {}, "seconds_left": {}.{}, "seconds_elapsed": {}.{} }}"#,
+                    Utc::now().to_rfc3339(),
                     self.progress_bar.position(),
                     self.progress_bar.length().unwrap_or(0),
                     self.progress_bar.eta().as_secs(),

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -99,7 +99,7 @@ impl DownloadProgressReporter {
 
             if should_report {
                 println!(
-                    r#"{{ "bytesDownloaded": {}, "bytesTotal": {}, "secondsLeft": {}.{}, "secondsElapsed": {}.{} }}"#,
+                    r#"{{ "bytes_downloaded": {}, "bytes_total": {}, "seconds_left": {}.{}, "seconds_elapsed": {}.{} }}"#,
                     self.progress_bar.position(),
                     self.progress_bar.length().unwrap_or(0),
                     self.progress_bar.eta().as_secs(),


### PR DESCRIPTION
## Content
This PR includes an update of `mithril-client-cli`.
- Fix the case inconsistency issue (use only snake case now).
- Fix a formatting problem with `seconds_left` and `seconds_elapsed` ("5s" and "001ms" was formatted as "5.1" in logs, instead of "5.001").
- Add `timestamp` in JSON progress logs.
- Add `--log-format-json` argument in `mithril-client-cli` commands, which displays `slog` logs in json format.
- Add `--log-output` argument in `mithril-client-cli` commands to redirect the `slog` logs to a file.

> [!IMPORTANT]  
> This PR includes impacting modifications `mithril-client-cli`. JSON progress logs were modified:
> -  `bytesDownloaded` is now `bytes_downloaded`
> -  `bytesTotal` is now `bytes_total`
> -  `secondsLeft` is now `seconds_left`
> -  `secondsElapsed` is now `seconds_elapsed`

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1234 
