### PR TITLE
Unified temp dir builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3400,7 +3400,7 @@ version = "0.1.0"
 
 [[package]]
 name = "mithril-client"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3479,7 +3479,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3576,7 +3576,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3623,7 +3623,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.109"
+version = "0.2.110"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3446,6 +3446,7 @@ dependencies = [
  "human_bytes",
  "indicatif",
  "mithril-client",
+ "mithril-common",
  "mithril-doc",
  "openssl",
  "openssl-probe",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.40"
+version = "0.4.41"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -321,7 +321,7 @@ impl CompressedArchiveSnapshotter {
                     return Err(SnapshotError::InvalidArchiveError(format!(
                         "can't unpack entry with error: '{:?}'",
                         e
-                    )))
+                    )));
                 }
                 Ok(_) => {
                     if let Err(e) = fs::remove_file(unpack_file_path) {
@@ -391,20 +391,12 @@ mod tests {
     use std::sync::Arc;
 
     use mithril_common::digesters::DummyImmutablesDbBuilder;
+    use mithril_common::test_utils::TempDir;
 
     use super::*;
 
     fn get_test_directory(dir_name: &str) -> PathBuf {
-        let test_dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join("snapshotter")
-            .join(dir_name);
-        if test_dir.exists() {
-            std::fs::remove_dir_all(&test_dir).unwrap();
-        }
-        std::fs::create_dir_all(&test_dir).unwrap();
-
-        test_dir
+        TempDir::create("snapshotter", dir_name)
     }
 
     #[test]
@@ -430,7 +422,7 @@ mod tests {
     fn should_create_directory_if_does_not_exist() {
         let test_dir = get_test_directory("should_create_directory_if_does_not_exist");
         let pending_snapshot_directory = test_dir.join("pending_snapshot");
-        let db_directory = std::env::temp_dir().join("whatever");
+        let db_directory = test_dir.join("whatever");
 
         Arc::new(
             CompressedArchiveSnapshotter::new(
@@ -449,9 +441,9 @@ mod tests {
         let test_dir =
             get_test_directory("should_clean_pending_snapshot_directory_if_already_exists");
         let pending_snapshot_directory = test_dir.join("pending_snapshot");
-        let db_directory = std::env::temp_dir().join("whatever");
+        let db_directory = test_dir.join("whatever");
 
-        std::fs::create_dir_all(&pending_snapshot_directory).unwrap();
+        fs::create_dir_all(&pending_snapshot_directory).unwrap();
 
         File::create(pending_snapshot_directory.join("whatever.txt")).unwrap();
 

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -206,26 +206,15 @@ mod tests {
     use mithril_common::{
         certificate_chain::MithrilCertificateVerifier,
         crypto_helper::{ProtocolClerk, ProtocolGenesisSigner},
-        test_utils::{fake_data, MithrilFixtureBuilder},
+        test_utils::{fake_data, MithrilFixtureBuilder, TempDir},
     };
     use sqlite::Connection;
-    use std::{fs, path::PathBuf};
+    use std::path::PathBuf;
 
     use super::*;
 
     fn get_temp_dir(dir_name: &str) -> PathBuf {
-        let dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join("genesis")
-            .join(dir_name);
-
-        if dir.exists() {
-            let _ = fs::remove_dir_all(&dir);
-        }
-
-        let _ = fs::create_dir_all(&dir);
-
-        dir
+        TempDir::create("genesis", dir_name)
     }
 
     fn create_fake_genesis_avk() -> ProtocolAggregateVerificationKey {

--- a/mithril-aggregator/tests/test_extensions/utilities.rs
+++ b/mithril-aggregator/tests/test_extensions/utilities.rs
@@ -1,3 +1,4 @@
+use mithril_common::test_utils::TempDir;
 use slog_scope::debug;
 use std::{
     path::PathBuf,
@@ -10,16 +11,7 @@ pub static COMMENT_COUNT: AtomicUsize = AtomicUsize::new(0);
 /// already exists, it is created if not. This directory is kept at the end to
 /// allow debuging.
 pub fn get_test_dir(subdir_name: &str) -> PathBuf {
-    let parent_dir = std::env::temp_dir().join("mithril_test").join(subdir_name);
-
-    if parent_dir.exists() {
-        std::fs::remove_dir_all(&parent_dir)
-            .unwrap_or_else(|e| panic!("Could not remove dir {parent_dir:?}: {e}"));
-    }
-    std::fs::create_dir_all(&parent_dir)
-        .unwrap_or_else(|e| panic!("Could not create dir {parent_dir:?}: {e}"));
-
-    parent_dir
+    TempDir::create("aggregator-integration", subdir_name)
 }
 
 pub fn comment(comment: String) {

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -49,6 +49,9 @@ slog-term = "2.9.0"
 thiserror = "1.0.56"
 tokio = { version = "1.35.1", features = ["full"] }
 
+[dev-dependencies]
+mithril-common = { path = "../mithril-common", features = ["test_tools"] }
+
 [features]
 portable = ["mithril-client/portable"]
 bundle_openssl = ["dep:openssl", "dep:openssl-probe"]

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.7.0"
+version = "0.7.1"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/snapshot/download.rs
+++ b/mithril-client-cli/src/commands/snapshot/download.rs
@@ -340,6 +340,7 @@ mod tests {
         common::{Beacon, ProtocolMessagePartKey},
         MithrilCertificateMetadata,
     };
+    use mithril_common::test_utils::TempDir;
 
     use super::*;
 
@@ -367,7 +368,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verify_snapshot_signature_should_remove_db_dir_if_messages_dismatch() {
+    async fn verify_snapshot_signature_should_remove_db_dir_if_messages_mismatch() {
         let progress_printer = ProgressPrinter::new(ProgressOutputType::Tty, 1);
         let certificate = dummy_certificate();
         let mut message = ProtocolMessage::new();
@@ -377,12 +378,10 @@ mod tests {
             "avk".to_string(),
         );
         let snapshot = Snapshot::dummy();
-        let db_dir = std::env::temp_dir().join("db");
-        if db_dir.exists() {
-            std::fs::remove_dir_all(&db_dir).unwrap();
-        }
-        std::fs::create_dir_all(&db_dir).unwrap();
-        println!("db_dir: '{:?}'", db_dir);
+        let db_dir = TempDir::create(
+            "client-cli",
+            "verify_snapshot_signature_should_remove_db_dir_if_messages_mismatch",
+        );
 
         let result = SnapshotDownloadCommand::verify_snapshot_signature(
             1,

--- a/mithril-client-cli/src/utils/unpacker.rs
+++ b/mithril-client-cli/src/utils/unpacker.rs
@@ -76,15 +76,10 @@ impl SnapshotUnpacker {
 #[cfg(test)]
 mod test {
     use super::*;
-    use std::fs::remove_dir_all;
+    use mithril_common::test_utils::TempDir;
 
     fn create_temporary_empty_directory(name: &str) -> PathBuf {
-        let pathdir = std::env::temp_dir().join(name);
-        if pathdir.exists() {
-            remove_dir_all(&pathdir).unwrap();
-        }
-        create_dir_all(&pathdir).unwrap();
-        pathdir
+        TempDir::create("client-cli", name)
     }
 
     #[test]

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.6.4"
+version = "0.6.5"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/tests/extensions/mod.rs
+++ b/mithril-client/tests/extensions/mod.rs
@@ -6,18 +6,11 @@ pub mod fake;
 pub mod mock;
 mod routes;
 
+use mithril_common::test_utils::TempDir;
 use std::path::PathBuf;
 
 pub fn get_test_dir(subdir_name: &str) -> PathBuf {
-    let dir = std::env::temp_dir().join("mithril_test").join(subdir_name);
-
-    if dir.exists() {
-        std::fs::remove_dir_all(&dir)
-            .unwrap_or_else(|e| panic!("Could not remove dir {dir:?}: {e}"));
-    }
-    std::fs::create_dir_all(&dir).unwrap_or_else(|e| panic!("Could not create dir {dir:?}: {e}"));
-
-    dir
+    TempDir::create("client_integration", subdir_name)
 }
 
 pub fn test_logger() -> slog::Logger {

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.8"
+version = "0.3.9"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/chain_observer/cli_observer.rs
+++ b/mithril-common/src/chain_observer/cli_observer.rs
@@ -448,8 +448,7 @@ impl ChainObserver for CardanoCliChainObserver {
     ) -> Result<Option<KESPeriod>, ChainObserverError> {
         let dir = std::env::temp_dir().join("mithril_kes_period");
         fs::create_dir_all(&dir).map_err(|e| ChainObserverError::General(e.into()))?;
-        let opcert_file =
-            std::env::temp_dir().join(format!("opcert_kes_period-{}", opcert.compute_hash()));
+        let opcert_file = dir.join(format!("opcert_kes_period-{}", opcert.compute_hash()));
         opcert
             .to_file(&opcert_file)
             .map_err(|e| ChainObserverError::General(e.into()))?;

--- a/mithril-common/src/chain_observer/pallas_observer.rs
+++ b/mithril-common/src/chain_observer/pallas_observer.rs
@@ -344,6 +344,7 @@ mod tests {
     use tokio::net::UnixListener;
 
     use super::*;
+    use crate::test_utils::TempDir;
     use crate::{chain_observer::test_cli_runner::TestCliRunner, CardanoNetwork};
 
     fn get_fake_utxo_by_address() -> UTxOByAddress {
@@ -463,21 +464,7 @@ mod tests {
 
     /// Creates a new work directory in the system's temporary folder.
     fn create_temp_dir(folder_name: &str) -> PathBuf {
-        #[cfg(not(target_os = "macos"))]
-        let temp_dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join("pallas_chain_observer_test")
-            .join(folder_name);
-
-        // macOS-domain addresses are variable-length filesystem pathnames of at most 104 characters.
-        #[cfg(target_os = "macos")]
-        let temp_dir: PathBuf = std::env::temp_dir().join(folder_name);
-
-        if temp_dir.exists() {
-            fs::remove_dir_all(&temp_dir).expect("Previous work dir removal failed");
-        }
-        fs::create_dir_all(&temp_dir).expect("Work dir creation failed");
-        temp_dir
+        TempDir::create_with_short_path("pallas_chain_observer_test", folder_name)
     }
 
     /// Sets up a mock server.

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -150,11 +150,11 @@ impl<'a> TryFrom<&'a mut Sum6KesBytes> for Sum6Kes<'a> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::test_utils::TempDir;
 
     #[test]
     fn compat_with_shelly_format() {
-        let temp_dir = std::env::temp_dir().join("testing");
-        fs::create_dir_all(&temp_dir).expect("temp dir creation should not fail");
+        let temp_dir = TempDir::create("crypto_helper", "compat_with_shelly_format");
         let sk_dir = temp_dir.join("dummy.skey");
         let cbor_string = "590260fe77acdfa56281e4b05198f5136018057a65f425411f0990cac4aca0f2917aa00a3d51e191f6f425d870aca3c6a2a41833621f5729d7bc0e3dfc3ae77d057e5e1253b71def7a54157b9f98973ca3c49edd9f311e5f4b23ac268b56a6ac040c14c6d2217925492e42f00dc89a2a01ff363571df0ca0db5ba37001cee56790cc01cd69c6aa760fca55a65a110305ea3c11da0a27be345a589329a584ebfc499c43c55e8c6db5d9c0b014692533ee78abd7ac1e79f7ec9335c7551d31668369b4d5111db78072f010043e35e5ca7f11acc3c05b26b9c7fe56f02aa41544f00cb7685e87f34c73b617260ade3c7b8d8c4df46693694998f85ad80d2cbab0b575b6ccd65d90574e84368169578bff57f751bc94f7eec5c0d7055ec88891a69545eedbfbd3c5f1b1c1fe09c14099f6b052aa215efdc5cb6cdc84aa810db41dbe8cb7d28f7c4beb75cc53915d3ac75fc9d0bf1c734a46e401e15150c147d013a938b7e07cc4f25a582b914e94783d15896530409b8acbe31ef471de8a1988ac78dfb7510729eff008084885f07df870b65e4f382ca15908e1dcda77384b5c724350de90cec22b1dcbb1cdaed88da08bb4772a82266ec154f5887f89860d0920dba705c45957ef6d93e42f6c9509c966277d368dd0eefa67c8147aa15d40a222f7953a4f34616500b310d00aa1b5b73eb237dc4f76c0c16813d321b2fc5ac97039be25b22509d1201d61f4ccc11cd4ff40fffe39f0e937b4722074d8e073a775d7283b715d46f79ce128e3f1362f35615fa72364d20b6db841193d96e58d9d8e86b516bbd1f05e45b39823a93f6e9f29d9e01acf2c12c072d1c64e0afbbabf6903ef542e".to_string();
 

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -95,6 +95,7 @@ pub enum ProtocolInitializerErrorWrapper {
     #[error("Period of key file, {0}, does not match with period provided by user, {1}")]
     KesMismatch(KESPeriod, KESPeriod),
 }
+
 /// Wrapper structure for [MithrilStm:StmInitializer](mithril_stm::stm::StmInitializer).
 /// It now obtains a KES signature over the Mithril key. This allows the signers prove
 /// their correct identity with respect to a Cardano PoolID.
@@ -303,22 +304,20 @@ impl KeyRegWrapper {
 
 #[cfg(test)]
 mod test {
-
     use super::*;
     use crate::crypto_helper::{cardano::ColdKeyGenerator, OpCert};
 
+    use crate::test_utils::TempDir;
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
-    use std::{fs, path::PathBuf};
+    use std::path::PathBuf;
 
-    fn setup_temp_directory() -> PathBuf {
-        let temp_dir = std::env::temp_dir().join("mithril_cardano_key_certification");
-        fs::create_dir_all(&temp_dir).expect("temp dir creation should not fail");
-        temp_dir
+    fn setup_temp_directory(test_name: &str) -> PathBuf {
+        TempDir::create("mithril_cardano_key_certification", test_name)
     }
 
     fn create_cryptographic_material(party_idx: u64) -> (ProtocolPartyId, PathBuf, PathBuf) {
-        let temp_dir = setup_temp_directory();
+        let temp_dir = setup_temp_directory(&format!("create_cryptographic_material_{party_idx}"));
         let keypair = ColdKeyGenerator::create_deterministic_keypair([party_idx as u8; 32]);
         let mut dummy_buffer = [0u8; Sum6Kes::SIZE + 4];
         let mut dummy_seed = [party_idx as u8; 32];

--- a/mithril-common/src/crypto_helper/cardano/opcert.rs
+++ b/mithril-common/src/crypto_helper/cardano/opcert.rs
@@ -179,22 +179,20 @@ impl<'de> Deserialize<'de> for OpCert {
 
 #[cfg(test)]
 mod tests {
-
     use super::*;
     use crate::crypto_helper::cardano::ColdKeyGenerator;
+    use crate::test_utils::TempDir;
 
     use kes_summed_ed25519::{kes::Sum6Kes, traits::KesSk};
-    use std::{fs, path::PathBuf};
+    use std::path::PathBuf;
 
-    fn setup_temp_directory() -> PathBuf {
-        let temp_dir = std::env::temp_dir().join("mithril_cardano_opcert");
-        fs::create_dir_all(&temp_dir).expect("temp dir creation should not fail");
-        temp_dir
+    fn setup_temp_directory(test_name: &str) -> PathBuf {
+        TempDir::create("mithril_cardano_opcert", test_name)
     }
 
     #[test]
     fn test_vector_opcert() {
-        let temp_dir = setup_temp_directory();
+        let temp_dir = setup_temp_directory("test_vector_opcert");
         let keypair = ColdKeyGenerator::create_deterministic_keypair([0u8; 32]);
         let mut dummy_key_buffer = [0u8; Sum6Kes::SIZE + 4];
         let mut dummy_seed = [0u8; 32];

--- a/mithril-common/src/digesters/cache/json_provider.rs
+++ b/mithril-common/src/digesters/cache/json_provider.rs
@@ -113,22 +113,11 @@ mod tests {
         ImmutableFileDigestCacheProvider, JsonImmutableFileDigestCacheProvider,
     };
     use crate::digesters::ImmutableFile;
-    use std::{collections::BTreeMap, fs, path::PathBuf};
+    use crate::test_utils::TempDir;
+    use std::{collections::BTreeMap, path::PathBuf};
 
     fn get_test_dir(subdir_name: &str) -> PathBuf {
-        let parent_dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join("json_digester_cache_provider")
-            .join(subdir_name);
-
-        if parent_dir.exists() {
-            fs::remove_dir_all(&parent_dir)
-                .unwrap_or_else(|e| panic!("Could not remove dir {parent_dir:?}: {e}"));
-        }
-        fs::create_dir_all(&parent_dir)
-            .unwrap_or_else(|e| panic!("Could not create dir {parent_dir:?}: {e}"));
-
-        parent_dir
+        TempDir::create("json_digester_cache_provider", subdir_name)
     }
 
     #[tokio::test]

--- a/mithril-common/src/digesters/cache/json_provider_builder.rs
+++ b/mithril-common/src/digesters/cache/json_provider_builder.rs
@@ -83,13 +83,16 @@ impl<'a> JsonImmutableFileDigestCacheProviderBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use crate::digesters::cache::JsonImmutableFileDigestCacheProviderBuilder;
+    use crate::test_utils::TempDir;
+    use std::path::PathBuf;
+
+    fn get_test_dir(subdir_name: &str) -> PathBuf {
+        TempDir::new("json_provider_builder", subdir_name).build_path()
+    }
 
     #[tokio::test]
     async fn create_dir_if_ensure_dir_exist_is_set() {
-        let dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join("json_provider_builder")
-            .join("create_dir_if_ensure_dir_exist_is_set");
+        let dir = get_test_dir("create_dir_if_ensure_dir_exist_is_set");
 
         JsonImmutableFileDigestCacheProviderBuilder::new(&dir, "test.json")
             .ensure_dir_exist()
@@ -102,10 +105,7 @@ mod tests {
 
     #[tokio::test]
     async fn dont_create_dir_if_ensure_dir_exist_is_not_set() {
-        let dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join("json_provider_builder")
-            .join("dont_create_dir_if_ensure_dir_exist_is_not_set");
+        let dir = get_test_dir("dont_create_dir_if_ensure_dir_exist_is_not_set");
 
         JsonImmutableFileDigestCacheProviderBuilder::new(&dir, "test.json")
             .build()

--- a/mithril-common/src/digesters/dummy_immutable_db_builder.rs
+++ b/mithril-common/src/digesters/dummy_immutable_db_builder.rs
@@ -1,3 +1,4 @@
+use crate::test_utils::TempDir;
 use crate::{digesters::ImmutableFile, entities::ImmutableFileNumber};
 use std::{
     fs::File,
@@ -115,19 +116,7 @@ impl DummyImmutablesDbBuilder {
     }
 
     fn get_test_dir(subdir_name: &str) -> PathBuf {
-        let parent_dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join(subdir_name)
-            .join("immutable");
-
-        if parent_dir.exists() {
-            std::fs::remove_dir_all(&parent_dir)
-                .unwrap_or_else(|e| panic!("Could not remove dir {parent_dir:?}: {e}"));
-        }
-        std::fs::create_dir_all(&parent_dir)
-            .unwrap_or_else(|e| panic!("Could not create dir {parent_dir:?}: {e}"));
-
-        parent_dir
+        TempDir::create(subdir_name, "immutable")
     }
 }
 

--- a/mithril-common/src/digesters/immutable_file.rs
+++ b/mithril-common/src/digesters/immutable_file.rs
@@ -182,22 +182,13 @@ impl Ord for ImmutableFile {
 #[cfg(test)]
 mod tests {
     use super::ImmutableFile;
-    use std::fs;
+    use crate::test_utils::TempDir;
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::{Path, PathBuf};
 
     fn get_test_dir(subdir_name: &str) -> PathBuf {
-        let parent_dir = std::env::temp_dir().join("mithril_test").join(subdir_name);
-
-        if parent_dir.exists() {
-            fs::remove_dir_all(&parent_dir)
-                .unwrap_or_else(|_| panic!("Could not remove dir {parent_dir:?}"));
-        }
-        fs::create_dir_all(&parent_dir)
-            .unwrap_or_else(|_| panic!("Could not create dir {parent_dir:?}"));
-
-        parent_dir
+        TempDir::create("immutable_file", subdir_name)
     }
 
     fn create_fake_files(parent_dir: &Path, child_filenames: &[&str]) {

--- a/mithril-common/src/digesters/mod.rs
+++ b/mithril-common/src/digesters/mod.rs
@@ -3,7 +3,6 @@
 pub mod cache;
 mod cardano_immutable_digester;
 mod dumb_immutable_observer;
-mod dummy_immutable_db_builder;
 mod immutable_digester;
 mod immutable_file;
 mod immutable_file_observer;
@@ -17,4 +16,9 @@ pub use immutable_file_observer::{
 };
 
 pub use dumb_immutable_observer::DumbImmutableDigester;
-pub use dummy_immutable_db_builder::{DummyImmutableDb, DummyImmutablesDbBuilder};
+
+cfg_test_tools! {
+    mod dummy_immutable_db_builder;
+
+    pub use dummy_immutable_db_builder::{DummyImmutableDb, DummyImmutablesDbBuilder};
+}

--- a/mithril-common/src/era/adapters/file.rs
+++ b/mithril-common/src/era/adapters/file.rs
@@ -29,20 +29,13 @@ impl EraReaderAdapter for FileAdapter {
 #[cfg(test)]
 mod tests {
     use crate::entities::Epoch;
+    use crate::era::SupportedEra;
+    use crate::test_utils::TempDir;
 
-    use super::super::super::SupportedEra;
     use super::*;
 
     fn get_temp_dir(dir_name: &str) -> PathBuf {
-        let dir = std::env::temp_dir().join("mithril_test").join(dir_name);
-
-        if dir.exists() {
-            let _ = fs::remove_dir_all(&dir);
-        }
-
-        let _ = fs::create_dir_all(&dir);
-
-        dir
+        TempDir::create("era-adapter", dir_name)
     }
 
     #[tokio::test]

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -16,9 +16,12 @@ pub mod fake_keys;
 mod fixture_builder;
 mod mithril_fixture;
 
+mod temp_dir;
+
 #[cfg(feature = "test_http_server")]
 #[cfg_attr(docsrs, doc(cfg(feature = "test_http_server")))]
 pub mod test_http_server;
 
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};
 pub use mithril_fixture::{MithrilFixture, SignerFixture};
+pub use temp_dir::*;

--- a/mithril-common/src/test_utils/temp_dir.rs
+++ b/mithril-common/src/test_utils/temp_dir.rs
@@ -1,3 +1,4 @@
+use sha2::{Digest, Sha256};
 use std::path::{Path, PathBuf};
 
 /// A builder of temp directory for tests purpose.
@@ -6,6 +7,7 @@ pub struct TempDir {
     module_name: String,
     name: String,
     enable_short_path: bool,
+    short_path_max_len: usize,
 }
 
 const TEMP_DIR_ROOT_NAME: &str = "mithril_test";
@@ -17,6 +19,8 @@ impl TempDir {
             module_name: module.into(),
             name: name.into(),
             enable_short_path: false,
+            // 90 to have some room for the folder content (in case of restrained length like socket path)
+            short_path_max_len: 90,
         }
     }
 
@@ -30,15 +34,30 @@ impl TempDir {
 
     /// Generate the path of the temp directory (no IO operation will be executed)
     pub fn build_path(&self) -> PathBuf {
+        const SHA_LENGTH: usize = 10;
         let base_dir = std::env::temp_dir().join(TEMP_DIR_ROOT_NAME);
 
+        // Short path only:
+        // Combined max len should be lower than `self.short_path_max_len` to have some rooms for
+        // the folder content.
+        // MacOS temp folder are not in the `/tmp` folder but in a dynamic path adding 45 chars.
+        // ie: /var/folders/_k/7j0m5c_n4g94vgx9gxknp4tm0000gn/T/
         if self.enable_short_path {
-            // Combined max len should be lower than 90 to have some rooms for the folder content
-            // macOS temp folder are not in the `/tmp` folder but in a dynamic path adding 45 chars
-            // ie: /var/folders/_k/7j0m5c_n4g94vgx9gxknp4tm0000gn/T/
-            let max_len = self.name.len().min(89 - base_dir.to_string_lossy().len());
+            // In order to discriminate two tests with the same name but within different modules
+            // we append the short sha of the module+name to the path.
+            let mut hasher = Sha256::new();
+            hasher.update(&self.module_name);
+            hasher.update(&self.name);
+            let sha = hex::encode(hasher.finalize());
+            let short_sha = &sha[0..SHA_LENGTH];
 
-            base_dir.join(&self.name[0..max_len])
+            // `-2` since when joining a path this adds a `/` and we also add a `_` to join the sha
+            let max_path_len =
+                self.short_path_max_len - SHA_LENGTH - 2 - base_dir.to_string_lossy().len();
+
+            let max_len = self.name.len().min(max_path_len);
+
+            base_dir.join([&self.name[0..max_len], "_", short_sha].concat())
         } else {
             base_dir.join(&self.module_name).join(&self.name)
         }
@@ -92,13 +111,13 @@ mod tests {
 
     #[test]
     fn non_short_path_are_in_a_mithril_test_slash_module_folder_structure() {
-        let path = TempDir::new("mod", "name").build();
+        let path = TempDir::new("temp_dir", "basic").build();
 
         assert_eq!(
             Some(
                 std::env::temp_dir()
                     .join(TEMP_DIR_ROOT_NAME)
-                    .join("mod")
+                    .join("temp_dir")
                     .as_path()
             ),
             path.parent()
@@ -108,7 +127,9 @@ mod tests {
 
     #[test]
     fn short_path_are_in_a_mithril_test_folder_structure() {
-        let path = TempDir::new("mod", "name").generate_shorter_path().build();
+        let path = TempDir::new("temp_dir", "basic_short_path")
+            .generate_shorter_path()
+            .build();
 
         assert_eq!(
             Some(std::env::temp_dir().join(TEMP_DIR_ROOT_NAME).as_path()),
@@ -153,5 +174,25 @@ mod tests {
             path: `{}`",
             path.display()
         );
+    }
+
+    #[test]
+    fn same_name_but_two_different_module_generate_different_path() {
+        let path1 = TempDir::new("module_a", "test").build_path();
+        let path2 = TempDir::new("module_b", "test").build_path();
+
+        assert_ne!(path1, path2);
+    }
+
+    #[test]
+    fn same_name_but_two_different_module_generate_different_path_even_with_short_path_enabled() {
+        let path1 = TempDir::new("module_a", "test")
+            .generate_shorter_path()
+            .build_path();
+        let path2 = TempDir::new("module_b", "test")
+            .generate_shorter_path()
+            .build_path();
+
+        assert_ne!(path1, path2);
     }
 }

--- a/mithril-common/src/test_utils/temp_dir.rs
+++ b/mithril-common/src/test_utils/temp_dir.rs
@@ -1,0 +1,157 @@
+use std::path::{Path, PathBuf};
+
+/// A builder of temp directory for tests purpose.
+#[derive(Clone)]
+pub struct TempDir {
+    module_name: String,
+    name: String,
+    enable_short_path: bool,
+}
+
+const TEMP_DIR_ROOT_NAME: &str = "mithril_test";
+
+impl TempDir {
+    /// `TempDir` builder factory
+    pub fn new<T: Into<String>>(module: T, name: T) -> Self {
+        Self {
+            module_name: module.into(),
+            name: name.into(),
+            enable_short_path: false,
+        }
+    }
+
+    /// Change path generation in order to guarantee a path that have at maximum 90 characters.
+    ///
+    /// Typically used for cases when the generated folder will include a socket.
+    pub fn generate_shorter_path(mut self) -> Self {
+        self.enable_short_path = true;
+        self
+    }
+
+    /// Generate the path of the temp directory (no IO operation will be executed)
+    pub fn build_path(&self) -> PathBuf {
+        let base_dir = std::env::temp_dir().join(TEMP_DIR_ROOT_NAME);
+
+        if self.enable_short_path {
+            // Combined max len should be lower than 90 to have some rooms for the folder content
+            // macOS temp folder are not in the `/tmp` folder but in a dynamic path adding 45 chars
+            // ie: /var/folders/_k/7j0m5c_n4g94vgx9gxknp4tm0000gn/T/
+            let max_len = self.name.len().min(89 - base_dir.to_string_lossy().len());
+
+            base_dir.join(&self.name[0..max_len])
+        } else {
+            base_dir.join(&self.module_name).join(&self.name)
+        }
+    }
+
+    /// Create a directory based of builder configuration in the system temp folder.
+    pub fn build(&self) -> PathBuf {
+        let path = self.build_path();
+        self.create_dir(&path);
+
+        path
+    }
+
+    /// Create on disk a temp directory based on the given module & name.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use crate::mithril_common::test_utils::TempDir;
+    /// TempDir::new("module", "name").build();
+    /// ```
+    pub fn create<T: Into<String>>(module: T, name: T) -> PathBuf {
+        Self::new(module, name).build()
+    }
+
+    /// Create on disk a temp directory based on the given module & name, the generated path
+    /// is guaranteed to be at most 90 characters long.
+    ///
+    /// Equivalent to:
+    /// ```
+    /// # use crate::mithril_common::test_utils::TempDir;
+    /// TempDir::new("module", "name").generate_shorter_path().build();
+    /// ```
+    pub fn create_with_short_path<T: Into<String>>(module: T, name: T) -> PathBuf {
+        Self::new(module, name).generate_shorter_path().build()
+    }
+
+    fn create_dir(&self, path: &Path) {
+        if path.exists() {
+            std::fs::remove_dir_all(path)
+                .unwrap_or_else(|e| panic!("Could not remove dir {path:?}: {e}"));
+        }
+
+        std::fs::create_dir_all(path)
+            .unwrap_or_else(|e| panic!("Could not create dir {path:?}: {e}"));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_short_path_are_in_a_mithril_test_slash_module_folder_structure() {
+        let path = TempDir::new("mod", "name").build();
+
+        assert_eq!(
+            Some(
+                std::env::temp_dir()
+                    .join(TEMP_DIR_ROOT_NAME)
+                    .join("mod")
+                    .as_path()
+            ),
+            path.parent()
+        );
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn short_path_are_in_a_mithril_test_folder_structure() {
+        let path = TempDir::new("mod", "name").generate_shorter_path().build();
+
+        assert_eq!(
+            Some(std::env::temp_dir().join(TEMP_DIR_ROOT_NAME).as_path()),
+            path.parent()
+        );
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn shorter_path_have_a_length_lower_than_90_chars_even_when_given_module_longer_than_that() {
+        let path = TempDir::new(
+            "module_longer_than_a_string_of_90_characters_so_this_test_can_fail_if_the_builder_is_a_bad_builder_that_do_nothing",
+            "name",
+        )
+            .generate_shorter_path()
+            .build_path();
+        let path_len = path.to_string_lossy().len();
+
+        assert!(
+            path_len <= 90,
+            "path with `short` option enabled was longer than 90 characters:\n\
+            path_len: `{path_len}`\n\
+            path: `{}`",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn shorter_path_have_a_length_lower_than_90_chars_even_when_given_name_longer_than_that() {
+        let path = TempDir::new(
+            "mod",
+            "name_longer_than_a_string_of_90_characters_so_this_test_can_fail_if_the_builder_is_a_bad_builder_that_do_nothing",
+        )
+            .generate_shorter_path()
+            .build_path();
+        let path_len = path.to_string_lossy().len();
+
+        assert!(
+            path_len <= 90,
+            "path with `short` option enabled was longer than 90 characters:\n\
+            path_len: `{path_len}`\n\
+            path: `{}`",
+            path.display()
+        );
+    }
+}

--- a/mithril-common/src/test_utils/temp_dir.rs
+++ b/mithril-common/src/test_utils/temp_dir.rs
@@ -11,6 +11,8 @@ pub struct TempDir {
 }
 
 const TEMP_DIR_ROOT_NAME: &str = "mithril_test";
+// 90 to have some room for the folder content (in case of restrained length like socket path)
+const DEFAULT_SHORT_PATH_MAX_LEN: usize = 90;
 
 impl TempDir {
     /// `TempDir` builder factory
@@ -19,8 +21,7 @@ impl TempDir {
             module_name: module.into(),
             name: name.into(),
             enable_short_path: false,
-            // 90 to have some room for the folder content (in case of restrained length like socket path)
-            short_path_max_len: 90,
+            short_path_max_len: DEFAULT_SHORT_PATH_MAX_LEN,
         }
     }
 
@@ -29,6 +30,12 @@ impl TempDir {
     /// Typically used for cases when the generated folder will include a socket.
     pub fn generate_shorter_path(mut self) -> Self {
         self.enable_short_path = true;
+        self
+    }
+
+    /// Set the max len that a short path can have
+    pub fn set_short_path_max_len(mut self, max_len: usize) -> Self {
+        self.short_path_max_len = max_len;
         self
     }
 
@@ -145,6 +152,7 @@ mod tests {
             "name",
         )
             .generate_shorter_path()
+            .set_short_path_max_len(90)
             .build_path();
         let path_len = path.to_string_lossy().len();
 
@@ -164,6 +172,7 @@ mod tests {
             "name_longer_than_a_string_of_90_characters_so_this_test_can_fail_if_the_builder_is_a_bad_builder_that_do_nothing",
         )
             .generate_shorter_path()
+            .set_short_path_max_len(90)
             .build_path();
         let path_len = path.to_string_lossy().len();
 

--- a/mithril-common/src/test_utils/temp_dir.rs
+++ b/mithril-common/src/test_utils/temp_dir.rs
@@ -45,9 +45,9 @@ impl TempDir {
         let base_dir = std::env::temp_dir().join(TEMP_DIR_ROOT_NAME);
 
         // Short path only:
-        // Combined max len should be lower than `self.short_path_max_len` to have some rooms for
+        // Combined max len should be lower than `self.short_path_max_len` to have some room for
         // the folder content.
-        // MacOS temp folder are not in the `/tmp` folder but in a dynamic path adding 45 chars.
+        // MacOS temp folders are not in the `/tmp` folder but in a dynamic path adding 45 chars.
         // ie: /var/folders/_k/7j0m5c_n4g94vgx9gxknp4tm0000gn/T/
         if self.enable_short_path {
             // In order to discriminate two tests with the same name but within different modules
@@ -70,7 +70,7 @@ impl TempDir {
         }
     }
 
-    /// Create a directory based of builder configuration in the system temp folder.
+    /// Create a directory based on the builder configuration in the system temp folder.
     pub fn build(&self) -> PathBuf {
         let path = self.build_path();
         self.create_dir(&path);

--- a/mithril-persistence/Cargo.toml
+++ b/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.1.0"
+version = "0.1.1"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.109"
+version = "0.2.110"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -348,26 +348,16 @@ mod tests {
 
     use super::*;
 
+    use mithril_common::test_utils::TempDir;
     use std::path::PathBuf;
 
-    fn get_test_dir() -> PathBuf {
-        let test_dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join("signer_service");
-
-        if test_dir.exists() {
-            fs::remove_dir_all(&test_dir)
-                .unwrap_or_else(|_| panic!("Could not remove dir {test_dir:?}"));
-        }
-        fs::create_dir_all(&test_dir)
-            .unwrap_or_else(|_| panic!("Could not create dir {test_dir:?}"));
-
-        test_dir
+    fn get_test_dir(test_name: &str) -> PathBuf {
+        TempDir::create("signer_service", test_name)
     }
 
     #[tokio::test]
     async fn test_auto_create_stores_directory() {
-        let stores_dir = get_test_dir().join("stores");
+        let stores_dir = get_test_dir("test_auto_create_stores_directory").join("stores");
         let config = Configuration {
             cardano_cli_path: PathBuf::new(),
             cardano_node_socket_path: PathBuf::new(),

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.0"
+version = "0.4.1"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
@@ -25,23 +25,13 @@ pub async fn tail(file_path: &Path, number_of_line: u64) -> StdResult<String> {
 #[cfg(test)]
 mod tests {
     use crate::utils::file_utils;
-    use std::fs;
+    use mithril_common::test_utils::TempDir;
     use std::fs::File;
     use std::io::prelude::*;
     use std::path::{Path, PathBuf};
 
     fn get_temp_dir(subfolder_name: &str) -> PathBuf {
-        let temp_dir = std::env::temp_dir()
-            .join("mithril_test")
-            .join(subfolder_name);
-        if temp_dir.exists() {
-            fs::remove_dir_all(&temp_dir)
-                .unwrap_or_else(|_| panic!("Could not remove dir {temp_dir:?}"));
-        }
-        fs::create_dir_all(&temp_dir)
-            .unwrap_or_else(|_| panic!("Could not create dir {temp_dir:?}"));
-
-        temp_dir
+        TempDir::create("e2e-file-utils", subfolder_name)
     }
 
     fn write_file(path: &Path, file_content: &str) {


### PR DESCRIPTION
## Content
This PR add an api to generate temp directory in `mithril_common` `test_tools`.

It can be used in two ways:

1. In it's complete form it's a builder pattern, use that to access all of its options:
```rust
let temp_dir = TempDir::new("module", "name")
    .generate_shorter_path()
    .set_short_path_max_len(80)
    .build();
```
2. Using shortcuts methods
```rust
let temp_dir = TempDir::create("module", "name");
let shorter_temp_dir = TempDir::create_with_short_path("module", "name");
```

With short path disabled (the default) the path generated is in the form of
- linux: `/tmp/mithril_test/$module/$name`
- macOS: `/var/folders/_k/7j0m5c_n4g94vgx9gxknp4tm0000gn/T/mithril_test/$module/$name`.

Shorter path are generated by not including a subfolder with the module but instead appending the first 10 characters of the sha256 hash of both the module & name. If even with that the path total length is longer than the `short_path_max_len` then the name is truncated as much as needed.

Example with the temp dir for `pallas_observer::test::get_current_stake_distribution_with_fallback`:
- linux: `/tmp/mithril_test/get_current_stake_distribution_with_fallback_5446f30db1`
- macOS: `/var/folders/_k/7j0m5c_n4g94vgx9gxknp4tm0000gn/T/mithril_test/get_current_stake_5446f30db1`.

In both cases if an a directory already exists with the same path it is removed alongside it's content.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1508
