### PR TITLE
Add and persist `slot_number` and `block_hash` to `CardanoTransaction`

### DIFF
--- a/mithril-aggregator/src/database/cardano_transaction_migration.rs
+++ b/mithril-aggregator/src/database/cardano_transaction_migration.rs
@@ -37,5 +37,19 @@ create index cardano_tx_immutable_file_number_index on cardano_tx(immutable_file
 vacuum;
 "#,
         ),
+        // Migration 3
+        // Add `slot_number` and `block_hash` columns to `cardano_tx`.
+        SqlMigration::new(
+            3,
+            r#"
+-- remove all data from the cardano tx table since the new columns are mandatory
+delete from cardano_tx;
+
+alter table cardano_tx add column slot_number integer not null;
+alter table cardano_tx add column block_hash text not null;
+
+vacuum;
+        "#,
+        ),
     ]
 }

--- a/mithril-aggregator/src/database/provider/cardano_transaction.rs
+++ b/mithril-aggregator/src/database/provider/cardano_transaction.rs
@@ -1,6 +1,7 @@
 use mithril_common::{
     entities::{
-        BlockNumber, CardanoDbBeacon, CardanoTransaction, ImmutableFileNumber, TransactionHash,
+        BlockHash, BlockNumber, CardanoDbBeacon, CardanoTransaction, ImmutableFileNumber,
+        SlotNumber, TransactionHash,
     },
     signable_builder::TransactionStore,
     StdResult,
@@ -26,6 +27,12 @@ pub struct CardanoTransactionRecord {
     /// Block number of the transaction
     pub block_number: BlockNumber,
 
+    /// Slot number of the transaction
+    pub slot_number: SlotNumber,
+
+    /// Block hash of the transaction
+    pub block_hash: BlockHash,
+
     /// Immutable file number of the transaction
     pub immutable_file_number: ImmutableFileNumber,
 }
@@ -35,6 +42,8 @@ impl From<CardanoTransaction> for CardanoTransactionRecord {
         Self {
             transaction_hash: transaction.transaction_hash,
             block_number: transaction.block_number,
+            slot_number: transaction.slot_number,
+            block_hash: transaction.block_hash,
             immutable_file_number: transaction.immutable_file_number,
         }
     }
@@ -45,6 +54,8 @@ impl From<CardanoTransactionRecord> for CardanoTransaction {
         CardanoTransaction {
             transaction_hash: other.transaction_hash,
             block_number: other.block_number,
+            slot_number: other.slot_number,
+            block_hash: other.block_hash,
             immutable_file_number: other.immutable_file_number,
         }
     }
@@ -55,17 +66,23 @@ impl SqLiteEntity for CardanoTransactionRecord {
     where
         Self: Sized,
     {
+        // TODO generalize this method
+        fn try_to_u64(field: &str, value: i64) -> Result<u64, HydrationError> {
+            u64::try_from(value)
+            .map_err(|e| HydrationError::InvalidData(format!("Integer field cardano_tx.{field} (value={value}) is incompatible with u64 representation. Error = {e}")))
+        }
+
         let transaction_hash = row.read::<&str, _>(0);
-        let block_number = row.read::<i64, _>(1);
-        let block_number = u64::try_from(block_number)
-            .map_err(|e| HydrationError::InvalidData(format!("Integer field cardano_tx.block_number (value={block_number}) is incompatible with u64 representation. Error = {e}")))?;
-        let immutable_file_number = row.read::<i64, _>(2);
-        let immutable_file_number = u64::try_from(immutable_file_number)
-            .map_err(|e| HydrationError::InvalidData(format!("Integer field cardano_tx.immutable_file_number (value={immutable_file_number}) is incompatible with u64 representation. Error = {e}")))?;
+        let block_number = try_to_u64("block_number", row.read::<i64, _>(1))?;
+        let slot_number = try_to_u64("slot_number", row.read::<i64, _>(2))?;
+        let block_hash = row.read::<&str, _>(3);
+        let immutable_file_number = try_to_u64("immutable_file_number", row.read::<i64, _>(4))?;
 
         Ok(Self {
             transaction_hash: transaction_hash.to_string(),
             block_number,
+            slot_number,
+            block_hash: block_hash.to_string(),
             immutable_file_number,
         })
     }
@@ -78,6 +95,8 @@ impl SqLiteEntity for CardanoTransactionRecord {
                 "text",
             ),
             ("block_number", "{:cardano_tx:}.block_number", "int"),
+            ("slot_number", "{:cardano_tx:}.slot_number", "int"),
+            ("block_hash", "{:cardano_tx:}.block_hash", "text"),
             (
                 "immutable_file_number",
                 "{:cardano_tx:}.immutable_file_number",
@@ -141,41 +160,56 @@ impl<'client> InsertCardanoTransactionProvider<'client> {
     }
 
     fn get_insert_condition(&self, record: &CardanoTransactionRecord) -> StdResult<WhereCondition> {
-        let expression =
-            "(transaction_hash, block_number, immutable_file_number) values (?1, ?2, ?3)";
-        let parameters = vec![
-            Value::String(record.transaction_hash.clone()),
-            Value::Integer(record.block_number.try_into()?),
-            Value::Integer(record.immutable_file_number.try_into()?),
-        ];
+        // let expression =
+        //     "(transaction_hash, block_number, slot_number, block_hash, immutable_file_number) values (?1, ?2, ?3, ?4, ?5)";
+        // let parameters = vec![
+        //     Value::String(record.transaction_hash.clone()),
+        //     Value::Integer(record.block_number.try_into()?),
+        //     Value::Integer(record.slot_number.try_into()?),
+        //     Value::String(record.block_hash.clone()),
+        //     Value::Integer(record.immutable_file_number.try_into()?),
+        // ];
 
-        Ok(WhereCondition::new(expression, parameters))
+        // Ok(WhereCondition::new(expression, parameters))
+        self.get_insert_many_condition(vec![record.clone()])
     }
 
     fn get_insert_many_condition(
         &self,
         transactions_records: Vec<CardanoTransactionRecord>,
-    ) -> WhereCondition {
-        let columns = "(transaction_hash, block_number, immutable_file_number)";
-        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*)")
+    ) -> StdResult<WhereCondition> {
+        fn map_record(record: CardanoTransactionRecord) -> StdResult<Vec<Value>> {
+            Ok(vec![
+                Value::String(record.transaction_hash),
+                Value::Integer(record.block_number.try_into().unwrap()),
+                Value::Integer(record.slot_number.try_into()?),
+                Value::String(record.block_hash.clone()),
+                Value::Integer(record.immutable_file_number.try_into().unwrap()),
+            ])
+        }
+
+        let columns =
+            "(transaction_hash, block_number, slot_number, block_hash, immutable_file_number)";
+        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*, ?*, ?*)")
             .take(transactions_records.len())
             .collect();
 
-        let values: Vec<Value> = transactions_records
-            .into_iter()
-            .flat_map(|record| {
-                vec![
-                    Value::String(record.transaction_hash),
-                    Value::Integer(record.block_number.try_into().unwrap()),
-                    Value::Integer(record.immutable_file_number.try_into().unwrap()),
-                ]
-            })
-            .collect();
+        // TODO see if we can find another way to do it
+        let values: StdResult<Vec<Vec<Value>>> =
+            transactions_records.into_iter().map(map_record).collect();
 
-        WhereCondition::new(
+        let values: Vec<Value> = values?.into_iter().flatten().collect();
+
+        // let values = transactions_records
+        //     .into_iter()
+        //     .flat_map(map_record) // Vec<StdResult<Vec<Value>>>
+        //     .flatten()
+        //     .collect::<Vec<Value>>();
+
+        Ok(WhereCondition::new(
             format!("{columns} values {}", values_columns.join(", ")).as_str(),
             values,
-        )
+        ))
     }
 }
 
@@ -231,28 +265,32 @@ impl CardanoTransactionRepository {
     }
 
     /// Return the [CardanoTransactionRecord] for the given transaction hash.
-    pub async fn get_transaction(
+    pub async fn get_transaction<T: Into<TransactionHash>>(
         &self,
-        transaction_hash: &TransactionHash,
+        transaction_hash: T,
     ) -> StdResult<Option<CardanoTransactionRecord>> {
         let provider = CardanoTransactionProvider::new(&self.connection);
-        let filters = provider.get_transaction_hash_condition(transaction_hash);
+        let filters = provider.get_transaction_hash_condition(&transaction_hash.into());
         let mut transactions = provider.find(filters)?;
 
         Ok(transactions.next())
     }
 
     /// Create a new [CardanoTransactionRecord] in the database.
-    pub async fn create_transaction(
+    pub async fn create_transaction<T: Into<TransactionHash>, U: Into<BlockHash>>(
         &self,
-        transaction_hash: &TransactionHash,
+        transaction_hash: T,
         block_number: BlockNumber,
+        slot_number: SlotNumber,
+        block_hash: U,
         immutable_file_number: ImmutableFileNumber,
     ) -> StdResult<Option<CardanoTransactionRecord>> {
         let provider = InsertCardanoTransactionProvider::new(&self.connection);
         let filters = provider.get_insert_condition(&CardanoTransactionRecord {
-            transaction_hash: transaction_hash.to_owned(),
+            transaction_hash: transaction_hash.into(),
             block_number,
+            slot_number,
+            block_hash: block_hash.into(),
             immutable_file_number,
         })?;
         let mut cursor = provider.find(filters)?;
@@ -266,7 +304,7 @@ impl CardanoTransactionRepository {
         transactions: Vec<CardanoTransactionRecord>,
     ) -> StdResult<Vec<CardanoTransactionRecord>> {
         let provider = InsertCardanoTransactionProvider::new(&self.connection);
-        let filters = provider.get_insert_many_condition(transactions);
+        let filters = provider.get_insert_many_condition(transactions)?;
         let cursor = provider.find(filters)?;
 
         Ok(cursor.collect())
@@ -315,13 +353,14 @@ mod tests {
             .unwrap()
     }
 
+    // TODO Is it really a useful test ?
     #[test]
     fn cardano_transaction_projection() {
         let projection = CardanoTransactionRecord::get_projection();
         let aliases = SourceAlias::new(&[("{:cardano_tx:}", "cardano_tx")]);
 
         assert_eq!(
-            "cardano_tx.transaction_hash as transaction_hash, cardano_tx.block_number as block_number, cardano_tx.immutable_file_number as immutable_file_number".to_string(),
+            "cardano_tx.transaction_hash as transaction_hash, cardano_tx.block_number as block_number, cardano_tx.slot_number as slot_number, cardano_tx.block_hash as block_hash, cardano_tx.immutable_file_number as immutable_file_number".to_string(),
             projection.expand(aliases)
         )
     }
@@ -369,13 +408,16 @@ mod tests {
                 transaction_hash:
                     "0405a78c637f5c637e3146e293c0045ea80a07fac8f245901e7b491182931650".to_string(),
                 block_number: 10,
+                slot_number: 50,
+                block_hash: "block_hash".to_string(),
                 immutable_file_number: 99,
             })
             .unwrap()
             .expand();
 
+        // TODO Why this assert ?
         assert_eq!(
-            "(transaction_hash, block_number, immutable_file_number) values (?1, ?2, ?3)"
+            "(transaction_hash, block_number, slot_number, block_hash, immutable_file_number) values (?1, ?2, ?3, ?4, ?5)"
                 .to_string(),
             expr
         );
@@ -385,12 +427,15 @@ mod tests {
                     "0405a78c637f5c637e3146e293c0045ea80a07fac8f245901e7b491182931650".to_string()
                 ),
                 Value::Integer(10),
+                Value::Integer(50),
+                Value::String("block_hash".to_string()),
                 Value::Integer(99)
             ],
             params
         );
     }
 
+    // TODO: Is it useful ?
     #[test]
     fn insert_provider_many_condition() {
         let connection = Connection::open_thread_safe(":memory:").unwrap();
@@ -398,30 +443,39 @@ mod tests {
         let (expr, params) = provider
             .get_insert_many_condition(vec![
                 CardanoTransactionRecord {
-                    transaction_hash: "tx-hash-123".to_string(),
+                    transaction_hash: "tx_hash-123".to_string(),
                     block_number: 10,
+                    slot_number: 50,
+                    block_hash: "block_hash-123".to_string(),
                     immutable_file_number: 99,
                 },
                 CardanoTransactionRecord {
-                    transaction_hash: "tx-hash-456".to_string(),
+                    transaction_hash: "tx_hash-456".to_string(),
                     block_number: 11,
+                    slot_number: 51,
+                    block_hash: "block_hash-456".to_string(),
                     immutable_file_number: 100,
                 },
             ])
+            .unwrap()
             .expand();
 
         assert_eq!(
-            "(transaction_hash, block_number, immutable_file_number) values (?1, ?2, ?3), (?4, ?5, ?6)"
+            "(transaction_hash, block_number, slot_number, block_hash, immutable_file_number) values (?1, ?2, ?3, ?4, ?5), (?6, ?7, ?8, ?9, ?10)"
                 .to_string(),
             expr
         );
         assert_eq!(
             vec![
-                Value::String("tx-hash-123".to_string()),
+                Value::String("tx_hash-123".to_string()),
                 Value::Integer(10),
+                Value::Integer(50),
+                Value::String("block_hash-123".to_string()),
                 Value::Integer(99),
-                Value::String("tx-hash-456".to_string()),
+                Value::String("tx_hash-456".to_string()),
                 Value::Integer(11),
+                Value::Integer(51),
+                Value::String("block_hash-456".to_string()),
                 Value::Integer(100)
             ],
             params
@@ -433,11 +487,11 @@ mod tests {
         let connection = get_connection().await;
         let repository = CardanoTransactionRepository::new(connection.clone());
         repository
-            .create_transaction(&"tx-hash-123".to_string(), 10, 99)
+            .create_transaction("tx-hash-123", 10, 50, "block_hash-123", 99)
             .await
             .unwrap();
         repository
-            .create_transaction(&"tx-hash-456".to_string(), 11, 100)
+            .create_transaction("tx-hash-456", 11, 51, "block_hash-456", 100)
             .await
             .unwrap();
         let transaction_result = repository
@@ -449,6 +503,8 @@ mod tests {
             Some(CardanoTransactionRecord {
                 transaction_hash: "tx-hash-123".to_string(),
                 block_number: 10,
+                slot_number: 50,
+                block_hash: "block_hash-123".to_string(),
                 immutable_file_number: 99
             }),
             transaction_result
@@ -460,22 +516,21 @@ mod tests {
         let connection = get_connection().await;
         let repository = CardanoTransactionRepository::new(connection.clone());
         repository
-            .create_transaction(&"tx-hash-123".to_string(), 10, 99)
+            .create_transaction("tx-hash-123", 10, 50, "block_hash-123", 99)
             .await
             .unwrap();
         repository
-            .create_transaction(&"tx-hash-123".to_string(), 11, 100)
+            .create_transaction("tx-hash-123", 11, 51, "block_hash-123-bis", 100)
             .await
             .unwrap();
-        let transaction_result = repository
-            .get_transaction(&"tx-hash-123".to_string())
-            .await
-            .unwrap();
+        let transaction_result = repository.get_transaction("tx-hash-123").await.unwrap();
 
         assert_eq!(
             Some(CardanoTransactionRecord {
                 transaction_hash: "tx-hash-123".to_string(),
                 block_number: 10,
+                slot_number: 50,
+                block_hash: "block_hash-123".to_string(),
                 immutable_file_number: 99
             }),
             transaction_result
@@ -488,45 +543,35 @@ mod tests {
         let repository = CardanoTransactionRepository::new(connection.clone());
 
         let cardano_transactions = vec![
-            CardanoTransaction {
-                transaction_hash: "tx-hash-123".to_string(),
-                block_number: 10,
-                immutable_file_number: 99,
-            },
-            CardanoTransaction {
-                transaction_hash: "tx-hash-456".to_string(),
-                block_number: 11,
-                immutable_file_number: 100,
-            },
+            CardanoTransaction::new("tx-hash-123", 10, 50, "block-hash-123", 99),
+            CardanoTransaction::new("tx-hash-456", 11, 51, "block-hash-456", 100),
         ];
         repository
             .store_transactions(&cardano_transactions)
             .await
             .unwrap();
 
-        let transaction_result = repository
-            .get_transaction(&"tx-hash-123".to_string())
-            .await
-            .unwrap();
+        let transaction_result = repository.get_transaction("tx-hash-123").await.unwrap();
 
         assert_eq!(
             Some(CardanoTransactionRecord {
                 transaction_hash: "tx-hash-123".to_string(),
                 block_number: 10,
+                slot_number: 50,
+                block_hash: "block-hash-123".to_string(),
                 immutable_file_number: 99
             }),
             transaction_result
         );
 
-        let transaction_result = repository
-            .get_transaction(&"tx-hash-456".to_string())
-            .await
-            .unwrap();
+        let transaction_result = repository.get_transaction("tx-hash-456").await.unwrap();
 
         assert_eq!(
             Some(CardanoTransactionRecord {
                 transaction_hash: "tx-hash-456".to_string(),
                 block_number: 11,
+                slot_number: 51,
+                block_hash: "block-hash-456".to_string(),
                 immutable_file_number: 100,
             }),
             transaction_result
@@ -534,7 +579,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_store_transactions_and_get_up_to_beacon_transactions() {
+    async fn repository_get_up_to_beacon_transactions() {
         let connection = get_connection().await;
         let repository = CardanoTransactionRepository::new(connection.clone());
 
@@ -542,6 +587,8 @@ mod tests {
             .map(|i| CardanoTransaction {
                 transaction_hash: format!("tx-hash-{i}"),
                 block_number: i % 10,
+                slot_number: i * 100,
+                block_hash: format!("block-hash-{i}"),
                 immutable_file_number: i,
             })
             .collect();
@@ -576,21 +623,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_store_transactions_and_get_all_stored_transactions() {
+    async fn repository_get_all_stored_transactions() {
         let connection = get_connection().await;
         let repository = CardanoTransactionRepository::new(connection.clone());
 
         let cardano_transactions = vec![
-            CardanoTransaction {
-                transaction_hash: "tx-hash-123".to_string(),
-                block_number: 10,
-                immutable_file_number: 99,
-            },
-            CardanoTransaction {
-                transaction_hash: "tx-hash-456".to_string(),
-                block_number: 11,
-                immutable_file_number: 100,
-            },
+            CardanoTransaction::new("tx-hash-123".to_string(), 10, 50, "block-hash-123", 99),
+            CardanoTransaction::new("tx-hash-456".to_string(), 11, 51, "block-hash-456", 100),
         ];
         repository
             .store_transactions(&cardano_transactions)
@@ -612,15 +651,17 @@ mod tests {
         let repository = CardanoTransactionRepository::new(connection.clone());
 
         repository
-            .create_transaction(&"tx-hash-000".to_string(), 1, 9)
+            .create_transaction("tx-hash-000", 1, 5, "block-hash", 9)
             .await
             .unwrap();
 
-        let cardano_transactions = vec![CardanoTransaction {
-            transaction_hash: "tx-hash-123".to_string(),
-            block_number: 10,
-            immutable_file_number: 99,
-        }];
+        let cardano_transactions = vec![CardanoTransaction::new(
+            "tx-hash-123",
+            10,
+            50,
+            "block-hash-123",
+            99,
+        )];
         repository
             .store_transactions(&cardano_transactions)
             .await
@@ -635,6 +676,8 @@ mod tests {
             Some(CardanoTransactionRecord {
                 transaction_hash: "tx-hash-000".to_string(),
                 block_number: 1,
+                slot_number: 5,
+                block_hash: "block-hash".to_string(),
                 immutable_file_number: 9
             }),
             transaction_result

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -140,8 +140,14 @@ mod tests {
         let mut transactions = vec![];
 
         for i in 1..=total_transactions {
-            let hash = format!("tx-{}", i);
-            transactions.push(CardanoTransaction::new(&hash, 10 * i as u64, i as u64));
+            let hash = format!("tx-{i}");
+            transactions.push(CardanoTransaction::new(
+                &hash,
+                10 * i as u64,
+                100 * i as u64,
+                format!("block_hash-{i}"),
+                i as u64,
+            ));
             hashes.push(hash);
         }
 

--- a/mithril-common/src/entities/cardano_transaction.rs
+++ b/mithril-common/src/entities/cardano_transaction.rs
@@ -4,6 +4,10 @@ use super::{BlockNumber, ImmutableFileNumber};
 
 /// TransactionHash is the unique identifier of a cardano transaction.
 pub type TransactionHash = String;
+/// Hash of a Cardano Block
+pub type BlockHash = String;
+/// [Cardano Slot number](https://docs.cardano.org/learn/cardano-node/#slotsandepochs)
+pub type SlotNumber = u64;
 
 #[derive(Debug, PartialEq, Clone)]
 /// Cardano transaction representation
@@ -14,20 +18,30 @@ pub struct CardanoTransaction {
     /// Block number of the transaction
     pub block_number: BlockNumber,
 
+    /// Slot number of the transaction
+    pub slot_number: SlotNumber,
+
+    /// Block hash of the transaction
+    pub block_hash: BlockHash,
+
     /// Immutable file number of the transaction
     pub immutable_file_number: ImmutableFileNumber,
 }
 
 impl CardanoTransaction {
     /// CardanoTransaction factory
-    pub fn new(
-        hash: &str,
+    pub fn new<T: Into<TransactionHash>, U: Into<BlockHash>>(
+        hash: T,
         block_number: BlockNumber,
+        slot_number: SlotNumber,
+        block_hash: U,
         immutable_file_number: ImmutableFileNumber,
     ) -> Self {
         Self {
-            transaction_hash: hash.to_owned(),
+            transaction_hash: hash.into(),
             block_number,
+            slot_number,
+            block_hash: block_hash.into(),
             immutable_file_number,
         }
     }
@@ -51,11 +65,8 @@ mod tests {
 
     #[test]
     fn test_convert_cardano_transaction_to_merkle_tree_node() {
-        let transaction = CardanoTransaction {
-            transaction_hash: "tx-hash-123".to_string(),
-            block_number: 1,
-            immutable_file_number: 1,
-        };
+        let transaction = CardanoTransaction::new("tx-hash-123", 10, 4, "block_hash", 1);
+
         let computed_mktree_node: MKTreeNode = transaction.into();
         let expected_mk_tree_node = MKTreeNode::new("tx-hash-123".as_bytes().to_vec());
         let non_expected_mk_tree_node = MKTreeNode::new("tx-hash-456".as_bytes().to_vec());

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -26,7 +26,7 @@ mod type_alias;
 pub use block_range::{BlockNumber, BlockRange, BlockRangeLength};
 pub use cardano_db_beacon::CardanoDbBeacon;
 pub use cardano_network::CardanoNetwork;
-pub use cardano_transaction::{CardanoTransaction, TransactionHash};
+pub use cardano_transaction::{BlockHash, CardanoTransaction, SlotNumber, TransactionHash};
 pub use cardano_transactions_set_proof::CardanoTransactionsSetProof;
 pub use cardano_transactions_snapshot::CardanoTransactionsSnapshot;
 pub use certificate::{Certificate, CertificateSignature};

--- a/mithril-common/src/messages/cardano_transactions_proof.rs
+++ b/mithril-common/src/messages/cardano_transactions_proof.rs
@@ -328,8 +328,8 @@ mod tests {
         async fn verify_hashes_from_verified_cardano_transaction_and_from_signable_builder_are_equals(
         ) {
             let transactions = vec![
-                CardanoTransaction::new("tx-hash-123", 1, 1),
-                CardanoTransaction::new("tx-hash-456", 2, 1),
+                CardanoTransaction::new("tx-hash-123", 10, 1, "block_hash", 1),
+                CardanoTransaction::new("tx-hash-456", 20, 2, "block_hash", 1),
             ];
 
             assert_eq!(

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -159,10 +159,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_merkle_root() {
-        let transaction_1 = CardanoTransaction::new("tx-hash-123", 1, 1);
-        let transaction_2 = CardanoTransaction::new("tx-hash-456", 2, 1);
-        let transaction_3 = CardanoTransaction::new("tx-hash-789", 3, 1);
-        let transaction_4 = CardanoTransaction::new("tx-hash-abc", 4, 1);
+        let transaction_1 = CardanoTransaction::new("tx-hash-123", 10, 1, "block_hash", 1);
+        let transaction_2 = CardanoTransaction::new("tx-hash-456", 20, 2, "block_hash", 1);
+        let transaction_3 = CardanoTransaction::new("tx-hash-789", 30, 3, "block_hash", 1);
+        let transaction_4 = CardanoTransaction::new("tx-hash-abc", 40, 4, "block_hash", 1);
 
         let transactions_set_reference = vec![
             transaction_1.clone(),
@@ -230,9 +230,9 @@ mod tests {
             ..CardanoDbBeacon::default()
         };
         let transactions = vec![
-            CardanoTransaction::new("tx-hash-123", 1, 11),
-            CardanoTransaction::new("tx-hash-456", 2, 12),
-            CardanoTransaction::new("tx-hash-789", 3, 13),
+            CardanoTransaction::new("tx-hash-123", 10, 1, "block_hash-", 11),
+            CardanoTransaction::new("tx-hash-456", 20, 2, "block_hash", 12),
+            CardanoTransaction::new("tx-hash-789", 30, 3, "block_hash", 13),
         ];
         let transaction_parser = Arc::new(DumbTransactionParser::new(transactions.clone()));
         let mut mock_transaction_store = MockTransactionStore::new();

--- a/mithril-signer/src/database/cardano_transaction_migration.rs
+++ b/mithril-signer/src/database/cardano_transaction_migration.rs
@@ -37,5 +37,19 @@ create index cardano_tx_immutable_file_number_index on cardano_tx(immutable_file
 vacuum;
 "#,
         ),
+        // Migration 3
+        // Add `slot_number` and `block_hash` columns to `cardano_tx`.
+        SqlMigration::new(
+            3,
+            r#"
+-- remove all data from the cardano tx table since the new columns are mandatory
+delete from cardano_tx;
+
+alter table cardano_tx add column slot_number integer not null;
+alter table cardano_tx add column block_hash text not null;
+
+vacuum;
+        "#,
+        ),
     ]
 }


### PR DESCRIPTION
## Content
This PR add two new fields to our `CardanoTransaction` type: `slot_number` and `block_hash`. This will allow comparison between a transaction and their incoming beacon that will include them (and the `block_number` that's already a part of our transaction type).

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1591
