### PR TITLE
Certificate hash in transaction set message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.32"
+version = "0.4.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.159"
+version = "0.2.160"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.32"
+version = "0.4.33"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/provider/cardano_transaction.rs
+++ b/mithril-aggregator/src/database/provider/cardano_transaction.rs
@@ -284,14 +284,6 @@ impl TransactionStore for CardanoTransactionRepository {
 
 #[async_trait]
 impl TransactionsRetriever for CardanoTransactionRepository {
-    async fn get_all(&self) -> StdResult<Vec<CardanoTransaction>> {
-        self.get_all_transactions().await.map(|v| {
-            v.into_iter()
-                .map(|record| record.into())
-                .collect::<Vec<CardanoTransaction>>()
-        })
-    }
-
     async fn get_up_to(&self, beacon: &Beacon) -> StdResult<Vec<CardanoTransaction>> {
         self.get_transactions_up_to(beacon).await.map(|v| {
             v.into_iter()
@@ -608,12 +600,12 @@ mod tests {
             .await
             .unwrap();
 
-        let transactions_result = repository.get_all().await.unwrap();
-        let transactions_expected = cardano_transactions
+        let transactions_result = repository.get_all_transactions().await.unwrap();
+        let transactions_expected: Vec<CardanoTransactionRecord> = cardano_transactions
             .iter()
             .rev()
-            .cloned()
-            .collect::<Vec<_>>();
+            .map(|tx| tx.clone().into())
+            .collect();
 
         assert_eq!(transactions_expected, transactions_result);
     }

--- a/mithril-aggregator/src/database/provider/cardano_transaction.rs
+++ b/mithril-aggregator/src/database/provider/cardano_transaction.rs
@@ -1,5 +1,5 @@
 use mithril_common::{
-    entities::{BlockNumber, CardanoTransaction, ImmutableFileNumber, TransactionHash},
+    entities::{Beacon, BlockNumber, CardanoTransaction, ImmutableFileNumber, TransactionHash},
     signable_builder::TransactionStore,
     sqlite::{
         HydrationError, Projection, Provider, SourceAlias, SqLiteEntity, SqliteConnection,
@@ -100,6 +100,13 @@ impl<'client> CardanoTransactionProvider<'client> {
         WhereCondition::new(
             "transaction_hash = ?*",
             vec![Value::String(transaction_hash.to_owned())],
+        )
+    }
+
+    pub(crate) fn get_transaction_up_to_beacon_condition(&self, beacon: &Beacon) -> WhereCondition {
+        WhereCondition::new(
+            "immutable_file_number <= ?*",
+            vec![Value::Integer(beacon.immutable_file_number as i64)],
         )
     }
 }
@@ -207,6 +214,18 @@ impl CardanoTransactionRepository {
         Ok(transactions.collect())
     }
 
+    /// Return all the [CardanoTransactionRecord]s in the database up to the given beacon.
+    pub async fn get_transactions_up_to(
+        &self,
+        beacon: &Beacon,
+    ) -> StdResult<Vec<CardanoTransactionRecord>> {
+        let provider = CardanoTransactionProvider::new(&self.connection);
+        let filters = provider.get_transaction_up_to_beacon_condition(beacon);
+        let transactions = provider.find(filters)?;
+
+        Ok(transactions.collect())
+    }
+
     /// Return the [CardanoTransactionRecord] for the given transaction hash.
     pub async fn get_transaction(
         &self,
@@ -272,6 +291,14 @@ impl TransactionsRetriever for CardanoTransactionRepository {
                 .collect::<Vec<CardanoTransaction>>()
         })
     }
+
+    async fn get_up_to(&self, beacon: &Beacon) -> StdResult<Vec<CardanoTransaction>> {
+        self.get_transactions_up_to(beacon).await.map(|v| {
+            v.into_iter()
+                .map(|record| record.into())
+                .collect::<Vec<CardanoTransaction>>()
+        })
+    }
 }
 
 #[cfg(test)]
@@ -320,6 +347,21 @@ mod tests {
             )],
             params,
         );
+    }
+
+    #[test]
+    fn provider_transaction_up_to_beacon_condition() {
+        let connection = Connection::open_thread_safe(":memory:").unwrap();
+        let provider = CardanoTransactionProvider::new(&connection);
+        let (expr, params) = provider
+            .get_transaction_up_to_beacon_condition(&Beacon {
+                immutable_file_number: 2309,
+                ..Beacon::default()
+            })
+            .expand();
+
+        assert_eq!("immutable_file_number <= ?1".to_string(), expr);
+        assert_eq!(vec![Value::Integer(2309)], params,);
     }
 
     #[test]
@@ -493,6 +535,55 @@ mod tests {
             }),
             transaction_result
         );
+    }
+
+    #[tokio::test]
+    async fn repository_store_transactions_and_get_up_to_beacon_transactions() {
+        let connection = get_connection().await;
+        let repository = CardanoTransactionRepository::new(connection.clone());
+
+        let cardano_transactions: Vec<CardanoTransaction> = (20..=40)
+            .map(|i| CardanoTransaction {
+                transaction_hash: format!("tx-hash-{i}"),
+                block_number: i % 10,
+                immutable_file_number: i,
+            })
+            .collect();
+        repository
+            .store_transactions(&cardano_transactions)
+            .await
+            .unwrap();
+
+        let transaction_result = repository
+            .get_up_to(&Beacon::new("".to_string(), 1, 34))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            cardano_transactions[0..=14]
+                .iter()
+                .cloned()
+                .rev()
+                .collect::<Vec<_>>(),
+            transaction_result
+        );
+
+        let transaction_result = repository
+            .get_up_to(&Beacon::new("".to_string(), 1, 300))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            cardano_transactions.into_iter().rev().collect::<Vec<_>>(),
+            transaction_result
+        );
+
+        let transaction_result = repository
+            .get_up_to(&Beacon::new("".to_string(), 1, 19))
+            .await
+            .unwrap();
+
+        assert_eq!(Vec::<CardanoTransaction>::new(), transaction_result);
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -9,3 +9,20 @@ pub mod router;
 mod signatures_routes;
 mod signer_routes;
 mod statistics_routes;
+
+/// Match the given result and do an early return with an internal server error (500)
+/// if it was an Error. Else return the unwrapped value.
+#[macro_export]
+macro_rules! unwrap_to_internal_server_error {
+    ($code:expr, $($warn_comment:tt)*) => {
+        match $code {
+            Ok(res) => res,
+            Err(err) => {
+                warn!($($warn_comment)*; "error" => ?err);
+                return Ok($crate::http_server::routes::reply::internal_server_error(
+                    err,
+                ));
+            }
+        }
+    };
+}

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -29,6 +29,9 @@ fn proof_cardano_transaction(
     warp::path!("proof" / "cardano-transaction")
         .and(warp::get())
         .and(warp::query::<CardanoTransactionProofQueryParams>())
+        .and(middlewares::with_signed_entity_service(
+            dependency_manager.clone(),
+        ))
         .and(middlewares::with_prover_service(dependency_manager))
         .and_then(handlers::proof_cardano_transaction)
 }
@@ -40,14 +43,16 @@ mod handlers {
     use slog_scope::{debug, warn};
 
     use crate::{
-        http_server::routes::reply, message_adapters::ToCardanoTransactionsProofsMessageAdapter,
-        services::ProverService,
+        http_server::routes::reply,
+        message_adapters::ToCardanoTransactionsProofsMessageAdapter,
+        services::{ProverService, SignedEntityService},
     };
 
     use super::CardanoTransactionProofQueryParams;
 
     pub async fn proof_cardano_transaction(
         transaction_parameters: CardanoTransactionProofQueryParams,
+        signed_entity_service: Arc<dyn SignedEntityService>,
         prover_service: Arc<dyn ProverService>,
     ) -> Result<impl warp::Reply, Infallible> {
         let transaction_hashes = transaction_parameters
@@ -60,17 +65,36 @@ mod handlers {
             transaction_parameters.transaction_hashes
         );
 
-        match prover_service
-            .compute_transactions_proofs(transaction_hashes.as_slice())
+        match signed_entity_service
+            .get_last_cardano_transaction_commitment()
             .await
         {
-            Ok(transactions_set_proofs) => Ok(reply::json(
-                &ToCardanoTransactionsProofsMessageAdapter::adapt(
-                    transactions_set_proofs,
-                    transaction_hashes,
-                ),
-                StatusCode::OK,
-            )),
+            Ok(Some(signed_entity)) => {
+                match prover_service
+                    .compute_transactions_proofs(
+                        &signed_entity.artifact.beacon,
+                        transaction_hashes.as_slice(),
+                    )
+                    .await
+                {
+                    Ok(transactions_set_proofs) => Ok(reply::json(
+                        &ToCardanoTransactionsProofsMessageAdapter::adapt(
+                            &signed_entity.certificate_id,
+                            transactions_set_proofs,
+                            transaction_hashes,
+                        ),
+                        StatusCode::OK,
+                    )),
+                    Err(err) => {
+                        warn!("proof_cardano_transaction::error"; "error" => ?err);
+                        Ok(reply::internal_server_error(err))
+                    }
+                }
+            }
+            Ok(None) => {
+                warn!("proof_cardano_transaction::not_found");
+                Ok(reply::empty(StatusCode::NOT_FOUND))
+            }
             Err(err) => {
                 warn!("proof_cardano_transaction::error"; "error" => ?err);
                 Ok(reply::internal_server_error(err))
@@ -82,13 +106,18 @@ mod handlers {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::vec;
 
     use mithril_common::test_utils::apispec::APISpec;
 
     use anyhow::anyhow;
+    use mithril_common::entities::{
+        CardanoTransactionsCommitment, CardanoTransactionsSetProof, SignedEntity,
+    };
     use serde_json::Value::Null;
     use warp::{http::Method, test::request};
 
+    use crate::services::MockSignedEntityService;
     use crate::{
         dependency_injection::DependenciesBuilder, http_server::SERVER_BASE_PATH,
         services::MockProverService, Configuration,
@@ -109,6 +138,44 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_ok() {
+        let config = Configuration::new_sample();
+        let mut builder = DependenciesBuilder::new(config);
+        let mut dependency_manager = builder.build_dependency_container().await.unwrap();
+        let mut mock_signed_entity_service = MockSignedEntityService::new();
+        mock_signed_entity_service
+            .expect_get_last_cardano_transaction_commitment()
+            .returning(|| Ok(Some(SignedEntity::<CardanoTransactionsCommitment>::dummy())));
+        dependency_manager.signed_entity_service = Arc::new(mock_signed_entity_service);
+
+        let mut mock_prover_service = MockProverService::new();
+        mock_prover_service
+            .expect_compute_transactions_proofs()
+            .returning(|_, _| Ok(vec![CardanoTransactionsSetProof::dummy()]));
+        dependency_manager.prover_service = Arc::new(mock_prover_service);
+
+        let method = Method::GET.as_str();
+        let path = "/proof/cardano-transaction";
+
+        let response = request()
+            .method(method)
+            .path(&format!(
+                "/{SERVER_BASE_PATH}{path}?transaction_hashes=tx-123,tx-456"
+            ))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+        );
+    }
+
+    #[tokio::test]
+    async fn proof_cardano_transaction_not_found() {
         let config = Configuration::new_sample();
         let mut builder = DependenciesBuilder::new(config);
         let dependency_manager = builder.build_dependency_container().await.unwrap();
@@ -139,12 +206,11 @@ mod tests {
         let config = Configuration::new_sample();
         let mut builder = DependenciesBuilder::new(config);
         let mut dependency_manager = builder.build_dependency_container().await.unwrap();
-        let mut mock_prover_service = MockProverService::new();
-        mock_prover_service
-            .expect_compute_transactions_proofs()
-            .returning(|_| Err(anyhow!("Error")))
-            .times(1);
-        dependency_manager.prover_service = Arc::new(mock_prover_service);
+        let mut mock_signed_entity_service = MockSignedEntityService::new();
+        mock_signed_entity_service
+            .expect_get_last_cardano_transaction_commitment()
+            .returning(|| Err(anyhow!("Error")));
+        dependency_manager.signed_entity_service = Arc::new(mock_signed_entity_service);
 
         let method = Method::GET.as_str();
         let path = "/proof/cardano-transaction";

--- a/mithril-aggregator/src/message_adapters/to_cardano_transactions_proof_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_cardano_transactions_proof_message.rs
@@ -1,6 +1,8 @@
+use mithril_common::messages::CardanoTransactionsSetProofMessagePart;
 use mithril_common::{
     entities::{CardanoTransactionsSetProof, TransactionHash},
     messages::CardanoTransactionsProofsMessage,
+    StdResult,
 };
 
 /// Adapter to spawn [CardanoTransactionsProofsMessage] from [CardanoTransactionsProofs] instances.
@@ -8,31 +10,50 @@ pub struct ToCardanoTransactionsProofsMessageAdapter;
 
 impl ToCardanoTransactionsProofsMessageAdapter {
     /// Turn an entity instance into message.
-    pub fn adapt(
+    pub fn try_adapt(
         certificate_hash: &str,
         transactions_set_proofs: Vec<CardanoTransactionsSetProof>,
         transaction_hashes_to_certify: Vec<TransactionHash>,
-    ) -> CardanoTransactionsProofsMessage {
-        let transactions_hashes_certified = transactions_set_proofs
-            .iter()
-            .flat_map(|proof| proof.transactions_hashes().to_vec())
-            .collect::<Vec<_>>();
-        let transactions_hashes_not_certified = transaction_hashes_to_certify
-            .iter()
-            .filter(|hash| !transactions_hashes_certified.contains(hash))
-            .cloned()
-            .collect::<Vec<_>>();
-        let transactions_set_proofs = transactions_set_proofs
-            .into_iter()
-            .map(|p| p.into())
-            .collect();
+    ) -> StdResult<CardanoTransactionsProofsMessage> {
+        let transactions_hashes_not_certified = compute_not_certified_transactions(
+            &transactions_set_proofs,
+            &transaction_hashes_to_certify,
+        );
 
-        CardanoTransactionsProofsMessage::new(
+        Ok(CardanoTransactionsProofsMessage::new(
             certificate_hash,
-            transactions_set_proofs,
+            try_adapt_set_proof_message(transactions_set_proofs)?,
             transactions_hashes_not_certified,
-        )
+        ))
     }
+}
+
+fn compute_not_certified_transactions(
+    transactions_set_proofs: &[CardanoTransactionsSetProof],
+    transaction_hashes_to_certify: &[TransactionHash],
+) -> Vec<TransactionHash> {
+    let transactions_hashes_certified = transactions_set_proofs
+        .iter()
+        .flat_map(|proof| proof.transactions_hashes().to_vec())
+        .collect::<Vec<_>>();
+
+    transaction_hashes_to_certify
+        .iter()
+        .filter(|hash| !transactions_hashes_certified.contains(hash))
+        .cloned()
+        .collect()
+}
+
+fn try_adapt_set_proof_message(
+    transactions_set_proofs: Vec<CardanoTransactionsSetProof>,
+) -> StdResult<Vec<CardanoTransactionsSetProofMessagePart>> {
+    let mut messages = vec![];
+
+    for set_proof in transactions_set_proofs {
+        messages.push(set_proof.try_into()?);
+    }
+
+    Ok(messages)
 }
 
 #[cfg(test)]
@@ -83,14 +104,15 @@ mod tests {
         }
 
         let certificate_hash = "certificate_hash";
-        let message = ToCardanoTransactionsProofsMessageAdapter::adapt(
+        let message = ToCardanoTransactionsProofsMessageAdapter::try_adapt(
             certificate_hash,
             transactions_set_proofs.clone(),
             transaction_hashes.to_vec(),
-        );
+        )
+        .unwrap();
         let transactions_set_proofs = transactions_set_proofs
             .into_iter()
-            .map(|p| p.into())
+            .map(|p| p.try_into().unwrap())
             .collect();
         let expected_message = CardanoTransactionsProofsMessage::new(
             certificate_hash,

--- a/mithril-aggregator/src/message_adapters/to_cardano_transactions_proof_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_cardano_transactions_proof_message.rs
@@ -9,6 +9,7 @@ pub struct ToCardanoTransactionsProofsMessageAdapter;
 impl ToCardanoTransactionsProofsMessageAdapter {
     /// Turn an entity instance into message.
     pub fn adapt(
+        certificate_hash: &str,
         transactions_set_proofs: Vec<CardanoTransactionsSetProof>,
         transaction_hashes_to_certify: Vec<TransactionHash>,
     ) -> CardanoTransactionsProofsMessage {
@@ -21,7 +22,13 @@ impl ToCardanoTransactionsProofsMessageAdapter {
             .filter(|hash| !transactions_hashes_certified.contains(hash))
             .cloned()
             .collect::<Vec<_>>();
+        let transactions_set_proofs = transactions_set_proofs
+            .into_iter()
+            .map(|p| p.into())
+            .collect();
+
         CardanoTransactionsProofsMessage::new(
+            certificate_hash,
             transactions_set_proofs,
             transactions_hashes_not_certified,
         )
@@ -75,11 +82,18 @@ mod tests {
             ))
         }
 
+        let certificate_hash = "certificate_hash";
         let message = ToCardanoTransactionsProofsMessageAdapter::adapt(
+            certificate_hash,
             transactions_set_proofs.clone(),
             transaction_hashes.to_vec(),
         );
+        let transactions_set_proofs = transactions_set_proofs
+            .into_iter()
+            .map(|p| p.into())
+            .collect();
         let expected_message = CardanoTransactionsProofsMessage::new(
+            certificate_hash,
             transactions_set_proofs,
             transactions_hashes_non_certified.to_vec(),
         );

--- a/mithril-aggregator/tests/open_message_expiration.rs
+++ b/mithril-aggregator/tests/open_message_expiration.rs
@@ -21,7 +21,7 @@ async fn open_message_expiration() {
     };
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
-        data_stores_directory: get_test_dir("create_certificate"),
+        data_stores_directory: get_test_dir("open_message_expiration"),
         ..Configuration::new_sample()
     };
     let mut tester =

--- a/mithril-aggregator/tests/open_message_newer_exists.rs
+++ b/mithril-aggregator/tests/open_message_newer_exists.rs
@@ -19,7 +19,7 @@ async fn open_message_newer_exists() {
     };
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
-        data_stores_directory: get_test_dir("create_certificate"),
+        data_stores_directory: get_test_dir("open_message_newer_exists"),
         ..Configuration::new_sample()
     };
     let mut tester =

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.159"
+version = "0.2.160"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -3,7 +3,7 @@ use hex::{FromHex, ToHex};
 use kes_summed_ed25519::kes::Sum6KesSig;
 use mithril_stm::stm::{StmAggrSig, StmAggrVerificationKey, StmSig, StmVerificationKeyPoP};
 
-use crate::crypto_helper::{OpCert, ProtocolKey, ProtocolKeyCodec, D};
+use crate::crypto_helper::{MKProof, OpCert, ProtocolKey, ProtocolKeyCodec, D};
 use crate::StdResult;
 
 /// Wrapper of [MithrilStm:StmVerificationKeyPoP](type@StmVerificationKeyPoP) to add serialization
@@ -34,6 +34,9 @@ pub type ProtocolGenesisSecretKey = ProtocolKey<ed25519_dalek::SigningKey>;
 
 /// Wrapper of [MithrilStm:StmAggrVerificationKey](struct@StmAggrVerificationKey).
 pub type ProtocolAggregateVerificationKey = ProtocolKey<StmAggrVerificationKey<D>>;
+
+/// Wrapper of [MKProof] to add serialization utilities.
+pub type ProtocolMkProof = ProtocolKey<MKProof>;
 
 impl ProtocolGenesisSignature {
     /// Create an instance from a bytes hex representation
@@ -80,6 +83,7 @@ impl ProtocolKeyCodec<ed25519_dalek::Signature> for ed25519_dalek::Signature {
 
 impl_codec_and_type_conversions_for_protocol_key!(
     json_hex_codec => StmVerificationKeyPoP, Sum6KesSig, StmSig, StmAggrSig<D>, OpCert,
-        ed25519_dalek::VerifyingKey, ed25519_dalek::SigningKey, StmAggrVerificationKey<D>
+        ed25519_dalek::VerifyingKey, ed25519_dalek::SigningKey, StmAggrVerificationKey<D>,
+        MKProof
 );
 impl_codec_and_type_conversions_for_protocol_key!(no_default_codec => ed25519_dalek::Signature);

--- a/mithril-common/src/entities/cardano_transactions_set_proof.rs
+++ b/mithril-common/src/entities/cardano_transactions_set_proof.rs
@@ -1,7 +1,7 @@
 use crate::crypto_helper::{MKProof, MKTree, MKTreeNode, MKTreeStore, ProtocolMkProof};
 use crate::entities::TransactionHash;
 use crate::messages::CardanoTransactionsSetProofMessagePart;
-use crate::StdResult;
+use crate::{StdError, StdResult};
 
 /// A cryptographic proof of a set of Cardano transactions is included in the global Cardano transactions set
 #[derive(Clone, Debug, PartialEq)]
@@ -63,12 +63,14 @@ impl CardanoTransactionsSetProof {
     }
 }
 
-impl From<CardanoTransactionsSetProof> for CardanoTransactionsSetProofMessagePart {
-    fn from(proof: CardanoTransactionsSetProof) -> Self {
-        Self {
+impl TryFrom<CardanoTransactionsSetProof> for CardanoTransactionsSetProofMessagePart {
+    type Error = StdError;
+
+    fn try_from(proof: CardanoTransactionsSetProof) -> Result<Self, Self::Error> {
+        Ok(Self {
             transactions_hashes: proof.transactions_hashes,
-            proof: proof.transactions_proof.to_json_hex().unwrap(),
-        }
+            proof: proof.transactions_proof.to_json_hex()?,
+        })
     }
 }
 

--- a/mithril-common/src/messages/cardano_transactions_proof.rs
+++ b/mithril-common/src/messages/cardano_transactions_proof.rs
@@ -1,11 +1,15 @@
-use crate::entities::{CardanoTransactionsSetProof, TransactionHash};
+use crate::entities::TransactionHash;
+use crate::messages::CardanoTransactionsSetProofMessagePart;
 use serde::{Deserialize, Serialize};
 
 /// A cryptographic proof for a set of Cardano transactions
 #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
 pub struct CardanoTransactionsProofsMessage {
+    /// Hash of the certificate that validate this proof merkle root
+    certificate_hash: String,
+
     /// Transactions that have been certified
-    certified_transactions: Vec<CardanoTransactionsSetProof>,
+    certified_transactions: Vec<CardanoTransactionsSetProofMessagePart>,
 
     /// Transactions that could not be certified
     non_certified_transactions: Vec<TransactionHash>,
@@ -14,10 +18,12 @@ pub struct CardanoTransactionsProofsMessage {
 impl CardanoTransactionsProofsMessage {
     /// Create a new `CardanoTransactionsProofsMessage`
     pub fn new(
-        certified_transactions: Vec<CardanoTransactionsSetProof>,
+        certificate_hash: &str,
+        certified_transactions: Vec<CardanoTransactionsSetProofMessagePart>,
         non_certified_transactions: Vec<TransactionHash>,
     ) -> Self {
         Self {
+            certificate_hash: certificate_hash.to_string(),
             certified_transactions,
             non_certified_transactions,
         }

--- a/mithril-common/src/messages/message_parts/cardano_transactions_set_proof.rs
+++ b/mithril-common/src/messages/message_parts/cardano_transactions_set_proof.rs
@@ -1,0 +1,12 @@
+use crate::entities::{HexEncodedKey, TransactionHash};
+use serde::{Deserialize, Serialize};
+
+/// A cryptographic proof of a set of Cardano transactions is included in the global Cardano transactions set
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CardanoTransactionsSetProofMessagePart {
+    /// Hashes of the certified transactions
+    pub transactions_hashes: Vec<TransactionHash>,
+
+    /// Proof of the transactions
+    pub proof: HexEncodedKey,
+}

--- a/mithril-common/src/messages/message_parts/mod.rs
+++ b/mithril-common/src/messages/message_parts/mod.rs
@@ -1,5 +1,7 @@
+mod cardano_transactions_set_proof;
 mod certificate_metadata;
 mod signer;
 
+pub use cardano_transactions_set_proof::CardanoTransactionsSetProofMessagePart;
 pub use certificate_metadata::CertificateMetadataMessagePart;
 pub use signer::{SignerMessagePart, SignerWithStakeMessagePart};

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.15
+  version: 0.1.16
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -342,6 +342,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CardanoTransactionProofMessage"
+        "404":
+          description: No Cardano transactions were ever signed
         "412":
           description: API version mismatch
         default:
@@ -1565,19 +1567,24 @@ components:
       type: object
       additionalProperties: false
       required:
+        - certificate_hash
         - certified_transactions
         - non_certified_transactions
       properties:
+        certificate_hash:
+          description: Hash of the certificate that validate the merkle root of this proof
+          type: string
+          format: bytes
         certified_transactions:
           description: Proofs for certified Cardano transactions
           type: array
           items:
             type: object
             required:
-              - transaction_hashes
+              - transactions_hashes
               - proof
             properties:
-              transaction_hashes:
+              transactions_hashes:
                 type: array
                 items:
                   description: Hash of the Cardano transactions
@@ -1595,8 +1602,9 @@ components:
             format: bytes
       example:
         {
+          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
           "certified_transactions": [{
-            "transaction_hashes": ["6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732", "5d0d1272e6e70736a1ea2cae34015876367ee64517f6328364f6b73930966732"],
+            "transactions_hashes": ["6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732", "5d0d1272e6e70736a1ea2cae34015876367ee64517f6328364f6b73930966732"],
             "proof": "5b73136372c38302c37342c3136362c313535b5b323136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c313532352c3230332c3235352c313030262c33136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c31358322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537"
           }],
           "non_certified_transactions": ["732d0d1272e6e70736367ee6f6328364f6b739309666a1ea2cae34015874517"],


### PR DESCRIPTION
## Content

This PR modify the `/proof/cardano-transaction` endpoint so it returns the certificate hash on which the proof merkle root relates to.
This also means that the `ProverService::compute_transactions_proofs` (and the repository behind it) now limit the set of transactions that's they works on. This in order to only works on what have been certified else they could work on transactions that are not in a certificate yet (typically the aggregator is waiting for single signatures).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1468
