### PR TITLE
Change mithril-client to accept an empty db directory instead of requiring it not exist and create it

### DIFF
--- a/mithril-client-cli/src/utils/cardano_db.rs
+++ b/mithril-client-cli/src/utils/cardano_db.rs
@@ -66,7 +66,7 @@ mod test {
 
     #[test]
     fn check_disk_space_error_should_return_error_if_error_is_not_error_not_enough_space() {
-        let error = CardanoDbUnpackerError::UnpackDirectoryAlreadyExists(PathBuf::new());
+        let error = CardanoDbUnpackerError::UnpackDirectoryDoesNotExist(PathBuf::new());
 
         let error = CardanoDbUtils::check_disk_space_error(anyhow!(error))
             .expect_err("check_disk_space_error should fail");
@@ -74,7 +74,7 @@ mod test {
         assert!(
             matches!(
                 error.downcast_ref::<CardanoDbUnpackerError>(),
-                Some(CardanoDbUnpackerError::UnpackDirectoryAlreadyExists(_))
+                Some(CardanoDbUnpackerError::UnpackDirectoryDoesNotExist(_))
             ),
             "Unexpected error: {:?}",
             error

--- a/mithril-client-cli/src/utils/unpacker.rs
+++ b/mithril-client-cli/src/utils/unpacker.rs
@@ -65,6 +65,17 @@ impl CardanoDbUnpacker {
             );
         }
 
+        // Check if the directory is writable by creating a temporary file
+        let temp_file_path = pathdir.join("temp_file");
+        std::fs::File::create(&temp_file_path).map_err(|e| {
+            CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(pathdir.to_owned(), e.into())
+        })?;
+
+        // Delete the temporary file
+        std::fs::remove_file(temp_file_path).map_err(|e| {
+            CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(pathdir.to_owned(), e.into())
+        })?;
+
         let free_space = fs2::available_space(pathdir)? as f64;
 
         if free_space < compression_algorithm.free_space_snapshot_ratio() * size as f64 {

--- a/mithril-client-cli/src/utils/unpacker.rs
+++ b/mithril-client-cli/src/utils/unpacker.rs
@@ -95,7 +95,7 @@ impl CardanoDbUnpacker {
 mod test {
     use super::*;
     use mithril_common::test_utils::TempDir;
-    use std::fs::{create_dir_all};
+    use std::fs::create_dir_all;
 
     fn create_temporary_empty_directory(name: &str) -> PathBuf {
         TempDir::create("client-cli", name)
@@ -157,7 +157,7 @@ mod test {
     #[test]
     fn should_return_error_if_unpack_directory_is_not_empty() {
         let pathdir = create_temporary_empty_directory("not_empty_directory").join("target_directory");
-        std::fs::create_dir_all(&pathdir).unwrap();
+        create_dir_all(&pathdir).unwrap();
         File::create(pathdir.join("file.txt")).unwrap();
 
         let error =

--- a/mithril-client-cli/src/utils/unpacker.rs
+++ b/mithril-client-cli/src/utils/unpacker.rs
@@ -1,6 +1,6 @@
 use human_bytes::human_bytes;
 use std::{
-    fs::{create_dir_all, remove_dir},
+    fs::{create_dir_all, remove_dir, File},
     path::{Path, PathBuf},
 };
 use thiserror::Error;
@@ -95,7 +95,6 @@ impl CardanoDbUnpacker {
 mod test {
     use super::*;
     use mithril_common::test_utils::TempDir;
-    use std::fs::File;
 
     fn create_temporary_empty_directory(name: &str) -> PathBuf {
         TempDir::create("client-cli", name)

--- a/mithril-client-cli/src/utils/unpacker.rs
+++ b/mithril-client-cli/src/utils/unpacker.rs
@@ -1,6 +1,6 @@
 use human_bytes::human_bytes;
 use std::{
-    fs::{create_dir_all, remove_dir, File},
+    fs::File,
     path::{Path, PathBuf},
 };
 use thiserror::Error;
@@ -67,7 +67,7 @@ impl CardanoDbUnpacker {
 
         // Check if the directory is writable by creating a temporary file
         let temp_file_path = pathdir.join("temp_file");
-        std::fs::File::create(&temp_file_path).map_err(|e| {
+        File::create(&temp_file_path).map_err(|e| {
             CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(pathdir.to_owned(), e.into())
         })?;
 
@@ -95,6 +95,7 @@ impl CardanoDbUnpacker {
 mod test {
     use super::*;
     use mithril_common::test_utils::TempDir;
+    use std::fs::{create_dir_all};
 
     fn create_temporary_empty_directory(name: &str) -> PathBuf {
         TempDir::create("client-cli", name)


### PR DESCRIPTION
## Content
This PR includes changes attempting to address issue #1572. Removing the requirement to have the `db` directory not exist and that it be created by the mithril-client to allow starting a download.

### Summary of the most significant changes:

#### Changes to error handling:

* [`mithril-client-cli/src/utils/unpacker.rs`](diffhunk://#diff-558182dd8d399f67a98e4e1a09f0328e50d1dad62cca259506b4554309a737caL32-L61): The `CardanoDbUnpackerError` enum has been updated. The error for when the unpack directory already exists has been replaced with an error for when the directory does not exist. The error message for when the unpack directory is not empty has also been revised.

#### Changes to the `CardanoDbUnpacker` implementation:

* [`mithril-client-cli/src/utils/unpacker.rs`](diffhunk://#diff-558182dd8d399f67a98e4e1a09f0328e50d1dad62cca259506b4554309a737caL32-L61): The `check_prerequisites` function now checks if the unpack directory does not exist or is not empty and raises the corresponding errors. The function no longer creates the directory if it does not exist.

#### Changes to test cases:

* [`mithril-client-cli/src/utils/unpacker.rs`](diffhunk://#diff-558182dd8d399f67a98e4e1a09f0328e50d1dad62cca259506b4554309a737caR85): The test case for when the unpack directory already exists has been replaced with a test case for when the directory does not exist. A new test case for when the unpack directory is not empty has also been added. [[1]](diffhunk://#diff-558182dd8d399f67a98e4e1a09f0328e50d1dad62cca259506b4554309a737caR85) [[2]](diffhunk://#diff-558182dd8d399f67a98e4e1a09f0328e50d1dad62cca259506b4554309a737caL94-R101) [[3]](diffhunk://#diff-558182dd8d399f67a98e4e1a09f0328e50d1dad62cca259506b4554309a737caL104-R110) [[4]](diffhunk://#diff-558182dd8d399f67a98e4e1a09f0328e50d1dad62cca259506b4554309a737caR144-R163)

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [X] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
I intend to check CI and any resulting checks, as much as I am able or have permissions to review. I also added a test to make sure the existing directory is writable via a temp file. 

I've only worked in rust minimally so these changes may not make sense to a senior rust developer, or if testing the existing directory is writable already occurs elsewhere but I overlooked it. I gave it a shot to contribute to fix the feature request I opened in the hopes that CI testing could vet out if this is a viable alternative. 

## Issue(s)
Relates to #1572
