### PR TITLE
Add toggle for unstable release publication in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -468,7 +468,7 @@ jobs:
           api_token: ${{ secrets[matrix.api_token_secret_name] }}
 
   unstable-release:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.ref))
+    if: vars.PUBLISH_UNSTABLE_RELEASE_IN_CI == true && github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith('refs/heads/hotfix', github.ref))
     runs-on: ubuntu-22.04
     needs:
       - build


### PR DESCRIPTION
## Content
This PR includes an optimization of the CI pipeline:
- Forks will not have the toggle activated by default and will not attempt to create an unstable release when fork is synchronized.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

