### PR TITLE
Fix signature related metrics name in signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3611,7 +3611,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.113"
+version = "0.2.114"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.113"
+version = "0.2.114"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/metrics/mod.rs
+++ b/mithril-signer/src/metrics/mod.rs
@@ -30,21 +30,21 @@ pub const SIGNER_REGISTRATION_SUCCESS_LAST_EPOCH_METRIC_HELP: &str =
 
 /// 'signature_registration_success_since_startup' metric name
 pub const SIGNATURE_REGISTRATION_SUCCESS_SINCE_STARTUP_METRIC_NAME: &str =
-    "mithril_signature_signature_registration_success_since_startup";
+    "mithril_signer_signature_registration_success_since_startup";
 /// 'signature_registration_success_since_startup' metric help
 pub const SIGNATURE_REGISTRATION_SUCCESS_SINCE_STARTUP_METRIC_HELP: &str =
     "Number of successful signature registrations since startup on a Mithril signature node";
 
 /// 'signature_registration_total_since_startup' metric name
 pub const SIGNATURE_REGISTRATION_TOTAL_SINCE_STARTUP_METRIC_NAME: &str =
-    "mithril_signature_signature_registration_total_since_startup";
+    "mithril_signer_signature_registration_total_since_startup";
 /// 'signature_registration_total_since_startup' metric help
 pub const SIGNATURE_REGISTRATION_TOTAL_SINCE_STARTUP_METRIC_HELP: &str =
     "Number of signature registrations since startup on a Mithril signature node";
 
 /// 'signature_registration_success_last_epoch' metric name
 pub const SIGNATURE_REGISTRATION_SUCCESS_LAST_EPOCH_METRIC_NAME: &str =
-    "mithril_signature_signature_registration_success_last_epoch";
+    "mithril_signer_signature_registration_success_last_epoch";
 /// 'signature_registration_success_last_epoch' metric help
 pub const SIGNATURE_REGISTRATION_SUCCESS_LAST_EPOCH_METRIC_HELP: &str =
     "Latest epoch at which signature successfully registered on a Mithril signature node";


### PR DESCRIPTION
## Content
This PR includes the fix of a typo in the name of the signature related metrics in the signer.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
Grafana dashboard need to be updated on the `testing-preview` and `testing-sanchonet` networks

## Issue(s)
Relates to #1096 
