### PR TITLE
Add `mithril-client-wasm` tests in multi platform test

### DIFF
--- a/.github/workflows/scripts/parse-wasm-headless-tests-results.sh
+++ b/.github/workflows/scripts/parse-wasm-headless-tests-results.sh
@@ -1,0 +1,20 @@
+FILENAME=$1
+
+if [ ! -e "$FILENAME" ]; then
+    echo "Error: File '$FILENAME' not found."
+    exit 1
+fi
+
+echo "Parse headless test results from file: '$FILENAME'"
+if grep -q 'title="FAILED"' "$FILENAME"; then
+    FAILED_INFO=$(grep -oE '<div id="[^"]+" title="FAILED">([^<]+)' "$FILENAME" | awk 'NR==1 {print substr($0, index($0,$4))}')
+    echo "$FAILED_INFO"
+    exit 1
+elif grep -q 'title="OK"' "$FILENAME"; then
+    grep -oE '<div id="[^"]+" title="OK">([^<]+)' "$FILENAME" | awk '{print substr($0, index($0,$4))}'
+    echo "Success: all tests passed."
+else
+    cat "$FILENAME"
+    echo "No test results found. Check '$FILENAME' output."
+    exit 1
+fi

--- a/.github/workflows/scripts/run-wasm-tests-browser-headless.py
+++ b/.github/workflows/scripts/run-wasm-tests-browser-headless.py
@@ -1,0 +1,44 @@
+import logging
+import argparse
+import sys
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+
+def run_headless_test():
+    parser = argparse.ArgumentParser(description='Run headless browser test.')
+    parser.add_argument('browser_type', choices=['chrome', 'firefox'], help='Browser type (chrome or firefox)')
+    args = parser.parse_args()
+
+    if args.browser_type.lower() == 'chrome':
+        options = webdriver.ChromeOptions()
+        options.add_argument("--headless=new")
+        driver = webdriver.Chrome(options=options)
+    elif args.browser_type.lower() == 'firefox':
+        options = webdriver.FirefoxOptions()
+        options.add_argument("--headless")
+        driver = webdriver.Firefox(options=options)
+    else:
+        logging.error("Invalid browser type. Supported types are 'chrome' and 'firefox'.")
+        return
+
+    try:
+        driver.get('http://localhost:8080/')
+
+        # Adjust the timeout to 3 minutes
+        wait = WebDriverWait(driver, 180)
+
+        # Wait until the div with id "tests_finished" is displayed
+        tests_finished_element = wait.until(EC.presence_of_element_located((By.ID, "tests_finished")))
+
+        html = driver.page_source
+        result_file = f"{args.browser_type.lower()}-results.html"
+        with open(result_file, "w", encoding="utf-8") as file:
+            file.write(html)
+
+    finally:
+        driver.quit()
+
+if __name__ == "__main__":
+    run_headless_test()

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -159,3 +159,77 @@ jobs:
       - name: Mithril Stake Distribution / download & restore latest
         shell: bash
         run:  ${{ steps.command.outputs.mithril_client }}  ${{ steps.prepare.outputs.debug_level }} mithril-stake-distribution download $MITHRIL_STAKE_DISTRIBUTION_HASH --download-dir /app
+
+  test-mithril-client-wasm:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-22.04 ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Download built artifacts
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          name: mithril-distribution-wasm
+          path: ./mithril-client-wasm
+          commit: ${{ steps.prepare.outputs.sha }} 
+          branch: ${{ steps.prepare.outputs.branch }}
+          workflow: ci.yml
+          workflow_conclusion: success
+
+      - name: Unpack 'mithril-client-wasm' package
+        working-directory: mithril-client-wasm
+        run: tar -xvzf pkg/*.tgz -C pkg/ && mv pkg/package/* pkg/
+
+      - name: Install dependencies
+        working-directory: mithril-client-wasm
+        run: make www-test-install
+
+      - name: Create .env file
+        working-directory: mithril-client-wasm
+        run: |
+          echo "AGGREGATOR_ENDPOINT=${{ inputs.aggregator_endpoint }}" > ./www-test/.env
+          echo "GENESIS_VERIFICATION_KEY=$(curl -s ${{ inputs.genesis_verification_key }})" >> ./www-test/.env
+
+      - name: Start the server
+        working-directory: mithril-client-wasm
+        shell: bash
+        run: make www-test-serve &
+
+      - name: Wait for the server to be ready
+        shell: bash
+        run: |
+          MAX_ATTEMPTS=30
+          CURRENT_ATTEMPT=0
+          while true
+          do
+            sleep 1
+            CURRENT_ATTEMPT=$(( ${CURRENT_ATTEMPT} + 1 ))
+            if nc -z localhost 8080; then
+              echo "Server is ready."
+              break
+            fi
+            if [ "$CURRENT_ATTEMPT" -ge "$MAX_ATTEMPTS" ]; then
+              echo "Error: Server not ready after $MAX_ATTEMPTS attempts."
+              exit 1
+            fi
+          done
+
+      - name: Install selenium
+        shell: bash
+        run: pip install selenium
+
+      - name: Run Chrome headless
+        shell: bash
+        run: |
+          python3 ./.github/workflows/scripts/run-wasm-tests-browser-headless.py chrome
+          ./.github/workflows/scripts/parse-wasm-headless-tests-results.sh chrome-results.html
+
+      - name: Run Firefox headless
+        shell: bash
+        run: |
+          python3 ./.github/workflows/scripts/run-wasm-tests-browser-headless.py firefox
+          ./.github/workflows/scripts/parse-wasm-headless-tests-results.sh firefox-results.html

--- a/mithril-client-wasm/Makefile
+++ b/mithril-client-wasm/Makefile
@@ -38,3 +38,9 @@ www-install:
 
 www-serve:
 	npm --prefix www run start
+
+www-test-install:
+	npm --prefix www-test install
+
+www-test-serve:
+	npm --prefix www-test run start

--- a/mithril-client-wasm/www-test/.gitignore
+++ b/mithril-client-wasm/www-test/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.env

--- a/mithril-client-wasm/www-test/README.md
+++ b/mithril-client-wasm/www-test/README.md
@@ -1,0 +1,29 @@
+# Mithril client wasm: www-test
+
+* A set of tests for the Mithril client WASM library, which is a client for interacting with a Mithril network. The tests cover functionalities provided by the MithrilClient class.
+
+## Download source code
+
+```bash
+# Download sources from github
+git clone https://github.com/input-output-hk/mithril
+
+# Go to sources directory
+cd mithril-client-wasm/
+```
+
+* Before running the tests, make sure to install the required dependencies. Use the following command:
+
+```bash
+make www-test-install
+```
+
+## Running the tests in the browser
+
+```bash
+make www-test-serve
+```
+
+## Test Results Display
+
+The results of each test are displayed in the DOM dynamically. Open [http://localhost:8080](http://localhost:8080) with your browser. (port 8080 is the default port)

--- a/mithril-client-wasm/www-test/bootstrap.js
+++ b/mithril-client-wasm/www-test/bootstrap.js
@@ -1,0 +1,5 @@
+// A dependency graph that contains any wasm must all be imported
+// asynchronously. This `bootstrap.js` file does the single async import, so
+// that no one else needs to worry about it again.
+import("./index.js")
+  .catch(e => console.error("Error importing `index.js`:", e));

--- a/mithril-client-wasm/www-test/index.html
+++ b/mithril-client-wasm/www-test/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Hello wasm-pack!</title>
+  </head>
+  <body>
+    <script src="./bootstrap.js"></script>
+  </body>
+</html>

--- a/mithril-client-wasm/www-test/index.js
+++ b/mithril-client-wasm/www-test/index.js
@@ -1,159 +1,127 @@
 import initMithrilClient, {
   MithrilClient,
-} from "@mithril-dev/mithril-client-wasm"
+} from "@mithril-dev/mithril-client-wasm";
 
-function display_test_result_in_dom(step_number, step_name, result, error) {
-  let div = document.createElement("div")
-  div.id = step_name
-  div.title = result
-  div.innerHTML = `Result test n°${step_number}: ${result}; function_name: ${step_name}${
-    error ? `; reason: ${error}` : ""
-  }`
-  document.body.appendChild(div)
+async function run_test(test_name, test_number, fun) {
+  try {
+    const result = await fun();
+    display_test_result_in_dom(test_name, test_number, "OK");
+    return result;
+  } catch (error) {
+    handle_error(test_name, test_number, error);
+  }
 }
 
-function handle_error(step_number, step_name, error) {
-  display_test_result_in_dom(step_number, step_name, "FAILED", error)
-  console.error(`Error at step ${step_number} (${step_name}):`, error)
-  add_finished_div()
+function display_test_result_in_dom(test_name, test_number, result, error) {
+  let div = document.createElement("div");
+  div.id = test_name;
+  div.title = result;
+  div.innerHTML = `Result test n°${test_number}: ${result}; function_name: ${test_name}${
+    error ? `; reason: ${error}` : ""
+  }`;
+  document.body.appendChild(div);
+}
+
+function handle_error(test_name, test_number, error) {
+  display_test_result_in_dom(test_name, test_number, "FAILED", error);
+  console.error(`Error at step ${test_number} (${test_name}):`, error);
+  add_finished_div();
   throw new Error(
-    `Stopping script due to error at step ${step_number}: ${error}`
-  )
+    `Stopping script due to error at step ${test_number}: ${error}`
+  );
 }
 
 function add_finished_div() {
-  let div = document.createElement("div")
-  div.id = "tests_finished"
-  document.body.appendChild(div)
+  let div = document.createElement("div");
+  div.id = "tests_finished";
+  document.body.appendChild(div);
 }
 
-await initMithrilClient()
-const aggregator_endpoint = process.env.AGGREGATOR_ENDPOINT
-const genesis_verification_key = process.env.GENESIS_VERIFICATION_KEY
-let client
-let test_name
-let test_number = 1
+await initMithrilClient();
+const aggregator_endpoint = process.env.AGGREGATOR_ENDPOINT;
+const genesis_verification_key = process.env.GENESIS_VERIFICATION_KEY;
+let client;
+let test_number = 1;
 
-// Test 'MithrilClient constructor'
-try {
-  test_name = "constructor"
-  client = new MithrilClient(aggregator_endpoint, genesis_verification_key)
-  display_test_result_in_dom(test_number, test_name, "OK")
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+await run_test("constructor", test_number, async () => {
+  client = new MithrilClient(aggregator_endpoint, genesis_verification_key);
+});
 
-// Test 'list_snapshots' function
-let snapshots
-try {
-  test_number++
-  test_name = "list_snapshots"
-  snapshots = await client.list_snapshots()
-  display_test_result_in_dom(test_number, test_name, "OK")
-  console.log("snapshots", snapshots)
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+let snapshots;
+test_number++;
+await run_test("list_snapshots", test_number, async () => {
+  snapshots = await client.list_snapshots();
+  console.log("snapshots", snapshots);
+});
 
-// Test 'get_snapshot' function
-try {
-  test_number++
-  test_name = "get_snapshot"
-  const snapshot = await client.get_snapshot(snapshots[0].digest)
-  display_test_result_in_dom(test_number, test_name, "OK")
-  console.log("snapshot", snapshot)
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+test_number++;
+await run_test("get_snapshot", test_number, async () => {
+  const snapshot = await client.get_snapshot(snapshots[0].digest);
+  console.log("snapshot", snapshot);
+});
 
-// Test 'list_mithril_stake_distributions' function
-let mithril_stake_distributions
-try {
-  test_number++
-  test_name = "list_mithril_stake_distributions"
-  mithril_stake_distributions = await client.list_mithril_stake_distributions()
-  display_test_result_in_dom(test_number, test_name, "OK")
-  console.log("mithril_stake_distributions", mithril_stake_distributions)
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+let mithril_stake_distributions;
+test_number++;
+await run_test("list_mithril_stake_distributions", test_number, async () => {
+  mithril_stake_distributions = await client.list_mithril_stake_distributions();
+  console.log("mithril_stake_distributions", mithril_stake_distributions);
+});
 
-// Test 'get_mithril_stake_distribution' function
-let mithril_stake_distribution
-try {
-  test_number++
-  test_name = "get_mithril_stake_distribution"
+let mithril_stake_distribution;
+test_number++;
+await run_test("get_mithril_stake_distribution", test_number, async () => {
   mithril_stake_distribution = await client.get_mithril_stake_distribution(
     mithril_stake_distributions[0].hash
-  )
-  display_test_result_in_dom(test_number, test_name, "OK")
-  console.log("mithril_stake_distribution", mithril_stake_distribution)
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+  );
+  console.log("mithril_stake_distribution", mithril_stake_distribution);
+});
 
-// Test 'get_mithril_certificate' function
-let certificate
-try {
-  test_number++
-  test_name = "get_mithril_certificate"
+let certificate;
+test_number++;
+await run_test("get_mithril_certificate", test_number, async () => {
   certificate = await client.get_mithril_certificate(
     mithril_stake_distribution.certificate_hash
-  )
-  display_test_result_in_dom(test_number, test_name, "OK")
-  console.log("certificate", certificate)
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+  );
+  console.log("certificate", certificate);
+});
 
-// Test 'verify_certificate_chain' function
-let last_certificate_from_chain
-try {
-  test_number++
-  test_name = "verify_certificate_chain"
+let last_certificate_from_chain;
+test_number++;
+await run_test("verify_certificate_chain", test_number, async () => {
   last_certificate_from_chain = await client.verify_certificate_chain(
     certificate.hash
-  )
-  display_test_result_in_dom(test_number, test_name, "OK")
-  console.log("last_certificate_from_chain", last_certificate_from_chain)
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+  );
+  console.log("last_certificate_from_chain", last_certificate_from_chain);
+});
 
-// Test 'compute_mithril_stake_distribution_message' function
-let mithril_stake_distribution_message
-try {
-  test_number++
-  test_name = "compute_mithril_stake_distribution_message"
-  mithril_stake_distribution_message =
-    await client.compute_mithril_stake_distribution_message(
-      mithril_stake_distribution
-    )
-  display_test_result_in_dom(test_number, test_name, "OK")
-  console.log(
-    "mithril_stake_distribution_message",
-    mithril_stake_distribution_message
-  )
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+let mithril_stake_distribution_message;
+test_number++;
+await run_test(
+  "compute_mithril_stake_distribution_message",
+  test_number,
+  async () => {
+    mithril_stake_distribution_message =
+      await client.compute_mithril_stake_distribution_message(
+        mithril_stake_distribution
+      );
+    console.log(
+      "mithril_stake_distribution_message",
+      mithril_stake_distribution_message
+    );
+  }
+);
 
-// Test 'verify_message_match_certificate' function
-try {
-  test_number++
-  test_name = "verify_message_match_certificate"
+test_number++;
+await run_test("verify_message_match_certificate", test_number, async () => {
   const valid_stake_distribution_message =
     await client.verify_message_match_certificate(
       mithril_stake_distribution_message,
       last_certificate_from_chain
-    )
-  display_test_result_in_dom(test_number, test_name, "OK")
+    );
   console.log(
     "valid_stake_distribution_message",
     valid_stake_distribution_message
-  )
-} catch (error) {
-  handle_error(test_number, test_name, error)
-}
+  );
+});
 
-add_finished_div()
+add_finished_div();

--- a/mithril-client-wasm/www-test/index.js
+++ b/mithril-client-wasm/www-test/index.js
@@ -15,9 +15,16 @@ function display_test_result_in_dom(step_number, step_name, result, error) {
 function handle_error(step_number, step_name, error) {
   display_test_result_in_dom(step_number, step_name, "FAILED", error)
   console.error(`Error at step ${step_number} (${step_name}):`, error)
+  add_finished_div()
   throw new Error(
     `Stopping script due to error at step ${step_number}: ${error}`
   )
+}
+
+function add_finished_div() {
+  let div = document.createElement("div")
+  div.id = "tests_finished"
+  document.body.appendChild(div)
 }
 
 await initMithrilClient()
@@ -148,3 +155,5 @@ try {
 } catch (error) {
   handle_error(test_number, test_name, error)
 }
+
+add_finished_div()

--- a/mithril-client-wasm/www-test/index.js
+++ b/mithril-client-wasm/www-test/index.js
@@ -1,0 +1,150 @@
+import initMithrilClient, {
+  MithrilClient,
+} from "@mithril-dev/mithril-client-wasm"
+
+function display_test_result_in_dom(step_number, step_name, result, error) {
+  let div = document.createElement("div")
+  div.id = step_name
+  div.title = result
+  div.innerHTML = `Result test n°${step_number}: ${result}; function_name: ${step_name}${
+    error ? `; reason: ${error}` : ""
+  }`
+  document.body.appendChild(div)
+}
+
+function handle_error(step_number, step_name, error) {
+  display_test_result_in_dom(step_number, step_name, "FAILED", error)
+  console.error(`Error at step ${step_number} (${step_name}):`, error)
+  throw new Error(
+    `Stopping script due to error at step ${step_number}: ${error}`
+  )
+}
+
+await initMithrilClient()
+const aggregator_endpoint = process.env.AGGREGATOR_ENDPOINT
+const genesis_verification_key = process.env.GENESIS_VERIFICATION_KEY
+let client
+let test_name
+let test_number = 1
+
+// Test 'MithrilClient constructor'
+try {
+  test_name = "constructor"
+  client = new MithrilClient(aggregator_endpoint, genesis_verification_key)
+  display_test_result_in_dom(test_number, test_name, "OK")
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'list_snapshots' function
+let snapshots
+try {
+  test_number++
+  test_name = "list_snapshots"
+  snapshots = await client.list_snapshots()
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log("snapshots", snapshots)
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'get_snapshot' function
+try {
+  test_number++
+  test_name = "get_snapshot"
+  const snapshot = await client.get_snapshot(snapshots[0].digest)
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log("snapshot", snapshot)
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'list_mithril_stake_distributions' function
+let mithril_stake_distributions
+try {
+  test_number++
+  test_name = "list_mithril_stake_distributions"
+  mithril_stake_distributions = await client.list_mithril_stake_distributions()
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log("mithril_stake_distributions", mithril_stake_distributions)
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'get_mithril_stake_distribution' function
+let mithril_stake_distribution
+try {
+  test_number++
+  test_name = "get_mithril_stake_distribution"
+  mithril_stake_distribution = await client.get_mithril_stake_distribution(
+    mithril_stake_distributions[0].hash
+  )
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log("mithril_stake_distribution", mithril_stake_distribution)
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'get_mithril_certificate' function
+let certificate
+try {
+  test_number++
+  test_name = "get_mithril_certificate"
+  certificate = await client.get_mithril_certificate(
+    mithril_stake_distribution.certificate_hash
+  )
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log("certificate", certificate)
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'verify_certificate_chain' function
+let last_certificate_from_chain
+try {
+  test_number++
+  test_name = "verify_certificate_chain"
+  last_certificate_from_chain = await client.verify_certificate_chain(
+    certificate.hash
+  )
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log("last_certificate_from_chain", last_certificate_from_chain)
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'compute_mithril_stake_distribution_message' function
+let mithril_stake_distribution_message
+try {
+  test_number++
+  test_name = "compute_mithril_stake_distribution_message"
+  mithril_stake_distribution_message =
+    await client.compute_mithril_stake_distribution_message(
+      mithril_stake_distribution
+    )
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log(
+    "mithril_stake_distribution_message",
+    mithril_stake_distribution_message
+  )
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}
+
+// Test 'verify_message_match_certificate' function
+try {
+  test_number++
+  test_name = "verify_message_match_certificate"
+  const valid_stake_distribution_message =
+    await client.verify_message_match_certificate(
+      mithril_stake_distribution_message,
+      last_certificate_from_chain
+    )
+  display_test_result_in_dom(test_number, test_name, "OK")
+  console.log(
+    "valid_stake_distribution_message",
+    valid_stake_distribution_message
+  )
+} catch (error) {
+  handle_error(test_number, test_name, error)
+}

--- a/mithril-client-wasm/www-test/package-lock.json
+++ b/mithril-client-wasm/www-test/package-lock.json
@@ -1,21 +1,18 @@
 {
-  "name": "create-wasm-app",
+  "name": "www-test",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "create-wasm-app",
+      "name": "www-test",
       "version": "0.1.0",
-      "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../pkg"
       },
-      "bin": {
-        "create-wasm-app": ".bin/create-wasm-app.js"
-      },
       "devDependencies": {
         "copy-webpack-plugin": "^5.0.0",
+        "dotenv-webpack": "^8.0.1",
         "webpack": "^5.88.2",
         "webpack-cli": "^4.7.2",
         "webpack-dev-server": "^4.15.1"
@@ -23,7 +20,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -84,9 +81,9 @@
       "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-      "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+      "version": "0.3.22",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.22.tgz",
+      "integrity": "sha512-Wf963MzWtA2sjrNt+g18IAln9lKnlRp+K2eH4jjIoF1wYeq3aMREpG09xhlhdzS0EjwU7qmUJYangWa+151vZw==",
       "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -142,9 +139,9 @@
       }
     },
     "node_modules/@types/eslint": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.1.tgz",
-      "integrity": "sha512-18PLWRzhy9glDQp3+wOgfLYRWlhgX0azxgJ63rdpoUHyrC9z0f5CkFburjQx4uD7ZCruw85ZtMt6K+L+R8fLJQ==",
+      "version": "8.56.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.2.tgz",
+      "integrity": "sha512-uQDwm1wFHmbBbCZCqAlq6Do9LYwByNZHWzXppSnay9SuwJ+VRbjkbLABer54kcPnMSlG6Fdiy2yaFXm/z9Z5gw==",
       "dev": true,
       "dependencies": {
         "@types/estree": "*",
@@ -219,9 +216,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.10.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.7.tgz",
-      "integrity": "sha512-fRbIKb8C/Y2lXxB5eVMj4IU7xpdox0Lh8bUPEdtLysaylsml1hOOx1+STloRs/B9nf7C6kPRmmg/V7aQW7usNg==",
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
+      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
       "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -856,9 +853,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==",
+      "version": "1.0.30001580",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001580.tgz",
+      "integrity": "sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA==",
       "dev": true,
       "funding": [
         {
@@ -1240,6 +1237,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/dotenv-defaults": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+      "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+      "dev": true,
+      "dependencies": {
+        "dotenv": "^8.2.0"
+      }
+    },
+    "node_modules/dotenv-webpack": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-8.0.1.tgz",
+      "integrity": "sha512-CdrgfhZOnx4uB18SgaoP9XHRN2v48BbjuXQsZY5ixs5A8579NxQkmMxRtI7aTwSiSQcM2ao12Fdu+L3ZS3bG4w==",
+      "dev": true,
+      "dependencies": {
+        "dotenv-defaults": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "webpack": "^4 || ^5"
+      }
+    },
     "node_modules/duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1259,9 +1289,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.625",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.625.tgz",
-      "integrity": "sha512-DENMhh3MFgaPDoXWrVIqSPInQoLImywfCwrSmVl3cf9QHzoZSiutHwGaB/Ql3VkqcQV30rzgdM+BjKqBAJxo5Q==",
+      "version": "1.4.645",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.645.tgz",
+      "integrity": "sha512-EeS1oQDCmnYsRDRy2zTeC336a/4LZ6WKqvSaM1jLocEk5ZuyszkQtCpsqvuvaIXGOUjwtvF6LTcS8WueibXvSw==",
       "dev": true
     },
     "node_modules/emojis-list": {
@@ -1605,9 +1635,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.4",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.4.tgz",
-      "integrity": "sha512-Cr4D/5wlrb0z9dgERpUL3LrmPKVDsETIJhaCMeDfuFYcqa5bldGV6wBsAN6X/vxlXQtFBMrXdXxdL8CbDTGniw==",
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
       "dev": true,
       "funding": [
         {
@@ -3295,15 +3325,16 @@
       }
     },
     "node_modules/set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.0.tgz",
+      "integrity": "sha512-4DBHDoyHlM1IRPGYcoxexgh67y4ueR53FKV1yyxwFMY7aCqcN/38M1+SwZ/qJQ8iLv7+ck385ot4CcisOAPT9w==",
       "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.2",
         "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
+        "has-property-descriptors": "^1.0.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3535,9 +3566,9 @@
       }
     },
     "node_modules/stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "dev": true
     },
     "node_modules/string_decoder": {
@@ -3595,9 +3626,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.26.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.26.0.tgz",
-      "integrity": "sha512-dytTGoE2oHgbNV9nTzgBEPaqAWvcJNl66VZ0BkJqlvp71IjO8CxdBx/ykCNb47cLnCmCvRZ6ZR0tLkqvZCdVBQ==",
+      "version": "5.27.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
+      "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -3857,19 +3888,19 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "version": "5.90.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.0.tgz",
+      "integrity": "sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
+        "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.11.5",
         "@webassemblyjs/wasm-edit": "^1.11.5",
         "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
+        "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.15.0",
         "es-module-lexer": "^1.2.1",
@@ -3883,7 +3914,7 @@
         "neo-async": "^2.6.2",
         "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
+        "terser-webpack-plugin": "^5.3.10",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
@@ -4317,6 +4348,12 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "pkg": {
+      "name": "mithril-client-wasm",
+      "version": "0.1.7",
+      "extraneous": true,
+      "license": "Apache-2.0"
     }
   }
 }

--- a/mithril-client-wasm/www-test/package.json
+++ b/mithril-client-wasm/www-test/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "www-test",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "build": "webpack --config webpack.config.js",
+    "start": "webpack-dev-server"
+  },
+  "dependencies": {
+    "@mithril-dev/mithril-client-wasm": "file:../pkg"
+  },
+  "devDependencies": {
+    "copy-webpack-plugin": "^5.0.0",
+    "dotenv-webpack": "^8.0.1",
+    "webpack": "^5.88.2",
+    "webpack-cli": "^4.7.2",
+    "webpack-dev-server": "^4.15.1"
+  }
+}

--- a/mithril-client-wasm/www-test/webpack.config.js
+++ b/mithril-client-wasm/www-test/webpack.config.js
@@ -1,0 +1,16 @@
+const CopyWebpackPlugin = require("copy-webpack-plugin")
+const path = require("path")
+const Dotenv = require("dotenv-webpack")
+
+module.exports = {
+  entry: "./bootstrap.js",
+  output: {
+    path: path.resolve(__dirname, "dist"),
+    filename: "bootstrap.js",
+  },
+  mode: "development",
+  plugins: [new CopyWebpackPlugin(["index.html"]), new Dotenv()],
+  experiments: {
+    asyncWebAssembly: true,
+  },
+}


### PR DESCRIPTION
## Content
This PR includes tests implementation for `mithril-client-wasm`. This tests are executed in headless mode with Google Chrome and Firefox from the manual workflow `Mithril Client multi-platform test`.

Two scripts were added:
- `run-wasm-tests-browser-headless.py`: call by the manual workflow to run browsers in headless mode and save the output to a html file with the test results. It takes the browser as argument (`chrome` or `firefox`).
- `parse-wasm-headless-tests-results.sh`: call by the manual workflow to handle both browsers test results

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Close to #1408 