### PR TITLE
Use new memory allocator 'jemallocator'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ As a minor extension, we have adopted a slightly different versioning convention
    - `portable` feature now has no effect and should be removed from crate dependencies.
    - Removed it from all other crates (including `mithril-common`).
 
+- Switched memory allocator to `jemallocator` on signer and aggregator to avoid memory fragmentation when signing transactions (which lead to RES memory not being properly returned to the OS).
+
 - Crates versions:
 
 |  Crate  |  Version  |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3774,6 +3774,7 @@ dependencies = [
  "slog-term",
  "sqlite",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -6087,6 +6088,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9402443cb8fd499b6f327e40565234ff34dbda27460c5b47db0db77443dd85d1"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "965fe0c26be5c56c94e38ba547249074803efd52adfb66de62107d95aab3eaca"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,6 +3479,7 @@ dependencies = [
  "tar",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "typetag",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.125"
+version = "0.2.126"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.61"
+version = "0.4.62"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -46,6 +46,9 @@ uuid = { version = "1.7.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 warp = "0.3.6"
 zstd = { version = "0.13.0", features = ["zstdmt"] }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.5.4", optional = true }
+
 [dev-dependencies]
 httpmock = "0.7.0"
 mithril-common = { path = "../mithril-common", features = [
@@ -57,4 +60,7 @@ slog-term = "2.9.0"
 tempfile = "3.9.0"
 
 [features]
+default = ["jemallocator"]
+
 bundle_openssl = ["dep:openssl", "dep:openssl-probe"]
+jemallocator = ["dep:tikv-jemallocator"]

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -64,6 +64,14 @@ pub use tools::{
 #[cfg(test)]
 pub use dependency_injection::tests::initialize_dependencies;
 
+// Memory allocator (to handle properly memory fragmentation)
+#[cfg(all(not(target_env = "msvc"), feature = "jemallocator"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(all(not(target_env = "msvc"), feature = "jemallocator"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[cfg(test)]
 pub(crate) mod test_tools {
     use slog::Drain;

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.125"
+version = "0.2.126"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -38,6 +38,9 @@ sqlite = { version = "0.34.0", features = ["bundled"] }
 thiserror = "1.0.56"
 tokio = { version = "1.35.1", features = ["full"] }
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.5.4", optional = true }
+
 [dev-dependencies]
 httpmock = "0.7.0"
 mithril-common = { path = "../mithril-common" }
@@ -46,4 +49,7 @@ prometheus-parse = "0.2.5"
 slog-term = "2.9.0"
 
 [features]
+default = ["jemallocator"]
+
 bundle_openssl = ["dep:openssl", "dep:openssl-probe"]
+jemallocator = ["dep:tikv-jemallocator"]

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -36,6 +36,14 @@ const HTTP_REQUEST_TIMEOUT_DURATION: u64 = 30000;
 const SQLITE_FILE: &str = "signer.sqlite3";
 const SQLITE_FILE_CARDANO_TRANSACTION: &str = "cardano-transaction.sqlite3";
 
+// Memory allocator (to handle properly memory fragmentation)
+#[cfg(all(not(target_env = "msvc"), feature = "jemallocator"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(all(not(target_env = "msvc"), feature = "jemallocator"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 #[cfg(test)]
 pub mod test_tools {
     use slog::Drain;


### PR DESCRIPTION
## Content
This PR includes the activation of a different memory allocator `jemallocator` through a feature. This will likely avoid having memory fragmentation resulting in resident memory of signer/aggregator not being correctly released when signing/proving Cardano transactions.

See https://github.com/input-output-hk/mithril/issues/1629#issuecomment-2069016167 for details.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Issue(s)
Closes #1629 
