### PR TITLE
Update `ci.yml` after the deletion of `doc.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,6 @@ on:
       - 'hotfix**'
   pull_request:
     types: [opened, reopened, synchronize]
-    paths-ignore: # ignore docs only changes since they use a dedicated workflows: docs.yml
-      - 'docs/**'
-      - 'mithril-explorer/**'
-      - '.github/workflows/docs.yml'
     branches-ignore:
       - 'hotfix**' # hotfix are handled by the push trigger
 


### PR DESCRIPTION
## Content
This PR includes an update of `ci.yml`. 
As the contents of `docs.yml` have been moved to `ci.yml` with the merge of the PR #1426, the paths-ignore filter must be removed.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1409 
