### PR TITLE
docs: add missing pre-requisites for building crates

### DIFF
--- a/demo/protocol-demo/README.md
+++ b/demo/protocol-demo/README.md
@@ -11,6 +11,7 @@ This cli implements a very simple version of the Mithril protocol for demonstrat
 **Install Rust**
 
 - Install a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain (latest stable version).
+- Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
 
 ## Download source code
 

--- a/docs/website/root/manual/developer-docs/nodes/mithril-aggregator.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-aggregator.md
@@ -37,6 +37,8 @@ Mithril aggregator is responsible for collecting individual signatures from the 
 
 * Install the latest stable version of the [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain.
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 * Install OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`.
 
 ## Download the source file

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client-library.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client-library.md
@@ -44,6 +44,8 @@ It is responsible for handling the different types of data certified by Mithril,
 
 * Install the latest stable version of the [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain.
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 * Install OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`
 
 ## Installation

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client.md
@@ -42,6 +42,8 @@ Mithril client is responsible for restoring the **Cardano** blockchain on an emp
 * Install the latest stable version of the [correctly configured](https://www.rust-lang.org/learn/get-started) Rust
   toolchain.
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 * Install OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`
 
 ## Download the source file

--- a/docs/website/root/manual/developer-docs/nodes/mithril-signer.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-signer.md
@@ -39,6 +39,8 @@ Mithril signer is responsible for producing individual signatures that are colle
 
 * Install the latest stable version of the [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain.
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 * Install OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`.
 
 ## Download the source file

--- a/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
@@ -25,7 +25,9 @@ Before proceeding with the installation, ensure that you have the following pre-
 
 1. **Install a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain**: make sure you have the latest stable version of Rust installed
 
-2. **Install OpenSSL development libraries**: On Ubuntu/Debian/Mint, run the following command to install the required OpenSSL development libraries:
+2. **Install Build Tools `build-essential` and `m4`**: On Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
+3. **Install OpenSSL development libraries**: On Ubuntu/Debian/Mint, run the following command to install the required OpenSSL development libraries:
 
  ```
 sudo apt install libssl-dev

--- a/docs/website/root/manual/getting-started/run-mithril-devnet.md
+++ b/docs/website/root/manual/getting-started/run-mithril-devnet.md
@@ -37,6 +37,8 @@ More information about the private Cardano/Mithril `devnet` is available [here](
 
 * Install the latest stable version of a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain.
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 * Install the OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`.
 
 ## Download the source file

--- a/docs/website/root/manual/getting-started/run-signer-node.md
+++ b/docs/website/root/manual/getting-started/run-signer-node.md
@@ -97,6 +97,8 @@ Note that this guide works on a Linux machine only.
 
 * Install a correctly configured Rust toolchain (latest stable version). You can follow the instructions provided [here](https://www.rust-lang.org/learn/get-started).
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 * Install OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`.
 
 * Install a recent version of `jq` (version 1.6+). You can install it by running `apt install jq`.

--- a/mithril-relay/README.md
+++ b/mithril-relay/README.md
@@ -12,6 +12,8 @@ The **Mithril relay** is an experimental implementation of a relay for Mithril s
 
 * Install the latest stable version of the [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain.
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 * Install OpenSSL development libraries. For example, on Ubuntu/Debian/Mint, run `apt install libssl-dev`
 
 ## Download the source file

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -27,6 +27,8 @@
 
 * Install a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain (latest stable version).
 
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
+
 ## Download source code
 
 ```bash

--- a/mithril-test-lab/mithril-end-to-end/README.md
+++ b/mithril-test-lab/mithril-end-to-end/README.md
@@ -9,7 +9,10 @@
 **Install Rust**
 
 * Install a [correctly configured](https://www.rust-lang.org/learn/get-started) Rust toolchain (latest stable version).
+
 * Install Rust [Clippy](https://github.com/rust-lang/rust-clippy) component.
+
+* Install Build Tools `build-essential` and `m4`. For example, on Ubuntu/Debian/Mint, run `sudo apt install build-essential m4`.
 
 ## Download source code
 


### PR DESCRIPTION
## Content
This PR includes the missing pre-requisites for building crates: 
- `build-essential` and `m4` tools were missing.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)
