### PR TITLE
Prune cardano transactions in signer after block range roots computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Support computation of the Cardano Transactions signature and proving with the pre-computed Block Range Merkle Roots retrieved from the database.
 
+- Prune Cardano Transactions from the signer database after the Block Range Merkle Roots have been computed.
+
 - Update website and explorer user interface to use the new mithril logo.
 
 - Crates versions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3705,7 +3705,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.135"
+version = "0.2.136"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.1.11"
+version = "0.1.12"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/provider/cardano_transaction/delete_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/provider/cardano_transaction/delete_cardano_transaction.rs
@@ -1,0 +1,139 @@
+use sqlite::Value;
+
+use mithril_common::entities::BlockNumber;
+use mithril_common::StdResult;
+
+use crate::database::record::CardanoTransactionRecord;
+use crate::sqlite::{
+    EntityCursor, Provider, SourceAlias, SqLiteEntity, SqliteConnection, WhereCondition,
+};
+
+/// Query to delete old [CardanoTransactionRecord] from the sqlite database
+pub struct DeleteCardanoTransactionProvider<'conn> {
+    connection: &'conn SqliteConnection,
+}
+
+impl<'conn> Provider<'conn> for DeleteCardanoTransactionProvider<'conn> {
+    type Entity = CardanoTransactionRecord;
+
+    fn get_connection(&'conn self) -> &'conn SqliteConnection {
+        self.connection
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        // it is important to alias the fields with the same name as the table
+        // since the table cannot be aliased in a RETURNING statement in SQLite.
+        let projection = Self::Entity::get_projection()
+            .expand(SourceAlias::new(&[("{:cardano_tx:}", "cardano_tx")]));
+
+        format!("delete from cardano_tx where {condition} returning {projection}")
+    }
+}
+
+impl<'conn> DeleteCardanoTransactionProvider<'conn> {
+    /// Create a new instance
+    pub fn new(connection: &'conn SqliteConnection) -> Self {
+        Self { connection }
+    }
+
+    fn get_prune_condition(&self, number_of_block_to_keep: BlockNumber) -> WhereCondition {
+        let number_of_block_to_keep = Value::Integer(number_of_block_to_keep.try_into().unwrap());
+
+        WhereCondition::new(
+            "block_number < ((select max(block_number) from cardano_tx) - ?*)",
+            vec![number_of_block_to_keep],
+        )
+    }
+
+    /// Prune the cardano transaction data after the given number of block.
+    pub fn prune(
+        &self,
+        number_of_block_to_keep: BlockNumber,
+    ) -> StdResult<EntityCursor<CardanoTransactionRecord>> {
+        let filters = self.get_prune_condition(number_of_block_to_keep);
+
+        self.find(filters)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::database::provider::{
+        GetCardanoTransactionProvider, InsertCardanoTransactionProvider,
+    };
+    use crate::database::test_helper::cardano_tx_db_connection;
+    use crate::sqlite::GetAllProvider;
+
+    use super::*;
+
+    fn insert_transactions(connection: &SqliteConnection, records: Vec<CardanoTransactionRecord>) {
+        let provider = InsertCardanoTransactionProvider::new(connection);
+        let condition = provider.get_insert_many_condition(records).unwrap();
+        let mut cursor = provider.find(condition).unwrap();
+        cursor.next().unwrap();
+    }
+
+    fn test_transaction_set() -> Vec<CardanoTransactionRecord> {
+        vec![
+            CardanoTransactionRecord::new("tx-hash-0", 10, 50, "block-hash-10", 1),
+            CardanoTransactionRecord::new("tx-hash-1", 10, 51, "block-hash-10", 1),
+            CardanoTransactionRecord::new("tx-hash-2", 11, 52, "block-hash-11", 1),
+            CardanoTransactionRecord::new("tx-hash-3", 11, 53, "block-hash-11", 1),
+            CardanoTransactionRecord::new("tx-hash-4", 12, 54, "block-hash-12", 1),
+            CardanoTransactionRecord::new("tx-hash-5", 12, 55, "block-hash-12", 1),
+        ]
+    }
+
+    #[test]
+    fn test_prune_work_even_without_transactions_in_db() {
+        let connection = cardano_tx_db_connection().unwrap();
+
+        let prune_provider = DeleteCardanoTransactionProvider::new(&connection);
+        let cursor = prune_provider
+            .prune(100)
+            .expect("pruning shouldn't crash without transactions stored");
+        assert_eq!(0, cursor.count());
+    }
+
+    #[test]
+    fn test_prune_keep_all_data_if_given_block_number_is_larger_than_stored_number_of_block() {
+        let connection = cardano_tx_db_connection().unwrap();
+        insert_transactions(&connection, test_transaction_set());
+
+        let prune_provider = DeleteCardanoTransactionProvider::new(&connection);
+        let cursor = prune_provider.prune(100_000).unwrap();
+        assert_eq!(0, cursor.count());
+
+        let get_provider = GetCardanoTransactionProvider::new(&connection);
+        let cursor = get_provider.get_all().unwrap();
+        assert_eq!(test_transaction_set().len(), cursor.count());
+    }
+
+    #[test]
+    fn test_prune_keep_only_tx_of_last_block_if_given_number_of_block_is_zero() {
+        let connection = cardano_tx_db_connection().unwrap();
+        insert_transactions(&connection, test_transaction_set());
+
+        let prune_provider = DeleteCardanoTransactionProvider::new(&connection);
+        let cursor = prune_provider.prune(0).unwrap();
+        assert_eq!(4, cursor.count());
+
+        let get_provider = GetCardanoTransactionProvider::new(&connection);
+        let cursor = get_provider.get_all().unwrap();
+        assert_eq!(2, cursor.count());
+    }
+
+    #[test]
+    fn test_prune_data_of_older_than_n_blocks() {
+        let connection = cardano_tx_db_connection().unwrap();
+        insert_transactions(&connection, test_transaction_set());
+
+        let prune_provider = DeleteCardanoTransactionProvider::new(&connection);
+        let cursor = prune_provider.prune(1).unwrap();
+        assert_eq!(2, cursor.count());
+
+        let get_provider = GetCardanoTransactionProvider::new(&connection);
+        let cursor = get_provider.get_all().unwrap();
+        assert_eq!(4, cursor.count());
+    }
+}

--- a/internal/mithril-persistence/src/database/provider/cardano_transaction/delete_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/provider/cardano_transaction/delete_cardano_transaction.rs
@@ -37,12 +37,13 @@ impl<'conn> DeleteCardanoTransactionProvider<'conn> {
         Self { connection }
     }
 
-    fn get_prune_condition(&self, threshold: BlockNumber) -> StdResult<WhereCondition> {
-        let threshold = Value::Integer(
-            threshold
-                .try_into()
-                .with_context(|| format!("Failed to convert threshold `{threshold}` to i64"))?,
-        );
+    fn get_prune_condition(
+        &self,
+        block_number_threshold: BlockNumber,
+    ) -> StdResult<WhereCondition> {
+        let threshold = Value::Integer(block_number_threshold.try_into().with_context(|| {
+            format!("Failed to convert threshold `{block_number_threshold}` to i64")
+        })?);
 
         Ok(WhereCondition::new("block_number < ?*", vec![threshold]))
     }
@@ -50,9 +51,9 @@ impl<'conn> DeleteCardanoTransactionProvider<'conn> {
     /// Prune the cardano transaction data below the given threshold.
     pub fn prune(
         &self,
-        threshold: BlockNumber,
+        block_number_threshold: BlockNumber,
     ) -> StdResult<EntityCursor<CardanoTransactionRecord>> {
-        let filters = self.get_prune_condition(threshold)?;
+        let filters = self.get_prune_condition(block_number_threshold)?;
 
         self.find(filters)
     }

--- a/internal/mithril-persistence/src/database/provider/cardano_transaction/mod.rs
+++ b/internal/mithril-persistence/src/database/provider/cardano_transaction/mod.rs
@@ -1,5 +1,7 @@
+mod delete_cardano_transaction;
 mod get_cardano_transaction;
 mod insert_cardano_transaction;
 
+pub use delete_cardano_transaction::*;
 pub use get_cardano_transaction::*;
 pub use insert_cardano_transaction::*;

--- a/internal/mithril-persistence/src/sqlite/connection_extensions.rs
+++ b/internal/mithril-persistence/src/sqlite/connection_extensions.rs
@@ -1,0 +1,79 @@
+use anyhow::Context;
+use sqlite::{ReadableWithIndex, Value};
+
+use mithril_common::StdResult;
+
+use crate::sqlite::SqliteConnection;
+
+/// Extension trait for the [SqliteConnection] type.
+pub trait ConnectionExtensions {
+    /// Execute the given sql query and return the value of the first cell read.
+    fn query_single_cell<Q: Into<String>, T: ReadableWithIndex>(
+        &self,
+        sql: Q,
+        params: &[Value],
+    ) -> StdResult<T>;
+}
+
+impl ConnectionExtensions for SqliteConnection {
+    fn query_single_cell<Q: Into<String>, T: ReadableWithIndex>(
+        &self,
+        sql: Q,
+        params: &[Value],
+    ) -> StdResult<T> {
+        let sql = sql.into();
+        let mut statement = self.prepare(&sql).with_context(|| {
+            format!(
+                "Prepare query error: SQL=`{}`",
+                &sql.replace('\n', " ").trim()
+            )
+        })?;
+        statement.bind(params)?;
+        statement.next()?;
+        statement
+            .read::<T, _>(0)
+            .with_context(|| "Read query error")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlite::Connection;
+
+    use super::*;
+
+    #[test]
+    fn test_query_string() {
+        let connection = Connection::open_thread_safe(":memory:").unwrap();
+        let value: String = connection.query_single_cell("select 'test'", &[]).unwrap();
+
+        assert_eq!(value, "test");
+    }
+
+    #[test]
+    fn test_query_max_number() {
+        let connection = Connection::open_thread_safe(":memory:").unwrap();
+        let value: i64 = connection
+            .query_single_cell(
+                "select max(a) from (select 10 a union select 90 a union select 45 a)",
+                &[],
+            )
+            .unwrap();
+
+        assert_eq!(value, 90);
+    }
+
+    #[test]
+    fn test_query_with_params() {
+        let connection = Connection::open_thread_safe(":memory:").unwrap();
+        let value: i64 = connection
+            .query_single_cell(
+                "select max(a) from (select 10 a union select 45 a union select 90 a) \
+                where a > ? and a < ?",
+                &[Value::Integer(10), Value::Integer(90)],
+            )
+            .unwrap();
+
+        assert_eq!(value, 45);
+    }
+}

--- a/internal/mithril-persistence/src/sqlite/connection_extensions.rs
+++ b/internal/mithril-persistence/src/sqlite/connection_extensions.rs
@@ -8,7 +8,7 @@ use crate::sqlite::SqliteConnection;
 /// Extension trait for the [SqliteConnection] type.
 pub trait ConnectionExtensions {
     /// Execute the given sql query and return the value of the first cell read.
-    fn query_single_cell<Q: Into<String>, T: ReadableWithIndex>(
+    fn query_single_cell<Q: AsRef<str>, T: ReadableWithIndex>(
         &self,
         sql: Q,
         params: &[Value],
@@ -16,16 +16,15 @@ pub trait ConnectionExtensions {
 }
 
 impl ConnectionExtensions for SqliteConnection {
-    fn query_single_cell<Q: Into<String>, T: ReadableWithIndex>(
+    fn query_single_cell<Q: AsRef<str>, T: ReadableWithIndex>(
         &self,
         sql: Q,
         params: &[Value],
     ) -> StdResult<T> {
-        let sql = sql.into();
         let mut statement = self.prepare(&sql).with_context(|| {
             format!(
                 "Prepare query error: SQL=`{}`",
-                &sql.replace('\n', " ").trim()
+                sql.as_ref().replace('\n', " ").trim()
             )
         })?;
         statement.bind(params)?;

--- a/internal/mithril-persistence/src/sqlite/mod.rs
+++ b/internal/mithril-persistence/src/sqlite/mod.rs
@@ -4,6 +4,7 @@
 //! structs.
 mod condition;
 mod connection_builder;
+mod connection_extensions;
 mod cursor;
 mod entity;
 mod projection;
@@ -12,6 +13,7 @@ mod source_alias;
 
 pub use condition::{GetAllCondition, WhereCondition};
 pub use connection_builder::{ConnectionBuilder, ConnectionOptions};
+pub use connection_extensions::ConnectionExtensions;
 pub use cursor::EntityCursor;
 pub use entity::{HydrationError, SqLiteEntity};
 pub use projection::{Projection, ProjectionField};

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.7"
+version = "0.5.8"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -382,6 +382,12 @@ impl Default for DefaultConfiguration {
     }
 }
 
+impl DefaultConfiguration {
+    fn namespace() -> String {
+        "default configuration".to_string()
+    }
+}
+
 impl From<ExecutionEnvironment> for ValueKind {
     fn from(value: ExecutionEnvironment) -> Self {
         match value {
@@ -396,92 +402,55 @@ impl Source for DefaultConfiguration {
         Box::new(self.clone())
     }
 
-    fn collect(&self) -> Result<Map<String, Value>, config::ConfigError> {
+    fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        fn into_value<V: Into<ValueKind>>(value: V) -> Value {
+            Value::new(Some(&DefaultConfiguration::namespace()), value.into())
+        }
         let mut result = Map::new();
-        let namespace = "default configuration".to_string();
         let myself = self.clone();
-        result.insert(
-            "environment".to_string(),
-            Value::new(Some(&namespace), ValueKind::from(myself.environment)),
-        );
-        result.insert(
-            "server_ip".to_string(),
-            Value::new(Some(&namespace), ValueKind::from(myself.server_ip)),
-        );
-        result.insert(
-            "server_port".to_string(),
-            Value::new(Some(&namespace), ValueKind::from(myself.server_port)),
-        );
-        result.insert(
-            "db_directory".to_string(),
-            Value::new(Some(&namespace), ValueKind::from(myself.db_directory)),
-        );
+        result.insert("environment".to_string(), into_value(myself.environment));
+        result.insert("server_ip".to_string(), into_value(myself.server_ip));
+        result.insert("server_port".to_string(), into_value(myself.server_port));
+        result.insert("db_directory".to_string(), into_value(myself.db_directory));
         result.insert(
             "snapshot_directory".to_string(),
-            Value::new(Some(&namespace), ValueKind::from(myself.snapshot_directory)),
+            into_value(myself.snapshot_directory),
         );
         result.insert(
             "snapshot_store_type".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.snapshot_store_type),
-            ),
+            into_value(myself.snapshot_store_type),
         );
         result.insert(
             "snapshot_uploader_type".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.snapshot_uploader_type),
-            ),
+            into_value(myself.snapshot_uploader_type),
         );
         result.insert(
             "era_reader_adapter_type".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.era_reader_adapter_type),
-            ),
+            into_value(myself.era_reader_adapter_type),
         );
         result.insert(
             "reset_digests_cache".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.reset_digests_cache),
-            ),
+            into_value(myself.reset_digests_cache),
         );
         result.insert(
             "disable_digests_cache".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.disable_digests_cache),
-            ),
+            into_value(myself.disable_digests_cache),
         );
         result.insert(
             "snapshot_compression_algorithm".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.snapshot_compression_algorithm),
-            ),
+            into_value(myself.snapshot_compression_algorithm),
         );
         result.insert(
             "snapshot_use_cdn_domain".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.snapshot_use_cdn_domain),
-            ),
+            into_value(myself.snapshot_use_cdn_domain),
         );
         result.insert(
             "signer_importer_run_interval".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.signer_importer_run_interval),
-            ),
+            into_value(myself.signer_importer_run_interval),
         );
         result.insert(
             "allow_unparsable_block".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.allow_unparsable_block),
-            ),
+            into_value(myself.allow_unparsable_block),
         );
 
         Ok(result)

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.135"
+version = "0.2.136"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/aggregator_client.rs
+++ b/mithril-signer/src/aggregator_client.rs
@@ -414,36 +414,15 @@ mod tests {
     use mithril_common::era::{EraChecker, SupportedEra};
     use mithril_common::messages::TryFromMessageAdapter;
     use serde_json::json;
-    use std::path::{Path, PathBuf};
 
     use crate::configuration::Configuration;
-    use mithril_common::era::adapters::EraReaderAdapterType;
     use mithril_common::test_utils::fake_data;
 
     fn setup_test() -> (MockServer, Configuration, APIVersionProvider) {
         let server = MockServer::start();
         let config = Configuration {
-            cardano_cli_path: PathBuf::new().join("cardano-cli"),
-            cardano_node_socket_path: PathBuf::new().join("whatever"),
-            network_magic: Some(42),
-            network: "testnet".to_string(),
             aggregator_endpoint: server.url(""),
-            relay_endpoint: None,
-            party_id: Some("0".to_string()),
-            run_interval: 100,
-            db_directory: Path::new("./db").to_path_buf(),
-            data_stores_directory: Path::new("./stores").to_path_buf(),
-            store_retention_limit: None,
-            kes_secret_key_path: None,
-            operational_certificate_path: None,
-            disable_digests_cache: false,
-            reset_digests_cache: false,
-            era_reader_adapter_type: EraReaderAdapterType::Bootstrap,
-            era_reader_adapter_params: None,
-            enable_metrics_server: true,
-            metrics_server_ip: "0.0.0.0".to_string(),
-            metrics_server_port: 9090,
-            allow_unparsable_block: false,
+            ..Configuration::new_sample("0")
         };
         let era_checker = EraChecker::new(SupportedEra::dummy(), Epoch(1));
         let api_version_provider = APIVersionProvider::new(Arc::new(era_checker));

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -100,8 +100,9 @@ pub struct Configuration {
 impl Configuration {
     /// Create a sample configuration mainly for tests
     #[doc(hidden)]
-    pub fn new_sample(party_id: &PartyId) -> Self {
-        let signer_temp_dir = tests_setup::setup_temp_directory_for_signer(party_id, false);
+    pub fn new_sample<P: Into<PartyId>>(party_id: P) -> Self {
+        let party_id: PartyId = party_id.into();
+        let signer_temp_dir = tests_setup::setup_temp_directory_for_signer(&party_id, false);
         Self {
             aggregator_endpoint: "http://0.0.0.0:8000".to_string(),
             relay_endpoint: None,
@@ -110,7 +111,7 @@ impl Configuration {
             db_directory: PathBuf::new(),
             network: "devnet".to_string(),
             network_magic: Some(42),
-            party_id: Some(party_id.to_owned()),
+            party_id: Some(party_id),
             run_interval: 5000,
             data_stores_directory: PathBuf::new(),
             store_retention_limit: None,

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -188,6 +188,12 @@ pub struct DefaultConfiguration {
     pub metrics_server_port: u16,
 }
 
+impl DefaultConfiguration {
+    fn namespace() -> String {
+        "default configuration".to_string()
+    }
+}
+
 impl Default for DefaultConfiguration {
     fn default() -> Self {
         Self {
@@ -204,29 +210,25 @@ impl Source for DefaultConfiguration {
     }
 
     fn collect(&self) -> Result<Map<String, Value>, ConfigError> {
+        fn into_value<V: Into<ValueKind>>(value: V) -> Value {
+            Value::new(Some(&DefaultConfiguration::namespace()), value.into())
+        }
         let mut result = Map::new();
-        let namespace = "default configuration".to_string();
         let myself = self.clone();
 
         result.insert(
             "era_reader_adapter_type".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.era_reader_adapter_type),
-            ),
+            into_value(myself.era_reader_adapter_type),
         );
 
         result.insert(
             "metrics_server_ip".to_string(),
-            Value::new(Some(&namespace), ValueKind::from(myself.metrics_server_ip)),
+            into_value(myself.metrics_server_ip),
         );
 
         result.insert(
             "metrics_server_port".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(myself.metrics_server_port),
-            ),
+            into_value(myself.metrics_server_port),
         );
 
         Ok(result)

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -7,7 +7,7 @@ use mithril_common::entities::{BlockNumber, BlockRange, CardanoTransaction, Immu
 use mithril_common::StdResult;
 use mithril_persistence::database::repository::CardanoTransactionRepository;
 
-use crate::TransactionStore;
+use crate::{TransactionPruner, TransactionStore};
 
 #[async_trait]
 impl TransactionStore for CardanoTransactionRepository {
@@ -44,5 +44,12 @@ impl TransactionStore for CardanoTransactionRepository {
             self.create_block_range_roots(block_ranges).await?;
         }
         Ok(())
+    }
+}
+
+#[async_trait]
+impl TransactionPruner for CardanoTransactionRepository {
+    async fn prune(&self, number_of_blocks_to_keep: BlockNumber) -> StdResult<()> {
+        self.prune_transaction(number_of_blocks_to_keep).await
     }
 }

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -15,7 +15,7 @@ pub mod metrics;
 mod protocol_initializer_store;
 mod runtime;
 mod single_signer;
-mod transactions_importer_with_prune_decorator;
+mod transactions_importer_with_pruner;
 
 #[cfg(test)]
 pub use aggregator_client::dumb::DumbAggregatorClient;
@@ -29,7 +29,7 @@ pub use metrics::*;
 pub use protocol_initializer_store::{ProtocolInitializerStore, ProtocolInitializerStorer};
 pub use runtime::*;
 pub use single_signer::*;
-pub use transactions_importer_with_prune_decorator::*;
+pub use transactions_importer_with_pruner::*;
 
 /// HTTP request timeout duration in milliseconds
 const HTTP_REQUEST_TIMEOUT_DURATION: u64 = 30000;

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -15,6 +15,7 @@ pub mod metrics;
 mod protocol_initializer_store;
 mod runtime;
 mod single_signer;
+mod transactions_importer_with_prune_decorator;
 
 #[cfg(test)]
 pub use aggregator_client::dumb::DumbAggregatorClient;
@@ -28,6 +29,7 @@ pub use metrics::*;
 pub use protocol_initializer_store::{ProtocolInitializerStore, ProtocolInitializerStorer};
 pub use runtime::*;
 pub use single_signer::*;
+pub use transactions_importer_with_prune_decorator::*;
 
 /// HTTP request timeout duration in milliseconds
 const HTTP_REQUEST_TIMEOUT_DURATION: u64 = 30000;

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -459,10 +459,7 @@ mod tests {
         crypto_helper::{MKMap, MKMapNode, MKTreeNode, ProtocolInitializer},
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
         entities::{BlockRange, CardanoDbBeacon, Epoch, ImmutableFileNumber, StakeDistribution},
-        era::{
-            adapters::{EraReaderAdapterType, EraReaderBootstrapAdapter},
-            EraChecker, EraReader,
-        },
+        era::{adapters::EraReaderBootstrapAdapter, EraChecker, EraReader},
         signable_builder::{
             BlockRangeRootRetriever, CardanoImmutableFilesFullSignableBuilder,
             CardanoTransactionsSignableBuilder, MithrilSignableBuilderService,
@@ -474,10 +471,7 @@ mod tests {
     use mithril_persistence::store::adapter::{DumbStoreAdapter, MemoryAdapter};
     use mithril_persistence::store::{StakeStore, StakeStorer};
     use mockall::mock;
-    use std::{
-        path::{Path, PathBuf},
-        sync::Arc,
-    };
+    use std::{path::Path, sync::Arc};
 
     use crate::{
         metrics::MetricsService, AggregatorClient, CardanoTransactionsImporter,
@@ -597,34 +591,9 @@ mod tests {
         maybe_services: Option<SignerServices>,
         maybe_config: Option<Configuration>,
     ) -> SignerRunner {
-        let services = init_services().await;
-        let config = Configuration {
-            aggregator_endpoint: "http://0.0.0.0:3000".to_string(),
-            relay_endpoint: None,
-            cardano_cli_path: PathBuf::new(),
-            cardano_node_socket_path: PathBuf::new(),
-            db_directory: PathBuf::new(),
-            network: "whatever".to_string(),
-            network_magic: None,
-            party_id: Some("1".to_string()),
-            run_interval: 100,
-            data_stores_directory: PathBuf::new(),
-            kes_secret_key_path: None,
-            operational_certificate_path: None,
-            disable_digests_cache: false,
-            store_retention_limit: None,
-            reset_digests_cache: false,
-            era_reader_adapter_type: EraReaderAdapterType::Bootstrap,
-            era_reader_adapter_params: None,
-            enable_metrics_server: true,
-            metrics_server_ip: "0.0.0.0".to_string(),
-            metrics_server_port: 9090,
-            allow_unparsable_block: false,
-        };
-
         SignerRunner::new(
-            maybe_config.unwrap_or(config),
-            maybe_services.unwrap_or(services),
+            maybe_config.unwrap_or(Configuration::new_sample("1")),
+            maybe_services.unwrap_or(init_services().await),
         )
     }
 

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -29,8 +29,8 @@ use mithril_persistence::{
 use crate::{
     aggregator_client::AggregatorClient, metrics::MetricsService, single_signer::SingleSigner,
     AggregatorHTTPClient, CardanoTransactionsImporter, Configuration, MithrilSingleSigner,
-    ProtocolInitializerStore, ProtocolInitializerStorer, HTTP_REQUEST_TIMEOUT_DURATION,
-    SQLITE_FILE, SQLITE_FILE_CARDANO_TRANSACTION,
+    ProtocolInitializerStore, ProtocolInitializerStorer, TransactionsImporterWithPruner,
+    HTTP_REQUEST_TIMEOUT_DURATION, SQLITE_FILE, SQLITE_FILE_CARDANO_TRANSACTION,
 };
 
 type StakeStoreService = Arc<StakeStore>;
@@ -274,7 +274,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             slog_scope::logger(),
         ));
         // Wrap the transaction importer with decorator to prune the transactions after import
-        let transactions_importer = Arc::new(crate::TransactionsImporterWithPruneDecorator::new(
+        let transactions_importer = Arc::new(TransactionsImporterWithPruner::new(
             self.config
                 .enable_transaction_pruning
                 .then_some(self.config.network_security_parameter),

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -275,7 +275,9 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
         ));
         // Wrap the transaction importer with decorator to prune the transactions after import
         let transactions_importer = Arc::new(crate::TransactionsImporterWithPruneDecorator::new(
-            None,
+            self.config
+                .enable_transaction_pruning
+                .then_some(self.config.network_security_parameter),
             transaction_store.clone(),
             transactions_importer,
         ));

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -350,7 +350,6 @@ mod tests {
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
         entities::{Epoch, TimePoint},
-        era::adapters::EraReaderAdapterType,
         test_utils::TempDir,
     };
 
@@ -366,27 +365,8 @@ mod tests {
     async fn test_auto_create_stores_directory() {
         let stores_dir = get_test_dir("test_auto_create_stores_directory").join("stores");
         let config = Configuration {
-            cardano_cli_path: PathBuf::new(),
-            cardano_node_socket_path: PathBuf::new(),
-            network_magic: None,
-            network: "preview".to_string(),
-            aggregator_endpoint: "".to_string(),
-            relay_endpoint: None,
-            party_id: Some("party-123456".to_string()),
-            run_interval: 1000,
-            db_directory: PathBuf::new(),
             data_stores_directory: stores_dir.clone(),
-            store_retention_limit: None,
-            kes_secret_key_path: None,
-            operational_certificate_path: None,
-            disable_digests_cache: false,
-            reset_digests_cache: false,
-            era_reader_adapter_type: EraReaderAdapterType::Bootstrap,
-            era_reader_adapter_params: None,
-            enable_metrics_server: true,
-            metrics_server_ip: "0.0.0.0".to_string(),
-            metrics_server_port: 9090,
-            allow_unparsable_block: false,
+            ..Configuration::new_sample("party-123456")
         };
 
         assert!(!stores_dir.exists());

--- a/mithril-signer/src/transactions_importer_with_prune_decorator.rs
+++ b/mithril-signer/src/transactions_importer_with_prune_decorator.rs
@@ -1,0 +1,130 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use mithril_common::entities::{BlockNumber, ImmutableFileNumber};
+use mithril_common::signable_builder::TransactionsImporter;
+use mithril_common::StdResult;
+
+/// Cardano transactions pruner
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait TransactionPruner: Send + Sync {
+    /// Prune the transactions older than the given number of blocks (based on the block range root
+    /// stored).
+    async fn prune(&self, number_of_blocks_to_keep: BlockNumber) -> StdResult<()>;
+}
+
+/// A decorator of [TransactionsImporter] that prunes the transactions older than a given number of
+/// blocks after running the import.
+///
+/// If the number of blocks to keep is not provided, no pruning is performed.
+pub struct TransactionsImporterWithPruneDecorator {
+    number_of_blocks_to_keep: Option<BlockNumber>,
+    transaction_pruner: Arc<dyn TransactionPruner>,
+    wrapped_importer: Arc<dyn TransactionsImporter>,
+}
+
+impl TransactionsImporterWithPruneDecorator {
+    /// Create a new instance of [TransactionsImporterWithPruneDecorator].
+    pub fn new(
+        number_of_blocks_to_keep: Option<BlockNumber>,
+        transaction_pruner: Arc<dyn TransactionPruner>,
+        wrapped_importer: Arc<dyn TransactionsImporter>,
+    ) -> Self {
+        Self {
+            number_of_blocks_to_keep,
+            transaction_pruner,
+            wrapped_importer,
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionsImporter for TransactionsImporterWithPruneDecorator {
+    async fn import(&self, up_to_beacon: ImmutableFileNumber) -> StdResult<()> {
+        self.wrapped_importer.import(up_to_beacon).await?;
+
+        if let Some(number_of_blocks_to_keep) = self.number_of_blocks_to_keep {
+            self.transaction_pruner
+                .prune(number_of_blocks_to_keep)
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::mock;
+    use mockall::predicate::eq;
+
+    use super::*;
+
+    mock! {
+        pub TransactionImporterImpl {}
+
+        #[async_trait]
+        impl TransactionsImporter for TransactionImporterImpl {
+            async fn import(&self, up_to_beacon: ImmutableFileNumber) -> StdResult<()>;
+        }
+    }
+
+    impl TransactionsImporterWithPruneDecorator {
+        pub fn new_with_mock<Ti, Pr>(
+            number_of_blocks_to_keep: Option<BlockNumber>,
+            transaction_pruner_mock_config: Pr,
+            importer_mock_config: Ti,
+        ) -> Self
+        where
+            Pr: FnOnce(&mut MockTransactionPruner),
+            Ti: FnOnce(&mut MockTransactionImporterImpl),
+        {
+            let mut transaction_pruner = MockTransactionPruner::new();
+            transaction_pruner_mock_config(&mut transaction_pruner);
+            let mut transaction_importer = MockTransactionImporterImpl::new();
+            importer_mock_config(&mut transaction_importer);
+
+            Self::new(
+                number_of_blocks_to_keep,
+                Arc::new(transaction_pruner),
+                Arc::new(transaction_importer),
+            )
+        }
+    }
+
+    #[tokio::test]
+    async fn test_does_not_prune_if_none_is_configured() {
+        let importer = TransactionsImporterWithPruneDecorator::new_with_mock(
+            None,
+            |mock| {
+                mock.expect_prune().never();
+            },
+            |mock| {
+                mock.expect_import().once().returning(|_| Ok(()));
+            },
+        );
+
+        importer.import(10).await.expect("Import should not fail");
+    }
+
+    #[tokio::test]
+    async fn test_does_prune_if_a_block_number_is_configured() {
+        let expected_block_number: BlockNumber = 5;
+        let importer = TransactionsImporterWithPruneDecorator::new_with_mock(
+            Some(expected_block_number),
+            |mock| {
+                mock.expect_prune()
+                    .with(eq(expected_block_number))
+                    .once()
+                    .returning(|_| Ok(()));
+            },
+            |mock| {
+                mock.expect_import().once().returning(|_| Ok(()));
+            },
+        );
+
+        importer.import(10).await.expect("Import should not fail");
+    }
+}


### PR DESCRIPTION
## Content
This PR add, to the signer only, a pruning of the cardano transactions after the computation of block ranges roots.

This is done using a decorator wrapping the existing `CardanoTransactionsImporter`.

Two new configuration parameters have been added to signer `Configuration` structure:
- `network_security_parameter`, default to `2160` (mainnet value).
- `enable_transaction_pruning`, default to `true`.

Since both have a default value our signer won't have to update their configurations.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

- As it was the third time that we needed to do a simple query to retrieve a single result from database, a system using a  extension trait on the [sqlite connection](https://docs.rs/sqlite/0.36.0/sqlite/struct.ConnectionThreadSafe.html) has been added to do that simply with reduced boilerplate.
- Some simplification has been done on the configuration system: a leaner way to hydrate default configuration (mithril-signer & mithril-aggregator) and generalized use of the test configuration values (`new_sample(party_id)`, mithril-signer).

## Issue(s)
Closes #1645
