### PR TITLE
fix: Output deprecation warning in JSON format when option --json is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.7.9"
+version = "0.7.10"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -46,6 +46,11 @@ pub struct CardanoDbDownloadCommand {
 }
 
 impl CardanoDbDownloadCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.json
+    }
+
     /// Command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.add_source(self.clone()).build()?;

--- a/mithril-client-cli/src/commands/cardano_db/list.rs
+++ b/mithril-client-cli/src/commands/cardano_db/list.rs
@@ -15,6 +15,11 @@ pub struct CardanoDbListCommand {
 }
 
 impl CardanoDbListCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.json
+    }
+
     /// Main command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;

--- a/mithril-client-cli/src/commands/cardano_db/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_db/mod.rs
@@ -87,5 +87,14 @@ pub mod deprecated {
                 Self::Show(cmd) => cmd.execute(config_builder).await,
             }
         }
+
+        /// Is JSON output enabled
+        pub fn is_json_output_enabled(&self) -> bool {
+            match self {
+                Self::List(cmd) => cmd.is_json_output_enabled(),
+                Self::Download(cmd) => cmd.is_json_output_enabled(),
+                Self::Show(cmd) => cmd.is_json_output_enabled(),
+            }
+        }
     }
 }

--- a/mithril-client-cli/src/commands/cardano_db/show.rs
+++ b/mithril-client-cli/src/commands/cardano_db/show.rs
@@ -24,6 +24,11 @@ pub struct CardanoDbShowCommand {
 }
 
 impl CardanoDbShowCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.json
+    }
+
     /// Cardano DB Show command
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -190,7 +190,12 @@ impl ArtifactCommands {
         match self {
             #[allow(deprecated)]
             Self::Snapshot(cmd) => {
-                eprintln!("`snapshot` command is deprecated, use `cardano-db` instead");
+                let message = "`snapshot` command is deprecated, use `cardano-db` instead";
+                if cmd.is_json_output_enabled() {
+                    eprintln!(r#"{{"warning": "{}", "type": "deprecation"}}"#, message);
+                } else {
+                    eprintln!("{}", message);
+                };
                 cmd.execute(config_builder).await
             }
             Self::CardanoDb(cmd) => cmd.execute(config_builder).await,


### PR DESCRIPTION
## Content
This PR outputs client deprecation warning formatted in JSON when the --json option is used

With --json option, the output is:
`` {"warning": "`snapshot` command is deprecated, use `cardano-db` instead", "type": "deprecation"} ``

without the option, the output is:
`` `snapshot` command is deprecated, use `cardano-db` instead ``

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1616
