### PR TITLE
Remove bottleneck in proof generation of Merkle map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Provide a feature to the `mithril-client` crate to allow selection of the TLS implementation used by the dependent `reqwest` crate.
 
+- **UNSTABLE** Cardano transactions certification:
+  - Optimize the performances of the computation of the proof with a Merkle map.
+
 - Crates versions:
 
 |  Crate  |  Version  |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.18"
+version = "0.5.19"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -147,9 +147,10 @@ impl ProverService for MithrilProverService {
         // 5 - Compute the proof for all transactions
         if let Ok(mk_proof) = mk_map.compute_proof(transaction_hashes) {
             self.mk_map_pool.give_back_resource_pool_item(mk_map)?;
+            let mk_proof_leaves = mk_proof.leaves();
             let transaction_hashes_certified: Vec<TransactionHash> = transaction_hashes
                 .iter()
-                .filter(|hash| mk_proof.contains(&hash.as_str().into()).is_ok())
+                .filter(|hash| mk_proof_leaves.contains(&hash.as_str().into()))
                 .cloned()
                 .collect();
 

--- a/mithril-common/benches/merkle_map.rs
+++ b/mithril-common/benches/merkle_map.rs
@@ -43,7 +43,8 @@ fn generate_block_ranges_nodes_iterator(
             block_range_index * total_transactions_per_block_range,
             (block_range_index + 1) * total_transactions_per_block_range,
         );
-        let mk_map_node = if block_range_index < max_uncompressed_block_ranges {
+        let mk_map_node = if block_range_index <= total_block_ranges - max_uncompressed_block_ranges
+        {
             let leaves = <Range<u64> as Clone>::clone(&block_range)
                 .map(|leaf_index| leaf_index.to_string())
                 .collect::<Vec<_>>();

--- a/mithril-common/benches/merkle_map.rs
+++ b/mithril-common/benches/merkle_map.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use mithril_common::{
-    crypto_helper::{MKMap, MKMapNode, MKMapProof, MKMapValue, MKTree, MKTreeNode},
+    crypto_helper::{MKMap, MKMapNode, MKMapValue, MKTree, MKTreeNode},
     entities::BlockRange,
 };
 
@@ -70,31 +70,6 @@ fn generate_merkle_map_compressed(
     mk_map
 }
 
-fn generate_merkle_map_root(
-    block_ranges_nodes_iterator: impl Iterator<Item = (BlockRange, MKMapNode<BlockRange>)>,
-    mk_map_compressed: &MKMap<BlockRange, MKMapNode<BlockRange>>,
-) -> MKMapNode<BlockRange> {
-    let total_full_mk_tree = 1;
-    let (mk_map, _) = generate_merkle_map(
-        block_ranges_nodes_iterator,
-        mk_map_compressed,
-        total_full_mk_tree,
-    );
-
-    mk_map.compute_root().unwrap().into()
-}
-
-fn generate_merkle_map_proof(
-    block_ranges_nodes_iterator: impl Iterator<Item = (BlockRange, MKMapNode<BlockRange>)>,
-    mk_map_compressed: &MKMap<BlockRange, MKMapNode<BlockRange>>,
-    total_proofs: u64,
-) -> MKMapProof<BlockRange> {
-    let (mk_map, leaves_to_prove_all) =
-        generate_merkle_map(block_ranges_nodes_iterator, mk_map_compressed, total_proofs);
-
-    mk_map.compute_proof(&leaves_to_prove_all).unwrap()
-}
-
 fn generate_merkle_map(
     block_ranges_nodes_iterator: impl Iterator<Item = (BlockRange, MKMapNode<BlockRange>)>,
     mk_map_compressed: &MKMap<BlockRange, MKMapNode<BlockRange>>,
@@ -144,15 +119,18 @@ fn create_merkle_map_root_benches(c: &mut Criterion) {
             BenchmarkId::from_parameter(total_leaves),
             total_leaves,
             |b, &_total_leaves| {
-                b.iter(|| {
-                    let mk_trees_by_block_range_iterator = generate_block_ranges_nodes_iterator(
-                        *total_leaves,
-                        TOTAL_TRANSACTIONS_PER_BLOCK,
-                        BLOCK_RANGE_LENGTH_BENCH,
-                        1,
-                    );
-                    generate_merkle_map_root(mk_trees_by_block_range_iterator, &mk_map_compressed);
-                });
+                let mk_trees_by_block_range_iterator = generate_block_ranges_nodes_iterator(
+                    *total_leaves,
+                    TOTAL_TRANSACTIONS_PER_BLOCK,
+                    BLOCK_RANGE_LENGTH_BENCH,
+                    MAX_TRANSACTIONS_PER_PROOF_BENCH,
+                );
+                let (mk_map, _leaves_to_prove_all) = generate_merkle_map(
+                    mk_trees_by_block_range_iterator,
+                    &mk_map_compressed,
+                    MAX_TRANSACTIONS_PER_PROOF_BENCH,
+                );
+                b.iter(|| mk_map.compute_root().unwrap());
             },
         );
     }
@@ -176,19 +154,18 @@ fn create_merkle_map_proof_benches(c: &mut Criterion) {
             BenchmarkId::from_parameter(total_leaves),
             total_leaves,
             |b, &_total_leaves| {
-                b.iter(|| {
-                    let mk_trees_by_block_range_iterator = generate_block_ranges_nodes_iterator(
-                        *total_leaves,
-                        TOTAL_TRANSACTIONS_PER_BLOCK,
-                        BLOCK_RANGE_LENGTH_BENCH,
-                        MAX_TRANSACTIONS_PER_PROOF_BENCH,
-                    );
-                    generate_merkle_map_proof(
-                        mk_trees_by_block_range_iterator,
-                        &mk_map_compressed,
-                        MAX_TRANSACTIONS_PER_PROOF_BENCH,
-                    );
-                });
+                let mk_trees_by_block_range_iterator = generate_block_ranges_nodes_iterator(
+                    *total_leaves,
+                    TOTAL_TRANSACTIONS_PER_BLOCK,
+                    BLOCK_RANGE_LENGTH_BENCH,
+                    MAX_TRANSACTIONS_PER_PROOF_BENCH,
+                );
+                let (mk_map, leaves_to_prove_all) = generate_merkle_map(
+                    mk_trees_by_block_range_iterator,
+                    &mk_map_compressed,
+                    MAX_TRANSACTIONS_PER_PROOF_BENCH,
+                );
+                b.iter(|| mk_map.compute_proof(&leaves_to_prove_all).unwrap());
             },
         );
     }
@@ -213,11 +190,12 @@ fn verify_merkle_map_proof_benches(c: &mut Criterion) {
             BLOCK_RANGE_LENGTH_BENCH,
             MAX_TRANSACTIONS_PER_PROOF_BENCH,
         );
-        let mk_map_proof = generate_merkle_map_proof(
+        let (mk_map, leaves_to_prove_all) = generate_merkle_map(
             mk_trees_by_block_range_iterator,
             &mk_map_compressed,
             MAX_TRANSACTIONS_PER_PROOF_BENCH,
         );
+        let mk_map_proof = mk_map.compute_proof(&leaves_to_prove_all).unwrap();
 
         group.bench_with_input(
             BenchmarkId::from_parameter(total_leaves),

--- a/mithril-common/benches/merkle_map.rs
+++ b/mithril-common/benches/merkle_map.rs
@@ -23,7 +23,7 @@ const TOTAL_TRANSACTIONS_BENCHES: &[u64] = &[
     B,
 ];
 const BLOCK_RANGE_LENGTH_BENCH: u64 = 15;
-const TOTAL_TRANSACTIONS_PER_BLOCK: u64 = 50;
+const TOTAL_TRANSACTIONS_PER_BLOCK: u64 = 15;
 const MAX_TRANSACTIONS_PER_PROOF_BENCH: u64 = 100;
 
 fn generate_block_ranges_nodes_iterator(

--- a/mithril-common/src/crypto_helper/merkle_tree.rs
+++ b/mithril-common/src/crypto_helper/merkle_tree.rs
@@ -158,6 +158,14 @@ impl MKProof {
             .ok_or(anyhow!("Leaves not found in the MKProof"))
     }
 
+    /// List the leaves of the proof
+    pub fn leaves(&self) -> Vec<MKTreeNode> {
+        self.inner_leaves
+            .iter()
+            .map(|(_, l)| (**l).clone())
+            .collect::<Vec<_>>()
+    }
+
     cfg_test_tools! {
         /// Build a [MKProof] based on the given leaves (*Test only*).
         pub fn from_leaves<T: Into<MKTreeNode> + Clone>(
@@ -443,5 +451,16 @@ mod tests {
                 leaves_not_verified[0].to_owned(),
             ])
             .unwrap_err();
+    }
+
+    #[test]
+    fn list_leaves() {
+        let mut leaves_to_verify = generate_leaves(10);
+        let _ = leaves_to_verify.drain(3..6).collect::<Vec<_>>();
+        let proof =
+            MKProof::from_leaves(&leaves_to_verify).expect("MKProof generation should not fail");
+
+        let proof_leaves = proof.leaves();
+        assert_eq!(proof_leaves, leaves_to_verify);
     }
 }

--- a/mithril-common/src/crypto_helper/merkle_tree.rs
+++ b/mithril-common/src/crypto_helper/merkle_tree.rs
@@ -149,11 +149,7 @@ impl MKProof {
     pub fn contains(&self, leaves: &[MKTreeNode]) -> StdResult<()> {
         leaves
             .iter()
-            .all(|leaf| {
-                self.inner_leaves
-                    .iter()
-                    .any(|(_, l)| ((**l).clone()) == *leaf)
-            })
+            .all(|leaf| self.inner_leaves.iter().any(|(_, l)| l.deref() == leaf))
             .then_some(())
             .ok_or(anyhow!("Leaves not found in the MKProof"))
     }
@@ -455,8 +451,7 @@ mod tests {
 
     #[test]
     fn list_leaves() {
-        let mut leaves_to_verify = generate_leaves(10);
-        let _ = leaves_to_verify.drain(3..6).collect::<Vec<_>>();
+        let leaves_to_verify = generate_leaves(10);
         let proof =
             MKProof::from_leaves(&leaves_to_verify).expect("MKProof generation should not fail");
 


### PR DESCRIPTION
## Content
This PR includes fix of some **bottlenecks identified in the proof generation** of the Merkle map:
- Fix bottleneck when Merkle map computes a proofs.
- Fix bottleneck when computing the list of certified items in a Mekle map proof.
- Refactor Merkle map benchmarks to make them more accurate.

### Benchmarks

![Screenshot from 2024-06-10 19-14-29](https://github.com/input-output-hk/mithril/assets/5566665/02205da0-b937-47c9-a0ea-ed40619868ae)

| Total Requests | Concurrency | Transactions/Request | Pool (x50): Request/s | Pool (x50) + Optimization MKMap proof computation: Request/s |
| -------------- | ----------- | -------------------- | --------------------- | ------------------------------------------------------------ |
| 1000           | 100         | 1                    | **281.4**                 | **1403.97**                                                      |
| 1000           | 100         | 2                    | **192.84**                | **468.39**                                                       |
| 1000           | 100         | 3                    | **138.47**                | **289.79**                                                       |
| 1000           | 100         | 4                    | **123.5**                 | **241.31**                                                       |
| 1000           | 100         | 5                    | **102.83**                | **149.93**                                                       |
| 1000           | 100         | 6                    | **84.58**                 | **137.74**                                                       |
| 1000           | 100         | 7                    | **73.35**                 | **111.12**                                                       |
| 1000           | 100         | 8                    | **65.93**                 | **99.63**                                                        |
| 1000           | 100         | 9                    | **60.79**                 | **80.79**                                                        |
| 1000           | 100         | 10                   | **56.39**                 | **79.55**                                                        |       

> Running on **Linux / 8 cores / 64 GB RAM / 2 TB SSD**

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1730 
