### PR TITLE
Update network compatibility table for releases

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -64,7 +64,7 @@ jobs:
           version-name: ${{ github.ref_name }}
           download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
-          compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "✔", "testing-sanchonet": "✔" }'
+          compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "⛔", "testing-sanchonet": "⛔" }'
 
       - name: Create pre-release ${{ github.ref_name }}
         uses: marvinpinto/action-automatic-releases@latest


### PR DESCRIPTION
## Content
This PR includes an updated **Mithril network compatibility table** for **(pre)releases** which makes 'testing-preview' and 'testing-sanchonet' incompatible with the released version.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
