### PR TITLE
More explicit error message when db dir is not writable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3382,7 +3382,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.5.18"
+version = "0.5.19"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/utils/unpacker.rs
+++ b/mithril-client-cli/src/utils/unpacker.rs
@@ -36,7 +36,7 @@ pub enum SnapshotUnpackerError {
     UnpackDirectoryAlreadyExists(PathBuf),
 
     /// Cannot write in the given directory.
-    #[error("Unpack directory '{0}' is not writable.")]
+    #[error("Unpack directory '{0}' is not writable, please check own or parents' permissions and ownership.")]
     UnpackDirectoryIsNotWritable(PathBuf, #[source] StdError),
 }
 
@@ -114,7 +114,7 @@ mod test {
         );
     }
 
-    // This test is not runned on Windows because `set_readonly` is not working on Windows 7+
+    // This test is not run on Windows because `set_readonly` is not working on Windows 7+
     // https://doc.rust-lang.org/std/fs/struct.Permissions.html#method.set_readonly
     #[cfg(not(target_os = "windows"))]
     #[test]


### PR DESCRIPTION
## Content

This PR makes error message when unpacking a snapshot and the `db/` directory is unwritable a bit more explicit and provides some guidance to the user.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

