### PR TITLE
Update CHANGELOG with `2423.0` distribution release 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 |---------- |-------------|
 | N/A | `-` |
 
-## Mithril Distribution [2423.0] - UNRELEASED
+## Mithril Distribution [2423.0] - 2024-06-12
 
 - **BREAKING** changes in Mithril client CLI:
   - The deprecated `snapshot` command is removed from the Mithril client CLI


### PR DESCRIPTION
## Content
This PR includes the rotation of the `CHANGELOG` file following the release of the [`2423.0`](https://github.com/input-output-hk/mithril/releases/tag/2423.0) distribution.

## Pre-submit checklist

- Branch
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1695
