### PR TITLE
Implement pooled resource item reset when given back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Provide a feature to the `mithril-client` crate to allow selection of the TLS implementation used by the dependent `reqwest` crate.
 
+- Implement a reset mechanism for mutable resources returned to a pool (`ResourcePool`) to keep it in a consistent state.
+
 - **UNSTABLE** Cardano transactions certification:
   - Optimize the performances of the computation of the proof with a Merkle map.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.14"
+version = "0.4.15"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.14"
+version = "0.4.15"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -158,7 +158,7 @@ impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
                 let value = value
                     .compute_root()?
                     .try_into()
-                    .map_err(|_| anyhow!("Merkel root could not be converted to V"))?;
+                    .map_err(|_| anyhow!("Merkle root could not be converted to V"))?;
                 self.replace(key.to_owned(), value)?;
             }
         }

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -16,7 +16,7 @@ use super::{MKProof, MKTree, MKTreeNode};
 pub trait MKMapKey: PartialEq + Eq + PartialOrd + Ord + Clone + Hash + Into<MKTreeNode> {}
 
 /// The trait implemented by the values of a MKMap
-pub trait MKMapValue<K: MKMapKey>: Clone + TryInto<MKTreeNode> {
+pub trait MKMapValue<K: MKMapKey>: Clone + TryInto<MKTreeNode> + TryFrom<MKTreeNode> {
     /// Get the root of the merkelized map value
     fn compute_root(&self) -> StdResult<MKTreeNode>;
 
@@ -119,6 +119,12 @@ impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
         Ok(())
     }
 
+    #[cfg(test)]
+    /// Get the provable keys of the merkelized map
+    pub fn get_provable_keys(&self) -> &BTreeSet<K> {
+        &self.provable_keys
+    }
+
     /// Check if the merkelized map contains a leaf (and returns the corresponding key and value if exists)
     pub fn contains(&self, leaf: &MKTreeNode) -> Option<(&K, &V)> {
         self.iter().find(|(_, v)| v.contains(leaf))
@@ -142,6 +148,22 @@ impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
     /// Check if the merkelized map is empty
     pub fn is_empty(&self) -> bool {
         self.inner_map_values.is_empty()
+    }
+
+    /// Compress the merkelized map
+    pub fn compress(&mut self) -> StdResult<()> {
+        let keys = self.provable_keys.clone();
+        for key in keys {
+            if let Some(value) = self.get(&key) {
+                let value = value
+                    .compute_root()?
+                    .try_into()
+                    .map_err(|_| anyhow!("Merkel root could not be converted to V"))?;
+                self.replace(key.to_owned(), value)?;
+            }
+        }
+
+        Ok(())
     }
 
     /// Get the root of the merkle tree of the merkelized map
@@ -531,6 +553,34 @@ mod tests {
         mk_map
             .insert(block_range_replacement, different_root_value)
             .expect_err("the MKMap should reject replacement with different root value");
+    }
+
+    #[test]
+    fn test_mk_map_should_compress_correctly() {
+        let entries = [
+            BlockRange::new(0, 3),
+            BlockRange::new(4, 6),
+            BlockRange::new(7, 9),
+        ]
+        .iter()
+        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
+        .collect::<Vec<_>>();
+        let merkle_tree_entries = &entries
+            .into_iter()
+            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
+            .collect::<Vec<(_, MKMapNode<_>)>>();
+        let mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        let mk_map_root_expected = mk_map.compute_root().unwrap();
+        let mk_map_provable_keys = mk_map.get_provable_keys();
+        assert!(!mk_map_provable_keys.is_empty());
+
+        let mut mk_map_compressed = mk_map.clone();
+        mk_map_compressed.compress().unwrap();
+
+        let mk_map_compressed_root = mk_map_compressed.compute_root().unwrap();
+        let mk_map_compressed_provable_keys = mk_map_compressed.get_provable_keys();
+        assert_eq!(mk_map_root_expected, mk_map_compressed_root);
+        assert!(mk_map_compressed_provable_keys.is_empty());
     }
 
     #[test]

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -8,7 +8,7 @@ use std::{
     sync::Arc,
 };
 
-use crate::{StdError, StdResult};
+use crate::{resource_pool::Reset, StdError, StdResult};
 
 use super::{MKProof, MKTree, MKTreeNode};
 
@@ -232,6 +232,12 @@ impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
             });
 
         leaves_by_keys
+    }
+}
+
+impl<K: MKMapKey, V: MKMapValue<K>> Reset for MKMap<K, V> {
+    fn reset(&mut self) -> StdResult<()> {
+        self.compress()
     }
 }
 

--- a/mithril-common/src/resource_pool.rs
+++ b/mithril-common/src/resource_pool.rs
@@ -208,7 +208,9 @@ impl<T: Reset + Send + Sync> Drop for ResourcePoolItem<'_, T> {
     }
 }
 
-/// Reset trait implemented by pooled resources
+/// Reset trait which is implemented by pooled resource items.
+/// As pool resource items are mutable, this will guarantee that the pool stays  consistent
+/// and that acquired resource items do not depend from previous computations.
 pub trait Reset {
     /// Reset the resource
     fn reset(&mut self) -> StdResult<()> {
@@ -216,13 +218,15 @@ pub trait Reset {
     }
 }
 
+cfg_test_tools! {
+    impl Reset for String {}
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use super::*;
-
-    impl Reset for String {}
 
     #[test]
     fn test_resource_pool_acquire_returns_resource_when_available() {

--- a/mithril-common/src/resource_pool.rs
+++ b/mithril-common/src/resource_pool.rs
@@ -153,12 +153,6 @@ impl<T: Send + Sync> ResourcePool<T> {
     }
 }
 
-impl<T: Send + Sync> Default for ResourcePool<T> {
-    fn default() -> Self {
-        Self::new(30, vec![])
-    }
-}
-
 /// Resource pool item which will return the resource to the pool when dropped
 pub struct ResourcePoolItem<'a, T: Send + Sync> {
     resource_pool: &'a ResourcePool<T>,

--- a/mithril-common/src/resource_pool.rs
+++ b/mithril-common/src/resource_pool.rs
@@ -24,7 +24,7 @@ pub enum ResourcePoolError {
 }
 
 /// Resource pool implementation (FIFO)
-pub struct ResourcePool<T: Send + Sync> {
+pub struct ResourcePool<T: Reset + Send + Sync> {
     /// The size of the pool
     size: usize,
 
@@ -38,7 +38,7 @@ pub struct ResourcePool<T: Send + Sync> {
     not_empty: Condvar,
 }
 
-impl<T: Send + Sync> ResourcePool<T> {
+impl<T: Reset + Send + Sync> ResourcePool<T> {
     /// Create a new resource pool
     pub fn new(pool_size: usize, resources: Vec<T>) -> Self {
         Self {
@@ -103,9 +103,12 @@ impl<T: Send + Sync> ResourcePool<T> {
         resource_pool_item: ResourcePoolItem<'_, T>,
     ) -> StdResult<()> {
         let mut resource_pool_item = resource_pool_item;
-        resource_pool_item
-            .take()
-            .map(|resource_item| self.give_back_resource(resource_item, self.discriminant()?));
+        resource_pool_item.take().map(|resource_item| {
+            let mut resource_item = resource_item;
+            resource_item.reset()?;
+
+            self.give_back_resource(resource_item, self.discriminant()?)
+        });
 
         Ok(())
     }
@@ -154,13 +157,13 @@ impl<T: Send + Sync> ResourcePool<T> {
 }
 
 /// Resource pool item which will return the resource to the pool when dropped
-pub struct ResourcePoolItem<'a, T: Send + Sync> {
+pub struct ResourcePoolItem<'a, T: Reset + Send + Sync> {
     resource_pool: &'a ResourcePool<T>,
     discriminant: u64,
     resource: Option<T>,
 }
 
-impl<'a, T: Send + Sync> ResourcePoolItem<'a, T> {
+impl<'a, T: Reset + Send + Sync> ResourcePoolItem<'a, T> {
     /// Create a new resource pool item
     pub fn new(resource_pool: &'a ResourcePool<T>, resource: T) -> Self {
         let discriminant = *resource_pool.discriminant.lock().unwrap();
@@ -182,7 +185,7 @@ impl<'a, T: Send + Sync> ResourcePoolItem<'a, T> {
     }
 }
 
-impl<T: Send + Sync> Deref for ResourcePoolItem<'_, T> {
+impl<T: Reset + Send + Sync> Deref for ResourcePoolItem<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &T {
@@ -190,13 +193,13 @@ impl<T: Send + Sync> Deref for ResourcePoolItem<'_, T> {
     }
 }
 
-impl<T: Send + Sync> DerefMut for ResourcePoolItem<'_, T> {
+impl<T: Reset + Send + Sync> DerefMut for ResourcePoolItem<'_, T> {
     fn deref_mut(&mut self) -> &mut T {
         self.resource.as_mut().unwrap()
     }
 }
 
-impl<T: Send + Sync> Drop for ResourcePoolItem<'_, T> {
+impl<T: Reset + Send + Sync> Drop for ResourcePoolItem<'_, T> {
     fn drop(&mut self) {
         self.take().map(|resource| {
             self.resource_pool
@@ -205,11 +208,21 @@ impl<T: Send + Sync> Drop for ResourcePoolItem<'_, T> {
     }
 }
 
+/// Reset trait implemented by pooled resources
+pub trait Reset {
+    /// Reset the resource
+    fn reset(&mut self) -> StdResult<()> {
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use super::*;
+
+    impl Reset for String {}
 
     #[test]
     fn test_resource_pool_acquire_returns_resource_when_available() {


### PR DESCRIPTION
## Content
When resources are given back to a resource pool (e.g. Merkle maps in the Cardano transaction prover), they need to be reset properly (e.g. the Merkle map should be compressed so that all its values are represented by their root). This will guarantee that pooled resources are consistent and do not depend from previous computations. (e.g. this will avoid the risk of memory overflow and provide a consistent proving time).

This PR includes:
- A `Reset` trait to be implemented by pooled resources of the `ResourcePool` (with a blanket implementation).
- Implementation of the `Reset` trait by the `MerkleMap` with a compression of the provable values to their root.

### Benchmarks

![Screenshot from 2024-06-11 18-08-01](https://github.com/input-output-hk/mithril/assets/5566665/a1371971-0c56-4e64-8640-47f3cefe3642)

| Total Requests | Concurrency | Transactions/Request | Pool (x50) : Request/s | Pool (x50) + Reset given back pooled MKMaps: Request/s |
| -------------- | ----------- | -------------------- | ---------------------- | ------------------------------------------------------ |
| 1000           | 100         | 1                    | **1380.67**                | **1378.26**                                                |
| 1000           | 100         | 2                    | **472.86**                 | **472.56**                                                 |
| 1000           | 100         | 3                    | **294.02**                 | **289.8**                                                  |
| 1000           | 100         | 4                    | **255.05**                 | **247.36**                                                 |
| 1000           | 100         | 5                    | **160.5**                  | **148.61**                                                 |
| 1000           | 100         | 6                    | **142.99**                 | **141.09**                                                 |
| 1000           | 100         | 7                    | **117.91**                 | **117.81**                                                 |
| 1000           | 100         | 8                    | **107.07**                 | **105.44**                                                 |
| 1000           | 100         | 9                    | **85.94**                  | **85.38**                                                  |
| 1000           | 100         | 10                   | **86.75**                  | **83.74**                                                  |  

> Running on **Linux / 8 cores / 64 GB RAM / 2 TB SSD**

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1743 
