### PR TITLE
Enhance client-cli standard output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-transaction"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "client-mithril-stake-distribution"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3400,7 +3400,7 @@ version = "0.1.0"
 
 [[package]]
 name = "mithril-client"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "async-trait",
  "futures",
@@ -3478,7 +3478,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3549,7 +3549,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3598,7 +3598,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client.md
@@ -15,9 +15,11 @@ Mithril client is responsible for restoring the **Cardano** blockchain on an emp
 
 :::tip
 
-* For more information about the **Mithril network**, please see the [architecture](../../../mithril/mithril-network/architecture.md) overview.
+* For more information about the **Mithril network**, please see
+  the [architecture](../../../mithril/mithril-network/architecture.md) overview.
 
-* For more information about the **Mithril client** node, please see [this overview](../../../mithril/mithril-network/client.md).
+* For more information about the **Mithril client** node, please
+  see [this overview](../../../mithril/mithril-network/client.md).
 
 * Check out the [`Bootstrap a Cardano node`](../../getting-started/bootstrap-cardano-node.md) guide.
 
@@ -29,7 +31,6 @@ Mithril client is responsible for restoring the **Cardano** blockchain on an emp
 
 :::
 
-
 ## Resources
 
 | Node | Source repository | Rust documentation | Docker packages |
@@ -38,7 +39,8 @@ Mithril client is responsible for restoring the **Cardano** blockchain on an emp
 
 ## Pre-requisites
 
-* Install the latest stable version of the [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain.
+* Install the latest stable version of the [correctly configured](https://www.rust-lang.org/learn/get-started) Rust
+  toolchain.
 
 * Install OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`
 
@@ -64,7 +66,7 @@ Switch to the desired branch/tag:
 git checkout **YOUR_BUILD_BRANCH_OR_TAG**
 ```
 
-Change the directory: 
+Change the directory:
 
 ```bash
 cd mithril/mithril-client-cli
@@ -198,7 +200,8 @@ If you wish to delve deeper and access several levels of logs from the Mithril c
 
 ### Registry image
 
-A list of available images on the registry can be found [here](https://github.com/input-output-hk/mithril/pkgs/container/mithril-client).
+A list of available images on the registry can be
+found [here](https://github.com/input-output-hk/mithril/pkgs/container/mithril-client).
 
 To prepare the environment variables, retrieve the values from the above **Mithril networks** table.
 
@@ -249,11 +252,11 @@ mithril_client mithril-stake-distribution list
 # 6- Download and verify the given Mithril stake distribution
 mithril_client mithril-stake-distribution download $MITHRIL_STAKE_DISTRIBUTION_ARTIFACT_HASH
 
-# 7- List Cardano transaction sets
-mithril_client --unstable cardano-transaction sets list
+# 7- List Cardano transaction commitments
+mithril_client --unstable cardano-transaction commitment list
 
-# 8- Show detailed information about a Cardano transaction sets
-mithril_client --unstable cardano-transaction sets show $CARDANO_TRANSACTION_SETS_HASH 
+# 8- Show detailed information about a Cardano transaction commitment
+mithril_client --unstable cardano-transaction commitment show $CARDANO_TRANSACTION_COMMITMENT_HASH
 
 # 9- Certify that given list of transactions hashes are included in the Cardano transactions set
 mithril_client --unstable cardano-transaction certify $TRANSACTION_HASH_1,$TRANSACTION_HASH_2
@@ -299,15 +302,16 @@ Here are the subcommands available:
 | Subcommand | Performed action |
 |------------|------------------|
 | **certify** | Certifies that given list of transactions hashes are included in the Cardano transactions set|
+| **commitment list** | Lists available Cardano transactions commitments|
+| **commitment show** | Shows information about a Cardano transactions commitment|
 | **help** | Prints this message or the help for the given subcommand(s)|
-| **sets list** | Lists available Cardano transactions sets|
-| **sets show** | Shows information about a Cardano transaction sets|
 
 ## Configuration parameters
 
 The configuration parameters can be set in either of the following ways:
 
-1. In a configuration file, depending on the `--run-mode` parameter. If the runtime mode is `testnet`, the file is located in `./conf/testnet.json`.
+1. In a configuration file, depending on the `--run-mode` parameter. If the runtime mode is `testnet`, the file is
+   located in `./conf/testnet.json`.
 
 2. The value can be overridden by an environment variable with the parameter name in uppercase.
 
@@ -358,20 +362,20 @@ Here is a list of the available parameters:
 | `artifact_hash` | `--artifact-hash` | - | - | Hash of the Mithril stake distribution artifact or `latest` for the latest artifact | - | - | :heavy_check_mark: |
 | `download_dir` | `--download-dir` | - | - | Directory where the Mithril stake distribution will be downloaded | . | - | - |
 
-`cardano-transaction --unstable sets show` command:
+`cardano-transaction commitment show` command:
 
 | Parameter | Command line (long) |  Command line (short) | Environment variable | Description | Default value | Example | Mandatory |
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
-| `hash` | `--hash` | - | `HASH` | Cardano transaction sets hash or `latest` for the latest Cardano transaction sets | - | - | :heavy_check_mark: |
+| `hash` | `--hash` | - | `HASH` | Cardano transaction commitment hash or `latest` for the latest Cardano transaction commitment | - | - | :heavy_check_mark: |
 | `json` | `--json` | - | - | Enable JSON output for command results | - | - | - |
 
-`cardano-transaction --unstable sets list` command:
+`cardano-transaction commitment list` command:
 
 | Parameter | Command line (long) |  Command line (short) | Environment variable | Description | Default value | Example | Mandatory |
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|
 | `json` | `--json` | - | - | Enable JSON output for command results | - | - | - |
 
-`cardano-transaction --unstable download` command:
+`cardano-transaction certify` command:
 
 | Parameter | Command line (long) |  Command line (short) | Environment variable | Description | Default value | Example | Mandatory |
 |-----------|---------------------|:---------------------:|----------------------|-------------|---------------|---------|:---------:|

--- a/examples/client-cardano-transaction/Cargo.toml
+++ b/examples/client-cardano-transaction/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-transaction"
 description = "Mithril client cardano-transaction example"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-transaction/src/main.rs
+++ b/examples/client-cardano-transaction/src/main.rs
@@ -50,7 +50,7 @@ async fn main() -> MithrilResult<()> {
 
     info!(logger, "Fetching a proof for the given transactions...",);
     let cardano_transaction_proof = client
-        .cardano_transaction_proof()
+        .cardano_transaction()
         .get_proofs(transactions_hashes)
         .await
         .unwrap();

--- a/examples/client-mithril-stake-distribution/Cargo.toml
+++ b/examples/client-mithril-stake-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-mithril-stake-distribution"
 description = "Mithril client stake distribution example"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-mithril-stake-distribution/src/main.rs
+++ b/examples/client-mithril-stake-distribution/src/main.rs
@@ -1,8 +1,6 @@
 //! This example shows how to implement a Mithril client and use its features.
 //!
 //! In this example, the client interacts by default with a real aggregator (`testing-preview`) to get the data.
-//!
-//! The [SlogFeedbackReceiver] is used to report the progress to the console.
 
 use anyhow::anyhow;
 use clap::Parser;

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.6.2"
+version = "0.7.0"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_transaction/certify.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/certify.rs
@@ -49,7 +49,7 @@ impl CardanoTransactionsCertifyCommand {
 
         progress_printer.report_step(1, "Fetching a proof for the given transactions…")?;
         let cardano_transaction_proof = client
-            .cardano_transaction_proof()
+            .cardano_transaction()
             .get_proofs(&self.transactions_hashes)
             .await
             .with_context(|| {

--- a/mithril-client-cli/src/commands/cardano_transaction/commitment_list.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/commitment_list.rs
@@ -8,15 +8,15 @@ use crate::commands::client_builder_with_fallback_genesis_key;
 use crate::configuration::ConfigParameters;
 use mithril_client::MithrilResult;
 
-/// Cardano transaction commitment LIST command
+/// Cardano transaction commitment list command
 #[derive(Parser, Debug, Clone)]
-pub struct CardanoTransactionSetsListCommand {
+pub struct CardanoTransactionCommitmentListCommand {
     /// Enable JSON output.
     #[clap(long)]
     json: bool,
 }
 
-impl CardanoTransactionSetsListCommand {
+impl CardanoTransactionCommitmentListCommand {
     /// Main command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;

--- a/mithril-client-cli/src/commands/cardano_transaction/commitment_list.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/commitment_list.rs
@@ -22,7 +22,7 @@ impl CardanoTransactionCommitmentListCommand {
         let config = config_builder.build()?;
         let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
-        let lines = client.cardano_transaction().list().await?;
+        let lines = client.cardano_transaction().list_commitments().await?;
 
         if self.json {
             println!("{}", serde_json::to_string(&lines)?);

--- a/mithril-client-cli/src/commands/cardano_transaction/commitment_show.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/commitment_show.rs
@@ -32,7 +32,7 @@ impl CardanoTransactionsCommitmentShowCommand {
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
 
         let get_list_of_artifact_ids = || async {
-            let transactions_sets = client.cardano_transaction().list().await.with_context(|| {
+            let transactions_sets = client.cardano_transaction().list_commitments().await.with_context(|| {
                 "Can not get the list of artifacts while retrieving the latest Cardano transaction commitment hash"
             })?;
 
@@ -44,7 +44,7 @@ impl CardanoTransactionsCommitmentShowCommand {
 
         let tx_sets = client
             .cardano_transaction()
-            .get(
+            .get_commitment(
                 &ExpanderUtils::expand_eventual_id_alias(&self.hash, get_list_of_artifact_ids())
                     .await?,
             )

--- a/mithril-client-cli/src/commands/cardano_transaction/commitment_show.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/commitment_show.rs
@@ -10,21 +10,22 @@ use crate::{
 };
 use mithril_client::MithrilResult;
 
-/// Clap command to show a given Cardano transaction sets
+/// Clap command to show a given Cardano transaction commitment
 #[derive(Parser, Debug, Clone)]
-pub struct CardanoTransactionsSetsShowCommand {
+pub struct CardanoTransactionsCommitmentShowCommand {
     /// Enable JSON output.
     #[clap(long)]
     json: bool,
 
-    /// Cardano transaction sets hash.
+    /// Cardano transaction commitment hash.
     ///
-    /// If `latest` is specified as hash, the command will return the latest Cardano transaction sets.
+    /// If `latest` is specified as hash, the command will return the latest Cardano transaction
+    /// commitment.
     hash: String,
 }
 
-impl CardanoTransactionsSetsShowCommand {
-    /// Cardano transaction sets Show command
+impl CardanoTransactionsCommitmentShowCommand {
+    /// Cardano transaction commitment Show command
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;
         let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
@@ -32,7 +33,7 @@ impl CardanoTransactionsSetsShowCommand {
 
         let get_list_of_artifact_ids = || async {
             let transactions_sets = client.cardano_transaction().list().await.with_context(|| {
-                "Can not get the list of artifacts while retrieving the latest Cardano transaction sets hash"
+                "Can not get the list of artifacts while retrieving the latest Cardano transaction commitment hash"
             })?;
 
             Ok(transactions_sets
@@ -50,7 +51,7 @@ impl CardanoTransactionsSetsShowCommand {
             .await?
             .ok_or_else(|| {
                 anyhow!(
-                    "Cardano transaction sets not found for hash: '{}'",
+                    "Cardano transaction commitment not found for hash: '{}'",
                     &self.hash
                 )
             })?;

--- a/mithril-client-cli/src/commands/cardano_transaction/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/mod.rs
@@ -1,11 +1,11 @@
 //! Commands for the Cardano Transaction Commitment artifact & Cardano Transactions Proof
 mod certify;
-mod sets_list;
-mod sets_show;
+mod commitment_list;
+mod commitment_show;
 
 pub use certify::*;
-pub use sets_list::*;
-pub use sets_show::*;
+pub use commitment_list::*;
+pub use commitment_show::*;
 
 use clap::Subcommand;
 use config::builder::DefaultState;
@@ -16,9 +16,9 @@ use mithril_client::MithrilResult;
 #[derive(Subcommand, Debug, Clone)]
 #[command(about = "[unstable] Cardano transactions management (alias: ctx)")]
 pub enum CardanoTransactionCommands {
-    /// Cardano transaction sets commands
+    /// Cardano transaction commitment commands
     #[clap(subcommand)]
-    Sets(CardanoTransactionSetsCommands),
+    Commitment(CardanoTransactionCommitmentCommands),
 
     /// Certify that a given list of transaction hashes are included in the Cardano transactions set
     #[clap(arg_required_else_help = false)]
@@ -27,28 +27,28 @@ pub enum CardanoTransactionCommands {
 
 /// Cardano transactions set
 #[derive(Subcommand, Debug, Clone)]
-pub enum CardanoTransactionSetsCommands {
+pub enum CardanoTransactionCommitmentCommands {
     /// List Cardano transaction sets
     #[clap(arg_required_else_help = false)]
-    List(CardanoTransactionSetsListCommand),
+    List(CardanoTransactionCommitmentListCommand),
 
     /// Show Cardano transaction sets
     #[clap(arg_required_else_help = false)]
-    Show(CardanoTransactionsSetsShowCommand),
+    Show(CardanoTransactionsCommitmentShowCommand),
 }
 
 impl CardanoTransactionCommands {
     /// Execute Cardano transaction command
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         match self {
-            Self::Sets(cmd) => cmd.execute(config_builder).await,
+            Self::Commitment(cmd) => cmd.execute(config_builder).await,
             Self::Certify(cmd) => cmd.execute(config_builder).await,
         }
     }
 }
 
-impl CardanoTransactionSetsCommands {
-    /// Execute Cardano transaction sets command
+impl CardanoTransactionCommitmentCommands {
+    /// Execute Cardano transaction commitment command
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,

--- a/mithril-client-cli/src/commands/cardano_transaction/sets_list.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/sets_list.rs
@@ -22,7 +22,7 @@ impl CardanoTransactionSetsListCommand {
         let config = config_builder.build()?;
         let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
-        let lines = client.cardano_transaction_proof().list().await?;
+        let lines = client.cardano_transaction().list().await?;
 
         if self.json {
             println!("{}", serde_json::to_string(&lines)?);

--- a/mithril-client-cli/src/commands/cardano_transaction/sets_show.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/sets_show.rs
@@ -31,7 +31,7 @@ impl CardanoTransactionsSetsShowCommand {
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
 
         let get_list_of_artifact_ids = || async {
-            let transactions_sets = client.cardano_transaction_proof().list().await.with_context(|| {
+            let transactions_sets = client.cardano_transaction().list().await.with_context(|| {
                 "Can not get the list of artifacts while retrieving the latest Cardano transaction sets hash"
             })?;
 
@@ -42,7 +42,7 @@ impl CardanoTransactionsSetsShowCommand {
         };
 
         let tx_sets = client
-            .cardano_transaction_proof()
+            .cardano_transaction()
             .get(
                 &ExpanderUtils::expand_eventual_id_alias(&self.hash, get_list_of_artifact_ids())
                     .await?,

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -41,8 +41,8 @@ impl LogOutputType {
 #[derive(Documenter, Parser, Debug, Clone)]
 #[clap(name = "mithril-client")]
 #[clap(
-    about = "This program shows, downloads and verifies certified blockchain artifacts.",
-    long_about = None
+about = "This program shows, downloads and verifies certified blockchain artifacts.",
+long_about = None
 )]
 #[command(version)]
 pub struct Args {
@@ -221,8 +221,13 @@ mod tests {
 
     #[tokio::test]
     async fn fail_if_cardano_tx_command_is_used_without_unstable_flag() {
-        let args = Args::try_parse_from(["mithril-client", "cardano-transaction", "sets", "list"])
-            .unwrap();
+        let args = Args::try_parse_from([
+            "mithril-client",
+            "cardano-transaction",
+            "commitment",
+            "list",
+        ])
+        .unwrap();
 
         args.execute()
             .await

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -20,14 +20,14 @@ use mithril_client_cli::commands::{
 };
 
 enum LogOutputType {
-    Stdout,
+    StdErr,
     File(String),
 }
 
 impl LogOutputType {
     fn get_writer(&self) -> MithrilResult<Box<dyn Write + Send>> {
         let writer: Box<dyn Write + Send> = match self {
-            LogOutputType::Stdout => Box::new(std::io::stdout()),
+            LogOutputType::StdErr => Box::new(std::io::stderr()),
             LogOutputType::File(filepath) => Box::new(
                 File::create(filepath)
                     .with_context(|| format!("Can not create output log file: {}", filepath))?,
@@ -109,7 +109,7 @@ impl Args {
         if let Some(output_filepath) = &self.log_output {
             LogOutputType::File(output_filepath.to_string())
         } else {
-            LogOutputType::Stdout
+            LogOutputType::StdErr
         }
     }
 
@@ -131,7 +131,7 @@ impl Args {
             slog_async::Async::new(drain).build().fuse()
         } else {
             match log_output_type {
-                LogOutputType::Stdout => self.wrap_drain(slog_term::TermDecorator::new().build()),
+                LogOutputType::StdErr => self.wrap_drain(slog_term::TermDecorator::new().build()),
                 LogOutputType::File(_) => self.wrap_drain(slog_term::PlainDecorator::new(writer)),
             }
         };

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -49,7 +49,7 @@ impl ProgressPrinter {
     /// Report the current step
     pub fn report_step(&self, step_number: u16, text: &str) -> MithrilResult<()> {
         match self.output_type {
-            ProgressOutputType::JsonReporter => println!(
+            ProgressOutputType::JsonReporter => eprintln!(
                 r#"{{"timestamp": "{timestamp}", "step_num": {step_number}, "total_steps": {number_of_steps}, "message": "{text}"}}"#,
                 timestamp = Utc::now().to_rfc3339(),
                 number_of_steps = self.number_of_steps,
@@ -119,7 +119,7 @@ impl DownloadProgressReporter {
             };
 
             if should_report {
-                println!("{}", ProgressBarJsonFormatter::format(&self.progress_bar));
+                eprintln!("{}", ProgressBarJsonFormatter::format(&self.progress_bar));
 
                 match self.last_json_report_instant.write() {
                     Ok(mut instant) => *instant = Some(Instant::now()),

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.1.10"
+version = "0.1.11"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -225,8 +225,8 @@ impl MithrilUnstableClient {
     pub async fn list_cardano_transactions_commitments(&self) -> WasmResult {
         let result = self
             .client
-            .cardano_transaction_proof()
-            .list()
+            .cardano_transaction()
+            .list_commitments()
             .await
             .map_err(|err| format!("{err:?}"))?;
 
@@ -238,8 +238,8 @@ impl MithrilUnstableClient {
     pub async fn get_cardano_transactions_commitment(&self, hash: &str) -> WasmResult {
         let result = self
             .client
-            .cardano_transaction_proof()
-            .get(hash)
+            .cardano_transaction()
+            .get_commitment(hash)
             .await
             .map_err(|err| format!("{err:?}"))?
             .ok_or(JsValue::from_str(&format!(
@@ -267,7 +267,7 @@ impl MithrilUnstableClient {
 
         let result = self
             .client
-            .cardano_transaction_proof()
+            .cardano_transaction()
             .get_proofs(&hashes)
             .await
             .map_err(|err| format!("{err:?}"))?;

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.6.3"
+version = "0.6.4"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/client.rs
+++ b/mithril-client/src/client.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use crate::aggregator_client::{AggregatorClient, AggregatorHTTPClient};
 #[cfg(feature = "unstable")]
-use crate::cardano_transaction_proof_client::CardanoTransactionProofClient;
+use crate::cardano_transaction_client::CardanoTransactionClient;
 use crate::certificate_client::{
     CertificateClient, CertificateVerifier, MithrilCertificateVerifier,
 };
@@ -23,7 +23,7 @@ use crate::MithrilResult;
 #[derive(Clone)]
 pub struct Client {
     #[cfg(feature = "unstable")]
-    cardano_transaction_proof_client: Arc<CardanoTransactionProofClient>,
+    cardano_transaction_client: Arc<CardanoTransactionClient>,
     certificate_client: Arc<CertificateClient>,
     mithril_stake_distribution_client: Arc<MithrilStakeDistributionClient>,
     snapshot_client: Arc<SnapshotClient>,
@@ -32,8 +32,8 @@ pub struct Client {
 impl Client {
     /// Get the client that fetches and verifies Mithril Cardano transaction proof.
     #[cfg(feature = "unstable")]
-    pub fn cardano_transaction_proof(&self) -> Arc<CardanoTransactionProofClient> {
-        self.cardano_transaction_proof_client.clone()
+    pub fn cardano_transaction(&self) -> Arc<CardanoTransactionClient> {
+        self.cardano_transaction_client.clone()
     }
 
     /// Get the client that fetches and verifies Mithril certificates.
@@ -140,9 +140,8 @@ impl ClientBuilder {
         };
 
         #[cfg(feature = "unstable")]
-        let cardano_transaction_proof_client = Arc::new(CardanoTransactionProofClient::new(
-            aggregator_client.clone(),
-        ));
+        let cardano_transaction_client =
+            Arc::new(CardanoTransactionClient::new(aggregator_client.clone()));
 
         let certificate_verifier = match self.certificate_verifier {
             None => Arc::new(
@@ -177,7 +176,7 @@ impl ClientBuilder {
 
         Ok(Client {
             #[cfg(feature = "unstable")]
-            cardano_transaction_proof_client,
+            cardano_transaction_client,
             certificate_client,
             mithril_stake_distribution_client,
             snapshot_client,

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! - [Snapshot][snapshot_client] list, get, download tarball and record statistics.
 //! - [Mithril stake distribution][mithril_stake_distribution_client] list and get.
-//! - [Cardano transactions proofs][cardano_transaction_proof_client] list & get commitment, get proofs
+//! - [Cardano transactions proofs][cardano_transaction_client] list & get commitment, get proofs
 //! _(available using crate feature_ **unstable**_)_.
 //! - [Certificates][certificate_client] list, get, and chain validation.
 //!
@@ -84,7 +84,7 @@ macro_rules! cfg_unstable {
 
 pub mod aggregator_client;
 cfg_unstable! {
-    pub mod cardano_transaction_proof_client;
+    pub mod cardano_transaction_client;
 }
 pub mod certificate_client;
 mod client;

--- a/mithril-client/src/type_alias.rs
+++ b/mithril-client/src/type_alias.rs
@@ -43,6 +43,8 @@ cfg_unstable! {
 
     pub use mithril_common::messages::VerifiedCardanoTransactions;
 
+    pub use mithril_common::messages::VerifyCardanoTransactionsProofsError;
+
     /// A commitment that Mithril have certified Cardano transactions up to a given [point of time][common::Beacon].
     ///
     pub use mithril_common::messages::CardanoTransactionCommitmentMessage as CardanoTransactionCommitment;

--- a/mithril-client/tests/cardano_transaction_proof.rs
+++ b/mithril-client/tests/cardano_transaction_proof.rs
@@ -17,10 +17,10 @@ async fn cardano_transaction_proof_get_validate() {
         .with_certificate_verifier(FakeCertificateVerifier::build_that_validate_any_certificate())
         .build()
         .expect("Should be able to create a Client");
-    let cardano_transaction_proof_client = client.cardano_transaction_proof();
+    let cardano_transaction_client = client.cardano_transaction();
 
     // 1 - get list of set proofs for wanted tx & associated certificate hash
-    let proofs = cardano_transaction_proof_client
+    let proofs = cardano_transaction_client
         .get_proofs(&transactions_hashes)
         .await
         .expect("Getting proof for the transactions should not fail");

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.5"
+version = "0.3.6"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -100,14 +100,14 @@ default = []
 full = ["random", "fs", "test_tools"]
 random = ["rand_core/getrandom"]
 fs = [
-  "tokio/fs",
-  "tokio/process",
-  "dep:minicbor",
-  "dep:pallas-addresses",
-  "dep:pallas-codec",
-  "dep:pallas-network",
-  "dep:pallas-primitives",
-  "dep:pallas-traverse",
+    "tokio/fs",
+    "tokio/process",
+    "dep:minicbor",
+    "dep:pallas-addresses",
+    "dep:pallas-codec",
+    "dep:pallas-network",
+    "dep:pallas-primitives",
+    "dep:pallas-traverse",
 ]
 
 # Portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it

--- a/mithril-common/src/messages/cardano_transactions_proof.rs
+++ b/mithril-common/src/messages/cardano_transactions_proof.rs
@@ -73,12 +73,15 @@ impl VerifiedCardanoTransactions {
     }
 }
 
+/// Error encountered or produced by the [cardano transaction proof verification][CardanoTransactionsProofsMessage::verify].
 #[derive(Error, Debug)]
 pub enum VerifyCardanoTransactionsProofsError {
     /// The verification of an individual [CardanoTransactionsSetProofMessagePart] failed.
     #[error("Invalid set proof for transactions hashes: {transactions_hashes:?}")]
     InvalidSetProof {
+        /// Hashes of the invalid transactions
         transactions_hashes: Vec<TransactionHash>,
+        /// Error source
         source: StdError,
     },
 
@@ -89,7 +92,7 @@ pub enum VerifyCardanoTransactionsProofsError {
     /// Not all certified transactions set proof have the same merkle root.
     ///
     /// This is problematic because all the set proof should be generated from the same
-    /// merkle tree which root is signed in the [crate::entities::Certificate][certificate].
+    /// merkle tree which root is signed in the [certificate][crate::entities::Certificate].
     #[error("All certified transactions set proofs must share the same Merkle root")]
     NonMatchingMerkleRoot,
 
@@ -116,8 +119,11 @@ impl CardanoTransactionsProofsMessage {
     /// Verify that all the certified transactions proofs are valid
     ///
     /// The following checks will be executed:
+    ///
     /// 1 - Check that each Merkle proof is valid
+    ///
     /// 2 - Check that all proofs share the same Merkle root
+    ///
     /// 3 - Assert that there's at least one certified transaction
     ///
     /// If every check is okay, the hex encoded Merkle root of the proof will be returned.

--- a/mithril-common/src/messages/mod.rs
+++ b/mithril-common/src/messages/mod.rs
@@ -23,6 +23,7 @@ pub use cardano_transaction_commitment_list::{
 };
 pub use cardano_transactions_proof::{
     CardanoTransactionsProofsMessage, VerifiedCardanoTransactions,
+    VerifyCardanoTransactionsProofsError,
 };
 pub use certificate::CertificateMessage;
 pub use certificate_list::{

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.10"
+version = "0.1.11"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/src/p2p/error.rs
+++ b/mithril-relay/src/p2p/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-/// [Peer] related errors.
+/// [Peer][crate::p2p::Peer] related errors.
 #[derive(Debug, Error)]
 pub enum PeerError {
     /// Topic does not exist

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.3.2"
+version = "0.3.3"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
@@ -24,8 +24,8 @@ pub enum MithrilStakeDistributionCommand {
 
 #[derive(Debug)]
 pub enum CardanoTransactionCommand {
-    ListSets,
-    ShowSets { hash: String },
+    ListCommitment,
+    ShowCommitment { hash: String },
     Certify { tx_hashes: Vec<TransactionHash> },
 }
 
@@ -71,19 +71,19 @@ impl Client {
                 ],
             },
             ClientCommand::CardanoTransaction(subcommand) => match subcommand {
-                CardanoTransactionCommand::ListSets => {
+                CardanoTransactionCommand::ListCommitment => {
                     vec![
                         "--unstable".to_string(),
                         "cardano-transaction".to_string(),
-                        "sets".to_string(),
+                        "commitment".to_string(),
                         "list".to_string(),
                     ]
                 }
-                CardanoTransactionCommand::ShowSets { hash } => {
+                CardanoTransactionCommand::ShowCommitment { hash } => {
                     vec![
                         "--unstable".to_string(),
                         "cardano-transaction".to_string(),
-                        "sets".to_string(),
+                        "commitment".to_string(),
                         "show".to_string(),
                         hash,
                     ]

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
@@ -2,7 +2,7 @@ use crate::utils::MithrilCommand;
 use anyhow::{anyhow, Context};
 use mithril_common::{entities::TransactionHash, StdResult};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
 pub struct Client {
@@ -16,10 +16,54 @@ pub enum SnapshotCommand {
     Download { digest: String },
 }
 
+impl SnapshotCommand {
+    fn name(&self) -> String {
+        match self {
+            SnapshotCommand::List() => "list".to_string(),
+            SnapshotCommand::Show { digest } => format!("show-{digest}"),
+            SnapshotCommand::Download { digest } => format!("download-{digest}"),
+        }
+    }
+
+    fn cli_arg(&self) -> Vec<String> {
+        match self {
+            SnapshotCommand::List() => {
+                vec!["list".to_string()]
+            }
+            SnapshotCommand::Show { digest } => {
+                vec!["show".to_string(), digest.clone()]
+            }
+            SnapshotCommand::Download { digest } => {
+                vec!["download".to_string(), digest.clone()]
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum MithrilStakeDistributionCommand {
     List,
     Download { hash: String },
+}
+
+impl MithrilStakeDistributionCommand {
+    fn name(&self) -> String {
+        match self {
+            MithrilStakeDistributionCommand::List => "list".to_string(),
+            MithrilStakeDistributionCommand::Download { hash } => format!("download-{hash}"),
+        }
+    }
+
+    fn cli_arg(&self) -> Vec<String> {
+        match self {
+            MithrilStakeDistributionCommand::List => {
+                vec!["list".to_string()]
+            }
+            MithrilStakeDistributionCommand::Download { hash } => {
+                vec!["download".to_string(), hash.clone()]
+            }
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -29,11 +73,74 @@ pub enum CardanoTransactionCommand {
     Certify { tx_hashes: Vec<TransactionHash> },
 }
 
+impl CardanoTransactionCommand {
+    fn name(&self) -> String {
+        match self {
+            CardanoTransactionCommand::ListCommitment => "list-commitment".to_string(),
+            CardanoTransactionCommand::ShowCommitment { hash } => format!("show-commitment-{hash}"),
+            CardanoTransactionCommand::Certify { tx_hashes } if tx_hashes.len() > 1 => {
+                // Only output first & last hash to avoid too long filenames
+                format!("certify-{}..{}", tx_hashes[0], tx_hashes.last().unwrap())
+            }
+            CardanoTransactionCommand::Certify { tx_hashes } => {
+                format!("certify-{}", tx_hashes.first().unwrap_or(&String::new()))
+            }
+        }
+    }
+
+    fn cli_arg(&self) -> Vec<String> {
+        match self {
+            CardanoTransactionCommand::ListCommitment => {
+                vec!["commitment".to_string(), "list".to_string()]
+            }
+            CardanoTransactionCommand::ShowCommitment { hash } => {
+                vec!["commitment".to_string(), "show".to_string(), hash.clone()]
+            }
+            CardanoTransactionCommand::Certify { tx_hashes } => {
+                vec!["certify".to_string(), tx_hashes.join(",")]
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum ClientCommand {
     Snapshot(SnapshotCommand),
     MithrilStakeDistribution(MithrilStakeDistributionCommand),
     CardanoTransaction(CardanoTransactionCommand),
+}
+
+impl ClientCommand {
+    fn name(&self) -> String {
+        match self {
+            ClientCommand::Snapshot(cmd) => format!("snapshot-{}", cmd.name()),
+            ClientCommand::MithrilStakeDistribution(cmd) => {
+                format!("msd-{}", cmd.name())
+            }
+            ClientCommand::CardanoTransaction(cmd) => {
+                format!("ctx-{}", cmd.name())
+            }
+        }
+    }
+
+    fn cli_arg(&self) -> Vec<String> {
+        let mut args = match self {
+            ClientCommand::Snapshot(cmd) => [vec!["snapshot".to_string()], cmd.cli_arg()].concat(),
+            ClientCommand::MithrilStakeDistribution(cmd) => [
+                vec!["mithril-stake-distribution".to_string()],
+                cmd.cli_arg(),
+            ]
+            .concat(),
+            ClientCommand::CardanoTransaction(cmd) => [
+                vec!["--unstable".to_string(), "cardano-transaction".to_string()],
+                cmd.cli_arg(),
+            ]
+            .concat(),
+        };
+        args.push("--json".to_string());
+
+        args
+    }
 }
 
 impl Client {
@@ -49,55 +156,11 @@ impl Client {
         Ok(Self { command })
     }
 
-    pub async fn run(&mut self, command: ClientCommand) -> StdResult<()> {
-        let args = match command {
-            ClientCommand::Snapshot(subcommand) => match subcommand {
-                SnapshotCommand::List() => vec!["snapshot".to_string(), "list".to_string()],
-                SnapshotCommand::Show { digest } => {
-                    vec!["snapshot".to_string(), "show".to_string(), digest]
-                }
-                SnapshotCommand::Download { digest } => {
-                    vec!["snapshot".to_string(), "download".to_string(), digest]
-                }
-            },
-            ClientCommand::MithrilStakeDistribution(subcommand) => match subcommand {
-                MithrilStakeDistributionCommand::List => {
-                    vec!["mithril-stake-distribution".to_string(), "list".to_string()]
-                }
-                MithrilStakeDistributionCommand::Download { hash } => vec![
-                    "mithril-stake-distribution".to_string(),
-                    "download".to_string(),
-                    hash,
-                ],
-            },
-            ClientCommand::CardanoTransaction(subcommand) => match subcommand {
-                CardanoTransactionCommand::ListCommitment => {
-                    vec![
-                        "--unstable".to_string(),
-                        "cardano-transaction".to_string(),
-                        "commitment".to_string(),
-                        "list".to_string(),
-                    ]
-                }
-                CardanoTransactionCommand::ShowCommitment { hash } => {
-                    vec![
-                        "--unstable".to_string(),
-                        "cardano-transaction".to_string(),
-                        "commitment".to_string(),
-                        "show".to_string(),
-                        hash,
-                    ]
-                }
-                CardanoTransactionCommand::Certify { tx_hashes } => {
-                    vec![
-                        "--unstable".to_string(),
-                        "cardano-transaction".to_string(),
-                        "certify".to_string(),
-                        tx_hashes.join(","),
-                    ]
-                }
-            },
-        };
+    pub async fn run(&mut self, command: ClientCommand) -> StdResult<PathBuf> {
+        let output_path = self
+            .command
+            .set_output_filename(&format!("mithril-client-{}", command.name()));
+        let args = command.cli_arg();
 
         let exit_status = self
             .command
@@ -107,7 +170,7 @@ impl Client {
             .with_context(|| "mithril-client crashed")?;
 
         if exit_status.success() {
-            Ok(())
+            Ok(output_path)
         } else {
             self.command
                 .tail_logs(Some(format!("mithril-client {args:?}").as_str()), 20)


### PR DESCRIPTION
## Content

This PR enhance the mithril-client in several ways:
- :warning: **breaking** :warning:  All logs and reporting are now sent to `stderr` meaning that only the command result is sent to `stdout` (you can pipe it to another command like `jq` now  :rocket: )
- `cardano-transaction certify $HASH1,$HASH2,...`:
  - now output a table of the certified/non-certified transaction in is default mode ( `json` disabled).
  - Better error message in the case when no transaction could be certified.
- `mithril-stake-distribution download $HASH`: Add the `--json` optional parameter.

Also in this PR:
- Streamline the naming of the cardano-transaction api:
  - use `commitment` instead of `sets` everywhere.
  - lib: simplify naming of the `cardano_transaction_proof_client` client to just `cardano_transaction_client` (since this client have also commitment related capabilities).
- Enhance E2E tests by checking the list of certified transactions by the client-cli instead of just checking the the client-cli did not fail.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1469
