### PR TITLE
Fix clippy lint from rust 1.76

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3426,7 +3426,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.2.162"
+version = "0.2.163"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.14"
+version = "0.3.15"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.2.162"
+version = "0.2.163"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/chain_observer/cli_observer.rs
+++ b/mithril-common/src/chain_observer/cli_observer.rs
@@ -492,8 +492,8 @@ mod tests {
     #[tokio::test]
     async fn test_cli_testnet_runner() {
         let runner = CardanoCliRunner::new(
-            PathBuf::new().join("cardano-cli"),
-            PathBuf::new().join("/tmp/whatever.sock"),
+            PathBuf::from("cardano-cli"),
+            PathBuf::from("/tmp/whatever.sock"),
             CardanoNetwork::TestNet(10),
         );
 
@@ -504,8 +504,8 @@ mod tests {
     #[tokio::test]
     async fn test_cli_devnet_runner() {
         let runner = CardanoCliRunner::new(
-            PathBuf::new().join("cardano-cli"),
-            PathBuf::new().join("/tmp/whatever.sock"),
+            PathBuf::from("cardano-cli"),
+            PathBuf::from("/tmp/whatever.sock"),
             CardanoNetwork::DevNet(25),
         );
 
@@ -516,8 +516,8 @@ mod tests {
     #[tokio::test]
     async fn test_cli_mainnet_runner() {
         let runner = CardanoCliRunner::new(
-            PathBuf::new().join("cardano-cli"),
-            PathBuf::new().join("/tmp/whatever.sock"),
+            PathBuf::from("cardano-cli"),
+            PathBuf::from("/tmp/whatever.sock"),
             CardanoNetwork::MainNet,
         );
 

--- a/mithril-common/src/signable_builder/mod.rs
+++ b/mithril-common/src/signable_builder/mod.rs
@@ -16,5 +16,5 @@ cfg_fs! {
     pub use cardano_transactions::*;
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "fs"))]
 pub use cardano_transactions::MockTransactionStore;

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.14"
+version = "0.3.15"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/merkle_tree.rs
+++ b/mithril-stm/src/merkle_tree.rs
@@ -295,7 +295,7 @@ impl<D: Clone + Digest> MerkleTreeCommitmentBatchCompat<D> {
     // todo: Maybe we want more granular errors, rather than only `BatchPathInvalid`
     pub fn check(
         &self,
-        batch_val: &Vec<MTLeaf>,
+        batch_val: &[MTLeaf],
         proof: &BatchPath<D>,
     ) -> Result<(), MerkleTreeError<D>>
     where


### PR DESCRIPTION
## Content

This PR fix the clippy lints that are raised from the latest rust version (1.76)

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
