### PR TITLE
Fix minimum `Squid` version in SPO guide

### DIFF
--- a/docs/website/root/manual/getting-started/run-signer-node.md
+++ b/docs/website/root/manual/getting-started/run-signer-node.md
@@ -101,7 +101,7 @@ Note that this guide works on a Linux machine only.
 
 * Install a recent version of `jq` (version 1.6+). You can install it by running `apt install jq`.
 
-* Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 5.2+). You can install it by running `apt install squid`.
+* Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 6.8+).
 
 ## Set up the Mithril signer node
 

--- a/docs/website/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
+++ b/docs/website/versioned_docs/version-maintained/manual/getting-started/run-signer-node.md
@@ -85,7 +85,7 @@ Note that this guide works on a Linux machine only.
 
 * Install a recent version of `jq` (version 1.6+). You can install it by running `apt install jq`.
 
-* Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 5.2+). You can install it by running `apt install squid`.
+* Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 6.8+).
 
 ## Set up the Mithril signer node
 


### PR DESCRIPTION
## Content
This PR includes a fix to the minimum recommended version of `Squid` to `6.8+` in the [Run a Mithril signer as an SPO](https://mithril.network/doc/manual/getting-started/run-signer-node)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

