### PR TITLE
Fix missing test data in nix flake build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,8 +37,9 @@
               isCargoFile = base == "Cargo.lock";
               isCargoConfig = parentDir == ".cargo" && base == "config";
               isOpenApiYaml = base == "openapi.yaml";
+              isTestDataAsset = lib.hasInfix "/test_data/" path;
             in
-              type == "directory" || matchesSuffix || isCargoFile || isCargoConfig || isOpenApiYaml;
+              type == "directory" || matchesSuffix || isCargoFile || isCargoConfig || isOpenApiYaml || isTestDataAsset;
           };
 
         buildInputs =


### PR DESCRIPTION
## Content
This PR includes a fix in the `nix flake` CI builds to make test data available.

The missing test data created these errors (as in this [job](https://ci.iog.io/build/2574301/nixlog/6)):
```
failures:

---- cardano_transaction_parser::tests::test_parse_up_to_given_beacon stdout ----
thread 'cardano_transaction_parser::tests::test_parse_up_to_given_beacon' panicked at mithril-common/src/cardano_transaction_parser.rs:249:9:
assertion failed: get_number_of_immutable_chunk_in_dir(db_path) >= 2

---- cardano_transaction_parser::tests::test_parse_expected_number_of_transactions stdout ----
thread 'cardano_transaction_parser::tests::test_parse_expected_number_of_transactions' panicked at mithril-common/src/cardano_transaction_parser.rs:227:9:
assertion failed: get_number_of_immutable_chunk_in_dir(db_path) >= 3
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
