### PR TITLE
Add toggle for network deployment in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -538,8 +538,7 @@ jobs:
           body_path: ./release-notes-addon.txt
 
   deploy-testing:
-    # Don't run on pull request from forks since they don't have access to all the needed secrets
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !github.event.pull_request.head.repo.fork)
+    if: vars.DEPLOY_NETWORKS_IN_CI == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Content
This PR includes an optimization of the CI pipeline:
- External contribution from forks are now tested for network deployment when a PR is cretaed on the main repository.
- Forks will not have the toggle activated by default, thus will not run the testing for network deployment (in particular when the fork is synchronized).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

