### PR TITLE
Send aggregator logs in the right output (`stdout` / `stderr`)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/website/adr/002-use-structured-logging.md
+++ b/docs/website/adr/002-use-structured-logging.md
@@ -4,13 +4,13 @@ title: |
   2. Use simple structured logging
 authors:
 - name: Mithril Team
-tags: [Draft]
+tags: [Superseded]
 date: 2022-04-24
 ---
 
 ## Status
 
-**Draft**
+Superseded by [ADR 7](/adr/7)
 
 ## Context
 

--- a/docs/website/adr/003-release/index.md
+++ b/docs/website/adr/003-release/index.md
@@ -4,13 +4,13 @@ title: |
   3. Release process and versioning
 authors:
 - name: Mithril Team
-tags: [Draft]
+tags: [Accepted]
 date: 2022-10-21
 ---
 
 ## Status
 
-**draft**
+Accepted
 
 ## Context
 

--- a/docs/website/adr/004-mithril-network-update-strategy.md
+++ b/docs/website/adr/004-mithril-network-update-strategy.md
@@ -4,13 +4,13 @@ title: |
   4. Mithril Network Upgrade Strategy
 authors:
 - name: Mithril Team
-tags: [Draft]
+tags: [Accepted]
 date: 2023-01-05
 ---
 
 ## Status
 
-**Draft**
+Accepted
 
 ## Context
 

--- a/docs/website/adr/006-errors-implementation.md
+++ b/docs/website/adr/006-errors-implementation.md
@@ -4,13 +4,13 @@ title: |
   6. Errors implementation Standard
 authors:
 - name: Mithril Team
-tags: [Draft]
+tags: [Accepted]
 date: 2023-09-27
 ---
 
 ## Status
 
-Draft
+Accepted
 
 ## Context
 

--- a/docs/website/adr/007-standardize-log-output.md
+++ b/docs/website/adr/007-standardize-log-output.md
@@ -1,0 +1,29 @@
+---
+slug: 7
+title: |
+  7. Standardize log output
+authors:
+- name: Mithril Team
+tags: [Accepted]
+date: 2024-04-07
+---
+
+## Status
+
+Accepted
+
+## Context
+
+* [ADR 2](/adr/2) is not completely relevant now, we have migrated recently the logs in the client to `stderr`. Only the result of the command execution is in `stdout`. This makes it possible to exploit the result, see our [blog post](/dev-blog/2024/02/26/mithril-client-cli-output-breaking-change).
+* Mithril aggregator logs are always redirected to `stdout` but it mixes 2 types of CLI commands, some of which would benefit from the logs output to `stderr`.
+* Mithril aggregator and Mithril client CLI have not a consistent log strategy, that's why we need to standardize them.
+
+## Decision
+
+* For commands that provide a result or execute an action, logs are sent to `stderr`. Only the result of the command is sent to `stdout`.
+* For commands that launch a program without an expected result (server), logs are sent to `stdout`.
+
+## Consequences
+
+* End users who use `stdout` logs would have a breaking change. They will have to retrieve the logs that come from `stderr` in addition.
+* Commands `genesis`, `era` and `tools` from Mithril aggregator now send their logs to `stderr`.

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.45"
+version = "0.4.46"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/mod.rs
+++ b/mithril-aggregator/src/commands/mod.rs
@@ -25,6 +25,14 @@ pub enum MainCommand {
     #[clap(alias("doc"), hide(true))]
     GenerateDoc(GenerateDocCommands),
 }
+/// Identifies the type of command
+pub enum CommandType {
+    /// Command that runs a server
+    Server,
+
+    /// Command that outputs some result after execution
+    CommandLine,
+}
 
 impl MainCommand {
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
@@ -38,6 +46,16 @@ impl MainCommand {
                 cmd.execute_with_configurations(&mut MainOpts::command(), &config_infos)
                     .map_err(|message| anyhow!(message))
             }
+        }
+    }
+
+    pub fn command_type(&self) -> CommandType {
+        match self {
+            MainCommand::Serve(_) => CommandType::Server,
+            MainCommand::Genesis(_) => CommandType::CommandLine,
+            MainCommand::Era(_) => CommandType::CommandLine,
+            MainCommand::Tools(_) => CommandType::CommandLine,
+            MainCommand::GenerateDoc(_) => CommandType::CommandLine,
         }
     }
 }

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -35,7 +35,7 @@ pub use crate::configuration::{
     ZstandardCompressionParameters,
 };
 pub use crate::multi_signer::{MultiSigner, MultiSignerImpl};
-pub use commands::MainOpts;
+pub use commands::{CommandType, MainOpts};
 pub use dependency_injection::DependencyContainer;
 pub use message_adapters::{
     FromRegisterSignerAdapter, ToCertificatePendingMessageAdapter, ToEpochSettingsMessageAdapter,

--- a/mithril-aggregator/src/main.rs
+++ b/mithril-aggregator/src/main.rs
@@ -1,19 +1,25 @@
 #![doc = include_str!("../README.md")]
 
 use clap::Parser;
-use mithril_aggregator::MainOpts;
+use mithril_aggregator::{CommandType, MainOpts};
 use mithril_common::StdResult;
-use slog::{Drain, Logger};
+use slog::{Drain, Fuse, Level, Logger};
+use slog_async::Async;
 use std::sync::Arc;
+
+fn build_io_logger<W: std::io::Write + Send + 'static>(log_level: Level, io: W) -> Fuse<Async> {
+    let drain = slog_bunyan::new(io).set_pretty(false).build().fuse();
+    let drain = slog::LevelFilter::new(drain, log_level).fuse();
+
+    slog_async::Async::new(drain).build().fuse()
+}
 
 /// Build a logger from args.
 pub fn build_logger(args: &MainOpts) -> Logger {
-    let drain = slog_bunyan::new(std::io::stdout())
-        .set_pretty(false)
-        .build()
-        .fuse();
-    let drain = slog::LevelFilter::new(drain, args.log_level()).fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
+    let drain = match args.command.command_type() {
+        CommandType::Server => build_io_logger(args.log_level(), std::io::stdout()),
+        CommandType::CommandLine => build_io_logger(args.log_level(), std::io::stderr()),
+    };
 
     Logger::root(Arc::new(drain), slog::o!())
 }


### PR DESCRIPTION
## Content
This PR includes an update of `mithril-aggregator` logs output.
Following the type of command (`Server` and `CommandLine`), aggregator logs won't be send in the same output.
- Server (`serve` command) -> `stdout`
- Command line (`genesis`, `era`, `tools`) -> `stderr`

A new ADR has been aded to describe this behavior.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1515 
