### PR TITLE
Remove 'portable' feature in make commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.57"
+version = "0.4.58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.7.10"
+version = "0.7.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.30"
+version = "0.3.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.123"
+version = "0.2.124"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.57"
+version = "0.4.58"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Makefile
+++ b/mithril-aggregator/Makefile
@@ -5,8 +5,7 @@ CARGO = cargo
 all: test build
 
 build:
-	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable,bundle_openssl
+	${CARGO} build --release --features bundle_openssl
 	cp ../target/release/mithril-aggregator .
 
 run: build

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.7.10"
+version = "0.7.11"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/Makefile
+++ b/mithril-client-cli/Makefile
@@ -10,8 +10,7 @@ CARGO = cargo
 all: test build
 
 build:
-	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable,bundle_openssl
+	${CARGO} build --release --features bundle_openssl
 	cp ../target/release/mithril-client .
 
 run: build

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.7.2"
+version = "0.7.3"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -76,7 +76,7 @@ full = ["fs"]
 
 # Enable file system releated functionnality, right now that mean ony snapshot download
 fs = ["flate2", "flume", "tar", "tokio/rt", "zstd"]
-portable = [] # deprecated, will be removed soon
+portable = []                                       # deprecated, will be removed soon
 unstable = []
 
 [package.metadata.docs.rs]

--- a/mithril-client/Makefile
+++ b/mithril-client/Makefile
@@ -10,8 +10,7 @@ CARGO = cargo
 all: test build
 
 build:
-	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable,full
+	${CARGO} build --release --features full
 
 test:
 	${CARGO} test --features full

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.30"
+version = "0.3.31"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Makefile
+++ b/mithril-common/Makefile
@@ -10,8 +10,7 @@ FEATURES := $(shell ${CARGO} metadata --quiet --no-deps \
 all: test build
 
 build:
-	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable,full
+	${CARGO} build --release --features full
 
 test:
 	${CARGO} test --features full

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.123"
+version = "0.2.124"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Makefile
+++ b/mithril-signer/Makefile
@@ -5,8 +5,7 @@ CARGO = cargo
 all: test build
 
 build:
-	# We use 'portable' feature to avoid SIGILL crashes
-	${CARGO} build --release --features portable,bundle_openssl
+	${CARGO} build --release --features bundle_openssl
 	cp ../target/release/mithril-signer .
 
 run: build


### PR DESCRIPTION
## Content
This PR includes removal of remaining `portable` feature usage in make commands.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
