### PR TITLE
Fix: MuxBearerClosed socket closed when reading data

### DIFF
--- a/mithril-common/src/chain_observer/pallas_observer.rs
+++ b/mithril-common/src/chain_observer/pallas_observer.rs
@@ -379,8 +379,6 @@ impl ChainObserver for PallasChainObserver {
 
         self.post_process_statequery(&mut client).await?;
 
-        client.abort().await;
-
         Ok(Some(Epoch(epoch as u64)))
     }
 
@@ -399,8 +397,6 @@ impl ChainObserver for PallasChainObserver {
 
         self.post_process_statequery(&mut client).await?;
 
-        client.abort().await;
-
         Ok(datums)
     }
 
@@ -412,8 +408,6 @@ impl ChainObserver for PallasChainObserver {
         let stake_distribution = self.get_stake_distribution(&mut client).await?;
 
         self.post_process_statequery(&mut client).await?;
-
-        client.abort().await;
 
         Ok(stake_distribution)
     }
@@ -427,8 +421,6 @@ impl ChainObserver for PallasChainObserver {
         let current_kes_period = self.get_kes_period(&mut client).await?;
 
         self.post_process_statequery(&mut client).await?;
-
-        client.abort().await;
 
         Ok(current_kes_period)
     }
@@ -760,7 +752,6 @@ mod tests {
                 .await
                 .unwrap();
             observer.post_process_statequery(&mut client).await.unwrap();
-            client.abort().await;
             chain_point
         });
 
@@ -784,7 +775,6 @@ mod tests {
                 .await
                 .unwrap();
             observer.post_process_statequery(&mut client).await.unwrap();
-            client.abort().await;
             genesis_config
         });
 
@@ -808,7 +798,6 @@ mod tests {
                 .await
                 .unwrap();
             observer.post_process_statequery(&mut client).await.unwrap();
-            client.abort().await;
             era
         });
 


### PR DESCRIPTION
Closes #1632.

`client.abort()` causes following error at cardano node `cardano.node.LocalErrorPolicy:Error:182 IP LocalAddress "/socket@58" ErrorPolicyUnhandledApplicationException (MuxError MuxBearerClosed "<socket: 58> closed when reading data, waiting on next header True")`. If remove this call, it works fine. 

When making this edit, I was guided by:
- Sebastian's comment in #1632 - "client should send `MsgRelease` and `MsgDone` after the query"
- Ouroboros network [spec](https://ouroboros-network.cardano.intersectmbo.org/pdfs/network-spec/network-spec.pdf), section 3.12 Local State Query mini-protocol, Figure 3.8: State machine of the Local State Query mini-protocol.
- [Examples](https://github.com/txpipe/pallas/blob/main/examples/n2c-miniprotocols/src/main.rs#L128) from Pallas library, in examples used same type of Client - NodeClient, containing multiplexer inside. And there is no abort call at the end of example. Although in this example we see only [`client.send_release()`](https://github.com/txpipe/pallas/blob/8fde4a5e11e9dab68907f4e6fecd8fa268e60dcf/examples/n2c-miniprotocols/src/main.rs#L81C5-L81C26) and no `send_done` as how is it done in [Mithril](https://github.com/input-output-hk/mithril/blob/820d9377e67c4e05ad3614f7b66b3e15249f5656/mithril-common/src/chain_observer/pallas_observer.rs#L344) and as Sebastian advises.
