### PR TITLE
feat(tls): Allow the underlying TLS implementation to be selected by feature flags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-As a minor extension, we have adopted a slightly different versioning convention for the Mithril distributions (https://mithril.network/doc/adr/3#decision)
+As a minor extension, we have adopted a slightly different versioning convention for the Mithril distributions (<https://mithril.network/doc/adr/3#decision>)
 
 ## Mithril Distribution [XXXX.X] - UNRELEASED
 
@@ -23,7 +23,9 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Implement a Resource Pool and use it for caching Block Range Merkle maps used by the Cardano transactions prover and improving the throughput.
 
-- Change the beacon of the Cardano Transactions to a block number instead of an immutable file number. 
+- Change the beacon of the Cardano Transactions to a block number instead of an immutable file number.
+
+- Provide a feature to the `mithril-client` crate to allow selection of the TLS implementation used by the dependent `reqwest` crate.
 
 - Crates versions:
 
@@ -41,10 +43,10 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Chain observers support the retrieval of the current Cardano chain point.
 
--  Deprecate `portable` feature of `mithril-stm` and `mithril-client`:
-   - Instead, always enable BLST `portable` feature in `mithril-stm` for runtime check of intel ADX instruction set.
-   - `portable` feature now has no effect and should be removed from crate dependencies.
-   - Removed it from all other crates (including `mithril-common`).
+- Deprecate `portable` feature of `mithril-stm` and `mithril-client`:
+  - Instead, always enable BLST `portable` feature in `mithril-stm` for runtime check of intel ADX instruction set.
+  - `portable` feature now has no effect and should be removed from crate dependencies.
+  - Removed it from all other crates (including `mithril-common`).
 
 - Switched memory allocator to `jemallocator` on signer and aggregator to avoid memory fragmentation when signing transactions (which lead to RES memory not being properly returned to the OS).
 
@@ -62,9 +64,9 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [2412.0] - 2024-03-26
 
-- **GitHub release**: https://github.com/input-output-hk/mithril/releases/tag/2412.0
+- **GitHub release**: <https://github.com/input-output-hk/mithril/releases/tag/2412.0>
 
-- _DEPRECATED_ the `snapshot` command in the Mithril client CLI: 
+- _DEPRECATED_ the `snapshot` command in the Mithril client CLI:
   - Renamed to `cardano-db snapshot`.
   - Will be **removed** in **2** distributions.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2423,6 +2423,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0bea761b46ae2b24eb4aef630d8d1c398157b6fc29e6350ecf090a0b70c952c"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.3.1",
+ "hyper-util",
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,7 +3347,7 @@ dependencies = [
  "soketto",
  "tracing",
  "url",
- "webpki-roots",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5165,6 +5182,7 @@ dependencies = [
  "http-body 1.0.0",
  "http-body-util",
  "hyper 1.3.1",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -5175,7 +5193,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.22.4",
+ "rustls-native-certs",
  "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -5183,6 +5204,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower-service",
  "url",
@@ -5190,6 +5212,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.2",
  "winreg 0.52.0",
 ]
 
@@ -5353,6 +5376,20 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
+dependencies = [
+ "log",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a218f0f6d05669de4eabfb24f31ce802035c952429d037507b4a4a39f0e60c5b"
@@ -5363,6 +5400,19 @@ dependencies = [
  "rustls-webpki 0.102.4",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.1.2",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -6355,6 +6405,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+dependencies = [
+ "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6952,6 +7013,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c452ad30530b54a4d8e71952716a212b08efd0f3562baa66c29a618b07da7c3"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "widestring"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -51,7 +51,7 @@ mithril-common = { path = "../mithril-common", version = "=0.4", features = [
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
 mithril-common = { path = "../mithril-common", version = "=0.4" }
-reqwest = { version = "0.12.0", features = ["json", "stream"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["charset", "http2", "macos-system-configuration", "json", "stream"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"
@@ -68,8 +68,8 @@ tokio = { version = "1.37.0", features = ["macros", "rt"] }
 warp = "0.3.6"
 
 [features]
-# Include nothing by default
-default = []
+# Include native-tls in reqwest by default
+default = ["native-tls"]
 
 # Full feature set
 full = ["fs"]
@@ -78,6 +78,17 @@ full = ["fs"]
 fs = ["flate2", "flume", "tar", "tokio/rt", "zstd"]
 portable = []                                       # deprecated, will be removed soon
 unstable = []
+
+# These features are for support of dependent crates only.
+# They do not change the operation of the main crate.
+native-tls = ["reqwest/native-tls"]
+native-tls-alpn = ["reqwest/native-tls-alpn"]
+native-tls-vendored = ["reqwest/native-tls-vendored"]
+
+rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
+rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -31,7 +31,13 @@ chrono = { version = "0.4.33", features = ["serde"] }
 flate2 = { version = "1.0.28", optional = true }
 flume = { version = "0.11.0", optional = true }
 futures = "0.3.30"
-reqwest = { version = "0.12.4", default-features = false, features = ["charset", "http2", "macos-system-configuration", "json", "stream"] }
+reqwest = { version = "0.12.4", default-features = false, features = [
+    "charset",
+    "http2",
+    "macos-system-configuration",
+    "json",
+    "stream",
+] }
 semver = "1.0.21"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
@@ -51,14 +57,19 @@ mithril-common = { path = "../mithril-common", version = "=0.4", features = [
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
 mithril-common = { path = "../mithril-common", version = "=0.4" }
-reqwest = { version = "0.12.4", default-features = false, features = ["charset", "http2", "macos-system-configuration", "json", "stream"] }
+reqwest = { version = "0.12.4", default-features = false, features = [
+    "charset",
+    "http2",
+    "macos-system-configuration",
+    "json",
+    "stream",
+] }
 
 [dev-dependencies]
 httpmock = "0.7.0"
 indicatif = { version = "0.17.7", features = ["tokio"] }
 mithril-common = { path = "../mithril-common", version = "=0.4", features = [
     "random",
-    # "test_tools", # This is pulling in Reqwest + OpenSSL.  Disable and see if it breaks anything.
 ] }
 mockall = "0.12.1"
 slog-async = "2.8.0"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -31,7 +31,7 @@ chrono = { version = "0.4.33", features = ["serde"] }
 flate2 = { version = "1.0.28", optional = true }
 flume = { version = "0.11.0", optional = true }
 futures = "0.3.30"
-reqwest = { version = "0.12.0", features = ["json", "stream"] }
+reqwest = { version = "0.12.4", default-features = false, features = ["charset", "http2", "macos-system-configuration", "json", "stream"] }
 semver = "1.0.21"
 serde = { version = "1.0.196", features = ["derive"] }
 serde_json = "1.0.113"
@@ -58,7 +58,7 @@ httpmock = "0.7.0"
 indicatif = { version = "0.17.7", features = ["tokio"] }
 mithril-common = { path = "../mithril-common", version = "=0.4", features = [
     "random",
-    "test_tools",
+    # "test_tools", # This is pulling in Reqwest + OpenSSL.  Disable and see if it breaks anything.
 ] }
 mockall = "0.12.1"
 slog-async = "2.8.0"

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.3"
+version = "0.8.4"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -79,7 +79,6 @@ slog-term = "2.9.0"
 tokio = { version = "1.37.0", features = ["macros", "rt"] }
 warp = "0.3.6"
 
-
 [features]
 # Include native-tls in reqwest by default
 default = ["native-tls"]

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -70,6 +70,7 @@ httpmock = "0.7.0"
 indicatif = { version = "0.17.7", features = ["tokio"] }
 mithril-common = { path = "../mithril-common", version = "=0.4", features = [
     "random",
+    "test_tools",
 ] }
 mockall = "0.12.1"
 slog-async = "2.8.0"
@@ -77,6 +78,7 @@ slog-scope = "4.4.0"
 slog-term = "2.9.0"
 tokio = { version = "1.37.0", features = ["macros", "rt"] }
 warp = "0.3.6"
+
 
 [features]
 # Include native-tls in reqwest by default


### PR DESCRIPTION
## Content

The `mithril-client` library uses the `reqwest` crate.  By default, `reqwest` uses `OpenSSL` for TLS support in HTTPS requests.  This causes any consumer of the library to have a dynamic dependency on a system OpenSSL library.

`reqwest` has a number of options for fulfilling `tls` functionality.  This patch just exposes that, using the same feature flags that `reqwest` uses.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

This PR came about because our project requires static linking of dependent libraries, and this was not possible when using the `mithril-client` crate.

## Issue(s)

Closes #1737 