### PR TITLE
Use `macOS-arm64` runner in CI

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -18,6 +18,11 @@ runs:
       shell: bash
       run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
     - name: Add commit short sha to Cargo.tomls version
       shell: ${{ runner.os == 'Windows' && 'pwsh' || 'bash' }}
       run: |

--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -38,6 +38,15 @@ runs:
         --version "${{ inputs.version-name }}" \
         --target "macos-x64"
 
+    - name: Package distribution (macOS-arm64)
+      shell: bash
+      run: |
+        python3 ./.github/workflows/scripts/package-distribution.py \
+        --input package-macOS-arm64/ \
+        --dest package/ \
+        --version "${{ inputs.version-name }}" \
+        --target "macos-arm64"
+
     - name: Package distribution (Windows-X64)
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,11 +75,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macos-12, windows-latest ]
+        os: [ macos-12, macos-14, windows-latest ]
 
         include:
           # Only build client on windows & mac
           - os: macos-12
+            binaries-build-args: --bin mithril-client --features bundle_openssl
+            libraries-build-args: --package mithril-stm --package mithril-client --features full,unstable
+          - os: macos-14
             binaries-build-args: --bin mithril-client --features bundle_openssl
             libraries-build-args: --package mithril-stm --package mithril-client --features full,unstable
           - os: windows-latest
@@ -163,13 +166,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-latest ]
+        os: [ ubuntu-22.04, macos-12, macos-14, windows-latest ]
 
         include:
           - os: ubuntu-22.04
             test-args: --features full,unstable --workspace
           # Only test client on windows & mac (since its the only binaries supported for those os for now)
           - os: macos-12
+            test-args: --package mithril-client --package mithril-client-cli --features full,unstable
+          - os: macos-14
             test-args: --package mithril-client --package mithril-client-cli --features full,unstable
           - os: windows-latest
             test-args: --package mithril-client --package mithril-client-cli --features full,unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,6 +525,12 @@ jobs:
           name: mithril-distribution-macOS-X64
           path: ./package-macOS-X64
 
+      - name: Download built artifacts (macOS-arm64)
+        uses: actions/download-artifact@v4
+        with:
+          name: mithril-distribution-macOS-arm64
+          path: ./package-macOS-arm64
+
       - name: Download built artifacts (Windows-X64)
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -45,6 +45,15 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
 
+      - name: Download built artifacts (macOS-arm64)
+        uses: dawidd6/action-download-artifact@v3
+        with:
+          name: mithril-distribution-macOS-arm64
+          path: ./package-macOS-arm64
+          commit: ${{ github.sha }}
+          workflow: ci.yml
+          workflow_conclusion: success
+
       - name: Download built artifacts (Windows-x64)
         uses: dawidd6/action-download-artifact@v3
         with:

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-latest ]
+        os: [ ubuntu-22.04, macos-12, macos-14, windows-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Implement a lock mechanism on `SignedEntityType` to prevent concurrent work on a same entity type.
 
+- Extended CI build and test steps for MacOS `arm64` runners and include pre-built binaries for MacOS `arm64` in the releases.
+
 - **UNSTABLE** Cardano transactions certification:
   - Optimize the performances of the computation of the proof with a Merkle map.
   - Handle rollback events from the Cardano chain by removing stale data.


### PR DESCRIPTION
## Content
This PR adds a new [macOS-arm64 runner](https://github.com/actions/runner-images/blob/macos-14-arm64/20240611.1/images/macos/macos-14-arm64-Readme.md) used for the following steps in the CI:
- build step for `mithril-client` binary, `mithril-client` and `mithril-stm` librairies
- test step for `mithril-client` binary and library
- packaging the pre-built binaries in the releases
- Mithril Client multi-platform test manual workflow

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Relates to #1751 
