### PR TITLE
Accept existing but empty `db` dir for `client-cli` cardano-db download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,7 +3436,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.7.4"
+version = "0.7.5"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -14,7 +14,7 @@ use crate::{
     commands::client_builder,
     configuration::ConfigParameters,
     utils::{
-        CardanoDbUnpacker, CardanoDbUtils, ExpanderUtils, IndicatifFeedbackReceiver,
+        CardanoDbDownloadChecker, CardanoDbUtils, ExpanderUtils, IndicatifFeedbackReceiver,
         ProgressOutputType, ProgressPrinter,
     },
 };
@@ -131,13 +131,13 @@ impl CardanoDbDownloadCommand {
     fn check_local_disk_info(
         step_number: u16,
         progress_printer: &ProgressPrinter,
-        db_dir: &PathBuf,
+        db_dir: &Path,
         cardano_db: &Snapshot,
     ) -> MithrilResult<()> {
         progress_printer.report_step(step_number, "Checking local disk info…")?;
 
-        CardanoDbUnpacker::ensure_dir_exist(db_dir)?;
-        if let Err(e) = CardanoDbUnpacker::check_prerequisites(
+        CardanoDbDownloadChecker::ensure_dir_exist(db_dir)?;
+        if let Err(e) = CardanoDbDownloadChecker::check_prerequisites(
             db_dir,
             cardano_db.size,
             cardano_db.compression_algorithm.unwrap_or_default(),

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -135,6 +135,8 @@ impl CardanoDbDownloadCommand {
         cardano_db: &Snapshot,
     ) -> MithrilResult<()> {
         progress_printer.report_step(step_number, "Checking local disk info…")?;
+
+        CardanoDbUnpacker::ensure_dir_exist(db_dir)?;
         if let Err(e) = CardanoDbUnpacker::check_prerequisites(
             db_dir,
             cardano_db.size,
@@ -143,13 +145,6 @@ impl CardanoDbDownloadCommand {
             progress_printer
                 .report_step(step_number, &CardanoDbUtils::check_disk_space_error(e)?)?;
         }
-
-        std::fs::create_dir_all(db_dir).with_context(|| {
-            format!(
-                "Download: could not create target directory '{}'.",
-                db_dir.display()
-            )
-        })?;
 
         Ok(())
     }

--- a/mithril-client-cli/src/utils/cardano_db.rs
+++ b/mithril-client-cli/src/utils/cardano_db.rs
@@ -3,7 +3,7 @@ use futures::Future;
 use indicatif::{MultiProgress, ProgressBar};
 use std::time::Duration;
 
-use super::CardanoDbUnpackerError;
+use super::CardanoDbDownloadCheckerError;
 use mithril_client::{MithrilError, MithrilResult};
 
 /// Utility functions for to the CardanoDb commands
@@ -12,11 +12,11 @@ pub struct CardanoDbUtils;
 impl CardanoDbUtils {
     /// Handle the error return by `check_prerequisites`
     pub fn check_disk_space_error(error: MithrilError) -> MithrilResult<String> {
-        if let Some(CardanoDbUnpackerError::NotEnoughSpace {
+        if let Some(CardanoDbDownloadCheckerError::NotEnoughSpace {
             left_space: _,
             pathdir: _,
             archive_size: _,
-        }) = error.downcast_ref::<CardanoDbUnpackerError>()
+        }) = error.downcast_ref::<CardanoDbDownloadCheckerError>()
         {
             Ok(format!("Warning: {}", error))
         } else {
@@ -51,7 +51,7 @@ mod test {
 
     #[test]
     fn check_disk_space_error_should_return_warning_message_if_error_is_not_enough_space() {
-        let not_enough_space_error = CardanoDbUnpackerError::NotEnoughSpace {
+        let not_enough_space_error = CardanoDbDownloadCheckerError::NotEnoughSpace {
             left_space: 1_f64,
             pathdir: PathBuf::new(),
             archive_size: 2_f64,
@@ -66,15 +66,15 @@ mod test {
 
     #[test]
     fn check_disk_space_error_should_return_error_if_error_is_not_error_not_enough_space() {
-        let error = CardanoDbUnpackerError::UnpackDirectoryNotEmpty(PathBuf::new());
+        let error = CardanoDbDownloadCheckerError::UnpackDirectoryNotEmpty(PathBuf::new());
 
         let error = CardanoDbUtils::check_disk_space_error(anyhow!(error))
             .expect_err("check_disk_space_error should fail");
 
         assert!(
             matches!(
-                error.downcast_ref::<CardanoDbUnpackerError>(),
-                Some(CardanoDbUnpackerError::UnpackDirectoryNotEmpty(_))
+                error.downcast_ref::<CardanoDbDownloadCheckerError>(),
+                Some(CardanoDbDownloadCheckerError::UnpackDirectoryNotEmpty(_))
             ),
             "Unexpected error: {:?}",
             error

--- a/mithril-client-cli/src/utils/cardano_db.rs
+++ b/mithril-client-cli/src/utils/cardano_db.rs
@@ -66,7 +66,7 @@ mod test {
 
     #[test]
     fn check_disk_space_error_should_return_error_if_error_is_not_error_not_enough_space() {
-        let error = CardanoDbUnpackerError::UnpackDirectoryAlreadyExists(PathBuf::new());
+        let error = CardanoDbUnpackerError::UnpackDirectoryNotEmpty(PathBuf::new());
 
         let error = CardanoDbUtils::check_disk_space_error(anyhow!(error))
             .expect_err("check_disk_space_error should fail");
@@ -74,7 +74,7 @@ mod test {
         assert!(
             matches!(
                 error.downcast_ref::<CardanoDbUnpackerError>(),
-                Some(CardanoDbUnpackerError::UnpackDirectoryAlreadyExists(_))
+                Some(CardanoDbUnpackerError::UnpackDirectoryNotEmpty(_))
             ),
             "Unexpected error: {:?}",
             error

--- a/mithril-client-cli/src/utils/mod.rs
+++ b/mithril-client-cli/src/utils/mod.rs
@@ -2,13 +2,13 @@
 //! This module contains tools needed for the commands layer.
 
 mod cardano_db;
+mod cardano_db_download_checker;
 mod expander;
 mod feedback_receiver;
 mod progress_reporter;
-mod unpacker;
 
 pub use cardano_db::*;
+pub use cardano_db_download_checker::*;
 pub use expander::*;
 pub use feedback_receiver::*;
 pub use progress_reporter::*;
-pub use unpacker::*;

--- a/mithril-client-cli/src/utils/unpacker.rs
+++ b/mithril-client-cli/src/utils/unpacker.rs
@@ -1,8 +1,11 @@
-use human_bytes::human_bytes;
+use std::ops::Not;
 use std::{
-    fs::{create_dir_all, remove_dir},
+    fs,
     path::{Path, PathBuf},
 };
+
+use anyhow::Context;
+use human_bytes::human_bytes;
 use thiserror::Error;
 
 use mithril_client::{common::CompressionAlgorithm, MithrilError, MithrilResult};
@@ -29,11 +32,11 @@ pub enum CardanoDbUnpackerError {
         archive_size: f64,
     },
 
-    /// The directory where the files from cardano db are expanded already exists.
-    /// An error is raised because it lets the user a chance to preserve a
-    /// previous work.
-    #[error("Unpack directory '{0}' already exists, please move or delete it.")]
-    UnpackDirectoryAlreadyExists(PathBuf),
+    /// The directory where the files from cardano db are expanded is not empty.
+    /// An error is raised to let the user handle what it wants to do with those
+    /// files.
+    #[error("Unpack directory '{0}' is not empty, please clean up it's content.")]
+    UnpackDirectoryNotEmpty(PathBuf),
 
     /// Cannot write in the given directory.
     #[error("Unpack directory '{0}' is not writable, please check own or parents' permissions and ownership.")]
@@ -41,6 +44,17 @@ pub enum CardanoDbUnpackerError {
 }
 
 impl CardanoDbUnpacker {
+    /// Ensure that the given path exist, create it otherwise
+    pub fn ensure_dir_exist(pathdir: &Path) -> MithrilResult<()> {
+        if !pathdir.exists() {
+            fs::create_dir_all(pathdir).map_err(|e| {
+                CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(pathdir.to_owned(), e.into())
+            })?;
+        }
+
+        Ok(())
+    }
+
     /// Check all prerequisites are met before starting to download and unpack
     /// big cardano db archive.
     pub fn check_prerequisites(
@@ -48,18 +62,53 @@ impl CardanoDbUnpacker {
         size: u64,
         compression_algorithm: CompressionAlgorithm,
     ) -> MithrilResult<()> {
-        if pathdir.exists() {
-            return Err(
-                CardanoDbUnpackerError::UnpackDirectoryAlreadyExists(pathdir.to_owned()).into(),
-            );
+        Self::check_path_is_dir_and_writable(pathdir)?;
+        Self::check_dir_writable(pathdir)?;
+        Self::check_disk_space(pathdir, size, compression_algorithm)
+    }
+
+    fn check_path_is_dir_and_writable(pathdir: &Path) -> MithrilResult<()> {
+        if pathdir.is_dir().not() {
+            anyhow::bail!("Given path is not a directory: {}", pathdir.display());
         }
-        create_dir_all(pathdir).map_err(|e| {
+
+        if fs::read_dir(pathdir)
+            .with_context(|| {
+                format!(
+                    "Could not list directory `{}` to check if it's empty",
+                    pathdir.display()
+                )
+            })?
+            .next()
+            .is_some()
+        {
+            return Err(CardanoDbUnpackerError::UnpackDirectoryNotEmpty(pathdir.to_owned()).into());
+        }
+
+        Ok(())
+    }
+
+    fn check_dir_writable(pathdir: &Path) -> MithrilResult<()> {
+        // Check if the directory is writable by creating a temporary file
+        let temp_file_path = pathdir.join("temp_file");
+        fs::File::create(&temp_file_path).map_err(|e| {
             CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(pathdir.to_owned(), e.into())
         })?;
-        let free_space = fs2::available_space(pathdir)? as f64;
-        // `remove_dir` doesn't remove intermediate directories that could have been created by `create_dir_all`
-        remove_dir(pathdir)?;
 
+        // Delete the temporary file
+        fs::remove_file(temp_file_path).map_err(|e| {
+            CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(pathdir.to_owned(), e.into())
+        })?;
+
+        Ok(())
+    }
+
+    fn check_disk_space(
+        pathdir: &Path,
+        size: u64,
+        compression_algorithm: CompressionAlgorithm,
+    ) -> MithrilResult<()> {
+        let free_space = fs2::available_space(pathdir)? as f64;
         if free_space < compression_algorithm.free_space_snapshot_ratio() * size as f64 {
             return Err(CardanoDbUnpackerError::NotEnoughSpace {
                 left_space: free_space,
@@ -68,32 +117,69 @@ impl CardanoDbUnpacker {
             }
             .into());
         }
-
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod test {
-    use super::*;
     use mithril_common::test_utils::TempDir;
 
+    use super::*;
+
     fn create_temporary_empty_directory(name: &str) -> PathBuf {
-        TempDir::create("client-cli", name)
+        TempDir::create("client-cli-unpacker", name)
     }
 
     #[test]
-    fn should_return_ok() {
-        let pathdir = create_temporary_empty_directory("return_ok").join("target_directory");
+    fn create_directory_if_it_doesnt_exist() {
+        let pathdir =
+            create_temporary_empty_directory("directory_does_not_exist").join("target_directory");
 
+        CardanoDbUnpacker::ensure_dir_exist(&pathdir).expect("ensure_dir_exist should not fail");
+
+        assert!(pathdir.exists());
+    }
+
+    #[test]
+    fn return_error_if_path_is_a_file() {
+        let pathdir =
+            create_temporary_empty_directory("fail_if_pathdir_is_file").join("target_directory");
+        fs::File::create(&pathdir).unwrap();
+
+        CardanoDbUnpacker::ensure_dir_exist(&pathdir).unwrap();
+        CardanoDbUnpacker::check_prerequisites(&pathdir, 12, CompressionAlgorithm::default())
+            .expect_err("check_prerequisites should fail");
+    }
+
+    #[test]
+    fn return_ok_if_unpack_directory_does_not_exist() {
+        let pathdir =
+            create_temporary_empty_directory("directory_does_not_exist").join("target_directory");
+
+        CardanoDbUnpacker::ensure_dir_exist(&pathdir).unwrap();
         CardanoDbUnpacker::check_prerequisites(&pathdir, 12, CompressionAlgorithm::default())
             .expect("check_prerequisites should not fail");
     }
 
     #[test]
-    fn should_return_error_if_unpack_directory_already_exists() {
-        let pathdir = create_temporary_empty_directory("existing_directory");
+    fn return_ok_if_unpack_directory_exist_and_empty() {
+        let pathdir =
+            create_temporary_empty_directory("existing_directory").join("target_directory");
+        fs::create_dir_all(&pathdir).unwrap();
 
+        CardanoDbUnpacker::ensure_dir_exist(&pathdir).unwrap();
+        CardanoDbUnpacker::check_prerequisites(&pathdir, 12, CompressionAlgorithm::default())
+            .expect("check_prerequisites should not fail");
+    }
+
+    #[test]
+    fn return_error_if_unpack_directory_exists_and_not_empty() {
+        let pathdir = create_temporary_empty_directory("existing_directory_not_empty");
+        fs::create_dir_all(&pathdir).unwrap();
+        fs::File::create(pathdir.join("file.txt")).unwrap();
+
+        CardanoDbUnpacker::ensure_dir_exist(&pathdir).unwrap();
         let error =
             CardanoDbUnpacker::check_prerequisites(&pathdir, 12, CompressionAlgorithm::default())
                 .expect_err("check_prerequisites should fail");
@@ -101,34 +187,7 @@ mod test {
         assert!(
             matches!(
                 error.downcast_ref::<CardanoDbUnpackerError>(),
-                Some(CardanoDbUnpackerError::UnpackDirectoryAlreadyExists(_))
-            ),
-            "Unexpected error: {:?}",
-            error
-        );
-    }
-
-    // This test is not run on Windows because `set_readonly` is not working on Windows 7+
-    // https://doc.rust-lang.org/std/fs/struct.Permissions.html#method.set_readonly
-    #[cfg(not(target_os = "windows"))]
-    #[test]
-    fn should_return_error_if_directory_could_not_be_created() {
-        let pathdir = create_temporary_empty_directory("read_only_directory");
-
-        let mut perms = std::fs::metadata(&pathdir).unwrap().permissions();
-        perms.set_readonly(true);
-        std::fs::set_permissions(&pathdir, perms).unwrap();
-
-        let targetdir = pathdir.join("target_directory");
-
-        let error =
-            CardanoDbUnpacker::check_prerequisites(&targetdir, 12, CompressionAlgorithm::default())
-                .expect_err("check_prerequisites should fail");
-
-        assert!(
-            matches!(
-                error.downcast_ref::<CardanoDbUnpackerError>(),
-                Some(CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(_, _))
+                Some(CardanoDbUnpackerError::UnpackDirectoryNotEmpty(_))
             ),
             "Unexpected error: {:?}",
             error
@@ -136,11 +195,12 @@ mod test {
     }
 
     #[test]
-    fn should_return_error_if_not_enough_available_space() {
+    fn return_error_if_not_enough_available_space() {
         let pathdir =
             create_temporary_empty_directory("enough_available_space").join("target_directory");
         let archive_size = u64::MAX;
 
+        CardanoDbUnpacker::ensure_dir_exist(&pathdir).unwrap();
         let error = CardanoDbUnpacker::check_prerequisites(
             &pathdir,
             archive_size,
@@ -160,5 +220,63 @@ mod test {
             "Unexpected error: {:?}",
             error
         );
+    }
+
+    // Those test are not on Windows because `set_readonly` is ignored for directories on Windows 7+
+    // https://doc.rust-lang.org/std/fs/struct.Permissions.html#method.set_readonly
+    #[cfg(not(target_os = "windows"))]
+    mod unix_only {
+        use super::*;
+
+        fn make_readonly(path: &Path) {
+            let mut perms = fs::metadata(path).unwrap().permissions();
+            perms.set_readonly(true);
+            fs::set_permissions(path, perms).unwrap();
+        }
+
+        #[test]
+        fn return_error_if_directory_could_not_be_created() {
+            let pathdir = create_temporary_empty_directory("read_only_directory");
+            let targetdir = pathdir.join("target_directory");
+            make_readonly(&pathdir);
+
+            let error = CardanoDbUnpacker::ensure_dir_exist(&targetdir)
+                .expect_err("ensure_dir_exist should fail");
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<CardanoDbUnpackerError>(),
+                    Some(CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(_, _))
+                ),
+                "Unexpected error: {:?}",
+                error
+            );
+        }
+
+        // This test is not run on Windows because `set_readonly` is ignored for directory on Windows 7+
+        // https://doc.rust-lang.org/std/fs/struct.Permissions.html#method.set_readonly
+        #[test]
+        fn return_error_if_existing_directory_is_not_writable() {
+            let pathdir =
+                create_temporary_empty_directory("existing_directory_not_writable").join("db");
+            fs::create_dir(&pathdir).unwrap();
+            make_readonly(&pathdir);
+
+            let error = CardanoDbUnpacker::check_prerequisites(
+                &pathdir,
+                12,
+                CompressionAlgorithm::default(),
+            )
+            .expect_err("check_prerequisites should fail");
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<CardanoDbUnpackerError>(),
+                    Some(CardanoDbUnpackerError::UnpackDirectoryIsNotWritable(_, _))
+                ),
+                "Unexpected error: {:?}",
+                error
+            );
+        }
     }
 }


### PR DESCRIPTION
## Content
This PR changes the checks that are done for the `cardano-db download` commands:
The `db` directory inside the `download_dir` can now exist beforehand, but it still required to be empty. As before if it doesn't exist it will be created.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1572, alternatives to #1573
