### PR TITLE
Fix Cardano transaction signed entity type timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.5"
+version = "0.4.6"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -91,9 +91,8 @@ impl SignedEntityType {
     pub fn get_open_message_timeout(&self) -> Option<Duration> {
         match self {
             Self::MithrilStakeDistribution(_) | Self::CardanoImmutableFilesFull(_) => None,
-            Self::CardanoStakeDistribution(_) | Self::CardanoTransactions(_) => {
-                Some(Duration::from_secs(600))
-            }
+            Self::CardanoStakeDistribution(_) => Some(Duration::from_secs(600)),
+            Self::CardanoTransactions(_) => Some(Duration::from_secs(1800)),
         }
     }
 


### PR DESCRIPTION
## Content
This PR includes a fix to extend the tiemeout of the **Cardano transaction** signed entity type from `600s` to `1800s`. This will avoid timeout on the `mainnet` when importing transactions from immutable files may take longer than expected which is responsible for the `testing-mainnet` unable to sign for few days.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1681
