### PR TITLE
Remove manual workflow step for old `snapshot` commands availability

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -120,14 +120,6 @@ jobs:
         working-directory: ./bin
         run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} cardano-db download $CDB_SNAPSHOT_DIGEST
 
-      - name: Cardano-db / check old 'snapshot' commands availability
-        shell: bash
-        working-directory: ./bin
-        run: |
-          ./mithril-client ${{ steps.prepare.outputs.debug_level }} snapshot list --help
-          ./mithril-client ${{ steps.prepare.outputs.debug_level }} snapshot show --help
-          ./mithril-client ${{ steps.prepare.outputs.debug_level }} snapshot download --help
-
       - name: Mithril Stake Distribution / list and get last hash
         shell: bash
         working-directory: ./bin
@@ -207,13 +199,6 @@ jobs:
       - name: Cardano-db / download & restore latest
         shell: bash
         run: ${{ steps.command.outputs.mithril_client }} ${{ steps.prepare.outputs.debug_level }} cardano-db download $CDB_SNAPSHOT_DIGEST --download-dir /app
-
-      - name: Cardano-db / check old 'snapshot' commands availability
-        shell: bash
-        run: |
-          ${{ steps.command.outputs.mithril_client }} ${{ steps.prepare.outputs.debug_level }} snapshot list --help
-          ${{ steps.command.outputs.mithril_client }} ${{ steps.prepare.outputs.debug_level }} snapshot show --help
-          ${{ steps.command.outputs.mithril_client }} ${{ steps.prepare.outputs.debug_level }} snapshot download --help
 
       - name: Mithril Stake Distribution / list and get last hash
         shell: bash


### PR DESCRIPTION
## Content
This PR includes a fix for the manual workflow `Mithril Client multi-platform test` that removes command compatibility steps due to the removal of the `snapshot` command.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)