### PR TITLE
Add aggregator stress test workflow

### DIFF
--- a/.github/workflows/aggregator-stress-test.yml
+++ b/.github/workflows/aggregator-stress-test.yml
@@ -1,0 +1,59 @@
+name: Aggregator stress test
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit_sha:
+        description: SHA of the commit on which the load-aggregator binary should be obtained.
+        required: true
+        type: string
+      num_signers:
+        description: Number of concurrent signers
+        required: true
+        type: string
+        default: "100"
+      num_clients:
+        description: Number of concurrent clients
+        required: true
+        type: string
+        default: "100"
+      enable_debug:
+        description: Enable debug output ("-vvv") for the aggregator stress test
+        required: true
+        type: boolean
+        default: false
+
+jobs:
+  stress-test:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+
+      - name: Prepare environment variables
+        id: prepare
+        shell: bash
+        run: |
+          if [[ "${{ inputs.enable_debug }}" == "true" ]]; then
+            echo "debug_level=-vvv" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Build the aggregator stress test
+        working-directory: mithril-test-lab/mithril-end-to-end
+        run: make build
+
+      - name: Run the aggregator stress test
+        working-directory: mithril-test-lab/mithril-end-to-end
+        run: |
+            ./load-aggregator ${{ steps.prepare.outputs.debug_level }} \
+            --cardano-cli-path script/mock-cardano-cli \
+            --aggregator-dir ../../target/release \
+            --num-signers=${{ inputs.num_signers }} \
+            --num-clients=${{ inputs.num_clients }}


### PR DESCRIPTION
## Content
This PR includes a new Github workflow for the aggregator stress test.
It makes it easy (triggered manually) to run stress tests on the aggregator by specifying the number of concurrent signers and clients.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)