### PR TITLE
Proof generation memory optimisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3397,7 +3397,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.58"
+version = "0.4.59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3550,7 +3550,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.58"
+version = "0.4.59"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/provider/cardano_transaction/get_cardano_transaction.rs
+++ b/mithril-aggregator/src/database/provider/cardano_transaction/get_cardano_transaction.rs
@@ -29,6 +29,15 @@ impl<'client> GetCardanoTransactionProvider<'client> {
         )
     }
 
+    pub fn get_transaction_hashes_condition(
+        &self,
+        transactions_hashes: Vec<TransactionHash>,
+    ) -> WhereCondition {
+        let hashes_values = transactions_hashes.into_iter().map(Value::String).collect();
+
+        WhereCondition::where_in("transaction_hash", hashes_values)
+    }
+
     pub fn get_transaction_up_to_beacon_condition(
         &self,
         beacon: ImmutableFileNumber,

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -12,11 +12,8 @@ use mithril_common::{
     StdResult,
 };
 
-#[cfg(test)]
-use mockall::automock;
-
 /// Prover service is the cryptographic engine in charge of producing cryptographic proofs for transactions
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait ProverService: Sync + Send {
     /// Compute the cryptographic proofs for the given transactions
@@ -28,11 +25,17 @@ pub trait ProverService: Sync + Send {
 }
 
 /// Transactions retriever
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait TransactionsRetriever: Sync + Send {
-    /// Get transactions up to given beacon using chronological order
+    /// Get all transactions up to given beacon using chronological order
     async fn get_up_to(&self, beacon: &CardanoDbBeacon) -> StdResult<Vec<CardanoTransaction>>;
+
+    /// Get a list of transactions by hashes using chronological order
+    async fn get_by_hashes(
+        &self,
+        hashes: Vec<TransactionHash>,
+    ) -> StdResult<Vec<CardanoTransaction>>;
 }
 
 /// Mithril prover

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -79,7 +79,7 @@ impl MithrilProverService {
                 .or_default()
                 .push(transaction.transaction_hash);
         }
-        let mk_hash_map = MKMap::new(
+        let mk_hash_map = MKMap::new_from_iter(
             transactions_by_block_ranges
                 .into_iter()
                 .try_fold(
@@ -88,8 +88,7 @@ impl MithrilProverService {
                         acc.push((block_range, MKTree::new(&transactions)?.into()));
                         Ok(acc)
                     },
-                )?
-                .as_slice(),
+                )?,
         )
         .with_context(|| "ProverService failed to compute the merkelized structure that proves ownership of the transaction")?;
 

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.31"
+version = "0.3.32"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -39,15 +39,20 @@ pub struct MKMap<K: MKMapKey, V: MKMapValue<K>> {
 impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
     /// MKMap factory
     pub fn new(entries: &[(K, V)]) -> StdResult<Self> {
+        Self::new_from_iter(entries.to_vec())
+    }
+
+    /// MKMap factory
+    pub fn new_from_iter<T: IntoIterator<Item = (K, V)>>(entries: T) -> StdResult<Self> {
         let inner_map_values = BTreeMap::default();
         let inner_merkle_tree = MKTree::new::<MKTreeNode>(&[])?;
         let mut mk_map = Self {
             inner_map_values,
             inner_merkle_tree,
         };
-        let sorted_entries = BTreeMap::from_iter(entries.to_vec());
+        let sorted_entries = BTreeMap::from_iter(entries);
         for (key, value) in sorted_entries {
-            mk_map.insert_unchecked(key.clone(), value.clone())?;
+            mk_map.insert_unchecked(key, value)?;
         }
 
         Ok(mk_map)
@@ -394,7 +399,7 @@ mod tests {
             .map(|(range, mktree)| (range.to_owned(), mktree.into()))
             .collect::<Vec<(_, MKMapNode<_>)>>();
         let mk_map_nodes = MKMap::new(merkle_tree_node_entries.as_slice()).unwrap();
-        let mk_map_full = MKMap::new(merkle_tree_full_entries.as_slice()).unwrap();
+        let mk_map_full = MKMap::new(merkle_tree_full_entries).unwrap();
 
         let mk_map_nodes_root = mk_map_nodes.compute_root().unwrap();
         let mk_map_full_root = mk_map_full.compute_root().unwrap();

--- a/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
+++ b/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
@@ -62,14 +62,14 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoImmutableFilesFullSignableBuild
 
 #[cfg(test)]
 mod tests {
+    use async_trait::async_trait;
     use std::path::Path;
-
-    use super::*;
 
     use crate::digesters::{ImmutableDigester, ImmutableDigesterError};
     use crate::entities::CardanoDbBeacon;
-    use async_trait::async_trait;
-    use slog::Drain;
+    use crate::test_utils::logger_for_tests;
+
+    use super::*;
 
     #[derive(Default)]
     pub struct ImmutableDigesterImpl;
@@ -85,19 +85,13 @@ mod tests {
         }
     }
 
-    fn create_logger() -> slog::Logger {
-        let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
-        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-        slog::Logger::root(Arc::new(drain), slog::o!())
-    }
     #[tokio::test]
     async fn compute_signable() {
         let digester = ImmutableDigesterImpl;
         let signable_builder = CardanoImmutableFilesFullSignableBuilder::new(
             Arc::new(digester),
             Path::new(""),
-            create_logger(),
+            logger_for_tests(),
         );
         let protocol_message = signable_builder
             .compute_protocol_message(CardanoDbBeacon::default())

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -117,15 +117,9 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoTransactionsSignableBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use slog::Drain;
+    use crate::test_utils::logger_for_tests;
 
-    fn create_logger() -> slog::Logger {
-        let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
-        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-        slog::Logger::root(Arc::new(drain), slog::o!())
-    }
+    use super::*;
 
     #[tokio::test]
     async fn test_compute_merkle_root_in_same_block_range() {
@@ -148,7 +142,7 @@ mod tests {
 
         let cardano_transaction_signable_builder = CardanoTransactionsSignableBuilder::new(
             Arc::new(MockTransactionsImporter::new()),
-            create_logger(),
+            logger_for_tests(),
         );
 
         let merkle_root_reference = cardano_transaction_signable_builder
@@ -209,7 +203,7 @@ mod tests {
 
         let cardano_transaction_signable_builder = CardanoTransactionsSignableBuilder::new(
             Arc::new(MockTransactionsImporter::new()),
-            create_logger(),
+            logger_for_tests(),
         );
 
         let merkle_root_reference = cardano_transaction_signable_builder
@@ -242,7 +236,7 @@ mod tests {
             .return_once(move |_| Ok(imported_transactions));
         let cardano_transactions_signable_builder = CardanoTransactionsSignableBuilder::new(
             Arc::new(transaction_importer),
-            create_logger(),
+            logger_for_tests(),
         );
 
         // Action
@@ -276,7 +270,7 @@ mod tests {
             .return_once(|_| Ok(vec![]));
         let cardano_transactions_signable_builder = CardanoTransactionsSignableBuilder::new(
             Arc::new(transaction_importer),
-            create_logger(),
+            logger_for_tests(),
         );
 
         let result = cardano_transactions_signable_builder

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -46,7 +46,7 @@ impl CardanoTransactionsSignableBuilder {
     // This will be not be the case when we use the cached intermediate merkle roots.
     fn compute_merkle_map_from_transactions(
         &self,
-        transactions: &[CardanoTransaction],
+        transactions: Vec<CardanoTransaction>,
     ) -> StdResult<MKMap<BlockRange, MKMapNode<BlockRange>>> {
         let mut transactions_by_block_ranges: HashMap<BlockRange, Vec<TransactionHash>> =
             HashMap::new();
@@ -55,9 +55,9 @@ impl CardanoTransactionsSignableBuilder {
             transactions_by_block_ranges
                 .entry(block_range)
                 .or_default()
-                .push(transaction.transaction_hash.to_owned());
+                .push(transaction.transaction_hash);
         }
-        let mk_hash_map = MKMap::new(
+        let mk_hash_map = MKMap::new_from_iter(
             transactions_by_block_ranges
                 .into_iter()
                 .try_fold(
@@ -66,15 +66,14 @@ impl CardanoTransactionsSignableBuilder {
                         acc.push((block_range, MKTree::new(&transactions)?.into()));
                         Ok(acc)
                     },
-                )?
-                .as_slice(),
+                )?,
         )
         .with_context(|| "ProverService failed to compute the merkelized structure that proves ownership of the transaction")?;
 
         Ok(mk_hash_map)
     }
 
-    fn compute_merkle_root(&self, transactions: &[CardanoTransaction]) -> StdResult<MKTreeNode> {
+    fn compute_merkle_root(&self, transactions: Vec<CardanoTransaction>) -> StdResult<MKTreeNode> {
         let mk_map = self.compute_merkle_map_from_transactions(transactions)?;
 
         let mk_root = mk_map.compute_root().with_context(|| {
@@ -100,7 +99,7 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoTransactionsSignableBuilder {
             .transaction_importer
             .import(beacon.immutable_file_number)
             .await?;
-        let mk_root = self.compute_merkle_root(&transactions)?;
+        let mk_root = self.compute_merkle_root(transactions)?;
 
         let mut protocol_message = ProtocolMessage::new();
         protocol_message.set_message_part(
@@ -153,7 +152,7 @@ mod tests {
         );
 
         let merkle_root_reference = cardano_transaction_signable_builder
-            .compute_merkle_root(&[
+            .compute_merkle_root(vec![
                 transaction_1.clone(),
                 transaction_2.clone(),
                 transaction_3.clone(),
@@ -163,14 +162,14 @@ mod tests {
         {
             let transactions_set = vec![transaction_1.clone()];
             let mk_root = cardano_transaction_signable_builder
-                .compute_merkle_root(&transactions_set)
+                .compute_merkle_root(transactions_set)
                 .unwrap();
             assert_ne!(merkle_root_reference, mk_root);
         }
         {
             let transactions_set = vec![transaction_1.clone(), transaction_2.clone()];
             let mk_root = cardano_transaction_signable_builder
-                .compute_merkle_root(&transactions_set)
+                .compute_merkle_root(transactions_set)
                 .unwrap();
             assert_ne!(merkle_root_reference, mk_root);
         }
@@ -182,7 +181,7 @@ mod tests {
                 transaction_4.clone(),
             ];
             let mk_root = cardano_transaction_signable_builder
-                .compute_merkle_root(&transactions_set)
+                .compute_merkle_root(transactions_set)
                 .unwrap();
             assert_ne!(merkle_root_reference, mk_root);
         }
@@ -195,7 +194,7 @@ mod tests {
                 transaction_2.clone(),
             ];
             let mk_root = cardano_transaction_signable_builder
-                .compute_merkle_root(&transactions_set)
+                .compute_merkle_root(transactions_set)
                 .unwrap();
             assert_ne!(merkle_root_reference, mk_root);
         }
@@ -214,11 +213,11 @@ mod tests {
         );
 
         let merkle_root_reference = cardano_transaction_signable_builder
-            .compute_merkle_root(&[transaction_1.clone(), transaction_2.clone()])
+            .compute_merkle_root(vec![transaction_1.clone(), transaction_2.clone()])
             .unwrap();
 
         let mk_root = cardano_transaction_signable_builder
-            .compute_merkle_root(&[transaction_2.clone(), transaction_1.clone()])
+            .compute_merkle_root(vec![transaction_2.clone(), transaction_1.clone()])
             .unwrap();
 
         assert_eq!(merkle_root_reference, mk_root);
@@ -254,7 +253,7 @@ mod tests {
 
         // Assert
         let mk_root = cardano_transactions_signable_builder
-            .compute_merkle_root(&transactions)
+            .compute_merkle_root(transactions)
             .unwrap();
         let mut signable_expected = ProtocolMessage::new();
         signable_expected.set_message_part(

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -25,3 +25,14 @@ pub mod test_http_server;
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};
 pub use mithril_fixture::{MithrilFixture, SignerFixture};
 pub use temp_dir::*;
+
+#[cfg(test)]
+pub(crate) fn logger_for_tests() -> slog::Logger {
+    use slog::Drain;
+    use std::sync::Arc;
+
+    let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
+    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).build().fuse();
+    slog::Logger::root(Arc::new(drain), slog::o!())
+}


### PR DESCRIPTION
## Content
This PR do some memory usage enhancement when computing a proof of Cardano transactions. Nothing ground breaking but this should reduce somehow the maximum memory needed for this operation.

- It mostly reduce the number of copy of the full transactions set retrieved from database needed to compute the merkle tree used for proof generation.
- It also separate the retrieval of the transactions to prove from the retrieval of the full transactions set (before we walked through the later to find the former).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1629