### PR TITLE
Rename `Beacon` common entity to  `CardanoDbBeacon`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3391,7 +3391,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.49"
+version = "0.4.50"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3464,7 +3464,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.6.9"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.21"
+version = "0.3.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3641,7 +3641,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.116"
+version = "0.2.117"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.1.4"
+version = "0.1.5"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/signed_entity_hydrator.rs
+++ b/internal/mithril-persistence/src/database/signed_entity_hydrator.rs
@@ -1,6 +1,8 @@
 //! Signed Entity helpers for persistence
 
-use mithril_common::entities::{Beacon, Epoch, SignedEntityType, SignedEntityTypeDiscriminants};
+use mithril_common::entities::{
+    CardanoDbBeacon, Epoch, SignedEntityType, SignedEntityTypeDiscriminants,
+};
 
 use crate::sqlite::HydrationError;
 
@@ -34,7 +36,7 @@ impl SignedEntityTypeHydrator {
                 SignedEntityType::CardanoStakeDistribution(epoch)
             }
             SignedEntityTypeDiscriminants::CardanoImmutableFilesFull => {
-                let beacon: Beacon = serde_json::from_str(beacon_str).map_err(|e| {
+                let beacon: CardanoDbBeacon = serde_json::from_str(beacon_str).map_err(|e| {
                     HydrationError::InvalidData(format!(
                         "Invalid Beacon JSON in open_message.beacon: '{beacon_str}'. Error: {e}"
                     ))
@@ -42,7 +44,7 @@ impl SignedEntityTypeHydrator {
                 SignedEntityType::CardanoImmutableFilesFull(beacon)
             }
             SignedEntityTypeDiscriminants::CardanoTransactions => {
-                let beacon: Beacon = serde_json::from_str(beacon_str).map_err(|e| {
+                let beacon: CardanoDbBeacon = serde_json::from_str(beacon_str).map_err(|e| {
                     HydrationError::InvalidData(format!(
                         "Invalid Beacon JSON in open_message.beacon: '{beacon_str}'. Error: {e}"
                     ))

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.49"
+version = "0.4.50"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -13,8 +13,8 @@ use crate::{
 use super::ArtifactBuilder;
 use mithril_common::{
     entities::{
-        Beacon, Certificate, CompressionAlgorithm, ProtocolMessage, ProtocolMessagePartKey,
-        Snapshot,
+        CardanoDbBeacon, Certificate, CompressionAlgorithm, ProtocolMessage,
+        ProtocolMessagePartKey, Snapshot,
     },
     StdResult,
 };
@@ -25,7 +25,7 @@ use mithril_common::{
 pub enum CardanoImmutableFilesFullArtifactError {
     /// Protocol message part is missing
     #[error("Missing protocol message for beacon: '{0}'.")]
-    MissingProtocolMessage(Beacon),
+    MissingProtocolMessage(CardanoDbBeacon),
 }
 
 /// A [CardanoImmutableFilesFullArtifact] builder
@@ -54,7 +54,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
 
     async fn create_snapshot_archive(
         &self,
-        beacon: &Beacon,
+        beacon: &CardanoDbBeacon,
         protocol_message: &ProtocolMessage,
     ) -> StdResult<OngoingSnapshot> {
         debug!("CardanoImmutableFilesFullArtifactBuilder: create snapshot archive");
@@ -135,10 +135,10 @@ impl CardanoImmutableFilesFullArtifactBuilder {
 }
 
 #[async_trait]
-impl ArtifactBuilder<Beacon, Snapshot> for CardanoImmutableFilesFullArtifactBuilder {
+impl ArtifactBuilder<CardanoDbBeacon, Snapshot> for CardanoImmutableFilesFullArtifactBuilder {
     async fn compute_artifact(
         &self,
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         certificate: &Certificate,
     ) -> StdResult<Snapshot> {
         let ongoing_snapshot = self
@@ -244,7 +244,7 @@ mod tests {
 
     #[tokio::test]
     async fn snapshot_archive_name_after_beacon_values() {
-        let beacon = Beacon::new("network".to_string(), 20, 145);
+        let beacon = CardanoDbBeacon::new("network".to_string(), 20, 145);
         let mut message = ProtocolMessage::new();
         message.set_message_part(
             ProtocolMessagePartKey::SnapshotDigest,
@@ -293,7 +293,7 @@ mod tests {
                 );
 
             let ongoing_snapshot = cardano_immutable_files_full_artifact_builder
-                .create_snapshot_archive(&Beacon::default(), &message)
+                .create_snapshot_archive(&CardanoDbBeacon::default(), &message)
                 .await
                 .expect("create_snapshot_archive should not fail");
             let file_name = ongoing_snapshot

--- a/mithril-aggregator/src/artifact_builder/cardano_transactions.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_transactions.rs
@@ -4,7 +4,8 @@ use super::ArtifactBuilder;
 use anyhow::{anyhow, Context};
 use mithril_common::{
     entities::{
-        Beacon, CardanoTransactionsSnapshot, Certificate, ProtocolMessagePartKey, SignedEntityType,
+        CardanoDbBeacon, CardanoTransactionsSnapshot, Certificate, ProtocolMessagePartKey,
+        SignedEntityType,
     },
     StdResult,
 };
@@ -20,10 +21,12 @@ impl CardanoTransactionsArtifactBuilder {
 }
 
 #[async_trait]
-impl ArtifactBuilder<Beacon, CardanoTransactionsSnapshot> for CardanoTransactionsArtifactBuilder {
+impl ArtifactBuilder<CardanoDbBeacon, CardanoTransactionsSnapshot>
+    for CardanoTransactionsArtifactBuilder
+{
     async fn compute_artifact(
         &self,
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         certificate: &Certificate,
     ) -> StdResult<CardanoTransactionsSnapshot> {
         let merkle_root = certificate
@@ -89,7 +92,7 @@ mod tests {
 
         let cardano_transaction_artifact_builder = CardanoTransactionsArtifactBuilder::new();
         cardano_transaction_artifact_builder
-            .compute_artifact(Beacon::default(), &certificate)
+            .compute_artifact(CardanoDbBeacon::default(), &certificate)
             .await
             .expect_err("The artifact building must fail since there is no CardanoTransactionsMerkleRoot part in its message.");
     }

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 use mithril_common::entities::{
-    Beacon, CompressionAlgorithm, HexEncodedGenesisVerificationKey, ProtocolParameters,
+    CardanoDbBeacon, CompressionAlgorithm, HexEncodedGenesisVerificationKey, ProtocolParameters,
     SignedEntityType, SignedEntityTypeDiscriminants,
 };
 use mithril_common::{CardanoNetwork, StdResult};
@@ -285,7 +285,7 @@ impl Configuration {
     /// The signed entity types are discarded if they are not declared in the [SignedEntityType] enum.
     pub fn list_allowed_signed_entity_types(
         &self,
-        beacon: &Beacon,
+        beacon: &CardanoDbBeacon,
     ) -> StdResult<Vec<SignedEntityType>> {
         let allowed_discriminants = self.list_allowed_signed_entity_types_discriminants()?;
         let signed_entity_types = allowed_discriminants

--- a/mithril-aggregator/src/database/provider/open_message.rs
+++ b/mithril-aggregator/src/database/provider/open_message.rs
@@ -626,7 +626,7 @@ impl OpenMessageRepository {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::entities::Beacon;
+    use mithril_common::entities::CardanoDbBeacon;
     use mithril_persistence::sqlite::SourceAlias;
     use sqlite::Connection;
 
@@ -769,7 +769,7 @@ else json_group_array( \
     fn provider_message_type_condition() {
         let connection = Connection::open_thread_safe(":memory:").unwrap();
         let provider = OpenMessageProvider::new(&connection);
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             network: "whatever".to_string(),
             epoch: Epoch(4),
             immutable_file_number: 400,
@@ -830,7 +830,7 @@ else json_group_array( \
         let (expr, params) = provider
             .get_insert_condition(
                 epoch,
-                &SignedEntityType::CardanoImmutableFilesFull(Beacon::new(
+                &SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
                     "testnet".to_string(),
                     2,
                     4,
@@ -911,7 +911,7 @@ else json_group_array( \
     async fn repository_get_open_message() {
         let connection = get_connection().await;
         let repository = OpenMessageRepository::new(connection.clone());
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
 
         for signed_entity_type in [
             SignedEntityType::MithrilStakeDistribution(beacon.epoch),
@@ -938,7 +938,7 @@ else json_group_array( \
         let open_message = repository
             .create_open_message(
                 epoch,
-                &SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+                &SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
                 &ProtocolMessage::new(),
             )
             .await
@@ -946,7 +946,7 @@ else json_group_array( \
 
         assert_eq!(Epoch(1), open_message.epoch);
         assert_eq!(
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
             open_message.signed_entity_type
         );
 
@@ -979,7 +979,7 @@ else json_group_array( \
         let open_message = repository
             .create_open_message(
                 epoch,
-                &SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+                &SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
                 &ProtocolMessage::new(),
             )
             .await
@@ -999,9 +999,9 @@ else json_group_array( \
     async fn repository_clean_open_message() {
         let connection = get_connection().await;
         let repository = OpenMessageRepository::new(connection.clone());
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             epoch: Epoch(1),
-            ..Beacon::default()
+            ..CardanoDbBeacon::default()
         };
         let _ = repository
             .create_open_message(
@@ -1014,7 +1014,7 @@ else json_group_array( \
         let _ = repository
             .create_open_message(
                 beacon.epoch,
-                &SignedEntityType::CardanoImmutableFilesFull(Beacon {
+                &SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon {
                     epoch: Epoch(2),
                     ..beacon
                 }),

--- a/mithril-aggregator/src/database/provider/signed_entity.rs
+++ b/mithril-aggregator/src/database/provider/signed_entity.rs
@@ -8,7 +8,8 @@ use std::sync::Arc;
 use mithril_common::{
     crypto_helper::ProtocolParameters,
     entities::{
-        Beacon, Epoch, SignedEntity, SignedEntityType, SignedEntityTypeDiscriminants, Snapshot,
+        CardanoDbBeacon, Epoch, SignedEntity, SignedEntityType, SignedEntityTypeDiscriminants,
+        Snapshot,
     },
     messages::{
         CardanoTransactionSnapshotListItemMessage, CardanoTransactionSnapshotMessage,
@@ -147,7 +148,7 @@ impl TryFrom<SignedEntityRecord> for CardanoTransactionSnapshotMessage {
         #[derive(Deserialize)]
         struct TmpCardanoTransaction {
             merkle_root: String,
-            beacon: Beacon,
+            beacon: CardanoDbBeacon,
             hash: String,
         }
         let artifact = serde_json::from_str::<TmpCardanoTransaction>(&value.artifact)?;
@@ -170,7 +171,7 @@ impl TryFrom<SignedEntityRecord> for CardanoTransactionSnapshotListItemMessage {
         #[derive(Deserialize)]
         struct TmpCardanoTransaction {
             merkle_root: String,
-            beacon: Beacon,
+            beacon: CardanoDbBeacon,
             hash: String,
         }
         let artifact = serde_json::from_str::<TmpCardanoTransaction>(&value.artifact)?;
@@ -634,7 +635,7 @@ impl SignedEntityStorer for SignedEntityStoreAdapter {
 mod tests {
     use crate::database::provider::{apply_all_migrations_to_db, disable_foreign_key_support};
     use mithril_common::entities::MithrilStakeDistribution;
-    use mithril_common::{entities::Beacon, test_utils::fake_data};
+    use mithril_common::{entities::CardanoDbBeacon, test_utils::fake_data};
     use sqlite::Connection;
 
     use super::*;
@@ -950,7 +951,8 @@ mod tests {
             .iter()
             .filter_map(|se| {
                 (se.signed_entity_type.index()
-                    == SignedEntityType::CardanoImmutableFilesFull(Beacon::default()).index())
+                    == SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default())
+                        .index())
                 .then_some(se.to_owned())
             })
             .collect();

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -96,7 +96,7 @@ pub mod tests {
         services::MockMessageService,
     };
     use mithril_common::{
-        entities::{Beacon, SignedEntityType},
+        entities::{CardanoDbBeacon, SignedEntityType},
         messages::ToMessageAdapter,
         test_utils::{apispec::APISpec, fake_data},
     };
@@ -125,7 +125,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_cardano_transactions_get_ok() {
         let signed_entity_records = create_signed_entities(
-            SignedEntityType::CardanoTransactions(Beacon::default()),
+            SignedEntityType::CardanoTransactions(CardanoDbBeacon::default()),
             fake_data::cardano_transactions_snapshot(5),
         );
         let message = ToCardanoTransactionListMessageAdapter::adapt(signed_entity_records);
@@ -192,7 +192,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_cardano_transaction_get_ok() {
         let signed_entity = create_signed_entities(
-            SignedEntityType::CardanoTransactions(Beacon::default()),
+            SignedEntityType::CardanoTransactions(CardanoDbBeacon::default()),
             fake_data::cardano_transactions_snapshot(1),
         )
         .first()

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -228,7 +228,7 @@ mod tests {
         services::{MockMessageService, MockSignedEntityService},
     };
     use mithril_common::{
-        entities::{Beacon, SignedEntityType},
+        entities::{CardanoDbBeacon, SignedEntityType},
         messages::ToMessageAdapter,
         test_utils::{apispec::APISpec, fake_data},
     };
@@ -257,7 +257,7 @@ mod tests {
     #[tokio::test]
     async fn test_snapshots_get_ok() {
         let signed_entities = create_signed_entities(
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
             fake_data::snapshots(5),
         );
         let message = ToSnapshotListMessageAdapter::adapt(signed_entities);
@@ -324,7 +324,7 @@ mod tests {
     #[tokio::test]
     async fn test_snapshot_digest_get_ok() {
         let signed_entity = create_signed_entities(
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
             fake_data::snapshots(1),
         )
         .first()
@@ -425,7 +425,7 @@ mod tests {
     #[tokio::test]
     async fn test_snapshot_local_download_returns_302_found_when_the_snapshot_exists() {
         let signed_entity = create_signed_entities(
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
             fake_data::snapshots(1),
         )
         .first()

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -116,12 +116,14 @@ mod tests {
     use super::*;
     use std::vec;
 
-    use mithril_common::{entities::Beacon, test_utils::apispec::APISpec};
+    use mithril_common::{
+        entities::{
+            CardanoDbBeacon, CardanoTransactionsSetProof, CardanoTransactionsSnapshot, SignedEntity,
+        },
+        test_utils::apispec::APISpec,
+    };
 
     use anyhow::anyhow;
-    use mithril_common::entities::{
-        CardanoTransactionsSetProof, CardanoTransactionsSnapshot, SignedEntity,
-    };
     use serde_json::Value::Null;
     use warp::{
         http::{Method, StatusCode},
@@ -157,9 +159,9 @@ mod tests {
 
         let cardano_transactions_snapshot = {
             let merkle_root = String::new();
-            let beacon = Beacon {
+            let beacon = CardanoDbBeacon {
                 immutable_file_number: 2309,
-                ..Beacon::default()
+                ..CardanoDbBeacon::default()
             };
             CardanoTransactionsSnapshot::new(merkle_root, beacon)
         };

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -106,7 +106,7 @@ mod tests {
     use mithril_common::entities::SignerWithStake;
     use mithril_common::{
         crypto_helper::tests_setup::*,
-        entities::{Beacon, Epoch, SignedEntityType},
+        entities::{CardanoDbBeacon, Epoch, SignedEntityType},
         test_utils::{fake_data, MithrilFixtureBuilder},
     };
     use std::sync::Arc;
@@ -181,7 +181,7 @@ mod tests {
 
         let mut open_message = OpenMessage {
             epoch,
-            signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(Beacon {
+            signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon {
                 epoch,
                 ..fake_data::beacon()
             }),

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 
 use anyhow::Context;
-use mithril_common::entities::{Beacon, SignedEntityType};
+use mithril_common::entities::{CardanoDbBeacon, SignedEntityType};
 use slog_scope::{crit, info, trace, warn};
 use std::fmt::Display;
 use std::sync::Arc;
@@ -12,17 +12,17 @@ use tokio::time::{sleep, Duration};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct IdleState {
-    current_beacon: Option<Beacon>,
+    current_beacon: Option<CardanoDbBeacon>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ReadyState {
-    current_beacon: Beacon,
+    current_beacon: CardanoDbBeacon,
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct SigningState {
-    current_beacon: Beacon,
+    current_beacon: CardanoDbBeacon,
     open_message: OpenMessage,
 }
 
@@ -180,7 +180,7 @@ impl AggregatorRuntime {
                 });
             }
             AggregatorState::Ready(state) => {
-                let chain_beacon: Beacon =
+                let chain_beacon: CardanoDbBeacon =
                     self.runner.get_beacon_from_chain().await.with_context(|| {
                         "AggregatorRuntime in the state READY can not get current beacon from chain"
                     })?;
@@ -220,7 +220,7 @@ impl AggregatorRuntime {
                 }
             }
             AggregatorState::Signing(state) => {
-                let chain_beacon: Beacon =
+                let chain_beacon: CardanoDbBeacon =
                     self.runner.get_beacon_from_chain().await.with_context(|| {
                         "AggregatorRuntime in the state SIGNING can not get current beacon from chain"
                     })?;
@@ -272,8 +272,8 @@ impl AggregatorRuntime {
     /// the certificate chain is valid.
     async fn try_transition_from_idle_to_ready(
         &mut self,
-        maybe_current_beacon: Option<Beacon>,
-        new_beacon: Beacon,
+        maybe_current_beacon: Option<CardanoDbBeacon>,
+        new_beacon: CardanoDbBeacon,
     ) -> Result<(), RuntimeError> {
         trace!("trying transition from IDLE to READY state");
 
@@ -373,7 +373,7 @@ impl AggregatorRuntime {
     /// beacon is detected.
     async fn transition_from_ready_to_signing(
         &mut self,
-        new_beacon: Beacon,
+        new_beacon: CardanoDbBeacon,
         open_message: OpenMessage,
     ) -> Result<SigningState, RuntimeError> {
         trace!("launching transition from READY to SIGNING state");
@@ -536,7 +536,7 @@ mod tests {
     pub async fn ready_new_epoch_detected() {
         let mut runner = MockAggregatorRunner::new();
         let beacon = fake_data::beacon();
-        let new_beacon = Beacon {
+        let new_beacon = CardanoDbBeacon {
             epoch: beacon.epoch + 1,
             ..beacon.clone()
         };
@@ -560,7 +560,7 @@ mod tests {
     pub async fn ready_open_message_not_exist() {
         let mut runner = MockAggregatorRunner::new();
         let beacon = fake_data::beacon();
-        let next_beacon = Beacon {
+        let next_beacon = CardanoDbBeacon {
             immutable_file_number: beacon.immutable_file_number + 1,
             ..beacon.clone()
         };

--- a/mithril-aggregator/src/services/certifier.rs
+++ b/mithril-aggregator/src/services/certifier.rs
@@ -12,8 +12,8 @@ use mithril_common::{
     certificate_chain::CertificateVerifier,
     crypto_helper::{ProtocolGenesisVerifier, PROTOCOL_VERSION},
     entities::{
-        Beacon, Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessage,
-        SignedEntityType, SingleSignatures, StakeDistributionParty,
+        CardanoDbBeacon, Certificate, CertificateMetadata, CertificateSignature, Epoch,
+        ProtocolMessage, SignedEntityType, SingleSignatures, StakeDistributionParty,
     },
     StdResult,
 };
@@ -391,7 +391,7 @@ impl CertifierService for MithrilCertifierService {
                     .get_current_immutable_beacon()
                     .await
                     .with_context(|| "Could not retrieve current beacon to create certificate")?;
-                Beacon {
+                CardanoDbBeacon {
                     epoch: *epoch,
                     ..beacon
                 }
@@ -506,7 +506,7 @@ mod tests {
     };
     use chrono::{DateTime, Days};
     use mithril_common::{
-        entities::{Beacon, ProtocolMessagePartKey},
+        entities::{CardanoDbBeacon, ProtocolMessagePartKey},
         test_utils::{fake_data, MithrilFixture, MithrilFixtureBuilder},
     };
 
@@ -568,7 +568,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_clean_epoch_when_inform_epoch() {
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epoch = beacon.epoch;
@@ -589,7 +589,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_mark_open_message_expired_when_exists() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
@@ -621,7 +621,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_mark_open_message_expired_when_does_not_expire() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
@@ -648,7 +648,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_mark_open_message_expired_when_has_not_expired_yet() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
@@ -675,7 +675,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_register_valid_single_signature() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=3).map(Epoch).collect::<Vec<_>>();
@@ -708,7 +708,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_register_invalid_single_signature() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let mut protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
@@ -740,7 +740,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_register_single_signature_for_certified_open_message() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
@@ -772,7 +772,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_register_single_signature_for_expired_open_message() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
@@ -804,7 +804,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_create_certificate_when_multi_signature_produced() {
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=3).map(Epoch).collect::<Vec<_>>();
@@ -817,7 +817,7 @@ mod tests {
             .await
             .unwrap();
 
-        let genesis_beacon = Beacon {
+        let genesis_beacon = CardanoDbBeacon {
             epoch: beacon.epoch - 1,
             ..beacon.clone()
         };
@@ -877,7 +877,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_create_certificate_for_open_message_not_created() {
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
@@ -890,7 +890,7 @@ mod tests {
 
     #[tokio::test]
     async fn should_not_create_certificate_for_open_message_already_certified() {
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epoch = beacon.epoch;
@@ -914,7 +914,7 @@ mod tests {
         mock_multi_signer
             .expect_create_multi_signature()
             .return_once(move |_| Ok(None));
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();

--- a/mithril-aggregator/src/services/message.rs
+++ b/mithril-aggregator/src/services/message.rs
@@ -194,7 +194,7 @@ mod tests {
 
     use mithril_common::{
         entities::{
-            Beacon, CardanoTransactionsSnapshot, MithrilStakeDistribution, SignedEntity,
+            CardanoDbBeacon, CardanoTransactionsSnapshot, MithrilStakeDistribution, SignedEntity,
             SignedEntityType, Snapshot,
         },
         messages::ToMessageAdapter,
@@ -234,9 +234,9 @@ mod tests {
         let configuration = Configuration::new_sample();
         let mut dep_builder = DependenciesBuilder::new(configuration);
         let service = dep_builder.get_message_service().await.unwrap();
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-        let genesis_beacon = Beacon {
+        let genesis_beacon = CardanoDbBeacon {
             epoch: beacon.epoch - 1,
             ..beacon.clone()
         };
@@ -263,9 +263,9 @@ mod tests {
         let configuration = Configuration::new_sample();
         let mut dep_builder = DependenciesBuilder::new(configuration);
         let service = dep_builder.get_message_service().await.unwrap();
-        let beacon = Beacon::new("devnet".to_string(), 3, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 3, 1);
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-        let genesis_beacon = Beacon {
+        let genesis_beacon = CardanoDbBeacon {
             epoch: beacon.epoch - 1,
             ..beacon.clone()
         };

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -6,7 +6,8 @@ use async_trait::async_trait;
 use mithril_common::{
     crypto_helper::{MKMap, MKMapNode, MKTree, MKTreeNode},
     entities::{
-        Beacon, BlockRange, CardanoTransaction, CardanoTransactionsSetProof, TransactionHash,
+        BlockRange, CardanoDbBeacon, CardanoTransaction, CardanoTransactionsSetProof,
+        TransactionHash,
     },
     StdResult,
 };
@@ -21,7 +22,7 @@ pub trait ProverService: Sync + Send {
     /// Compute the cryptographic proofs for the given transactions
     async fn compute_transactions_proofs(
         &self,
-        up_to: &Beacon,
+        up_to: &CardanoDbBeacon,
         transaction_hashes: &[TransactionHash],
     ) -> StdResult<Vec<CardanoTransactionsSetProof>>;
 }
@@ -31,7 +32,7 @@ pub trait ProverService: Sync + Send {
 #[async_trait]
 pub trait TransactionsRetriever: Sync + Send {
     /// Get transactions up to given beacon using chronological order
-    async fn get_up_to(&self, beacon: &Beacon) -> StdResult<Vec<CardanoTransaction>>;
+    async fn get_up_to(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>>;
 }
 
 /// Mithril prover
@@ -82,7 +83,7 @@ impl MithrilProverService {
 impl ProverService for MithrilProverService {
     async fn compute_transactions_proofs(
         &self,
-        up_to: &Beacon,
+        up_to: &CardanoDbBeacon,
         transaction_hashes: &[TransactionHash],
     ) -> StdResult<Vec<CardanoTransactionsSetProof>> {
         let transactions = self.transaction_retriever.get_up_to(up_to).await?;

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 use mithril_common::{
     entities::{
-        Beacon, CardanoTransactionsSnapshot, Certificate, Epoch, MithrilStakeDistribution,
+        CardanoDbBeacon, CardanoTransactionsSnapshot, Certificate, Epoch, MithrilStakeDistribution,
         SignedEntity, SignedEntityType, SignedEntityTypeDiscriminants, Snapshot,
     },
     signable_builder::Artifact,
@@ -72,9 +72,10 @@ pub struct MithrilSignedEntityService {
     signed_entity_storer: Arc<dyn SignedEntityStorer>,
     mithril_stake_distribution_artifact_builder:
         Arc<dyn ArtifactBuilder<Epoch, MithrilStakeDistribution>>,
-    cardano_immutable_files_full_artifact_builder: Arc<dyn ArtifactBuilder<Beacon, Snapshot>>,
+    cardano_immutable_files_full_artifact_builder:
+        Arc<dyn ArtifactBuilder<CardanoDbBeacon, Snapshot>>,
     cardano_transactions_artifact_builder:
-        Arc<dyn ArtifactBuilder<Beacon, CardanoTransactionsSnapshot>>,
+        Arc<dyn ArtifactBuilder<CardanoDbBeacon, CardanoTransactionsSnapshot>>,
 }
 
 impl MithrilSignedEntityService {
@@ -84,9 +85,11 @@ impl MithrilSignedEntityService {
         mithril_stake_distribution_artifact_builder: Arc<
             dyn ArtifactBuilder<Epoch, MithrilStakeDistribution>,
         >,
-        cardano_immutable_files_full_artifact_builder: Arc<dyn ArtifactBuilder<Beacon, Snapshot>>,
+        cardano_immutable_files_full_artifact_builder: Arc<
+            dyn ArtifactBuilder<CardanoDbBeacon, Snapshot>,
+        >,
         cardano_transactions_artifact_builder: Arc<
-            dyn ArtifactBuilder<Beacon, CardanoTransactionsSnapshot>,
+            dyn ArtifactBuilder<CardanoDbBeacon, CardanoTransactionsSnapshot>,
         >,
     ) -> Self {
         Self {
@@ -332,9 +335,10 @@ mod tests {
         mock_signed_entity_storer: MockSignedEntityStorer,
         mock_mithril_stake_distribution_artifact_builder:
             MockArtifactBuilder<Epoch, MithrilStakeDistribution>,
-        mock_cardano_immutable_files_full_artifact_builder: MockArtifactBuilder<Beacon, Snapshot>,
+        mock_cardano_immutable_files_full_artifact_builder:
+            MockArtifactBuilder<CardanoDbBeacon, Snapshot>,
         mock_cardano_transactions_artifact_builder:
-            MockArtifactBuilder<Beacon, CardanoTransactionsSnapshot>,
+            MockArtifactBuilder<CardanoDbBeacon, CardanoTransactionsSnapshot>,
     }
 
     impl MockDependencyInjector {
@@ -346,11 +350,11 @@ mod tests {
                     MithrilStakeDistribution,
                 >::new(),
                 mock_cardano_immutable_files_full_artifact_builder: MockArtifactBuilder::<
-                    Beacon,
+                    CardanoDbBeacon,
                     Snapshot,
                 >::new(),
                 mock_cardano_transactions_artifact_builder: MockArtifactBuilder::<
-                    Beacon,
+                    CardanoDbBeacon,
                     CardanoTransactionsSnapshot,
                 >::new(),
             }
@@ -416,7 +420,8 @@ mod tests {
         let artifact_builder_service = mock_container.build_artifact_builder_service();
 
         let certificate = fake_data::certificate("hash".to_string());
-        let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(Beacon::default());
+        let signed_entity_type =
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
         let artifact = artifact_builder_service
             .compute_artifact(signed_entity_type.clone(), &certificate)
             .await
@@ -428,7 +433,7 @@ mod tests {
     #[tokio::test]
     async fn should_store_the_artifact_when_creating_artifact_for_a_cardano_immutable_files() {
         generic_test_that_the_artifact_is_stored(
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
             fake_data::snapshots(1).first().unwrap().to_owned(),
             &|mock_injector| &mut mock_injector.mock_cardano_immutable_files_full_artifact_builder,
         )
@@ -440,7 +445,7 @@ mod tests {
         let mut mock_container = MockDependencyInjector::new();
 
         let expected =
-            CardanoTransactionsSnapshot::new("merkle_root".to_string(), Beacon::default());
+            CardanoTransactionsSnapshot::new("merkle_root".to_string(), CardanoDbBeacon::default());
 
         mock_container
             .mock_cardano_transactions_artifact_builder
@@ -449,14 +454,14 @@ mod tests {
             .returning(|_, _| {
                 Ok(CardanoTransactionsSnapshot::new(
                     "merkle_root".to_string(),
-                    Beacon::default(),
+                    CardanoDbBeacon::default(),
                 ))
             });
 
         let artifact_builder_service = mock_container.build_artifact_builder_service();
 
         let certificate = fake_data::certificate("hash".to_string());
-        let signed_entity_type = SignedEntityType::CardanoTransactions(Beacon::default());
+        let signed_entity_type = SignedEntityType::CardanoTransactions(CardanoDbBeacon::default());
         let artifact = artifact_builder_service
             .compute_artifact(signed_entity_type.clone(), &certificate)
             .await
@@ -468,8 +473,8 @@ mod tests {
     #[tokio::test]
     async fn should_store_the_artifact_when_creating_artifact_for_cardano_transactions() {
         generic_test_that_the_artifact_is_stored(
-            SignedEntityType::CardanoTransactions(Beacon::default()),
-            CardanoTransactionsSnapshot::new("merkle_root".to_string(), Beacon::default()),
+            SignedEntityType::CardanoTransactions(CardanoDbBeacon::default()),
+            CardanoTransactionsSnapshot::new("merkle_root".to_string(), CardanoDbBeacon::default()),
             &|mock_injector| &mut mock_injector.mock_cardano_transactions_artifact_builder,
         )
         .await;

--- a/mithril-aggregator/src/services/ticker.rs
+++ b/mithril-aggregator/src/services/ticker.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use mithril_common::{
     chain_observer::ChainObserver,
     digesters::ImmutableFileObserver,
-    entities::{Beacon, Epoch},
+    entities::{CardanoDbBeacon, Epoch},
     CardanoNetwork, StdResult,
 };
 use thiserror::Error;
@@ -28,7 +28,7 @@ pub trait TickerService: Send + Sync {
     async fn get_current_epoch(&self) -> StdResult<Epoch>;
 
     /// Return the current Beacon used for CardanoImmutableFileDigest message type.
-    async fn get_current_immutable_beacon(&self) -> StdResult<Beacon>;
+    async fn get_current_immutable_beacon(&self) -> StdResult<CardanoDbBeacon>;
 }
 
 /// ## MithrilTickerService
@@ -69,7 +69,7 @@ impl TickerService for MithrilTickerService {
         Ok(epoch)
     }
 
-    async fn get_current_immutable_beacon(&self) -> StdResult<Beacon> {
+    async fn get_current_immutable_beacon(&self) -> StdResult<CardanoDbBeacon> {
         let epoch = self.get_current_epoch().await?;
         let immutable_file_number = self
             .immutable_observer
@@ -81,7 +81,7 @@ impl TickerService for MithrilTickerService {
                 )
             })?;
 
-        Ok(Beacon::new(
+        Ok(CardanoDbBeacon::new(
             self.network.to_string(),
             *epoch,
             immutable_file_number,
@@ -127,7 +127,7 @@ mod tests {
         let beacon = ticker_service.get_current_immutable_beacon().await.unwrap();
 
         assert_eq!(
-            Beacon {
+            CardanoDbBeacon {
                 epoch: Epoch(10),
                 immutable_file_number: 99,
                 network: "devnet".to_string()

--- a/mithril-aggregator/src/store/pending_certificate_store.rs
+++ b/mithril-aggregator/src/store/pending_certificate_store.rs
@@ -64,7 +64,7 @@ impl CertificatePendingStore {
 mod test {
     use super::*;
 
-    use mithril_common::entities::{Beacon, SignedEntityType};
+    use mithril_common::entities::{CardanoDbBeacon, SignedEntityType};
     use mithril_common::test_utils::fake_data;
     use mithril_persistence::store::adapter::DumbStoreAdapter;
 
@@ -72,7 +72,7 @@ mod test {
         let mut adapter: DumbStoreAdapter<String, CertificatePending> = DumbStoreAdapter::new();
 
         if is_populated {
-            let beacon = Beacon::new("testnet".to_string(), 0, 0);
+            let beacon = CardanoDbBeacon::new("testnet".to_string(), 0, 0);
             let certificate_pending = CertificatePending::new(
                 beacon.clone(),
                 SignedEntityType::dummy(),
@@ -108,7 +108,7 @@ mod test {
     #[tokio::test]
     async fn save_certificate_pending_once() {
         let store = get_certificate_pending_store(false).await;
-        let beacon = Beacon::new("testnet".to_string(), 0, 1);
+        let beacon = CardanoDbBeacon::new("testnet".to_string(), 0, 1);
         let signed_entity_type = SignedEntityType::dummy();
         let certificate_pending = CertificatePending::new(
             beacon,
@@ -134,7 +134,7 @@ mod test {
     #[tokio::test]
     async fn remove_certificate_pending() {
         let store = get_certificate_pending_store(true).await;
-        let beacon = Beacon::new("testnet".to_string(), 0, 0);
+        let beacon = CardanoDbBeacon::new("testnet".to_string(), 0, 0);
         let certificate_pending = store.remove().await.unwrap().unwrap();
 
         assert_eq!(beacon, certificate_pending.beacon);

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -194,7 +194,7 @@ mod test {
     use anyhow::Context;
     use mithril_common::{
         entities::{
-            Beacon, Certificate, Epoch, ImmutableFileNumber,
+            CardanoDbBeacon, Certificate, Epoch, ImmutableFileNumber,
             SignedEntityType::{
                 CardanoImmutableFilesFull, CardanoStakeDistribution, CardanoTransactions,
                 MithrilStakeDistribution,
@@ -230,7 +230,7 @@ mod test {
     ) -> Certificate {
         let certificate = CertificateRecord::dummy_genesis(
             certificate_hash,
-            Beacon::new("testnet".to_string(), epoch, immutable_file_number),
+            CardanoDbBeacon::new("testnet".to_string(), epoch, immutable_file_number),
         );
 
         certificate.into()
@@ -245,7 +245,7 @@ mod test {
         let certificate = CertificateRecord::dummy(
             certificate_hash,
             previous_hash,
-            Beacon::new("testnet".to_string(), epoch, immutable_file_number),
+            CardanoDbBeacon::new("testnet".to_string(), epoch, immutable_file_number),
         );
 
         certificate.into()

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -7,7 +7,7 @@ use mithril_common::{
         ProtocolAggregateVerificationKey, ProtocolGenesisSignature, ProtocolGenesisSigner,
         ProtocolGenesisVerifier,
     },
-    entities::{Beacon, ProtocolParameters},
+    entities::{CardanoDbBeacon, ProtocolParameters},
     protocol::SignerBuilder,
     BeaconProvider, StdResult,
 };
@@ -37,7 +37,7 @@ pub struct GenesisToolsDependency {
 
 pub struct GenesisTools {
     protocol_parameters: ProtocolParameters,
-    beacon: Beacon,
+    beacon: CardanoDbBeacon,
     genesis_avk: ProtocolAggregateVerificationKey,
     genesis_verifier: Arc<ProtocolGenesisVerifier>,
     certificate_verifier: Arc<dyn CertificateVerifier>,
@@ -47,7 +47,7 @@ pub struct GenesisTools {
 impl GenesisTools {
     pub fn new(
         protocol_parameters: ProtocolParameters,
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         genesis_avk: ProtocolAggregateVerificationKey,
         genesis_verifier: Arc<ProtocolGenesisVerifier>,
         certificate_verifier: Arc<dyn CertificateVerifier>,

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -3,8 +3,8 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        Beacon, Epoch, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
-        StakeDistribution, StakeDistributionParty,
+        CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType,
+        SignedEntityTypeDiscriminants, StakeDistribution, StakeDistributionParty,
     },
     test_utils::MithrilFixtureBuilder,
 };
@@ -23,7 +23,7 @@ async fn certificate_chain() {
         ..Configuration::new_sample()
     };
     let mut tester =
-        RuntimeTester::build(Beacon::new("net".to_string(), 1, 1), configuration).await;
+        RuntimeTester::build(CardanoDbBeacon::new("net".to_string(), 1, 1), configuration).await;
     let observer = tester.observer.clone();
 
     comment!("Create signers & declare stake distribution");
@@ -47,7 +47,7 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new_genesis(
-            Beacon::new("devnet".to_string(), 1, 1),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 1),
             initial_fixture.compute_and_encode_avk()
         )
     );
@@ -73,11 +73,15 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 2),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 2),
             StakeDistributionParty::from_signers(initial_fixture.signers_with_stake()).as_slice(),
             initial_fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(1)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -96,11 +100,19 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 3),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 3),
             StakeDistributionParty::from_signers(initial_fixture.signers_with_stake()).as_slice(),
             initial_fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 1, 3)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                3
+            )),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -121,11 +133,19 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 4),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 4),
             StakeDistributionParty::from_signers(initial_fixture.signers_with_stake()).as_slice(),
             initial_fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 1, 4)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                4
+            )),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -185,11 +205,15 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 2, 4),
+            CardanoDbBeacon::new("devnet".to_string(), 2, 4),
             StakeDistributionParty::from_signers(initial_fixture.signers_with_stake()).as_slice(),
             initial_fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(2)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -216,7 +240,7 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 3, 5),
+            CardanoDbBeacon::new("devnet".to_string(), 3, 5),
             StakeDistributionParty::from_signers(initial_fixture.signers_with_stake()).as_slice(),
             initial_fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(3)),
@@ -247,7 +271,7 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 4, 6),
+            CardanoDbBeacon::new("devnet".to_string(), 4, 6),
             StakeDistributionParty::from_signers(next_fixture.signers_with_stake()).as_slice(),
             next_fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(4)),
@@ -278,10 +302,14 @@ async fn certificate_chain() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 4, 7),
+            CardanoDbBeacon::new("devnet".to_string(), 4, 7),
             StakeDistributionParty::from_signers(next_fixture.signers_with_stake()).as_slice(),
             next_fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 4, 7)),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
+                "devnet".to_string(),
+                4,
+                7
+            )),
             ExpectedCertificate::identifier(&SignedEntityType::MithrilStakeDistribution(Epoch(4))),
         )
     );

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -3,8 +3,8 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        Beacon, Epoch, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
-        StakeDistributionParty,
+        CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType,
+        SignedEntityTypeDiscriminants, StakeDistributionParty,
     },
     test_utils::MithrilFixtureBuilder,
 };
@@ -22,8 +22,11 @@ async fn create_certificate() {
         data_stores_directory: get_test_dir("create_certificate"),
         ..Configuration::new_sample()
     };
-    let mut tester =
-        RuntimeTester::build(Beacon::new("devnet".to_string(), 1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        CardanoDbBeacon::new("devnet".to_string(), 1, 1),
+        configuration,
+    )
+    .await;
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()
@@ -39,7 +42,7 @@ async fn create_certificate() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new_genesis(
-            Beacon::new("devnet".to_string(), 1, 1),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 1),
             fixture.compute_and_encode_avk()
         )
     );
@@ -72,11 +75,15 @@ async fn create_certificate() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 2),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 2),
             StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
             fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(1)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -101,14 +108,22 @@ async fn create_certificate() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 3),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 3),
             &signers_for_immutables
                 .iter()
                 .map(|s| s.signer_with_stake.clone().into())
                 .collect::<Vec<_>>(),
             fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 1, 3)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                3
+            )),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 

--- a/mithril-aggregator/tests/era_checker.rs
+++ b/mithril-aggregator/tests/era_checker.rs
@@ -1,7 +1,7 @@
 mod test_extensions;
 use mithril_aggregator::{Configuration, RuntimeError};
 use mithril_common::{
-    entities::{Beacon, Epoch, ProtocolParameters},
+    entities::{CardanoDbBeacon, Epoch, ProtocolParameters},
     era::{EraMarker, SupportedEra},
     test_utils::MithrilFixtureBuilder,
 };
@@ -24,7 +24,7 @@ async fn testing_eras() {
         ..Configuration::new_sample()
     };
     let mut tester =
-        RuntimeTester::build(Beacon::new("net".to_string(), 1, 1), configuration).await;
+        RuntimeTester::build(CardanoDbBeacon::new("net".to_string(), 1, 1), configuration).await;
     tester.era_reader_adapter.set_markers(vec![
         EraMarker::new("unsupported", Some(Epoch(0))),
         EraMarker::new(&SupportedEra::dummy().to_string(), Some(Epoch(12))),

--- a/mithril-aggregator/tests/genesis_to_signing.rs
+++ b/mithril-aggregator/tests/genesis_to_signing.rs
@@ -2,7 +2,7 @@ mod test_extensions;
 
 use mithril_aggregator::Configuration;
 use mithril_common::{
-    entities::{Beacon, ProtocolParameters},
+    entities::{CardanoDbBeacon, ProtocolParameters},
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
@@ -20,7 +20,7 @@ async fn genesis_to_signing() {
         ..Configuration::new_sample()
     };
     let mut tester =
-        RuntimeTester::build(Beacon::new("net".to_string(), 1, 1), configuration).await;
+        RuntimeTester::build(CardanoDbBeacon::new("net".to_string(), 1, 1), configuration).await;
 
     comment!("Create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()
@@ -37,7 +37,7 @@ async fn genesis_to_signing() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new_genesis(
-            Beacon::new("devnet".to_string(), 1, 1),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 1),
             fixture.compute_and_encode_avk()
         )
     );

--- a/mithril-aggregator/tests/open_message_expiration.rs
+++ b/mithril-aggregator/tests/open_message_expiration.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        Beacon, Epoch, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
-        StakeDistributionParty,
+        CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType,
+        SignedEntityTypeDiscriminants, StakeDistributionParty,
     },
     test_utils::MithrilFixtureBuilder,
 };
@@ -24,8 +24,11 @@ async fn open_message_expiration() {
         data_stores_directory: get_test_dir("open_message_expiration"),
         ..Configuration::new_sample()
     };
-    let mut tester =
-        RuntimeTester::build(Beacon::new("devnet".to_string(), 1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        CardanoDbBeacon::new("devnet".to_string(), 1, 1),
+        configuration,
+    )
+    .await;
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()
@@ -41,7 +44,7 @@ async fn open_message_expiration() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new_genesis(
-            Beacon::new("devnet".to_string(), 1, 1),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 1),
             fixture.compute_and_encode_avk()
         )
     );
@@ -74,11 +77,15 @@ async fn open_message_expiration() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 2),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 2),
             StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
             fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(1)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -116,11 +123,15 @@ async fn open_message_expiration() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 2),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 2),
             StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
             fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(1)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -143,14 +154,22 @@ async fn open_message_expiration() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 4),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 4),
             &signers_for_immutables
                 .iter()
                 .map(|s| s.signer_with_stake.clone().into())
                 .collect::<Vec<_>>(),
             fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 1, 4)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                4
+            )),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 }

--- a/mithril-aggregator/tests/open_message_newer_exists.rs
+++ b/mithril-aggregator/tests/open_message_newer_exists.rs
@@ -3,8 +3,8 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        Beacon, Epoch, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
-        StakeDistributionParty,
+        CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType,
+        SignedEntityTypeDiscriminants, StakeDistributionParty,
     },
     test_utils::MithrilFixtureBuilder,
 };
@@ -22,8 +22,11 @@ async fn open_message_newer_exists() {
         data_stores_directory: get_test_dir("open_message_newer_exists"),
         ..Configuration::new_sample()
     };
-    let mut tester =
-        RuntimeTester::build(Beacon::new("devnet".to_string(), 1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        CardanoDbBeacon::new("devnet".to_string(), 1, 1),
+        configuration,
+    )
+    .await;
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()
@@ -39,7 +42,7 @@ async fn open_message_newer_exists() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new_genesis(
-            Beacon::new("devnet".to_string(), 1, 1),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 1),
             fixture.compute_and_encode_avk()
         )
     );
@@ -72,11 +75,15 @@ async fn open_message_newer_exists() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 2),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 2),
             StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
             fixture.compute_and_encode_avk(),
             SignedEntityType::MithrilStakeDistribution(Epoch(1)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 
@@ -111,14 +118,22 @@ async fn open_message_newer_exists() {
     assert_last_certificate_eq!(
         tester,
         ExpectedCertificate::new(
-            Beacon::new("devnet".to_string(), 1, 4),
+            CardanoDbBeacon::new("devnet".to_string(), 1, 4),
             &signers_for_immutables
                 .iter()
                 .map(|s| s.signer_with_stake.clone().into())
                 .collect::<Vec<_>>(),
             fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoImmutableFilesFull(Beacon::new("devnet".to_string(), 1, 4)),
-            ExpectedCertificate::genesis_identifier(&Beacon::new("devnet".to_string(), 1, 1)),
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                4
+            )),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                1,
+                1
+            )),
         )
     );
 }

--- a/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
@@ -5,7 +5,7 @@ use mithril_aggregator::{
     services::{CertifierService, TickerService},
 };
 use mithril_common::{
-    entities::{Beacon, Epoch, SignedEntityType, SignedEntityTypeDiscriminants},
+    entities::{CardanoDbBeacon, Epoch, SignedEntityType, SignedEntityTypeDiscriminants},
     BeaconProvider, StdResult,
 };
 use std::sync::Arc;
@@ -32,8 +32,8 @@ impl AggregatorObserver {
         self.ticker_service.get_current_epoch().await.unwrap()
     }
 
-    /// Get the current [Beacon] known to the aggregator
-    pub async fn current_beacon(&self) -> Beacon {
+    /// Get the current [CardanoDbBeacon] known to the aggregator
+    pub async fn current_beacon(&self) -> CardanoDbBeacon {
         self.ticker_service
             .get_current_immutable_beacon()
             .await

--- a/mithril-aggregator/tests/test_extensions/expected_certificate.rs
+++ b/mithril-aggregator/tests/test_extensions/expected_certificate.rs
@@ -1,5 +1,5 @@
 use mithril_common::entities::{
-    Beacon, HexEncodedAgregateVerificationKey, PartyId, SignedEntityType, Stake,
+    CardanoDbBeacon, HexEncodedAgregateVerificationKey, PartyId, SignedEntityType, Stake,
     StakeDistributionParty,
 };
 use std::collections::BTreeMap;
@@ -8,7 +8,7 @@ use std::collections::BTreeMap;
 pub struct ExpectedCertificate {
     identifier: String,
     previous_identifier: Option<String>,
-    beacon: Beacon,
+    beacon: CardanoDbBeacon,
     signers: BTreeMap<PartyId, Stake>,
     avk: HexEncodedAgregateVerificationKey,
     signed_type: Option<SignedEntityType>,
@@ -16,7 +16,7 @@ pub struct ExpectedCertificate {
 
 impl ExpectedCertificate {
     pub fn new(
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         signers: &[StakeDistributionParty],
         avk: HexEncodedAgregateVerificationKey,
         signed_type: SignedEntityType,
@@ -32,7 +32,7 @@ impl ExpectedCertificate {
         }
     }
 
-    pub fn new_genesis(beacon: Beacon, avk: HexEncodedAgregateVerificationKey) -> Self {
+    pub fn new_genesis(beacon: CardanoDbBeacon, avk: HexEncodedAgregateVerificationKey) -> Self {
         Self {
             identifier: Self::genesis_identifier(&beacon),
             previous_identifier: None,
@@ -47,7 +47,7 @@ impl ExpectedCertificate {
         format!("certificate-{:?}", signed_types)
     }
 
-    pub fn genesis_identifier(beacon: &Beacon) -> String {
+    pub fn genesis_identifier(beacon: &CardanoDbBeacon) -> String {
         format!("genesis-{:?}", beacon)
     }
 }

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -12,7 +12,7 @@ use mithril_common::{
     crypto_helper::ProtocolGenesisSigner,
     digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
     entities::{
-        Beacon, Certificate, CertificateSignature, Epoch, ImmutableFileNumber,
+        CardanoDbBeacon, Certificate, CertificateSignature, Epoch, ImmutableFileNumber,
         SignedEntityTypeDiscriminants, Snapshot, StakeDistribution,
     },
     era::{adapters::EraReaderDummyAdapter, EraMarker, EraReader, SupportedEra},
@@ -79,7 +79,7 @@ fn build_logger() -> slog_scope::GlobalLoggerGuard {
 }
 
 impl RuntimeTester {
-    pub async fn build(start_beacon: Beacon, configuration: Configuration) -> Self {
+    pub async fn build(start_beacon: CardanoDbBeacon, configuration: Configuration) -> Self {
         let logger = build_logger();
         let snapshot_uploader = Arc::new(DumbSnapshotUploader::new());
         let immutable_file_observer = Arc::new(DumbImmutableFileObserver::new());

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.7.6"
+version = "0.7.7"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -334,7 +334,7 @@ impl Source for CardanoDbDownloadCommand {
 #[cfg(test)]
 mod tests {
     use mithril_client::{
-        common::{Beacon, ProtocolMessagePartKey},
+        common::{CardanoDbBeacon, ProtocolMessagePartKey},
         MithrilCertificateMetadata,
     };
     use mithril_common::test_utils::TempDir;
@@ -354,7 +354,7 @@ mod tests {
         MithrilCertificate {
             hash: "hash".to_string(),
             previous_hash: "previous_hash".to_string(),
-            beacon: Beacon::new("testnet".to_string(), 10, 100),
+            beacon: CardanoDbBeacon::new("testnet".to_string(), 10, 100),
             metadata: MithrilCertificateMetadata::dummy(),
             protocol_message: protocol_message.clone(),
             signed_message: "signed_message".to_string(),

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.6.9"
+version = "0.7.0"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/cardano_transaction_client.rs
+++ b/mithril-client/src/cardano_transaction_client.rs
@@ -159,7 +159,7 @@ impl CardanoTransactionClient {
 #[cfg(test)]
 mod tests {
     use crate::aggregator_client::{AggregatorClientError, MockAggregatorHTTPClient};
-    use crate::common::Beacon;
+    use crate::common::CardanoDbBeacon;
     use crate::{
         CardanoTransactionSnapshot, CardanoTransactionSnapshotListItem, CardanoTransactionsProofs,
         CardanoTransactionsSetProof,
@@ -174,7 +174,7 @@ mod tests {
         vec![
             CardanoTransactionSnapshotListItem {
                 merkle_root: "mk-123".to_string(),
-                beacon: Beacon::new("network".to_string(), 1, 1),
+                beacon: CardanoDbBeacon::new("network".to_string(), 1, 1),
                 hash: "hash-123".to_string(),
                 certificate_hash: "cert-hash-123".to_string(),
                 created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
@@ -183,7 +183,7 @@ mod tests {
             },
             CardanoTransactionSnapshotListItem {
                 merkle_root: "mk-456".to_string(),
-                beacon: Beacon::new("network".to_string(), 1, 2),
+                beacon: CardanoDbBeacon::new("network".to_string(), 1, 2),
                 hash: "hash-456".to_string(),
                 certificate_hash: "cert-hash-456".to_string(),
                 created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
@@ -213,7 +213,7 @@ mod tests {
         let mut http_client = MockAggregatorHTTPClient::new();
         let message = CardanoTransactionSnapshot {
             merkle_root: "mk-123".to_string(),
-            beacon: Beacon::new("network".to_string(), 1, 1),
+            beacon: CardanoDbBeacon::new("network".to_string(), 1, 1),
             hash: "hash-123".to_string(),
             certificate_hash: "cert-hash-123".to_string(),
             created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")

--- a/mithril-client/src/type_alias.rs
+++ b/mithril-client/src/type_alias.rs
@@ -45,7 +45,7 @@ cfg_unstable! {
 
     pub use mithril_common::messages::VerifyCardanoTransactionsProofsError;
 
-    /// A snapshot that allow to know up to which [point of time][common::Beacon] Mithril have certified Cardano transactions.
+    /// A snapshot that allow to know up to which [point of time][common::CardanoDbBeacon] Mithril have certified Cardano transactions.
     ///
     pub use mithril_common::messages::CardanoTransactionSnapshotMessage as CardanoTransactionSnapshot;
 

--- a/mithril-client/src/type_alias.rs
+++ b/mithril-client/src/type_alias.rs
@@ -57,7 +57,7 @@ cfg_unstable! {
 /// `mithril-common` re-exports
 pub mod common {
     pub use mithril_common::entities::{
-        Beacon, CompressionAlgorithm, Epoch, ProtocolMessage, ProtocolMessagePartKey,
+        CardanoDbBeacon, CompressionAlgorithm, Epoch, ProtocolMessage, ProtocolMessagePartKey,
         ProtocolParameters,
     };
     cfg_unstable! {

--- a/mithril-client/tests/extensions/fake.rs
+++ b/mithril-client/tests/extensions/fake.rs
@@ -199,7 +199,7 @@ mod file {
     use super::*;
     use mithril_client::{MessageBuilder, Snapshot, SnapshotListItem};
     use mithril_common::digesters::DummyImmutableDb;
-    use mithril_common::entities::{Beacon, CompressionAlgorithm};
+    use mithril_common::entities::{CardanoDbBeacon, CompressionAlgorithm};
     use mithril_common::test_utils::fake_data;
     use mithril_common::test_utils::test_http_server::{test_http_server, TestHttpServer};
     use std::path::{Path, PathBuf};
@@ -215,7 +215,7 @@ mod file {
             immutable_db: &DummyImmutableDb,
             work_dir: &Path,
         ) -> TestHttpServer {
-            let beacon = Beacon {
+            let beacon = CardanoDbBeacon {
                 immutable_file_number: immutable_db.last_immutable_number().unwrap(),
                 ..fake_data::beacon()
             };

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.21"
+version = "0.3.22"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/benches/digester.rs
+++ b/mithril-common/benches/digester.rs
@@ -4,7 +4,7 @@ use mithril_common::{
     digesters::{
         cache::MemoryImmutableFileDigestCacheProvider, CardanoImmutableDigester, ImmutableDigester,
     },
-    entities::{Beacon, ImmutableFileNumber},
+    entities::{CardanoDbBeacon, ImmutableFileNumber},
 };
 use slog::Drain;
 use std::{
@@ -63,7 +63,7 @@ async fn compute_digest(
     digester
         .compute_digest(
             &db_dir(),
-            &Beacon::new("devnet".to_string(), 1, number_of_immutables),
+            &CardanoDbBeacon::new("devnet".to_string(), 1, number_of_immutables),
         )
         .await
         .expect("digest computation should not fail");

--- a/mithril-common/src/beacon_provider.rs
+++ b/mithril-common/src/beacon_provider.rs
@@ -6,18 +6,18 @@ use thiserror::Error;
 
 use crate::StdResult;
 use crate::{
-    chain_observer::ChainObserver, digesters::ImmutableFileObserver, entities::Beacon,
+    chain_observer::ChainObserver, digesters::ImmutableFileObserver, entities::CardanoDbBeacon,
     CardanoNetwork,
 };
 
-/// Provide the current [Beacon] of a cardano node.
+/// Provide the current [CardanoDbBeacon] of a cardano node.
 #[async_trait]
 pub trait BeaconProvider
 where
     Self: Sync + Send,
 {
-    /// Get the current [Beacon] of the cardano node.
-    async fn get_current_beacon(&self) -> StdResult<Beacon>;
+    /// Get the current [CardanoDbBeacon] of the cardano node.
+    async fn get_current_beacon(&self) -> StdResult<CardanoDbBeacon>;
 }
 
 /// [BeaconProvider] related errors.
@@ -52,7 +52,7 @@ impl BeaconProviderImpl {
 
 #[async_trait]
 impl BeaconProvider for BeaconProviderImpl {
-    async fn get_current_beacon(&self) -> StdResult<Beacon> {
+    async fn get_current_beacon(&self) -> StdResult<CardanoDbBeacon> {
         let epoch = self
             .chain_observer
             .get_current_epoch()
@@ -71,7 +71,7 @@ impl BeaconProvider for BeaconProviderImpl {
                 )
             })?;
 
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             network: self.network.to_string(),
             epoch,
             immutable_file_number,

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -11,7 +11,7 @@ use crate::{
         PROTOCOL_VERSION,
     },
     entities::{
-        Beacon, Certificate, CertificateMetadata, CertificateSignature, ProtocolMessage,
+        CardanoDbBeacon, Certificate, CertificateMetadata, CertificateSignature, ProtocolMessage,
         ProtocolMessagePartKey, ProtocolParameters,
     },
     StdResult,
@@ -65,7 +65,7 @@ impl CertificateGenesisProducer {
     /// Create a Genesis Certificate
     pub fn create_genesis_certificate(
         protocol_parameters: ProtocolParameters,
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         genesis_avk: ProtocolAggregateVerificationKey,
         genesis_signature: ProtocolGenesisSignature,
     ) -> StdResult<Certificate> {

--- a/mithril-common/src/chain_observer/fake_observer.rs
+++ b/mithril-common/src/chain_observer/fake_observer.rs
@@ -13,10 +13,10 @@ pub struct FakeObserver {
     /// [get_current_stake_distribution]: ChainObserver::get_current_stake_distribution
     pub signers: RwLock<Vec<SignerWithStake>>,
 
-    /// A [Beacon], used by [get_current_epoch]
+    /// A [CardanoDbBeacon], used by [get_current_epoch]
     ///
     /// [get_current_epoch]: ChainObserver::get_current_epoch
-    pub current_beacon: RwLock<Option<Beacon>>,
+    pub current_beacon: RwLock<Option<CardanoDbBeacon>>,
 
     /// A list of [TxDatum], used by [get_current_datums]
     ///
@@ -26,7 +26,7 @@ pub struct FakeObserver {
 
 impl FakeObserver {
     /// FakeObserver factory
-    pub fn new(current_beacon: Option<Beacon>) -> Self {
+    pub fn new(current_beacon: Option<CardanoDbBeacon>) -> Self {
         Self {
             signers: RwLock::new(vec![]),
             current_beacon: RwLock::new(current_beacon),
@@ -37,7 +37,7 @@ impl FakeObserver {
     /// Increase by one the epoch of the [current_beacon][`FakeObserver::current_beacon`].
     pub async fn next_epoch(&self) -> Option<Epoch> {
         let mut current_beacon = self.current_beacon.write().await;
-        *current_beacon = current_beacon.as_ref().map(|beacon| Beacon {
+        *current_beacon = current_beacon.as_ref().map(|beacon| CardanoDbBeacon {
             epoch: beacon.epoch + 1,
             ..beacon.clone()
         });

--- a/mithril-common/src/digesters/cardano_immutable_digester.rs
+++ b/mithril-common/src/digesters/cardano_immutable_digester.rs
@@ -3,7 +3,7 @@ use crate::{
         cache::ImmutableFileDigestCacheProvider, ImmutableDigester, ImmutableDigesterError,
         ImmutableFile,
     },
-    entities::{Beacon, HexEncodedDigest, ImmutableFileName},
+    entities::{CardanoDbBeacon, HexEncodedDigest, ImmutableFileName},
 };
 use async_trait::async_trait;
 use sha2::{Digest, Sha256};
@@ -42,7 +42,7 @@ impl ImmutableDigester for CardanoImmutableDigester {
     async fn compute_digest(
         &self,
         dirpath: &Path,
-        beacon: &Beacon,
+        beacon: &CardanoDbBeacon,
     ) -> Result<String, ImmutableDigesterError> {
         let up_to_file_number = beacon.immutable_file_number;
         let immutables = ImmutableFile::list_completed_in_dir(dirpath)?
@@ -110,7 +110,7 @@ impl ImmutableDigester for CardanoImmutableDigester {
 
 fn compute_hash(
     logger: Logger,
-    beacon: &Beacon,
+    beacon: &CardanoDbBeacon,
     entries: BTreeMap<ImmutableFile, Option<HexEncodedDigest>>,
 ) -> CacheComputationResult {
     let mut hasher = Sha256::new();
@@ -177,7 +177,7 @@ mod tests {
             CardanoImmutableDigester, DummyImmutablesDbBuilder, ImmutableDigester,
             ImmutableDigesterError,
         },
-        entities::{Beacon, ImmutableFileNumber},
+        entities::{CardanoDbBeacon, ImmutableFileNumber},
     };
     use sha2::Sha256;
     use slog::Drain;
@@ -225,7 +225,7 @@ mod tests {
     async fn fail_if_no_file_in_folder() {
         let immutable_db = db_builder("fail_if_no_file_in_folder").build();
         let digester = CardanoImmutableDigester::new(None, create_logger());
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
 
         let result = digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -251,7 +251,7 @@ mod tests {
             .with_non_immutables(&["not_immutable"])
             .build();
         let digester = CardanoImmutableDigester::new(None, create_logger());
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
 
         assert!(digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -265,7 +265,7 @@ mod tests {
             .append_immutable_trio()
             .build();
         let digester = CardanoImmutableDigester::new(None, create_logger());
-        let beacon = Beacon::new("devnet".to_string(), 1, 1);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 1);
 
         let result = digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -292,7 +292,7 @@ mod tests {
             .append_immutable_trio()
             .build();
         let digester = CardanoImmutableDigester::new(None, create_logger());
-        let beacon = Beacon::new("devnet".to_string(), 1, 10);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 10);
 
         let result = digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -323,7 +323,7 @@ mod tests {
             Some(Arc::new(MemoryImmutableFileDigestCacheProvider::default())),
             logger.clone(),
         );
-        let beacon = Beacon::new("devnet".to_string(), 1, 100);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 100);
 
         let result = digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -346,7 +346,7 @@ mod tests {
         let cache = Arc::new(MemoryImmutableFileDigestCacheProvider::default());
         let logger = create_logger();
         let digester = CardanoImmutableDigester::new(Some(cache.clone()), logger.clone());
-        let beacon = Beacon::new("devnet".to_string(), 1, 2);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 2);
 
         digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -382,7 +382,7 @@ mod tests {
             Some(Arc::new(MemoryImmutableFileDigestCacheProvider::default())),
             logger.clone(),
         );
-        let beacon = Beacon::new("devnet".to_string(), 1, 3);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 3);
 
         let without_cache_digest = no_cache_digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -420,7 +420,7 @@ mod tests {
         let cache = MemoryImmutableFileDigestCacheProvider::default();
         let logger = create_logger();
         let digester = CardanoImmutableDigester::new(Some(Arc::new(cache)), logger.clone());
-        let beacon = Beacon::new("devnet".to_string(), 1, 50);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 50);
 
         let now = Instant::now();
         digester
@@ -462,7 +462,7 @@ mod tests {
         });
         let logger = create_logger();
         let digester = CardanoImmutableDigester::new(Some(Arc::new(cache)), logger.clone());
-        let beacon = Beacon::new("devnet".to_string(), 1, 3);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 3);
 
         digester
             .compute_digest(&immutable_db.dir, &beacon)
@@ -485,7 +485,7 @@ mod tests {
         cache.expect_store().returning(|_| Ok(()));
         let logger = create_logger();
         let digester = CardanoImmutableDigester::new(Some(Arc::new(cache)), logger.clone());
-        let beacon = Beacon::new("devnet".to_string(), 1, 3);
+        let beacon = CardanoDbBeacon::new("devnet".to_string(), 1, 3);
 
         digester
             .compute_digest(&immutable_db.dir, &beacon)

--- a/mithril-common/src/digesters/dumb_immutable_observer.rs
+++ b/mithril-common/src/digesters/dumb_immutable_observer.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use crate::{
     digesters::{ImmutableDigester, ImmutableDigesterError},
-    entities::Beacon,
+    entities::CardanoDbBeacon,
 };
 use async_trait::async_trait;
 use tokio::sync::RwLock;
@@ -39,7 +39,7 @@ impl ImmutableDigester for DumbImmutableDigester {
     async fn compute_digest(
         &self,
         dirpath: &Path,
-        beacon: &Beacon,
+        beacon: &CardanoDbBeacon,
     ) -> Result<String, ImmutableDigesterError> {
         if self.is_success {
             Ok(self.digest.read().await.clone())

--- a/mithril-common/src/digesters/immutable_digester.rs
+++ b/mithril-common/src/digesters/immutable_digester.rs
@@ -1,6 +1,6 @@
 use crate::{
     digesters::ImmutableFileListingError,
-    entities::{Beacon, ImmutableFileNumber},
+    entities::{CardanoDbBeacon, ImmutableFileNumber},
 };
 use async_trait::async_trait;
 use std::{
@@ -16,7 +16,7 @@ use thiserror::Error;
 /// mod test {
 ///     use async_trait::async_trait;
 ///     use mithril_common::digesters::{ImmutableDigester, ImmutableDigesterError};
-///     use mithril_common::entities::Beacon;
+///     use mithril_common::entities::CardanoDbBeacon;
 ///     use mockall::mock;
 ///     use std::path::Path;
 ///
@@ -28,7 +28,7 @@ use thiserror::Error;
 ///             async fn compute_digest(
 ///               &self,
 ///               dirpath: &Path,
-///               beacon: &Beacon,
+///               beacon: &CardanoDbBeacon,
 ///             ) -> Result<String, ImmutableDigesterError>;
 ///         }
 ///     }
@@ -52,7 +52,7 @@ pub trait ImmutableDigester: Sync + Send {
     async fn compute_digest(
         &self,
         dirpath: &Path,
-        beacon: &Beacon,
+        beacon: &CardanoDbBeacon,
     ) -> Result<String, ImmutableDigesterError>;
 }
 

--- a/mithril-common/src/entities/cardano_transactions_snapshot.rs
+++ b/mithril-common/src/entities/cardano_transactions_snapshot.rs
@@ -2,7 +2,7 @@ use crate::signable_builder::Artifact;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use super::Beacon;
+use super::CardanoDbBeacon;
 
 /// Snapshot of a set of Cardano transactions
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -14,12 +14,12 @@ pub struct CardanoTransactionsSnapshot {
     pub merkle_root: String,
 
     /// Beacon of the Cardano transactions set
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 }
 
 impl CardanoTransactionsSnapshot {
     /// Creates a new [CardanoTransactionsSnapshot]
-    pub fn new(merkle_root: String, beacon: Beacon) -> Self {
+    pub fn new(merkle_root: String, beacon: CardanoDbBeacon) -> Self {
         let mut cardano_transactions_snapshot = Self {
             merkle_root,
             beacon,
@@ -56,13 +56,13 @@ mod tests {
 
         assert_eq!(
             hash_expected,
-            CardanoTransactionsSnapshot::new("mk-root-123".to_string(), Beacon::default())
+            CardanoTransactionsSnapshot::new("mk-root-123".to_string(), CardanoDbBeacon::default())
                 .compute_hash()
         );
 
         assert_ne!(
             hash_expected,
-            CardanoTransactionsSnapshot::new("mk-root-456".to_string(), Beacon::default())
+            CardanoTransactionsSnapshot::new("mk-root-456".to_string(), CardanoDbBeacon::default())
                 .compute_hash()
         );
     }

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -1,7 +1,7 @@
 use crate::crypto_helper::{
     ProtocolAggregateVerificationKey, ProtocolGenesisSignature, ProtocolMultiSignature,
 };
-use crate::entities::{Beacon, CertificateMetadata, ProtocolMessage};
+use crate::entities::{CardanoDbBeacon, CertificateMetadata, ProtocolMessage};
 use std::cmp::Ordering;
 use std::fmt::{Debug, Formatter};
 
@@ -35,7 +35,7 @@ pub struct Certificate {
 
     /// Mithril beacon on the Cardano chain
     /// aka BEACON(p,n)
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Certificate metadata
     /// aka METADATA(p,n)
@@ -62,7 +62,7 @@ impl Certificate {
     /// Certificate factory
     pub fn new(
         previous_hash: String,
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         metadata: CertificateMetadata,
         protocol_message: ProtocolMessage,
         aggregate_verification_key: ProtocolAggregateVerificationKey,
@@ -223,7 +223,7 @@ mod tests {
 
         let certificate = Certificate::new(
             "previous_hash".to_string(),
-            Beacon::new("testnet".to_string(), 10, 100),
+            CardanoDbBeacon::new("testnet".to_string(), 10, 100),
             CertificateMetadata::new(
                 "0.1.0".to_string(),
                 ProtocolParameters::new(1000, 100, 0.123),
@@ -254,7 +254,7 @@ mod tests {
         assert_ne!(
             HASH_EXPECTED,
             Certificate {
-                beacon: Beacon::new("testnet-modified".to_string(), 10, 100),
+                beacon: CardanoDbBeacon::new("testnet-modified".to_string(), 10, 100),
                 ..certificate.clone()
             }
             .compute_hash(),
@@ -324,7 +324,7 @@ mod tests {
 
         let genesis_certificate = Certificate::new(
             "previous_hash".to_string(),
-            Beacon::new("testnet".to_string(), 10, 100),
+            CardanoDbBeacon::new("testnet".to_string(), 10, 100),
             CertificateMetadata::new(
                 "0.1.0".to_string(),
                 ProtocolParameters::new(1000, 100, 0.123),

--- a/mithril-common/src/entities/certificate_pending.rs
+++ b/mithril-common/src/entities/certificate_pending.rs
@@ -1,4 +1,4 @@
-use crate::entities::{Beacon, PartyId, ProtocolParameters, Signer};
+use crate::entities::{CardanoDbBeacon, PartyId, ProtocolParameters, Signer};
 use serde::{Deserialize, Serialize};
 
 use super::SignedEntityType;
@@ -7,7 +7,7 @@ use super::SignedEntityType;
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CertificatePending {
     /// Current Beacon
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Signed entity type
     #[serde(rename = "entity_type")]
@@ -31,7 +31,7 @@ pub struct CertificatePending {
 impl CertificatePending {
     /// CertificatePending factory
     pub fn new(
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         signed_entity_type: SignedEntityType,
         protocol_parameters: ProtocolParameters,
         next_protocol_parameters: ProtocolParameters,

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -1,7 +1,7 @@
 //! The entities used by, and exchanged between, the aggregator, signers and client.
 
-mod beacon;
 mod block_range;
+mod cardano_db_beacon;
 mod cardano_network;
 mod cardano_transaction;
 mod cardano_transactions_set_proof;
@@ -22,8 +22,8 @@ mod single_signatures;
 mod snapshot;
 mod type_alias;
 
-pub use beacon::{Beacon, BeaconComparison, BeaconComparisonError};
 pub use block_range::{BlockNumber, BlockRange, BlockRangeLength};
+pub use cardano_db_beacon::{BeaconComparison, BeaconComparisonError, CardanoDbBeacon};
 pub use cardano_network::CardanoNetwork;
 pub use cardano_transaction::{CardanoTransaction, TransactionHash};
 pub use cardano_transactions_set_proof::CardanoTransactionsSetProof;

--- a/mithril-common/src/entities/signed_entity.rs
+++ b/mithril-common/src/entities/signed_entity.rs
@@ -1,5 +1,5 @@
 #[cfg(any(test, feature = "test_tools"))]
-use super::{Beacon, Epoch};
+use super::{CardanoDbBeacon, Epoch};
 use super::{CardanoTransactionsSnapshot, MithrilStakeDistribution, SignedEntityType, Snapshot};
 use crate::signable_builder::Artifact;
 #[cfg(any(test, feature = "test_tools"))]
@@ -34,7 +34,7 @@ impl SignedEntity<Snapshot> {
         pub fn dummy() -> Self {
             SignedEntity {
                 signed_entity_id: "snapshot-id-123".to_string(),
-                signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(Beacon::default()),
+                signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default()),
                 certificate_id: "certificate-hash-123".to_string(),
                 artifact: fake_data::snapshots(1)[0].to_owned(),
                 created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
@@ -68,9 +68,9 @@ impl SignedEntity<CardanoTransactionsSnapshot> {
         pub fn dummy() -> Self {
             SignedEntity {
                 signed_entity_id: "snapshot-id-123".to_string(),
-                signed_entity_type: SignedEntityType::CardanoTransactions(Beacon::default()),
+                signed_entity_type: SignedEntityType::CardanoTransactions(CardanoDbBeacon::default()),
                 certificate_id: "certificate-hash-123".to_string(),
-                artifact: CardanoTransactionsSnapshot::new("mkroot123".to_string(), Beacon::default()),
+                artifact: CardanoTransactionsSnapshot::new("mkroot123".to_string(), CardanoDbBeacon::default()),
                 created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
                     .unwrap()
                     .with_timezone(&Utc),

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use strum::{AsRefStr, Display, EnumDiscriminants, EnumString};
 
-use super::{Beacon, Epoch};
+use super::{CardanoDbBeacon, Epoch};
 
 /// Database representation of the SignedEntityType::MithrilStakeDistribution value
 const ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION: usize = 0;
@@ -35,10 +35,10 @@ pub enum SignedEntityType {
     CardanoStakeDistribution(Epoch),
 
     /// Full Cardano Immutable Files
-    CardanoImmutableFilesFull(Beacon),
+    CardanoImmutableFilesFull(CardanoDbBeacon),
 
     /// Cardano Transactions
-    CardanoTransactions(Beacon),
+    CardanoTransactions(CardanoDbBeacon),
 }
 
 impl SignedEntityType {
@@ -90,7 +90,10 @@ impl SignedEntityType {
     }
 
     /// Create a SignedEntityType from beacon and SignedEntityTypeDiscriminants
-    pub fn from_beacon(discriminant: &SignedEntityTypeDiscriminants, beacon: &Beacon) -> Self {
+    pub fn from_beacon(
+        discriminant: &SignedEntityTypeDiscriminants,
+        beacon: &CardanoDbBeacon,
+    ) -> Self {
         match discriminant {
             SignedEntityTypeDiscriminants::MithrilStakeDistribution => {
                 Self::MithrilStakeDistribution(beacon.epoch)

--- a/mithril-common/src/entities/snapshot.rs
+++ b/mithril-common/src/entities/snapshot.rs
@@ -1,4 +1,4 @@
-use crate::{entities::Beacon, signable_builder::Artifact};
+use crate::{entities::CardanoDbBeacon, signable_builder::Artifact};
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, IntoEnumIterator};
@@ -10,7 +10,7 @@ pub struct Snapshot {
     pub digest: String,
 
     /// Mithril beacon on the Cardano chain
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Size of the snapshot file in Bytes
     pub size: u64,
@@ -66,7 +66,7 @@ impl Snapshot {
     /// Snapshot factory
     pub fn new(
         digest: String,
-        beacon: Beacon,
+        beacon: CardanoDbBeacon,
         size: u64,
         locations: Vec<String>,
         compression_algorithm: CompressionAlgorithm,

--- a/mithril-common/src/messages/cardano_transaction_snapshot.rs
+++ b/mithril-common/src/messages/cardano_transaction_snapshot.rs
@@ -2,7 +2,7 @@ use chrono::DateTime;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-use crate::entities::Beacon;
+use crate::entities::CardanoDbBeacon;
 #[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_data;
 
@@ -13,7 +13,7 @@ pub struct CardanoTransactionSnapshotMessage {
     pub merkle_root: String,
 
     /// Beacon of the Cardano transactions snapshot
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Hash of the Cardano Transactions snapshot
     pub hash: String,

--- a/mithril-common/src/messages/cardano_transaction_snapshot_list.rs
+++ b/mithril-common/src/messages/cardano_transaction_snapshot_list.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::entities::Beacon;
+use crate::entities::CardanoDbBeacon;
 #[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_data;
 
@@ -15,7 +15,7 @@ pub struct CardanoTransactionSnapshotListItemMessage {
     pub merkle_root: String,
 
     /// Beacon of the Cardano transactions snapshot
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Hash of the Cardano Transactions snapshot
     pub hash: String,

--- a/mithril-common/src/messages/cardano_transactions_proof.rs
+++ b/mithril-common/src/messages/cardano_transactions_proof.rs
@@ -315,7 +315,7 @@ mod tests {
     #[cfg(feature = "fs")]
     mod fs_only {
         use crate::cardano_transaction_parser::DumbTransactionParser;
-        use crate::entities::{Beacon, CardanoTransaction};
+        use crate::entities::{CardanoDbBeacon, CardanoTransaction};
         use crate::signable_builder::{
             CardanoTransactionsSignableBuilder, MockTransactionStore, SignableBuilder,
         };
@@ -390,9 +390,9 @@ mod tests {
                 Logger::root(slog::Discard, slog::o!()),
             );
             cardano_transaction_signable_builder
-                .compute_protocol_message(Beacon {
+                .compute_protocol_message(CardanoDbBeacon {
                     immutable_file_number,
-                    ..Beacon::default()
+                    ..CardanoDbBeacon::default()
                 })
                 .await
                 .unwrap()

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -5,7 +5,7 @@ use std::fmt::{Debug, Formatter};
 #[cfg(any(test, feature = "test_tools"))]
 use crate::entities::ProtocolMessagePartKey;
 use crate::entities::{
-    Beacon, Certificate, CertificateMetadata, CertificateSignature, ProtocolMessage,
+    CardanoDbBeacon, Certificate, CertificateMetadata, CertificateSignature, ProtocolMessage,
 };
 use crate::messages::CertificateMetadataMessagePart;
 
@@ -29,7 +29,7 @@ pub struct CertificateMessage {
 
     /// Mithril beacon on the Cardano chain
     /// aka BEACON(p,n)
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Certificate metadata
     /// aka METADATA(p,n)
@@ -73,7 +73,7 @@ impl CertificateMessage {
             Self {
                 hash: "hash".to_string(),
                 previous_hash: "previous_hash".to_string(),
-                beacon: Beacon::new("testnet".to_string(), 10, 100),
+                beacon: CardanoDbBeacon::new("testnet".to_string(), 10, 100),
                 metadata: CertificateMetadataMessagePart::dummy(),
                 protocol_message: protocol_message.clone(),
                 signed_message: "signed_message".to_string(),
@@ -233,7 +233,7 @@ mod tests {
         CertificateMessage {
             hash: "hash".to_string(),
             previous_hash: "previous_hash".to_string(),
-            beacon: Beacon::new("testnet".to_string(), 10, 100),
+            beacon: CardanoDbBeacon::new("testnet".to_string(), 10, 100),
             metadata: CertificateMetadataMessagePart {
                 protocol_version: "0.1.0".to_string(),
                 protocol_parameters: ProtocolParameters::new(1000, 100, 0.123),

--- a/mithril-common/src/messages/certificate_list.rs
+++ b/mithril-common/src/messages/certificate_list.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Formatter};
 
 use crate::entities::{
-    Beacon, ProtocolMessage, ProtocolMessagePartKey, ProtocolParameters, ProtocolVersion,
+    CardanoDbBeacon, ProtocolMessage, ProtocolMessagePartKey, ProtocolParameters, ProtocolVersion,
 };
 
 /// Message structure of a certificate list
@@ -54,7 +54,7 @@ pub struct CertificateListItemMessage {
 
     /// Mithril beacon on the Cardano chain
     /// aka BEACON(p,n)
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Certificate metadata
     /// aka METADATA(p,n)
@@ -89,7 +89,7 @@ impl CertificateListItemMessage {
         Self {
             hash: "hash".to_string(),
             previous_hash: "previous_hash".to_string(),
-            beacon: Beacon::new("testnet".to_string(), 10, 100),
+            beacon: CardanoDbBeacon::new("testnet".to_string(), 10, 100),
             metadata: CertificateListItemMessageMetadata {
                 protocol_version: "0.1.0".to_string(),
                 protocol_parameters: ProtocolParameters::new(1000, 100, 0.123),
@@ -152,7 +152,7 @@ mod tests {
         vec![CertificateListItemMessage {
             hash: "hash".to_string(),
             previous_hash: "previous_hash".to_string(),
-            beacon: Beacon::new("testnet".to_string(), 10, 100),
+            beacon: CardanoDbBeacon::new("testnet".to_string(), 10, 100),
             metadata: CertificateListItemMessageMetadata {
                 protocol_version: "0.1.0".to_string(),
                 protocol_parameters: ProtocolParameters::new(1000, 100, 0.123),

--- a/mithril-common/src/messages/certificate_pending.rs
+++ b/mithril-common/src/messages/certificate_pending.rs
@@ -1,13 +1,13 @@
 use serde::{Deserialize, Serialize};
 
-use crate::entities::{Beacon, ProtocolParameters, SignedEntityType};
+use crate::entities::{CardanoDbBeacon, ProtocolParameters, SignedEntityType};
 use crate::messages::SignerMessagePart;
 
 /// Structure to transport [crate::entities::CertificatePending] data.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CertificatePendingMessage {
     /// Current Beacon
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Signed entity type
     #[serde(rename = "entity_type")]
@@ -33,7 +33,7 @@ impl CertificatePendingMessage {
         /// Provide a dummy instance for test.
         pub fn dummy() -> Self {
             Self {
-                beacon: Beacon::default(),
+                beacon: CardanoDbBeacon::default(),
                 signed_entity_type: SignedEntityType::dummy(),
                 protocol_parameters: ProtocolParameters {
                     k: 5,
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
 
     fn golden_message() -> CertificatePendingMessage {
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             network: "preview".to_string(),
             epoch: Epoch(86),
             immutable_file_number: 1728,

--- a/mithril-common/src/messages/snapshot.rs
+++ b/mithril-common/src/messages/snapshot.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::entities::{Beacon, CompressionAlgorithm, Epoch};
+use crate::entities::{CardanoDbBeacon, CompressionAlgorithm, Epoch};
 
 /// Message structure of a snapshot
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -10,7 +10,7 @@ pub struct SnapshotMessage {
     pub digest: String,
 
     /// Mithril beacon on the Cardano chain
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Hash of the associated certificate
     pub certificate_hash: String,
@@ -38,7 +38,7 @@ impl SnapshotMessage {
     pub fn dummy() -> Self {
         Self {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,
@@ -63,7 +63,7 @@ mod tests {
     fn golden_message_v1() -> SnapshotMessage {
         SnapshotMessage {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,
@@ -83,7 +83,7 @@ mod tests {
     fn golden_message_v2() -> SnapshotMessage {
         SnapshotMessage {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,

--- a/mithril-common/src/messages/snapshot_download.rs
+++ b/mithril-common/src/messages/snapshot_download.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::entities::{Beacon, CompressionAlgorithm, Epoch};
+use crate::entities::{CardanoDbBeacon, CompressionAlgorithm, Epoch};
 
 /// Message structure of a snapshot
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -9,7 +9,7 @@ pub struct SnapshotDownloadMessage {
     pub digest: String,
 
     /// Mithril beacon on the Cardano chain
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Size of the snapshot file in Bytes
     pub size: u64,
@@ -29,7 +29,7 @@ impl SnapshotDownloadMessage {
     pub fn dummy() -> Self {
         Self {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,
@@ -49,7 +49,7 @@ mod tests {
     fn golden_message_v1() -> SnapshotDownloadMessage {
         SnapshotDownloadMessage {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,

--- a/mithril-common/src/messages/snapshot_list.rs
+++ b/mithril-common/src/messages/snapshot_list.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-use crate::entities::{Beacon, CompressionAlgorithm, Epoch};
+use crate::entities::{CardanoDbBeacon, CompressionAlgorithm, Epoch};
 
 /// Message structure of a snapshot list
 pub type SnapshotListMessage = Vec<SnapshotListItemMessage>;
@@ -13,7 +13,7 @@ pub struct SnapshotListItemMessage {
     pub digest: String,
 
     /// Mithril beacon on the Cardano chain
-    pub beacon: Beacon,
+    pub beacon: CardanoDbBeacon,
 
     /// Hash of the associated certificate
     pub certificate_hash: String,
@@ -41,7 +41,7 @@ impl SnapshotListItemMessage {
     pub fn dummy() -> Self {
         Self {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,
@@ -66,7 +66,7 @@ mod tests {
     fn golden_message_v1() -> SnapshotListMessage {
         vec![SnapshotListItemMessage {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,
@@ -86,7 +86,7 @@ mod tests {
     fn golden_message_v2() -> SnapshotListMessage {
         vec![SnapshotListItemMessage {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,
@@ -106,7 +106,7 @@ mod tests {
     fn golden_message_v3() -> SnapshotListMessage {
         vec![SnapshotListItemMessage {
             digest: "0b9f5ad7f33cc523775c82249294eb8a1541d54f08eb3107cafc5638403ec7c6".to_string(),
-            beacon: Beacon {
+            beacon: CardanoDbBeacon {
                 network: "preview".to_string(),
                 epoch: Epoch(86),
                 immutable_file_number: 1728,

--- a/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
+++ b/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::{
     digesters::ImmutableDigester,
-    entities::{Beacon, ProtocolMessage, ProtocolMessagePartKey},
+    entities::{CardanoDbBeacon, ProtocolMessage, ProtocolMessagePartKey},
     signable_builder::SignableBuilder,
     StdResult,
 };
@@ -36,8 +36,11 @@ impl CardanoImmutableFilesFullSignableBuilder {
 }
 
 #[async_trait]
-impl SignableBuilder<Beacon> for CardanoImmutableFilesFullSignableBuilder {
-    async fn compute_protocol_message(&self, beacon: Beacon) -> StdResult<ProtocolMessage> {
+impl SignableBuilder<CardanoDbBeacon> for CardanoImmutableFilesFullSignableBuilder {
+    async fn compute_protocol_message(
+        &self,
+        beacon: CardanoDbBeacon,
+    ) -> StdResult<ProtocolMessage> {
         debug!(self.logger, "SignableBuilder::compute_signable({beacon:?})");
         let digest = self
             .immutable_digester
@@ -64,7 +67,7 @@ mod tests {
     use super::*;
 
     use crate::digesters::{ImmutableDigester, ImmutableDigesterError};
-    use crate::entities::Beacon;
+    use crate::entities::CardanoDbBeacon;
     use async_trait::async_trait;
     use slog::Drain;
 
@@ -76,7 +79,7 @@ mod tests {
         async fn compute_digest(
             &self,
             _dirpath: &Path,
-            beacon: &Beacon,
+            beacon: &CardanoDbBeacon,
         ) -> Result<String, ImmutableDigesterError> {
             Ok(format!("immutable {}", beacon.immutable_file_number))
         }
@@ -97,7 +100,7 @@ mod tests {
             create_logger(),
         );
         let protocol_message = signable_builder
-            .compute_protocol_message(Beacon::default())
+            .compute_protocol_message(CardanoDbBeacon::default())
             .await
             .unwrap();
 

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -12,7 +12,7 @@ use crate::{
     cardano_transaction_parser::TransactionParser,
     crypto_helper::{MKMap, MKMapNode, MKTree, MKTreeNode},
     entities::{
-        Beacon, BlockRange, CardanoTransaction, ProtocolMessage, ProtocolMessagePartKey,
+        BlockRange, CardanoDbBeacon, CardanoTransaction, ProtocolMessage, ProtocolMessagePartKey,
         TransactionHash,
     },
     signable_builder::SignableBuilder,
@@ -98,9 +98,12 @@ impl CardanoTransactionsSignableBuilder {
 }
 
 #[async_trait]
-impl SignableBuilder<Beacon> for CardanoTransactionsSignableBuilder {
+impl SignableBuilder<CardanoDbBeacon> for CardanoTransactionsSignableBuilder {
     // TODO: return a protocol message computed from the transactions when it's ready to be implemented
-    async fn compute_protocol_message(&self, beacon: Beacon) -> StdResult<ProtocolMessage> {
+    async fn compute_protocol_message(
+        &self,
+        beacon: CardanoDbBeacon,
+    ) -> StdResult<ProtocolMessage> {
         debug!(
             self.logger,
             "Compute protocol message for CardanoTransactions at beacon: {beacon}"
@@ -222,9 +225,9 @@ mod tests {
     #[tokio::test]
     async fn test_compute_signable() {
         // Arrange
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             immutable_file_number: 14,
-            ..Beacon::default()
+            ..CardanoDbBeacon::default()
         };
         let transactions = vec![
             CardanoTransaction::new("tx-hash-123", 1, 11),
@@ -268,7 +271,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_signable_with_no_transaction_return_error() {
-        let beacon = Beacon::default();
+        let beacon = CardanoDbBeacon::default();
         let transactions = vec![];
         let transaction_parser = Arc::new(DumbTransactionParser::new(transactions.clone()));
         let mut mock_transaction_store = MockTransactionStore::new();

--- a/mithril-common/src/signable_builder/signable_builder_service.rs
+++ b/mithril-common/src/signable_builder/signable_builder_service.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use std::sync::Arc;
 
 use crate::{
-    entities::{Beacon, Epoch, ProtocolMessage, SignedEntityType},
+    entities::{CardanoDbBeacon, Epoch, ProtocolMessage, SignedEntityType},
     signable_builder::SignableBuilder,
     StdResult,
 };
@@ -25,16 +25,16 @@ pub trait SignableBuilderService: Send + Sync {
 /// Mithril Signable Builder Service
 pub struct MithrilSignableBuilderService {
     mithril_stake_distribution_builder: Arc<dyn SignableBuilder<Epoch>>,
-    immutable_signable_builder: Arc<dyn SignableBuilder<Beacon>>,
-    cardano_transactions_signable_builder: Arc<dyn SignableBuilder<Beacon>>,
+    immutable_signable_builder: Arc<dyn SignableBuilder<CardanoDbBeacon>>,
+    cardano_transactions_signable_builder: Arc<dyn SignableBuilder<CardanoDbBeacon>>,
 }
 
 impl MithrilSignableBuilderService {
     /// MithrilSignableBuilderService factory
     pub fn new(
         mithril_stake_distribution_builder: Arc<dyn SignableBuilder<Epoch>>,
-        immutable_signable_builder: Arc<dyn SignableBuilder<Beacon>>,
-        cardano_transactions_signable_builder: Arc<dyn SignableBuilder<Beacon>>,
+        immutable_signable_builder: Arc<dyn SignableBuilder<CardanoDbBeacon>>,
+        cardano_transactions_signable_builder: Arc<dyn SignableBuilder<CardanoDbBeacon>>,
     ) -> Self {
         Self {
             mithril_stake_distribution_builder,
@@ -116,8 +116,9 @@ mod tests {
             .return_once(move |_| Ok(protocol_message_clone));
 
         let mock_cardano_immutable_files_full_signable_builder =
-            MockSignableBuilderImpl::<Beacon>::new();
-        let mock_cardano_transactions_signable_builder = MockSignableBuilderImpl::<Beacon>::new();
+            MockSignableBuilderImpl::<CardanoDbBeacon>::new();
+        let mock_cardano_transactions_signable_builder =
+            MockSignableBuilderImpl::<CardanoDbBeacon>::new();
 
         let signable_builder_service = MithrilSignableBuilderService::new(
             Arc::new(mock_mithril_stake_distribution_signable_builder),
@@ -140,12 +141,13 @@ mod tests {
             MockSignableBuilderImpl::<Epoch>::new();
 
         let mut mock_cardano_immutable_files_full_signable_builder =
-            MockSignableBuilderImpl::<Beacon>::new();
+            MockSignableBuilderImpl::<CardanoDbBeacon>::new();
         mock_cardano_immutable_files_full_signable_builder
             .expect_compute_protocol_message()
             .once()
             .return_once(move |_| Ok(protocol_message_clone));
-        let mock_cardano_transactions_signable_builder = MockSignableBuilderImpl::<Beacon>::new();
+        let mock_cardano_transactions_signable_builder =
+            MockSignableBuilderImpl::<CardanoDbBeacon>::new();
 
         let signable_builder_service = MithrilSignableBuilderService::new(
             Arc::new(mock_mithril_stake_distribution_signable_builder),
@@ -153,7 +155,8 @@ mod tests {
             Arc::new(mock_cardano_transactions_signable_builder),
         );
 
-        let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(Beacon::default());
+        let signed_entity_type =
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
         signable_builder_service
             .compute_protocol_message(signed_entity_type)
             .await
@@ -168,9 +171,9 @@ mod tests {
             MockSignableBuilderImpl::<Epoch>::new();
 
         let mock_cardano_immutable_files_full_signable_builder =
-            MockSignableBuilderImpl::<Beacon>::new();
+            MockSignableBuilderImpl::<CardanoDbBeacon>::new();
         let mut mock_cardano_transactions_signable_builder =
-            MockSignableBuilderImpl::<Beacon>::new();
+            MockSignableBuilderImpl::<CardanoDbBeacon>::new();
         mock_cardano_transactions_signable_builder
             .expect_compute_protocol_message()
             .once()
@@ -182,7 +185,7 @@ mod tests {
             Arc::new(mock_cardano_transactions_signable_builder),
         );
 
-        let signed_entity_type = SignedEntityType::CardanoTransactions(Beacon::default());
+        let signed_entity_type = SignedEntityType::CardanoTransactions(CardanoDbBeacon::default());
         signable_builder_service
             .compute_protocol_message(signed_entity_type)
             .await

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -16,15 +16,15 @@ use crate::{
 use super::fake_keys;
 
 /// Fake Beacon
-pub fn beacon() -> entities::Beacon {
+pub fn beacon() -> entities::CardanoDbBeacon {
     let network = "testnet".to_string();
     let immutable_file_number = 100;
     let epoch = 10;
-    entities::Beacon::new(network, epoch, immutable_file_number)
+    entities::CardanoDbBeacon::new(network, epoch, immutable_file_number)
 }
 
 /// Fake Digest
-pub fn digest(beacon: &entities::Beacon) -> Vec<u8> {
+pub fn digest(beacon: &entities::CardanoDbBeacon) -> Vec<u8> {
     format!(
         "digest-{}-{}-{}",
         beacon.network, beacon.epoch, beacon.immutable_file_number
@@ -225,7 +225,7 @@ pub fn cardano_transactions_snapshot(total: u64) -> Vec<entities::CardanoTransac
         .map(|idx| {
             entities::CardanoTransactionsSnapshot::new(
                 format!("merkleroot-{idx}"),
-                entities::Beacon {
+                entities::CardanoDbBeacon {
                     immutable_file_number: idx,
                     ..beacon()
                 },

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -14,7 +14,7 @@ use crate::{
         ProtocolSignerVerificationKeySignature, ProtocolStakeDistribution,
     },
     entities::{
-        Beacon, Certificate, HexEncodedAgregateVerificationKey, PartyId, ProtocolMessage,
+        CardanoDbBeacon, Certificate, HexEncodedAgregateVerificationKey, PartyId, ProtocolMessage,
         ProtocolParameters, Signer, SignerWithStake, SingleSignatures, Stake, StakeDistribution,
         StakeDistributionParty,
     },
@@ -170,7 +170,7 @@ impl MithrilFixture {
     }
 
     /// Create a genesis certificate using the fixture signers for the given beacon
-    pub fn create_genesis_certificate(&self, beacon: &Beacon) -> Certificate {
+    pub fn create_genesis_certificate(&self, beacon: &CardanoDbBeacon) -> Certificate {
         let genesis_avk = self.compute_avk();
         let genesis_signer = ProtocolGenesisSigner::create_deterministic_genesis_signer();
         let genesis_producer = CertificateGenesisProducer::new(Some(Arc::new(genesis_signer)));

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.116"
+version = "0.2.117"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -8,7 +8,7 @@ use mockall::automock;
 
 use mithril_common::crypto_helper::{KESPeriod, OpCert, ProtocolOpCert, SerDeShelleyFileFormat};
 use mithril_common::entities::{
-    Beacon, CertificatePending, Epoch, EpochSettings, PartyId, ProtocolMessage,
+    CardanoDbBeacon, CertificatePending, Epoch, EpochSettings, PartyId, ProtocolMessage,
     ProtocolMessagePartKey, ProtocolParameters, SignedEntityType, Signer, SignerWithStake,
     SingleSignatures,
 };
@@ -29,7 +29,7 @@ pub trait Runner: Send + Sync {
     async fn get_pending_certificate(&self) -> StdResult<Option<CertificatePending>>;
 
     /// Fetch the current beacon from the Cardano node.
-    async fn get_current_beacon(&self) -> StdResult<Beacon>;
+    async fn get_current_beacon(&self) -> StdResult<CardanoDbBeacon>;
 
     /// Register the signer verification key to the aggregator.
     async fn register_signer_to_aggregator(
@@ -131,7 +131,7 @@ impl Runner for SignerRunner {
             .map_err(|e| e.into())
     }
 
-    async fn get_current_beacon(&self) -> StdResult<Beacon> {
+    async fn get_current_beacon(&self) -> StdResult<CardanoDbBeacon> {
         debug!("RUNNER: get_current_epoch");
 
         self.services
@@ -501,7 +501,7 @@ mod tests {
 
         #[async_trait]
         impl BeaconProvider for FakeBeaconProvider {
-            async fn get_current_beacon(&self) -> StdResult<Beacon>;
+            async fn get_current_beacon(&self) -> StdResult<CardanoDbBeacon>;
         }
     }
 

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -352,7 +352,7 @@ mod tests {
     use mithril_common::{
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
-        entities::{Beacon, Epoch},
+        entities::{CardanoDbBeacon, Epoch},
         era::adapters::EraReaderAdapterType,
     };
 
@@ -394,7 +394,7 @@ mod tests {
         assert!(!stores_dir.exists());
         let chain_observer_builder: fn(&Configuration) -> StdResult<ChainObserverService> =
             |_config| {
-                Ok(Arc::new(FakeObserver::new(Some(Beacon {
+                Ok(Arc::new(FakeObserver::new(Some(CardanoDbBeacon {
                     epoch: Epoch(1),
                     immutable_file_number: 1,
                     network: "devnet".to_string(),

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -5,7 +5,8 @@ use tokio::{sync::Mutex, time::sleep};
 use mithril_common::{
     crypto_helper::ProtocolInitializerError,
     entities::{
-        Beacon, CertificatePending, Epoch, EpochSettings, SignedEntityType, SignerWithStake,
+        CardanoDbBeacon, CertificatePending, Epoch, EpochSettings, SignedEntityType,
+        SignerWithStake,
     },
 };
 
@@ -429,7 +430,7 @@ impl StateMachine {
         })
     }
 
-    async fn get_current_beacon(&self, context: &str) -> Result<Beacon, RuntimeError> {
+    async fn get_current_beacon(&self, context: &str) -> Result<CardanoDbBeacon, RuntimeError> {
         let current_beacon =
             self.runner
                 .get_current_beacon()
@@ -603,7 +604,7 @@ mod tests {
 
     #[tokio::test]
     async fn registered_to_registered() {
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             immutable_file_number: 99,
             epoch: Epoch(9),
             ..Default::default()
@@ -641,7 +642,7 @@ mod tests {
 
     #[tokio::test]
     async fn registered_to_signed() {
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             immutable_file_number: 99,
             epoch: Epoch(9),
             ..Default::default()
@@ -699,7 +700,7 @@ mod tests {
 
     #[tokio::test]
     async fn signed_to_registered() {
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             immutable_file_number: 99,
             epoch: Epoch(9),
             ..Default::default()
@@ -741,12 +742,12 @@ mod tests {
 
     #[tokio::test]
     async fn signed_to_unregistered() {
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             immutable_file_number: 99,
             epoch: Epoch(9),
             ..Default::default()
         };
-        let new_beacon = Beacon {
+        let new_beacon = CardanoDbBeacon {
             epoch: Epoch(10),
             ..beacon.clone()
         };
@@ -779,7 +780,7 @@ mod tests {
 
     #[tokio::test]
     async fn signed_to_signed_no_pending_certificate() {
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             immutable_file_number: 99,
             epoch: Epoch(9),
             ..Default::default()
@@ -820,7 +821,7 @@ mod tests {
 
     #[tokio::test]
     async fn signed_to_signed_unsigned_pending_certificate() {
-        let beacon = Beacon {
+        let beacon = CardanoDbBeacon {
             immutable_file_number: 99,
             epoch: Epoch(9),
             ..Default::default()

--- a/mithril-signer/tests/test_extensions/certificate_handler.rs
+++ b/mithril-signer/tests/test_extensions/certificate_handler.rs
@@ -4,7 +4,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use mithril_common::{
     entities::{
-        Beacon, CertificatePending, Epoch, EpochSettings, SignedEntityType, Signer,
+        CardanoDbBeacon, CertificatePending, Epoch, EpochSettings, SignedEntityType, Signer,
         SingleSignatures,
     },
     test_utils::fake_data,
@@ -39,7 +39,7 @@ impl FakeAggregator {
         *settings = false;
     }
 
-    async fn get_beacon(&self) -> Result<Beacon, AggregatorClientError> {
+    async fn get_beacon(&self) -> Result<CardanoDbBeacon, AggregatorClientError> {
         let beacon = self
             .beacon_provider
             .get_current_beacon()
@@ -130,7 +130,7 @@ mod tests {
     async fn init() -> (Arc<FakeObserver>, FakeAggregator) {
         let immutable_observer = Arc::new(DumbImmutableFileObserver::new());
         immutable_observer.shall_return(Some(1)).await;
-        let chain_observer = Arc::new(FakeObserver::new(Some(Beacon {
+        let chain_observer = Arc::new(FakeObserver::new(Some(CardanoDbBeacon {
             epoch: Epoch(1),
             immutable_file_number: 1,
             network: "devnet".to_string(),

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -10,7 +10,7 @@ use mithril_common::{
     cardano_transaction_parser::DumbTransactionParser,
     chain_observer::{ChainObserver, FakeObserver},
     digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
-    entities::{Beacon, Epoch, SignerWithStake},
+    entities::{CardanoDbBeacon, Epoch, SignerWithStake},
     era::{adapters::EraReaderDummyAdapter, EraChecker, EraMarker, EraReader, SupportedEra},
     signable_builder::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
@@ -94,7 +94,7 @@ impl StateMachineTester {
 
         let immutable_observer = Arc::new(DumbImmutableFileObserver::new());
         immutable_observer.shall_return(Some(1)).await;
-        let chain_observer = Arc::new(FakeObserver::new(Some(Beacon {
+        let chain_observer = Arc::new(FakeObserver::new(Some(CardanoDbBeacon {
             epoch: Epoch(1),
             immutable_file_number: 1,
             network: "devnet".to_string(),

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.7"
+version = "0.4.8"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/bin/load-aggregator/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/bin/load-aggregator/main.rs
@@ -5,7 +5,7 @@ use tokio::sync::oneshot;
 
 use mithril_common::{
     digesters::{DummyImmutableDb, DummyImmutablesDbBuilder},
-    entities::{Beacon, Epoch, ProtocolParameters, SignedEntityType, SingleSignatures},
+    entities::{CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType, SingleSignatures},
     test_utils::MithrilFixture,
     StdResult,
 };
@@ -225,7 +225,7 @@ async fn main_scenario(
     wait::for_pending_certificate(
         &parameters.aggregator,
         Duration::from_secs(60),
-        &SignedEntityType::CardanoImmutableFilesFull(Beacon::new(
+        &SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::new(
             "devnet".to_string(),
             *current_epoch.deref(),
             parameters.immutable_db.last_immutable_number().unwrap() - 1,

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use mithril_common::{
     digesters::{CardanoImmutableDigester, DummyImmutableDb, ImmutableDigester},
     entities::{
-        Beacon, Epoch, ProtocolMessage, ProtocolMessagePartKey, ProtocolParameters,
+        CardanoDbBeacon, Epoch, ProtocolMessage, ProtocolMessagePartKey, ProtocolParameters,
         SignedEntityType, Signer, SingleSignatures,
     },
     messages::{RegisterSignatureMessage, RegisterSignerMessage},
@@ -99,10 +99,10 @@ pub async fn compute_immutable_files_signatures(
     epoch: Epoch,
     signers_fixture: &MithrilFixture,
     timeout: Duration,
-) -> StdResult<(Beacon, Vec<SingleSignatures>)> {
+) -> StdResult<(CardanoDbBeacon, Vec<SingleSignatures>)> {
     spin_while_waiting!(
         {
-            let beacon = Beacon::new(
+            let beacon = CardanoDbBeacon::new(
                 "devnet".to_string(),
                 *epoch,
                 // Minus one because the last immutable isn't "finished"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -626,8 +626,8 @@ components:
           format: double
       example: { "k": 857, "m": 6172, "phi_f": 0.2 }
 
-    Beacon:
-      description: Beacon represents a point in the Cardano chain at which a Mithril certificate should be produced
+    CardanoDbBeacon:
+      description: A point in the Cardano chain at which a Mithril certificate of the Cardano Database should be produced
       type: object
       additionalProperties: true
       required:
@@ -667,7 +667,7 @@ components:
         - next_signers
       properties:
         beacon:
-          $ref: "#/components/schemas/Beacon"
+          $ref: "#/components/schemas/CardanoDbBeacon"
         entity_type:
           $ref: "#/components/schemas/SignedEntityType"
         protocol:
@@ -1094,7 +1094,7 @@ components:
           type: string
           format: bytes
         beacon:
-          $ref: "#/components/schemas/Beacon"
+          $ref: "#/components/schemas/CardanoDbBeacon"
         metadata:
           $ref: "#/components/schemas/CertificateListItemMessageMetadata"
         protocol_message:
@@ -1210,7 +1210,7 @@ components:
           type: string
           format: bytes
         beacon:
-          $ref: "#/components/schemas/Beacon"
+          $ref: "#/components/schemas/CardanoDbBeacon"
         metadata:
           $ref: "#/components/schemas/CertificateMetadata"
         protocol_message:
@@ -1326,7 +1326,7 @@ components:
           type: string
           format: bytes
         beacon:
-          $ref: "#/components/schemas/Beacon"
+          $ref: "#/components/schemas/CardanoDbBeacon"
         certificate_hash:
           description: Hash of the associated certificate
           type: string
@@ -1417,7 +1417,7 @@ components:
           type: string
           format: bytes
         beacon:
-          $ref: "#/components/schemas/Beacon"
+          $ref: "#/components/schemas/CardanoDbBeacon"
         size:
           description: Size of the snapshot file in Bytes
           type: integer
@@ -1573,7 +1573,7 @@ components:
             type: string
             format: bytes
           beacon:
-            $ref: "#/components/schemas/Beacon"
+            $ref: "#/components/schemas/CardanoDbBeacon"
           created_at:
             description: Date and time at which the Cardano transactions set was created
             type: string
@@ -1616,7 +1616,7 @@ components:
           type: string
           format: bytes
         beacon:
-          $ref: "#/components/schemas/Beacon"
+          $ref: "#/components/schemas/CardanoDbBeacon"
         created_at:
           description: Date and time at which the Cardano transactions set was created
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.19
+  version: 0.1.20
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content

This PR rename the common `Beacon` entity to  `CardanoDbBeacon`. Since the introduction of the signed entity types the beacon name is no longer tied to the Cardano Db as before, this PR make that explicit.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1562
