### PR TITLE
Fix `npm` authentication to registry in CI

### DIFF
--- a/.github/workflows/actions/publish-npm-package/action.yml
+++ b/.github/workflows/actions/publish-npm-package/action.yml
@@ -65,6 +65,8 @@ runs:
       NPM_TOKEN: ${{ inputs.api_token }}
     run: |
       echo "test publish '@${{ inputs.scope }}/${{ inputs.package }}' package"
+      npm set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+      npm whoami
       cd ${{ inputs.package }}/pkg
       npm publish --tag ${{ inputs.tag }} --access ${{ inputs.access }} --dry-run
 
@@ -75,5 +77,7 @@ runs:
       NPM_TOKEN: ${{ inputs.api_token }}
     run: |
       echo "Publish '@${{ inputs.scope }}/${{ inputs.package }}' package"
+      npm set "//registry.npmjs.org/:_authToken=${NPM_TOKEN}"
+      npm whoami
       cd ${{ inputs.package }}/pkg
       npm publish --tag ${{ inputs.tag }} --access ${{ inputs.access }}


### PR DESCRIPTION
## Content
This PR includes a fix for authenticating to the `npm` registry in the CI/CD.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
