### PR TITLE
Adapt multi platform test for Cardano transactions

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -69,7 +69,25 @@ jobs:
           echo "NETWORK=${{ inputs.network }}" >> $GITHUB_ENV
           echo "AGGREGATOR_ENDPOINT=${{ inputs.aggregator_endpoint }}" >> $GITHUB_ENV
           echo "GENESIS_VERIFICATION_KEY=$(curl -s ${{ inputs.genesis_verification_key }})" >> $GITHUB_ENV
+          echo "TRANSACTIONS_HASHES_TO_CERTIFY=${{ inputs.transactions_hashes_to_certify }}" >> $GITHUB_ENV
 
+      - name: Assessing aggregator capabilities (Unix)
+        id: aggregator_capability_unix
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          CTX_CAPABILITY=$(wget -q -O - $AGGREGATOR_ENDPOINT | jq '.capabilities.signed_entity_types | contains(["CardanoTransactions"])')
+          echo "ctx_enabled=$CTX_CAPABILITY" >> $GITHUB_OUTPUT
+
+      - name: Assessing aggregator capabilities (Windows)
+        id: aggregator_capability_windows
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          aria2c -o aggregator_capabilities.json $AGGREGATOR_ENDPOINT
+          CTX_CAPABILITY=$(jq '.capabilities.signed_entity_types | contains(["CardanoTransactions"])' aggregator_capabilities.json)
+          echo "ctx_enabled=$CTX_CAPABILITY" >> $GITHUB_OUTPUT
+          
       - name: Checkout binary
         uses: dawidd6/action-download-artifact@v3
         with:
@@ -114,6 +132,12 @@ jobs:
         working-directory: ./bin
         run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} mithril-stake-distribution download $MITHRIL_STAKE_DISTRIBUTION_HASH
 
+      - name: Cardano transaction certify
+        if: steps.aggregator_capability_unix.outputs.ctx_enabled == 'true' || steps.aggregator_capability_windows.outputs.ctx_enabled == 'true'
+        shell: bash
+        working-directory: ./bin
+        run: ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-transaction certify $TRANSACTIONS_HASHES_TO_CERTIFY
+
   test-docker:
     strategy:
       fail-fast: false
@@ -133,6 +157,14 @@ jobs:
           echo "NETWORK=${{ inputs.network }}" >> $GITHUB_ENV
           echo "AGGREGATOR_ENDPOINT=${{ inputs.aggregator_endpoint }}" >> $GITHUB_ENV
           echo "GENESIS_VERIFICATION_KEY=$(curl -s ${{ inputs.genesis_verification_key }})" >> $GITHUB_ENV
+          echo "TRANSACTIONS_HASHES_TO_CERTIFY=${{ inputs.transactions_hashes_to_certify }}" >> $GITHUB_ENV
+
+      - name: Assessing aggregator capabilities
+        id: aggregator_capability
+        shell: bash
+        run: |
+          CTX_CAPABILITY=$(wget -q -O - $AGGREGATOR_ENDPOINT | jq '.capabilities.signed_entity_types | contains(["CardanoTransactions"])')
+          echo "ctx_enabled=$CTX_CAPABILITY" >> $GITHUB_OUTPUT
 
       - name: Prepare Mithril client command
         id: command
@@ -163,6 +195,11 @@ jobs:
       - name: Mithril Stake Distribution / download & restore latest
         shell: bash
         run: ${{ steps.command.outputs.mithril_client }}  ${{ steps.prepare.outputs.debug_level }} mithril-stake-distribution download $MITHRIL_STAKE_DISTRIBUTION_HASH --download-dir /app
+
+      - name: Cardano transaction certify
+        if: steps.aggregator_capability.outputs.ctx_enabled == 'true'
+        shell: bash
+        run: ${{ steps.command.outputs.mithril_client }} --unstable ${{ steps.prepare.outputs.debug_level }} cardano-transaction certify $TRANSACTIONS_HASHES_TO_CERTIFY
 
   test-mithril-client-wasm:
     strategy:

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -132,6 +132,20 @@ jobs:
         working-directory: ./bin
         run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} mithril-stake-distribution download $MITHRIL_STAKE_DISTRIBUTION_HASH
 
+      - name: Cardano transaction / list and get last commitment
+        if: steps.aggregator_capability_unix.outputs.ctx_enabled == 'true' || steps.aggregator_capability_windows.outputs.ctx_enabled == 'true'
+        shell: bash
+        working-directory: ./bin
+        run: |
+          ./mithril-client ${{ steps.prepare.outputs.debug_level }} --unstable cardano-transaction commitment list
+          echo "CTX_COMMITMENT_HASH=$(./mithril-client --unstable cardano-transaction commitment list --json | jq -r '.[0].hash')" >> $GITHUB_ENV
+
+      - name: Cardano transaction / show commitment
+        if: steps.aggregator_capability_unix.outputs.ctx_enabled == 'true' || steps.aggregator_capability_windows.outputs.ctx_enabled == 'true'
+        shell: bash
+        working-directory: ./bin
+        run: ./mithril-client --unstable cardano-transaction commitment show $CTX_COMMITMENT_HASH
+
       - name: Cardano transaction certify
         if: steps.aggregator_capability_unix.outputs.ctx_enabled == 'true' || steps.aggregator_capability_windows.outputs.ctx_enabled == 'true'
         shell: bash
@@ -196,6 +210,18 @@ jobs:
         shell: bash
         run: ${{ steps.command.outputs.mithril_client }}  ${{ steps.prepare.outputs.debug_level }} mithril-stake-distribution download $MITHRIL_STAKE_DISTRIBUTION_HASH --download-dir /app
 
+      - name: Cardano transaction / list and get last commitment
+        if: steps.aggregator_capability.outputs.ctx_enabled == 'true'
+        shell: bash
+        run: |
+          ${{ steps.command.outputs.mithril_client }} --unstable cardano-transaction commitment list
+          echo "CTX_COMMITMENT_HASH=$(${{ steps.command.outputs.mithril_client }} --unstable cardano-transaction commitment list --json | jq -r '.[0].hash')" >> $GITHUB_ENV
+
+      - name: Cardano transaction / show commitment
+        if: steps.aggregator_capability.outputs.ctx_enabled == 'true'
+        shell: bash
+        run: ${{ steps.command.outputs.mithril_client }} --unstable cardano-transaction commitment show $CTX_COMMITMENT_HASH
+    
       - name: Cardano transaction certify
         if: steps.aggregator_capability.outputs.ctx_enabled == 'true'
         shell: bash

--- a/mithril-client-wasm/www-test/index.js
+++ b/mithril-client-wasm/www-test/index.js
@@ -162,7 +162,7 @@ if (aggregator_capabilities.includes("CardanoTransactions")) {
 
     let proof_certificate;
     test_number++;
-    await run_test("proof verify_certificate_chain", test_number, async () => {
+    await run_test("proof_verify_certificate_chain", test_number, async () => {
       proof_certificate = await client.verify_certificate_chain(
         ctx_proof.certificate_hash
       );
@@ -185,7 +185,7 @@ if (aggregator_capabilities.includes("CardanoTransactions")) {
     );
 
     test_number++;
-    await run_test("proof verify_message_match_certificate", test_number, async () => {
+    await run_test("proof_verify_message_match_certificate", test_number, async () => {
       const valid_stake_distribution_message =
         await client.verify_message_match_certificate(
           ctx_proof_message,


### PR DESCRIPTION
## Content
This PR includes update to the GitHub Actions workflow `Mithril Client multi-platform test` to support testing for Cardano transactions.

- Implementation of a conditional step to certify Cardano transactions if the aggregator capability is enabled.
- Fix function names in `mithril-client-wasm/www-test/index.js` to ensure consistency in test naming.

Run on `testing-sanchonet` with Cardano transaction signing capability:
https://github.com/input-output-hk/mithril/actions/runs/8020577209

Run on `testing-preview` without Cardano transaction signing capability:
https://github.com/input-output-hk/mithril/actions/runs/8020604356

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1510 
