### PR TITLE
New migration to add indexes on foreign keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.52"
+version = "0.4.53"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.52"
+version = "0.4.53"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -699,5 +699,31 @@ update pending_certificate
         );
         "#,
         ),
+        // Migration 24
+        // Add indexes for foreign keys
+        SqlMigration::new(
+            24,
+            r#"
+-- `certificate` table
+create index certificate_parent_certificate_id_index on certificate(parent_certificate_id);
+
+-- `signer_registration` table
+create index signer_registration_epoch_setting_id_index on signer_registration(epoch_setting_id);
+create index signer_registration_signer_id_index on signer_registration(signer_id);
+
+-- `open_message` table
+create index open_message_epoch_setting_id_index on open_message(epoch_setting_id);
+create index open_message_signed_entity_type_id_index on open_message(signed_entity_type_id);
+
+-- `signed_entity` table
+create index signed_entity_signed_entity_type_id_index on signed_entity(signed_entity_type_id);
+create index signed_entity_certificate_id_index on signed_entity(certificate_id);
+
+-- `single_signature` table
+create index single_signature_open_message_id_index on single_signature(open_message_id);
+create index single_signature_signer_id_index on single_signature(signer_id);
+create index single_signature_registration_epoch_setting_id_index on single_signature(registration_epoch_setting_id);
+"#,
+        ),
     ]
 }


### PR DESCRIPTION
## Content
This PR includes a new migration for the aggregator node database.
The migration creates indexes on foreign keys columns.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
Indexes are named `tablecolumn_index` to avoid conflicts when columns have the same name in different tables.

## Issue(s)
Closes #1603 
