### PR TITLE
Fix `update_release` action version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,7 +551,8 @@ jobs:
           files: package/*
 
       - name: Update unstable release body with release notes addon
-        uses: tubone24/update_release@v1
+        # specific version since this action does not support giving only the major number
+        uses: tubone24/update_release@v1.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: unstable

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -76,7 +76,8 @@ jobs:
           files: package/*
 
       - name: Update release body with release notes addon
-        uses: tubone24/update_release@v1
+        # specific version since this action does not support giving only the major number
+        uses: tubone24/update_release@v1.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.ref_name }}


### PR DESCRIPTION
## Content

This PR fix a regression in our CI workflows introduced by #1521 : the `tubone24/update_release` don't support import by giving only the major version.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1520 
