### PR TITLE
Fix aggregator stress test

### DIFF
--- a/.github/workflows/aggregator-stress-test.yml
+++ b/.github/workflows/aggregator-stress-test.yml
@@ -52,20 +52,26 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
 
+      - name: Download test runners
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          name: mithril-tooling-Linux-X64
+          path: ./bin
+          commit: ${{ inputs.commit_sha }}
+          workflow: ci.yml
+          workflow_conclusion: success
+
       - name: Set permissions
         shell: bash
         working-directory: ./bin
-        run: chmod +x ./mithril-aggregator
-
-      - name: Build the aggregator stress test
-        working-directory: mithril-test-lab/mithril-end-to-end
-        run: make build
+        run: |
+          chmod +x ./mithril-aggregator
+          chmod +x ./load-aggregator
 
       - name: Run the aggregator stress test
-        working-directory: mithril-test-lab/mithril-end-to-end
         run: |
-            ./load-aggregator ${{ steps.prepare.outputs.debug_level }} \
-            --cardano-cli-path script/mock-cardano-cli \
-            --aggregator-dir ../../bin \
+            ./bin/load-aggregator ${{ steps.prepare.outputs.debug_level }} \
+            --cardano-cli-path ./mithril-test-lab/mithril-end-to-end/script/mock-cardano-cli \
+            --aggregator-dir ./bin \
             --num-signers=${{ inputs.num_signers }} \
             --num-clients=${{ inputs.num_clients }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       # We separate the build in 2 steps as we want to avoid side effects with Rust feature unification.
       - name: Cargo build - Tooling
         shell: bash
-        run: cargo build --release -p mithril-end-to-end
+        run: cargo build --release --bin mithril-end-to-end --bin load-aggregator
 
       - name: Build Mithril workspace & publish artifacts
         uses: ./.github/workflows/actions/build-upload-mithril-artifact
@@ -58,8 +58,10 @@ jobs:
       - name: Publish End-to-end runner (${{ runner.os }}-${{ runner.arch }})
         uses: actions/upload-artifact@v4
         with:
-          name: mithril-end-to-end-${{ runner.os }}-${{ runner.arch }}
-          path: target/release/mithril-end-to-end
+          name: mithril-tooling-${{ runner.os }}-${{ runner.arch }}
+          path: |
+            target/release/mithril-end-to-end
+            target/release/load-aggregator
           if-no-files-found: error
 
       - name: Prepare test lab eras
@@ -302,7 +304,7 @@ jobs:
       - name: Download rust test runner
         uses: actions/download-artifact@v4
         with:
-          name: mithril-end-to-end-${{ runner.os }}-${{ runner.arch }}
+          name: mithril-tooling-${{ runner.os }}-${{ runner.arch }}
           path: ./
 
       - run: |

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -58,6 +58,8 @@ pub async fn bootstrap_aggregator(
     )
     .await?;
 
+    restart_aggregator_and_move_one_epoch_forward(&mut aggregator, current_epoch, args).await?;
+
     info!(">> Send the Signer Key Registrations payloads for the genesis signers");
     let errors = fake_signer::register_signers_to_aggregator(
         &aggregator,
@@ -66,20 +68,8 @@ pub async fn bootstrap_aggregator(
     )
     .await?;
     assert_eq!(0, errors);
-    aggregator.stop().await.unwrap();
 
-    info!(">> Move one epoch forward in order to issue the genesis certificate");
-    *current_epoch += 1;
-    fake_chain::set_epoch(&args.mock_epoch_file_path(), *current_epoch);
-
-    info!(">> Restarting the aggregator still with a large run interval");
-    aggregator.serve().unwrap();
-    wait::for_http_response(
-        &format!("{}/epoch-settings", aggregator.endpoint()),
-        Duration::from_secs(10),
-        "Waiting for the aggregator to start",
-    )
-    .await?;
+    restart_aggregator_and_move_one_epoch_forward(&mut aggregator, current_epoch, args).await?;
 
     info!(">> Send the Signer Key Registrations payloads for next genesis signers");
     let errors = fake_signer::register_signers_to_aggregator(
@@ -114,4 +104,27 @@ pub async fn bootstrap_aggregator(
     info!(">> Aggregator bootrapped");
 
     Ok(aggregator)
+}
+
+async fn restart_aggregator_and_move_one_epoch_forward(
+    aggregator: &mut Aggregator,
+    current_epoch: &mut Epoch,
+    args: &AggregatorParameters,
+) -> StdResult<()> {
+    info!(">> Stop the aggregator to move one epoch forward");
+    aggregator.stop().await.unwrap();
+
+    *current_epoch += 1;
+    fake_chain::set_epoch(&args.mock_epoch_file_path(), *current_epoch);
+
+    info!(">> Restarting the aggregator with a large run interval");
+    aggregator.serve().unwrap();
+    wait::for_http_response(
+        &format!("{}/epoch-settings", aggregator.endpoint()),
+        Duration::from_secs(10),
+        "Waiting for the aggregator to start",
+    )
+    .await?;
+
+    Ok(())
 }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -60,6 +60,14 @@ pub async fn bootstrap_aggregator(
 
     restart_aggregator_and_move_one_epoch_forward(&mut aggregator, current_epoch, args).await?;
 
+    fake_signer::try_register_signer_until_registration_round_is_open(
+        &aggregator,
+        &signers_fixture.signers()[0],
+        *current_epoch + 1,
+        Duration::from_secs(60),
+    )
+    .await?;
+
     info!(">> Send the Signer Key Registrations payloads for the genesis signers");
     let errors = fake_signer::register_signers_to_aggregator(
         &aggregator,
@@ -68,6 +76,14 @@ pub async fn bootstrap_aggregator(
     )
     .await?;
     assert_eq!(0, errors);
+
+    fake_signer::try_register_signer_until_registration_round_is_open(
+        &aggregator,
+        &signers_fixture.signers()[0],
+        *current_epoch + 1,
+        Duration::from_secs(60),
+    )
+    .await?;
 
     restart_aggregator_and_move_one_epoch_forward(&mut aggregator, current_epoch, args).await?;
 

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/wait.rs
@@ -48,7 +48,7 @@ where
             }
             _ => request_first_list_item_with_expected_size::<I>(url, expected_size).await,
         },
-        Err(err) => Err(anyhow!(err).context("Request to `{url}` failed")),
+        Err(err) => Err(anyhow!(err).context(format!("Request to `{url}` failed"))),
     }
 }
 


### PR DESCRIPTION
## Content
This PR includes a fix for the aggregator stress test.
Due to updates on the aggregator node, the bootstrap of the aggregator stress test was no longer working (e.g. [here](https://github.com/input-output-hk/mithril/actions/runs/8846364647/job/24292095762#step:8:153)).
To succeed, an additional step was required, involving a restart of the aggregator and to move one epoch forward before the signing registration.

The results of the Github workflow that the aggregator stress test with 500 signers and 500 clients can be found [here](https://github.com/input-output-hk/mithril/actions/runs/9109203593/job/25041569586#step:8:273).

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1676 
