### PR TITLE
Update CHANGELOG with `2418.1` distribution release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,13 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Update website and explorer user interface to use the new mithril logo.
 
-## Mithril Distribution [2418.1] - UNRELEASED
+- Crates versions:
+
+|  Crate  |  Version  |
+|---------- |-------------|
+| N/A | `-` |
+
+## Mithril Distribution [2418.1] - 2024-05-13
 
 - **BREAKING** changes in Mithril client CLI:
   - Certificate chain structure has been modified to remove coupling with immutable file number.
@@ -34,7 +40,13 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 |  Crate  |  Version  |
 |---------- |-------------|
-| N/A | `-` |
+| mithril-aggregator | `0.5.0` |
+| mithril-client | `0.8.0` |
+| mithril-client-cli | `0.8.0` |
+| mithril-client-wasm | `0.3.0` |
+| mithril-common | `0.4.0` |
+| mithril-signer | `0.2.130` |
+| mithril-stm | `0.3.19` |
 
 ## Mithril Distribution [2412.0] - 2024-03-26
 


### PR DESCRIPTION
## Content
This PR includes the rotation of the `CHANGELOG` file following the release of the [`2418.1`](https://github.com/input-output-hk/mithril/releases/tag/2418.1) distribution.

## Pre-submit checklist

- Branch
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1614
