### PR TITLE
Store block range roots in db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.62"
+version = "0.4.63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3601,7 +3601,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.3.33"
+version = "0.3.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3699,7 +3699,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.126"
+version = "0.2.127"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.1.6"
+version = "0.1.7"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/sqlite/condition.rs
+++ b/internal/mithril-persistence/src/sqlite/condition.rs
@@ -138,9 +138,6 @@ impl WhereCondition {
 }
 
 /// Get all condition builder.
-///
-/// By default, nothing will be filtered out when using this condition. But you
-/// can override this behavior by implementing this trait for your type.
 pub trait GetAllCondition {
     /// Get the condition for a get all query.
     fn get_all_condition() -> WhereCondition {

--- a/internal/mithril-persistence/src/sqlite/condition.rs
+++ b/internal/mithril-persistence/src/sqlite/condition.rs
@@ -137,6 +137,17 @@ impl WhereCondition {
     }
 }
 
+/// Get all condition builder.
+///
+/// By default, nothing will be filtered out when using this condition. But you
+/// can override this behavior by implementing this trait for your type.
+pub trait GetAllCondition {
+    /// Get the condition for a get all query.
+    fn get_all_condition() -> WhereCondition {
+        WhereCondition::default()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -348,5 +359,16 @@ mod tests {
 
         assert_eq!("a = ?1", &sql);
         assert_eq!(1, params.len());
+    }
+
+    #[test]
+    fn expression_get_all_default() {
+        impl GetAllCondition for String {}
+
+        let expression = String::get_all_condition();
+        let (sql, params) = expression.expand();
+
+        assert_eq!("true".to_string(), sql);
+        assert!(params.is_empty());
     }
 }

--- a/internal/mithril-persistence/src/sqlite/mod.rs
+++ b/internal/mithril-persistence/src/sqlite/mod.rs
@@ -10,12 +10,12 @@ mod projection;
 mod provider;
 mod source_alias;
 
-pub use condition::WhereCondition;
+pub use condition::{GetAllCondition, WhereCondition};
 pub use connection_builder::{ConnectionBuilder, ConnectionOptions};
 pub use cursor::EntityCursor;
 pub use entity::{HydrationError, SqLiteEntity};
 pub use projection::{Projection, ProjectionField};
-pub use provider::Provider;
+pub use provider::{GetAllProvider, Provider};
 pub use source_alias::SourceAlias;
 
 use mithril_common::StdResult;

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.62"
+version = "0.4.63"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/cardano_transaction_migration.rs
+++ b/mithril-aggregator/src/database/cardano_transaction_migration.rs
@@ -59,5 +59,18 @@ vacuum;
 create index block_number_index on cardano_tx(block_number);
 "#,
         ),
+        // Migration 5
+        // Add `block_range_root` table
+        SqlMigration::new(
+            5,
+            r#"
+create table block_range_root (
+    start         integer   not null,
+    end           integer   not null,
+    merkle_root   text      not null,
+    primary key (start, end)
+);
+"#,
+        ),
     ]
 }

--- a/mithril-aggregator/src/database/provider/block_range_root/get_block_range_root.rs
+++ b/mithril-aggregator/src/database/provider/block_range_root/get_block_range_root.rs
@@ -29,6 +29,6 @@ impl<'client> Provider<'client> for GetBlockRangeRootProvider<'client> {
         let aliases = SourceAlias::new(&[("{:block_range_root:}", "block_range_root")]);
         let projection = Self::Entity::get_projection().expand(aliases);
 
-        format!("select {projection} from block_range_root where {condition} order by rowid")
+        format!("select {projection} from block_range_root where {condition} order by start, end")
     }
 }

--- a/mithril-aggregator/src/database/provider/block_range_root/get_block_range_root.rs
+++ b/mithril-aggregator/src/database/provider/block_range_root/get_block_range_root.rs
@@ -1,0 +1,34 @@
+use mithril_persistence::sqlite::{Provider, SourceAlias, SqLiteEntity, SqliteConnection};
+
+use crate::database::record::BlockRangeRootRecord;
+
+/// Simple queries to retrieve [BlockRangeRootRecord] from the sqlite database.
+pub struct GetBlockRangeRootProvider<'client> {
+    connection: &'client SqliteConnection,
+}
+
+impl<'client> GetBlockRangeRootProvider<'client> {
+    #[cfg(test)]
+    /// Create a new instance
+    pub fn new(connection: &'client SqliteConnection) -> Self {
+        Self { connection }
+    }
+}
+
+#[cfg(test)]
+impl mithril_persistence::sqlite::GetAllCondition for GetBlockRangeRootProvider<'_> {}
+
+impl<'client> Provider<'client> for GetBlockRangeRootProvider<'client> {
+    type Entity = BlockRangeRootRecord;
+
+    fn get_connection(&'client self) -> &'client SqliteConnection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[("{:block_range_root:}", "block_range_root")]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+
+        format!("select {projection} from block_range_root where {condition} order by rowid")
+    }
+}

--- a/mithril-aggregator/src/database/provider/block_range_root/get_interval_without_block_range_provider.rs
+++ b/mithril-aggregator/src/database/provider/block_range_root/get_interval_without_block_range_provider.rs
@@ -1,0 +1,43 @@
+use mithril_persistence::sqlite::{
+    Provider, SourceAlias, SqLiteEntity, SqliteConnection, WhereCondition,
+};
+
+use crate::database::record::IntervalWithoutBlockRangeRootRecord;
+
+/// Query that return the interval of block numbers that does not have a block range root.
+pub struct GetIntervalWithoutBlockRangeRootProvider<'client> {
+    connection: &'client SqliteConnection,
+}
+
+impl<'client> GetIntervalWithoutBlockRangeRootProvider<'client> {
+    /// Create a new instance
+    pub fn new(connection: &'client SqliteConnection) -> Self {
+        Self { connection }
+    }
+
+    pub fn get_interval_without_block_range_condition(&self) -> WhereCondition {
+        WhereCondition::default()
+    }
+}
+
+impl<'client> Provider<'client> for GetIntervalWithoutBlockRangeRootProvider<'client> {
+    type Entity = IntervalWithoutBlockRangeRootRecord;
+
+    fn get_connection(&'client self) -> &'client SqliteConnection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[
+            ("{:interval_start:}", "interval_start"),
+            ("{:interval_end:}", "interval_end"),
+        ]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+
+        format!(
+            "select {projection} from \
+        (select max(end) as start from block_range_root where {condition}) as interval_start, \
+        (select max(block_number) as end from cardano_tx where {condition}) as interval_end"
+        )
+    }
+}

--- a/mithril-aggregator/src/database/provider/block_range_root/insert_block_range.rs
+++ b/mithril-aggregator/src/database/provider/block_range_root/insert_block_range.rs
@@ -1,0 +1,65 @@
+use std::iter::repeat;
+
+use sqlite::Value;
+
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{
+    Provider, SourceAlias, SqLiteEntity, SqliteConnection, WhereCondition,
+};
+
+use crate::database::record::BlockRangeRootRecord;
+
+/// Query to insert [BlockRangeRootRecord] in the sqlite database
+pub struct InsertBlockRangeRootProvider<'client> {
+    connection: &'client SqliteConnection,
+}
+
+impl<'client> InsertBlockRangeRootProvider<'client> {
+    /// Create a new instance
+    pub fn new(connection: &'client SqliteConnection) -> Self {
+        Self { connection }
+    }
+
+    /// Condition to insert multiples records.
+    pub fn get_insert_many_condition(
+        &self,
+        block_range_records: Vec<BlockRangeRootRecord>,
+    ) -> StdResult<WhereCondition> {
+        let columns = "(start, end, merkle_root)";
+        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*)")
+            .take(block_range_records.len())
+            .collect();
+
+        let values: StdResult<Vec<Value>> =
+            block_range_records
+                .into_iter()
+                .try_fold(vec![], |mut vec, record| {
+                    vec.append(&mut vec![
+                        Value::Integer(record.range.start.try_into()?),
+                        Value::Integer(record.range.end.try_into()?),
+                        Value::String(record.merkle_root.to_hex()),
+                    ]);
+                    Ok(vec)
+                });
+
+        Ok(WhereCondition::new(
+            format!("{columns} values {}", values_columns.join(", ")).as_str(),
+            values?,
+        ))
+    }
+}
+
+impl<'client> Provider<'client> for InsertBlockRangeRootProvider<'client> {
+    type Entity = BlockRangeRootRecord;
+
+    fn get_connection(&'client self) -> &'client SqliteConnection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[("{:block_range_root:}", "block_range_root")]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+
+        format!("insert or ignore into block_range_root {condition} returning {projection}")
+    }
+}

--- a/mithril-aggregator/src/database/provider/block_range_root/mod.rs
+++ b/mithril-aggregator/src/database/provider/block_range_root/mod.rs
@@ -1,0 +1,8 @@
+mod get_block_range_root;
+mod get_interval_without_block_range_provider;
+mod insert_block_range;
+
+#[cfg(test)]
+pub use get_block_range_root::*;
+pub use get_interval_without_block_range_provider::*;
+pub use insert_block_range::*;

--- a/mithril-aggregator/src/database/provider/cardano_transaction/get_cardano_transaction.rs
+++ b/mithril-aggregator/src/database/provider/cardano_transaction/get_cardano_transaction.rs
@@ -1,6 +1,8 @@
+use std::ops::Range;
+
 use sqlite::Value;
 
-use mithril_common::entities::{ImmutableFileNumber, TransactionHash};
+use mithril_common::entities::{BlockNumber, ImmutableFileNumber, TransactionHash};
 use mithril_persistence::sqlite::{
     Provider, SourceAlias, SqLiteEntity, SqliteConnection, WhereCondition,
 };
@@ -46,6 +48,20 @@ impl<'client> GetCardanoTransactionProvider<'client> {
             "immutable_file_number <= ?*",
             vec![Value::Integer(beacon as i64)],
         )
+    }
+
+    pub fn get_transaction_between_blocks_condition(
+        &self,
+        range: Range<BlockNumber>,
+    ) -> WhereCondition {
+        WhereCondition::new(
+            "block_number >= ?*",
+            vec![Value::Integer(range.start as i64)],
+        )
+        .and_where(WhereCondition::new(
+            "block_number < ?*",
+            vec![Value::Integer(range.end as i64)],
+        ))
     }
 }
 

--- a/mithril-aggregator/src/database/provider/certificate/get_certificate.rs
+++ b/mithril-aggregator/src/database/provider/certificate/get_certificate.rs
@@ -4,7 +4,7 @@ use sqlite::{ConnectionThreadSafe, Value};
 use mithril_common::entities::Epoch;
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{
-    EntityCursor, Provider, SourceAlias, SqLiteEntity, WhereCondition,
+    EntityCursor, GetAllCondition, Provider, SourceAlias, SqLiteEntity, WhereCondition,
 };
 
 use crate::database::record::CertificateRecord;
@@ -54,15 +54,9 @@ impl<'client> GetCertificateRecordProvider<'client> {
 
         Ok(certificate_record)
     }
-
-    /// Get all CertificateRecords.
-    pub fn get_all(&self) -> StdResult<EntityCursor<CertificateRecord>> {
-        let filters = WhereCondition::default();
-        let certificate_record = self.find(filters)?;
-
-        Ok(certificate_record)
-    }
 }
+
+impl GetAllCondition for GetCertificateRecordProvider<'_> {}
 
 impl<'client> Provider<'client> for GetCertificateRecordProvider<'client> {
     type Entity = CertificateRecord;
@@ -81,6 +75,7 @@ impl<'client> Provider<'client> for GetCertificateRecordProvider<'client> {
 #[cfg(test)]
 mod tests {
     use mithril_common::crypto_helper::tests_setup::setup_certificate_chain;
+    use mithril_persistence::sqlite::GetAllProvider;
 
     use crate::database::test_helper::{insert_certificate_records, main_db_connection};
 

--- a/mithril-aggregator/src/database/provider/mod.rs
+++ b/mithril-aggregator/src/database/provider/mod.rs
@@ -1,4 +1,5 @@
 //! Aggregator related database providers
+mod block_range_root;
 mod cardano_transaction;
 mod certificate;
 mod epoch_setting;
@@ -9,6 +10,7 @@ mod signer_registration;
 mod single_signature;
 mod stake_pool;
 
+pub use block_range_root::*;
 pub use cardano_transaction::*;
 pub use certificate::*;
 pub use epoch_setting::*;

--- a/mithril-aggregator/src/database/provider/signed_entity/get_signed_entity.rs
+++ b/mithril-aggregator/src/database/provider/signed_entity/get_signed_entity.rs
@@ -97,16 +97,10 @@ impl<'client> GetSignedEntityRecordProvider<'client> {
 
         Ok(signed_entity_record)
     }
-
-    #[cfg(test)]
-    /// Get all SignedEntityRecords.
-    pub fn get_all(&self) -> StdResult<EntityCursor<SignedEntityRecord>> {
-        let filters = WhereCondition::default();
-        let signed_entity_record = self.find(filters)?;
-
-        Ok(signed_entity_record)
-    }
 }
+
+#[cfg(test)]
+impl mithril_persistence::sqlite::GetAllCondition for GetSignedEntityRecordProvider<'_> {}
 
 impl<'client> Provider<'client> for GetSignedEntityRecordProvider<'client> {
     type Entity = SignedEntityRecord;
@@ -127,6 +121,7 @@ impl<'client> Provider<'client> for GetSignedEntityRecordProvider<'client> {
 #[cfg(test)]
 mod tests {
     use mithril_common::entities::{CardanoDbBeacon, SignedEntityType};
+    use mithril_persistence::sqlite::GetAllProvider;
 
     use crate::database::test_helper::{insert_signed_entities, main_db_connection};
 

--- a/mithril-aggregator/src/database/provider/signer_registration/get_signer_registration.rs
+++ b/mithril-aggregator/src/database/provider/signer_registration/get_signer_registration.rs
@@ -55,16 +55,10 @@ impl<'client> GetSignerRegistrationRecordProvider<'client> {
 
         Ok(signer_registration_record)
     }
-
-    #[cfg(test)]
-    /// Get all SignerRegistrationRecords.
-    pub fn get_all(&self) -> StdResult<EntityCursor<SignerRegistrationRecord>> {
-        let filters = WhereCondition::default();
-        let signer_registration_record = self.find(filters)?;
-
-        Ok(signer_registration_record)
-    }
 }
+
+#[cfg(test)]
+impl mithril_persistence::sqlite::GetAllCondition for GetSignerRegistrationRecordProvider<'_> {}
 
 impl<'client> Provider<'client> for GetSignerRegistrationRecordProvider<'client> {
     type Entity = SignerRegistrationRecord;
@@ -86,6 +80,7 @@ mod tests {
 
     use mithril_common::entities::SignerWithStake;
     use mithril_common::test_utils::MithrilFixtureBuilder;
+    use mithril_persistence::sqlite::GetAllProvider;
 
     use crate::database::test_helper::{insert_signer_registrations, main_db_connection};
 

--- a/mithril-aggregator/src/database/record/block_range_root.rs
+++ b/mithril-aggregator/src/database/record/block_range_root.rs
@@ -11,8 +11,7 @@ use crate::database::record::hydrator::try_to_u64;
 pub struct BlockRangeRootRecord {
     /// Range of block numbers covered
     pub range: BlockRange,
-    /// Merkle root of the block range, computed from the list of all transactions that are
-    /// included in the range
+    /// Merkle root of the block range, computed from the list of included transactions
     pub merkle_root: MKTreeNode,
 }
 

--- a/mithril-aggregator/src/database/record/block_range_root.rs
+++ b/mithril-aggregator/src/database/record/block_range_root.rs
@@ -36,17 +36,25 @@ impl SqLiteEntity for BlockRangeRootRecord {
         Self: Sized,
     {
         let start = try_to_u64("block_range.start", row.read::<i64, _>(0))?;
-        let _end = try_to_u64("block_range.end", row.read::<i64, _>(1))?;
+        let end = try_to_u64("block_range.end", row.read::<i64, _>(1))?;
+        let range = BlockRange::from_block_number(start);
         let merkle_root = row.read::<&str, _>(2);
 
+        if range.start != start || range.end != end {
+            return Err(HydrationError::InvalidData(format!(
+                "Invalid block range: start={start}, end={end}, expected_start={}, expected_end={}",
+                range.start, range.end
+            )));
+        }
+
         Ok(Self {
-            range: BlockRange::from_block_number(start),
+            range,
             merkle_root: MKTreeNode::from_hex(merkle_root)
                 .map_err(|e| HydrationError::InvalidData(
                     format!(
                         "Field block_range.merkle_root (value={merkle_root}) is incompatible with hex representation. Error = {e}")
                 )
-            )?,
+                )?,
         })
     }
 
@@ -56,5 +64,56 @@ impl SqLiteEntity for BlockRangeRootRecord {
             ("end", "{:block_range_root:}.end", "int"),
             ("merkle_root", "{:block_range_root:}.merkle_root", "text"),
         ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mithril_common::entities::BlockNumber;
+    use sqlite::Connection;
+
+    fn select_block_range_from_db(start: BlockNumber, end: BlockNumber, merkle_root: &str) -> Row {
+        let conn = Connection::open(":memory:").unwrap();
+        let query = format!("SELECT {start}, {end}, '{merkle_root}'");
+        let mut statement = conn.prepare(query).unwrap();
+        statement.iter().next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn hydrate_succeed_if_valid_block_range_in_row() {
+        // A valid block range has both bounds as multiples of block range length and the interval
+        // size is equal to block range length.
+        let row = select_block_range_from_db(0, BlockRange::LENGTH, "AAAA");
+        let res = BlockRangeRootRecord::hydrate(row).expect("Expected hydrate to succeed");
+
+        assert_eq!(
+            res,
+            BlockRangeRootRecord {
+                range: BlockRange::from_block_number(0),
+                merkle_root: MKTreeNode::from_hex("AAAA").unwrap(),
+            }
+        );
+    }
+
+    #[test]
+    fn hydrate_fail_if_invalid_block_range_in_row() {
+        for invalid_row in [
+            // Start is not a multiple of block range length
+            select_block_range_from_db(1, BlockRange::LENGTH, "AAAA"),
+            // End is not a multiple of block range length
+            select_block_range_from_db(0, BlockRange::LENGTH - 1, "AAAA"),
+            // Interval is not equal to block range length
+            select_block_range_from_db(0, BlockRange::LENGTH * 4, "AAAA"),
+        ] {
+            let res =
+                BlockRangeRootRecord::hydrate(invalid_row).expect_err("Expected hydrate to fail");
+
+            assert!(
+                format!("{res:?}").contains("Invalid block range"),
+                "Expected 'Invalid block range' error, got {:?}",
+                res
+            );
+        }
     }
 }

--- a/mithril-aggregator/src/database/record/block_range_root.rs
+++ b/mithril-aggregator/src/database/record/block_range_root.rs
@@ -1,0 +1,61 @@
+use sqlite::Row;
+
+use mithril_common::crypto_helper::MKTreeNode;
+use mithril_common::entities::BlockRange;
+use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
+
+use crate::database::record::hydrator::try_to_u64;
+
+/// Block range root record is the representation of block range with its merkle root precomputed.
+#[derive(Debug, PartialEq, Clone)]
+pub struct BlockRangeRootRecord {
+    /// Range of block numbers covered
+    pub range: BlockRange,
+    /// Merkle root of the block range, computed from the list of all transactions that are
+    /// included in the range
+    pub merkle_root: MKTreeNode,
+}
+
+impl From<(BlockRange, MKTreeNode)> for BlockRangeRootRecord {
+    fn from(value: (BlockRange, MKTreeNode)) -> Self {
+        Self {
+            range: value.0,
+            merkle_root: value.1,
+        }
+    }
+}
+
+impl From<BlockRangeRootRecord> for (BlockRange, MKTreeNode) {
+    fn from(value: BlockRangeRootRecord) -> Self {
+        (value.range, value.merkle_root)
+    }
+}
+
+impl SqLiteEntity for BlockRangeRootRecord {
+    fn hydrate(row: Row) -> Result<Self, HydrationError>
+    where
+        Self: Sized,
+    {
+        let start = try_to_u64("block_range.start", row.read::<i64, _>(0))?;
+        let _end = try_to_u64("block_range.end", row.read::<i64, _>(1))?;
+        let merkle_root = row.read::<&str, _>(2);
+
+        Ok(Self {
+            range: BlockRange::from_block_number(start),
+            merkle_root: MKTreeNode::from_hex(merkle_root)
+                .map_err(|e| HydrationError::InvalidData(
+                    format!(
+                        "Field block_range.merkle_root (value={merkle_root}) is incompatible with hex representation. Error = {e}")
+                )
+            )?,
+        })
+    }
+
+    fn get_projection() -> Projection {
+        Projection::from(&[
+            ("start", "{:block_range_root:}.start", "int"),
+            ("end", "{:block_range_root:}.end", "int"),
+            ("merkle_root", "{:block_range_root:}.merkle_root", "text"),
+        ])
+    }
+}

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -17,6 +17,8 @@ use mithril_persistence::{
     sqlite::{HydrationError, Projection, SqLiteEntity},
 };
 
+use crate::database::record::hydrator;
+
 era_deprecate!("Remove immutable_file_number");
 /// Certificate record is the representation of a stored certificate.
 #[derive(Debug, PartialEq, Clone)]
@@ -312,7 +314,7 @@ impl SqLiteEntity for CertificateRecord {
         let network = row.read::<&str, _>(6).to_string();
         let immutable_file_number = row.read::<i64, _>(7);
         let signed_entity_type_id = row.read::<i64, _>(8);
-        let signed_entity_beacon_string = super::read_signed_entity_beacon_column(&row, 9);
+        let signed_entity_beacon_string = hydrator::read_signed_entity_beacon_column(&row, 9);
         let protocol_version = row.read::<&str, _>(10).to_string();
         let protocol_parameters_string = row.read::<&str, _>(11);
         let protocol_message_string = row.read::<&str, _>(12);

--- a/mithril-aggregator/src/database/record/interval_without_block_range_root.rs
+++ b/mithril-aggregator/src/database/record/interval_without_block_range_root.rs
@@ -1,0 +1,39 @@
+use sqlite::Row;
+
+use mithril_common::entities::BlockNumber;
+use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
+
+use crate::database::record::hydrator::try_to_u64;
+
+/// Interval of block numbers without block ranges root.
+pub struct IntervalWithoutBlockRangeRootRecord {
+    /// Start of the interval
+    pub start: Option<BlockNumber>,
+    /// End of the interval
+    pub end: Option<BlockNumber>,
+}
+
+impl SqLiteEntity for IntervalWithoutBlockRangeRootRecord {
+    fn hydrate(row: Row) -> Result<Self, HydrationError>
+    where
+        Self: Sized,
+    {
+        let start = row
+            .read::<Option<i64>, _>(0)
+            .map(|v| try_to_u64("interval_start.start", v))
+            .transpose()?;
+        let end = row
+            .read::<Option<i64>, _>(1)
+            .map(|v| try_to_u64("interval_end.end", v))
+            .transpose()?;
+
+        Ok(Self { start, end })
+    }
+
+    fn get_projection() -> Projection {
+        Projection::from(&[
+            ("start", "{:interval_start:}.start", "int"),
+            ("end", "{:interval_end:}.end", "int"),
+        ])
+    }
+}

--- a/mithril-aggregator/src/database/record/interval_without_block_range_root.rs
+++ b/mithril-aggregator/src/database/record/interval_without_block_range_root.rs
@@ -1,16 +1,43 @@
+use std::ops::Range;
+
+use anyhow::anyhow;
 use sqlite::Row;
 
 use mithril_common::entities::BlockNumber;
+use mithril_common::StdResult;
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
 use crate::database::record::hydrator::try_to_u64;
 
 /// Interval of block numbers (`[start, end[`) without block ranges root.
 pub struct IntervalWithoutBlockRangeRootRecord {
-    /// Start of the interval
+    /// Start of the interval, fetched from the last block range root end
     pub start: Option<BlockNumber>,
-    /// End of the interval
+    /// End of the interval, fetched from the last transaction block number
     pub end: Option<BlockNumber>,
+}
+
+impl IntervalWithoutBlockRangeRootRecord {
+    /// Deduce from self the range of blocks that are available to compute block range roots.
+    pub fn to_range(&self) -> StdResult<Option<Range<BlockNumber>>> {
+        match (self.start, self.end) {
+            // No transactions stored - nothing can be computed
+            (_, None) => Ok(None),
+            // Transactions stored but no block range root - everything can be computed
+            (None, Some(end)) => Ok(Some(0..(end + 1))),
+            // Last stored transactions is at the end of the last block range - nothing to compute
+            (Some(start), Some(end)) if (end + 1) == start => Ok(None),
+            (Some(start), Some(end)) if end < start => {
+                Err(anyhow!(
+                        "Inconsistent state: \
+                        Last block range root block number ({start}) is higher than the last transaction block number ({end}). \
+                        Did you forgot to prune obsolete `block_range_root` after a transaction rollback ?"
+                    ))
+            }
+            // Nominal case
+            (Some(start), Some(end)) => Ok(Some(start..(end + 1))),
+        }
+    }
 }
 
 impl SqLiteEntity for IntervalWithoutBlockRangeRootRecord {
@@ -35,5 +62,82 @@ impl SqLiteEntity for IntervalWithoutBlockRangeRootRecord {
             ("start", "{:interval_start:}.start", "int"),
             ("end", "{:interval_end:}.end", "int"),
         ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_without_block_range_nor_transactions_yield_none() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: None,
+            end: None,
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(None, range);
+    }
+
+    #[test]
+    fn db_with_only_transactions_yield_a_range() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: None,
+            end: Some(10),
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(Some(0..11), range);
+    }
+
+    #[test]
+    fn db_with_only_block_range_and_no_transactions_yield_none() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: Some(10),
+            end: None,
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(None, range);
+    }
+
+    #[test]
+    fn db_with_both_block_range_and_transactions_yield_a_range() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: Some(2),
+            end: Some(10),
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(Some(2..11), range);
+    }
+
+    #[test]
+    fn db_with_last_transaction_block_number_right_at_the_end_of_the_last_block_range_yield_none() {
+        // Reminder: the end of the block range is exclusive
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: Some(10),
+            end: Some(9),
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(None, range);
+    }
+
+    #[test]
+    fn db_with_last_transaction_block_number_below_the_end_of_the_last_block_range_yield_an_error()
+    {
+        // Reminder: the end of the block range is exclusive
+        let res = IntervalWithoutBlockRangeRootRecord {
+            start: Some(10),
+            end: Some(8),
+        }
+        .to_range()
+        .unwrap_err();
+        assert!(
+            format!("{res:?}").contains("Inconsistent state"),
+            "Expected 'Inconsistent state' error, got {res:?}",
+        );
     }
 }

--- a/mithril-aggregator/src/database/record/interval_without_block_range_root.rs
+++ b/mithril-aggregator/src/database/record/interval_without_block_range_root.rs
@@ -5,7 +5,7 @@ use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
 use crate::database::record::hydrator::try_to_u64;
 
-/// Interval of block numbers without block ranges root.
+/// Interval of block numbers (`[start, end[`) without block ranges root.
 pub struct IntervalWithoutBlockRangeRootRecord {
     /// Start of the interval
     pub start: Option<BlockNumber>,

--- a/mithril-aggregator/src/database/record/mod.rs
+++ b/mithril-aggregator/src/database/record/mod.rs
@@ -1,8 +1,10 @@
 //! Aggregator related database records
 
+mod block_range_root;
 mod cardano_transaction;
 mod certificate;
 mod epoch_setting;
+mod interval_without_block_range_root;
 mod open_message;
 mod open_message_with_single_signatures;
 mod signed_entity;
@@ -11,9 +13,11 @@ mod signer_registration;
 mod single_signature;
 mod stake_pool;
 
+pub use block_range_root::*;
 pub use cardano_transaction::*;
 pub use certificate::*;
 pub use epoch_setting::*;
+pub use interval_without_block_range_root::*;
 pub use open_message::*;
 pub use open_message_with_single_signatures::*;
 pub use signed_entity::*;
@@ -22,16 +26,30 @@ pub use signer_registration::*;
 pub use single_signature::*;
 pub use stake_pool::*;
 
-pub(crate) fn read_signed_entity_beacon_column<U: sqlite::RowIndex + Clone>(
-    row: &sqlite::Row,
-    column_index: U,
-) -> String {
-    // TODO: We need to check first that the cell can be read as a string first
-    // (e.g. when beacon json is '{"network": "dev", "epoch": 1, "immutable_file_number": 2}').
-    // If it fails, we fallback on reading the cell as an integer (e.g. when beacon json is '5').
-    // Maybe there is a better way of doing this.
-    match row.try_read::<&str, _>(column_index.clone()) {
-        Ok(value) => value.to_string(),
-        Err(_) => (row.read::<i64, _>(column_index)).to_string(),
+// TODO: this probably should be in `mithril-persistence` crate
+pub(crate) mod hydrator {
+    use mithril_persistence::sqlite::HydrationError;
+
+    pub fn read_signed_entity_beacon_column<U: sqlite::RowIndex + Clone>(
+        row: &sqlite::Row,
+        column_index: U,
+    ) -> String {
+        // TODO: We need to check first that the cell can be read as a string first
+        // (e.g. when beacon json is '{"network": "dev", "epoch": 1, "immutable_file_number": 2}').
+        // If it fails, we fallback on reading the cell as an integer (e.g. when beacon json is '5').
+        // Maybe there is a better way of doing this.
+        match row.try_read::<&str, _>(column_index.clone()) {
+            Ok(value) => value.to_string(),
+            Err(_) => (row.read::<i64, _>(column_index)).to_string(),
+        }
+    }
+
+    pub fn try_to_u64(field: &str, value: i64) -> Result<u64, HydrationError> {
+        u64::try_from(value)
+            .map_err(|e|
+                HydrationError::InvalidData(
+                    format!("Integer field {field} (value={value}) is incompatible with u64 representation. Error = {e}")
+                )
+            )
     }
 }

--- a/mithril-aggregator/src/database/record/open_message.rs
+++ b/mithril-aggregator/src/database/record/open_message.rs
@@ -6,6 +6,8 @@ use mithril_common::entities::{Epoch, ProtocolMessage, SignedEntityType};
 use mithril_persistence::database::SignedEntityTypeHydrator;
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
+use crate::database::record::hydrator;
+
 /// ## OpenMessage
 ///
 /// An open message is a message open for signatures. Every signer may send a
@@ -79,7 +81,7 @@ impl SqLiteEntity for OpenMessageRecord {
         let epoch_setting_id = row.read::<i64, _>(1);
         let epoch_val = u64::try_from(epoch_setting_id)
             .map_err(|e| panic!("Integer field open_message.epoch_setting_id (value={epoch_setting_id}) is incompatible with u64 Epoch representation. Error = {e}"))?;
-        let beacon_str = super::read_signed_entity_beacon_column(&row, 2);
+        let beacon_str = hydrator::read_signed_entity_beacon_column(&row, 2);
         let signed_entity_type_id = usize::try_from(row.read::<i64, _>(3)).map_err(|e| {
             panic!(
                 "Integer field open_message.signed_entity_type_id cannot be turned into usize: {e}"

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -13,6 +13,8 @@ use mithril_common::StdError;
 use mithril_persistence::database::SignedEntityTypeHydrator;
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
+use crate::database::record::hydrator;
+
 /// SignedEntity record is the representation of a stored signed_entity.
 #[derive(Debug, PartialEq, Clone)]
 pub struct SignedEntityRecord {
@@ -239,7 +241,7 @@ impl SqLiteEntity for SignedEntityRecord {
         let signed_entity_id = row.read::<&str, _>(0).to_string();
         let signed_entity_type_id_int = row.read::<i64, _>(1);
         let certificate_id = row.read::<&str, _>(2).to_string();
-        let beacon_str = super::read_signed_entity_beacon_column(&row, 3);
+        let beacon_str = hydrator::read_signed_entity_beacon_column(&row, 3);
         let artifact_str = row.read::<&str, _>(4).to_string();
         let created_at = row.read::<&str, _>(5);
 

--- a/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
@@ -1,7 +1,7 @@
 use std::ops::Range;
 use std::sync::Arc;
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
 use async_trait::async_trait;
 
 use mithril_common::crypto_helper::MKTreeNode;
@@ -208,18 +208,7 @@ impl TransactionStore for CardanoTransactionRepository {
         match row {
             // Should be impossible - the request as written in the provider always returns a single row
             None => panic!("IntervalWithoutBlockRangeProvider should always return a single row"),
-            Some(interval) => match (interval.start, interval.end) {
-                (_, None) => Ok(None),
-                (None, Some(end)) => Ok(Some(0..(end + 1))),
-                (Some(start), Some(end)) if end < start => {
-                    Err(anyhow!(
-                        "Inconsistent state: \
-                        Last block range root block number ({start}) is higher than the last transaction block number ({end}). \
-                        Did you forgot to prune obsolete `block_range_root` after a transaction rollback ?"
-                    ))
-                }
-                (Some(start), Some(end)) => Ok(Some(start..(end + 1))),
-            },
+            Some(interval) => interval.to_range(),
         }
     }
 
@@ -573,60 +562,8 @@ mod tests {
         let connection = Arc::new(cardano_tx_db_connection().unwrap());
         let repository = CardanoTransactionRepository::new(connection);
 
-        {
-            let interval = repository
-                .get_block_interval_without_block_range_root()
-                .await
-                .unwrap();
-
-            assert_eq!(None, interval);
-        }
-
-        // The last transaction block number give the upper bound
-        let last_transaction_block_number = BlockRange::LENGTH * 4;
-        repository
-            .create_transaction("tx-1", last_transaction_block_number, 50, "block-1", 99)
-            .await
-            .unwrap();
-
-        {
-            let interval = repository
-                .get_block_interval_without_block_range_root()
-                .await
-                .unwrap();
-
-            assert_eq!(Some(0..(last_transaction_block_number + 1)), interval);
-        }
-        {
-            // The last block range give the lower bound
-            let last_block_range = BlockRange::from_block_number(0);
-            repository
-                .store_block_range_roots(vec![(
-                    last_block_range.clone(),
-                    MKTreeNode::from_hex("AAAA").unwrap(),
-                )])
-                .await
-                .unwrap();
-
-            let interval = repository
-                .get_block_interval_without_block_range_root()
-                .await
-                .unwrap();
-
-            assert_eq!(
-                Some(last_block_range.end..(last_transaction_block_number + 1)),
-                interval
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn repository_get_block_interval_without_block_range_root_when_last_block_range_higher_than_stored_transactions(
-    ) {
-        let connection = Arc::new(cardano_tx_db_connection().unwrap());
-        let repository = CardanoTransactionRepository::new(connection);
-
-        let last_block_range = BlockRange::from_block_number(BlockRange::LENGTH * 10);
+        // The last block range give the lower bound
+        let last_block_range = BlockRange::from_block_number(0);
         repository
             .store_block_range_roots(vec![(
                 last_block_range.clone(),
@@ -635,32 +572,22 @@ mod tests {
             .await
             .unwrap();
 
-        // Only block range in db
-        {
-            let interval = repository
-                .get_block_interval_without_block_range_root()
-                .await
-                .unwrap();
+        // The last transaction block number give the upper bound
+        let last_transaction_block_number = BlockRange::LENGTH * 4;
+        repository
+            .create_transaction("tx-1", last_transaction_block_number, 50, "block-1", 99)
+            .await
+            .unwrap();
 
-            assert_eq!(None, interval);
-        }
-        // Inconsistent state: Highest transaction block number is below the last computed block range
-        {
-            let last_transaction_block_number = last_block_range.end - 10;
-            repository
-                .create_transaction("tx-1", last_transaction_block_number, 50, "block-1", 99)
-                .await
-                .unwrap();
+        let interval = repository
+            .get_block_interval_without_block_range_root()
+            .await
+            .unwrap();
 
-            let res = repository
-                .get_block_interval_without_block_range_root()
-                .await;
-
-            assert!(
-                res.is_err(),
-                "Inconsistent state should raise an error, found:\n{res:?}"
-            );
-        }
+        assert_eq!(
+            Some(last_block_range.end..(last_transaction_block_number + 1)),
+            interval
+        );
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
@@ -213,11 +213,10 @@ impl TransactionStore for CardanoTransactionRepository {
                 (_, None) => Ok(None),
                 (None, Some(end)) => Ok(Some(0..(end + 1))),
                 (Some(start), Some(end)) if end < start => {
-                    // To discuss : should we prune all block ranges from the DB to force recompute ?
                     warn!(
                         "Last computed block range is higher than the last transaction block number. \
-                        This should not happen. Did you forgot to prune the `block_range` table after pruning the\
-                        `cardano_tx` table ?";
+                        This should not happen. Did you forgot to prune the `block_range_root` table \
+                        after pruning the `cardano_tx` table ?";
                         "start" => start, "end" => end
                     );
                     Ok(None)

--- a/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
@@ -242,7 +242,9 @@ impl TransactionStore for CardanoTransactionRepository {
         &self,
         block_ranges: Vec<(BlockRange, MKTreeNode)>,
     ) -> StdResult<()> {
-        self.create_block_ranges(block_ranges).await?;
+        if !block_ranges.is_empty() {
+            self.create_block_ranges(block_ranges).await?;
+        }
         Ok(())
     }
 }

--- a/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
@@ -44,7 +44,7 @@ impl CardanoTransactionRepository {
     }
 
     /// Return all the [CardanoTransactionRecord]s in the database using chronological order.
-    pub async fn get_transactions_between_blocks(
+    pub async fn get_transactions_in_range_blocks(
         &self,
         range: Range<BlockNumber>,
     ) -> StdResult<Vec<CardanoTransactionRecord>> {
@@ -118,7 +118,7 @@ impl CardanoTransactionRepository {
     }
 
     /// Create new [BlockRangeRootRecord]s in the database.
-    pub async fn create_block_ranges<T: Into<BlockRangeRootRecord>>(
+    pub async fn create_block_range_roots<T: Into<BlockRangeRootRecord>>(
         &self,
         block_ranges: Vec<T>,
     ) -> StdResult<Vec<BlockRangeRootRecord>> {
@@ -226,23 +226,23 @@ impl TransactionStore for CardanoTransactionRepository {
         }
     }
 
-    async fn get_transactions_between(
+    async fn get_transactions_in_range(
         &self,
         range: Range<BlockNumber>,
     ) -> StdResult<Vec<CardanoTransaction>> {
-        self.get_transactions_between_blocks(range).await.map(|v| {
+        self.get_transactions_in_range_blocks(range).await.map(|v| {
             v.into_iter()
                 .map(|record| record.into())
                 .collect::<Vec<CardanoTransaction>>()
         })
     }
 
-    async fn store_block_ranges(
+    async fn store_block_range_roots(
         &self,
         block_ranges: Vec<(BlockRange, MKTreeNode)>,
     ) -> StdResult<()> {
         if !block_ranges.is_empty() {
-            self.create_block_ranges(block_ranges).await?;
+            self.create_block_range_roots(block_ranges).await?;
         }
         Ok(())
     }
@@ -535,7 +535,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn repository_get_transactions_between_blocks() {
+    async fn repository_get_transactions_in_range_blocks() {
         let connection = Arc::new(cardano_tx_db_connection().unwrap());
         let repository = CardanoTransactionRepository::new(connection);
 
@@ -550,23 +550,23 @@ mod tests {
             .unwrap();
 
         {
-            let transaction_result = repository.get_transactions_between(0..10).await.unwrap();
+            let transaction_result = repository.get_transactions_in_range(0..10).await.unwrap();
             assert_eq!(Vec::<CardanoTransaction>::new(), transaction_result);
         }
         {
-            let transaction_result = repository.get_transactions_between(13..21).await.unwrap();
+            let transaction_result = repository.get_transactions_in_range(13..21).await.unwrap();
             assert_eq!(Vec::<CardanoTransaction>::new(), transaction_result);
         }
         {
-            let transaction_result = repository.get_transactions_between(9..12).await.unwrap();
+            let transaction_result = repository.get_transactions_in_range(9..12).await.unwrap();
             assert_eq!(transactions[0..=1].to_vec(), transaction_result);
         }
         {
-            let transaction_result = repository.get_transactions_between(10..13).await.unwrap();
+            let transaction_result = repository.get_transactions_in_range(10..13).await.unwrap();
             assert_eq!(transactions.clone(), transaction_result);
         }
         {
-            let transaction_result = repository.get_transactions_between(11..14).await.unwrap();
+            let transaction_result = repository.get_transactions_in_range(11..14).await.unwrap();
             assert_eq!(transactions[1..=2].to_vec(), transaction_result);
         }
     }
@@ -604,7 +604,7 @@ mod tests {
             // The last block range give the lower bound
             let last_block_range = BlockRange::from_block_number(0);
             repository
-                .store_block_ranges(vec![(
+                .store_block_range_roots(vec![(
                     last_block_range.clone(),
                     MKTreeNode::from_hex("AAAA").unwrap(),
                 )])
@@ -631,7 +631,7 @@ mod tests {
 
         let last_block_range = BlockRange::from_block_number(BlockRange::LENGTH * 10);
         repository
-            .store_block_ranges(vec![(
+            .store_block_range_roots(vec![(
                 last_block_range.clone(),
                 MKTreeNode::from_hex("AAAA").unwrap(),
             )])
@@ -672,7 +672,7 @@ mod tests {
         let repository = CardanoTransactionRepository::new(connection.clone());
 
         repository
-            .store_block_ranges(vec![
+            .store_block_range_roots(vec![
                 (
                     BlockRange::from_block_number(0),
                     MKTreeNode::from_hex("AAAA").unwrap(),
@@ -709,11 +709,11 @@ mod tests {
         let range = BlockRange::from_block_number(0);
 
         repository
-            .store_block_ranges(vec![(range.clone(), MKTreeNode::from_hex("AAAA").unwrap())])
+            .store_block_range_roots(vec![(range.clone(), MKTreeNode::from_hex("AAAA").unwrap())])
             .await
             .unwrap();
         repository
-            .store_block_ranges(vec![(range.clone(), MKTreeNode::from_hex("BBBB").unwrap())])
+            .store_block_range_roots(vec![(range.clone(), MKTreeNode::from_hex("BBBB").unwrap())])
             .await
             .unwrap();
 

--- a/mithril-aggregator/src/database/repository/certificate_repository.rs
+++ b/mithril-aggregator/src/database/repository/certificate_repository.rs
@@ -7,7 +7,7 @@ use sqlite::ConnectionThreadSafe;
 use mithril_common::certificate_chain::{CertificateRetriever, CertificateRetrieverError};
 use mithril_common::entities::{Certificate, Epoch};
 use mithril_common::StdResult;
-use mithril_persistence::sqlite::Provider;
+use mithril_persistence::sqlite::{GetAllProvider, Provider};
 
 use crate::database::provider::{
     DeleteCertificateProvider, GetCertificateRecordProvider, InsertCertificateRecordProvider,

--- a/mithril-aggregator/src/database/repository/signer_store.rs
+++ b/mithril-aggregator/src/database/repository/signer_store.rs
@@ -7,7 +7,7 @@ use chrono::Utc;
 use mockall::automock;
 
 use mithril_common::StdResult;
-use mithril_persistence::sqlite::SqliteConnection;
+use mithril_persistence::sqlite::{GetAllProvider, SqliteConnection};
 
 use crate::database::provider::{
     GetSignerRecordProvider, ImportSignerRecordProvider, RegisterSignerRecordProvider,

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -136,7 +136,7 @@ pub struct DependenciesBuilder {
     /// Cardano transactions store.
     pub transaction_store: Option<Arc<dyn TransactionStore>>,
 
-    /// Cardano transactions parser.
+    /// Cardano block scanner.
     pub block_scanner: Option<Arc<dyn BlockScanner>>,
 
     /// Immutable file digester service.
@@ -724,7 +724,7 @@ impl DependenciesBuilder {
         Ok(Arc::new(block_scanner))
     }
 
-    /// Transaction parser.
+    /// Block scanner
     pub async fn get_block_scanner(&mut self) -> Result<Arc<dyn BlockScanner>> {
         if self.block_scanner.is_none() {
             self.block_scanner = Some(self.build_block_scanner().await?);
@@ -1198,7 +1198,7 @@ impl DependenciesBuilder {
             signed_entity_storer: self.get_signed_entity_storer().await?,
             signer_getter: self.get_signer_store().await?,
             message_service: self.get_message_service().await?,
-            transaction_parser: self.get_block_scanner().await?,
+            block_scanner: self.get_block_scanner().await?,
             transaction_store: self.get_transaction_store().await?,
             prover_service: self.get_prover_service().await?,
         };

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -87,8 +87,8 @@ pub struct DependencyContainer {
     /// Cardano transactions store.
     pub transaction_store: Arc<dyn TransactionStore>,
 
-    /// Cardano transactions parser.
-    pub transaction_parser: Arc<dyn BlockScanner>,
+    /// Cardano block scanner.
+    pub block_scanner: Arc<dyn BlockScanner>,
 
     /// Immutable file observer service.
     pub immutable_file_observer: Arc<dyn ImmutableFileObserver>,

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -3,7 +3,7 @@ use tokio::sync::RwLock;
 
 use mithril_common::{
     api_version::APIVersionProvider,
-    cardano_transaction_parser::TransactionParser,
+    cardano_block_scanner::BlockScanner,
     certificate_chain::CertificateVerifier,
     chain_observer::ChainObserver,
     crypto_helper::ProtocolGenesisVerifier,
@@ -88,7 +88,7 @@ pub struct DependencyContainer {
     pub transaction_store: Arc<dyn TransactionStore>,
 
     /// Cardano transactions parser.
-    pub transaction_parser: Arc<dyn TransactionParser>,
+    pub transaction_parser: Arc<dyn BlockScanner>,
 
     /// Immutable file observer service.
     pub immutable_file_observer: Arc<dyn ImmutableFileObserver>,

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -1,18 +1,18 @@
+use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
-#[cfg(test)]
-use mockall::automock;
 use slog::{debug, Logger};
 
 use mithril_common::cardano_block_scanner::BlockScanner;
-use mithril_common::entities::{CardanoTransaction, ImmutableFileNumber};
+use mithril_common::crypto_helper::{MKTree, MKTreeNode};
+use mithril_common::entities::{BlockNumber, BlockRange, CardanoTransaction, ImmutableFileNumber};
 use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
 
 /// Cardano transactions store
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait TransactionStore: Send + Sync {
     /// Get the highest known transaction beacon
@@ -26,6 +26,23 @@ pub trait TransactionStore: Send + Sync {
 
     /// Store list of transactions
     async fn store_transactions(&self, transactions: Vec<CardanoTransaction>) -> StdResult<()>;
+
+    /// Get the interval of blocks whose merkle root has yet to be computed
+    async fn get_block_interval_without_block_range_root(
+        &self,
+    ) -> StdResult<Option<Range<BlockNumber>>>;
+
+    /// Get transactions between two block numbers
+    async fn get_transactions_between(
+        &self,
+        range: Range<BlockNumber>,
+    ) -> StdResult<Vec<CardanoTransaction>>;
+
+    /// Store list of block ranges with their corresponding merkle root
+    async fn store_block_ranges(
+        &self,
+        block_ranges: Vec<(BlockRange, MKTreeNode)>,
+    ) -> StdResult<()>;
 }
 
 /// Import and store [CardanoTransaction].
@@ -57,6 +74,12 @@ impl CardanoTransactionsImporter {
             rescan_offset,
             dirpath: dirpath.to_owned(),
         }
+    }
+
+    async fn import_transactions(&self, up_to_beacon: ImmutableFileNumber) -> StdResult<()> {
+        let from = self.get_starting_beacon().await?;
+        self.parse_and_store_transactions_not_imported_yet(from, up_to_beacon)
+            .await
     }
 
     async fn get_starting_beacon(&self) -> StdResult<Option<u64>> {
@@ -98,6 +121,41 @@ impl CardanoTransactionsImporter {
             .await?;
         Ok(())
     }
+
+    async fn import_block_ranges(&self) -> StdResult<()> {
+        match self
+            .transaction_store
+            .get_block_interval_without_block_range_root()
+            .await?
+        {
+            None => {
+                // Nothing to do
+                Ok(())
+            }
+            Some(range) => {
+                let block_ranges =
+                    BlockRange::all_ranges_in(BlockRange::start(range.start)..range.end);
+
+                if block_ranges.is_empty() {
+                    return Ok(());
+                }
+
+                let mut block_ranges_with_merkle_root: Vec<(BlockRange, MKTreeNode)> = vec![];
+                for block_range in block_ranges {
+                    let transactions = self
+                        .transaction_store
+                        .get_transactions_between(block_range.start..block_range.end)
+                        .await?;
+                    let merkle_root = MKTree::new(&transactions)?.compute_root()?;
+                    block_ranges_with_merkle_root.push((block_range, merkle_root));
+                }
+
+                self.transaction_store
+                    .store_block_ranges(block_ranges_with_merkle_root)
+                    .await
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -106,9 +164,8 @@ impl TransactionsImporter for CardanoTransactionsImporter {
         &self,
         up_to_beacon: ImmutableFileNumber,
     ) -> StdResult<Vec<CardanoTransaction>> {
-        let from = self.get_starting_beacon().await?;
-        self.parse_and_store_transactions_not_imported_yet(from, up_to_beacon)
-            .await?;
+        self.import_transactions(up_to_beacon).await?;
+        self.import_block_ranges().await?;
 
         let transactions = self.transaction_store.get_up_to(up_to_beacon).await?;
         Ok(transactions)
@@ -118,9 +175,10 @@ impl TransactionsImporter for CardanoTransactionsImporter {
 #[cfg(test)]
 mod tests {
     use mockall::mock;
-    use mockall::predicate::eq;
 
-    use mithril_common::cardano_block_scanner::ScannedBlock;
+    use mithril_common::cardano_block_scanner::{DumbBlockScanner, ScannedBlock};
+    use mithril_common::crypto_helper::MKTree;
+    use mithril_common::entities::BlockNumber;
 
     use crate::database::repository::CardanoTransactionRepository;
     use crate::database::test_helper::cardano_tx_db_connection;
@@ -141,164 +199,390 @@ mod tests {
         }
     }
 
-    fn build_importer<TParser, TStore>(
-        scanner_mock_config: TParser,
-        store_mock_config: TStore,
-    ) -> CardanoTransactionsImporter
-    where
-        TParser: FnOnce(&mut MockBlockScannerImpl),
-        TStore: FnOnce(&mut MockTransactionStore),
-    {
-        let db_path = Path::new("");
-        let mut scanner = MockBlockScannerImpl::new();
-        scanner_mock_config(&mut scanner);
+    impl CardanoTransactionsImporter {
+        pub fn new_for_test(
+            scanner: Arc<dyn BlockScanner>,
+            transaction_store: Arc<dyn TransactionStore>,
+        ) -> Self {
+            CardanoTransactionsImporter::new(
+                scanner,
+                transaction_store,
+                Path::new(""),
+                None,
+                crate::test_tools::logger_for_tests(),
+            )
+        }
+    }
 
-        let mut store = MockTransactionStore::new();
-        store.expect_get_up_to().returning(|_| Ok(vec![]));
-        store_mock_config(&mut store);
+    fn build_blocks(
+        start_block_number: BlockNumber,
+        number_of_consecutive_block: BlockNumber,
+    ) -> Vec<ScannedBlock> {
+        (start_block_number..(start_block_number + number_of_consecutive_block))
+            .map(|block_number| {
+                ScannedBlock::new(
+                    format!("block_hash-{}", block_number),
+                    block_number,
+                    block_number * 100,
+                    block_number * 10,
+                    vec![format!("tx_hash-{}", block_number)],
+                )
+            })
+            .collect()
+    }
 
-        CardanoTransactionsImporter::new(
-            Arc::new(scanner),
-            Arc::new(store),
-            db_path,
-            None,
-            crate::test_tools::logger_for_tests(),
-        )
+    fn into_transactions(blocks: &[ScannedBlock]) -> Vec<CardanoTransaction> {
+        blocks
+            .iter()
+            .flat_map(|b| b.clone().into_transactions())
+            .collect()
+    }
+
+    fn merkle_root_for_blocks(block_ranges: &[ScannedBlock]) -> MKTreeNode {
+        let tx: Vec<_> = block_ranges
+            .iter()
+            .flat_map(|br| br.clone().into_transactions())
+            .collect();
+        MKTree::new(&tx).unwrap().compute_root().unwrap()
     }
 
     #[tokio::test]
     async fn if_nothing_stored_parse_and_store_all_transactions() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+
         let blocks = vec![
             ScannedBlock::new("block_hash-1", 10, 15, 11, vec!["tx_hash-1", "tx_hash-2"]),
             ScannedBlock::new("block_hash-2", 20, 25, 12, vec!["tx_hash-3", "tx_hash-4"]),
         ];
-        let transactions: Vec<CardanoTransaction> = blocks
-            .iter()
-            .flat_map(|b| b.clone().into_transactions())
-            .collect();
+        let expected_transactions = into_transactions(&blocks);
         let up_to_beacon = 12;
 
-        let importer = build_importer(
-            |scanner_mock| {
-                scanner_mock
-                    .expect_scan()
-                    .withf(move |_, from, until| from.is_none() && until == &up_to_beacon)
-                    .return_once(move |_, _, _| Ok(blocks));
-            },
-            |store_mock| {
-                let expected_stored_transactions = transactions.clone();
-                store_mock
-                    .expect_get_highest_beacon()
-                    .returning(|| Ok(None));
-                store_mock
-                    .expect_store_transactions()
-                    .with(eq(expected_stored_transactions))
-                    .returning(|_| Ok(()))
-                    .once();
-            },
-        );
+        let importer = {
+            let mut scanner_mock = MockBlockScannerImpl::new();
+            scanner_mock
+                .expect_scan()
+                .withf(move |_, from, until| from.is_none() && until == &up_to_beacon)
+                .return_once(move |_, _, _| Ok(blocks));
+            CardanoTransactionsImporter::new_for_test(Arc::new(scanner_mock), repository.clone())
+        };
 
         importer
-            .import(up_to_beacon)
+            .import_transactions(up_to_beacon)
             .await
-            .expect("Transactions Parser should succeed");
+            .expect("Transactions Importer should succeed");
+
+        let stored_transactions = repository.get_up_to(10000).await.unwrap();
+        assert_eq!(expected_transactions, stored_transactions);
     }
 
     #[tokio::test]
-    async fn if_all_stored_nothing_is_parsed_and_stored() {
-        let up_to_beacon = 12;
+    async fn if_nothing_stored_parse_and_store_all_block_ranges() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
 
-        let importer = build_importer(
-            |scanner_mock| {
-                scanner_mock.expect_scan().never();
-            },
-            |store_mock| {
-                store_mock
-                    .expect_get_highest_beacon()
-                    .returning(|| Ok(Some(12)));
-                store_mock.expect_store_transactions().never();
-            },
+        let blocks = build_blocks(0, BlockRange::LENGTH * 5 + 1);
+        let transactions = into_transactions(&blocks);
+        repository.store_transactions(transactions).await.unwrap();
+
+        let importer = CardanoTransactionsImporter::new_for_test(
+            Arc::new(MockBlockScannerImpl::new()),
+            repository.clone(),
         );
 
         importer
-            .import(up_to_beacon)
+            .import_block_ranges()
             .await
-            .expect("Transactions Parser should succeed");
+            .expect("Transactions Importer should succeed");
+
+        let block_range_roots = repository.get_all_block_range_root().unwrap();
+        assert_eq!(
+            vec![
+                BlockRange::from_block_number(0),
+                BlockRange::from_block_number(BlockRange::LENGTH),
+                BlockRange::from_block_number(BlockRange::LENGTH * 2),
+                BlockRange::from_block_number(BlockRange::LENGTH * 3),
+                BlockRange::from_block_number(BlockRange::LENGTH * 4),
+            ],
+            block_range_roots
+                .into_iter()
+                .map(|r| r.range)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]
-    async fn if_all_half_are_stored_the_other_half_is_parsed_and_stored() {
-        let blocks = [
-            ScannedBlock::new("block_hash-1", 10, 15, 11, vec!["tx_hash-1", "tx_hash-2"]),
-            ScannedBlock::new("block_hash-2", 20, 25, 12, vec!["tx_hash-3", "tx_hash-4"]),
-        ];
-        let transactions: Vec<CardanoTransaction> = blocks
-            .iter()
-            .flat_map(|b| b.clone().into_transactions())
-            .collect();
+    async fn if_all_block_ranges_computed_nothing_computed_and_stored() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+
+        let importer = CardanoTransactionsImporter::new_for_test(
+            Arc::new(MockBlockScannerImpl::new()),
+            repository.clone(),
+        );
+
+        importer
+            .import_block_ranges()
+            .await
+            .expect("Transactions Importer should succeed");
+
+        let block_range_roots = repository.get_all_block_range_root().unwrap();
+        assert!(
+            block_range_roots.is_empty(),
+            "No block range root should be stored, found: {block_range_roots:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn if_all_transactions_stored_nothing_is_parsed_and_stored() {
+        let up_to_beacon = 12;
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+        let scanner = DumbBlockScanner::new(vec![
+            ScannedBlock::new("block_hash-1", 10, 15, 10, vec!["tx_hash-1", "tx_hash-2"]),
+            ScannedBlock::new("block_hash-2", 20, 25, 11, vec!["tx_hash-3", "tx_hash-4"]),
+        ]);
+
+        let last_tx = CardanoTransaction::new("tx-20", 30, 35, "block_hash-3", up_to_beacon);
+        repository
+            .store_transactions(vec![last_tx.clone()])
+            .await
+            .unwrap();
+
+        let importer =
+            CardanoTransactionsImporter::new_for_test(Arc::new(scanner), repository.clone());
+
+        importer
+            .import_transactions(up_to_beacon)
+            .await
+            .expect("Transactions Importer should succeed");
+
+        let transactions = repository.get_up_to(10000).await.unwrap();
+        assert_eq!(vec![last_tx], transactions);
+    }
+
+    #[tokio::test]
+    async fn if_half_transactions_are_stored_the_other_half_is_parsed_and_stored() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+
+        let stored_block =
+            ScannedBlock::new("block_hash-1", 10, 15, 11, vec!["tx_hash-1", "tx_hash-2"]);
+        let to_store_block =
+            ScannedBlock::new("block_hash-2", 20, 25, 12, vec!["tx_hash-3", "tx_hash-4"]);
+        let expected_transactions: Vec<CardanoTransaction> = [
+            stored_block.clone().into_transactions(),
+            to_store_block.clone().into_transactions(),
+        ]
+        .concat();
         let up_to_beacon = 14;
 
-        let importer = build_importer(
-            |scanner_mock| {
-                let scanned_blocks = vec![blocks[1].clone()];
-                scanner_mock
-                    .expect_scan()
-                    .withf(move |_, from, until| from == &Some(13) && until == &up_to_beacon)
-                    .return_once(move |_, _, _| Ok(scanned_blocks));
-            },
-            |store_mock| {
-                store_mock
-                    .expect_get_highest_beacon()
-                    .returning(|| Ok(Some(12)));
-                let expected_to_store_transactions = transactions[2..=3].to_vec();
-                store_mock
-                    .expect_store_transactions()
-                    .with(eq(expected_to_store_transactions))
-                    .returning(|_| Ok(()))
-                    .once();
-            },
-        );
+        repository
+            .store_transactions(stored_block.clone().into_transactions())
+            .await
+            .unwrap();
+
+        let importer = {
+            let scanned_blocks = vec![to_store_block.clone()];
+            let mut scanner_mock = MockBlockScannerImpl::new();
+            scanner_mock
+                .expect_scan()
+                .withf(move |_, from, until| from == &Some(12) && until == &up_to_beacon)
+                .return_once(move |_, _, _| Ok(scanned_blocks))
+                .once();
+            CardanoTransactionsImporter::new_for_test(Arc::new(scanner_mock), repository.clone())
+        };
+
+        let stored_transactions = repository.get_up_to(10000).await.unwrap();
+        assert_eq!(stored_block.into_transactions(), stored_transactions);
 
         importer
-            .import(up_to_beacon)
+            .import_transactions(up_to_beacon)
             .await
-            .expect("Transactions Parser should succeed");
+            .expect("Transactions Importer should succeed");
+
+        let stored_transactions = repository.get_up_to(10000).await.unwrap();
+        assert_eq!(expected_transactions, stored_transactions);
     }
 
     #[tokio::test]
-    async fn importing_twice_starting_with_nothing_in_a_real_db_should_yield_the_transactions_in_same_order(
+    async fn if_half_block_ranges_are_stored_the_other_half_is_computed_and_stored() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+
+        let blocks = build_blocks(0, BlockRange::LENGTH * 4 + 1);
+        let transactions = into_transactions(&blocks);
+        repository.store_transactions(transactions).await.unwrap();
+        repository
+            .store_block_ranges(
+                blocks[0..((BlockRange::LENGTH * 2) as usize)]
+                    .iter()
+                    .map(|b| {
+                        (
+                            BlockRange::from_block_number(b.block_number),
+                            MKTreeNode::from_hex("AAAA").unwrap(),
+                        )
+                    })
+                    .collect(),
+            )
+            .await
+            .unwrap();
+
+        let importer = CardanoTransactionsImporter::new_for_test(
+            Arc::new(MockBlockScannerImpl::new()),
+            repository.clone(),
+        );
+
+        let block_range_roots = repository.get_all_block_range_root().unwrap();
+        assert_eq!(
+            vec![
+                BlockRange::from_block_number(0),
+                BlockRange::from_block_number(BlockRange::LENGTH),
+            ],
+            block_range_roots
+                .into_iter()
+                .map(|r| r.range)
+                .collect::<Vec<_>>()
+        );
+
+        importer
+            .import_block_ranges()
+            .await
+            .expect("Transactions Importer should succeed");
+
+        let block_range_roots = repository.get_all_block_range_root().unwrap();
+        assert_eq!(
+            vec![
+                BlockRange::from_block_number(0),
+                BlockRange::from_block_number(BlockRange::LENGTH),
+                BlockRange::from_block_number(BlockRange::LENGTH * 2),
+                BlockRange::from_block_number(BlockRange::LENGTH * 3),
+            ],
+            block_range_roots
+                .into_iter()
+                .map(|r| r.range)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    // async fn block_range_root_compute_work_on_block_range_starting_before_last_block_range_root_and_finishing_before_last_tx(
+    async fn block_range_root_only_retrieve_only_strictly_required_transactions() {
+        fn transactions_for_block(range: Range<BlockNumber>) -> StdResult<Vec<CardanoTransaction>> {
+            Ok(build_blocks(range.start, range.count() as BlockNumber)
+                .iter()
+                .flat_map(|b| b.clone().into_transactions())
+                .collect())
+        }
+
+        let importer = {
+            let mut store_mock = MockTransactionStore::new();
+            store_mock
+                .expect_get_block_interval_without_block_range_root()
+                // Specification of the interval without block range root
+                // Note: in reality the lower bound will always be a multiple of BlockRange::LENGTH
+                // since it's computed from the `block_range_root` table
+                .returning(|| Ok(Some((BlockRange::LENGTH + 2)..(BlockRange::LENGTH * 5))))
+                .once();
+            store_mock
+                .expect_get_transactions_between()
+                // Lower bound should be the block number that start after the last known block range end
+                //
+                // if it's not a multiple of BlockRange::LENGTH, it should be the start block number
+                // of the block range that contains the end of the last known block range.
+                //
+                // Upper bound should be the block number of the highest transaction in a db that can be
+                // included in a block range
+                .withf(|range| {
+                    let expected_range = BlockRange::LENGTH..=(BlockRange::LENGTH * 5);
+                    expected_range.contains(&range.start) && expected_range.contains(&range.end)
+                })
+                .returning(transactions_for_block);
+            store_mock.expect_store_block_ranges().returning(|_| Ok(()));
+
+            CardanoTransactionsImporter::new_for_test(
+                Arc::new(MockBlockScannerImpl::new()),
+                Arc::new(store_mock),
+            )
+        };
+
+        importer
+            .import_block_ranges()
+            .await
+            .expect("Transactions Importer should succeed");
+    }
+
+    #[tokio::test]
+    async fn compute_block_range_merkle_root() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+
+        // 2 block ranges worth of blocks with one more block that should be ignored for merkle root computation
+        let blocks = build_blocks(0, BlockRange::LENGTH * 2 + 1);
+        let transactions = into_transactions(&blocks);
+        let expected_block_range_roots = vec![
+            (
+                BlockRange::from_block_number(0),
+                merkle_root_for_blocks(&blocks[0..(BlockRange::LENGTH as usize)]),
+            ),
+            (
+                BlockRange::from_block_number(BlockRange::LENGTH),
+                merkle_root_for_blocks(
+                    &blocks[(BlockRange::LENGTH as usize)..((BlockRange::LENGTH * 2) as usize)],
+                ),
+            ),
+        ];
+
+        repository.store_transactions(transactions).await.unwrap();
+
+        let importer = CardanoTransactionsImporter::new_for_test(
+            Arc::new(MockBlockScannerImpl::new()),
+            repository.clone(),
+        );
+
+        importer
+            .import_block_ranges()
+            .await
+            .expect("Transactions Importer should succeed");
+
+        let block_range_roots = repository.get_all_block_range_root().unwrap();
+        assert_eq!(
+            expected_block_range_roots,
+            block_range_roots
+                .into_iter()
+                .map(|br| br.into())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn importing_twice_starting_with_nothing_in_a_real_db_should_yield_transactions_in_same_order(
     ) {
         let blocks = vec![
             ScannedBlock::new("block_hash-1", 10, 15, 11, vec!["tx_hash-1", "tx_hash-2"]),
             ScannedBlock::new("block_hash-2", 20, 25, 12, vec!["tx_hash-3", "tx_hash-4"]),
         ];
-        let transactions: Vec<CardanoTransaction> = blocks
-            .iter()
-            .flat_map(|b| b.clone().into_transactions())
-            .collect();
+        let transactions = into_transactions(&blocks);
         let importer = {
             let connection = cardano_tx_db_connection().unwrap();
             let mut scanner = MockBlockScannerImpl::new();
             scanner.expect_scan().return_once(move |_, _, _| Ok(blocks));
 
-            CardanoTransactionsImporter::new(
+            CardanoTransactionsImporter::new_for_test(
                 Arc::new(scanner),
                 Arc::new(CardanoTransactionRepository::new(Arc::new(connection))),
-                Path::new(""),
-                None,
-                crate::test_tools::logger_for_tests(),
             )
         };
 
         let cold_imported_transactions = importer
             .import(12)
             .await
-            .expect("Transactions Parser should succeed");
+            .expect("Transactions Importer should succeed");
 
         let warm_imported_transactions = importer
             .import(12)
             .await
-            .expect("Transactions Parser should succeed");
+            .expect("Transactions Importer should succeed");
 
         assert_eq!(transactions, cold_imported_transactions);
         assert_eq!(cold_imported_transactions, warm_imported_transactions);

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -182,7 +182,7 @@ mod tests {
 
     use mithril_common::cardano_block_scanner::{DumbBlockScanner, ScannedBlock};
     use mithril_common::crypto_helper::MKTree;
-    use mithril_common::entities::BlockNumber;
+    use mithril_common::entities::{BlockNumber, BlockRangesSequence};
 
     use crate::database::repository::CardanoTransactionRepository;
     use crate::database::test_helper::cardano_tx_db_connection;
@@ -534,8 +534,8 @@ mod tests {
                 // Upper bound should be the block number of the highest transaction in a db that can be
                 // included in a block range
                 .withf(|range| {
-                    let expected_range = BlockRange::LENGTH..=(BlockRange::LENGTH * 5);
-                    expected_range.contains(&range.start) && expected_range.contains(&range.end)
+                    BlockRangesSequence::new(BlockRange::LENGTH..(BlockRange::LENGTH * 5))
+                        .contains(range)
                 })
                 .returning(transactions_for_block);
             store_mock

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -6,7 +6,7 @@ use async_trait::async_trait;
 use mockall::automock;
 use slog::{debug, Logger};
 
-use mithril_common::cardano_transaction_parser::TransactionParser;
+use mithril_common::cardano_block_scanner::BlockScanner;
 use mithril_common::entities::{CardanoTransaction, ImmutableFileNumber};
 use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
@@ -30,7 +30,7 @@ pub trait TransactionStore: Send + Sync {
 
 /// Import and store [CardanoTransaction].
 pub struct CardanoTransactionsImporter {
-    transaction_parser: Arc<dyn TransactionParser>,
+    block_scanner: Arc<dyn BlockScanner>,
     transaction_store: Arc<dyn TransactionStore>,
     logger: Logger,
     rescan_offset: Option<usize>,
@@ -44,14 +44,14 @@ impl CardanoTransactionsImporter {
     /// immutables starting after the highest immutable known in the store.
     /// This is useful when one of the last immutable was not full scanned.
     pub fn new(
-        transaction_parser: Arc<dyn TransactionParser>,
+        block_scanner: Arc<dyn BlockScanner>,
         transaction_store: Arc<dyn TransactionStore>,
         dirpath: &Path,
         rescan_offset: Option<usize>,
         logger: Logger,
     ) -> Self {
         Self {
-            transaction_parser,
+            block_scanner,
             transaction_store,
             logger,
             rescan_offset,
@@ -79,10 +79,7 @@ impl CardanoTransactionsImporter {
             return Ok(());
         }
 
-        let parsed_transactions = self
-            .transaction_parser
-            .parse(&self.dirpath, from, until)
-            .await?;
+        let parsed_transactions = self.block_scanner.parse(&self.dirpath, from, until).await?;
         debug!(
             self.logger,
             "TransactionsImporter retrieved '{}' Cardano transactions between immutables '{}' and '{until}'",
@@ -123,10 +120,10 @@ mod tests {
     use super::*;
 
     mock! {
-        pub TransactionParserImpl { }
+        pub BlockScannerImpl { }
 
         #[async_trait]
-        impl TransactionParser for TransactionParserImpl {
+        impl BlockScanner for BlockScannerImpl {
             async fn parse(
               &self,
               dirpath: &Path,
@@ -137,19 +134,19 @@ mod tests {
     }
 
     fn build_importer(
-        parser_mock_config: &dyn Fn(&mut MockTransactionParserImpl),
+        scanner_mock_config: &dyn Fn(&mut MockBlockScannerImpl),
         store_mock_config: &dyn Fn(&mut MockTransactionStore),
     ) -> CardanoTransactionsImporter {
         let db_path = Path::new("");
-        let mut parser = MockTransactionParserImpl::new();
-        parser_mock_config(&mut parser);
+        let mut scanner = MockBlockScannerImpl::new();
+        scanner_mock_config(&mut scanner);
 
         let mut store = MockTransactionStore::new();
         store.expect_get_up_to().returning(|_| Ok(vec![]));
         store_mock_config(&mut store);
 
         CardanoTransactionsImporter::new(
-            Arc::new(parser),
+            Arc::new(scanner),
             Arc::new(store),
             db_path,
             None,
@@ -168,9 +165,9 @@ mod tests {
         let up_to_beacon = 12;
 
         let importer = build_importer(
-            &|parser_mock| {
+            &|scanner_mock| {
                 let parsed_transactions = transactions.clone();
-                parser_mock
+                scanner_mock
                     .expect_parse()
                     .withf(move |_, from, until| from.is_none() && until == &up_to_beacon)
                     .return_once(move |_, _, _| Ok(parsed_transactions));
@@ -199,8 +196,8 @@ mod tests {
         let up_to_beacon = 12;
 
         let importer = build_importer(
-            &|parser_mock| {
-                parser_mock.expect_parse().never();
+            &|scanner_mock| {
+                scanner_mock.expect_parse().never();
             },
             &|store_mock| {
                 store_mock
@@ -227,9 +224,9 @@ mod tests {
         let up_to_beacon = 14;
 
         let importer = build_importer(
-            &|parser_mock| {
+            &|scanner_mock| {
                 let parsed_transactions = transactions[2..=3].to_vec();
-                parser_mock
+                scanner_mock
                     .expect_parse()
                     .withf(move |_, from, until| from == &Some(13) && until == &up_to_beacon)
                     .return_once(move |_, _, _| Ok(parsed_transactions));
@@ -265,13 +262,13 @@ mod tests {
         let importer = {
             let connection = cardano_tx_db_connection().unwrap();
             let parsed_transactions = transactions.clone();
-            let mut parser = MockTransactionParserImpl::new();
-            parser
+            let mut scanner = MockBlockScannerImpl::new();
+            scanner
                 .expect_parse()
                 .return_once(move |_, _, _| Ok(parsed_transactions));
 
             CardanoTransactionsImporter::new(
-                Arc::new(parser),
+                Arc::new(scanner),
                 Arc::new(CardanoTransactionRepository::new(Arc::new(connection))),
                 Path::new(""),
                 None,
@@ -305,7 +302,7 @@ mod tests {
                 .returning(move || Ok(Some(highest_stored_beacon)));
 
             CardanoTransactionsImporter::new(
-                Arc::new(MockTransactionParserImpl::new()),
+                Arc::new(MockBlockScannerImpl::new()),
                 Arc::new(store),
                 Path::new(""),
                 Some(rescan_offset as usize),

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -137,10 +137,8 @@ impl CardanoTransactionsImporter {
         };
 
         debug!(
-            self.logger,
-            "TransactionsImporter - computing Block Range Roots";
-            "start_block" => block_ranges.first().map(|br| br.start).unwrap_or(0),
-            "end_block" => block_ranges.last().map(|br| br.end).unwrap_or(0),
+            self.logger, "TransactionsImporter - computing Block Range Roots";
+            "start_block" => block_ranges.start(), "end_block" => block_ranges.end(),
         );
 
         let mut block_ranges_with_merkle_root: Vec<(BlockRange, MKTreeNode)> = vec![];

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -79,7 +79,13 @@ impl CardanoTransactionsImporter {
             return Ok(());
         }
 
-        let parsed_transactions = self.block_scanner.parse(&self.dirpath, from, until).await?;
+        // todo: temp algorithm, should be optimized to avoid loading all blocks & transactions
+        // at once in memory (probably using iterators)
+        let scanned_blocks = self.block_scanner.scan(&self.dirpath, from, until).await?;
+        let parsed_transactions: Vec<CardanoTransaction> = scanned_blocks
+            .into_iter()
+            .flat_map(|b| b.into_transactions())
+            .collect();
         debug!(
             self.logger,
             "TransactionsImporter retrieved '{}' Cardano transactions between immutables '{}' and '{until}'",
@@ -114,6 +120,8 @@ mod tests {
     use mockall::mock;
     use mockall::predicate::eq;
 
+    use mithril_common::cardano_block_scanner::ScannedBlock;
+
     use crate::database::repository::CardanoTransactionRepository;
     use crate::database::test_helper::cardano_tx_db_connection;
 
@@ -124,19 +132,23 @@ mod tests {
 
         #[async_trait]
         impl BlockScanner for BlockScannerImpl {
-            async fn parse(
+            async fn scan(
               &self,
               dirpath: &Path,
               from_immutable: Option<ImmutableFileNumber>,
               until_immutable: ImmutableFileNumber,
-            ) -> StdResult<Vec<CardanoTransaction>>;
+            ) -> StdResult<Vec<ScannedBlock>>;
         }
     }
 
-    fn build_importer(
-        scanner_mock_config: &dyn Fn(&mut MockBlockScannerImpl),
-        store_mock_config: &dyn Fn(&mut MockTransactionStore),
-    ) -> CardanoTransactionsImporter {
+    fn build_importer<TParser, TStore>(
+        scanner_mock_config: TParser,
+        store_mock_config: TStore,
+    ) -> CardanoTransactionsImporter
+    where
+        TParser: FnOnce(&mut MockBlockScannerImpl),
+        TStore: FnOnce(&mut MockTransactionStore),
+    {
         let db_path = Path::new("");
         let mut scanner = MockBlockScannerImpl::new();
         scanner_mock_config(&mut scanner);
@@ -156,23 +168,24 @@ mod tests {
 
     #[tokio::test]
     async fn if_nothing_stored_parse_and_store_all_transactions() {
-        let transactions = vec![
-            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-1", 11),
-            CardanoTransaction::new("tx_hash-2", 10, 20, "block_hash-1", 11),
-            CardanoTransaction::new("tx_hash-3", 20, 25, "block_hash-2", 12),
-            CardanoTransaction::new("tx_hash-4", 20, 30, "block_hash-2", 12),
+        let blocks = vec![
+            ScannedBlock::new("block_hash-1", 10, 15, 11, vec!["tx_hash-1", "tx_hash-2"]),
+            ScannedBlock::new("block_hash-2", 20, 25, 12, vec!["tx_hash-3", "tx_hash-4"]),
         ];
+        let transactions: Vec<CardanoTransaction> = blocks
+            .iter()
+            .flat_map(|b| b.clone().into_transactions())
+            .collect();
         let up_to_beacon = 12;
 
         let importer = build_importer(
-            &|scanner_mock| {
-                let parsed_transactions = transactions.clone();
+            |scanner_mock| {
                 scanner_mock
-                    .expect_parse()
+                    .expect_scan()
                     .withf(move |_, from, until| from.is_none() && until == &up_to_beacon)
-                    .return_once(move |_, _, _| Ok(parsed_transactions));
+                    .return_once(move |_, _, _| Ok(blocks));
             },
-            &|store_mock| {
+            |store_mock| {
                 let expected_stored_transactions = transactions.clone();
                 store_mock
                     .expect_get_highest_beacon()
@@ -196,10 +209,10 @@ mod tests {
         let up_to_beacon = 12;
 
         let importer = build_importer(
-            &|scanner_mock| {
-                scanner_mock.expect_parse().never();
+            |scanner_mock| {
+                scanner_mock.expect_scan().never();
             },
-            &|store_mock| {
+            |store_mock| {
                 store_mock
                     .expect_get_highest_beacon()
                     .returning(|| Ok(Some(12)));
@@ -215,23 +228,25 @@ mod tests {
 
     #[tokio::test]
     async fn if_all_half_are_stored_the_other_half_is_parsed_and_stored() {
-        let transactions = vec![
-            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-10", 11),
-            CardanoTransaction::new("tx_hash-2", 20, 20, "block_hash-20", 12),
-            CardanoTransaction::new("tx_hash-3", 30, 25, "block_hash-30", 13),
-            CardanoTransaction::new("tx_hash-4", 40, 30, "block_hash-40", 14),
+        let blocks = [
+            ScannedBlock::new("block_hash-1", 10, 15, 11, vec!["tx_hash-1", "tx_hash-2"]),
+            ScannedBlock::new("block_hash-2", 20, 25, 12, vec!["tx_hash-3", "tx_hash-4"]),
         ];
+        let transactions: Vec<CardanoTransaction> = blocks
+            .iter()
+            .flat_map(|b| b.clone().into_transactions())
+            .collect();
         let up_to_beacon = 14;
 
         let importer = build_importer(
-            &|scanner_mock| {
-                let parsed_transactions = transactions[2..=3].to_vec();
+            |scanner_mock| {
+                let scanned_blocks = vec![blocks[1].clone()];
                 scanner_mock
-                    .expect_parse()
+                    .expect_scan()
                     .withf(move |_, from, until| from == &Some(13) && until == &up_to_beacon)
-                    .return_once(move |_, _, _| Ok(parsed_transactions));
+                    .return_once(move |_, _, _| Ok(scanned_blocks));
             },
-            &|store_mock| {
+            |store_mock| {
                 store_mock
                     .expect_get_highest_beacon()
                     .returning(|| Ok(Some(12)));
@@ -253,19 +268,18 @@ mod tests {
     #[tokio::test]
     async fn importing_twice_starting_with_nothing_in_a_real_db_should_yield_the_transactions_in_same_order(
     ) {
-        let transactions = vec![
-            CardanoTransaction::new("tx_hash-1", 10, 15, "block_hash-1", 11),
-            CardanoTransaction::new("tx_hash-2", 10, 20, "block_hash-1", 11),
-            CardanoTransaction::new("tx_hash-3", 20, 25, "block_hash-2", 12),
-            CardanoTransaction::new("tx_hash-4", 20, 30, "block_hash-2", 12),
+        let blocks = vec![
+            ScannedBlock::new("block_hash-1", 10, 15, 11, vec!["tx_hash-1", "tx_hash-2"]),
+            ScannedBlock::new("block_hash-2", 20, 25, 12, vec!["tx_hash-3", "tx_hash-4"]),
         ];
+        let transactions: Vec<CardanoTransaction> = blocks
+            .iter()
+            .flat_map(|b| b.clone().into_transactions())
+            .collect();
         let importer = {
             let connection = cardano_tx_db_connection().unwrap();
-            let parsed_transactions = transactions.clone();
             let mut scanner = MockBlockScannerImpl::new();
-            scanner
-                .expect_parse()
-                .return_once(move |_, _, _| Ok(parsed_transactions));
+            scanner.expect_scan().return_once(move |_, _, _| Ok(blocks));
 
             CardanoTransactionsImporter::new(
                 Arc::new(scanner),

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -13,6 +13,10 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore", "openapi.yaml"]
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [[bench]]
+name = "block_range"
+harness = false
+
+[[bench]]
 name = "digester"
 harness = false
 required-features = ["fs"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.3.33"
+version = "0.3.34"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/benches/block_range.rs
+++ b/mithril-common/benches/block_range.rs
@@ -1,0 +1,29 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+
+use mithril_common::entities::BlockRange;
+
+fn all_block_ranges_in(c: &mut Criterion) {
+    let mut group = c.benchmark_group("all_block_ranges_in");
+    for end_bound in [
+        BlockRange::LENGTH * 100,
+        BlockRange::LENGTH * 10_000,
+        BlockRange::LENGTH * 10_000_000,
+        BlockRange::LENGTH * 10_000_000_000,
+    ] {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(format!("0..{end_bound}")),
+            &end_bound,
+            |b, &end_bound| {
+                b.iter(|| BlockRange::all_block_ranges_in(0..end_bound));
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    name = benches;
+    config = Criterion::default().sample_size(100);
+    targets = all_block_ranges_in
+);
+criterion_main!(benches);

--- a/mithril-common/src/cardano_block_scanner.rs
+++ b/mithril-common/src/cardano_block_scanner.rs
@@ -62,7 +62,7 @@ pub trait BlockScanner: Sync + Send {
     ) -> StdResult<Vec<ScannedBlock>>;
 }
 
-/// Dumb transaction parser
+/// Dumb Block Scanner
 pub struct DumbBlockScanner {
     blocks: RwLock<Vec<ScannedBlock>>,
 }
@@ -161,7 +161,7 @@ impl ScannedBlock {
     }
 }
 
-/// Cardano transaction parser
+/// Cardano block scanner
 pub struct CardanoBlockScanner {
     logger: Logger,
     /// When set to true, no error is returned in case of unparsable block, and an error log is written instead.

--- a/mithril-common/src/entities/block_range.rs
+++ b/mithril-common/src/entities/block_range.rs
@@ -58,8 +58,8 @@ impl BlockRange {
         Self::start_with_length(number, Self::LENGTH)
     }
 
-    /// Get all [BlockRange] contained in the given interval
-    pub fn all_ranges_in(interval: Range<BlockNumber>) -> Vec<BlockRange> {
+    /// Get all [BlockRange] strictly contained in the given interval
+    pub fn all_block_ranges_in(interval: Range<BlockNumber>) -> Vec<BlockRange> {
         let all_numbers: Vec<BlockNumber> =
             interval.skip_while(|i| i % Self::LENGTH != 0).collect();
         all_numbers
@@ -213,29 +213,29 @@ mod tests {
     }
 
     #[test]
-    fn test_block_range_all_ranges_in() {
-        assert_eq!(BlockRange::all_ranges_in(0..0), vec![]);
-        assert_eq!(BlockRange::all_ranges_in(0..1), vec![]);
-        assert_eq!(BlockRange::all_ranges_in(0..14), vec![]);
-        assert_eq!(BlockRange::all_ranges_in(1..15), vec![]);
+    fn test_block_range_all_block_ranges_in() {
+        assert_eq!(BlockRange::all_block_ranges_in(0..0), vec![]);
+        assert_eq!(BlockRange::all_block_ranges_in(0..1), vec![]);
+        assert_eq!(BlockRange::all_block_ranges_in(0..14), vec![]);
+        assert_eq!(BlockRange::all_block_ranges_in(1..15), vec![]);
         assert_eq!(
-            BlockRange::all_ranges_in(0..15),
+            BlockRange::all_block_ranges_in(0..15),
             vec![BlockRange::new(0, 15)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(0..16),
+            BlockRange::all_block_ranges_in(0..16),
             vec![BlockRange::new(0, 15)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(14..30),
+            BlockRange::all_block_ranges_in(14..30),
             vec![BlockRange::new(15, 30)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(14..31),
+            BlockRange::all_block_ranges_in(14..31),
             vec![BlockRange::new(15, 30)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(14..61),
+            BlockRange::all_block_ranges_in(14..61),
             vec![
                 BlockRange::new(15, 30),
                 BlockRange::new(30, 45),

--- a/mithril-common/src/entities/block_range.rs
+++ b/mithril-common/src/entities/block_range.rs
@@ -179,6 +179,11 @@ impl BlockRangesSequence {
         self.end
     }
 
+    /// Returns `true` if range is contained in the sequence.
+    pub fn contains(&self, range: &Range<BlockNumber>) -> bool {
+        self.start <= range.start && range.end <= self.end
+    }
+
     /// Returns `true` if the block ranges sequence contains no elements.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
@@ -336,6 +341,20 @@ mod tests {
             BlockRange::all_block_ranges_in(0..(BlockRange::LENGTH * 15)).len(),
             15
         );
+    }
+
+    #[test]
+    fn test_block_ranges_sequence_contains() {
+        let block_range = BlockRange::new(15, 30);
+        assert!(BlockRange::all_block_ranges_in(0..15)
+            .contains(&block_range)
+            .not());
+        assert!(BlockRange::all_block_ranges_in(30..60)
+            .contains(&block_range)
+            .not());
+        assert!(BlockRange::all_block_ranges_in(0..30).contains(&block_range));
+        assert!(BlockRange::all_block_ranges_in(15..30).contains(&block_range));
+        assert!(BlockRange::all_block_ranges_in(15..45).contains(&block_range));
     }
 
     #[test]

--- a/mithril-common/src/entities/block_range.rs
+++ b/mithril-common/src/entities/block_range.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     cmp::Ordering,
     fmt::{Display, Formatter, Result},
-    ops::{Deref, Range, RangeInclusive},
+    ops::{Deref, Range},
 };
 
 use crate::{
@@ -59,7 +59,7 @@ impl BlockRange {
     }
 
     /// Get all [BlockRange] contained in the given interval
-    pub fn all_ranges_in(interval: RangeInclusive<BlockNumber>) -> Vec<BlockRange> {
+    pub fn all_ranges_in(interval: Range<BlockNumber>) -> Vec<BlockRange> {
         let all_numbers: Vec<BlockNumber> =
             interval.skip_while(|i| i % Self::LENGTH != 0).collect();
         all_numbers
@@ -214,26 +214,28 @@ mod tests {
 
     #[test]
     fn test_block_range_all_ranges_in() {
-        assert_eq!(BlockRange::all_ranges_in(0..=0), vec![]);
-        assert_eq!(BlockRange::all_ranges_in(1..=16), vec![]);
+        assert_eq!(BlockRange::all_ranges_in(0..0), vec![]);
+        assert_eq!(BlockRange::all_ranges_in(0..1), vec![]);
+        assert_eq!(BlockRange::all_ranges_in(0..14), vec![]);
+        assert_eq!(BlockRange::all_ranges_in(1..15), vec![]);
         assert_eq!(
-            BlockRange::all_ranges_in(0..=15),
+            BlockRange::all_ranges_in(0..15),
             vec![BlockRange::new(0, 15)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(0..=16),
+            BlockRange::all_ranges_in(0..16),
             vec![BlockRange::new(0, 15)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(14..=29),
+            BlockRange::all_ranges_in(14..30),
             vec![BlockRange::new(15, 30)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(14..=30),
+            BlockRange::all_ranges_in(14..31),
             vec![BlockRange::new(15, 30)]
         );
         assert_eq!(
-            BlockRange::all_ranges_in(14..=61),
+            BlockRange::all_ranges_in(14..61),
             vec![
                 BlockRange::new(15, 30),
                 BlockRange::new(30, 45),

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -24,7 +24,7 @@ mod snapshot;
 mod time_point;
 mod type_alias;
 
-pub use block_range::{BlockRange, BlockRangeLength};
+pub use block_range::{BlockRange, BlockRangeLength, BlockRangesSequence};
 pub use cardano_chain_point::{BlockHash, BlockNumber, ChainPoint, SlotNumber};
 pub use cardano_db_beacon::CardanoDbBeacon;
 pub use cardano_network::CardanoNetwork;

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -68,7 +68,7 @@ cfg_test_tools! {
 cfg_fs! {
     mod time_point_provider;
     pub mod digesters;
-    pub mod cardano_transaction_parser;
+    pub mod cardano_block_scanner;
 
     pub use time_point_provider::{TimePointProvider, TimePointProviderImpl};
 }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.126"
+version = "0.2.127"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -182,7 +182,7 @@ mod tests {
 
     use mithril_common::cardano_block_scanner::{DumbBlockScanner, ScannedBlock};
     use mithril_common::crypto_helper::MKTree;
-    use mithril_common::entities::BlockNumber;
+    use mithril_common::entities::{BlockNumber, BlockRangesSequence};
 
     use crate::database::repository::CardanoTransactionRepository;
     use crate::database::test_utils::cardano_tx_db_connection;
@@ -534,8 +534,8 @@ mod tests {
                 // Upper bound should be the block number of the highest transaction in a db that can be
                 // included in a block range
                 .withf(|range| {
-                    let expected_range = BlockRange::LENGTH..=(BlockRange::LENGTH * 5);
-                    expected_range.contains(&range.start) && expected_range.contains(&range.end)
+                    BlockRangesSequence::new(BlockRange::LENGTH..(BlockRange::LENGTH * 5))
+                        .contains(range)
                 })
                 .returning(transactions_for_block);
             store_mock

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -137,10 +137,8 @@ impl CardanoTransactionsImporter {
         };
 
         debug!(
-            self.logger,
-            "TransactionsImporter - computing Block Range Roots";
-            "start_block" => block_ranges.first().map(|br| br.start).unwrap_or(0),
-            "end_block" => block_ranges.last().map(|br| br.end).unwrap_or(0),
+            self.logger, "TransactionsImporter - computing Block Range Roots";
+            "start_block" => block_ranges.start(), "end_block" => block_ranges.end(),
         );
 
         let mut block_ranges_with_merkle_root: Vec<(BlockRange, MKTreeNode)> = vec![];

--- a/mithril-signer/src/database/cardano_transaction_migration.rs
+++ b/mithril-signer/src/database/cardano_transaction_migration.rs
@@ -59,5 +59,18 @@ vacuum;
 create index block_number_index on cardano_tx(block_number);
 "#,
         ),
+        // Migration 5
+        // Add `block_range_root` table
+        SqlMigration::new(
+            5,
+            r#"
+create table block_range_root (
+    start         integer   not null,
+    end           integer   not null,
+    merkle_root   text      not null,
+    primary key (start, end)
+);
+"#,
+        ),
     ]
 }

--- a/mithril-signer/src/database/provider/block_range_root/get_block_range_root.rs
+++ b/mithril-signer/src/database/provider/block_range_root/get_block_range_root.rs
@@ -29,6 +29,6 @@ impl<'client> Provider<'client> for GetBlockRangeRootProvider<'client> {
         let aliases = SourceAlias::new(&[("{:block_range_root:}", "block_range_root")]);
         let projection = Self::Entity::get_projection().expand(aliases);
 
-        format!("select {projection} from block_range_root where {condition} order by rowid")
+        format!("select {projection} from block_range_root where {condition} order by start, end")
     }
 }

--- a/mithril-signer/src/database/provider/block_range_root/get_block_range_root.rs
+++ b/mithril-signer/src/database/provider/block_range_root/get_block_range_root.rs
@@ -1,0 +1,34 @@
+use mithril_persistence::sqlite::{Provider, SourceAlias, SqLiteEntity, SqliteConnection};
+
+use crate::database::record::BlockRangeRootRecord;
+
+/// Simple queries to retrieve [BlockRangeRootRecord] from the sqlite database.
+pub struct GetBlockRangeRootProvider<'client> {
+    connection: &'client SqliteConnection,
+}
+
+impl<'client> GetBlockRangeRootProvider<'client> {
+    #[cfg(test)]
+    /// Create a new instance
+    pub fn new(connection: &'client SqliteConnection) -> Self {
+        Self { connection }
+    }
+}
+
+#[cfg(test)]
+impl mithril_persistence::sqlite::GetAllCondition for GetBlockRangeRootProvider<'_> {}
+
+impl<'client> Provider<'client> for GetBlockRangeRootProvider<'client> {
+    type Entity = BlockRangeRootRecord;
+
+    fn get_connection(&'client self) -> &'client SqliteConnection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[("{:block_range_root:}", "block_range_root")]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+
+        format!("select {projection} from block_range_root where {condition} order by rowid")
+    }
+}

--- a/mithril-signer/src/database/provider/block_range_root/get_interval_without_block_range_provider.rs
+++ b/mithril-signer/src/database/provider/block_range_root/get_interval_without_block_range_provider.rs
@@ -1,0 +1,43 @@
+use mithril_persistence::sqlite::{
+    Provider, SourceAlias, SqLiteEntity, SqliteConnection, WhereCondition,
+};
+
+use crate::database::record::IntervalWithoutBlockRangeRootRecord;
+
+/// Query that return the interval of block numbers that does not have a block range root.
+pub struct GetIntervalWithoutBlockRangeRootProvider<'client> {
+    connection: &'client SqliteConnection,
+}
+
+impl<'client> GetIntervalWithoutBlockRangeRootProvider<'client> {
+    /// Create a new instance
+    pub fn new(connection: &'client SqliteConnection) -> Self {
+        Self { connection }
+    }
+
+    pub fn get_interval_without_block_range_condition(&self) -> WhereCondition {
+        WhereCondition::default()
+    }
+}
+
+impl<'client> Provider<'client> for GetIntervalWithoutBlockRangeRootProvider<'client> {
+    type Entity = IntervalWithoutBlockRangeRootRecord;
+
+    fn get_connection(&'client self) -> &'client SqliteConnection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[
+            ("{:interval_start:}", "interval_start"),
+            ("{:interval_end:}", "interval_end"),
+        ]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+
+        format!(
+            "select {projection} from \
+        (select max(end) as start from block_range_root where {condition}) as interval_start, \
+        (select max(block_number) as end from cardano_tx where {condition}) as interval_end"
+        )
+    }
+}

--- a/mithril-signer/src/database/provider/block_range_root/insert_block_range.rs
+++ b/mithril-signer/src/database/provider/block_range_root/insert_block_range.rs
@@ -1,0 +1,65 @@
+use std::iter::repeat;
+
+use sqlite::Value;
+
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{
+    Provider, SourceAlias, SqLiteEntity, SqliteConnection, WhereCondition,
+};
+
+use crate::database::record::BlockRangeRootRecord;
+
+/// Query to insert [BlockRangeRootRecord] in the sqlite database
+pub struct InsertBlockRangeRootProvider<'client> {
+    connection: &'client SqliteConnection,
+}
+
+impl<'client> InsertBlockRangeRootProvider<'client> {
+    /// Create a new instance
+    pub fn new(connection: &'client SqliteConnection) -> Self {
+        Self { connection }
+    }
+
+    /// Condition to insert multiples records.
+    pub fn get_insert_many_condition(
+        &self,
+        block_range_records: Vec<BlockRangeRootRecord>,
+    ) -> StdResult<WhereCondition> {
+        let columns = "(start, end, merkle_root)";
+        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*)")
+            .take(block_range_records.len())
+            .collect();
+
+        let values: StdResult<Vec<Value>> =
+            block_range_records
+                .into_iter()
+                .try_fold(vec![], |mut vec, record| {
+                    vec.append(&mut vec![
+                        Value::Integer(record.range.start.try_into()?),
+                        Value::Integer(record.range.end.try_into()?),
+                        Value::String(record.merkle_root.to_hex()),
+                    ]);
+                    Ok(vec)
+                });
+
+        Ok(WhereCondition::new(
+            format!("{columns} values {}", values_columns.join(", ")).as_str(),
+            values?,
+        ))
+    }
+}
+
+impl<'client> Provider<'client> for InsertBlockRangeRootProvider<'client> {
+    type Entity = BlockRangeRootRecord;
+
+    fn get_connection(&'client self) -> &'client SqliteConnection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[("{:block_range_root:}", "block_range_root")]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+
+        format!("insert or ignore into block_range_root {condition} returning {projection}")
+    }
+}

--- a/mithril-signer/src/database/provider/block_range_root/mod.rs
+++ b/mithril-signer/src/database/provider/block_range_root/mod.rs
@@ -1,0 +1,8 @@
+mod get_block_range_root;
+mod get_interval_without_block_range_provider;
+mod insert_block_range;
+
+#[cfg(test)]
+pub use get_block_range_root::*;
+pub use get_interval_without_block_range_provider::*;
+pub use insert_block_range::*;

--- a/mithril-signer/src/database/provider/cardano_transaction/get_cardano_transaction.rs
+++ b/mithril-signer/src/database/provider/cardano_transaction/get_cardano_transaction.rs
@@ -1,6 +1,7 @@
 use sqlite::Value;
+use std::ops::RangeInclusive;
 
-use mithril_common::entities::{ImmutableFileNumber, TransactionHash};
+use mithril_common::entities::{BlockNumber, ImmutableFileNumber, TransactionHash};
 use mithril_persistence::sqlite::{
     Provider, SourceAlias, SqLiteEntity, SqliteConnection, WhereCondition,
 };
@@ -37,6 +38,20 @@ impl<'client> GetCardanoTransactionProvider<'client> {
             "immutable_file_number <= ?*",
             vec![Value::Integer(beacon as i64)],
         )
+    }
+
+    pub fn get_transaction_between_blocks_condition(
+        &self,
+        range: RangeInclusive<BlockNumber>,
+    ) -> WhereCondition {
+        WhereCondition::new(
+            "block_number >= ?*",
+            vec![Value::Integer(*range.start() as i64)],
+        )
+        .and_where(WhereCondition::new(
+            "block_number <= ?*",
+            vec![Value::Integer(*range.end() as i64)],
+        ))
     }
 }
 

--- a/mithril-signer/src/database/provider/cardano_transaction/get_cardano_transaction.rs
+++ b/mithril-signer/src/database/provider/cardano_transaction/get_cardano_transaction.rs
@@ -1,5 +1,5 @@
 use sqlite::Value;
-use std::ops::RangeInclusive;
+use std::ops::Range;
 
 use mithril_common::entities::{BlockNumber, ImmutableFileNumber, TransactionHash};
 use mithril_persistence::sqlite::{
@@ -42,15 +42,15 @@ impl<'client> GetCardanoTransactionProvider<'client> {
 
     pub fn get_transaction_between_blocks_condition(
         &self,
-        range: RangeInclusive<BlockNumber>,
+        range: Range<BlockNumber>,
     ) -> WhereCondition {
         WhereCondition::new(
             "block_number >= ?*",
-            vec![Value::Integer(*range.start() as i64)],
+            vec![Value::Integer(range.start as i64)],
         )
         .and_where(WhereCondition::new(
-            "block_number <= ?*",
-            vec![Value::Integer(*range.end() as i64)],
+            "block_number < ?*",
+            vec![Value::Integer(range.end as i64)],
         ))
     }
 }

--- a/mithril-signer/src/database/provider/mod.rs
+++ b/mithril-signer/src/database/provider/mod.rs
@@ -1,5 +1,7 @@
 //! Signer related database providers
 
+mod block_range_root;
 mod cardano_transaction;
 
+pub use block_range_root::*;
 pub use cardano_transaction::*;

--- a/mithril-signer/src/database/record/block_range_root.rs
+++ b/mithril-signer/src/database/record/block_range_root.rs
@@ -11,8 +11,7 @@ use crate::database::record::hydrator::try_to_u64;
 pub struct BlockRangeRootRecord {
     /// Range of block numbers covered
     pub range: BlockRange,
-    /// Merkle root of the block range, computed from the list of all transactions that are
-    /// included in the range
+    /// Merkle root of the block range, computed from the list of included transactions
     pub merkle_root: MKTreeNode,
 }
 

--- a/mithril-signer/src/database/record/block_range_root.rs
+++ b/mithril-signer/src/database/record/block_range_root.rs
@@ -1,0 +1,61 @@
+use sqlite::Row;
+
+use mithril_common::crypto_helper::MKTreeNode;
+use mithril_common::entities::BlockRange;
+use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
+
+use crate::database::record::hydrator::try_to_u64;
+
+/// Block range root record is the representation of block range with its merkle root precomputed.
+#[derive(Debug, PartialEq, Clone)]
+pub struct BlockRangeRootRecord {
+    /// Range of block numbers covered
+    pub range: BlockRange,
+    /// Merkle root of the block range, computed from the list of all transactions that are
+    /// included in the range
+    pub merkle_root: MKTreeNode,
+}
+
+impl From<(BlockRange, MKTreeNode)> for BlockRangeRootRecord {
+    fn from(value: (BlockRange, MKTreeNode)) -> Self {
+        Self {
+            range: value.0,
+            merkle_root: value.1,
+        }
+    }
+}
+
+impl From<BlockRangeRootRecord> for (BlockRange, MKTreeNode) {
+    fn from(value: BlockRangeRootRecord) -> Self {
+        (value.range, value.merkle_root)
+    }
+}
+
+impl SqLiteEntity for BlockRangeRootRecord {
+    fn hydrate(row: Row) -> Result<Self, HydrationError>
+    where
+        Self: Sized,
+    {
+        let start = try_to_u64("block_range.start", row.read::<i64, _>(0))?;
+        let _end = try_to_u64("block_range.end", row.read::<i64, _>(1))?;
+        let merkle_root = row.read::<&str, _>(2);
+
+        Ok(Self {
+            range: BlockRange::from_block_number(start),
+            merkle_root: MKTreeNode::from_hex(merkle_root)
+                .map_err(|e| HydrationError::InvalidData(
+                    format!(
+                        "Field block_range.merkle_root (value={merkle_root}) is incompatible with hex representation. Error = {e}")
+                )
+            )?,
+        })
+    }
+
+    fn get_projection() -> Projection {
+        Projection::from(&[
+            ("start", "{:block_range_root:}.start", "int"),
+            ("end", "{:block_range_root:}.end", "int"),
+            ("merkle_root", "{:block_range_root:}.merkle_root", "text"),
+        ])
+    }
+}

--- a/mithril-signer/src/database/record/block_range_root.rs
+++ b/mithril-signer/src/database/record/block_range_root.rs
@@ -36,11 +36,19 @@ impl SqLiteEntity for BlockRangeRootRecord {
         Self: Sized,
     {
         let start = try_to_u64("block_range.start", row.read::<i64, _>(0))?;
-        let _end = try_to_u64("block_range.end", row.read::<i64, _>(1))?;
+        let end = try_to_u64("block_range.end", row.read::<i64, _>(1))?;
+        let range = BlockRange::from_block_number(start);
         let merkle_root = row.read::<&str, _>(2);
 
+        if range.start != start || range.end != end {
+            return Err(HydrationError::InvalidData(format!(
+                "Invalid block range: start={start}, end={end}, expected_start={}, expected_end={}",
+                range.start, range.end
+            )));
+        }
+
         Ok(Self {
-            range: BlockRange::from_block_number(start),
+            range,
             merkle_root: MKTreeNode::from_hex(merkle_root)
                 .map_err(|e| HydrationError::InvalidData(
                     format!(
@@ -56,5 +64,56 @@ impl SqLiteEntity for BlockRangeRootRecord {
             ("end", "{:block_range_root:}.end", "int"),
             ("merkle_root", "{:block_range_root:}.merkle_root", "text"),
         ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mithril_common::entities::BlockNumber;
+    use sqlite::Connection;
+
+    fn select_block_range_from_db(start: BlockNumber, end: BlockNumber, merkle_root: &str) -> Row {
+        let conn = Connection::open(":memory:").unwrap();
+        let query = format!("SELECT {start}, {end}, '{merkle_root}'");
+        let mut statement = conn.prepare(query).unwrap();
+        statement.iter().next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn hydrate_succeed_if_valid_block_range_in_row() {
+        // A valid block range has both bounds as multiples of block range length and the interval
+        // size is equal to block range length.
+        let row = select_block_range_from_db(0, BlockRange::LENGTH, "AAAA");
+        let res = BlockRangeRootRecord::hydrate(row).expect("Expected hydrate to succeed");
+
+        assert_eq!(
+            res,
+            BlockRangeRootRecord {
+                range: BlockRange::from_block_number(0),
+                merkle_root: MKTreeNode::from_hex("AAAA").unwrap(),
+            }
+        );
+    }
+
+    #[test]
+    fn hydrate_fail_if_invalid_block_range_in_row() {
+        for invalid_row in [
+            // Start is not a multiple of block range length
+            select_block_range_from_db(1, BlockRange::LENGTH, "AAAA"),
+            // End is not a multiple of block range length
+            select_block_range_from_db(0, BlockRange::LENGTH - 1, "AAAA"),
+            // Interval is not equal to block range length
+            select_block_range_from_db(0, BlockRange::LENGTH * 4, "AAAA"),
+        ] {
+            let res =
+                BlockRangeRootRecord::hydrate(invalid_row).expect_err("Expected hydrate to fail");
+
+            assert!(
+                format!("{res:?}").contains("Invalid block range"),
+                "Expected 'Invalid block range' error, got {:?}",
+                res
+            );
+        }
     }
 }

--- a/mithril-signer/src/database/record/cardano_transaction.rs
+++ b/mithril-signer/src/database/record/cardano_transaction.rs
@@ -5,6 +5,8 @@ use mithril_common::entities::{
 };
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
+use crate::database::record::hydrator::try_to_u64;
+
 /// Cardano Transaction record is the representation of a cardano transaction.
 #[derive(Debug, PartialEq, Clone)]
 pub struct CardanoTransactionRecord {
@@ -53,17 +55,12 @@ impl SqLiteEntity for CardanoTransactionRecord {
     where
         Self: Sized,
     {
-        // TODO: generalize this method to other hydrator
-        fn try_to_u64(field: &str, value: i64) -> Result<u64, HydrationError> {
-            u64::try_from(value)
-                .map_err(|e| HydrationError::InvalidData(format!("Integer field cardano_tx.{field} (value={value}) is incompatible with u64 representation. Error = {e}")))
-        }
-
         let transaction_hash = row.read::<&str, _>(0);
-        let block_number = try_to_u64("block_number", row.read::<i64, _>(1))?;
-        let slot_number = try_to_u64("slot_number", row.read::<i64, _>(2))?;
+        let block_number = try_to_u64("cardano_tx.block_number", row.read::<i64, _>(1))?;
+        let slot_number = try_to_u64("cardano_tx.slot_number", row.read::<i64, _>(2))?;
         let block_hash = row.read::<&str, _>(3);
-        let immutable_file_number = try_to_u64("immutable_file_number", row.read::<i64, _>(4))?;
+        let immutable_file_number =
+            try_to_u64("cardano_tx.immutable_file_number", row.read::<i64, _>(4))?;
 
         Ok(Self {
             transaction_hash: transaction_hash.to_string(),

--- a/mithril-signer/src/database/record/interval_without_block_range_root.rs
+++ b/mithril-signer/src/database/record/interval_without_block_range_root.rs
@@ -1,0 +1,39 @@
+use sqlite::Row;
+
+use mithril_common::entities::BlockNumber;
+use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
+
+use crate::database::record::hydrator::try_to_u64;
+
+/// Interval of block numbers without block ranges root.
+pub struct IntervalWithoutBlockRangeRootRecord {
+    /// Start of the interval
+    pub start: Option<BlockNumber>,
+    /// End of the interval
+    pub end: Option<BlockNumber>,
+}
+
+impl SqLiteEntity for IntervalWithoutBlockRangeRootRecord {
+    fn hydrate(row: Row) -> Result<Self, HydrationError>
+    where
+        Self: Sized,
+    {
+        let start = row
+            .read::<Option<i64>, _>(0)
+            .map(|v| try_to_u64("interval_start.start", v))
+            .transpose()?;
+        let end = row
+            .read::<Option<i64>, _>(1)
+            .map(|v| try_to_u64("interval_end.end", v))
+            .transpose()?;
+
+        Ok(Self { start, end })
+    }
+
+    fn get_projection() -> Projection {
+        Projection::from(&[
+            ("start", "{:interval_start:}.start", "int"),
+            ("end", "{:interval_end:}.end", "int"),
+        ])
+    }
+}

--- a/mithril-signer/src/database/record/interval_without_block_range_root.rs
+++ b/mithril-signer/src/database/record/interval_without_block_range_root.rs
@@ -1,16 +1,43 @@
+use std::ops::Range;
+
+use anyhow::anyhow;
 use sqlite::Row;
 
 use mithril_common::entities::BlockNumber;
+use mithril_common::StdResult;
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
 use crate::database::record::hydrator::try_to_u64;
 
 /// Interval of block numbers (`[start, end[`) without block ranges root.
 pub struct IntervalWithoutBlockRangeRootRecord {
-    /// Start of the interval
+    /// Start of the interval, fetched from the last block range root end
     pub start: Option<BlockNumber>,
-    /// End of the interval
+    /// End of the interval, fetched from the last transaction block number
     pub end: Option<BlockNumber>,
+}
+
+impl IntervalWithoutBlockRangeRootRecord {
+    /// Deduce from self the range of blocks that are available to compute block range roots.
+    pub fn to_range(&self) -> StdResult<Option<Range<BlockNumber>>> {
+        match (self.start, self.end) {
+            // No transactions stored - nothing can be computed
+            (_, None) => Ok(None),
+            // Transactions stored but no block range root - everything can be computed
+            (None, Some(end)) => Ok(Some(0..(end + 1))),
+            // Last stored transactions is at the end of the last block range - nothing to compute
+            (Some(start), Some(end)) if (end + 1) == start => Ok(None),
+            (Some(start), Some(end)) if end < start => {
+                Err(anyhow!(
+                        "Inconsistent state: \
+                        Last block range root block number ({start}) is higher than the last transaction block number ({end}). \
+                        Did you forgot to prune obsolete `block_range_root` after a transaction rollback ?"
+                    ))
+            }
+            // Nominal case
+            (Some(start), Some(end)) => Ok(Some(start..(end + 1))),
+        }
+    }
 }
 
 impl SqLiteEntity for IntervalWithoutBlockRangeRootRecord {
@@ -35,5 +62,82 @@ impl SqLiteEntity for IntervalWithoutBlockRangeRootRecord {
             ("start", "{:interval_start:}.start", "int"),
             ("end", "{:interval_end:}.end", "int"),
         ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn db_without_block_range_nor_transactions_yield_none() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: None,
+            end: None,
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(None, range);
+    }
+
+    #[test]
+    fn db_with_only_transactions_yield_a_range() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: None,
+            end: Some(10),
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(Some(0..11), range);
+    }
+
+    #[test]
+    fn db_with_only_block_range_and_no_transactions_yield_none() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: Some(10),
+            end: None,
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(None, range);
+    }
+
+    #[test]
+    fn db_with_both_block_range_and_transactions_yield_a_range() {
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: Some(2),
+            end: Some(10),
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(Some(2..11), range);
+    }
+
+    #[test]
+    fn db_with_last_transaction_block_number_right_at_the_end_of_the_last_block_range_yield_none() {
+        // Reminder: the end of the block range is exclusive
+        let range = IntervalWithoutBlockRangeRootRecord {
+            start: Some(10),
+            end: Some(9),
+        }
+        .to_range()
+        .unwrap();
+        assert_eq!(None, range);
+    }
+
+    #[test]
+    fn db_with_last_transaction_block_number_below_the_end_of_the_last_block_range_yield_an_error()
+    {
+        // Reminder: the end of the block range is exclusive
+        let res = IntervalWithoutBlockRangeRootRecord {
+            start: Some(10),
+            end: Some(8),
+        }
+        .to_range()
+        .unwrap_err();
+        assert!(
+            format!("{res:?}").contains("Inconsistent state"),
+            "Expected 'Inconsistent state' error, got {res:?}",
+        );
     }
 }

--- a/mithril-signer/src/database/record/interval_without_block_range_root.rs
+++ b/mithril-signer/src/database/record/interval_without_block_range_root.rs
@@ -5,7 +5,7 @@ use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
 use crate::database::record::hydrator::try_to_u64;
 
-/// Interval of block numbers without block ranges root.
+/// Interval of block numbers (`[start, end[`) without block ranges root.
 pub struct IntervalWithoutBlockRangeRootRecord {
     /// Start of the interval
     pub start: Option<BlockNumber>,

--- a/mithril-signer/src/database/record/mod.rs
+++ b/mithril-signer/src/database/record/mod.rs
@@ -1,5 +1,23 @@
 //! Signer related database records
 
+mod block_range_root;
 mod cardano_transaction;
+mod interval_without_block_range_root;
 
+pub use block_range_root::*;
 pub use cardano_transaction::*;
+pub use interval_without_block_range_root::*;
+
+// TODO: this probably should be in `mithril-persistence` crate
+pub(crate) mod hydrator {
+    use mithril_persistence::sqlite::HydrationError;
+
+    pub fn try_to_u64(field: &str, value: i64) -> Result<u64, HydrationError> {
+        u64::try_from(value)
+            .map_err(|e|
+                HydrationError::InvalidData(
+                    format!("Integer field {field} (value={value}) is incompatible with u64 representation. Error = {e}")
+                )
+            )
+    }
+}

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -262,25 +262,30 @@ mod tests {
         let connection = Arc::new(cardano_tx_db_connection().unwrap());
         let repository = CardanoTransactionRepository::new(connection);
         repository
-            .create_transaction("tx-hash-123", 10, 50, "block_hash-123", 99)
+            .create_transactions(vec![
+                CardanoTransaction::new("tx_hash-123", 10, 50, "block_hash-123", 99),
+                CardanoTransaction::new("tx_hash-456", 11, 51, "block_hash-456", 100),
+            ])
             .await
             .unwrap();
-        repository
-            .create_transaction("tx-hash-456", 11, 51, "block_hash-456", 100)
-            .await
-            .unwrap();
-        let transaction_result = repository.get_transaction("tx-hash-123").await.unwrap();
 
-        assert_eq!(
-            Some(CardanoTransactionRecord {
-                transaction_hash: "tx-hash-123".to_string(),
-                block_number: 10,
-                slot_number: 50,
-                block_hash: "block_hash-123".to_string(),
-                immutable_file_number: 99
-            }),
-            transaction_result
-        );
+        {
+            let transaction_result = repository.get_transaction("tx_hash-123").await.unwrap();
+            assert_eq!(
+                Some(CardanoTransactionRecord {
+                    transaction_hash: "tx_hash-123".to_string(),
+                    block_number: 10,
+                    slot_number: 50,
+                    block_hash: "block_hash-123".to_string(),
+                    immutable_file_number: 99
+                }),
+                transaction_result
+            );
+        }
+        {
+            let transaction_result = repository.get_transaction("not-exist").await.unwrap();
+            assert_eq!(None, transaction_result);
+        }
     }
 
     #[tokio::test]

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -130,6 +130,20 @@ impl TransactionStore for CardanoTransactionRepository {
         }
     }
 
+    async fn get_block_interval_without_associated_block_range_and_merkle_root(
+        &self,
+    ) -> StdResult<Option<(BlockNumber, BlockNumber)>> {
+        todo!()
+    }
+
+    async fn get_transactions_between(
+        &self,
+        _start: BlockNumber,
+        _end: BlockNumber,
+    ) -> StdResult<Vec<CardanoTransaction>> {
+        todo!()
+    }
+
     async fn get_up_to(&self, beacon: ImmutableFileNumber) -> StdResult<Vec<CardanoTransaction>> {
         self.get_transactions_up_to(beacon).await.map(|v| {
             v.into_iter()

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -133,6 +133,24 @@ impl CardanoTransactionRepository {
     }
 }
 
+#[cfg(test)]
+pub mod test_extensions {
+    use mithril_persistence::sqlite::GetAllProvider;
+
+    use crate::database::provider::GetBlockRangeRootProvider;
+
+    use super::*;
+
+    impl CardanoTransactionRepository {
+        pub fn get_all_block_range_root(&self) -> StdResult<Vec<BlockRangeRootRecord>> {
+            let provider = GetBlockRangeRootProvider::new(&self.connection);
+            let records = provider.get_all()?;
+
+            Ok(records.collect())
+        }
+    }
+}
+
 #[async_trait]
 impl TransactionStore for CardanoTransactionRepository {
     async fn get_highest_beacon(&self) -> StdResult<Option<ImmutableFileNumber>> {

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -3,8 +3,10 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 
+use mithril_common::crypto_helper::MKTreeNode;
 use mithril_common::entities::{
-    BlockHash, BlockNumber, CardanoTransaction, ImmutableFileNumber, SlotNumber, TransactionHash,
+    BlockHash, BlockNumber, BlockRange, CardanoTransaction, ImmutableFileNumber, SlotNumber,
+    TransactionHash,
 };
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{Provider, SqliteConnection, WhereCondition};
@@ -144,6 +146,13 @@ impl TransactionStore for CardanoTransactionRepository {
                 .with_context(|| "CardanoTransactionRepository can not store transactions")?;
         }
         Ok(())
+    }
+
+    async fn store_block_ranges(
+        &self,
+        _block_ranges: Vec<(BlockRange, MKTreeNode)>,
+    ) -> StdResult<()> {
+        todo!()
     }
 }
 

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -213,11 +213,10 @@ impl TransactionStore for CardanoTransactionRepository {
                 (_, None) => Ok(None),
                 (None, Some(end)) => Ok(Some(0..(end + 1))),
                 (Some(start), Some(end)) if end < start => {
-                    // To discuss : should we prune all block ranges from the DB to force recompute ?
                     warn!(
                         "Last computed block range is higher than the last transaction block number. \
-                        This should not happen. Did you forgot to prune the `block_range` table after pruning the\
-                        `cardano_tx` table ?";
+                        This should not happen. Did you forgot to prune the `block_range_root` table \
+                        after pruning the `cardano_tx` table ?";
                         "start" => start, "end" => end
                     );
                     Ok(None)

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -242,7 +242,9 @@ impl TransactionStore for CardanoTransactionRepository {
         &self,
         block_ranges: Vec<(BlockRange, MKTreeNode)>,
     ) -> StdResult<()> {
-        self.create_block_ranges(block_ranges).await?;
+        if !block_ranges.is_empty() {
+            self.create_block_ranges(block_ranges).await?;
+        }
         Ok(())
     }
 }

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -1,3 +1,4 @@
+use std::ops::RangeInclusive;
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -138,8 +139,7 @@ impl TransactionStore for CardanoTransactionRepository {
 
     async fn get_transactions_between(
         &self,
-        _start: BlockNumber,
-        _end: BlockNumber,
+        range: RangeInclusive<BlockNumber>,
     ) -> StdResult<Vec<CardanoTransaction>> {
         todo!()
     }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -454,7 +454,7 @@ impl Runner for SignerRunner {
 mod tests {
     use mithril_common::{
         api_version::APIVersionProvider,
-        cardano_transaction_parser::DumbTransactionParser,
+        cardano_block_scanner::DumbBlockScanner,
         chain_observer::{ChainObserver, FakeObserver},
         crypto_helper::ProtocolInitializer,
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
@@ -534,7 +534,7 @@ mod tests {
             ));
         let mithril_stake_distribution_signable_builder =
             Arc::new(MithrilStakeDistributionSignableBuilder::default());
-        let transaction_parser = Arc::new(DumbTransactionParser::new(vec![]));
+        let transaction_parser = Arc::new(DumbBlockScanner::new(vec![]));
         let transaction_store = Arc::new(MockTransactionStore::new());
         let transaction_importer = Arc::new(CardanoTransactionsImporter::new(
             transaction_parser.clone(),

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -4,7 +4,7 @@ use std::{fs, sync::Arc, time::Duration};
 
 use mithril_common::{
     api_version::APIVersionProvider,
-    cardano_transaction_parser::CardanoTransactionParser,
+    cardano_block_scanner::CardanoBlockScanner,
     chain_observer::{CardanoCliRunner, ChainObserver, ChainObserverBuilder, ChainObserverType},
     crypto_helper::{OpCert, ProtocolPartyId, SerDeShelleyFileFormat},
     digesters::{
@@ -257,7 +257,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             ));
         let mithril_stake_distribution_signable_builder =
             Arc::new(MithrilStakeDistributionSignableBuilder::default());
-        let transaction_parser = Arc::new(CardanoTransactionParser::new(
+        let block_scanner = Arc::new(CardanoBlockScanner::new(
             slog_scope::logger(),
             self.config
                 .get_network()?
@@ -267,7 +267,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             transaction_sqlite_connection,
         ));
         let transactions_importer = CardanoTransactionsImporter::new(
-            transaction_parser,
+            block_scanner,
             transaction_store,
             &self.config.db_directory,
             // Rescan the last immutable when importing transactions, it may have been partially imported

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 
 use mithril_common::{
     api_version::APIVersionProvider,
-    cardano_transaction_parser::DumbTransactionParser,
+    cardano_block_scanner::DumbBlockScanner,
     chain_observer::{ChainObserver, FakeObserver},
     digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
     entities::{Epoch, SignerWithStake, TimePoint},
@@ -150,7 +150,7 @@ impl StateMachineTester {
             ));
         let mithril_stake_distribution_signable_builder =
             Arc::new(MithrilStakeDistributionSignableBuilder::default());
-        let transaction_parser = Arc::new(DumbTransactionParser::new(vec![]));
+        let transaction_parser = Arc::new(DumbBlockScanner::new(vec![]));
         let transaction_store = Arc::new(CardanoTransactionRepository::new(
             transaction_sqlite_connection,
         ));


### PR DESCRIPTION
## Content
This PR add block range root (aka a `BlockRange` and it's associated transactions merkle root) computation and storage.

This step is added to the `CardanoTransactionImporter` of signer & aggregator nodes after the import of the transactions.

Other changes:
- `mithril-common`: Change and rename the `TransactionParser` into a `BlockScanner` that returns a dedicated type `ScannedBlock` that can be converted into a list of transactions. This simplify the next refactor to make it stream the blocks in order to lessen the scanning footprint (#1646).
- `mithril-persistence`: Add a system to add quickly a `get_all` method to a type that implement the `Provider` trait. You can now implement the `GetAllCondition` trait to the entity of the provider to automatically derive the `GetAllProvider` trait that define the `get_all` method.
 
## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1633
