### PR TITLE
Fix runbook for certificate hashes re-computation

### DIFF
--- a/docs/runbook/recompute-certificates-hash/README.md
+++ b/docs/runbook/recompute-certificates-hash/README.md
@@ -8,7 +8,7 @@ export CARDANO_NETWORK=**CARDANO_NETWORK**
 export MITHRIL_DISTRIBUTION_LINUX_PKG=**MITHRIL_DISTRIBUTION_LINUX_PKG**
 ```
 
-Here is an exmaple for the `release-mainnet` network:
+Here is an example for the `release-mainnet` network:
 ```bash
 export MITHRIL_VM=aggregator.release-mainnet.api.mithril.network
 export CARDANO_NETWORK=mainnet
@@ -108,7 +108,7 @@ Then disconnect from the aggregator VM:
 exit
 ```
 
-## Databse rollback procedure
+## Database rollback procedure
 
 If the recomputation fails, you can rollback the database,and try again the process.
 

--- a/docs/runbook/recompute-certificates-hash/config/tools.json
+++ b/docs/runbook/recompute-certificates-hash/config/tools.json
@@ -13,5 +13,6 @@
     "snapshot_uploader_type": "local",
     "genesis_verification_key": "-",
     "era_adapter_type": "bootstrap",
-    "cardano_node_version": "-"
+    "cardano_node_version": "-",
+    "chain_observer_type": "cardano-cli"
 }


### PR DESCRIPTION
## Content
This PR includes a fix to the runbook for [certificate hashes re-computation](https://github.com/input-output-hk/mithril/tree/main/docs/runbook/recompute-certificates-hash)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
