### PR TITLE
Use BLST portable feature to enable runtime ADX instruction set check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
       # We separate the build in 2 steps as we want to avoid side effects with Rust feature unification.
       - name: Cargo build - Tooling
         shell: bash
-        run: |
-          cargo build --features portable --release -p mithril-end-to-end
+        run: cargo build --release -p mithril-end-to-end
 
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
@@ -166,7 +165,7 @@ jobs:
 
         include:
           - os: ubuntu-22.04
-            test-args: --features portable,full,unstable --workspace
+            test-args: --features full,unstable --workspace
           # Only test client on windows & mac (since its the only binaries supported for those os for now)
           - os: macos-12
             test-args: --package mithril-client --package mithril-client-cli --features full,unstable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Chain observers support the retrieval of the current Cardano chain point.
 
+-  Deprecate `portable` feature of `mithril-stm` and `mithril-client`:
+   - Instead, always enable BLST `portable` feature in `mithril-stm` for runtime check of intel ADX instruction set.
+   - `portable` feature now has no effect and should be removed from crate dependencies.
+   - Removed it from all other crates (including `mithril-common`).
+
 - Crates versions:
 
 |  Crate  |  Version  |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.56"
+version = "0.4.57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.29"
+version = "0.3.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.122"
+version = "0.2.123"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3729,7 +3729,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.17"
+version = "0.3.18"
 dependencies = [
  "bincode",
  "blake2 0.10.6",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "mithrildemo"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "base64 0.22.0",
  "blake2 0.10.6",

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithrildemo"
-version = "0.1.33"
+version = "0.1.34"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -30,6 +30,3 @@ mithril-stm = { path = "../../mithril-stm" }
 mithril-stm = { path = "../../mithril-stm", default-features = false, features = [
     "num-integer-backend",
 ] }
-
-[features]
-portable = ["mithril-common/portable", "mithril-stm/portable"]

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.56"
+version = "0.4.57"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -57,7 +57,4 @@ slog-term = "2.9.0"
 tempfile = "3.9.0"
 
 [features]
-portable = [
-    "mithril-common/portable",
-] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 bundle_openssl = ["dep:openssl", "dep:openssl-probe"]

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -53,5 +53,4 @@ tokio = { version = "1.35.1", features = ["full"] }
 mithril-common = { path = "../mithril-common", features = ["test_tools"] }
 
 [features]
-portable = ["mithril-client/portable"]
 bundle_openssl = ["dep:openssl", "dep:openssl-probe"]

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.7.8"
+version = "0.7.9"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -76,7 +76,7 @@ full = ["fs"]
 
 # Enable file system releated functionnality, right now that mean ony snapshot download
 fs = ["flate2", "flume", "tar", "tokio/rt", "zstd"]
-portable = ["mithril-common/portable"]
+portable = [] # deprecated, will be removed soon
 unstable = []
 
 [package.metadata.docs.rs]

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.7.1"
+version = "0.7.2"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.29"
+version = "0.3.30"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -117,9 +117,6 @@ fs = [
     "dep:pallas-traverse",
 ]
 
-# Portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
-portable = ["mithril-stm/portable"]
-
 # Disable signer certification, to be used only for tests
 allow_skip_signer_certification = []
 # Enable all tests tools

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -46,7 +46,4 @@ prometheus-parse = "0.2.5"
 slog-term = "2.9.0"
 
 [features]
-portable = [
-    "mithril-common/portable",
-] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
 bundle_openssl = ["dep:openssl", "dep:openssl-probe"]

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.122"
+version = "0.2.123"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.18 (11-04-2024)
+
+- Deprecate `portable` feature:
+    - Instead, always enable BLST `portable` feature for runtime check of intel ADX instruction set.
+    - `portable` feature now has no effect and should be removed from crate dependencies.
+
 ## 0.3.7 (10-10-2023)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.17"
+version = "0.3.18"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -54,7 +54,5 @@ harness = false
 default = ["rug-backend"]
 rug-backend = ["rug/default"]
 num-integer-backend = ["num-bigint", "num-rational", "num-traits"]
-portable = [
-    "blst/portable",
-] # portable feature avoids SIGILL crashes on CPUs not supporting Intel ADX instruction set when built on CPUs that support it
+portable = [] # deprecated, will be removed soon
 benchmark-internals = [] # For benchmarking multi_sig

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -15,7 +15,8 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
 blake2 = "0.10.6"
-blst = { version = "0.3.11" }
+# Enforce blst portable feature for runtime detection of Intel ADX instruction set.
+blst = { version = "0.3.11", features = ["portable"] }
 digest = { version = "0.10.7", features = ["alloc"] }
 num-bigint = { version = "0.4.4", optional = true }
 num-rational = { version = "0.4.1", optional = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -41,5 +41,4 @@ tokio-util = { version = "0.7.10", features = ["codec"] }
 
 [features]
 default = []
-portable = ["mithril-common/portable"]
 allow_skip_signer_certification = []

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.8"
+version = "0.4.9"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content
This PR changes the `mithril-stm` dependencies in order to always enforce the `portable` features of [BLST](https://crates.io/crates/blst).
This enable a runtime check of the ADX instruction set instead of the compile time check that we used before, allowing users with older CPUs to use our compiled binaries instead of needing to compile them themselves.

Making this changes make the `mithril-stm` portable feature, and all equivalent features in all our crates, useless as it now do strictly nothing.

For compatibility purpose, since those crates are published to crates.io, the portable feature is kept on `mithril-stm` and `mithril-client` but is removed on the other crates (the CI have been adapted for this change).

We should communicate this change to advertise users that depends on our crates.io published crates that this feature will be removed soon.

## Pre-submit checklist

- Branch
  - [ ] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1614