### PR TITLE
fix: clippy warnings with Rust `1.79.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.20"
+version = "0.5.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.6"
+version = "0.2.7"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/store/adapter/memory_adapter.rs
+++ b/internal/mithril-persistence/src/store/adapter/memory_adapter.rs
@@ -17,10 +17,7 @@ where
 {
     /// MemoryAdapter factory
     pub fn new(data: Option<Vec<(K, V)>>) -> Result<Self, AdapterError> {
-        let data = match data {
-            None => Vec::new(),
-            Some(v) => v,
-        };
+        let data = data.unwrap_or_default();
         let mut values = HashMap::new();
         let mut index = Vec::new();
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.20"
+version = "0.5.21"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -61,10 +61,13 @@ impl VerificationKeyStorer for VerificationKeyStore {
         epoch: Epoch,
         signer: SignerWithStake,
     ) -> StdResult<Option<SignerWithStake>> {
-        let mut signers = match self.adapter.read().await.get_record(&epoch).await? {
-            Some(s) => s,
-            None => HashMap::new(),
-        };
+        let mut signers = self
+            .adapter
+            .read()
+            .await
+            .get_record(&epoch)
+            .await?
+            .unwrap_or_default();
         let prev_signer = signers.insert(signer.party_id.to_owned(), signer.clone());
         self.adapter
             .write()


### PR DESCRIPTION
## Content
This PR includes fixes to clippy warnings occurring following the release of Rust `1.79.0`.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

