### PR TITLE
Sqlite auto rollback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.4"
+version = "0.2.5"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -182,7 +182,7 @@ impl CardanoTransactionRepository {
     ) -> StdResult<()> {
         const DB_TRANSACTION_SIZE: usize = 100000;
         for transactions_in_db_transaction_chunk in transactions.chunks(DB_TRANSACTION_SIZE) {
-            self.connection.execute("BEGIN TRANSACTION;")?;
+            let transaction = self.connection.begin_transaction()?;
 
             // Chunk transactions to avoid an error when we exceed sqlite binding limitations
             for transactions_in_chunk in transactions_in_db_transaction_chunk.chunks(100) {
@@ -191,7 +191,7 @@ impl CardanoTransactionRepository {
                     .with_context(|| "CardanoTransactionRepository can not store transactions")?;
             }
 
-            self.connection.execute("END TRANSACTION;")?;
+            transaction.commit()?;
         }
         Ok(())
     }

--- a/internal/mithril-persistence/src/sqlite/connection_extensions.rs
+++ b/internal/mithril-persistence/src/sqlite/connection_extensions.rs
@@ -3,10 +3,13 @@ use sqlite::{ReadableWithIndex, Value};
 
 use mithril_common::StdResult;
 
-use crate::sqlite::{EntityCursor, Query, SqliteConnection};
+use crate::sqlite::{EntityCursor, Query, SqliteConnection, Transaction};
 
 /// Extension trait for the [SqliteConnection] type.
 pub trait ConnectionExtensions {
+    /// Begin a transaction on the connection.
+    fn begin_transaction(&self) -> StdResult<Transaction>;
+
     /// Execute the given sql query and return the value of the first cell read.
     fn query_single_cell<Q: AsRef<str>, T: ReadableWithIndex>(
         &self,
@@ -30,6 +33,10 @@ pub trait ConnectionExtensions {
 }
 
 impl ConnectionExtensions for SqliteConnection {
+    fn begin_transaction(&self) -> StdResult<Transaction> {
+        Ok(Transaction::begin(self)?)
+    }
+
     fn query_single_cell<Q: AsRef<str>, T: ReadableWithIndex>(
         &self,
         sql: Q,

--- a/internal/mithril-persistence/src/sqlite/mod.rs
+++ b/internal/mithril-persistence/src/sqlite/mod.rs
@@ -10,6 +10,7 @@ mod entity;
 mod projection;
 mod query;
 mod source_alias;
+mod transaction;
 
 pub use condition::{GetAllCondition, WhereCondition};
 pub use connection_builder::{ConnectionBuilder, ConnectionOptions};
@@ -19,6 +20,7 @@ pub use entity::{HydrationError, SqLiteEntity};
 pub use projection::{Projection, ProjectionField};
 pub use query::Query;
 pub use source_alias::SourceAlias;
+pub use transaction::Transaction;
 
 use mithril_common::StdResult;
 use sqlite::ConnectionThreadSafe;

--- a/internal/mithril-persistence/src/sqlite/transaction.rs
+++ b/internal/mithril-persistence/src/sqlite/transaction.rs
@@ -1,0 +1,134 @@
+use crate::sqlite::SqliteConnection;
+
+/// Sqlite transaction wrapper.
+///
+/// Transactions are automatically rolled back if this struct object is dropped and
+/// the transaction was not committed.
+pub struct Transaction<'a> {
+    connection: &'a SqliteConnection,
+    // An active transaction is one that has yet to be committed or rolled back.
+    is_active: bool,
+}
+
+impl<'a> Transaction<'a> {
+    /// Begin a new transaction.
+    pub fn begin(connection: &'a SqliteConnection) -> Result<Self, sqlite::Error> {
+        connection.execute("BEGIN TRANSACTION")?;
+        Ok(Self {
+            connection,
+            is_active: true,
+        })
+    }
+
+    /// Commit the transaction.
+    pub fn commit(mut self) -> Result<(), sqlite::Error> {
+        self.connection.execute("COMMIT TRANSACTION")?;
+        self.is_active = false;
+        Ok(())
+    }
+
+    /// Rollback the transaction.
+    pub fn rollback(mut self) -> Result<(), sqlite::Error> {
+        self.connection.execute("ROLLBACK TRANSACTION")?;
+        self.is_active = false;
+        Ok(())
+    }
+}
+
+impl Drop for Transaction<'_> {
+    fn drop(&mut self) {
+        if self.is_active {
+            self.connection.execute("ROLLBACK TRANSACTION").unwrap();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sqlite::ConnectionExtensions;
+    use anyhow::anyhow;
+    use mithril_common::StdResult;
+    use sqlite::Connection;
+
+    fn init_database() -> SqliteConnection {
+        let connection = Connection::open_thread_safe(":memory:").unwrap();
+        connection
+            .execute("create table query_test(text_data text not null primary key);")
+            .unwrap();
+
+        connection
+    }
+
+    fn get_number_of_rows(connection: &SqliteConnection) -> i64 {
+        connection
+            .query_single_cell("select count(*) from query_test", &[])
+            .unwrap()
+    }
+
+    #[test]
+    fn test_commit() {
+        let connection = init_database();
+
+        assert_eq!(0, get_number_of_rows(&connection));
+        {
+            let transaction = Transaction::begin(&connection).unwrap();
+            connection
+                .execute("insert into query_test(text_data) values ('row 1')")
+                .unwrap();
+            transaction.commit().unwrap();
+        }
+        assert_eq!(1, get_number_of_rows(&connection));
+    }
+
+    #[test]
+    fn test_rollback() {
+        let connection = init_database();
+
+        assert_eq!(0, get_number_of_rows(&connection));
+        {
+            let transaction = Transaction::begin(&connection).unwrap();
+            connection
+                .execute("insert into query_test(text_data) values ('row 1')")
+                .unwrap();
+            transaction.rollback().unwrap();
+        }
+        assert_eq!(0, get_number_of_rows(&connection));
+    }
+
+    #[test]
+    fn test_auto_rollback_when_dropping() {
+        let connection = init_database();
+
+        assert_eq!(0, get_number_of_rows(&connection));
+        {
+            let _transaction = Transaction::begin(&connection).unwrap();
+            connection
+                .execute("insert into query_test(text_data) values ('row 1')")
+                .unwrap();
+        }
+        assert_eq!(0, get_number_of_rows(&connection));
+    }
+
+    #[test]
+    fn test_auto_rollback_when_dropping_because_of_an_error() {
+        fn failing_function() -> StdResult<()> {
+            Err(anyhow!("This is an error"))
+        }
+        fn failing_function_that_insert_data(connection: &SqliteConnection) -> StdResult<()> {
+            let transaction = Transaction::begin(connection).unwrap();
+            connection
+                .execute("insert into query_test(text_data) values ('row 1')")
+                .unwrap();
+            failing_function()?;
+            transaction.commit().unwrap();
+            Ok(())
+        }
+
+        let connection = init_database();
+
+        assert_eq!(0, get_number_of_rows(&connection));
+        let _err = failing_function_that_insert_data(&connection).unwrap_err();
+        assert_eq!(0, get_number_of_rows(&connection));
+    }
+}


### PR DESCRIPTION
## Content

This PR add a light layer to easily open, commit, and rollback SQLite transactions.

This is done by adding a `Transaction` struct to `mithril-persistence` that:
- wrap a **borrowed** SQLite connection.
- define three public methods: `begin` (the constructor), `commit` and `rollback`.
- `commit` and `rollback` method move self, meaning that using either of them remove the transaction of the current scope: the compiler won't allow to use several `commit` or `rollback` on the same transaction.
- Implement `Drop` to automatically rollback the transaction when it goes out of scope if it was still active.

Also a `begin_transaction` extension method is added to the sqlite transaction so they can be created without needing to import the new type.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
While this system make using SQLite transactions easier it should not be used on our main SQLite database until we implement a connection pool system instead of sharing a global connection. Else we would be at risk of opening a transaction when one was already opened leading to at minimum an error or at worst a crash.

## Issue(s)
Closes #1741
