### PR TITLE
Add `chain_point` to `TimePoint` structure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3452,7 +3452,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3607,7 +3607,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.138"
+version = "0.2.139"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.11"
+version = "0.5.12"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -459,6 +459,7 @@ impl Source for DefaultConfiguration {
 
 #[cfg(test)]
 mod test {
+    use mithril_common::entities::ChainPoint;
     use mithril_common::test_utils::fake_data;
 
     use super::*;
@@ -610,7 +611,8 @@ mod test {
     #[test]
     fn test_list_allowed_signed_entity_types_with_specific_configuration() {
         let beacon = fake_data::beacon();
-        let time_point = TimePoint::new(*beacon.epoch, beacon.immutable_file_number);
+        let chain_point = ChainPoint::dummy();
+        let time_point = TimePoint::new(*beacon.epoch, beacon.immutable_file_number, chain_point);
 
         let config = Configuration {
             network: beacon.network.clone(),

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -486,6 +486,7 @@ pub mod tests {
     };
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
+    use mithril_common::entities::ChainPoint;
     use mithril_common::{
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
@@ -607,7 +608,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_get_time_point_from_chain() {
-        let expected = TimePoint::new(2, 17);
+        let expected = TimePoint::new(2, 17, ChainPoint::dummy());
         let mut dependencies = initialize_dependencies().await;
         let immutable_file_observer = Arc::new(DumbImmutableFileObserver::default());
         immutable_file_observer

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -191,7 +191,8 @@ impl CertificatesHashMigrator {
 #[cfg(test)]
 mod test {
     use mithril_common::entities::{
-        ImmutableFileNumber, SignedEntityType, SignedEntityTypeDiscriminants as Type, TimePoint,
+        ChainPoint, ImmutableFileNumber, SignedEntityType, SignedEntityTypeDiscriminants as Type,
+        TimePoint,
     };
     use mithril_common::test_utils::fake_data;
     use mithril_persistence::sqlite::{ConnectionBuilder, ConnectionOptions, SqliteConnection};
@@ -217,8 +218,10 @@ mod test {
             .unwrap()
     }
 
+    /// Note: If we want to create CardanoTransaction test certificate then another method
+    /// that take a ChainPoint as parameter should be created.
     fn time_at(epoch: u64, immutable_file_number: ImmutableFileNumber) -> TimePoint {
-        TimePoint::new(epoch, immutable_file_number)
+        TimePoint::new(epoch, immutable_file_number, ChainPoint::dummy())
     }
 
     fn dummy_genesis(certificate_hash: &str, time_point: TimePoint) -> Certificate {

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -3,7 +3,7 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType,
+        CardanoDbBeacon, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
         SignedEntityTypeDiscriminants, StakeDistribution, StakeDistributionParty, TimePoint,
     },
     test_utils::MithrilFixtureBuilder,
@@ -22,7 +22,11 @@ async fn certificate_chain() {
         data_stores_directory: get_test_dir("certificate_chain"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(TimePoint::new(1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        TimePoint::new(1, 1, ChainPoint::new(10, 1, "block_hash-1")),
+        configuration,
+    )
+    .await;
     let observer = tester.observer.clone();
 
     comment!("Create signers & declare stake distribution");

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -3,7 +3,7 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType,
+        CardanoDbBeacon, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
         SignedEntityTypeDiscriminants, StakeDistributionParty, TimePoint,
     },
     test_utils::MithrilFixtureBuilder,
@@ -22,7 +22,11 @@ async fn create_certificate() {
         data_stores_directory: get_test_dir("create_certificate"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(TimePoint::new(1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        TimePoint::new(1, 1, ChainPoint::new(10, 1, "block_hash-1")),
+        configuration,
+    )
+    .await;
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()

--- a/mithril-aggregator/tests/era_checker.rs
+++ b/mithril-aggregator/tests/era_checker.rs
@@ -1,7 +1,7 @@
 mod test_extensions;
 use mithril_aggregator::{Configuration, RuntimeError};
 use mithril_common::{
-    entities::{Epoch, ProtocolParameters, TimePoint},
+    entities::{ChainPoint, Epoch, ProtocolParameters, TimePoint},
     era::{EraMarker, SupportedEra},
     test_utils::MithrilFixtureBuilder,
 };
@@ -23,7 +23,11 @@ async fn testing_eras() {
         data_stores_directory: get_test_dir("testing_eras"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(TimePoint::new(1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        TimePoint::new(1, 1, ChainPoint::new(10, 1, "block_hash-1")),
+        configuration,
+    )
+    .await;
     tester.era_reader_adapter.set_markers(vec![
         EraMarker::new("unsupported", Some(Epoch(0))),
         EraMarker::new(&SupportedEra::dummy().to_string(), Some(Epoch(12))),

--- a/mithril-aggregator/tests/genesis_to_signing.rs
+++ b/mithril-aggregator/tests/genesis_to_signing.rs
@@ -2,7 +2,7 @@ mod test_extensions;
 
 use mithril_aggregator::Configuration;
 use mithril_common::{
-    entities::{CardanoDbBeacon, ProtocolParameters, TimePoint},
+    entities::{CardanoDbBeacon, ChainPoint, ProtocolParameters, TimePoint},
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
@@ -19,7 +19,11 @@ async fn genesis_to_signing() {
         data_stores_directory: get_test_dir("genesis_to_signing"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(TimePoint::new(1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        TimePoint::new(1, 1, ChainPoint::new(10, 1, "block_hash-1")),
+        configuration,
+    )
+    .await;
 
     comment!("Create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()

--- a/mithril-aggregator/tests/open_message_expiration.rs
+++ b/mithril-aggregator/tests/open_message_expiration.rs
@@ -5,8 +5,8 @@ use std::time::Duration;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        CardanoDbBeacon, ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants,
-        TimePoint,
+        CardanoDbBeacon, ChainPoint, ProtocolParameters, SignedEntityType,
+        SignedEntityTypeDiscriminants, TimePoint,
     },
     test_utils::MithrilFixtureBuilder,
 };
@@ -24,7 +24,11 @@ async fn open_message_expiration() {
         data_stores_directory: get_test_dir("open_message_expiration"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(TimePoint::new(1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        TimePoint::new(1, 1, ChainPoint::new(10, 1, "block_hash-1")),
+        configuration,
+    )
+    .await;
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()

--- a/mithril-aggregator/tests/open_message_newer_exists.rs
+++ b/mithril-aggregator/tests/open_message_newer_exists.rs
@@ -3,7 +3,7 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        CardanoDbBeacon, Epoch, ProtocolParameters, SignedEntityType,
+        CardanoDbBeacon, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
         SignedEntityTypeDiscriminants, StakeDistributionParty, TimePoint,
     },
     test_utils::MithrilFixtureBuilder,
@@ -22,7 +22,11 @@ async fn open_message_newer_exists() {
         data_stores_directory: get_test_dir("open_message_newer_exists"),
         ..Configuration::new_sample()
     };
-    let mut tester = RuntimeTester::build(TimePoint::new(1, 1), configuration).await;
+    let mut tester = RuntimeTester::build(
+        TimePoint::new(1, 1, ChainPoint::new(10, 1, "block_hash-1")),
+        configuration,
+    )
+    .await;
 
     comment!("create signers & declare stake distribution");
     let fixture = MithrilFixtureBuilder::default()

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.9"
+version = "0.4.10"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/cardano_block_scanner/interface.rs
+++ b/mithril-common/src/cardano_block_scanner/interface.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use std::path::Path;
 
 use async_trait::async_trait;
@@ -90,7 +89,7 @@ cfg_test_tools! {
                         all_blocks.append(&mut forward_blocks);
                     }
                     ChainScannedBlocks::RollBackward(_) => {
-                        return Err(anyhow!("poll_all: RollBackward not supported"));
+                        return Err(anyhow::anyhow!("poll_all: RollBackward not supported"));
                     }
                 };
             }

--- a/mithril-common/src/chain_observer/fake_observer.rs
+++ b/mithril-common/src/chain_observer/fake_observer.rs
@@ -32,8 +32,8 @@ impl FakeObserver {
     pub fn new(current_time_point: Option<TimePoint>) -> Self {
         Self {
             signers: RwLock::new(vec![]),
-            current_time_point: RwLock::new(current_time_point),
-            current_chain_point: RwLock::new(None),
+            current_time_point: RwLock::new(current_time_point.clone()),
+            current_chain_point: RwLock::new(current_time_point.map(|t| t.chain_point)),
             datums: RwLock::new(vec![]),
         }
     }

--- a/mithril-common/src/entities/cardano_chain_point.rs
+++ b/mithril-common/src/entities/cardano_chain_point.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 cfg_fs! {
     use pallas_network::miniprotocols::{chainsync::Tip, Point};
 }
@@ -26,9 +27,47 @@ pub struct ChainPoint {
 }
 
 impl ChainPoint {
+    /// [ChainPoint] factory
+    pub fn new<T: Into<BlockHash>>(
+        slot_number: SlotNumber,
+        block_number: BlockNumber,
+        block_hash: T,
+    ) -> ChainPoint {
+        ChainPoint {
+            slot_number,
+            block_number,
+            block_hash: block_hash.into(),
+        }
+    }
+
     /// Check if origin chain point
     pub fn is_origin(&self) -> bool {
         self.slot_number == 0 && self.block_number == 0 && self.block_hash.is_empty()
+    }
+
+    cfg_test_tools! {
+        /// Create a dummy ChainPoint
+        pub fn dummy() -> Self {
+            Self {
+                slot_number: 100,
+                block_number: 50,
+                block_hash: "block_hash-50".to_string(),
+            }
+        }
+    }
+}
+
+impl PartialOrd for ChainPoint {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for ChainPoint {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.block_number
+            .cmp(&other.block_number)
+            .then(self.slot_number.cmp(&other.slot_number))
     }
 }
 
@@ -79,5 +118,60 @@ cfg_fs! {
             let point: Point = chain_point.into();
             Tip(point, block_number)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cmp::Ordering;
+
+    use super::*;
+
+    #[test]
+    fn chain_point_ord_cmp_block_number_take_precedence_over_other_fields() {
+        let chain_point1 = ChainPoint {
+            slot_number: 15,
+            block_number: 10,
+            block_hash: "hash2".to_string(),
+        };
+        let chain_point2 = ChainPoint {
+            slot_number: 5,
+            block_number: 20,
+            block_hash: "hash1".to_string(),
+        };
+
+        assert_eq!(Ordering::Less, chain_point1.cmp(&chain_point2));
+    }
+
+    #[test]
+    fn chain_point_ord_cmp_if_block_number_equals_then_compare_slot_numbers() {
+        let chain_point1 = ChainPoint {
+            slot_number: 15,
+            block_number: 0,
+            block_hash: "hash2".to_string(),
+        };
+        let chain_point2 = ChainPoint {
+            slot_number: 5,
+            block_number: 0,
+            block_hash: "hash1".to_string(),
+        };
+
+        assert_eq!(Ordering::Greater, chain_point1.cmp(&chain_point2));
+    }
+
+    #[test]
+    fn chain_point_ord_cmp_block_hash_doesnt_matter() {
+        let chain_point1 = ChainPoint {
+            slot_number: 5,
+            block_number: 10,
+            block_hash: "hash1".to_string(),
+        };
+        let chain_point2 = ChainPoint {
+            slot_number: 5,
+            block_number: 10,
+            block_hash: "hash2".to_string(),
+        };
+
+        assert_eq!(Ordering::Equal, chain_point1.cmp(&chain_point2));
     }
 }

--- a/mithril-common/src/entities/cardano_chain_point.rs
+++ b/mithril-common/src/entities/cardano_chain_point.rs
@@ -68,6 +68,7 @@ impl Ord for ChainPoint {
         self.block_number
             .cmp(&other.block_number)
             .then(self.slot_number.cmp(&other.slot_number))
+            .then(self.block_hash.cmp(&other.block_hash))
     }
 }
 
@@ -160,7 +161,7 @@ mod tests {
     }
 
     #[test]
-    fn chain_point_ord_cmp_block_hash_doesnt_matter() {
+    fn chain_point_ord_cmp_if_block_number_and_slot_number_equals_then_compare_block_hash() {
         let chain_point1 = ChainPoint {
             slot_number: 5,
             block_number: 10,
@@ -172,6 +173,6 @@ mod tests {
             block_hash: "hash2".to_string(),
         };
 
-        assert_eq!(Ordering::Equal, chain_point1.cmp(&chain_point2));
+        assert_eq!(Ordering::Less, chain_point1.cmp(&chain_point2));
     }
 }

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -28,10 +28,10 @@ pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMeth
 pub use mithril_fixture::{MithrilFixture, SignerFixture};
 pub use temp_dir::*;
 #[cfg(test)]
-pub(crate) use utils::*;
+pub use utils::*;
 
 #[cfg(test)]
-pub(crate) mod utils {
+mod utils {
     use std::fs::File;
     use std::io;
     use std::sync::Arc;

--- a/mithril-common/src/time_point_provider.rs
+++ b/mithril-common/src/time_point_provider.rs
@@ -20,12 +20,12 @@ where
 /// [TimePointProvider] related errors.
 #[derive(Error, Debug)]
 pub enum TimePointProviderError {
-    /// Raised reading the current epoch succeeded but yield no result.
-    #[error("No epoch yield by the chain observer, is your cardano node ready ?")]
+    /// Raised when reading the current epoch succeeded but yielded no result.
+    #[error("No epoch yielded by the chain observer, is your cardano node ready?")]
     NoEpoch,
 
-    /// Raised reading the current chain point succeeded but yield no result.
-    #[error("No chain point yield by the chain observer, is your cardano node ready ?")]
+    /// Raised when reading the current chain point succeeded but yielded no result.
+    #[error("No chain point yielded by the chain observer, is your cardano node ready?")]
     NoChainPoint,
 }
 

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.138"
+version = "0.2.139"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -133,16 +133,11 @@ impl Runner for SignerRunner {
     async fn get_current_time_point(&self) -> StdResult<TimePoint> {
         debug!("RUNNER: get_current_time_point");
 
-        let time_point = self
-            .services
+        self.services
             .time_point_provider
             .get_current_time_point()
             .await
-            .with_context(|| "Runner can not get current time point")?;
-        Ok(TimePoint::new(
-            *time_point.epoch,
-            time_point.immutable_file_number,
-        ))
+            .with_context(|| "Runner can not get current time point")
     }
 
     async fn register_signer_to_aggregator(

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -354,16 +354,14 @@ pub struct SignerServices {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use mithril_common::{
-        chain_observer::FakeObserver,
-        digesters::DumbImmutableFileObserver,
-        entities::{Epoch, TimePoint},
+        chain_observer::FakeObserver, digesters::DumbImmutableFileObserver, entities::TimePoint,
         test_utils::TempDir,
     };
 
     use super::*;
-
-    use std::path::PathBuf;
 
     fn get_test_dir(test_name: &str) -> PathBuf {
         TempDir::create("signer_service", test_name)
@@ -379,12 +377,7 @@ mod tests {
 
         assert!(!stores_dir.exists());
         let chain_observer_builder: fn(&Configuration) -> StdResult<ChainObserverService> =
-            |_config| {
-                Ok(Arc::new(FakeObserver::new(Some(TimePoint {
-                    epoch: Epoch(1),
-                    immutable_file_number: 1,
-                }))))
-            };
+            |_config| Ok(Arc::new(FakeObserver::new(Some(TimePoint::dummy()))));
         let immutable_file_observer_builder: fn(
             &Configuration,
         )

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -463,13 +463,12 @@ impl StateMachine {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::{
-        entities::{CardanoDbBeacon, Epoch, ProtocolMessage},
-        test_utils::fake_data,
-    };
+    use mithril_common::entities::{CardanoDbBeacon, ChainPoint, Epoch, ProtocolMessage};
+    use mithril_common::test_utils::fake_data;
+
+    use crate::runtime::runner::MockSignerRunner;
 
     use super::*;
-    use crate::runtime::runner::MockSignerRunner;
 
     fn init_state_machine(init_state: SignerState, runner: MockSignerRunner) -> StateMachine {
         let metrics_service = Arc::new(MetricsService::new().unwrap());
@@ -615,6 +614,7 @@ mod tests {
         let time_point = TimePoint {
             immutable_file_number: 99,
             epoch: Epoch(9),
+            chain_point: ChainPoint::dummy(),
         };
         let state = SignerState::Registered {
             epoch: time_point.epoch,
@@ -654,6 +654,7 @@ mod tests {
         let time_point = TimePoint {
             immutable_file_number: 99,
             epoch: Epoch(9),
+            chain_point: ChainPoint::dummy(),
         };
         let state = SignerState::Registered {
             epoch: time_point.epoch,
@@ -713,6 +714,7 @@ mod tests {
         let time_point = TimePoint {
             immutable_file_number: 99,
             epoch: Epoch(9),
+            chain_point: ChainPoint::dummy(),
         };
         let time_point_clone = time_point.clone();
         let beacon = CardanoDbBeacon::new(
@@ -760,6 +762,7 @@ mod tests {
         let time_point = TimePoint {
             immutable_file_number: 99,
             epoch: Epoch(9),
+            chain_point: ChainPoint::dummy(),
         };
         let new_time_point = TimePoint {
             epoch: Epoch(10),
@@ -797,6 +800,7 @@ mod tests {
         let time_point = TimePoint {
             immutable_file_number: 99,
             epoch: Epoch(9),
+            chain_point: ChainPoint::dummy(),
         };
         let time_point_clone = time_point.clone();
         let state = SignerState::Signed {
@@ -834,6 +838,7 @@ mod tests {
         let time_point = TimePoint {
             immutable_file_number: 99,
             epoch: Epoch(9),
+            chain_point: ChainPoint::dummy(),
         };
         let time_point_clone = time_point.clone();
         let state = SignerState::Signed {

--- a/mithril-signer/tests/test_extensions/certificate_handler.rs
+++ b/mithril-signer/tests/test_extensions/certificate_handler.rs
@@ -127,10 +127,11 @@ impl AggregatorClient for FakeAggregator {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::{
-        chain_observer::ChainObserver, chain_observer::FakeObserver,
-        digesters::DumbImmutableFileObserver, test_utils::fake_data, CardanoNetwork,
-    };
+    use mithril_common::chain_observer::{ChainObserver, FakeObserver};
+    use mithril_common::digesters::DumbImmutableFileObserver;
+    use mithril_common::entities::ChainPoint;
+    use mithril_common::test_utils::fake_data;
+    use mithril_common::CardanoNetwork;
 
     use super::*;
 
@@ -140,6 +141,7 @@ mod tests {
         let chain_observer = Arc::new(FakeObserver::new(Some(TimePoint {
             epoch: Epoch(1),
             immutable_file_number: 1,
+            chain_point: ChainPoint::dummy(),
         })));
         let time_point_provider = Arc::new(TimePointProviderImpl::new(
             chain_observer.clone(),

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -10,7 +10,7 @@ use mithril_common::{
     cardano_block_scanner::DumbBlockScanner,
     chain_observer::{ChainObserver, FakeObserver},
     digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
-    entities::{Epoch, SignerWithStake, TimePoint},
+    entities::{ChainPoint, Epoch, SignerWithStake, TimePoint},
     era::{adapters::EraReaderDummyAdapter, EraChecker, EraMarker, EraReader, SupportedEra},
     signable_builder::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
@@ -98,6 +98,11 @@ impl StateMachineTester {
         let chain_observer = Arc::new(FakeObserver::new(Some(TimePoint {
             epoch: Epoch(1),
             immutable_file_number: 1,
+            chain_point: ChainPoint {
+                slot_number: 1,
+                block_number: 1,
+                block_hash: "block_hash-1".to_string(),
+            },
         })));
         let time_point_provider = Arc::new(TimePointProviderImpl::new(
             chain_observer.clone(),


### PR DESCRIPTION
## Content

This PR modify the `TimePoint` structure to add a `chain_point` property and update the `TimePointProvider` to retrieve it using `ChainObserver::get_current_chain_point`.

In order to keep the Ord capability of the `TimePoint`, Ord is added to `ChainPoint` as well.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1697