### PR TITLE
Fix signer metrics server caught signal log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.120"
+version = "0.2.121"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.120"
+version = "0.2.121"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/metrics/server.rs
+++ b/mithril-signer/src/metrics/server.rs
@@ -75,8 +75,8 @@ impl MetricsServer {
                 .await?;
         axum::serve(listener, app)
             .with_graceful_shutdown(async {
-                warn!("MetricsServer: shutting down HTTP server after receiving signal");
                 shutdown_rx.await.ok();
+                warn!("MetricsServer: shutting down HTTP server after receiving signal");
             })
             .await?;
 


### PR DESCRIPTION
## Content
This PR includes a fix to prevent the `MetricsServer: shutting down HTTP server after receiving signal`  log to be displayed on the signer even when no signal has been caught (i.e. the metrics server is still operating correctly).

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1620
