### PR TITLE
Fix: make prover not certify transactions stored but not certified yet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,7 +994,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-transaction"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -3514,7 +3514,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.9.2"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "async-trait",
  "futures",
@@ -3768,7 +3768,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/client-cardano-transaction/Cargo.toml
+++ b/examples/client-cardano-transaction/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-transaction"
 description = "Mithril client cardano-transaction example"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-transaction/src/main.rs
+++ b/examples/client-cardano-transaction/src/main.rs
@@ -76,7 +76,7 @@ async fn main() -> MithrilResult<()> {
         .compute_cardano_transactions_proofs_message(&certificate, &verified_transactions);
     if !certificate.match_message(&message) {
         return Err(anyhow!(
-            "Proof and certificate doesn't match (certificate hash = '{}').",
+            "Proof and certificate don't match (certificate hash = '{}').",
             certificate.hash
         ));
     }

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.3"
+version = "0.2.4"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/query/cardano_transaction/get_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/query/cardano_transaction/get_cardano_transaction.rs
@@ -29,12 +29,16 @@ impl GetCardanoTransactionQuery {
         }
     }
 
-    pub fn by_transaction_hashes(transactions_hashes: Vec<TransactionHash>) -> Self {
+    pub fn by_transaction_hashes(
+        transactions_hashes: Vec<TransactionHash>,
+        up_to: BlockNumber,
+    ) -> Self {
         let hashes_values = transactions_hashes.into_iter().map(Value::String).collect();
+        let condition = WhereCondition::where_in("transaction_hash", hashes_values).and_where(
+            WhereCondition::new("block_number <= ?*", vec![Value::Integer(up_to as i64)]),
+        );
 
-        Self {
-            condition: WhereCondition::where_in("transaction_hash", hashes_values),
-        }
+        Self { condition }
     }
 
     pub fn by_block_ranges(block_ranges: Vec<BlockRange>) -> Self {

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -326,10 +326,10 @@ mod tests {
         let repository = CardanoTransactionRepository::new(connection);
         repository
             .create_transactions(vec![
-                CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 99),
-                CardanoTransactionRecord::new("tx_hash-456", 11, 51, "block_hash-456", 100),
-                CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 101),
-                CardanoTransactionRecord::new("tx_hash-000", 101, 100, "block_hash-000", 110),
+                CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 1234),
+                CardanoTransactionRecord::new("tx_hash-456", 11, 51, "block_hash-456", 1234),
+                CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 1234),
+                CardanoTransactionRecord::new("tx_hash-000", 101, 100, "block_hash-000", 1234),
             ])
             .await
             .unwrap();
@@ -342,8 +342,8 @@ mod tests {
 
             assert_eq!(
                 vec![
-                    CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 99),
-                    CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 101),
+                    CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 1234),
+                    CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 1234),
                 ],
                 transactions
             );
@@ -356,8 +356,8 @@ mod tests {
 
             assert_eq!(
                 vec![
-                    CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 99),
-                    CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 101),
+                    CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 1234),
+                    CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 1234),
                 ],
                 transactions
             );
@@ -370,9 +370,9 @@ mod tests {
 
             assert_eq!(
                 vec![
-                    CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 99),
-                    CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 101),
-                    CardanoTransactionRecord::new("tx_hash-000", 101, 100, "block_hash-000", 110),
+                    CardanoTransactionRecord::new("tx_hash-123", 10, 50, "block_hash-123", 1234),
+                    CardanoTransactionRecord::new("tx_hash-789", 12, 52, "block_hash-789", 1234),
+                    CardanoTransactionRecord::new("tx_hash-000", 101, 100, "block_hash-000", 1234),
                 ],
                 transactions
             );

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.16"
+version = "0.5.17"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
@@ -54,12 +54,15 @@ impl TransactionsRetriever for CardanoTransactionRepository {
     async fn get_by_hashes(
         &self,
         hashes: Vec<TransactionHash>,
+        up_to: BlockNumber,
     ) -> StdResult<Vec<CardanoTransaction>> {
-        self.get_transaction_by_hashes(hashes).await.map(|v| {
-            v.into_iter()
-                .map(|record| record.into())
-                .collect::<Vec<CardanoTransaction>>()
-        })
+        self.get_transaction_by_hashes(hashes, up_to)
+            .await
+            .map(|v| {
+                v.into_iter()
+                    .map(|record| record.into())
+                    .collect::<Vec<CardanoTransaction>>()
+            })
     }
 
     async fn get_by_block_ranges(

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -40,6 +40,7 @@ pub trait TransactionsRetriever: Sync + Send {
     async fn get_by_hashes(
         &self,
         hashes: Vec<TransactionHash>,
+        up_to: BlockNumber,
     ) -> StdResult<Vec<CardanoTransaction>>;
 
     /// Get by block ranges
@@ -76,10 +77,11 @@ impl MithrilProverService {
     async fn get_block_ranges(
         &self,
         transaction_hashes: &[TransactionHash],
+        up_to: BlockNumber,
     ) -> StdResult<Vec<BlockRange>> {
         let transactions = self
             .transaction_retriever
-            .get_by_hashes(transaction_hashes.to_vec())
+            .get_by_hashes(transaction_hashes.to_vec(), up_to)
             .await?;
         let block_ranges = transactions
             .iter()
@@ -114,11 +116,11 @@ impl MithrilProverService {
 impl ProverService for MithrilProverService {
     async fn compute_transactions_proofs(
         &self,
-        _up_to: BlockNumber,
+        up_to: BlockNumber,
         transaction_hashes: &[TransactionHash],
     ) -> StdResult<Vec<CardanoTransactionsSetProof>> {
         // 1 - Compute the set of block ranges with transactions to prove
-        let block_ranges_transactions = self.get_block_ranges(transaction_hashes).await?;
+        let block_ranges_transactions = self.get_block_ranges(transaction_hashes, up_to).await?;
         let block_range_transactions = self
             .get_all_transactions_for_block_ranges(&block_ranges_transactions)
             .await?;
@@ -357,7 +359,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_proof_for_one_set_of_three_known_transactions() {
+    async fn compute_proof_for_one_set_of_three_certified_transactions() {
         let total_block_ranges = 5;
         let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
@@ -373,8 +375,8 @@ mod tests {
                 let transactions_to_prove = transactions_to_prove.clone();
                 transaction_retriever_mock
                     .expect_get_by_hashes()
-                    .with(eq(transaction_hashes_to_prove))
-                    .return_once(move |_| Ok(transactions_to_prove));
+                    .with(eq(transaction_hashes_to_prove), eq(test_data.beacon))
+                    .return_once(move |_, _| Ok(transactions_to_prove));
 
                 let block_ranges_to_prove = test_data.block_ranges_to_prove.clone();
                 let all_transactions_in_block_ranges_to_prove =
@@ -411,6 +413,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cant_compute_proof_for_not_yet_certified_transaction() {
+        let total_block_ranges = 5;
+        let total_transactions_per_block_range = 3;
+        let transactions = CardanoTransactionsBuilder::new()
+            .max_transactions_per_block(1)
+            .blocks_per_block_range(total_transactions_per_block_range)
+            .build_block_ranges(total_block_ranges);
+        let transactions_to_prove =
+            test_data::filter_transactions_for_indices(&[1, 2, 4], &transactions);
+        let test_data = test_data::build_test_data(&transactions_to_prove, &transactions);
+        let prover = build_prover(
+            |transaction_retriever_mock| {
+                let transaction_hashes_to_prove = test_data.transaction_hashes_to_prove.clone();
+                transaction_retriever_mock
+                    .expect_get_by_hashes()
+                    .with(eq(transaction_hashes_to_prove), eq(test_data.beacon))
+                    .return_once(move |_, _| Ok(vec![]));
+                transaction_retriever_mock
+                    .expect_get_by_block_ranges()
+                    .with(eq(vec![]))
+                    .return_once(move |_| Ok(vec![]));
+            },
+            |block_range_root_retriever_mock| {
+                let block_ranges_map = test_data.block_ranges_map.clone();
+                block_range_root_retriever_mock
+                    .expect_compute_merkle_map_from_block_range_roots()
+                    .return_once(|_| {
+                        Ok(test_data::compute_mk_map_from_block_ranges_map(
+                            block_ranges_map,
+                        ))
+                    });
+            },
+        );
+        prover.compute_cache(test_data.beacon).await.unwrap();
+
+        let transactions_set_proof = prover
+            .compute_transactions_proofs(test_data.beacon, &test_data.transaction_hashes_to_prove)
+            .await
+            .unwrap();
+
+        assert_eq!(transactions_set_proof.len(), 0);
+    }
+
+    #[tokio::test]
     async fn cant_compute_proof_for_unknown_transaction() {
         let total_block_ranges = 5;
         let total_transactions_per_block_range = 3;
@@ -427,8 +473,8 @@ mod tests {
                 let transactions_to_prove = transactions_to_prove.clone();
                 transaction_retriever_mock
                     .expect_get_by_hashes()
-                    .with(eq(transaction_hashes_to_prove))
-                    .return_once(move |_| Ok(transactions_to_prove));
+                    .with(eq(transaction_hashes_to_prove), eq(test_data.beacon))
+                    .return_once(move |_, _| Ok(transactions_to_prove));
 
                 let block_ranges_to_prove = test_data.block_ranges_to_prove.clone();
                 let all_transactions_in_block_ranges_to_prove =
@@ -460,7 +506,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn compute_proof_for_one_set_of_three_known_transactions_and_two_unknowns() {
+    async fn compute_proof_for_one_set_of_three_certified_transactions_and_two_unknowns() {
         let total_block_ranges = 5;
         let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
@@ -484,8 +530,8 @@ mod tests {
                 let transactions_to_prove = transactions_to_prove.clone();
                 transaction_retriever_mock
                     .expect_get_by_hashes()
-                    .with(eq(transaction_hashes_to_prove))
-                    .return_once(move |_| Ok(transactions_to_prove));
+                    .with(eq(transaction_hashes_to_prove), eq(test_data.beacon))
+                    .return_once(move |_, _| Ok(transactions_to_prove));
 
                 let block_ranges_to_prove = test_data.block_ranges_to_prove.clone();
                 let all_transactions_in_block_ranges_to_prove =
@@ -536,7 +582,7 @@ mod tests {
             |transaction_retriever_mock| {
                 transaction_retriever_mock
                     .expect_get_by_hashes()
-                    .returning(|_| Err(anyhow!("Error")));
+                    .returning(|_, _| Err(anyhow!("Error")));
             },
             |block_range_root_retriever_mock| {
                 block_range_root_retriever_mock
@@ -568,7 +614,7 @@ mod tests {
                 let transactions_to_prove = transactions_to_prove.clone();
                 transaction_retriever_mock
                     .expect_get_by_hashes()
-                    .return_once(move |_| Ok(transactions_to_prove));
+                    .return_once(move |_, _| Ok(transactions_to_prove));
 
                 let all_transactions_in_block_ranges_to_prove =
                     test_data.all_transactions_in_block_ranges_to_prove.clone();

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -360,12 +360,10 @@ mod tests {
 
     #[tokio::test]
     async fn compute_proof_for_one_set_of_three_certified_transactions() {
-        let total_block_ranges = 5;
-        let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
             .max_transactions_per_block(1)
-            .blocks_per_block_range(total_transactions_per_block_range)
-            .build_block_ranges(total_block_ranges);
+            .blocks_per_block_range(3)
+            .build_block_ranges(5);
         let transactions_to_prove =
             test_data::filter_transactions_for_indices(&[1, 2, 4], &transactions);
         let test_data = test_data::build_test_data(&transactions_to_prove, &transactions);
@@ -414,12 +412,10 @@ mod tests {
 
     #[tokio::test]
     async fn cant_compute_proof_for_not_yet_certified_transaction() {
-        let total_block_ranges = 5;
-        let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
             .max_transactions_per_block(1)
-            .blocks_per_block_range(total_transactions_per_block_range)
-            .build_block_ranges(total_block_ranges);
+            .blocks_per_block_range(3)
+            .build_block_ranges(5);
         let transactions_to_prove =
             test_data::filter_transactions_for_indices(&[1, 2, 4], &transactions);
         let test_data = test_data::build_test_data(&transactions_to_prove, &transactions);
@@ -458,12 +454,10 @@ mod tests {
 
     #[tokio::test]
     async fn cant_compute_proof_for_unknown_transaction() {
-        let total_block_ranges = 5;
-        let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
             .max_transactions_per_block(1)
-            .blocks_per_block_range(total_transactions_per_block_range)
-            .build_block_ranges(total_block_ranges);
+            .blocks_per_block_range(3)
+            .build_block_ranges(5);
         let transactions_to_prove = test_data::filter_transactions_for_indices(&[], &transactions);
         let mut test_data = test_data::build_test_data(&transactions_to_prove, &transactions);
         test_data.transaction_hashes_to_prove = vec!["tx-unknown-123".to_string()];
@@ -507,12 +501,10 @@ mod tests {
 
     #[tokio::test]
     async fn compute_proof_for_one_set_of_three_certified_transactions_and_two_unknowns() {
-        let total_block_ranges = 5;
-        let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
             .max_transactions_per_block(1)
-            .blocks_per_block_range(total_transactions_per_block_range)
-            .build_block_ranges(total_block_ranges);
+            .blocks_per_block_range(3)
+            .build_block_ranges(5);
         let transactions_to_prove =
             test_data::filter_transactions_for_indices(&[1, 2, 4], &transactions);
         let transaction_hashes_unknown =
@@ -569,12 +561,10 @@ mod tests {
 
     #[tokio::test]
     async fn cant_compute_proof_if_transaction_retriever_fails() {
-        let total_block_ranges = 5;
-        let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
             .max_transactions_per_block(1)
-            .blocks_per_block_range(total_transactions_per_block_range)
-            .build_block_ranges(total_block_ranges);
+            .blocks_per_block_range(3)
+            .build_block_ranges(5);
         let transactions_to_prove =
             test_data::filter_transactions_for_indices(&[1, 2, 4], &transactions);
         let test_data = test_data::build_test_data(&transactions_to_prove, &transactions);
@@ -600,12 +590,10 @@ mod tests {
 
     #[tokio::test]
     async fn cant_compute_proof_if_block_range_root_retriever_fails() {
-        let total_block_ranges = 5;
-        let total_transactions_per_block_range = 3;
         let transactions = CardanoTransactionsBuilder::new()
             .max_transactions_per_block(1)
-            .blocks_per_block_range(total_transactions_per_block_range)
-            .build_block_ranges(total_block_ranges);
+            .blocks_per_block_range(3)
+            .build_block_ranges(5);
         let transactions_to_prove =
             test_data::filter_transactions_for_indices(&[1, 2, 4], &transactions);
         let test_data = test_data::build_test_data(&transactions_to_prove, &transactions);

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.9.2"
+version = "0.9.4"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_transaction/certify.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/certify.rs
@@ -126,7 +126,7 @@ Mithril may not have signed those transactions yet, please try again later."
             .compute_cardano_transactions_proofs_message(certificate, verified_transactions);
         if !certificate.match_message(&message) {
             return Err(anyhow!(
-                "Proof and certificate doesn't match (certificate hash = '{}').",
+                "Proof and certificate don't match (certificate hash = '{}').",
                 certificate.hash
             ));
         }

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.3.3"
+version = "0.3.4"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/www/index.js
+++ b/mithril-client-wasm/www/index.js
@@ -104,7 +104,7 @@ console.log("Ensuire that the proof is indeed signed in the associated certifica
 if ((await client.verify_message_match_certificate(protocol_message, proof_certificate)) === true) {
   displayMessageInDOM("Result", "The proof is signed in the associated certificate &#x2713;");
 } else {
-  displayMessageInDOM("Result", "Proof and certificate doesn't match &#x2717;");
+  displayMessageInDOM("Result", "Proof and certificate don't match &#x2717;");
 }
 displayMessageInDOM("Transactions hashes certified", format_tx_list(proof.transactions_hashes));
 displayMessageInDOM("Transactions hashes not certified", format_tx_list(proof.non_certified_transactions));


### PR DESCRIPTION
## Content
This PR includes a fix to the **Cardano transactions prover** to avoid certifying transactions stored in the database, but not already certified. This was causing the error: `Proof and certificate don't match` when trying to verify this type of transactions instead of marking them as **not certified**.

### Benchmarks

![Screenshot from 2024-06-06 15-23-44](https://github.com/input-output-hk/mithril/assets/5566665/f7fc7084-fa21-436b-8d49-ef54faca989e)

| Total Requests | Concurrency | Transactions/Request | Pool (x50) : Request/s | Pool (x50) + Fix not yet certified transactions: Request/s |
| -------------- | ----------- | -------------------- | ---------------------- | ---------------------------------------------------------- |
| 1000           | 100         | 1                    | **273.78**                 | **275.95**                                                     |
| 1000           | 100         | 2                    | **201.6**                  | **200.65**                                                     |
| 1000           | 100         | 3                    | **143.14**                 | **150.64**                                                     |
| 1000           | 100         | 4                    | **115.41**                 | **124.02**                                                     |
| 1000           | 100         | 5                    | **91.15**                  | **103.31**                                                     |
| 1000           | 100         | 6                    | **80.58**                  | **87.72**                                                      |
| 1000           | 100         | 7                    | **74.23**                  | **77.33**                                                      |
| 1000           | 100         | 8                    | **65.05**                  | **68.08**                                                      |
| 1000           | 100         | 9                    | **58.78**                  | **61.77**                                                      |
| 1000           | 100         | 10                   | **52.51**                  | **58.13**                                                      |

> Running on **Linux / 8 cores / 64 GB RAM / 2 TB SSD**

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1719
