### PR TITLE
Handle rollbacks when reading blocks from the chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - **UNSTABLE** Cardano transactions certification:
   - Optimize the performances of the computation of the proof with a Merkle map.
+  - Handle rollback events from the Cardano chain by removing stale data.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.19"
+version = "0.5.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.142"
+version = "0.2.143"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.5"
+version = "0.2.6"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/query/block_range_root/delete_block_range_root.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/delete_block_range_root.rs
@@ -30,7 +30,7 @@ impl Query for DeleteBlockRangeRootQuery {
 }
 
 impl DeleteBlockRangeRootQuery {
-    pub fn include_or_greater_block_number_threshold(
+    pub fn contains_or_above_block_number_threshold(
         block_number_threshold: BlockNumber,
     ) -> StdResult<Self> {
         let block_range = BlockRange::from_block_number(block_number_threshold);
@@ -87,7 +87,7 @@ mod tests {
 
         let cursor = connection
             .fetch(
-                DeleteBlockRangeRootQuery::include_or_greater_block_number_threshold(100).unwrap(),
+                DeleteBlockRangeRootQuery::contains_or_above_block_number_threshold(100).unwrap(),
             )
             .expect("pruning shouldn't crash without block range root stored");
         assert_eq!(0, cursor.count());
@@ -128,7 +128,7 @@ mod tests {
         insert_block_range_roots(&connection, dataset.clone());
 
         let query =
-            DeleteBlockRangeRootQuery::include_or_greater_block_number_threshold(block_threshold)
+            DeleteBlockRangeRootQuery::contains_or_above_block_number_threshold(block_threshold)
                 .unwrap();
         let cursor = connection.fetch(query).unwrap();
         assert_eq!(delete_record_number, cursor.count());

--- a/internal/mithril-persistence/src/database/query/block_range_root/delete_block_range_root.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/delete_block_range_root.rs
@@ -1,0 +1,139 @@
+use anyhow::Context;
+use sqlite::Value;
+
+use mithril_common::entities::{BlockNumber, BlockRange};
+use mithril_common::StdResult;
+
+use crate::database::record::BlockRangeRootRecord;
+use crate::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
+
+/// Query to delete old [BlockRangeRootRecord] from the sqlite database
+pub struct DeleteBlockRangeRootQuery {
+    condition: WhereCondition,
+}
+
+impl Query for DeleteBlockRangeRootQuery {
+    type Entity = BlockRangeRootRecord;
+
+    fn filters(&self) -> WhereCondition {
+        self.condition.clone()
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        // it is important to alias the fields with the same name as the table
+        // since the table cannot be aliased in a RETURNING statement in SQLite.
+        let aliases = SourceAlias::new(&[("{:block_range_root:}", "block_range_root")]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+
+        format!("delete from block_range_root where {condition} returning {projection}")
+    }
+}
+
+impl DeleteBlockRangeRootQuery {
+    pub fn include_or_greater_block_number_threshold(
+        block_number_threshold: BlockNumber,
+    ) -> StdResult<Self> {
+        let block_range = BlockRange::from_block_number(block_number_threshold);
+        let threshold = Value::Integer(block_range.start.try_into().with_context(|| {
+            format!("Failed to convert threshold `{block_number_threshold}` to i64")
+        })?);
+
+        Ok(Self {
+            condition: WhereCondition::new("start >= ?*", vec![threshold]),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::crypto_helper::MKTreeNode;
+    use mithril_common::entities::BlockRange;
+
+    use crate::database::query::{GetBlockRangeRootQuery, InsertBlockRangeRootQuery};
+    use crate::database::test_helper::cardano_tx_db_connection;
+    use crate::sqlite::{ConnectionExtensions, SqliteConnection};
+
+    use super::*;
+
+    fn insert_block_range_roots(connection: &SqliteConnection, records: Vec<BlockRangeRootRecord>) {
+        connection
+            .fetch_first(InsertBlockRangeRootQuery::insert_many(records).unwrap())
+            .unwrap();
+    }
+
+    fn block_range_root_dataset() -> Vec<BlockRangeRootRecord> {
+        [
+            (
+                BlockRange::from_block_number(BlockRange::LENGTH),
+                MKTreeNode::from_hex("AAAA").unwrap(),
+            ),
+            (
+                BlockRange::from_block_number(BlockRange::LENGTH * 2),
+                MKTreeNode::from_hex("BBBB").unwrap(),
+            ),
+            (
+                BlockRange::from_block_number(BlockRange::LENGTH * 3),
+                MKTreeNode::from_hex("CCCC").unwrap(),
+            ),
+        ]
+        .into_iter()
+        .map(BlockRangeRootRecord::from)
+        .collect()
+    }
+
+    #[test]
+    fn test_prune_work_even_without_block_range_root_in_db() {
+        let connection = cardano_tx_db_connection().unwrap();
+
+        let cursor = connection
+            .fetch(
+                DeleteBlockRangeRootQuery::include_or_greater_block_number_threshold(100).unwrap(),
+            )
+            .expect("pruning shouldn't crash without block range root stored");
+        assert_eq!(0, cursor.count());
+    }
+
+    #[test]
+    fn test_prune_all_data_if_given_block_number_is_lower_than_stored_number_of_block() {
+        parameterized_test_prune_block_range(0, block_range_root_dataset().len());
+    }
+
+    #[test]
+    fn test_prune_keep_all_block_range_root_if_given_number_of_block_is_greater_than_the_highest_one(
+    ) {
+        parameterized_test_prune_block_range(100_000, 0);
+    }
+
+    #[test]
+    fn test_prune_block_range_when_block_number_is_block_range_start() {
+        parameterized_test_prune_block_range(BlockRange::LENGTH * 2, 2);
+    }
+
+    #[test]
+    fn test_prune_block_range_when_block_number_is_in_block_range() {
+        parameterized_test_prune_block_range(BlockRange::LENGTH * 2 + 1, 2);
+    }
+
+    #[test]
+    fn test_keep_block_range_when_block_number_is_just_before_range_start() {
+        parameterized_test_prune_block_range(BlockRange::LENGTH * 2 - 1, 3);
+    }
+
+    fn parameterized_test_prune_block_range(
+        block_threshold: BlockNumber,
+        delete_record_number: usize,
+    ) {
+        let connection = cardano_tx_db_connection().unwrap();
+        let dataset = block_range_root_dataset();
+        insert_block_range_roots(&connection, dataset.clone());
+
+        let query =
+            DeleteBlockRangeRootQuery::include_or_greater_block_number_threshold(block_threshold)
+                .unwrap();
+        let cursor = connection.fetch(query).unwrap();
+        assert_eq!(delete_record_number, cursor.count());
+
+        let cursor = connection.fetch(GetBlockRangeRootQuery::all()).unwrap();
+        assert_eq!(dataset.len() - delete_record_number, cursor.count());
+    }
+}

--- a/internal/mithril-persistence/src/database/query/block_range_root/mod.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/mod.rs
@@ -1,7 +1,9 @@
+mod delete_block_range_root;
 mod get_block_range_root;
 mod get_interval_without_block_range;
 mod insert_block_range;
 
+pub use delete_block_range_root::*;
 pub use get_block_range_root::*;
 pub use get_interval_without_block_range::*;
 pub use insert_block_range::*;

--- a/internal/mithril-persistence/src/database/query/cardano_transaction/delete_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/query/cardano_transaction/delete_cardano_transaction.rs
@@ -40,7 +40,7 @@ impl DeleteCardanoTransactionQuery {
         })
     }
 
-    pub fn after_block_number_threshold(block_number_threshold: BlockNumber) -> StdResult<Self> {
+    pub fn above_block_number_threshold(block_number_threshold: BlockNumber) -> StdResult<Self> {
         let threshold = Value::Integer(block_number_threshold.try_into().with_context(|| {
             format!("Failed to convert threshold `{block_number_threshold}` to i64")
         })?);
@@ -130,7 +130,7 @@ mod tests {
         }
     }
 
-    mod prune_after_threshold_tests {
+    mod prune_above_threshold_tests {
         use super::*;
 
         #[test]
@@ -138,7 +138,7 @@ mod tests {
             let connection = cardano_tx_db_connection().unwrap();
 
             let cursor = connection
-                .fetch(DeleteCardanoTransactionQuery::after_block_number_threshold(100).unwrap())
+                .fetch(DeleteCardanoTransactionQuery::above_block_number_threshold(100).unwrap())
                 .expect("pruning shouldn't crash without transactions stored");
             assert_eq!(0, cursor.count());
         }
@@ -148,7 +148,7 @@ mod tests {
             let connection = cardano_tx_db_connection().unwrap();
             insert_transactions(&connection, test_transaction_set());
 
-            let query = DeleteCardanoTransactionQuery::after_block_number_threshold(0).unwrap();
+            let query = DeleteCardanoTransactionQuery::above_block_number_threshold(0).unwrap();
             let cursor = connection.fetch(query).unwrap();
             assert_eq!(test_transaction_set().len(), cursor.count());
 
@@ -163,7 +163,7 @@ mod tests {
             insert_transactions(&connection, test_transaction_set());
 
             let query =
-                DeleteCardanoTransactionQuery::after_block_number_threshold(100_000).unwrap();
+                DeleteCardanoTransactionQuery::above_block_number_threshold(100_000).unwrap();
             let cursor = connection.fetch(query).unwrap();
             assert_eq!(0, cursor.count());
 
@@ -176,7 +176,7 @@ mod tests {
             let connection = cardano_tx_db_connection().unwrap();
             insert_transactions(&connection, test_transaction_set());
 
-            let query = DeleteCardanoTransactionQuery::after_block_number_threshold(10).unwrap();
+            let query = DeleteCardanoTransactionQuery::above_block_number_threshold(10).unwrap();
             let cursor = connection.fetch(query).unwrap();
             assert_eq!(4, cursor.count());
 

--- a/internal/mithril-persistence/src/database/query/cardano_transaction/delete_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/query/cardano_transaction/delete_cardano_transaction.rs
@@ -39,6 +39,16 @@ impl DeleteCardanoTransactionQuery {
             condition: WhereCondition::new("block_number < ?*", vec![threshold]),
         })
     }
+
+    pub fn after_block_number_threshold(block_number_threshold: BlockNumber) -> StdResult<Self> {
+        let threshold = Value::Integer(block_number_threshold.try_into().with_context(|| {
+            format!("Failed to convert threshold `{block_number_threshold}` to i64")
+        })?);
+
+        Ok(Self {
+            condition: WhereCondition::new("block_number > ?*", vec![threshold]),
+        })
+    }
 }
 
 #[cfg(test)]
@@ -66,52 +76,112 @@ mod tests {
         ]
     }
 
-    #[test]
-    fn test_prune_work_even_without_transactions_in_db() {
-        let connection = cardano_tx_db_connection().unwrap();
+    mod prune_below_threshold_tests {
+        use super::*;
 
-        let cursor = connection
-            .fetch(DeleteCardanoTransactionQuery::below_block_number_threshold(100).unwrap())
-            .expect("pruning shouldn't crash without transactions stored");
-        assert_eq!(0, cursor.count());
+        #[test]
+        fn test_prune_work_even_without_transactions_in_db() {
+            let connection = cardano_tx_db_connection().unwrap();
+
+            let cursor = connection
+                .fetch(DeleteCardanoTransactionQuery::below_block_number_threshold(100).unwrap())
+                .expect("pruning shouldn't crash without transactions stored");
+            assert_eq!(0, cursor.count());
+        }
+
+        #[test]
+        fn test_prune_all_data_if_given_block_number_is_larger_than_stored_number_of_block() {
+            let connection = cardano_tx_db_connection().unwrap();
+            insert_transactions(&connection, test_transaction_set());
+
+            let query =
+                DeleteCardanoTransactionQuery::below_block_number_threshold(100_000).unwrap();
+            let cursor = connection.fetch(query).unwrap();
+            assert_eq!(test_transaction_set().len(), cursor.count());
+
+            let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
+            assert_eq!(0, cursor.count());
+        }
+
+        #[test]
+        fn test_prune_keep_all_tx_of_last_block_if_given_number_of_block_is_zero() {
+            let connection = cardano_tx_db_connection().unwrap();
+            insert_transactions(&connection, test_transaction_set());
+
+            let query = DeleteCardanoTransactionQuery::below_block_number_threshold(0).unwrap();
+            let cursor = connection.fetch(query).unwrap();
+            assert_eq!(0, cursor.count());
+
+            let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
+            assert_eq!(test_transaction_set().len(), cursor.count());
+        }
+
+        #[test]
+        fn test_prune_data_of_below_given_blocks() {
+            let connection = cardano_tx_db_connection().unwrap();
+            insert_transactions(&connection, test_transaction_set());
+
+            let query = DeleteCardanoTransactionQuery::below_block_number_threshold(12).unwrap();
+            let cursor = connection.fetch(query).unwrap();
+            assert_eq!(4, cursor.count());
+
+            let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
+            assert_eq!(2, cursor.count());
+        }
     }
 
-    #[test]
-    fn test_prune_all_data_if_given_block_number_is_larger_than_stored_number_of_block() {
-        let connection = cardano_tx_db_connection().unwrap();
-        insert_transactions(&connection, test_transaction_set());
+    mod prune_after_threshold_tests {
+        use super::*;
 
-        let query = DeleteCardanoTransactionQuery::below_block_number_threshold(100_000).unwrap();
-        let cursor = connection.fetch(query).unwrap();
-        assert_eq!(test_transaction_set().len(), cursor.count());
+        #[test]
+        fn test_prune_work_even_without_transactions_in_db() {
+            let connection = cardano_tx_db_connection().unwrap();
 
-        let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
-        assert_eq!(0, cursor.count());
-    }
+            let cursor = connection
+                .fetch(DeleteCardanoTransactionQuery::after_block_number_threshold(100).unwrap())
+                .expect("pruning shouldn't crash without transactions stored");
+            assert_eq!(0, cursor.count());
+        }
 
-    #[test]
-    fn test_prune_keep_all_tx_of_last_block_if_given_number_of_block_is_zero() {
-        let connection = cardano_tx_db_connection().unwrap();
-        insert_transactions(&connection, test_transaction_set());
+        #[test]
+        fn test_prune_all_data_if_given_block_number_is_lower_than_stored_number_of_block() {
+            let connection = cardano_tx_db_connection().unwrap();
+            insert_transactions(&connection, test_transaction_set());
 
-        let query = DeleteCardanoTransactionQuery::below_block_number_threshold(0).unwrap();
-        let cursor = connection.fetch(query).unwrap();
-        assert_eq!(0, cursor.count());
+            let query = DeleteCardanoTransactionQuery::after_block_number_threshold(0).unwrap();
+            let cursor = connection.fetch(query).unwrap();
+            assert_eq!(test_transaction_set().len(), cursor.count());
 
-        let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
-        assert_eq!(test_transaction_set().len(), cursor.count());
-    }
+            let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
+            assert_eq!(0, cursor.count());
+        }
 
-    #[test]
-    fn test_prune_data_of_below_given_blocks() {
-        let connection = cardano_tx_db_connection().unwrap();
-        insert_transactions(&connection, test_transaction_set());
+        #[test]
+        fn test_prune_keep_all_tx_of_last_block_if_given_number_of_block_is_greater_than_the_highest_one(
+        ) {
+            let connection = cardano_tx_db_connection().unwrap();
+            insert_transactions(&connection, test_transaction_set());
 
-        let query = DeleteCardanoTransactionQuery::below_block_number_threshold(12).unwrap();
-        let cursor = connection.fetch(query).unwrap();
-        assert_eq!(4, cursor.count());
+            let query =
+                DeleteCardanoTransactionQuery::after_block_number_threshold(100_000).unwrap();
+            let cursor = connection.fetch(query).unwrap();
+            assert_eq!(0, cursor.count());
 
-        let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
-        assert_eq!(2, cursor.count());
+            let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
+            assert_eq!(test_transaction_set().len(), cursor.count());
+        }
+
+        #[test]
+        fn test_prune_data_of_above_given_blocks() {
+            let connection = cardano_tx_db_connection().unwrap();
+            insert_transactions(&connection, test_transaction_set());
+
+            let query = DeleteCardanoTransactionQuery::after_block_number_threshold(10).unwrap();
+            let cursor = connection.fetch(query).unwrap();
+            assert_eq!(4, cursor.count());
+
+            let cursor = connection.fetch(GetCardanoTransactionQuery::all()).unwrap();
+            assert_eq!(2, cursor.count());
+        }
     }
 }

--- a/internal/mithril-persistence/src/database/query/cardano_transaction/get_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/query/cardano_transaction/get_cardano_transaction.rs
@@ -31,11 +31,14 @@ impl GetCardanoTransactionQuery {
 
     pub fn by_transaction_hashes(
         transactions_hashes: Vec<TransactionHash>,
-        up_to: BlockNumber,
+        up_to_or_equal: BlockNumber,
     ) -> Self {
         let hashes_values = transactions_hashes.into_iter().map(Value::String).collect();
         let condition = WhereCondition::where_in("transaction_hash", hashes_values).and_where(
-            WhereCondition::new("block_number <= ?*", vec![Value::Integer(up_to as i64)]),
+            WhereCondition::new(
+                "block_number <= ?*",
+                vec![Value::Integer(up_to_or_equal as i64)],
+            ),
         );
 
         Self { condition }

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -1018,13 +1018,7 @@ mod tests {
         let repository = CardanoTransactionRepository::new(connection);
 
         let cardano_transactions = vec![
-            CardanoTransaction::new(
-                "tx-hash-123",
-                BlockRange::LENGTH * 1,
-                50,
-                "block-hash-123",
-                50,
-            ),
+            CardanoTransaction::new("tx-hash-123", BlockRange::LENGTH, 50, "block-hash-123", 50),
             CardanoTransaction::new(
                 "tx-hash-123",
                 BlockRange::LENGTH * 3 - 1,
@@ -1047,7 +1041,7 @@ mod tests {
         repository
             .create_block_range_roots(vec![
                 (
-                    BlockRange::from_block_number(BlockRange::LENGTH * 1),
+                    BlockRange::from_block_number(BlockRange::LENGTH),
                     MKTreeNode::from_hex("AAAA").unwrap(),
                 ),
                 (

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -265,13 +265,15 @@ impl CardanoTransactionRepository {
         &self,
         block_number: BlockNumber,
     ) -> StdResult<()> {
-        // todo: add sqlite rollback
+        let transaction = self.connection.begin_transaction()?;
         let query = DeleteCardanoTransactionQuery::after_block_number_threshold(block_number)?;
         self.connection.fetch_first(query)?;
 
         let query =
             DeleteBlockRangeRootQuery::include_or_greater_block_number_threshold(block_number)?;
         self.connection.fetch_first(query)?;
+        transaction.commit()?;
+
         Ok(())
     }
 }

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -257,20 +257,20 @@ impl CardanoTransactionRepository {
         Ok(())
     }
 
-    /// Remove transactions and block range roots that have been caught in a rollback
+    /// Remove transactions and block range roots that are in a rolled-back fork
     ///
-    /// * Remove transactions with block number greater than the given block number
-    /// * Remove block range roots that include or are greater than the given block number
+    /// * Remove transactions with block number strictly greater than the given block number
+    /// * Remove block range roots that have lower bound range strictly above the given block number
     pub async fn remove_rolled_back_transactions_and_block_range(
         &self,
         block_number: BlockNumber,
     ) -> StdResult<()> {
         let transaction = self.connection.begin_transaction()?;
-        let query = DeleteCardanoTransactionQuery::after_block_number_threshold(block_number)?;
+        let query = DeleteCardanoTransactionQuery::above_block_number_threshold(block_number)?;
         self.connection.fetch_first(query)?;
 
         let query =
-            DeleteBlockRangeRootQuery::include_or_greater_block_number_threshold(block_number)?;
+            DeleteBlockRangeRootQuery::contains_or_above_block_number_threshold(block_number)?;
         self.connection.fetch_first(query)?;
         transaction.commit()?;
 

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -256,6 +256,16 @@ impl CardanoTransactionRepository {
 
         Ok(())
     }
+
+    /// Remove transactions with block number greater than the given one
+    pub async fn remove_transactions_greater_than(
+        &self,
+        block_number: BlockNumber,
+    ) -> StdResult<()> {
+        let query = DeleteCardanoTransactionQuery::after_block_number_threshold(block_number)?;
+        self.connection.fetch_first(query)?;
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.19"
+version = "0.5.20"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-aggregator/src/database/repository/cardano_transaction_repository.rs
@@ -47,6 +47,14 @@ impl TransactionStore for CardanoTransactionRepository {
         }
         Ok(())
     }
+
+    async fn remove_rolled_back_transactions_and_block_range(
+        &self,
+        block_number: BlockNumber,
+    ) -> StdResult<()> {
+        self.remove_rolled_back_transactions_and_block_range(block_number)
+            .await
+    }
 }
 
 #[async_trait]

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -39,6 +39,15 @@ pub trait TransactionStore: Send + Sync {
         &self,
         block_ranges: Vec<(BlockRange, MKTreeNode)>,
     ) -> StdResult<()>;
+
+    /// Remove transactions and block range roots that have been caught in a rollback
+    ///
+    /// * Remove transactions with block number greater than the given block number
+    /// * Remove block range roots that include or are greater than the given block number
+    async fn remove_rolled_back_transactions_and_block_range(
+        &self,
+        block_number: BlockNumber,
+    ) -> StdResult<()>;
 }
 
 /// Import and store [CardanoTransaction].
@@ -107,8 +116,10 @@ impl CardanoTransactionsImporter {
                         .store_transactions(parsed_transactions)
                         .await?;
                 }
-                ChainScannedBlocks::RollBackward(_) => {
-                    return Err(anyhow!("RollBackward not supported"));
+                ChainScannedBlocks::RollBackward(chain_point) => {
+                    self.transaction_store
+                        .remove_rolled_back_transactions_and_block_range(chain_point.block_number)
+                        .await?;
                 }
             }
         }
@@ -174,6 +185,7 @@ impl TransactionsImporter for CardanoTransactionsImporter {
 
 #[cfg(test)]
 mod tests {
+    use mithril_common::test_utils::CardanoTransactionsBuilder;
     use mockall::mock;
 
     use mithril_common::cardano_block_scanner::{
@@ -376,10 +388,10 @@ mod tests {
         let up_to_block_number = 12;
         let connection = cardano_tx_db_connection().unwrap();
         let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
-        let scanner = DumbBlockScanner::new(vec![
+        let scanner = DumbBlockScanner::new(vec![]).forwards(vec![vec![
             ScannedBlock::new("block_hash-1", 10, 15, 10, vec!["tx_hash-1", "tx_hash-2"]),
             ScannedBlock::new("block_hash-2", 20, 25, 11, vec!["tx_hash-3", "tx_hash-4"]),
-        ]);
+        ]]);
 
         let last_tx = CardanoTransaction::new("tx-20", 30, 35, "block_hash-3", up_to_block_number);
         repository
@@ -619,7 +631,7 @@ mod tests {
             let connection = Arc::new(cardano_tx_db_connection().unwrap());
             let repository = Arc::new(CardanoTransactionRepository::new(connection.clone()));
             let importer = CardanoTransactionsImporter::new_for_test(
-                Arc::new(DumbBlockScanner::new(blocks.clone())),
+                Arc::new(DumbBlockScanner::new(vec![]).forwards(vec![blocks.clone()])),
                 Arc::new(CardanoTransactionRepository::new(connection.clone())),
             );
             (importer, repository)
@@ -639,5 +651,104 @@ mod tests {
 
         assert_eq!(transactions, cold_imported_transactions);
         assert_eq!(cold_imported_transactions, warm_imported_transactions);
+    }
+
+    #[tokio::test]
+    async fn when_rollbackward_should_remove_transactions() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+
+        let expected_remaining_transactions =
+            ScannedBlock::new("block_hash-130", 130, 5, 1, vec!["tx_hash-6", "tx_hash-7"])
+                .into_transactions();
+        repository
+            .store_transactions(expected_remaining_transactions.clone())
+            .await
+            .unwrap();
+        repository
+            .store_transactions(
+                ScannedBlock::new(
+                    "block_hash-131",
+                    131,
+                    10,
+                    2,
+                    vec!["tx_hash-8", "tx_hash-9", "tx_hash-10"],
+                )
+                .into_transactions(),
+            )
+            .await
+            .unwrap();
+
+        let chain_point = ChainPoint::new(1, 130, "block_hash-131");
+        let scanner = DumbBlockScanner::new(vec![]).backward(chain_point);
+
+        let importer =
+            CardanoTransactionsImporter::new_for_test(Arc::new(scanner), repository.clone());
+
+        importer
+            .import(3000)
+            .await
+            .expect("Transactions Importer should succeed");
+
+        let stored_transactions = repository.get_all().await.unwrap();
+        assert_eq!(expected_remaining_transactions, stored_transactions);
+    }
+
+    #[tokio::test]
+    async fn when_rollbackward_should_remove_block_ranges() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(connection)));
+
+        let expected_remaining_block_ranges = vec![
+            BlockRange::from_block_number(0),
+            BlockRange::from_block_number(BlockRange::LENGTH),
+            BlockRange::from_block_number(BlockRange::LENGTH * 2),
+        ];
+
+        repository
+            .store_block_range_roots(
+                expected_remaining_block_ranges
+                    .iter()
+                    .map(|b| (b.clone(), MKTreeNode::from_hex("AAAA").unwrap()))
+                    .collect(),
+            )
+            .await
+            .unwrap();
+        repository
+            .store_block_range_roots(
+                [
+                    BlockRange::from_block_number(BlockRange::LENGTH * 3),
+                    BlockRange::from_block_number(BlockRange::LENGTH * 4),
+                    BlockRange::from_block_number(BlockRange::LENGTH * 5),
+                ]
+                .iter()
+                .map(|b| (b.clone(), MKTreeNode::from_hex("AAAA").unwrap()))
+                .collect(),
+            )
+            .await
+            .unwrap();
+
+        let block_range_roots = repository.get_all_block_range_root().unwrap();
+        assert_eq!(6, block_range_roots.len());
+
+        let chain_point = ChainPoint::new(1, BlockRange::LENGTH * 3, "block_hash-131");
+        let scanner = DumbBlockScanner::new(vec![]).backward(chain_point);
+
+        let importer =
+            CardanoTransactionsImporter::new_for_test(Arc::new(scanner), repository.clone());
+
+        importer
+            .import(3000)
+            .await
+            .expect("Transactions Importer should succeed");
+
+        let block_range_roots = repository.get_all_block_range_root().unwrap();
+        assert_eq!(
+            expected_remaining_block_ranges,
+            block_range_roots
+                .into_iter()
+                .map(|r| r.range)
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -184,7 +184,6 @@ impl TransactionsImporter for CardanoTransactionsImporter {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::test_utils::CardanoTransactionsBuilder;
     use mockall::mock;
 
     use mithril_common::cardano_block_scanner::{

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -39,10 +39,10 @@ pub trait TransactionStore: Send + Sync {
         block_ranges: Vec<(BlockRange, MKTreeNode)>,
     ) -> StdResult<()>;
 
-    /// Remove transactions and block range roots that have been caught in a rollback
+    /// Remove transactions and block range roots that are in a rolled-back fork
     ///
-    /// * Remove transactions with block number greater than the given block number
-    /// * Remove block range roots that include or are greater than the given block number
+    /// * Remove transactions with block number strictly greater than the given block number
+    /// * Remove block range roots that have lower bound range strictly above the given block number
     async fn remove_rolled_back_transactions_and_block_range(
         &self,
         block_number: BlockNumber,

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -185,7 +185,7 @@ async fn certificate_chain() {
     let next_epoch_verification_keys = tester
         .dependencies
         .verification_key_store
-        .get_verification_keys(new_epoch + 1)
+        .get_verification_keys(new_epoch.offset_to_recording_epoch())
         .await
         .expect("get_verification_keys should not fail");
     assert_eq!(

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -3,8 +3,8 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{
-        CardanoDbBeacon, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
-        SignedEntityTypeDiscriminants, StakeDistributionParty, TimePoint,
+        CardanoDbBeacon, CardanoTransactionsSigningConfig, ChainPoint, Epoch, ProtocolParameters,
+        SignedEntityType, SignedEntityTypeDiscriminants, StakeDistributionParty, TimePoint,
     },
     test_utils::MithrilFixtureBuilder,
 };
@@ -20,6 +20,10 @@ async fn create_certificate() {
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
         data_stores_directory: get_test_dir("create_certificate"),
+        cardano_transactions_signing_config: CardanoTransactionsSigningConfig {
+            security_parameter: 0,
+            step: 30,
+        },
         ..Configuration::new_sample()
     };
     let mut tester = RuntimeTester::build(

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -267,7 +267,6 @@ impl RuntimeTester {
             .get_last_immutable_number()
             .await?;
         let blocks_to_scan: Vec<ScannedBlock> = ((expected - increment + 1)..=expected)
-            .into_iter()
             .map(|block_number| {
                 let block_hash = format!("block_hash-{block_number}");
                 let slot_number = 10 * block_number;

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -8,11 +8,12 @@ use mithril_aggregator::{
     SignerRegistrationError,
 };
 use mithril_common::{
-    chain_observer::FakeObserver,
+    cardano_block_scanner::{DumbBlockScanner, ScannedBlock},
+    chain_observer::{ChainObserver, FakeObserver},
     crypto_helper::ProtocolGenesisSigner,
-    digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
+    digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
     entities::{
-        Certificate, CertificateSignature, Epoch, ImmutableFileNumber,
+        BlockNumber, Certificate, CertificateSignature, ChainPoint, Epoch, ImmutableFileNumber,
         SignedEntityTypeDiscriminants, Snapshot, StakeDistribution, TimePoint,
     },
     era::{adapters::EraReaderDummyAdapter, EraMarker, EraReader, SupportedEra},
@@ -70,6 +71,7 @@ pub struct RuntimeTester {
     pub era_reader_adapter: Arc<EraReaderDummyAdapter>,
     pub observer: Arc<AggregatorObserver>,
     pub open_message_repository: Arc<OpenMessageRepository>,
+    pub block_scanner: Arc<DumbBlockScanner>,
     _logs_guard: slog_scope::GlobalLoggerGuard,
 }
 
@@ -98,6 +100,7 @@ impl RuntimeTester {
                 &SupportedEra::dummy().to_string(),
                 Some(Epoch(0)),
             )]));
+        let block_scanner = Arc::new(DumbBlockScanner::new());
         let mut deps_builder = DependenciesBuilder::new(configuration);
         deps_builder.snapshot_uploader = Some(snapshot_uploader.clone());
         deps_builder.chain_observer = Some(chain_observer.clone());
@@ -105,6 +108,7 @@ impl RuntimeTester {
         deps_builder.immutable_digester = Some(digester.clone());
         deps_builder.snapshotter = Some(snapshotter.clone());
         deps_builder.era_reader = Some(Arc::new(EraReader::new(era_reader_adapter.clone())));
+        deps_builder.block_scanner = Some(block_scanner.clone());
 
         let dependencies = deps_builder.build_dependency_container().await.unwrap();
         let runtime = deps_builder.create_aggregator_runner().await.unwrap();
@@ -126,6 +130,7 @@ impl RuntimeTester {
             era_reader_adapter,
             observer,
             open_message_repository,
+            block_scanner,
             _logs_guard: logger,
         }
     }
@@ -241,6 +246,75 @@ impl RuntimeTester {
             .with_context(|| "inform_epoch should not fail")?;
 
         Ok(new_epoch)
+    }
+
+    /// increase the block number in the fake observer
+    pub async fn increase_block_number(&mut self, increment: u64, expected: u64) -> StdResult<()> {
+        let new_block_number = self
+            .chain_observer
+            .increase_block_number(increment)
+            .await
+            .ok_or_else(|| anyhow!("no block number returned".to_string()))?;
+
+        anyhow::ensure!(
+            expected == new_block_number,
+            "expected to increase block number up to {expected}, got {new_block_number}",
+        );
+
+        // Make the block scanner return new blocks
+        let current_immutable = self
+            .immutable_file_observer
+            .get_last_immutable_number()
+            .await?;
+        let blocks_to_scan: Vec<ScannedBlock> = ((expected - increment + 1)..=expected)
+            .into_iter()
+            .map(|block_number| {
+                let block_hash = format!("block_hash-{block_number}");
+                let slot_number = 10 * block_number;
+                ScannedBlock::new(
+                    block_hash,
+                    block_number,
+                    slot_number,
+                    current_immutable,
+                    vec![format!("tx_hash-{block_number}-1")],
+                )
+            })
+            .collect();
+        self.block_scanner.add_forwards(vec![blocks_to_scan]);
+
+        Ok(())
+    }
+
+    pub async fn cardano_chain_send_rollback(
+        &mut self,
+        rollback_to_block_number: BlockNumber,
+    ) -> StdResult<()> {
+        let actual_block_number = self
+            .chain_observer
+            .get_current_chain_point()
+            .await?
+            .map(|c| c.block_number)
+            .ok_or_else(|| anyhow!("no block number returned".to_string()))?;
+        let decrement = actual_block_number - rollback_to_block_number;
+        let new_block_number = self
+            .chain_observer
+            .decrease_block_number(decrement)
+            .await
+            .ok_or_else(|| anyhow!("no block number returned".to_string()))?;
+
+        anyhow::ensure!(
+            rollback_to_block_number == new_block_number,
+            "expected to increase block number up to {rollback_to_block_number}, got {new_block_number}",
+        );
+
+        let chain_point = ChainPoint {
+            slot_number: 1,
+            block_number: rollback_to_block_number,
+            block_hash: format!("block_hash-{rollback_to_block_number}"),
+        };
+        self.block_scanner.add_backward(chain_point);
+
+        Ok(())
     }
 
     /// Register the given signers in the registerer

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.15"
+version = "0.4.16"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/cardano_block_scanner/dumb_block_scanner.rs
+++ b/mithril-common/src/cardano_block_scanner/dumb_block_scanner.rs
@@ -180,7 +180,6 @@ mod tests {
         assert_eq!(blocks, None);
     }
 
-    // TODO To remove with poll_all
     #[tokio::test]
     async fn dumb_scanned_construct_a_streamer_based_on_its_stored_blocks() {
         let expected_blocks = vec![ScannedBlock::new("hash-1", 1, 10, 20, Vec::<&str>::new())];

--- a/mithril-common/src/cardano_block_scanner/dumb_block_scanner.rs
+++ b/mithril-common/src/cardano_block_scanner/dumb_block_scanner.rs
@@ -44,14 +44,17 @@ impl BlockScanner for DumbBlockScanner {
 
 /// Dumb block streamer
 pub struct DumbBlockStreamer {
-    blocks: VecDeque<Vec<ScannedBlock>>,
+    streamer_responses: VecDeque<ChainScannedBlocks>,
 }
 
 impl DumbBlockStreamer {
     /// Factory - the resulting streamer can be polled one time for each list of blocks given
     pub fn new(blocks: Vec<Vec<ScannedBlock>>) -> Self {
         Self {
-            blocks: VecDeque::from(blocks),
+            streamer_responses: blocks
+                .into_iter()
+                .map(ChainScannedBlocks::RollForwards)
+                .collect(),
         }
     }
 }
@@ -59,10 +62,7 @@ impl DumbBlockStreamer {
 #[async_trait]
 impl BlockStreamer for DumbBlockStreamer {
     async fn poll_next(&mut self) -> StdResult<Option<ChainScannedBlocks>> {
-        Ok(self
-            .blocks
-            .pop_front()
-            .map(ChainScannedBlocks::RollForwards))
+        Ok(self.streamer_responses.pop_front())
     }
 }
 

--- a/mithril-common/src/cardano_block_scanner/interface.rs
+++ b/mithril-common/src/cardano_block_scanner/interface.rs
@@ -56,7 +56,7 @@ pub trait BlockScanner: Sync + Send {
 }
 
 /// [ChainScannedBlocks] allows to scan new blocks and handle rollbacks
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum ChainScannedBlocks {
     /// Roll forward on the chain to the next list of [ScannedBlock]
     RollForwards(Vec<ScannedBlock>),

--- a/mithril-common/src/chain_observer/fake_observer.rs
+++ b/mithril-common/src/chain_observer/fake_observer.rs
@@ -18,9 +18,6 @@ pub struct FakeObserver {
     /// [get_current_epoch]: ChainObserver::get_current_epoch
     pub current_time_point: RwLock<Option<TimePoint>>,
 
-    /// The current chain point
-    pub current_chain_point: RwLock<Option<ChainPoint>>,
-
     /// A list of [TxDatum], used by [get_current_datums]
     ///
     /// [get_current_datums]: ChainObserver::get_current_datums
@@ -33,7 +30,6 @@ impl FakeObserver {
         Self {
             signers: RwLock::new(vec![]),
             current_time_point: RwLock::new(current_time_point.clone()),
-            current_chain_point: RwLock::new(current_time_point.map(|t| t.chain_point)),
             datums: RwLock::new(vec![]),
         }
     }
@@ -49,6 +45,23 @@ impl FakeObserver {
         current_time_point.as_ref().map(|b| b.epoch)
     }
 
+    /// Increase the block number of the [current_time_point][`FakeObserver::current_time_point`] by
+    /// the given increment.
+    pub async fn increase_block_number(&self, increment: BlockNumber) -> Option<BlockNumber> {
+        let mut current_time_point = self.current_time_point.write().await;
+        *current_time_point = current_time_point.as_ref().map(|time_point| TimePoint {
+            chain_point: ChainPoint {
+                block_number: time_point.chain_point.block_number + increment,
+                ..time_point.chain_point.clone()
+            },
+            ..time_point.clone()
+        });
+
+        current_time_point
+            .as_ref()
+            .map(|b| b.chain_point.block_number)
+    }
+
     /// Set the signers that will use to compute the result of
     /// [get_current_stake_distribution][ChainObserver::get_current_stake_distribution].
     pub async fn set_signers(&self, new_signers: Vec<SignerWithStake>) {
@@ -56,11 +69,10 @@ impl FakeObserver {
         *signers = new_signers;
     }
 
-    /// Set the chain point that will use to compute the result of
-    /// [get_current_chain_point][ChainObserver::get_current_chain_point].
-    pub async fn set_current_chain_point(&self, new_current_chain_point: Option<ChainPoint>) {
-        let mut current_chain_point = self.current_chain_point.write().await;
-        *current_chain_point = new_current_chain_point;
+    /// Set the time point
+    pub async fn set_current_time_point(&self, new_current_time_point: Option<TimePoint>) {
+        let mut current_time_point = self.current_time_point.write().await;
+        *current_time_point = new_current_time_point;
     }
 
     /// Set the datums that will use to compute the result of
@@ -100,7 +112,12 @@ impl ChainObserver for FakeObserver {
     }
 
     async fn get_current_chain_point(&self) -> Result<Option<ChainPoint>, ChainObserverError> {
-        Ok(self.current_chain_point.read().await.clone())
+        Ok(self
+            .current_time_point
+            .read()
+            .await
+            .as_ref()
+            .map(|time_point| time_point.chain_point.clone()))
     }
 
     async fn get_current_stake_distribution(
@@ -143,12 +160,12 @@ mod tests {
     async fn test_get_current_chain_point() {
         let fake_observer = FakeObserver::new(None);
         fake_observer
-            .set_current_chain_point(Some(fake_data::chain_point()))
+            .set_current_time_point(Some(TimePoint::dummy()))
             .await;
         let chain_point = fake_observer.get_current_chain_point().await.unwrap();
 
         assert_eq!(
-            Some(fake_data::chain_point()),
+            Some(TimePoint::dummy().chain_point),
             chain_point,
             "get current chain point should not fail"
         );
@@ -184,5 +201,24 @@ mod tests {
             .expect("get_current_datums should not fail");
 
         assert_eq!(fake_datums, datums);
+    }
+
+    #[tokio::test]
+    async fn test_increase_block_number() {
+        let fake_observer = FakeObserver::new(None);
+        fake_observer
+            .set_current_time_point(Some(TimePoint::dummy()))
+            .await;
+        fake_observer.increase_block_number(375).await;
+
+        let chain_point = fake_observer.get_current_chain_point().await.unwrap();
+        assert_eq!(
+            Some(ChainPoint {
+                block_number: TimePoint::dummy().chain_point.block_number + 375,
+                ..TimePoint::dummy().chain_point
+            }),
+            chain_point,
+            "get current chain point should not fail"
+        );
     }
 }

--- a/mithril-common/src/crypto_helper/merkle_tree.rs
+++ b/mithril-common/src/crypto_helper/merkle_tree.rs
@@ -1,6 +1,4 @@
-use anyhow::anyhow;
-#[cfg(any(test, feature = "test_tools"))]
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use blake2::{Blake2s256, Digest};
 use ckb_merkle_mountain_range::{
     MMRStoreReadOps, MMRStoreWriteOps, Merge, MerkleProof, Result as MMRResult, MMR,
@@ -293,7 +291,11 @@ impl MKTree {
 
     /// Generate root of the Merkle tree
     pub fn compute_root(&self) -> StdResult<MKTreeNode> {
-        Ok((*self.inner_tree.get_root()?).clone())
+        Ok((*self
+            .inner_tree
+            .get_root()
+            .with_context(|| "Could not compute Merkle Tree root")?)
+        .clone())
     }
 
     /// Generate Merkle proof of memberships in the tree

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.142"
+version = "0.2.143"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -184,7 +184,6 @@ impl TransactionsImporter for CardanoTransactionsImporter {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::test_utils::CardanoTransactionsBuilder;
     use mockall::mock;
 
     use mithril_common::cardano_block_scanner::{

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -39,10 +39,10 @@ pub trait TransactionStore: Send + Sync {
         block_ranges: Vec<(BlockRange, MKTreeNode)>,
     ) -> StdResult<()>;
 
-    /// Remove transactions and block range roots that have been caught in a rollback
+    /// Remove transactions and block range roots that are in a rolled-back fork
     ///
-    /// * Remove transactions with block number greater than the given block number
-    /// * Remove block range roots that include or are greater than the given block number
+    /// * Remove transactions with block number strictly greater than the given block number
+    /// * Remove block range roots that have lower bound range strictly above the given block number
     async fn remove_rolled_back_transactions_and_block_range(
         &self,
         block_number: BlockNumber,

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -45,6 +45,10 @@ impl TransactionStore for CardanoTransactionRepository {
         }
         Ok(())
     }
+
+    async fn remove_transactions_greater_than(&self, block_number: BlockNumber) -> StdResult<()> {
+        self.remove_transactions_greater_than(block_number).await
+    }
 }
 
 #[async_trait]

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -46,8 +46,12 @@ impl TransactionStore for CardanoTransactionRepository {
         Ok(())
     }
 
-    async fn remove_transactions_greater_than(&self, block_number: BlockNumber) -> StdResult<()> {
-        self.remove_transactions_greater_than(block_number).await
+    async fn remove_rolled_back_transactions_and_block_range(
+        &self,
+        block_number: BlockNumber,
+    ) -> StdResult<()> {
+        self.remove_rolled_back_transactions_and_block_range(block_number)
+            .await
     }
 }
 

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -535,7 +535,7 @@ mod tests {
             ));
         let mithril_stake_distribution_signable_builder =
             Arc::new(MithrilStakeDistributionSignableBuilder::default());
-        let transaction_parser = Arc::new(DumbBlockScanner::new(vec![]));
+        let transaction_parser = Arc::new(DumbBlockScanner::new());
         let transaction_store = Arc::new(MockTransactionStore::new());
         let transaction_importer = Arc::new(CardanoTransactionsImporter::new(
             transaction_parser.clone(),

--- a/mithril-signer/tests/create_cardano_transaction_single_signature.rs
+++ b/mithril-signer/tests/create_cardano_transaction_single_signature.rs
@@ -1,0 +1,78 @@
+mod test_extensions;
+
+use mithril_common::{
+    crypto_helper::tests_setup,
+    entities::{ChainPoint, Epoch, SignedEntityTypeDiscriminants, TimePoint},
+    test_utils::MithrilFixtureBuilder,
+};
+
+use test_extensions::StateMachineTester;
+
+#[rustfmt::skip]
+#[tokio::test]
+async fn test_create_cardano_transaction_single_signature() {
+    let protocol_parameters = tests_setup::setup_protocol_parameters();
+    let fixture = MithrilFixtureBuilder::default()
+        .with_signers(10)
+        .with_protocol_parameters(protocol_parameters.into())
+        .build();
+    let signers_with_stake = fixture.signers_with_stake();
+    let initial_time_point = TimePoint {
+        epoch: Epoch(1),
+        immutable_file_number: 1,
+        chain_point: ChainPoint {
+            slot_number: 1,
+            // Note: the starting block number must be greater than the cardano_transactions_signing_config.step
+            // so first block range root computation is not on block 0.
+            block_number: 100,
+            block_hash: "block_hash-100".to_string(),
+        },
+    };
+    let mut tester = StateMachineTester::init(&signers_with_stake, initial_time_point)
+        .await
+        .expect("state machine tester init should not fail");
+    let total_signer_registrations_expected = 3;
+    let total_signature_registrations_expected = 2;
+
+    tester
+        .comment("state machine starts in Init and transit to Unregistered state.")
+        .is_init().await.unwrap()
+        .aggregator_send_signed_entity(SignedEntityTypeDiscriminants::CardanoTransactions).await
+        .cycle_unregistered().await.unwrap()
+
+        .comment("getting an epoch settings changes the state → Registered")
+        .aggregator_send_epoch_settings().await
+        .cycle_registered().await.unwrap()
+        .register_signers(&signers_with_stake[..2]).await.unwrap()
+        .check_protocol_initializer(Epoch(2)).await.unwrap()
+        .check_stake_store(Epoch(2)).await.unwrap()
+
+        .comment("waiting 2 epoch for the registration to be effective")
+        .increase_epoch(2).await.unwrap()
+        .cycle_unregistered().await.unwrap()
+        .cycle_registered().await.unwrap()
+
+        .increase_epoch(3).await.unwrap()
+        .cycle_unregistered().await.unwrap()
+
+        .comment("creating a new certificate pending with a cardano transaction signed entity → Registered")
+        .increase_block_number(70, 170).await.unwrap()
+        .cycle_registered().await.unwrap()
+
+        .comment("signer can now create a single signature → Signed")
+        .cycle_signed().await.unwrap()
+
+        .comment("more cycles do not change the state = Signed")
+        .cycle_signed().await.unwrap()
+        .cycle_signed().await.unwrap()
+
+        .comment("new blocks means a new signature with the same stake distribution → Signed")
+        .increase_block_number(125, 295).await.unwrap()
+        .cardano_chain_send_rollback(230).await.unwrap()
+        .cycle_registered().await.unwrap()
+        .cycle_signed().await.unwrap()
+
+        .comment("metrics should be correctly computed")
+        .check_metrics(total_signer_registrations_expected,total_signature_registrations_expected).await.unwrap()
+        ;
+}

--- a/mithril-signer/tests/create_immutable_files_full_single_signature.rs
+++ b/mithril-signer/tests/create_immutable_files_full_single_signature.rs
@@ -1,19 +1,30 @@
 mod test_extensions;
 
 use mithril_common::{
-    crypto_helper::tests_setup, entities::Epoch, test_utils::MithrilFixtureBuilder,
+    crypto_helper::tests_setup,
+    entities::{ChainPoint, Epoch, TimePoint},
+    test_utils::MithrilFixtureBuilder,
 };
 
 use test_extensions::StateMachineTester;
 
 #[rustfmt::skip]
 #[tokio::test]
-async fn test_create_single_signature() {
+async fn test_create_immutable_files_full_single_signature() {
 
     let protocol_parameters = tests_setup::setup_protocol_parameters();
     let fixture = MithrilFixtureBuilder::default().with_signers(10).with_protocol_parameters(protocol_parameters.into()).build();
     let signers_with_stake = fixture.signers_with_stake();
-    let mut tester = StateMachineTester::init(&signers_with_stake).await.expect("state machine tester init should not fail");
+    let initial_time_point = TimePoint {
+        epoch: Epoch(1),
+        immutable_file_number: 1,
+        chain_point: ChainPoint {
+            slot_number: 1,
+            block_number: 100,
+            block_hash: "block_hash-100".to_string(),
+        },
+    };
+    let mut tester = StateMachineTester::init(&signers_with_stake, initial_time_point).await.expect("state machine tester init should not fail");
     let total_signer_registrations_expected = 4;
     let total_signature_registrations_expected = 3;
 

--- a/mithril-signer/tests/era_switch.rs
+++ b/mithril-signer/tests/era_switch.rs
@@ -2,7 +2,7 @@ mod test_extensions;
 
 use mithril_common::{
     crypto_helper::tests_setup,
-    entities::Epoch,
+    entities::{ChainPoint, Epoch, TimePoint},
     era::{EraMarker, SupportedEra},
     test_utils::MithrilFixtureBuilder,
 };
@@ -15,7 +15,16 @@ async fn era_fail_at_startup() {
     let protocol_parameters = tests_setup::setup_protocol_parameters();
     let fixture = MithrilFixtureBuilder::default().with_signers(10).with_protocol_parameters(protocol_parameters.into()).build();
     let signers_with_stake = fixture.signers_with_stake();
-    let mut tester = StateMachineTester::init(&signers_with_stake)
+    let initial_time_point = TimePoint {
+        epoch: Epoch(1),
+        immutable_file_number: 1,
+        chain_point: ChainPoint {
+            slot_number: 1,
+            block_number: 100,
+            block_hash: "block_hash-100".to_string(),
+        },
+    };
+    let mut tester = StateMachineTester::init(&signers_with_stake, initial_time_point)
         .await.expect("state machine tester init should not fail");
     tester.set_era_markers(vec![EraMarker::new("whatever", Some(Epoch(0)))]);
 

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -150,7 +150,7 @@ impl StateMachineTester {
             ));
         let mithril_stake_distribution_signable_builder =
             Arc::new(MithrilStakeDistributionSignableBuilder::default());
-        let transaction_parser = Arc::new(DumbBlockScanner::new(vec![]));
+        let transaction_parser = Arc::new(DumbBlockScanner::new());
         let transaction_store = Arc::new(CardanoTransactionRepository::new(
             transaction_sqlite_connection,
         ));

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -396,7 +396,6 @@ impl StateMachineTester {
         // Make the block scanner return new blocks
         let current_immutable = self.immutable_observer.get_last_immutable_number().await?;
         let blocks_to_scan: Vec<ScannedBlock> = ((expected - increment + 1)..=expected)
-            .into_iter()
             .map(|block_number| {
                 let block_hash = format!("block_hash-{block_number}");
                 let slot_number = 10 * block_number;


### PR DESCRIPTION
## Content

This PR implement on the transaction importer rollback logic. If a Rollback event is received, the importer will:

- Delete the transaction records with a block number strictly greater than the block number of the roll backward chain point.
- Delete the block range root records with a start greater or equal to the start of the block range compute from the roll backward chain point.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1724
