### PR TITLE
Upgrade `testing-preview` VM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,7 +584,7 @@ jobs:
             terraform_backend_bucket: hydra-terraform-admin
             google_region: europe-west1
             google_zone: europe-west1-b
-            google_machine_type: e2-standard-8
+            google_machine_type: e2-highmem-8
             google_compute_instance_boot_disk_size: 200
             google_compute_instance_data_disk_size: 250
           - environment: testing-sanchonet


### PR DESCRIPTION
## Content
This PR includes an upgrade of the `testing-preview` VM from `e2-standard-8` to `e2-highmem-8`.
This will help avoid reaching memory limit which has occurred since the activation of the Cardano transactions signature on the network.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1591 
