### PR TITLE
Chain observer retrieves the current Chain Point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Support incremental import for Cardano Transactions instead of scanning the whole immutable database for every signing round.
 
+- Chain observers support the retrieval of the current Cardano chain point.
+
 - Crates versions:
 
 |  Crate  |  Version  |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.54"
+version = "0.4.55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.28"
+version = "0.3.29"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.54"
+version = "0.4.55"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/tools/mocks.rs
+++ b/mithril-aggregator/src/tools/mocks.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use mithril_common::chain_observer::{ChainAddress, ChainObserver, ChainObserverError, TxDatum};
 use mithril_common::crypto_helper::{KESPeriod, OpCert};
-use mithril_common::entities::{Epoch, StakeDistribution};
+use mithril_common::entities::{ChainPoint, Epoch, StakeDistribution};
 use mockall::mock;
 
 mock! {
@@ -15,6 +15,8 @@ mock! {
         ) -> Result<Vec<TxDatum>, ChainObserverError>;
 
         async fn get_current_epoch(&self) -> Result<Option<Epoch>, ChainObserverError>;
+
+        async fn get_current_chain_point(&self) -> Result<Option<ChainPoint>, ChainObserverError>;
 
         async fn get_current_stake_distribution(
             &self,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.28"
+version = "0.3.29"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/chain_observer/interface.rs
+++ b/mithril-common/src/chain_observer/interface.rs
@@ -36,6 +36,9 @@ pub trait ChainObserver: Sync + Send {
     /// Retrieve the current epoch of the Cardano network
     async fn get_current_epoch(&self) -> Result<Option<Epoch>, ChainObserverError>;
 
+    /// Retrieve the current chain point of the Cardano network
+    async fn get_current_chain_point(&self) -> Result<Option<ChainPoint>, ChainObserverError>;
+
     /// Retrieve the current stake distribution of the Cardano network
     async fn get_current_stake_distribution(
         &self,

--- a/mithril-common/src/chain_observer/pallas_observer.rs
+++ b/mithril-common/src/chain_observer/pallas_observer.rs
@@ -25,7 +25,7 @@ use std::{
 use crate::{
     chain_observer::{interface::*, ChainAddress, TxDatum},
     crypto_helper::{encode_bech32, KESPeriod, OpCert},
-    entities::{Epoch, StakeDistribution},
+    entities::{ChainPoint, Epoch, StakeDistribution},
     CardanoNetwork, StdResult,
 };
 
@@ -382,6 +382,11 @@ impl ChainObserver for PallasChainObserver {
         client.abort().await;
 
         Ok(Some(Epoch(epoch as u64)))
+    }
+
+    async fn get_current_chain_point(&self) -> Result<Option<ChainPoint>, ChainObserverError> {
+        // TODO: Implement get_current_chain_point with pallas
+        todo!("Implement get_current_chain_point")
     }
 
     async fn get_current_datums(

--- a/mithril-common/src/chain_observer/test_cli_runner.rs
+++ b/mithril-common/src/chain_observer/test_cli_runner.rs
@@ -169,6 +169,23 @@ pool1qz2vzszautc2c8mljnqre2857dpmheq7kgt6vav0s38tvvhxm6w   1.051e-6
         Ok(output.to_string())
     }
 
+    /// launches the chain point info.
+    async fn launch_chain_point(&self) -> StdResult<String> {
+        let output = r#"
+{
+    "block": 1270276,
+    "epoch": 299,
+    "era": "Conway",
+    "hash": "7383b17d7b05b0953cf0649abff60173995eb9febe556889333e20e1e5b7ca84",
+    "slot": 25886617,
+    "slotInEpoch": 53017,
+    "slotsToEpochEnd": 33383,
+    "syncProgress": "100.00"
+}"#;
+
+        Ok(output.to_string())
+    }
+
     /// launches the kes period.
     async fn launch_kes_period(&self, _opcert_file: &str) -> StdResult<String> {
         let output = r#"

--- a/mithril-common/src/entities/block_range.rs
+++ b/mithril-common/src/entities/block_range.rs
@@ -8,11 +8,9 @@ use std::{
 
 use crate::{
     crypto_helper::{MKMapKey, MKTreeNode},
+    entities::BlockNumber,
     StdResult,
 };
-
-/// BlockNumber is the block number of a Cardano transaction.
-pub type BlockNumber = u64;
 
 /// BlockRangeLength is the length of a block range.
 pub type BlockRangeLength = u64;

--- a/mithril-common/src/entities/cardano_chain_point.rs
+++ b/mithril-common/src/entities/cardano_chain_point.rs
@@ -1,0 +1,23 @@
+use serde::{Deserialize, Serialize};
+
+/// [Cardano Slot number](https://docs.cardano.org/learn/cardano-node/#slotsandepochs)
+pub type SlotNumber = u64;
+
+/// BlockNumber is the block number of a Cardano transaction.
+pub type BlockNumber = u64;
+
+/// Hash of a Cardano Block
+pub type BlockHash = String;
+
+///The Cardano chain point which is used to identify a specific point in the Cardano chain.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ChainPoint {
+    /// The slot number
+    pub slot_number: SlotNumber,
+
+    ///  The block number
+    pub block_number: BlockNumber,
+
+    /// The hex encoded block hash
+    pub block_hash: BlockHash,
+}

--- a/mithril-common/src/entities/cardano_transaction.rs
+++ b/mithril-common/src/entities/cardano_transaction.rs
@@ -1,13 +1,10 @@
-use crate::crypto_helper::MKTreeNode;
-
-use super::{BlockNumber, ImmutableFileNumber};
+use crate::{
+    crypto_helper::MKTreeNode,
+    entities::{BlockHash, BlockNumber, ImmutableFileNumber, SlotNumber},
+};
 
 /// TransactionHash is the unique identifier of a cardano transaction.
 pub type TransactionHash = String;
-/// Hash of a Cardano Block
-pub type BlockHash = String;
-/// [Cardano Slot number](https://docs.cardano.org/learn/cardano-node/#slotsandepochs)
-pub type SlotNumber = u64;
 
 #[derive(Debug, PartialEq, Clone)]
 /// Cardano transaction representation

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -1,6 +1,7 @@
 //! The entities used by, and exchanged between, the aggregator, signers and client.
 
 mod block_range;
+mod cardano_chain_point;
 mod cardano_db_beacon;
 mod cardano_network;
 mod cardano_transaction;
@@ -23,10 +24,11 @@ mod snapshot;
 mod time_point;
 mod type_alias;
 
-pub use block_range::{BlockNumber, BlockRange, BlockRangeLength};
+pub use block_range::{BlockRange, BlockRangeLength};
+pub use cardano_chain_point::{BlockHash, BlockNumber, ChainPoint, SlotNumber};
 pub use cardano_db_beacon::CardanoDbBeacon;
 pub use cardano_network::CardanoNetwork;
-pub use cardano_transaction::{BlockHash, CardanoTransaction, SlotNumber, TransactionHash};
+pub use cardano_transaction::{CardanoTransaction, TransactionHash};
 pub use cardano_transactions_set_proof::CardanoTransactionsSetProof;
 pub use cardano_transactions_snapshot::CardanoTransactionsSnapshot;
 pub use certificate::{Certificate, CertificateSignature};

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -28,6 +28,15 @@ pub fn beacon() -> entities::CardanoDbBeacon {
     entities::CardanoDbBeacon::new(network, *time_point.epoch, time_point.immutable_file_number)
 }
 
+/// Fake ChainPoint
+pub fn chain_point() -> entities::ChainPoint {
+    entities::ChainPoint {
+        slot_number: 500,
+        block_number: 42,
+        block_hash: "1b69b3202fbe500".to_string(),
+    }
+}
+
 /// Fake Digest
 pub fn digest(beacon: &entities::CardanoDbBeacon) -> Vec<u8> {
     format!(

--- a/mithril-common/src/time_point_provider.rs
+++ b/mithril-common/src/time_point_provider.rs
@@ -76,7 +76,7 @@ impl TimePointProvider for TimePointProviderImpl {
 mod tests {
     use crate::chain_observer::{ChainAddress, ChainObserver, ChainObserverError, TxDatum};
     use crate::digesters::DumbImmutableFileObserver;
-    use crate::entities::{Epoch, StakeDistribution};
+    use crate::entities::{ChainPoint, Epoch, StakeDistribution};
     use anyhow::anyhow;
 
     use super::*;
@@ -94,6 +94,14 @@ mod tests {
 
         async fn get_current_epoch(&self) -> Result<Option<Epoch>, ChainObserverError> {
             Ok(Some(Epoch(42)))
+        }
+
+        async fn get_current_chain_point(&self) -> Result<Option<ChainPoint>, ChainObserverError> {
+            Ok(Some(ChainPoint {
+                slot_number: 500,
+                block_number: 42,
+                block_hash: "1b69b3202fbe500".to_string(),
+            }))
         }
 
         async fn get_current_stake_distribution(


### PR DESCRIPTION
## Content
This PR includes the support for the chain observers of the retrieval of the current Cardano chain point:
- Upgraded `ChainObserver` trait.
- Upgraded `FakeChainObserver` and mocks implementations.
- Upgraded `CardanoCliObserver` implementation.
- Prepared `PallasChainObserver` implementation (not implemented yet).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
The `PallasChainObserver` does not currently implement the `get_current_chain_point`. 
This will be done in a separate PR by @falcucci .

## Issue(s)
Relates to #1589 
