### PR TITLE
Fix building mithril-common with some features and targets combinatory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.154"
+version = "0.2.155"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -96,8 +96,8 @@ default = []
 # Full feature set
 full = ["random", "database", "fs", "test_tools"]
 random = ["rand_core/getrandom"]
-database = ["sqlite"]
-fs = ["tokio/fs", "tokio/process", "pallas-network", "pallas-traverse"]
+database = ["dep:sqlite"]
+fs = ["tokio/fs", "tokio/process", "dep:pallas-network", "dep:pallas-traverse"]
 
 # Portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 portable = ["mithril-stm/portable"]
@@ -107,8 +107,8 @@ allow_skip_signer_certification = []
 # Enable all tests tools
 test_tools = ["apispec", "test_http_server", "random"]
 # Enable tools to helps validate conformity to an OpenAPI specification
-apispec = ["glob", "http", "jsonschema", "warp"]
-test_http_server = ["warp"]
+apispec = ["dep:glob", "dep:http", "dep:jsonschema", "dep:warp"]
+test_http_server = ["dep:warp"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.154"
+version = "0.2.155"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -77,6 +77,7 @@ mithril-stm = { path = "../mithril-stm", version = "0.3", default-features = fal
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 mockall = "0.12.0"
 pallas-codec = "0.21.0"
+rand_core = { version = "0.6.4", features = ["getrandom"] }
 reqwest = { version = "0.11.22", features = ["json"] }
 slog-async = "2.8.0"
 slog-scope = "4.4.0"
@@ -104,7 +105,7 @@ portable = ["mithril-stm/portable"]
 # Disable signer certification, to be used only for tests
 allow_skip_signer_certification = []
 # Enable all tests tools
-test_tools = ["apispec", "test_http_server"]
+test_tools = ["apispec", "test_http_server", "random"]
 # Enable tools to helps validate conformity to an OpenAPI specification
 apispec = ["glob", "http", "jsonschema", "warp"]
 test_http_server = ["warp"]

--- a/mithril-common/Makefile
+++ b/mithril-common/Makefile
@@ -1,6 +1,11 @@
-.PHONY: all build test check debug run help doc
+.PHONY: all build test check doc check-all-features-set
 
 CARGO = cargo
+# All the crates features excluding the two that have little to no impact to the code
+FEATURES := $(shell ${CARGO} metadata --quiet --no-deps \
+	| jq -r '.packages[] | select(.name=="mithril-common") | .features \
+	  | del(.allow_skip_signer_certification) | del(.portable) \
+	  | keys | join(" ")')
 
 all: test build
 
@@ -18,3 +23,17 @@ check:
 
 doc:
 	${CARGO} doc --no-deps --open --features full
+
+# Compute the powerset of all the given features and save it to a file
+.feature-sets:
+	powerset() { [ $$# -eq 0 ] && echo || (shift; powerset "$$@") | while read r ; do echo "$$1 $$r"; echo "$$r"; done };\
+	powerset $$(echo "$(FEATURES)") > .features-sets
+
+check-all-features-set: .feature-sets
+	# Read the file to run cargo clippy on all those features sets
+	cat .features-sets | while read features_set; do \
+		echo "Clippy common with feature '$$features_set''"; \
+		${CARGO} clippy -p mithril-common --features "$$features_set"; \
+	done
+
+	rm .features-sets

--- a/mithril-common/src/chain_observer/builder.rs
+++ b/mithril-common/src/chain_observer/builder.rs
@@ -4,7 +4,9 @@ use thiserror::Error;
 
 use crate::{chain_observer::ChainObserver, CardanoNetwork, StdResult};
 
-use super::{CardanoCliChainObserver, CardanoCliRunner, FakeObserver, PallasChainObserver};
+#[cfg(any(test, feature = "test_tools"))]
+use super::FakeObserver;
+use super::{CardanoCliChainObserver, CardanoCliRunner, PallasChainObserver};
 
 /// Type of chain observers available
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -16,7 +18,7 @@ pub enum ChainObserverType {
     /// Pallas chain observer.
     Pallas,
     /// Fake chain observer.
-    #[cfg(feature = "test_tools")]
+    #[cfg(any(test, feature = "test_tools"))]
     Fake,
 }
 
@@ -25,6 +27,7 @@ impl Display for ChainObserverType {
         match self {
             Self::CardanoCli => write!(f, "cardano-cli"),
             Self::Pallas => write!(f, "pallas"),
+            #[cfg(any(test, feature = "test_tools"))]
             Self::Fake => write!(f, "fake"),
         }
     }
@@ -85,7 +88,7 @@ impl ChainObserverBuilder {
                 );
                 Ok(Arc::new(observer))
             }
-            #[cfg(feature = "test_tools")]
+            #[cfg(any(test, feature = "test_tools"))]
             ChainObserverType::Fake => Ok(Arc::new(FakeObserver::default())),
         }
     }

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -4,25 +4,25 @@
 mod builder;
 #[cfg(all(feature = "fs", feature = "random"))]
 mod cli_observer;
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 mod fake_observer;
 mod interface;
 mod model;
 #[cfg(all(feature = "fs", feature = "random"))]
 mod pallas_observer;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "fs", feature = "random"))]
 mod test_cli_runner;
-
-#[cfg(test)]
-pub use cli_observer::CliRunner;
 
 #[cfg(all(feature = "fs", feature = "random"))]
 pub use builder::{ChainObserverBuilder, ChainObserverType};
 #[cfg(all(feature = "fs", feature = "random"))]
+pub use cli_observer::CliRunner;
+#[cfg(all(feature = "fs", feature = "random"))]
 pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
-#[cfg(feature = "test_tools")]
-pub use fake_observer::FakeObserver;
+cfg_test_tools! {
+    pub use fake_observer::FakeObserver;
+}
 #[cfg(test)]
 pub use interface::MockChainObserver;
 pub use interface::{ChainObserver, ChainObserverError};

--- a/mithril-common/src/crypto_helper/cardano/cold_key.rs
+++ b/mithril-common/src/crypto_helper/cardano/cold_key.rs
@@ -3,11 +3,14 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 
 /// A cold key generator / test only
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct ColdKeyGenerator();
 
 impl ColdKeyGenerator {
-    pub(crate) fn create_deterministic_keypair(seed: [u8; 32]) -> ColdSecretKey {
+    #[doc(hidden)]
+    /// Create a deterministic secret key using the given seed. (test only)
+    pub fn create_deterministic_keypair(seed: [u8; 32]) -> ColdSecretKey {
         let mut rng = ChaCha20Rng::from_seed(seed);
         ColdSecretKey::generate(&mut rng)
     }

--- a/mithril-common/src/crypto_helper/cardano/mod.rs
+++ b/mithril-common/src/crypto_helper/cardano/mod.rs
@@ -1,11 +1,11 @@
 mod codec;
-#[cfg(feature = "random")]
+#[cfg(any(test, feature = "random"))]
 mod cold_key;
 mod key_certification;
 mod opcert;
 
 pub use codec::*;
-#[cfg(feature = "random")]
+#[cfg(any(test, feature = "random"))]
 pub use cold_key::*;
 pub use key_certification::*;
 pub use opcert::*;

--- a/mithril-common/src/crypto_helper/era.rs
+++ b/mithril-common/src/crypto_helper/era.rs
@@ -49,12 +49,12 @@ impl EraMarkersSigner {
         Self::create_test_signer(rng)
     }
 
-    cfg_random! {
-        /// [EraMarkersSigner] non deterministic
-        pub fn create_non_deterministic_signer() -> Self {
-            let rng = rand_core::OsRng;
-            Self::create_test_signer(rng)
-        }
+    #[cfg(any(test, feature = "random"))]
+    #[cfg_attr(docsrs, doc(cfg(feature = "random")))]
+    /// [EraMarkersSigner] non deterministic
+    pub fn create_non_deterministic_signer() -> Self {
+        let rng = rand_core::OsRng;
+        Self::create_test_signer(rng)
     }
 
     /// [EraMarkersSigner] from [EraMarkersVerifierSecretKey]

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -6,11 +6,11 @@ mod conversions;
 mod era;
 mod genesis;
 mod merkle_tree;
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 pub mod tests_setup;
 mod types;
 
-#[cfg(feature = "random")]
+#[cfg(any(test, feature = "random"))]
 pub use cardano::ColdKeyGenerator;
 
 pub use cardano::{

--- a/mithril-common/src/entities/signed_entity.rs
+++ b/mithril-common/src/entities/signed_entity.rs
@@ -1,8 +1,8 @@
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 use super::{Beacon, Epoch};
 use super::{CardanoTransactionsCommitment, MithrilStakeDistribution, SignedEntityType, Snapshot};
 use crate::signable_builder::Artifact;
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_data;
 use chrono::{DateTime, Utc};
 

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -34,7 +34,7 @@ macro_rules! cfg_random {
 macro_rules! cfg_test_tools {
     ($($item:item)*) => {
         $(
-            #[cfg(feature = "test_tools")]
+            #[cfg(any(test, feature = "test_tools"))]
             #[cfg_attr(docsrs, doc(cfg(feature = "test_tools")))]
             $item
         )*
@@ -67,8 +67,9 @@ pub mod sqlite;
 #[cfg(feature = "database")]
 pub mod store;
 
-#[cfg(feature = "test_tools")]
-pub mod test_utils;
+cfg_test_tools! {
+    pub mod test_utils;
+}
 
 #[cfg(feature = "fs")]
 pub use beacon_provider::{BeaconProvider, BeaconProviderImpl};

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -1,4 +1,5 @@
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Shared datatypes and traits used by Mithril rust projects
 //!

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -2,13 +2,14 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 use crate::entities::ProtocolMessagePartKey;
 use crate::entities::{
     Beacon, Certificate, CertificateMetadata, CertificateSignature, ProtocolMessage,
 };
 use crate::messages::CertificateMetadataMessagePart;
-#[cfg(feature = "test_tools")]
+
+#[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_keys;
 use crate::StdError;
 

--- a/mithril-common/src/messages/message_parts/signer.rs
+++ b/mithril-common/src/messages/message_parts/signer.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_keys;
 use crate::{
     crypto_helper::{KESPeriod, ProtocolOpCert, ProtocolSignerVerificationKeySignature},

--- a/mithril-common/src/messages/mithril_stake_distribution.rs
+++ b/mithril-common/src/messages/mithril_stake_distribution.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::entities::Epoch;
 use crate::entities::ProtocolParameters;
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_data;
 
 use super::SignerWithStakeMessagePart;

--- a/mithril-common/src/messages/register_signature.rs
+++ b/mithril-common/src/messages/register_signature.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
 use crate::entities::{HexEncodedSingleSignature, LotteryIndex, PartyId, SignedEntityType};
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_keys;
 
 era_deprecate!("make signed_entity_type of RegisterSignatureMessage not optional");

--- a/mithril-common/src/messages/register_signer.rs
+++ b/mithril-common/src/messages/register_signer.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
-#[cfg(feature = "test_tools")]
+#[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_keys;
 use crate::{
     crypto_helper::KESPeriod,


### PR DESCRIPTION
## Content

This PR fix the building of mithril-common for all it's matrix of features and targets.

Some examples that raise errors right now:
- building with only the `test_tools` features fails because it's need the `ColdKeyGenerator` that's behind the `random` feature.
- building with only the `--all-targets` directive fails horribly (30 errors) because the tests use a lot of tools that are behind the `test_tools` feature.
- building it with only the `fs` and `random` features would fails since the `FakeObserver` is behind the `test_tools` feature that is disabled.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
In order to check more easily if a feature combinatory is failing a new target has been added to the mithril-common makefiles that compute all features combinatory (the "powerset" of features) and run a cargo clippy on them.
