### PR TITLE
Fix clippy warning in common when using only `fs` flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3454,7 +3454,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.2"
+version = "0.3.3"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/chain_observer/mod.rs
+++ b/mithril-common/src/chain_observer/mod.rs
@@ -1,31 +1,28 @@
 //! Tools to request metadata, like the current epoch or the stake distribution, from the Cardano
 
-#[cfg(all(feature = "fs", feature = "random"))]
-mod builder;
-#[cfg(all(feature = "fs", feature = "random"))]
-mod cli_observer;
 mod interface;
 mod model;
-#[cfg(all(feature = "fs", feature = "random"))]
-mod pallas_observer;
 
-#[cfg(all(test, feature = "fs", feature = "random"))]
-mod test_cli_runner;
-
-#[cfg(all(feature = "fs", feature = "random"))]
-pub use builder::{ChainObserverBuilder, ChainObserverType};
-#[cfg(all(feature = "fs", feature = "random"))]
-pub use cli_observer::CliRunner;
-#[cfg(all(feature = "fs", feature = "random"))]
-pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
 #[cfg(test)]
 pub use interface::MockChainObserver;
 pub use interface::{ChainObserver, ChainObserverError};
 pub use model::{
     ChainAddress, TxDatum, TxDatumBuilder, TxDatumError, TxDatumFieldTypeName, TxDatumFieldValue,
 };
-#[cfg(all(feature = "fs", feature = "random"))]
-pub use pallas_observer::PallasChainObserver;
+
+cfg_fs_random! {
+    mod builder;
+    mod cli_observer;
+    mod pallas_observer;
+
+    #[cfg(test)]
+    mod test_cli_runner;
+
+    pub use builder::{ChainObserverBuilder, ChainObserverType};
+    pub use cli_observer::CliRunner;
+    pub use cli_observer::{CardanoCliChainObserver, CardanoCliRunner};
+    pub use pallas_observer::PallasChainObserver;
+}
 
 cfg_test_tools! {
     mod fake_observer;

--- a/mithril-common/src/chain_observer/model.rs
+++ b/mithril-common/src/chain_observer/model.rs
@@ -7,11 +7,12 @@ use thiserror::Error;
 
 use crate::{StdError, StdResult};
 
-cfg_fs! {
+cfg_fs_random! {
     use serde::Deserialize;
     use anyhow::Context;
     use minicbor::{Decode, Decoder, decode};
     use pallas_primitives::{alonzo::PlutusData, ToCanonicalJson};
+
     /// [Datum] represents an inline datum from UTxO.
     #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
     #[serde(rename_all = "lowercase")]

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -30,6 +30,16 @@ macro_rules! cfg_random {
     }
 }
 
+macro_rules! cfg_fs_random {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(feature = "fs", feature = "random"))]
+            #[cfg_attr(docsrs, doc(all(feature = "fs", feature = "random")))]
+            $item
+        )*
+    }
+}
+
 macro_rules! cfg_test_tools {
     ($($item:item)*) => {
         $(


### PR DESCRIPTION
## Content

This PR fix the clippy warning that can be seen in some [CI jobs](https://github.com/input-output-hk/mithril/actions/runs/7889979563/job/21532181108) : 

```shell
Run cargo build --lib --release --package mithril-stm --package mithril-client --features full,unstable 
   Compiling mithril-common v0.3.2+80ee079 (/home/runner/work/mithril/mithril/mithril-common)
   Compiling mithril-stm v0.3.15+80ee079 (/home/runner/work/mithril/mithril/mithril-stm)
warning: function `try_inspect` is never used
  --> mithril-common/src/chain_observer/model.rs:33:12
   |
33 |     pub fn try_inspect<R>(inner: Vec<u8>) -> StdResult<R>
   |            ^^^^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: type alias `Datums` is never used
  --> mithril-common/src/chain_observer/model.rs:46:14
   |
46 |     pub type Datums = Vec<TxDatum>;
   |              ^^^^^^

warning: `mithril-common` (lib) generated 2 warnings
   Compiling mithril-client v0.6.2+80ee079 (/home/runner/work/mithril/mithril/mithril-client)
    Finished release [optimized] target(s) in 14.12s
```

It also add a `cfg_fs_random` "flag" in `mithril-common` to correctly document the feature flag needed by some objects.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
