### PR TITLE
Compute message to sign for Cardano transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-merkle-mountain-range"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d15193decfa1e0b151ce19e42d118db048459a27720fb3de7d3103c30adccb12"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3424,6 +3433,7 @@ dependencies = [
  "bech32",
  "blake2 0.10.6",
  "chrono",
+ "ckb-merkle-mountain-range",
  "criterion",
  "digest 0.10.7",
  "ed25519-dalek",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.28"
+version = "0.4.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.153"
+version = "0.2.154"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.28"
+version = "0.4.29"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_transactions.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_transactions.rs
@@ -36,17 +36,23 @@ impl ArtifactBuilder<Beacon, CardanoTransactionsCommitment> for CardanoTransacti
             .with_context(|| {
                 format!(
                     "Can not compute CardanoTransactionsCommitment artifact for signed_entity: {:?}",
-                    SignedEntityType::CardanoTransactions(beacon)
+                    SignedEntityType::CardanoTransactions(beacon.clone())
                 )
             })?;
 
-        Ok(CardanoTransactionsCommitment::new(merkle_root.to_string()))
+        Ok(CardanoTransactionsCommitment::new(
+            merkle_root.to_string(),
+            beacon,
+        ))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::{entities::ProtocolMessage, test_utils::fake_data};
+    use mithril_common::{
+        entities::ProtocolMessage,
+        test_utils::fake_data::{self},
+    };
 
     use super::*;
 
@@ -65,10 +71,11 @@ mod tests {
 
         let cardano_transaction_artifact_builder = CardanoTransactionsArtifactBuilder::new();
         let artifact = cardano_transaction_artifact_builder
-            .compute_artifact(Beacon::default(), &certificate)
+            .compute_artifact(certificate.beacon.clone(), &certificate)
             .await
             .unwrap();
-        let artifact_expected = CardanoTransactionsCommitment::new("merkleroot".to_string());
+        let artifact_expected =
+            CardanoTransactionsCommitment::new("merkleroot".to_string(), certificate.beacon);
         assert_eq!(artifact_expected, artifact);
     }
 

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -405,7 +405,8 @@ mod tests {
 
     #[tokio::test]
     async fn build_artifact_for_cardano_transactions_store_nothing_in_db() {
-        let expected = CardanoTransactionsCommitment::new("merkle_root".to_string());
+        let expected =
+            CardanoTransactionsCommitment::new("merkle_root".to_string(), Beacon::default());
         let mut mock_signed_entity_storer = MockSignedEntityStorer::new();
         mock_signed_entity_storer
             .expect_store_signed_entity()

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -22,6 +22,7 @@ async-trait = "0.1.73"
 bech32 = "0.9.1"
 blake2 = "0.10.6"
 chrono = { version = "0.4.31", features = ["serde"] }
+ckb-merkle-mountain-range = "0.6.0"
 digest = "0.10.7"
 ed25519-dalek = { version = "2.0.0", features = ["rand_core", "serde"] }
 fixed = "1.24.0"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.153"
+version = "0.2.154"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/merkle_tree.rs
+++ b/mithril-common/src/crypto_helper/merkle_tree.rs
@@ -1,0 +1,185 @@
+use anyhow::anyhow;
+use blake2::{Blake2s256, Digest};
+use ckb_merkle_mountain_range::{util::MemStore, Merge, MerkleProof, Result as MMRResult, MMR};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, ops::Deref};
+
+use crate::{StdError, StdResult};
+
+/// Alias for a byte
+type Bytes = Vec<u8>;
+
+/// Alias for a Merkle tree leaf position
+type MKTreeLeafPosition = u64;
+
+/// A node of a Merkle tree
+#[derive(Debug, PartialEq, Eq, Clone, Hash, Serialize, Deserialize)]
+pub struct MKTreeNode {
+    hash: Bytes,
+}
+
+impl MKTreeNode {
+    /// MKTreeNode factory
+    pub fn new(hash: Bytes) -> Self {
+        Self { hash }
+    }
+}
+
+impl Deref for MKTreeNode {
+    type Target = Bytes;
+
+    fn deref(&self) -> &Self::Target {
+        &self.hash
+    }
+}
+
+impl From<String> for MKTreeNode {
+    fn from(other: String) -> Self {
+        Self {
+            hash: other.as_bytes().to_vec(),
+        }
+    }
+}
+
+impl TryFrom<MKTree<'_>> for MKTreeNode {
+    type Error = StdError;
+    fn try_from(other: MKTree) -> Result<Self, Self::Error> {
+        other.compute_root()
+    }
+}
+
+struct MergeMKTreeNode {}
+
+impl Merge for MergeMKTreeNode {
+    type Item = MKTreeNode;
+
+    fn merge(lhs: &Self::Item, rhs: &Self::Item) -> MMRResult<Self::Item> {
+        let mut hasher = Blake2s256::new();
+        hasher.update(lhs.deref());
+        hasher.update(rhs.deref());
+        let hash_merge = hasher.finalize();
+
+        Ok(Self::Item::new(hash_merge.to_vec()))
+    }
+}
+
+/// A Merkle proof
+#[derive(Serialize, Deserialize)]
+pub struct MKProof {
+    inner_root: MKTreeNode,
+    inner_leaves: Vec<(MKTreeLeafPosition, MKTreeNode)>,
+    inner_proof_size: u64,
+    inner_proof_items: Vec<MKTreeNode>,
+}
+
+impl MKProof {
+    /// Verification of a Merkle proof
+    pub fn verify(&self) -> StdResult<()> {
+        MerkleProof::<MKTreeNode, MergeMKTreeNode>::new(
+            self.inner_proof_size,
+            self.inner_proof_items.clone(),
+        )
+        .verify(self.inner_root.to_owned(), self.inner_leaves.to_owned())?
+        .then_some(())
+        .ok_or(anyhow!("Invalid MKProof"))
+    }
+}
+
+/// A Merkle tree
+pub struct MKTree<'a> {
+    inner_leaves: HashMap<&'a MKTreeNode, MKTreeLeafPosition>,
+    inner_tree: MMR<MKTreeNode, MergeMKTreeNode, &'a MemStore<MKTreeNode>>,
+}
+
+impl<'a> MKTree<'a> {
+    /// MKTree factory
+    pub fn new(leaves: &'a [MKTreeNode], store: &'a MemStore<MKTreeNode>) -> StdResult<Self> {
+        let mut inner_tree =
+            MMR::<MKTreeNode, MergeMKTreeNode, &MemStore<MKTreeNode>>::new(0, store);
+        let mut inner_leaves = HashMap::new();
+        for leaf in leaves {
+            let inner_tree_position = inner_tree.push(leaf.to_owned())?;
+            inner_leaves.insert(leaf, inner_tree_position);
+        }
+        inner_tree.commit()?;
+
+        Ok(Self {
+            inner_leaves,
+            inner_tree,
+        })
+    }
+
+    /// Number of leaves in the Merkle tree
+    pub fn total_leaves(&self) -> usize {
+        self.inner_leaves.len()
+    }
+
+    /// Generate root of the Merkle tree
+    pub fn compute_root(&self) -> StdResult<MKTreeNode> {
+        Ok(self.inner_tree.get_root()?)
+    }
+
+    /// Generate Merkle proof of memberships in the tree
+    pub fn compute_proof(&self, leaves: &[MKTreeNode]) -> StdResult<MKProof> {
+        let inner_leaves = leaves
+            .iter()
+            .map(|leaf| {
+                if let Some(leaf_position) = self.inner_leaves.get(leaf) {
+                    Ok((*leaf_position, leaf.to_owned()))
+                } else {
+                    Err(anyhow!("Leaf not found in the Merkle tree"))
+                }
+            })
+            .collect::<StdResult<Vec<_>>>()?;
+        let proof = self.inner_tree.gen_proof(
+            inner_leaves
+                .iter()
+                .map(|(leaf_position, _leaf)| *leaf_position)
+                .collect(),
+        )?;
+        return Ok(MKProof {
+            inner_root: self.compute_root()?,
+            inner_leaves,
+            inner_proof_size: proof.mmr_size(),
+            inner_proof_items: proof.proof_items().to_vec(),
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ckb_merkle_mountain_range::util::MemStore;
+
+    use super::MKTree;
+
+    #[test]
+    fn test_should_accept_valid_proof_generated_by_merkle_tree() {
+        let total_leaves = 100000;
+        let leaves = (0..total_leaves)
+            .map(|i| format!("test-{i}").into())
+            .collect::<Vec<_>>();
+        let store = MemStore::default();
+        let mktree = MKTree::new(&leaves, &store).expect("MKTree creation should not fail");
+        let leaves_to_verify = &[leaves[0].to_owned(), leaves[3].to_owned()];
+        let proof = mktree
+            .compute_proof(leaves_to_verify)
+            .expect("MKProof generation should not fail");
+        proof.verify().expect("The MKProof should be valid");
+    }
+
+    #[test]
+    fn test_should_reject_invalid_proof_generated_by_merkle_tree() {
+        let total_leaves = 100000;
+        let leaves = (0..total_leaves)
+            .map(|i| format!("test-{i}").into())
+            .collect::<Vec<_>>();
+        let store = MemStore::default();
+        let mktree = MKTree::new(&leaves, &store).expect("MKTree creation should not fail");
+        let leaves_to_verify = &[leaves[0].to_owned(), leaves[3].to_owned()];
+        let mut proof = mktree
+            .compute_proof(leaves_to_verify)
+            .expect("MKProof generation should not fail");
+        proof.inner_root = leaves[10].to_owned();
+        proof.verify().expect_err("The MKProof should be invalid");
+    }
+}

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -23,6 +23,7 @@ pub use era::{
     EraMarkersVerifierSignature, EraMarkersVerifierVerificationKey,
 };
 pub use genesis::{ProtocolGenesisError, ProtocolGenesisSigner, ProtocolGenesisVerifier};
+pub use merkle_tree::{MKProof, MKTree, MKTreeNode, MKTreeStore};
 pub use types::*;
 
 /// The current protocol version

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -5,6 +5,7 @@ mod codec;
 mod conversions;
 mod era;
 mod genesis;
+mod merkle_tree;
 #[cfg(feature = "test_tools")]
 pub mod tests_setup;
 mod types;

--- a/mithril-common/src/entities/cardano_transaction.rs
+++ b/mithril-common/src/entities/cardano_transaction.rs
@@ -1,3 +1,5 @@
+use crate::crypto_helper::MKTreeNode;
+
 use super::ImmutableFileNumber;
 
 /// TransactionHash is the unique identifier of a cardano transaction.
@@ -17,4 +19,51 @@ pub struct CardanoTransaction {
 
     /// Immutable file number of the transaction
     pub immutable_file_number: ImmutableFileNumber,
+}
+
+impl CardanoTransaction {
+    /// CardanoTransaction factory
+    pub fn new(
+        hash: &str,
+        block_number: BlockNumber,
+        immutable_file_number: ImmutableFileNumber,
+    ) -> Self {
+        Self {
+            transaction_hash: hash.to_owned(),
+            block_number,
+            immutable_file_number,
+        }
+    }
+}
+
+impl From<CardanoTransaction> for MKTreeNode {
+    fn from(other: CardanoTransaction) -> Self {
+        (&other).into()
+    }
+}
+
+impl From<&CardanoTransaction> for MKTreeNode {
+    fn from(other: &CardanoTransaction) -> Self {
+        MKTreeNode::new(other.transaction_hash.as_bytes().to_vec())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_convert_cardano_transaction_to_merkle_tree_node() {
+        let transaction = CardanoTransaction {
+            transaction_hash: "tx-hash-123".to_string(),
+            block_number: 1,
+            immutable_file_number: 1,
+        };
+        let computed_mktree_node: MKTreeNode = transaction.into();
+        let expected_mk_tree_node = MKTreeNode::new("tx-hash-123".as_bytes().to_vec());
+        let non_expected_mk_tree_node = MKTreeNode::new("tx-hash-456".as_bytes().to_vec());
+
+        assert_eq!(expected_mk_tree_node, computed_mktree_node);
+        assert_ne!(non_expected_mk_tree_node, computed_mktree_node);
+    }
 }

--- a/mithril-common/src/entities/cardano_transactions_commitment.rs
+++ b/mithril-common/src/entities/cardano_transactions_commitment.rs
@@ -1,23 +1,32 @@
-use serde::{Deserialize, Serialize};
-
 use crate::signable_builder::Artifact;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use super::Beacon;
 
 /// Commitment of a set of Cardano transactions
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct CardanoTransactionsCommitment {
     merkle_root: String,
+    beacon: Beacon,
 }
 
 impl CardanoTransactionsCommitment {
     /// Creates a new [CardanoTransactionsCommitment]
-    pub fn new(merkle_root: String) -> Self {
-        Self { merkle_root }
+    pub fn new(merkle_root: String, beacon: Beacon) -> Self {
+        Self {
+            merkle_root,
+            beacon,
+        }
     }
 }
 
 #[typetag::serde]
 impl Artifact for CardanoTransactionsCommitment {
     fn get_id(&self) -> String {
-        self.merkle_root.clone()
+        let mut hasher = Sha256::new();
+        hasher.update(self.merkle_root.clone().as_bytes());
+        hasher.update(self.beacon.compute_hash().as_bytes());
+        hex::encode(hasher.finalize())
     }
 }

--- a/mithril-common/src/entities/signed_entity.rs
+++ b/mithril-common/src/entities/signed_entity.rs
@@ -70,7 +70,7 @@ impl SignedEntity<CardanoTransactionsCommitment> {
                 signed_entity_id: "snapshot-id-123".to_string(),
                 signed_entity_type: SignedEntityType::CardanoTransactions(Beacon::default()),
                 certificate_id: "certificate-hash-123".to_string(),
-                artifact: CardanoTransactionsCommitment::new("mkroot123".to_string()),
+                artifact: CardanoTransactionsCommitment::new("mkroot123".to_string(), Beacon::default()),
                 created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
                     .unwrap()
                     .with_timezone(&Utc),


### PR DESCRIPTION
## Content
This PR includes:
- Computation of the Merkle tree of the Cardano transactions set and the associated Merkle root 
- Use the Merkle root as a protocol message part to be signed in the signer and aggregator

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1436 
