### PR TITLE
Fix `open_message.is_expired` in aggregator runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.59"
+version = "0.4.60"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes fixes for:
- `get_current_non_certified_open_message`: the `open_message.is_expired` condition was never verified.
- `list_allowed_signed_entity_types_discriminants`: if the same valid `signed_entity_types` was provided several times in the configuration, it was nevertheless added (filter was only on default `signed_entity_types`).

In addition, we also refactored the UT in the aggregator `runner` and `configuration`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)