### PR TITLE
Stabilize test removing most of the time dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.8.1"
+version = "0.8.2"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -237,8 +237,8 @@ mod tests {
     fn check_seconds_left_and_elapsed_time_are_used_by_the_formatter() {
         // 4 steps
         let progress_bar = ProgressBar::new(4);
-        // 1 step done in 15 ms, left 45ms to finish the 4th steps
-        sleep(Duration::from_millis(15));
+        // 1 step done in 150 ms, left 450ms to finish the 4th steps
+        sleep(Duration::from_millis(150));
         progress_bar.set_position(1);
 
         let json_string = ProgressBarJsonFormatter::format(&progress_bar);
@@ -247,19 +247,19 @@ mod tests {
         let milliseconds_elapsed = progress_bar.elapsed().as_millis();
 
         // Milliseconds in json may not be exactly the same as the one we get because of the test duration.
-        // We need to have a difference not more than 4ms to keep the same 2 first milliseconds digits.
-        let delta = 4;
+        // We need to have a difference not more than 49ms to keep the same 1 first milliseconds digits.
+        let delta = 49;
 
-        assert!(((45 - delta)..=(45 + delta)).contains(&milliseconds_left));
+        assert!(((450 - delta)..=(450 + delta)).contains(&milliseconds_left));
         assert!(
-            json_string.contains(r#""seconds_left": 0.04"#), // Should be close to 0.045
+            json_string.contains(r#""seconds_left": 0.4"#), // Should be close to 0.450
             "Not expected value in json output: {}",
             json_string
         );
 
-        assert!(((15 - delta)..(15 + delta)).contains(&milliseconds_elapsed));
+        assert!(((150 - delta)..(150 + delta)).contains(&milliseconds_elapsed));
         assert!(
-            json_string.contains(r#""seconds_elapsed": 0.01"#), // Should be close to 0.015
+            json_string.contains(r#""seconds_elapsed": 0.1"#), // Should be close to 0.150
             "Not expected value in json output: {}",
             json_string
         );

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -235,10 +235,13 @@ mod tests {
 
     #[test]
     fn check_seconds_left_and_elapsed_time_are_used_by_the_formatter() {
+        let expected_milliseconds_left: u128 = 450;
+        let expected_milliseconds_elapsed: u128 = 150;
+
         // 4 steps
         let progress_bar = ProgressBar::new(4);
         // 1 step done in 150 ms, left 450ms to finish the 4th steps
-        sleep(Duration::from_millis(150));
+        sleep(Duration::from_millis(expected_milliseconds_elapsed as u64));
         progress_bar.set_position(1);
 
         let json_string = ProgressBarJsonFormatter::format(&progress_bar);
@@ -250,14 +253,26 @@ mod tests {
         // We need to have a difference not more than 49ms to keep the same 1 first milliseconds digits.
         let delta = 49;
 
-        assert!(((450 - delta)..=(450 + delta)).contains(&milliseconds_left));
+        assert!(
+            ((expected_milliseconds_left - delta)..=(expected_milliseconds_left + delta))
+                .contains(&milliseconds_left),
+            "milliseconds_left should be close to {} but it's {}",
+            &expected_milliseconds_left,
+            &milliseconds_left
+        );
         assert!(
             json_string.contains(r#""seconds_left": 0.4"#), // Should be close to 0.450
             "Not expected value in json output: {}",
             json_string
         );
 
-        assert!(((150 - delta)..(150 + delta)).contains(&milliseconds_elapsed));
+        assert!(
+            ((expected_milliseconds_elapsed - delta)..=(expected_milliseconds_elapsed + delta))
+                .contains(&milliseconds_elapsed),
+            "milliseconds_elapsed should be close to {} but it's {}",
+            &expected_milliseconds_elapsed,
+            &milliseconds_elapsed
+        );
         assert!(
             json_string.contains(r#""seconds_elapsed": 0.1"#), // Should be close to 0.150
             "Not expected value in json output: {}",

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -235,8 +235,8 @@ mod tests {
 
     #[test]
     fn check_seconds_left_and_elapsed_time_are_used_by_the_formatter() {
-        let expected_milliseconds_left: u128 = 450;
-        let expected_milliseconds_elapsed: u128 = 150;
+        let expected_milliseconds_left: u128 = 45;
+        let expected_milliseconds_elapsed: u128 = 15;
 
         // 4 steps
         let progress_bar = ProgressBar::new(4);
@@ -251,7 +251,7 @@ mod tests {
 
         // Milliseconds in json may not be exactly the same as the one we get because of the test duration.
         // We need to have a difference not more than 49ms to keep the same 1 first milliseconds digits.
-        let delta = 49;
+        let delta = 4;
         // TODO: to remove, it-s just to investigation on CI.
         let error_message = format!(
             "\n- milliseconds_left:{milliseconds_left}\n- milliseconds_elapsed:{milliseconds_elapsed}\n- json_string:{json_string}"
@@ -266,7 +266,7 @@ mod tests {
             &error_message
         );
         assert!(
-            json_string.contains(r#""seconds_left": 0.4"#), // Should be close to 0.450
+            json_string.contains(r#""seconds_left": 0.04"#), // Should be close to 0.450
             "Not expected value in json output: {}",
             json_string
         );
@@ -280,7 +280,7 @@ mod tests {
             &error_message
         );
         assert!(
-            json_string.contains(r#""seconds_elapsed": 0.1"#), // Should be close to 0.150
+            json_string.contains(r#""seconds_elapsed": 0.01"#), // Should be close to 0.150
             "Not expected value in json output: {}",
             json_string
         );

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -252,13 +252,18 @@ mod tests {
         // Milliseconds in json may not be exactly the same as the one we get because of the test duration.
         // We need to have a difference not more than 49ms to keep the same 1 first milliseconds digits.
         let delta = 49;
+        // TODO: to remove, it-s just to investigation on CI.
+        let error_message = format!(
+            "\n- milliseconds_left:{milliseconds_left}\n- milliseconds_elapsed:{milliseconds_elapsed}\n- json_string:{json_string}"
+        );
 
         assert!(
             ((expected_milliseconds_left - delta)..=(expected_milliseconds_left + delta))
                 .contains(&milliseconds_left),
-            "milliseconds_left should be close to {} but it's {}",
+            "milliseconds_left should be close to {} but it's {}. {}",
             &expected_milliseconds_left,
-            &milliseconds_left
+            &milliseconds_left,
+            &error_message
         );
         assert!(
             json_string.contains(r#""seconds_left": 0.4"#), // Should be close to 0.450
@@ -269,9 +274,10 @@ mod tests {
         assert!(
             ((expected_milliseconds_elapsed - delta)..=(expected_milliseconds_elapsed + delta))
                 .contains(&milliseconds_elapsed),
-            "milliseconds_elapsed should be close to {} but it's {}",
+            "milliseconds_elapsed should be close to {} but it's {}. {}",
             &expected_milliseconds_elapsed,
-            &milliseconds_elapsed
+            &milliseconds_elapsed,
+            &error_message
         );
         assert!(
             json_string.contains(r#""seconds_elapsed": 0.1"#), // Should be close to 0.150


### PR DESCRIPTION
## Content
ProgressBar calculates elapsed time and left time using function `now`. 
Even we set ProgressBar with hard coded values, we could never be sure what the json looks like.
Depending on the machines, the result may not be the same.

For testing, we create a format function that is not time dependent.
We create a second test which checks that we send the right parameters to the format function. 
It doesn't check the exact values but only if they are consistent. 

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [X] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
 
## Issue(s)
Closes #1466
