### PR TITLE
Optimize block range roots computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,7 +3447,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.4.64"
+version = "0.4.65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3746,7 +3746,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.128"
+version = "0.2.129"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.4.64"
+version = "0.4.65"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -155,6 +156,14 @@ impl CardanoTransactionsImporter {
 
             let merkle_root = MKTree::new(&transactions)?.compute_root()?;
             block_ranges_with_merkle_root.push((block_range, merkle_root));
+
+            if block_ranges_with_merkle_root.len() >= 100 {
+                let block_ranges_with_merkle_root_save =
+                    mem::take(&mut block_ranges_with_merkle_root);
+                self.transaction_store
+                    .store_block_range_roots(block_ranges_with_merkle_root_save)
+                    .await?;
+            }
         }
 
         self.transaction_store

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.128"
+version = "0.2.129"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -1,3 +1,4 @@
+use std::mem;
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -155,6 +156,14 @@ impl CardanoTransactionsImporter {
 
             let merkle_root = MKTree::new(&transactions)?.compute_root()?;
             block_ranges_with_merkle_root.push((block_range, merkle_root));
+
+            if block_ranges_with_merkle_root.len() >= 100 {
+                let block_ranges_with_merkle_root_save =
+                    mem::take(&mut block_ranges_with_merkle_root);
+                self.transaction_store
+                    .store_block_range_roots(block_ranges_with_merkle_root_save)
+                    .await?;
+            }
         }
 
         self.transaction_store


### PR DESCRIPTION
## Content
This PR includes an optimization on the computation of the block range roots so that there is a limited accumulation of the computed root before they are stored in the database (in particular to avoid the error `variable number must be between ?1 and ?32766` from SQLite).

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1633 