### PR TITLE
Incremental storage of Cardano transactions

### DIFF
--- a/mithril-aggregator/src/database/provider/cardano_transaction.rs
+++ b/mithril-aggregator/src/database/provider/cardano_transaction.rs
@@ -3,7 +3,6 @@ use mithril_common::{
         BlockHash, BlockNumber, CardanoDbBeacon, CardanoTransaction, ImmutableFileNumber,
         SlotNumber, TransactionHash,
     },
-    signable_builder::TransactionStore,
     StdResult,
 };
 use mithril_persistence::sqlite::{
@@ -16,7 +15,7 @@ use async_trait::async_trait;
 use sqlite::{Row, Value};
 use std::{iter::repeat, sync::Arc};
 
-use crate::services::TransactionsRetriever;
+use crate::services::{TransactionStore, TransactionsRetriever};
 
 /// Cardano Transaction record is the representation of a cardano transaction.
 #[derive(Debug, PartialEq, Clone)]

--- a/mithril-aggregator/src/database/provider/test_helper.rs
+++ b/mithril-aggregator/src/database/provider/test_helper.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 use mithril_common::{entities::Epoch, test_utils::fake_keys, StdResult};
 use mithril_persistence::sqlite::SqliteConnection;
 
-use crate::database::{migration::get_migrations, provider::UpdateSingleSignatureRecordProvider};
+use crate::database::provider::UpdateSingleSignatureRecordProvider;
 
 use super::SingleSignatureRecord;
 
@@ -45,7 +45,15 @@ pub fn disable_foreign_key_support(connection: &SqliteConnection) -> StdResult<(
 }
 
 pub fn apply_all_migrations_to_db(connection: &SqliteConnection) -> StdResult<()> {
-    for migration in get_migrations() {
+    for migration in crate::database::migration::get_migrations() {
+        connection.execute(&migration.alterations)?;
+    }
+
+    Ok(())
+}
+
+pub fn apply_all_transactions_db_migrations(connection: &SqliteConnection) -> StdResult<()> {
+    for migration in crate::database::cardano_transaction_migration::get_migrations() {
         connection.execute(&migration.alterations)?;
     }
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -33,7 +33,7 @@ use mithril_common::{
     signable_builder::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
         MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
-        SignableBuilderService, TransactionStore,
+        SignableBuilderService,
     },
     TimePointProvider, TimePointProviderImpl,
 };
@@ -61,6 +61,7 @@ use crate::{
         MithrilEpochService, MithrilMessageService, MithrilProverService,
         MithrilSignedEntityService, MithrilStakeDistributionService, MithrilTickerService,
         ProverService, SignedEntityService, StakeDistributionService, TickerService,
+        TransactionStore,
     },
     tools::{CExplorerSignerRetriever, GcpFileUploader, GenesisToolsDependency, SignersImporter},
     AggregatorConfig, AggregatorRunner, AggregatorRuntime, CertificatePendingStore,

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1084,6 +1084,8 @@ impl DependenciesBuilder {
             self.get_transaction_parser().await?,
             self.get_transaction_store().await?,
             &self.configuration.db_directory,
+            // Rescan the last two immutables when importing transactions
+            Some(2),
             self.get_logger().await?,
         ));
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -57,10 +57,10 @@ use crate::{
     event_store::{EventMessage, EventStore, TransmitterService},
     http_server::routes::router,
     services::{
-        CertifierService, MessageService, MithrilCertifierService, MithrilEpochService,
-        MithrilMessageService, MithrilProverService, MithrilSignedEntityService,
-        MithrilStakeDistributionService, MithrilTickerService, ProverService, SignedEntityService,
-        StakeDistributionService, TickerService,
+        CardanoTransactionsImporter, CertifierService, MessageService, MithrilCertifierService,
+        MithrilEpochService, MithrilMessageService, MithrilProverService,
+        MithrilSignedEntityService, MithrilStakeDistributionService, MithrilTickerService,
+        ProverService, SignedEntityService, StakeDistributionService, TickerService,
     },
     tools::{CExplorerSignerRetriever, GcpFileUploader, GenesisToolsDependency, SignersImporter},
     AggregatorConfig, AggregatorRunner, AggregatorRuntime, CertificatePendingStore,
@@ -1079,10 +1079,14 @@ impl DependenciesBuilder {
             &self.configuration.db_directory,
             self.get_logger().await?,
         ));
-        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+        let transactions_importer = Arc::new(CardanoTransactionsImporter::new(
             self.get_transaction_parser().await?,
             self.get_transaction_store().await?,
             &self.configuration.db_directory,
+            self.get_logger().await?,
+        ));
+        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+            transactions_importer,
             self.get_logger().await?,
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -10,7 +10,7 @@ use mithril_common::{
     digesters::{ImmutableDigester, ImmutableFileObserver},
     entities::{Epoch, ProtocolParameters, SignerWithStake, StakeDistribution},
     era::{EraChecker, EraReader},
-    signable_builder::{SignableBuilderService, TransactionStore},
+    signable_builder::SignableBuilderService,
     test_utils::MithrilFixture,
     TimePointProvider,
 };
@@ -18,21 +18,20 @@ use mithril_persistence::{sqlite::SqliteConnection, store::StakeStorer};
 
 use crate::{
     configuration::*,
-    database::provider::{CertificateRepository, SignedEntityStorer, SignerGetter, StakePoolStore},
+    database::provider::{
+        CertificateRepository, OpenMessageRepository, SignedEntityStorer, SignerGetter,
+        StakePoolStore,
+    },
     event_store::{EventMessage, TransmitterService},
     multi_signer::MultiSigner,
     services::{
-        CertifierService, ProverService, SignedEntityService, StakeDistributionService,
-        TickerService,
+        CertifierService, EpochService, MessageService, ProverService, SignedEntityService,
+        StakeDistributionService, TickerService, TransactionStore,
     },
     signer_registerer::SignerRecorder,
     snapshot_uploaders::SnapshotUploader,
     CertificatePendingStore, ProtocolParametersStorer, SignerRegisterer,
     SignerRegistrationRoundOpener, Snapshotter, VerificationKeyStorer,
-};
-use crate::{
-    database::provider::OpenMessageRepository,
-    services::{EpochService, MessageService},
 };
 
 /// MultiSignerWrapper wraps a [MultiSigner]

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -65,21 +65,14 @@ pub use tools::{
 pub use dependency_injection::tests::initialize_dependencies;
 
 #[cfg(test)]
-/// Create a [slog scope global logger][slog_scope::GlobalLoggerGuard] to use
-/// when debugging some tests that have logs.
-///
-/// * Remove it after use: it's only mean for debugging, leaving it expose the tests to the two
-/// following points.
-/// * Don't put it in more than one tests at a time since it is set globally meaning that a test that
-/// end will clean up the logger for the test that are still running.
-/// * Don't run more than one test at a time with it: logs from more than one tests will be mixed
-/// together otherwise.
-pub fn global_logger_for_tests() -> slog_scope::GlobalLoggerGuard {
+pub(crate) mod test_tools {
     use slog::Drain;
     use std::sync::Arc;
 
-    let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
-    slog_scope::set_global_logger(slog::Logger::root(Arc::new(drain), slog::o!()))
+    pub fn logger_for_tests() -> slog::Logger {
+        let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
+        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+        let drain = slog_async::Async::new(drain).build().fuse();
+        slog::Logger::root(Arc::new(drain), slog::o!())
+    }
 }

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -24,7 +24,7 @@ pub trait TransactionStore: Send + Sync {
     ) -> StdResult<Vec<CardanoTransaction>>;
 
     /// Store list of transactions
-    async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
+    async fn store_transactions(&self, transactions: Vec<CardanoTransaction>) -> StdResult<()>;
 }
 
 /// Import and store [CardanoTransaction].
@@ -89,12 +89,9 @@ impl CardanoTransactionsImporter {
             from.unwrap_or(0)
         );
 
-        let transaction_chunk_size = 100;
-        for transactions_in_chunk in parsed_transactions.chunks(transaction_chunk_size) {
-            self.transaction_store
-                .store_transactions(transactions_in_chunk)
-                .await?;
-        }
+        self.transaction_store
+            .store_transactions(parsed_transactions)
+            .await?;
         Ok(())
     }
 }

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -1,0 +1,54 @@
+use async_trait::async_trait;
+use mithril_common::cardano_transaction_parser::TransactionParser;
+use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction};
+use mithril_common::signable_builder::{TransactionStore, TransactionsImporter};
+use mithril_common::StdResult;
+use slog::{debug, Logger};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Import and store [CardanoTransaction].
+pub struct CardanoTransactionsImporter {
+    transaction_parser: Arc<dyn TransactionParser>,
+    transaction_store: Arc<dyn TransactionStore>,
+    logger: Logger,
+    dirpath: PathBuf,
+}
+
+impl CardanoTransactionsImporter {
+    /// Constructor
+    pub fn new(
+        transaction_parser: Arc<dyn TransactionParser>,
+        transaction_store: Arc<dyn TransactionStore>,
+        dirpath: &Path,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            transaction_parser,
+            transaction_store,
+            logger,
+            dirpath: dirpath.to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionsImporter for CardanoTransactionsImporter {
+    async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>> {
+        let transactions = self.transaction_parser.parse(&self.dirpath, beacon).await?;
+        debug!(
+            self.logger,
+            "Retrieved {} Cardano transactions at beacon: {beacon}",
+            transactions.len()
+        );
+
+        let transaction_chunk_size = 100;
+        for transactions_in_chunk in transactions.chunks(transaction_chunk_size) {
+            self.transaction_store
+                .store_transactions(transactions_in_chunk)
+                .await?;
+        }
+
+        Ok(transactions)
+    }
+}

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -1,11 +1,22 @@
 use async_trait::async_trait;
 use mithril_common::cardano_transaction_parser::TransactionParser;
 use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction};
-use mithril_common::signable_builder::{TransactionStore, TransactionsImporter};
+use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
 use slog::{debug, Logger};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+#[cfg(test)]
+use mockall::automock;
+
+/// Cardano transactions store
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait TransactionStore: Send + Sync {
+    /// Store list of transactions
+    async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
+}
 
 /// Import and store [CardanoTransaction].
 pub struct CardanoTransactionsImporter {

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -71,7 +71,10 @@ impl CardanoTransactionsImporter {
         until: ImmutableFileNumber,
     ) -> StdResult<()> {
         if from.is_some_and(|f| f >= until) {
-            // Db is up-to-date - nothing to do
+            debug!(
+                self.logger,
+                "TransactionsImporter does not need to retrieve Cardano transactions, the database is up to date for immutable '{until}'",
+            );
             return Ok(());
         }
 
@@ -81,7 +84,7 @@ impl CardanoTransactionsImporter {
             .await?;
         debug!(
             self.logger,
-            "Retrieved {} Cardano transactions at between immutables {} and {until}",
+            "TransactionsImporter retrieved '{}' Cardano transactions between immutables '{}' and '{until}'",
             parsed_transactions.len(),
             from.unwrap_or(0)
         );

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use mithril_common::cardano_transaction_parser::TransactionParser;
-use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction};
+use mithril_common::entities::{CardanoTransaction, ImmutableFileNumber};
 use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
 use slog::{debug, Logger};
@@ -45,14 +45,17 @@ impl CardanoTransactionsImporter {
 
 #[async_trait]
 impl TransactionsImporter for CardanoTransactionsImporter {
-    async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>> {
+    async fn import(
+        &self,
+        up_to_beacon: ImmutableFileNumber,
+    ) -> StdResult<Vec<CardanoTransaction>> {
         let transactions = self
             .transaction_parser
-            .parse(&self.dirpath, None, beacon.immutable_file_number)
+            .parse(&self.dirpath, None, up_to_beacon)
             .await?;
         debug!(
             self.logger,
-            "Retrieved {} Cardano transactions at beacon: {beacon}",
+            "Retrieved {} Cardano transactions at beacon: {up_to_beacon}",
             transactions.len()
         );
 

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -46,7 +46,10 @@ impl CardanoTransactionsImporter {
 #[async_trait]
 impl TransactionsImporter for CardanoTransactionsImporter {
     async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>> {
-        let transactions = self.transaction_parser.parse(&self.dirpath, beacon).await?;
+        let transactions = self
+            .transaction_parser
+            .parse(&self.dirpath, None, beacon.immutable_file_number)
+            .await?;
         debug!(
             self.logger,
             "Retrieved {} Cardano transactions at beacon: {beacon}",

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -14,6 +14,15 @@ use mockall::automock;
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait TransactionStore: Send + Sync {
+    /// Get the highest known transaction beacon
+    async fn get_highest_beacon(&self) -> StdResult<Option<ImmutableFileNumber>>;
+
+    /// Get stored transactions up to the given beacon
+    async fn get_up_to(
+        &self,
+        immutable_file_number: ImmutableFileNumber,
+    ) -> StdResult<Vec<CardanoTransaction>>;
+
     /// Store list of transactions
     async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
 }
@@ -23,23 +32,67 @@ pub struct CardanoTransactionsImporter {
     transaction_parser: Arc<dyn TransactionParser>,
     transaction_store: Arc<dyn TransactionStore>,
     logger: Logger,
+    rescan_offset: Option<usize>,
     dirpath: PathBuf,
 }
 
 impl CardanoTransactionsImporter {
     /// Constructor
+    ///
+    /// About `rescan_offset`: if Some(x) the importer will be asked to rescan the previous 'x'
+    /// immutables starting from the highest immutable known in the store.
+    /// This is useful when one of the last immutable was not full scanned.
     pub fn new(
         transaction_parser: Arc<dyn TransactionParser>,
         transaction_store: Arc<dyn TransactionStore>,
         dirpath: &Path,
+        rescan_offset: Option<usize>,
         logger: Logger,
     ) -> Self {
         Self {
             transaction_parser,
             transaction_store,
             logger,
+            rescan_offset,
             dirpath: dirpath.to_owned(),
         }
+    }
+
+    async fn get_starting_beacon(&self) -> StdResult<Option<u64>> {
+        let highest = self.transaction_store.get_highest_beacon().await?;
+        let rescan_offset = self.rescan_offset.unwrap_or(0);
+        let highest = highest.map(|h| (h + 1).saturating_sub(rescan_offset as u64));
+        Ok(highest)
+    }
+
+    async fn parse_and_store_missing_transactions(
+        &self,
+        from: Option<u64>,
+        until: ImmutableFileNumber,
+    ) -> StdResult<()> {
+        if from.is_some_and(|f| f >= until) {
+            // Db is up-to-date - nothing to do
+            return Ok(());
+        }
+
+        let parsed_transactions = self
+            .transaction_parser
+            .parse(&self.dirpath, from, until)
+            .await?;
+        debug!(
+            self.logger,
+            "Retrieved {} Cardano transactions at between immutables {} and {until}",
+            parsed_transactions.len(),
+            from.unwrap_or(0)
+        );
+
+        let transaction_chunk_size = 100;
+        for transactions_in_chunk in parsed_transactions.chunks(transaction_chunk_size) {
+            self.transaction_store
+                .store_transactions(transactions_in_chunk)
+                .await?;
+        }
+        Ok(())
     }
 }
 
@@ -49,23 +102,227 @@ impl TransactionsImporter for CardanoTransactionsImporter {
         &self,
         up_to_beacon: ImmutableFileNumber,
     ) -> StdResult<Vec<CardanoTransaction>> {
-        let transactions = self
-            .transaction_parser
-            .parse(&self.dirpath, None, up_to_beacon)
+        let from = self.get_starting_beacon().await?;
+        self.parse_and_store_missing_transactions(from, up_to_beacon)
             .await?;
-        debug!(
-            self.logger,
-            "Retrieved {} Cardano transactions at beacon: {up_to_beacon}",
-            transactions.len()
+
+        let transactions = self.transaction_store.get_up_to(up_to_beacon).await?;
+        Ok(transactions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::database::provider::{
+        apply_all_transactions_db_migrations, CardanoTransactionRepository,
+    };
+    use mockall::mock;
+    use mockall::predicate::eq;
+    use sqlite::Connection;
+
+    use super::*;
+
+    mock! {
+        pub TransactionParserImpl { }
+
+        #[async_trait]
+        impl TransactionParser for TransactionParserImpl {
+            async fn parse(
+              &self,
+              dirpath: &Path,
+              from_immutable: Option<ImmutableFileNumber>,
+              until_immutable: ImmutableFileNumber,
+            ) -> StdResult<Vec<CardanoTransaction>>;
+        }
+    }
+
+    fn build_importer(
+        parser_mock_config: &dyn Fn(&mut MockTransactionParserImpl),
+        store_mock_config: &dyn Fn(&mut MockTransactionStore),
+    ) -> CardanoTransactionsImporter {
+        let db_path = Path::new("");
+        let mut parser = MockTransactionParserImpl::new();
+        parser_mock_config(&mut parser);
+
+        let mut store = MockTransactionStore::new();
+        store.expect_get_up_to().returning(|_| Ok(vec![]));
+        store_mock_config(&mut store);
+
+        CardanoTransactionsImporter::new(
+            Arc::new(parser),
+            Arc::new(store),
+            db_path,
+            None,
+            crate::test_tools::logger_for_tests(),
+        )
+    }
+
+    #[tokio::test]
+    async fn if_nothing_stored_parse_and_store_all_transactions() {
+        let transactions = vec![
+            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-1", 11),
+            CardanoTransaction::new("tx_hash-2", 10, 20, "block_hash-1", 11),
+            CardanoTransaction::new("tx_hash-3", 20, 25, "block_hash-2", 12),
+            CardanoTransaction::new("tx_hash-4", 20, 30, "block_hash-2", 12),
+        ];
+        let up_to_beacon = 12;
+
+        let importer = build_importer(
+            &|parser_mock| {
+                let parsed_transactions = transactions.clone();
+                parser_mock
+                    .expect_parse()
+                    .withf(move |_, from, until| from.is_none() && until == &up_to_beacon)
+                    .return_once(move |_, _, _| Ok(parsed_transactions));
+            },
+            &|store_mock| {
+                let expected_stored_transactions = transactions.clone();
+                store_mock
+                    .expect_get_highest_beacon()
+                    .returning(|| Ok(None));
+                store_mock
+                    .expect_store_transactions()
+                    .with(eq(expected_stored_transactions))
+                    .returning(|_| Ok(()))
+                    .once();
+            },
         );
 
-        let transaction_chunk_size = 100;
-        for transactions_in_chunk in transactions.chunks(transaction_chunk_size) {
-            self.transaction_store
-                .store_transactions(transactions_in_chunk)
-                .await?;
-        }
+        importer
+            .import(up_to_beacon)
+            .await
+            .expect("Transactions Parser should succeed");
+    }
 
-        Ok(transactions)
+    #[tokio::test]
+    async fn if_all_stored_nothing_is_parsed_and_stored() {
+        let up_to_beacon = 12;
+
+        let importer = build_importer(
+            &|parser_mock| {
+                parser_mock.expect_parse().never();
+            },
+            &|store_mock| {
+                store_mock
+                    .expect_get_highest_beacon()
+                    .returning(|| Ok(Some(12)));
+                store_mock.expect_store_transactions().never();
+            },
+        );
+
+        importer
+            .import(up_to_beacon)
+            .await
+            .expect("Transactions Parser should succeed");
+    }
+
+    #[tokio::test]
+    async fn if_all_half_are_stored_the_other_half_is_parsed_and_stored() {
+        let transactions = vec![
+            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-10", 11),
+            CardanoTransaction::new("tx_hash-2", 20, 20, "block_hash-20", 12),
+            CardanoTransaction::new("tx_hash-3", 30, 25, "block_hash-30", 13),
+            CardanoTransaction::new("tx_hash-4", 40, 30, "block_hash-40", 14),
+        ];
+        let up_to_beacon = 14;
+
+        let importer = build_importer(
+            &|parser_mock| {
+                let parsed_transactions = transactions[2..=3].to_vec();
+                parser_mock
+                    .expect_parse()
+                    .withf(move |_, from, until| from == &Some(13) && until == &up_to_beacon)
+                    .return_once(move |_, _, _| Ok(parsed_transactions));
+            },
+            &|store_mock| {
+                store_mock
+                    .expect_get_highest_beacon()
+                    .returning(|| Ok(Some(12)));
+                let expected_to_store_transactions = transactions[2..=3].to_vec();
+                store_mock
+                    .expect_store_transactions()
+                    .with(eq(expected_to_store_transactions))
+                    .returning(|_| Ok(()))
+                    .once();
+            },
+        );
+
+        importer
+            .import(up_to_beacon)
+            .await
+            .expect("Transactions Parser should succeed");
+    }
+
+    #[tokio::test]
+    async fn importing_twice_starting_with_nothing_in_a_real_db_should_yield_the_transactions_in_same_order(
+    ) {
+        let transactions = vec![
+            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-1", 11),
+            CardanoTransaction::new("tx_hash-2", 10, 20, "block_hash-1", 11),
+            CardanoTransaction::new("tx_hash-3", 20, 25, "block_hash-2", 12),
+            CardanoTransaction::new("tx_hash-4", 20, 30, "block_hash-2", 12),
+        ];
+        let importer = {
+            let connection = Connection::open_thread_safe(":memory:").unwrap();
+            apply_all_transactions_db_migrations(&connection).unwrap();
+            let parsed_transactions = transactions.clone();
+            let mut parser = MockTransactionParserImpl::new();
+            parser
+                .expect_parse()
+                .return_once(move |_, _, _| Ok(parsed_transactions));
+
+            CardanoTransactionsImporter::new(
+                Arc::new(parser),
+                Arc::new(CardanoTransactionRepository::new(Arc::new(connection))),
+                Path::new(""),
+                None,
+                crate::test_tools::logger_for_tests(),
+            )
+        };
+
+        let cold_imported_transactions = importer
+            .import(12)
+            .await
+            .expect("Transactions Parser should succeed");
+
+        let warm_imported_transactions = importer
+            .import(12)
+            .await
+            .expect("Transactions Parser should succeed");
+
+        assert_eq!(transactions, cold_imported_transactions);
+        assert_eq!(cold_imported_transactions, warm_imported_transactions);
+    }
+
+    #[tokio::test]
+    async fn change_parsed_lower_bound_when_rescan_limit_is_set() {
+        fn importer_with_offset(
+            highest_stored_beacon: ImmutableFileNumber,
+            rescan_offset: ImmutableFileNumber,
+        ) -> CardanoTransactionsImporter {
+            let mut store = MockTransactionStore::new();
+            store
+                .expect_get_highest_beacon()
+                .returning(move || Ok(Some(highest_stored_beacon)));
+
+            CardanoTransactionsImporter::new(
+                Arc::new(MockTransactionParserImpl::new()),
+                Arc::new(store),
+                Path::new(""),
+                Some(rescan_offset as usize),
+                crate::test_tools::logger_for_tests(),
+            )
+        }
+        let importer = importer_with_offset(8, 3);
+
+        let from = importer.get_starting_beacon().await.unwrap();
+        // Expected should be: highest_stored_beacon + 1 - rescan_offset
+        assert_eq!(Some(6), from);
+
+        let importer = importer_with_offset(5, 10);
+
+        let from = importer.get_starting_beacon().await.unwrap();
+        // If sub overflow it should be 0
+        assert_eq!(Some(0), from);
     }
 }

--- a/mithril-aggregator/src/services/mod.rs
+++ b/mithril-aggregator/src/services/mod.rs
@@ -9,6 +9,7 @@
 //!
 //! Each service is defined by a public API (a trait) that is used in the controllers (runtimes).
 
+mod cardano_transactions_importer;
 mod certifier;
 mod epoch_service;
 mod message;
@@ -17,6 +18,7 @@ mod signed_entity;
 mod stake_distribution;
 mod ticker;
 
+pub use cardano_transactions_importer::*;
 pub use certifier::*;
 pub use epoch_service::*;
 pub use message::*;

--- a/mithril-common/src/cardano_transaction_parser.rs
+++ b/mithril-common/src/cardano_transaction_parser.rs
@@ -2,8 +2,8 @@
 use crate::{
     digesters::ImmutableFile,
     entities::{
-        BlockHash, BlockNumber, CardanoDbBeacon, CardanoTransaction, ImmutableFileNumber,
-        SlotNumber, TransactionHash,
+        BlockHash, BlockNumber, CardanoTransaction, ImmutableFileNumber, SlotNumber,
+        TransactionHash,
     },
     StdResult,
 };
@@ -23,7 +23,7 @@ use tokio::sync::RwLock;
 ///     use anyhow::anyhow;
 ///     use async_trait::async_trait;
 ///     use mithril_common::cardano_transaction_parser::TransactionParser;
-///     use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction};
+///     use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction, ImmutableFileNumber};
 ///     use mithril_common::StdResult;
 ///     use mockall::mock;
 ///     use std::path::Path;
@@ -36,7 +36,8 @@ use tokio::sync::RwLock;
 ///             async fn parse(
 ///               &self,
 ///               dirpath: &Path,
-///               beacon: &CardanoDbBeacon,
+///               from_immutable: Option<ImmutableFileNumber>,
+///               until_immutable: ImmutableFileNumber,
 ///             ) -> StdResult<Vec<CardanoTransaction>>;
 ///         }
 ///     }
@@ -56,7 +57,8 @@ pub trait TransactionParser: Sync + Send {
     async fn parse(
         &self,
         dirpath: &Path,
-        beacon: &CardanoDbBeacon,
+        from_immutable: Option<ImmutableFileNumber>,
+        until_immutable: ImmutableFileNumber,
     ) -> StdResult<Vec<CardanoTransaction>>;
 }
 
@@ -85,7 +87,8 @@ impl TransactionParser for DumbTransactionParser {
     async fn parse(
         &self,
         _dirpath: &Path,
-        _beacon: &CardanoDbBeacon,
+        _from_immutable: Option<ImmutableFileNumber>,
+        _until_immutable: ImmutableFileNumber,
     ) -> StdResult<Vec<CardanoTransaction>> {
         Ok(self.transactions.read().await.clone())
     }
@@ -198,12 +201,14 @@ impl CardanoTransactionParser {
 
 #[async_trait]
 impl TransactionParser for CardanoTransactionParser {
+    // Todo: update implem to parse from the lower bound
     async fn parse(
         &self,
         dirpath: &Path,
-        beacon: &CardanoDbBeacon,
+        _from_immutable: Option<ImmutableFileNumber>,
+        until_immutable: ImmutableFileNumber,
     ) -> StdResult<Vec<CardanoTransaction>> {
-        let up_to_file_number = beacon.immutable_file_number;
+        let up_to_file_number = until_immutable;
         let immutable_chunks = ImmutableFile::list_completed_in_dir(dirpath)?
             .into_iter()
             .filter(|f| f.number <= up_to_file_number && f.filename.contains("chunk"))
@@ -275,16 +280,13 @@ mod tests {
         let db_path = Path::new("../mithril-test-lab/test_data/immutable/");
         assert!(get_number_of_immutable_chunk_in_dir(db_path) >= 3);
 
-        let beacon = CardanoDbBeacon {
-            immutable_file_number: 2,
-            ..CardanoDbBeacon::default()
-        };
+        let until_immutable_file = 2;
         let tx_count: usize = immutable_files.iter().map(|(_, count)| *count).sum();
         let cardano_transaction_parser =
             CardanoTransactionParser::new(Logger::root(slog::Discard, slog::o!()), false);
 
         let transactions = cardano_transaction_parser
-            .parse(db_path, &beacon)
+            .parse(db_path, None, until_immutable_file)
             .await
             .unwrap();
 
@@ -292,16 +294,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_parse_from_lower_bound_until_upper_bound() {
+        todo!()
+    }
+
+    #[tokio::test]
     async fn test_parse_should_error_with_unparsable_block_format() {
         let db_path = Path::new("../mithril-test-lab/test_data/parsing_error/immutable/");
-        let beacon = CardanoDbBeacon {
-            immutable_file_number: 4831,
-            ..CardanoDbBeacon::default()
-        };
+        let until_immutable_file = 4831;
         let cardano_transaction_parser =
             CardanoTransactionParser::new(Logger::root(slog::Discard, slog::o!()), false);
 
-        let result = cardano_transaction_parser.parse(db_path, &beacon).await;
+        let result = cardano_transaction_parser
+            .parse(db_path, None, until_immutable_file)
+            .await;
 
         assert!(result.is_err());
     }
@@ -314,17 +320,14 @@ mod tests {
         );
         let filepath = temp_dir.join("test.log");
         let db_path = Path::new("../mithril-test-lab/test_data/parsing_error/immutable/");
-        let beacon = CardanoDbBeacon {
-            immutable_file_number: 4831,
-            ..CardanoDbBeacon::default()
-        };
+        let until_immutable_file = 4831;
         // We create a block to drop the logger and force a flush before we read the log file.
         {
             let cardano_transaction_parser =
                 CardanoTransactionParser::new(create_file_logger(&filepath), true);
 
             cardano_transaction_parser
-                .parse(db_path, &beacon)
+                .parse(db_path, None, until_immutable_file)
                 .await
                 .expect_err("parse should have failed");
         }
@@ -340,16 +343,13 @@ mod tests {
         let db_path = Path::new("../mithril-test-lab/test_data/immutable/");
         assert!(get_number_of_immutable_chunk_in_dir(db_path) >= 2);
 
-        let beacon = CardanoDbBeacon {
-            immutable_file_number: 1,
-            ..CardanoDbBeacon::default()
-        };
+        let until_immutable_file = 1;
         let tx_count: usize = immutable_files.iter().map(|(_, count)| *count).sum();
         let cardano_transaction_parser =
             CardanoTransactionParser::new(Logger::root(slog::Discard, slog::o!()), false);
 
         let transactions = cardano_transaction_parser
-            .parse(db_path, &beacon)
+            .parse(db_path, None, until_immutable_file)
             .await
             .unwrap();
 

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -1,15 +1,10 @@
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 use anyhow::Context;
 use async_trait::async_trait;
 use slog::{debug, Logger};
 
 use crate::{
-    cardano_transaction_parser::TransactionParser,
     crypto_helper::{MKMap, MKMapNode, MKTree, MKTreeNode},
     entities::{
         BlockRange, CardanoDbBeacon, CardanoTransaction, ProtocolMessage, ProtocolMessagePartKey,
@@ -33,32 +28,23 @@ pub trait TransactionStore: Send + Sync {
 /// Cardano transactions importer
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait TransactionImporter: Send + Sync {
+pub trait TransactionsImporter: Send + Sync {
     /// Returns all transactions up to the given beacon
     async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>>;
 }
 
 /// A [CardanoTransactionsSignableBuilder] builder
 pub struct CardanoTransactionsSignableBuilder {
-    transaction_parser: Arc<dyn TransactionParser>,
-    transaction_store: Arc<dyn TransactionStore>,
+    transaction_importer: Arc<dyn TransactionsImporter>,
     logger: Logger,
-    dirpath: PathBuf,
 }
 
 impl CardanoTransactionsSignableBuilder {
     /// Constructor
-    pub fn new(
-        transaction_parser: Arc<dyn TransactionParser>,
-        transaction_store: Arc<dyn TransactionStore>,
-        dirpath: &Path,
-        logger: Logger,
-    ) -> Self {
+    pub fn new(transaction_importer: Arc<dyn TransactionsImporter>, logger: Logger) -> Self {
         Self {
-            transaction_parser,
-            transaction_store,
+            transaction_importer,
             logger,
-            dirpath: dirpath.to_owned(),
         }
     }
 
@@ -106,27 +92,6 @@ impl CardanoTransactionsSignableBuilder {
 }
 
 #[async_trait]
-impl TransactionImporter for CardanoTransactionsSignableBuilder {
-    async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>> {
-        let transactions = self.transaction_parser.parse(&self.dirpath, beacon).await?;
-        debug!(
-            self.logger,
-            "Retrieved {} Cardano transactions at beacon: {beacon}",
-            transactions.len()
-        );
-
-        let transaction_chunk_size = 100;
-        for transactions_in_chunk in transactions.chunks(transaction_chunk_size) {
-            self.transaction_store
-                .store_transactions(transactions_in_chunk)
-                .await?;
-        }
-
-        Ok(transactions)
-    }
-}
-
-#[async_trait]
 impl SignableBuilder<CardanoDbBeacon> for CardanoTransactionsSignableBuilder {
     async fn compute_protocol_message(
         &self,
@@ -137,7 +102,7 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoTransactionsSignableBuilder {
             "Compute protocol message for CardanoTransactions at beacon: {beacon}"
         );
 
-        let transactions = self.import(&beacon).await?;
+        let transactions = self.transaction_importer.import(&beacon).await?;
         let mk_root = self.compute_merkle_root(&transactions)?;
 
         let mut protocol_message = ProtocolMessage::new();
@@ -156,9 +121,6 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoTransactionsSignableBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::cardano_transaction_parser::DumbTransactionParser;
-    use crate::signable_builder::MockTransactionStore;
-
     use super::*;
     use slog::Drain;
 
@@ -189,9 +151,7 @@ mod tests {
         }
 
         let cardano_transaction_signable_builder = CardanoTransactionsSignableBuilder::new(
-            Arc::new(DumbTransactionParser::new(vec![])),
-            Arc::new(MockTransactionStore::new()),
-            Path::new("/tmp"),
+            Arc::new(MockTransactionsImporter::new()),
             create_logger(),
         );
 
@@ -252,9 +212,7 @@ mod tests {
             CardanoTransaction::new("tx-hash-456", BlockRange::LENGTH + 1, 20, "block_hash", 1);
 
         let cardano_transaction_signable_builder = CardanoTransactionsSignableBuilder::new(
-            Arc::new(DumbTransactionParser::new(vec![])),
-            Arc::new(MockTransactionStore::new()),
-            Path::new("/tmp"),
+            Arc::new(MockTransactionsImporter::new()),
             create_logger(),
         );
 
@@ -281,16 +239,13 @@ mod tests {
             CardanoTransaction::new("tx-hash-456", 20, 2, "block_hash", 12),
             CardanoTransaction::new("tx-hash-789", 30, 3, "block_hash", 13),
         ];
-        let transaction_parser = Arc::new(DumbTransactionParser::new(transactions.clone()));
-        let mut mock_transaction_store = MockTransactionStore::new();
-        mock_transaction_store
-            .expect_store_transactions()
-            .returning(|_| Ok(()));
-        let transaction_store = Arc::new(mock_transaction_store);
+        let imported_transactions = transactions.clone();
+        let mut transaction_importer = MockTransactionsImporter::new();
+        transaction_importer
+            .expect_import()
+            .return_once(move |_| Ok(imported_transactions));
         let cardano_transactions_signable_builder = CardanoTransactionsSignableBuilder::new(
-            transaction_parser,
-            transaction_store,
-            Path::new("/tmp"),
+            Arc::new(transaction_importer),
             create_logger(),
         );
 
@@ -319,17 +274,12 @@ mod tests {
     #[tokio::test]
     async fn test_compute_signable_with_no_transaction_return_error() {
         let beacon = CardanoDbBeacon::default();
-        let transactions = vec![];
-        let transaction_parser = Arc::new(DumbTransactionParser::new(transactions.clone()));
-        let mut mock_transaction_store = MockTransactionStore::new();
-        mock_transaction_store
-            .expect_store_transactions()
-            .returning(|_| Ok(()));
-        let transaction_store = Arc::new(mock_transaction_store);
+        let mut transaction_importer = MockTransactionsImporter::new();
+        transaction_importer
+            .expect_import()
+            .return_once(|_| Ok(vec![]));
         let cardano_transactions_signable_builder = CardanoTransactionsSignableBuilder::new(
-            transaction_parser,
-            transaction_store,
-            Path::new("/tmp"),
+            Arc::new(transaction_importer),
             create_logger(),
         );
 

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -17,14 +17,6 @@ use crate::{
 #[cfg(test)]
 use mockall::automock;
 
-/// Cardano transactions store
-#[cfg_attr(test, automock)]
-#[async_trait]
-pub trait TransactionStore: Send + Sync {
-    /// Store list of transactions
-    async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
-}
-
 /// Cardano transactions importer
 #[cfg_attr(test, automock)]
 #[async_trait]

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -14,6 +14,7 @@ use crate::{
     StdResult,
 };
 
+use crate::entities::ImmutableFileNumber;
 #[cfg(test)]
 use mockall::automock;
 
@@ -22,7 +23,8 @@ use mockall::automock;
 #[async_trait]
 pub trait TransactionsImporter: Send + Sync {
     /// Returns all transactions up to the given beacon
-    async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>>;
+    async fn import(&self, up_to_beacon: ImmutableFileNumber)
+        -> StdResult<Vec<CardanoTransaction>>;
 }
 
 /// A [CardanoTransactionsSignableBuilder] builder
@@ -94,7 +96,10 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoTransactionsSignableBuilder {
             "Compute protocol message for CardanoTransactions at beacon: {beacon}"
         );
 
-        let transactions = self.transaction_importer.import(&beacon).await?;
+        let transactions = self
+            .transaction_importer
+            .import(beacon.immutable_file_number)
+            .await?;
         let mk_root = self.compute_merkle_root(&transactions)?;
 
         let mut protocol_message = ProtocolMessage::new();

--- a/mithril-common/src/signable_builder/mod.rs
+++ b/mithril-common/src/signable_builder/mod.rs
@@ -15,6 +15,3 @@ cfg_fs! {
     pub use cardano_immutable_full_signable_builder::*;
     pub use cardano_transactions::*;
 }
-
-#[cfg(all(test, feature = "fs"))]
-pub use cardano_transactions::MockTransactionStore;

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -24,7 +24,7 @@ pub trait TransactionStore: Send + Sync {
     ) -> StdResult<Vec<CardanoTransaction>>;
 
     /// Store list of transactions
-    async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
+    async fn store_transactions(&self, transactions: Vec<CardanoTransaction>) -> StdResult<()>;
 }
 
 /// Import and store [CardanoTransaction].
@@ -89,12 +89,9 @@ impl CardanoTransactionsImporter {
             from.unwrap_or(0)
         );
 
-        let transaction_chunk_size = 100;
-        for transactions_in_chunk in parsed_transactions.chunks(transaction_chunk_size) {
-            self.transaction_store
-                .store_transactions(transactions_in_chunk)
-                .await?;
-        }
+        self.transaction_store
+            .store_transactions(parsed_transactions)
+            .await?;
         Ok(())
     }
 }

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use mithril_common::cardano_transaction_parser::TransactionParser;
-use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction};
+use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction, ImmutableFileNumber};
 use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
 use slog::{debug, Logger};
@@ -14,6 +14,14 @@ use mockall::automock;
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait TransactionStore: Send + Sync {
+    /// Get stored transactions at most up to the given beacon
+    ///
+    /// Alongside the transactions it will return the highest immutable file number
+    async fn get_at_most_to(
+        &self,
+        beacon: &CardanoDbBeacon,
+    ) -> StdResult<Option<(ImmutableFileNumber, Vec<CardanoTransaction>)>>;
+
     /// Store list of transactions
     async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
 }
@@ -46,21 +54,27 @@ impl CardanoTransactionsImporter {
 #[async_trait]
 impl TransactionsImporter for CardanoTransactionsImporter {
     async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>> {
-        let transactions = self.transaction_parser.parse(&self.dirpath, beacon).await?;
-        debug!(
-            self.logger,
-            "Retrieved {} Cardano transactions at beacon: {beacon}",
-            transactions.len()
-        );
+        if let Some((_highest_immutable, stored_transactions)) =
+            self.transaction_store.get_at_most_to(beacon).await?
+        {
+            Ok(stored_transactions)
+        } else {
+            let transactions = self.transaction_parser.parse(&self.dirpath, beacon).await?;
+            debug!(
+                self.logger,
+                "Retrieved {} Cardano transactions at beacon: {beacon}",
+                transactions.len()
+            );
 
-        let transaction_chunk_size = 100;
-        for transactions_in_chunk in transactions.chunks(transaction_chunk_size) {
-            self.transaction_store
-                .store_transactions(transactions_in_chunk)
-                .await?;
+            let transaction_chunk_size = 100;
+            for transactions_in_chunk in transactions.chunks(transaction_chunk_size) {
+                self.transaction_store
+                    .store_transactions(transactions_in_chunk)
+                    .await?;
+            }
+
+            Ok(transactions)
         }
-
-        Ok(transactions)
     }
 }
 
@@ -124,10 +138,42 @@ mod tests {
             },
             &|store_mock| {
                 let expected_stored_transactions = transactions.clone();
+                store_mock.expect_get_at_most_to().returning(|_| Ok(None));
                 store_mock
                     .expect_store_transactions()
                     .with(eq(expected_stored_transactions))
-                    .return_once(|_| Ok(()));
+                    .returning(|_| Ok(()))
+                    .once();
+            },
+        );
+        let imported_transactions = importer
+            .import(&beacon)
+            .await
+            .expect("Transactions Parser should succeed");
+
+        assert_eq!(transactions, imported_transactions);
+    }
+
+    #[tokio::test]
+    async fn if_all_stored_nothing_is_parsed_and_stored() {
+        let transactions = vec![
+            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-1", 1),
+            CardanoTransaction::new("tx_hash-2", 10, 20, "block_hash-1", 1),
+            CardanoTransaction::new("tx_hash-3", 20, 25, "block_hash-2", 2),
+            CardanoTransaction::new("tx_hash-4", 20, 30, "block_hash-2", 2),
+        ];
+        let beacon = CardanoDbBeacon::new("", 1, 3);
+
+        let importer = build_importer(
+            &|parser_mock| {
+                parser_mock.expect_parse().never();
+            },
+            &|store_mock| {
+                let stored_transactions = transactions.clone();
+                store_mock
+                    .expect_get_at_most_to()
+                    .return_once(|_| Ok(Some((2, stored_transactions))));
+                store_mock.expect_store_transactions().never();
             },
         );
         let imported_transactions = importer

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -1,0 +1,54 @@
+use async_trait::async_trait;
+use mithril_common::cardano_transaction_parser::TransactionParser;
+use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction};
+use mithril_common::signable_builder::{TransactionStore, TransactionsImporter};
+use mithril_common::StdResult;
+use slog::{debug, Logger};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Import and store [CardanoTransaction].
+pub struct CardanoTransactionsImporter {
+    transaction_parser: Arc<dyn TransactionParser>,
+    transaction_store: Arc<dyn TransactionStore>,
+    logger: Logger,
+    dirpath: PathBuf,
+}
+
+impl CardanoTransactionsImporter {
+    /// Constructor
+    pub fn new(
+        transaction_parser: Arc<dyn TransactionParser>,
+        transaction_store: Arc<dyn TransactionStore>,
+        dirpath: &Path,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            transaction_parser,
+            transaction_store,
+            logger,
+            dirpath: dirpath.to_owned(),
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionsImporter for CardanoTransactionsImporter {
+    async fn import(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>> {
+        let transactions = self.transaction_parser.parse(&self.dirpath, beacon).await?;
+        debug!(
+            self.logger,
+            "Retrieved {} Cardano transactions at beacon: {beacon}",
+            transactions.len()
+        );
+
+        let transaction_chunk_size = 100;
+        for transactions_in_chunk in transactions.chunks(transaction_chunk_size) {
+            self.transaction_store
+                .store_transactions(transactions_in_chunk)
+                .await?;
+        }
+
+        Ok(transactions)
+    }
+}

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -1,11 +1,22 @@
 use async_trait::async_trait;
 use mithril_common::cardano_transaction_parser::TransactionParser;
 use mithril_common::entities::{CardanoDbBeacon, CardanoTransaction};
-use mithril_common::signable_builder::{TransactionStore, TransactionsImporter};
+use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
 use slog::{debug, Logger};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+
+#[cfg(test)]
+use mockall::automock;
+
+/// Cardano transactions store
+#[cfg_attr(test, automock)]
+#[async_trait]
+pub trait TransactionStore: Send + Sync {
+    /// Store list of transactions
+    async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
+}
 
 /// Import and store [CardanoTransaction].
 pub struct CardanoTransactionsImporter {

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -71,7 +71,10 @@ impl CardanoTransactionsImporter {
         until: ImmutableFileNumber,
     ) -> StdResult<()> {
         if from.is_some_and(|f| f >= until) {
-            // Db is up-to-date - nothing to do
+            debug!(
+                self.logger,
+                "TransactionsImporter does not need to retrieve Cardano transactions, the database is up to date for immutable '{until}'",
+            );
             return Ok(());
         }
 
@@ -81,7 +84,7 @@ impl CardanoTransactionsImporter {
             .await?;
         debug!(
             self.logger,
-            "Retrieved {} Cardano transactions at between immutables {} and {until}",
+            "TransactionsImporter retrieved '{}' Cardano transactions between immutables '{}' and '{until}'",
             parsed_transactions.len(),
             from.unwrap_or(0)
         );

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -63,3 +63,78 @@ impl TransactionsImporter for CardanoTransactionsImporter {
         Ok(transactions)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use mockall::mock;
+    use mockall::predicate::eq;
+
+    use super::*;
+
+    mock! {
+        pub TransactionParserImpl { }
+
+        #[async_trait]
+        impl TransactionParser for TransactionParserImpl {
+            async fn parse(
+              &self,
+              dirpath: &Path,
+              beacon: &CardanoDbBeacon,
+            ) -> StdResult<Vec<CardanoTransaction>>;
+        }
+    }
+
+    fn build_importer(
+        parser_mock_config: &dyn Fn(&mut MockTransactionParserImpl),
+        store_mock_config: &dyn Fn(&mut MockTransactionStore),
+    ) -> CardanoTransactionsImporter {
+        let db_path = Path::new("");
+        let mut parser = MockTransactionParserImpl::new();
+        parser_mock_config(&mut parser);
+
+        let mut store = MockTransactionStore::new();
+        store_mock_config(&mut store);
+
+        CardanoTransactionsImporter::new(
+            Arc::new(parser),
+            Arc::new(store),
+            db_path,
+            crate::test_tools::logger_for_tests(),
+        )
+    }
+
+    #[tokio::test]
+    async fn if_nothing_stored_parse_and_store_all_transactions() {
+        let transactions = vec![
+            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-1", 1),
+            CardanoTransaction::new("tx_hash-2", 10, 20, "block_hash-1", 1),
+            CardanoTransaction::new("tx_hash-3", 20, 25, "block_hash-2", 2),
+            CardanoTransaction::new("tx_hash-4", 20, 30, "block_hash-2", 2),
+        ];
+        let beacon = CardanoDbBeacon::new("", 1, 3);
+
+        let importer = build_importer(
+            &|parser_mock| {
+                let expected_beacon = beacon.clone();
+                let parsed_transactions = transactions.clone();
+                parser_mock
+                    .expect_parse()
+                    .withf(move |_, beacon_arg| beacon_arg == &expected_beacon)
+                    .return_once(move |_, _| Ok(parsed_transactions));
+            },
+            &|store_mock| {
+                let expected_stored_transactions = transactions.clone();
+                store_mock
+                    .expect_store_transactions()
+                    .with(eq(expected_stored_transactions))
+                    .return_once(|_| Ok(()));
+            },
+        );
+        let imported_transactions = importer
+            .import(&beacon)
+            .await
+            .expect("Transactions Parser should succeed");
+
+        assert_eq!(transactions, imported_transactions);
+    }
+}

--- a/mithril-signer/src/database/mod.rs
+++ b/mithril-signer/src/database/mod.rs
@@ -4,3 +4,19 @@
 pub mod cardano_transaction_migration;
 pub mod migration;
 pub mod provider;
+
+#[cfg(test)]
+pub mod test_utils {
+    use mithril_common::StdResult;
+    use mithril_persistence::sqlite::SqliteConnection;
+
+    use super::*;
+
+    pub fn apply_all_transactions_db_migrations(connection: &SqliteConnection) -> StdResult<()> {
+        for migration in cardano_transaction_migration::get_migrations() {
+            connection.execute(&migration.alterations)?;
+        }
+
+        Ok(())
+    }
+}

--- a/mithril-signer/src/database/provider/cardano_transaction.rs
+++ b/mithril-signer/src/database/provider/cardano_transaction.rs
@@ -1,9 +1,9 @@
+use crate::TransactionStore;
 use mithril_common::{
     entities::{
         BlockHash, BlockNumber, CardanoDbBeacon, CardanoTransaction, ImmutableFileNumber,
         SlotNumber, TransactionHash,
     },
-    signable_builder::TransactionStore,
     StdResult,
 };
 use mithril_persistence::sqlite::{

--- a/mithril-signer/src/database/provider/cardano_transaction.rs
+++ b/mithril-signer/src/database/provider/cardano_transaction.rs
@@ -343,21 +343,14 @@ mod tests {
     use mithril_persistence::sqlite::SourceAlias;
     use sqlite::Connection;
 
-    use crate::{Configuration, ProductionServiceBuilder};
+    use crate::database::test_utils::apply_all_transactions_db_migrations;
 
     use super::*;
 
     async fn get_connection() -> Arc<SqliteConnection> {
-        let party_id = "party-id-123".to_string();
-        let configuration = Configuration::new_sample(&party_id);
-        let production_service_builder = ProductionServiceBuilder::new(&configuration);
-        production_service_builder
-            .build_sqlite_connection(
-                ":memory:",
-                crate::database::cardano_transaction_migration::get_migrations(),
-            )
-            .await
-            .unwrap()
+        let connection = Connection::open_thread_safe(":memory:").unwrap();
+        apply_all_transactions_db_migrations(&connection).unwrap();
+        Arc::new(connection)
     }
 
     #[test]

--- a/mithril-signer/src/database/provider/cardano_transaction.rs
+++ b/mithril-signer/src/database/provider/cardano_transaction.rs
@@ -292,6 +292,13 @@ impl CardanoTransactionRepository {
 
 #[async_trait]
 impl TransactionStore for CardanoTransactionRepository {
+    async fn get_at_most_to(
+        &self,
+        _beacon: &CardanoDbBeacon,
+    ) -> StdResult<Option<(ImmutableFileNumber, Vec<CardanoTransaction>)>> {
+        todo!()
+    }
+
     async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()> {
         let records: Vec<CardanoTransactionRecord> =
             transactions.iter().map(|tx| tx.to_owned().into()).collect();

--- a/mithril-signer/src/database/provider/cardano_transaction.rs
+++ b/mithril-signer/src/database/provider/cardano_transaction.rs
@@ -292,10 +292,11 @@ impl CardanoTransactionRepository {
 
 #[async_trait]
 impl TransactionStore for CardanoTransactionRepository {
-    async fn get_at_most_to(
-        &self,
-        _beacon: &CardanoDbBeacon,
-    ) -> StdResult<Option<(ImmutableFileNumber, Vec<CardanoTransaction>)>> {
+    async fn get_highest_beacon(&self) -> StdResult<Option<ImmutableFileNumber>> {
+        todo!()
+    }
+
+    async fn get_up_to(&self, _beacon: ImmutableFileNumber) -> StdResult<Vec<CardanoTransaction>> {
         todo!()
     }
 

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -35,3 +35,16 @@ const HTTP_REQUEST_TIMEOUT_DURATION: u64 = 30000;
 /// SQLite file names
 const SQLITE_FILE: &str = "signer.sqlite3";
 const SQLITE_FILE_CARDANO_TRANSACTION: &str = "cardano-transaction.sqlite3";
+
+#[cfg(test)]
+pub mod test_tools {
+    use slog::Drain;
+    use std::sync::Arc;
+
+    pub fn logger_for_tests() -> slog::Logger {
+        let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
+        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+        let drain = slog_async::Async::new(drain).build().fuse();
+        slog::Logger::root(Arc::new(drain), slog::o!())
+    }
+}

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -7,6 +7,7 @@
 //! for more information on how it works.
 
 mod aggregator_client;
+mod cardano_transactions_importer;
 mod configuration;
 pub mod database;
 mod message_adapters;
@@ -18,6 +19,7 @@ mod single_signer;
 #[cfg(test)]
 pub use aggregator_client::dumb::DumbAggregatorClient;
 pub use aggregator_client::*;
+pub use cardano_transactions_importer::*;
 pub use configuration::{Configuration, DefaultConfiguration};
 pub use message_adapters::{
     FromEpochSettingsAdapter, FromPendingCertificateMessageAdapter, ToRegisterSignerMessageAdapter,

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -458,7 +458,7 @@ mod tests {
         chain_observer::{ChainObserver, FakeObserver},
         crypto_helper::ProtocolInitializer,
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
-        entities::{CardanoDbBeacon, CardanoTransaction, Epoch, StakeDistribution},
+        entities::{CardanoDbBeacon, Epoch, StakeDistribution},
         era::{
             adapters::{EraReaderAdapterType, EraReaderBootstrapAdapter},
             EraChecker, EraReader,
@@ -466,7 +466,6 @@ mod tests {
         signable_builder::{
             CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
             MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
-            TransactionStore,
         },
         test_utils::{fake_data, MithrilFixtureBuilder},
         TimePointProvider, TimePointProviderImpl,
@@ -481,22 +480,11 @@ mod tests {
 
     use crate::{
         metrics::MetricsService, AggregatorClient, CardanoTransactionsImporter,
-        DumbAggregatorClient, MithrilSingleSigner, MockAggregatorClient, ProtocolInitializerStore,
-        SingleSigner,
+        DumbAggregatorClient, MithrilSingleSigner, MockAggregatorClient, MockTransactionStore,
+        ProtocolInitializerStore, SingleSigner,
     };
 
     use super::*;
-
-    mock! {
-        TransactionStoreImpl { }
-
-        #[async_trait]
-        impl TransactionStore for TransactionStoreImpl
-        {
-            async fn store_transactions(&self, transactions: &[CardanoTransaction]) -> StdResult<()>;
-
-        }
-    }
 
     const DIGESTER_RESULT: &str = "a digest";
 
@@ -547,7 +535,7 @@ mod tests {
         let mithril_stake_distribution_signable_builder =
             Arc::new(MithrilStakeDistributionSignableBuilder::default());
         let transaction_parser = Arc::new(DumbTransactionParser::new(vec![]));
-        let transaction_store = Arc::new(MockTransactionStoreImpl::new());
+        let transaction_store = Arc::new(MockTransactionStore::new());
         let transaction_importer = Arc::new(CardanoTransactionsImporter::new(
             transaction_parser.clone(),
             transaction_store.clone(),

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -540,6 +540,7 @@ mod tests {
             transaction_parser.clone(),
             transaction_store.clone(),
             Path::new(""),
+            None,
             slog_scope::logger(),
         ));
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -480,8 +480,9 @@ mod tests {
     };
 
     use crate::{
-        metrics::MetricsService, AggregatorClient, DumbAggregatorClient, MithrilSingleSigner,
-        MockAggregatorClient, ProtocolInitializerStore, SingleSigner,
+        metrics::MetricsService, AggregatorClient, CardanoTransactionsImporter,
+        DumbAggregatorClient, MithrilSingleSigner, MockAggregatorClient, ProtocolInitializerStore,
+        SingleSigner,
     };
 
     use super::*;
@@ -547,10 +548,14 @@ mod tests {
             Arc::new(MithrilStakeDistributionSignableBuilder::default());
         let transaction_parser = Arc::new(DumbTransactionParser::new(vec![]));
         let transaction_store = Arc::new(MockTransactionStoreImpl::new());
-        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+        let transaction_importer = Arc::new(CardanoTransactionsImporter::new(
             transaction_parser.clone(),
             transaction_store.clone(),
             Path::new(""),
+            slog_scope::logger(),
+        ));
+        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+            transaction_importer,
             slog_scope::logger(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -29,9 +29,10 @@ use mithril_persistence::{
 
 use crate::{
     aggregator_client::AggregatorClient, database::provider::CardanoTransactionRepository,
-    metrics::MetricsService, single_signer::SingleSigner, AggregatorHTTPClient, Configuration,
-    MithrilSingleSigner, ProtocolInitializerStore, ProtocolInitializerStorer,
-    HTTP_REQUEST_TIMEOUT_DURATION, SQLITE_FILE, SQLITE_FILE_CARDANO_TRANSACTION,
+    metrics::MetricsService, single_signer::SingleSigner, AggregatorHTTPClient,
+    CardanoTransactionsImporter, Configuration, MithrilSingleSigner, ProtocolInitializerStore,
+    ProtocolInitializerStorer, HTTP_REQUEST_TIMEOUT_DURATION, SQLITE_FILE,
+    SQLITE_FILE_CARDANO_TRANSACTION,
 };
 
 type StakeStoreService = Arc<StakeStore>;
@@ -275,10 +276,14 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
         let transaction_store = Arc::new(CardanoTransactionRepository::new(
             transaction_sqlite_connection,
         ));
-        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+        let transactions_importer = CardanoTransactionsImporter::new(
             transaction_parser,
             transaction_store,
             &self.config.db_directory,
+            slog_scope::logger(),
+        );
+        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+            Arc::new(transactions_importer),
             slog_scope::logger(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -280,6 +280,8 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             transaction_parser,
             transaction_store,
             &self.config.db_directory,
+            // Rescan the last two immutables when importing transactions
+            Some(2),
             slog_scope::logger(),
         );
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -21,10 +21,10 @@ use mithril_common::{
 use mithril_persistence::store::{adapter::MemoryAdapter, StakeStore, StakeStorer};
 
 use mithril_signer::{
-    database::provider::CardanoTransactionRepository, metrics::*, AggregatorClient, Configuration,
-    MetricsService, MithrilSingleSigner, ProductionServiceBuilder, ProtocolInitializerStore,
-    ProtocolInitializerStorer, RuntimeError, SignerRunner, SignerServices, SignerState,
-    StateMachine,
+    database::provider::CardanoTransactionRepository, metrics::*, AggregatorClient,
+    CardanoTransactionsImporter, Configuration, MetricsService, MithrilSingleSigner,
+    ProductionServiceBuilder, ProtocolInitializerStore, ProtocolInitializerStorer, RuntimeError,
+    SignerRunner, SignerServices, SignerState, StateMachine,
 };
 
 use super::FakeAggregator;
@@ -154,10 +154,14 @@ impl StateMachineTester {
         let transaction_store = Arc::new(CardanoTransactionRepository::new(
             transaction_sqlite_connection,
         ));
-        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+        let transaction_importer = Arc::new(CardanoTransactionsImporter::new(
             transaction_parser.clone(),
             transaction_store.clone(),
             Path::new(""),
+            slog_scope::logger(),
+        ));
+        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+            transaction_importer,
             slog_scope::logger(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -158,6 +158,7 @@ impl StateMachineTester {
             transaction_parser.clone(),
             transaction_store.clone(),
             Path::new(""),
+            None,
             slog_scope::logger(),
         ));
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(


### PR DESCRIPTION
## Content

This PR optimize the retrieval of cardano transactions. Before each time a Cardano Transaction signed entity type was signed the whole cardano chain was parsed. Now we only parse the immutables that was not parsed before, with a parameter that allow to re-parse previous immutables in case of a previous failure.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

## Issue(s)
Relates to #1591
