### PR TITLE
Implement `open_message` timeout in aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.146"
+version = "0.2.147"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.20"
+version = "0.4.21"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -601,5 +601,14 @@ alter table signer add column last_registered_at text null;
 update signer set last_registered_at = created_at; 
         "#,
         ),
+        // Migration 20
+        // Alter `open_message` table to add `expires_at` and 'is_expired' fields
+        SqlMigration::new(
+            20,
+            r#"
+alter table open_message add column is_expired bool not null default false;
+alter table open_message add column expires_at text null;
+        "#,
+        ),
     ]
 }

--- a/mithril-aggregator/src/database/provider/open_message.rs
+++ b/mithril-aggregator/src/database/provider/open_message.rs
@@ -566,7 +566,7 @@ impl OpenMessageRepository {
         Ok(messages.next())
     }
 
-    /// Return the expired [OpenMessageRecord]s for the given Epoch and [SignedEntityType]
+    /// Return the expired [OpenMessageRecord] for the given Epoch and [SignedEntityType] if it exists
     pub async fn get_expired_open_message(
         &self,
         signed_entity_type: &SignedEntityType,

--- a/mithril-aggregator/src/database/provider/open_message.rs
+++ b/mithril-aggregator/src/database/provider/open_message.rs
@@ -36,8 +36,14 @@ pub struct OpenMessageRecord {
     /// Has this open message been converted into a certificate?
     pub is_certified: bool,
 
+    /// Has this open message expired
+    pub is_expired: bool,
+
     /// Message creation datetime, it is set by the database.
     pub created_at: DateTime<Utc>,
+
+    /// Message expiration datetime, if it exists.
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 impl OpenMessageRecord {
@@ -54,7 +60,9 @@ impl OpenMessageRecord {
             signed_entity_type,
             protocol_message: ProtocolMessage::new(),
             is_certified: false,
+            is_expired: false,
             created_at: Utc::now(),
+            expires_at: None,
         }
     }
 }
@@ -67,7 +75,9 @@ impl From<OpenMessageWithSingleSignaturesRecord> for OpenMessageRecord {
             signed_entity_type: value.signed_entity_type,
             protocol_message: value.protocol_message,
             is_certified: value.is_certified,
+            is_expired: value.is_expired,
             created_at: value.created_at,
+            expires_at: value.expires_at,
         }
     }
 }
@@ -109,21 +119,29 @@ impl SqLiteEntity for OpenMessageRecord {
         })?;
         let signed_entity_type = SignedEntityType::hydrate(signed_entity_type_id, &beacon_str)?;
         let is_certified = row.read::<i64, _>(5) != 0;
-        let datetime = &row.read::<&str, _>(6);
+        let datetime = &row.read::<&str, _>(7);
         let created_at =
             DateTime::parse_from_rfc3339(datetime).map_err(|e| {
                 HydrationError::InvalidData(format!(
                     "Could not turn open_message.created_at field value '{datetime}' to rfc3339 Datetime. Error: {e}"
                 ))
             })?.with_timezone(&Utc);
-
+        let is_expired = row.read::<i64, _>(6) != 0;
+        let datetime = &row.read::<Option<&str>, _>(8);
+        let expires_at = datetime.map(|datetime| DateTime::parse_from_rfc3339(datetime).map_err(|e| {
+                HydrationError::InvalidData(format!(
+                    "Could not turn open_message.expires_at field value '{datetime}' to rfc3339 Datetime. Error: {e}"
+                ))
+            })).transpose()?.map(|datetime| datetime.with_timezone(&Utc));
         let open_message = Self {
             open_message_id,
             epoch: Epoch(epoch_val),
             signed_entity_type,
             protocol_message,
             is_certified,
+            is_expired,
             created_at,
+            expires_at,
         };
 
         Ok(open_message)
@@ -153,7 +171,9 @@ impl SqLiteEntity for OpenMessageRecord {
                 "text",
             ),
             ("is_certified", "{:open_message:}.is_certified", "bool"),
+            ("is_expired", "{:open_message:}.is_expired", "bool"),
             ("created_at", "{:open_message:}.created_at", "text"),
+            ("expires_at", "{:open_message:}.expires_at", "text"),
         ])
     }
 }
@@ -182,6 +202,10 @@ impl<'client> OpenMessageProvider<'client> {
                 Value::String(signed_entity_type.get_json_beacon()?),
             ],
         ))
+    }
+
+    fn get_expired_entity_type_condition(&self, now: &str) -> WhereCondition {
+        WhereCondition::new("expires_at < ?*", vec![Value::String(now.to_string())])
     }
 
     // Useful in test and probably in the future.
@@ -227,7 +251,7 @@ impl<'client> InsertOpenMessageProvider<'client> {
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
     ) -> StdResult<WhereCondition> {
-        let expression = "(open_message_id, epoch_setting_id, beacon, signed_entity_type_id, protocol_message, created_at) values (?*, ?*, ?*, ?*, ?*, ?*)";
+        let expression = "(open_message_id, epoch_setting_id, beacon, signed_entity_type_id, protocol_message, expires_at, created_at) values (?*, ?*, ?*, ?*, ?*, ?*, ?*)";
         let beacon_str = signed_entity_type.get_json_beacon()?;
         let parameters = vec![
             Value::String(Uuid::new_v4().to_string()),
@@ -235,6 +259,10 @@ impl<'client> InsertOpenMessageProvider<'client> {
             Value::String(beacon_str),
             Value::Integer(signed_entity_type.index() as i64),
             Value::String(serde_json::to_string(protocol_message)?),
+            signed_entity_type
+                .get_open_message_timeout()
+                .map(|t| Value::String((Utc::now() + t).to_rfc3339()))
+                .unwrap_or(Value::Null),
             Value::String(Utc::now().to_rfc3339()),
         ];
 
@@ -267,8 +295,8 @@ impl<'client> UpdateOpenMessageProvider<'client> {
 
     fn get_update_condition(&self, open_message: &OpenMessageRecord) -> StdResult<WhereCondition> {
         let expression = "epoch_setting_id = ?*, beacon = ?*, \
-signed_entity_type_id = ?*, protocol_message = ?*, is_certified = ?* \
-where open_message_id = ?*";
+signed_entity_type_id = ?*, protocol_message = ?*, is_certified = ?*, \
+is_expired = ?*, expires_at = ?* where open_message_id = ?*";
         let beacon_str = open_message.signed_entity_type.get_json_beacon()?;
         let parameters = vec![
             Value::Integer(
@@ -281,6 +309,11 @@ where open_message_id = ?*";
             Value::Integer(open_message.signed_entity_type.index() as i64),
             Value::String(serde_json::to_string(&open_message.protocol_message)?),
             Value::Integer(open_message.is_certified as i64),
+            Value::Integer(open_message.is_expired as i64),
+            open_message
+                .expires_at
+                .map(|d| Value::String(d.to_rfc3339()))
+                .unwrap_or(Value::Null),
             Value::String(open_message.open_message_id.to_string()),
         ];
 
@@ -350,11 +383,17 @@ pub struct OpenMessageWithSingleSignaturesRecord {
     /// Has this message been converted into a Certificate?
     pub is_certified: bool,
 
+    /// Has this open message expired
+    pub is_expired: bool,
+
     /// associated single signatures
     pub single_signatures: Vec<SingleSignatures>,
 
     /// Message creation datetime, it is set by the database.
     pub created_at: DateTime<Utc>,
+
+    /// Message expiration datetime, if it exists.
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 impl SqLiteEntity for OpenMessageWithSingleSignaturesRecord {
@@ -362,7 +401,7 @@ impl SqLiteEntity for OpenMessageWithSingleSignaturesRecord {
     where
         Self: Sized,
     {
-        let single_signatures = &row.read::<&str, _>(7);
+        let single_signatures = &row.read::<&str, _>(9);
         let single_signatures: Vec<SingleSignatures> = serde_json::from_str(single_signatures)
             .map_err(|e| {
                 HydrationError::InvalidData(format!(
@@ -378,8 +417,10 @@ impl SqLiteEntity for OpenMessageWithSingleSignaturesRecord {
             signed_entity_type: open_message.signed_entity_type,
             protocol_message: open_message.protocol_message,
             is_certified: open_message.is_certified,
+            is_expired: open_message.is_expired,
             single_signatures,
             created_at: open_message.created_at,
+            expires_at: open_message.expires_at,
         };
 
         Ok(open_message)
@@ -409,7 +450,9 @@ impl SqLiteEntity for OpenMessageWithSingleSignaturesRecord {
                 "text",
             ),
             ("is_certified", "{:open_message:}.is_certified", "bool"),
+            ("is_expired", "{:open_message:}.is_expired", "bool"),
             ("created_at", "{:open_message:}.created_at", "text"),
+            ("expires_at", "{:open_message:}.expires_at", "text"),
             (
                 "single_signatures",
                 "case when {:single_signature:}.signer_id is null then json('[]') \
@@ -523,6 +566,21 @@ impl OpenMessageRepository {
         Ok(messages.next())
     }
 
+    /// Return the expired [OpenMessageRecord]s for the given Epoch and [SignedEntityType]
+    pub async fn get_expired_open_message(
+        &self,
+        signed_entity_type: &SignedEntityType,
+    ) -> StdResult<Option<OpenMessageRecord>> {
+        let provider = OpenMessageProvider::new(&self.connection);
+        let now = Utc::now().to_rfc3339();
+        let filters = provider
+            .get_expired_entity_type_condition(&now)
+            .and_where(provider.get_signed_entity_type_condition(signed_entity_type)?);
+        let mut messages = provider.find(filters)?;
+
+        Ok(messages.next())
+    }
+
     /// Create a new [OpenMessageRecord] in the database.
     pub async fn create_open_message(
         &self,
@@ -609,7 +667,9 @@ values (1, '{"k": 100, "m": 5, "phi": 0.65 }'), (2, '{"k": 100, "m": 5, "phi": 0
                     '{ "message_parts": {
                         "next_aggregate_verification_key":"7b226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b3131312c3230352c3133392c3131322c32382c392c3233382c3134382c3133342c302c3230372c3233302c3234312c3130352c3135372c3131302c3232362c3131342c32362c35332c3136362c3235342c3230382c3132372c3231362c3230362c3230302c34382c35352c32312c3231372c31335d2c226e725f6c6561766573223a332c22686173686572223a6e756c6c7d2c22746f74616c5f7374616b65223a32383439323639303636317d"
                     }}',
-                    1
+                    1,
+                    0,
+                    '2021-07-27T01:02:44.505640275+00:00'
                 );
 
                 insert into single_signature values(
@@ -638,7 +698,7 @@ values (1, '{"k": 100, "m": 5, "phi": 0.65 }'), (2, '{"k": 100, "m": 5, "phi": 0
             .get_open_message(&SignedEntityType::MithrilStakeDistribution(Epoch(275)))
             .await
             .expect("Getting Golden open message should not fail")
-            .expect("A open message should exist for this signed entity type");
+            .expect("An open message should exist for this signed entity type");
 
         repository
             .get_open_message_with_single_signatures(&SignedEntityType::MithrilStakeDistribution(
@@ -647,7 +707,7 @@ values (1, '{"k": 100, "m": 5, "phi": 0.65 }'), (2, '{"k": 100, "m": 5, "phi": 0
             .await
             .expect("Getting Golden open message should not fail")
             .expect(
-                "A open message with single signatures should exist for this signed entity type",
+                "An open message with single signatures should exist for this signed entity type",
             );
     }
 
@@ -663,8 +723,11 @@ values (1, '{"k": 100, "m": 5, "phi": 0.65 }'), (2, '{"k": 100, "m": 5, "phi": 0
             "open_message.open_message_id as open_message_id, \
 open_message.epoch_setting_id as epoch_setting_id, open_message.beacon as beacon, \
 open_message.signed_entity_type_id as signed_entity_type_id, \
-open_message.protocol_message as protocol_message, open_message.is_certified as is_certified, \
+open_message.protocol_message as protocol_message, \
+open_message.is_certified as is_certified, \
+open_message.is_expired as is_expired, \
 open_message.created_at as created_at, \
+open_message.expires_at as expires_at, \
 case when single_signature.signer_id is null then json('[]') \
 else json_group_array( \
     json_object( \
@@ -684,7 +747,7 @@ else json_group_array( \
         let aliases = SourceAlias::new(&[("{:open_message:}", "open_message")]);
 
         assert_eq!(
-            "open_message.open_message_id as open_message_id, open_message.epoch_setting_id as epoch_setting_id, open_message.beacon as beacon, open_message.signed_entity_type_id as signed_entity_type_id, open_message.protocol_message as protocol_message, open_message.is_certified as is_certified, open_message.created_at as created_at".to_string(),
+            "open_message.open_message_id as open_message_id, open_message.epoch_setting_id as epoch_setting_id, open_message.beacon as beacon, open_message.signed_entity_type_id as signed_entity_type_id, open_message.protocol_message as protocol_message, open_message.is_certified as is_certified, open_message.is_expired as is_expired, open_message.created_at as created_at, open_message.expires_at as expires_at".to_string(),
             projection.expand(aliases)
         )
     }
@@ -746,6 +809,17 @@ else json_group_array( \
     }
 
     #[test]
+    fn provider_expired_entity_type_condition() {
+        let connection = Connection::open_thread_safe(":memory:").unwrap();
+        let provider = OpenMessageProvider::new(&connection);
+        let now = Utc::now().to_rfc3339();
+        let (expr, params) = provider.get_expired_entity_type_condition(&now).expand();
+
+        assert_eq!("expires_at < ?1".to_string(), expr);
+        assert_eq!(vec![Value::String(now)], params);
+    }
+
+    #[test]
     fn insert_provider_condition() {
         let connection = Connection::open_thread_safe(":memory:").unwrap();
         let provider = InsertOpenMessageProvider::new(&connection);
@@ -763,7 +837,7 @@ else json_group_array( \
             .unwrap()
             .expand();
 
-        assert_eq!("(open_message_id, epoch_setting_id, beacon, signed_entity_type_id, protocol_message, created_at) values (?1, ?2, ?3, ?4, ?5, ?6)".to_string(), expr);
+        assert_eq!("(open_message_id, epoch_setting_id, beacon, signed_entity_type_id, protocol_message, expires_at, created_at) values (?1, ?2, ?3, ?4, ?5, ?6, ?7)".to_string(), expr);
         assert_eq!(Value::Integer(12), params[1]);
         assert_eq!(
             Value::String(
@@ -788,7 +862,9 @@ else json_group_array( \
             signed_entity_type: SignedEntityType::dummy(),
             protocol_message: ProtocolMessage::new(),
             is_certified: true,
+            is_expired: false,
             created_at: DateTime::<Utc>::default(),
+            expires_at: None,
         };
         let (expr, params) = provider
             .get_update_condition(&open_message)
@@ -796,7 +872,7 @@ else json_group_array( \
             .expand();
 
         assert_eq!(
-            "epoch_setting_id = ?1, beacon = ?2, signed_entity_type_id = ?3, protocol_message = ?4, is_certified = ?5 where open_message_id = ?6"
+            "epoch_setting_id = ?1, beacon = ?2, signed_entity_type_id = ?3, protocol_message = ?4, is_certified = ?5, is_expired = ?6, expires_at = ?7 where open_message_id = ?8"
                 .to_string(),
             expr
         );
@@ -807,6 +883,11 @@ else json_group_array( \
                 Value::Integer(open_message.signed_entity_type.index() as i64),
                 Value::String(serde_json::to_string(&open_message.protocol_message).unwrap()),
                 Value::Integer(open_message.is_certified as i64),
+                Value::Integer(open_message.is_expired as i64),
+                open_message
+                    .expires_at
+                    .map(|d| Value::String(d.to_rfc3339()))
+                    .unwrap_or(Value::Null),
                 Value::String(open_message.open_message_id.to_string()),
             ],
             params

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -16,7 +16,6 @@ use mithril_common::{
     BeaconProvider,
 };
 
-use crate::services::{EpochService, MessageService};
 use crate::{
     configuration::*,
     database::provider::{CertificateRepository, SignedEntityStorer, SignerGetter, StakePoolStore},
@@ -27,6 +26,10 @@ use crate::{
     snapshot_uploaders::SnapshotUploader,
     CertificatePendingStore, ProtocolParametersStorer, SignerRegisterer,
     SignerRegistrationRoundOpener, Snapshotter, VerificationKeyStorer,
+};
+use crate::{
+    database::provider::OpenMessageRepository,
+    services::{EpochService, MessageService},
 };
 
 /// MultiSignerWrapper wraps a [MultiSigner]
@@ -60,6 +63,9 @@ pub struct DependencyContainer {
 
     /// Certificate store.
     pub certificate_repository: Arc<CertificateRepository>,
+
+    /// Open message store.
+    pub open_message_repository: Arc<OpenMessageRepository>,
 
     /// Verification key store.
     pub verification_key_store: Arc<dyn VerificationKeyStorer>,

--- a/mithril-aggregator/src/entities/open_message.rs
+++ b/mithril-aggregator/src/entities/open_message.rs
@@ -24,11 +24,17 @@ pub struct OpenMessage {
     /// Has this message been converted into a Certificate?
     pub is_certified: bool,
 
+    /// Has this open message expired
+    pub is_expired: bool,
+
     /// associated single signatures
     pub single_signatures: Vec<SingleSignatures>,
 
     /// Message creation datetime
     pub created_at: DateTime<Utc>,
+
+    /// Message expiration datetime, if it exists.
+    pub expires_at: Option<DateTime<Utc>>,
 }
 
 impl OpenMessage {
@@ -54,11 +60,13 @@ impl OpenMessage {
             signed_entity_type,
             protocol_message: ProtocolMessage::new(),
             is_certified: false,
+            is_expired: false,
             single_signatures: vec![
                 fake_data::single_signatures(vec![1, 4, 5]),
                 fake_data::single_signatures(vec![2, 3, 8]),
             ],
             created_at: Utc::now(),
+            expires_at: None,
         }
     }
 }
@@ -70,8 +78,10 @@ impl From<OpenMessageRecord> for OpenMessage {
             signed_entity_type: record.signed_entity_type,
             protocol_message: record.protocol_message,
             is_certified: record.is_certified,
+            is_expired: record.is_expired,
             single_signatures: vec![],
             created_at: record.created_at,
+            expires_at: record.expires_at,
         }
     }
 }
@@ -83,8 +93,10 @@ impl From<OpenMessageWithSingleSignaturesRecord> for OpenMessage {
             signed_entity_type: record.signed_entity_type,
             protocol_message: record.protocol_message,
             is_certified: record.is_certified,
+            is_expired: record.is_expired,
             single_signatures: record.single_signatures,
             created_at: record.created_at,
+            expires_at: record.expires_at,
         }
     }
 }
@@ -111,15 +123,19 @@ mod test {
             signed_entity_type: SignedEntityType::dummy(),
             protocol_message: ProtocolMessage::default(),
             is_certified: false,
+            is_expired: false,
             created_at,
+            expires_at: None,
         };
         let expected = OpenMessage {
             epoch: Epoch(1),
             signed_entity_type: SignedEntityType::dummy(),
             protocol_message: ProtocolMessage::default(),
             is_certified: false,
+            is_expired: false,
             single_signatures: vec![],
             created_at,
+            expires_at: None,
         };
         let result: OpenMessage = record.into();
 
@@ -135,7 +151,9 @@ mod test {
             signed_entity_type: SignedEntityType::dummy(),
             protocol_message: ProtocolMessage::default(),
             is_certified: false,
+            is_expired: false,
             created_at,
+            expires_at: None,
             single_signatures: vec![fake_data::single_signatures(vec![1, 4, 5])],
         };
         let expected = OpenMessage {
@@ -143,8 +161,10 @@ mod test {
             signed_entity_type: SignedEntityType::dummy(),
             protocol_message: ProtocolMessage::default(),
             is_certified: false,
+            is_expired: false,
             single_signatures: vec![fake_data::single_signatures(vec![1, 4, 5])],
             created_at,
+            expires_at: None,
         };
         let result: OpenMessage = record.into();
 

--- a/mithril-aggregator/tests/open_message_expiration.rs
+++ b/mithril-aggregator/tests/open_message_expiration.rs
@@ -1,0 +1,156 @@
+mod test_extensions;
+
+use std::time::Duration;
+
+use mithril_aggregator::Configuration;
+use mithril_common::{
+    entities::{
+        Beacon, Epoch, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
+        StakeDistributionParty,
+    },
+    test_utils::MithrilFixtureBuilder,
+};
+use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
+
+#[tokio::test]
+async fn open_message_expiration() {
+    let protocol_parameters = ProtocolParameters {
+        k: 5,
+        m: 150,
+        phi_f: 0.95,
+    };
+    let configuration = Configuration {
+        protocol_parameters: protocol_parameters.clone(),
+        data_stores_directory: get_test_dir("create_certificate").join("aggregator.sqlite3"),
+        ..Configuration::new_sample()
+    };
+    let mut tester =
+        RuntimeTester::build(Beacon::new("devnet".to_string(), 1, 1), configuration).await;
+
+    comment!("create signers & declare stake distribution");
+    let fixture = MithrilFixtureBuilder::default()
+        .with_signers(10)
+        .with_protocol_parameters(protocol_parameters.clone())
+        .build();
+
+    tester.init_state_from_fixture(&fixture).await.unwrap();
+
+    comment!("Boostrap the genesis certificate");
+    tester.register_genesis_certificate(&fixture).await.unwrap();
+
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new_genesis(
+            Beacon::new("devnet".to_string(), 1, 1),
+            fixture.compute_and_encode_avk()
+        )
+    );
+
+    comment!("Increase immutable number");
+    tester.increase_immutable_number().await.unwrap();
+
+    comment!("start the runtime state machine");
+    cycle!(tester, "ready");
+    cycle!(tester, "signing");
+
+    comment!("register signers");
+    tester
+        .register_signers(&fixture.signers_fixture())
+        .await
+        .unwrap();
+    cycle_err!(tester, "signing");
+
+    comment!("signers send their single signature");
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            &fixture.signers_fixture(),
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the MithrilStakeDistribution");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            Beacon::new("devnet".to_string(), 1, 2),
+            StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::MithrilStakeDistribution(Epoch(1)),
+            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+        )
+    );
+
+    comment!("The state machine should get back to signing to sign CardanoImmutableFilesFull");
+    // todo!: remove this immutable increase:
+    // right now because we only have one state machine for all signed entity type we need it else
+    // the state machine will stay in the idle state since its beacon didn't change.
+    // With one state machine per signed entity type this problem will disappear.
+    tester.increase_immutable_number().await.unwrap();
+    cycle!(tester, "signing");
+
+    comment!(
+        "Schedule the open message for CardanoImmutableFilesFull to expire, and wait until it does"
+    );
+    let open_message_timeout = Duration::from_millis(100);
+    tester
+        .activate_open_message_expiration(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            open_message_timeout,
+        )
+        .await
+        .unwrap();
+    tokio::time::sleep(2 * open_message_timeout).await;
+    let signers_for_immutables = &fixture.signers_fixture()[0..=6];
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            signers_for_immutables,
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should not issue a certificate for the CardanoImmutableFilesFull");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            Beacon::new("devnet".to_string(), 1, 2),
+            StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::MithrilStakeDistribution(Epoch(1)),
+            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+        )
+    );
+
+    comment!("Increase the immutable file number");
+    tester.increase_immutable_number().await.unwrap();
+    cycle!(tester, "signing");
+
+    comment!("The state machine should get back to signing to sign CardanoImmutableFilesFull");
+    let signers_for_immutables = &fixture.signers_fixture()[0..=6];
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            signers_for_immutables,
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the CardanoImmutableFilesFull");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            Beacon::new("devnet".to_string(), 1, 4),
+            &signers_for_immutables
+                .iter()
+                .map(|s| s.signer_with_stake.clone().into())
+                .collect::<Vec<_>>(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 1, 4)),
+            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+        )
+    );
+}

--- a/mithril-aggregator/tests/open_message_newer_exists.rs
+++ b/mithril-aggregator/tests/open_message_newer_exists.rs
@@ -1,0 +1,124 @@
+mod test_extensions;
+
+use mithril_aggregator::Configuration;
+use mithril_common::{
+    entities::{
+        Beacon, Epoch, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
+        StakeDistributionParty,
+    },
+    test_utils::MithrilFixtureBuilder,
+};
+use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
+
+#[tokio::test]
+async fn open_message_newer_exists() {
+    let protocol_parameters = ProtocolParameters {
+        k: 5,
+        m: 150,
+        phi_f: 0.95,
+    };
+    let configuration = Configuration {
+        protocol_parameters: protocol_parameters.clone(),
+        data_stores_directory: get_test_dir("create_certificate").join("aggregator.sqlite3"),
+        ..Configuration::new_sample()
+    };
+    let mut tester =
+        RuntimeTester::build(Beacon::new("devnet".to_string(), 1, 1), configuration).await;
+
+    comment!("create signers & declare stake distribution");
+    let fixture = MithrilFixtureBuilder::default()
+        .with_signers(10)
+        .with_protocol_parameters(protocol_parameters.clone())
+        .build();
+
+    tester.init_state_from_fixture(&fixture).await.unwrap();
+
+    comment!("Boostrap the genesis certificate");
+    tester.register_genesis_certificate(&fixture).await.unwrap();
+
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new_genesis(
+            Beacon::new("devnet".to_string(), 1, 1),
+            fixture.compute_and_encode_avk()
+        )
+    );
+
+    comment!("Increase immutable number");
+    tester.increase_immutable_number().await.unwrap();
+
+    comment!("start the runtime state machine");
+    cycle!(tester, "ready");
+    cycle!(tester, "signing");
+
+    comment!("register signers");
+    tester
+        .register_signers(&fixture.signers_fixture())
+        .await
+        .unwrap();
+    cycle_err!(tester, "signing");
+
+    comment!("signers send their single signature");
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            &fixture.signers_fixture(),
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the MithrilStakeDistribution");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            Beacon::new("devnet".to_string(), 1, 2),
+            StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::MithrilStakeDistribution(Epoch(1)),
+            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+        )
+    );
+
+    comment!("The state machine should get back to signing to sign CardanoImmutableFilesFull");
+    // todo!: remove this immutable increase:
+    // right now because we only have one state machine for all signed entity type we need it else
+    // the state machine will stay in the idle state since its beacon didn't change.
+    // With one state machine per signed entity type this problem will disappear.
+    tester.increase_immutable_number().await.unwrap();
+    cycle!(tester, "signing");
+
+    comment!("The state machine should stay there as it is not able to create a certificate for the CardanoImmutableFilesFull");
+    cycle_err!(tester, "signing");
+
+    comment!("Increase the immutable file number");
+    tester.increase_immutable_number().await.unwrap();
+    cycle!(tester, "ready");
+
+    comment!("The state machine should get back to signing to sign CardanoImmutableFilesFull");
+    cycle!(tester, "signing");
+    let signers_for_immutables = &fixture.signers_fixture()[0..=6];
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            signers_for_immutables,
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the CardanoImmutableFilesFull");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            Beacon::new("devnet".to_string(), 1, 4),
+            &signers_for_immutables
+                .iter()
+                .map(|s| s.signer_with_stake.clone().into())
+                .collect::<Vec<_>>(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 1, 4)),
+            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+        )
+    );
+}

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context};
-use mithril_aggregator::database::provider::SignedEntityRecord;
+use chrono::Utc;
+use mithril_aggregator::database::provider::{OpenMessageRepository, SignedEntityRecord};
 use mithril_aggregator::{
     dependency_injection::DependenciesBuilder, event_store::EventMessage, AggregatorRuntime,
     Configuration, DependencyContainer, DumbSnapshotUploader, DumbSnapshotter,
@@ -22,6 +23,7 @@ use mithril_common::{
 use slog::Drain;
 use slog_scope::debug;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use crate::test_extensions::{AggregatorObserver, ExpectedCertificate};
@@ -65,6 +67,7 @@ pub struct RuntimeTester {
     pub receiver: UnboundedReceiver<EventMessage>,
     pub era_reader_adapter: Arc<EraReaderDummyAdapter>,
     pub observer: Arc<AggregatorObserver>,
+    pub open_message_repository: Arc<OpenMessageRepository>,
     _logs_guard: slog_scope::GlobalLoggerGuard,
 }
 
@@ -104,6 +107,7 @@ impl RuntimeTester {
         let runtime = deps_builder.create_aggregator_runner().await.unwrap();
         let receiver = deps_builder.get_event_transmitter_receiver().await.unwrap();
         let observer = Arc::new(AggregatorObserver::new(&mut deps_builder).await);
+        let open_message_repository = deps_builder.get_open_message_repository().await.unwrap();
 
         Self {
             snapshot_uploader,
@@ -117,6 +121,7 @@ impl RuntimeTester {
             receiver,
             era_reader_adapter,
             observer,
+            open_message_repository,
             _logs_guard: logger,
         }
     }
@@ -358,6 +363,31 @@ impl RuntimeTester {
                 beacon.network, beacon.epoch, beacon.immutable_file_number
             ))
             .await;
+    }
+
+    /// Activate open message expiration
+    pub async fn activate_open_message_expiration(
+        &self,
+        discriminant: SignedEntityTypeDiscriminants,
+        timeout: Duration,
+    ) -> StdResult<()> {
+        let signed_entity_type = self
+            .observer
+            .get_current_signed_entity_type(discriminant)
+            .await?;
+        let mut open_message = self
+            .open_message_repository
+            .get_open_message(&signed_entity_type)
+            .await
+            .with_context(|| "Querying open message should not fail")?
+            .ok_or(anyhow!("An open message should exist"))?;
+        open_message.expires_at = Some(Utc::now() + timeout);
+        self.open_message_repository
+            .update_open_message(&open_message)
+            .await
+            .with_context(|| "Saving open message should not fail")?;
+
+        Ok(())
     }
 
     /// Update the Era markers

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -269,7 +269,7 @@ impl RuntimeTester {
             .get_open_message(&signed_entity_type)
             .await
             .with_context(|| {
-                format!("A open message should exist for signed_entity_type: {signed_entity_type}")
+                format!("An open message should exist for signed_entity_type: {signed_entity_type}")
             })?
             .ok_or(anyhow!("There should be a message to be signed."))?
             .protocol_message;

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.146"
+version = "0.2.147"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -1,5 +1,6 @@
 use crate::StdResult;
 use serde::{Deserialize, Serialize};
+use std::time::Duration;
 use strum::{Display, EnumDiscriminants};
 
 cfg_database! {
@@ -104,6 +105,14 @@ impl SignedEntityType {
         };
 
         Ok(value)
+    }
+
+    /// Return the associated open message timeout
+    pub fn get_open_message_timeout(&self) -> Option<Duration> {
+        match self {
+            Self::MithrilStakeDistribution(_) | Self::CardanoImmutableFilesFull(_) => None,
+            Self::CardanoStakeDistribution(_) => Some(Duration::from_secs(600)),
+        }
     }
 }
 

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -114,6 +114,21 @@ impl SignedEntityType {
             Self::CardanoStakeDistribution(_) => Some(Duration::from_secs(600)),
         }
     }
+
+    /// Create a SignedEntityType from beacon and SignedEntityTypeDiscriminants
+    pub fn from_beacon(discriminant: &SignedEntityTypeDiscriminants, beacon: &Beacon) -> Self {
+        match discriminant {
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution => {
+                Self::MithrilStakeDistribution(beacon.epoch)
+            }
+            SignedEntityTypeDiscriminants::CardanoStakeDistribution => {
+                Self::CardanoStakeDistribution(beacon.epoch)
+            }
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull => {
+                Self::CardanoImmutableFilesFull(beacon.to_owned())
+            }
+        }
+    }
 }
 
 impl SignedEntityTypeDiscriminants {


### PR DESCRIPTION
## Content
This PR includes a mechanism that associates a timeout (or not) to any signed entity type. When an open message is opened for longer than its timeout (if exists), the open message is discarded and thus allows for handling the next open message.

Open message timeouts:
| Signed Entity Type | Timeout |
| --- |:---:|
| `MithrilStakeDistribution` | - |
| `CardanoStakeDistribution` | 600s |
| `CardanoImmutableFilesFull` | - |

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1387
