### PR TITLE
Specify explicitly permissions for prerelease creation

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   create-pre-release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3


### PR DESCRIPTION
## Content

This is a tentative fix to avoid 403 errors when the tag is not the head of any branchs.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

