### PR TITLE
Prune history of gh-pages branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -866,3 +866,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN || github.token }}
           publish_dir: ./github-pages
+          force_orphan: true


### PR DESCRIPTION
## Content

This will prune the git history and allow easier navigation using git log --graph et al.

Before:
![image](https://github.com/input-output-hk/mithril/assets/2621189/5fe18b26-0d71-4472-a392-02d8d08cacff)

After: (as seen in hydra repo)

![image](https://github.com/input-output-hk/mithril/assets/2621189/c3802e46-7b71-4512-99f5-b99882e8388a)

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->
This PR includes...
