### PR TITLE
Signed entity lock mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Implement a reset mechanism for mutable resources returned to a pool (`ResourcePool`) to keep it in a consistent state.
 
+- Implement a lock mechanism on `SignedEntityType` to prevent concurrent work on a same entity type.
+
 - **UNSTABLE** Cardano transactions certification:
   - Optimize the performances of the computation of the proof with a Merkle map.
   - Handle rollback events from the Cardano chain by removing stale data.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.21"
+version = "0.5.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.143"
+version = "0.2.144"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.21"
+version = "0.5.22"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -11,7 +11,6 @@ use tokio::{
 };
 use warp::Filter;
 
-use mithril_common::signed_entity_lock::SignedEntityLock;
 use mithril_common::{
     api_version::APIVersionProvider,
     cardano_block_scanner::{BlockScanner, CardanoBlockScanner},
@@ -35,6 +34,7 @@ use mithril_common::{
         MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
         SignableBuilderService,
     },
+    signed_entity_type_lock::SignedEntityTypeLock,
     MithrilTickerService, TickerService,
 };
 use mithril_persistence::{
@@ -1189,7 +1189,7 @@ impl DependenciesBuilder {
             block_scanner: self.get_block_scanner().await?,
             transaction_store: self.get_transaction_repository().await?,
             prover_service: self.get_prover_service().await?,
-            signed_entity_lock: Arc::new(SignedEntityLock::default()),
+            signed_entity_type_lock: Arc::new(SignedEntityTypeLock::default()),
         };
 
         Ok(dependency_manager)

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -11,6 +11,7 @@ use tokio::{
 };
 use warp::Filter;
 
+use mithril_common::signed_entity_lock::SignedEntityLock;
 use mithril_common::{
     api_version::APIVersionProvider,
     cardano_block_scanner::{BlockScanner, CardanoBlockScanner},
@@ -1188,6 +1189,7 @@ impl DependenciesBuilder {
             block_scanner: self.get_block_scanner().await?,
             transaction_store: self.get_transaction_repository().await?,
             prover_service: self.get_prover_service().await?,
+            signed_entity_lock: Arc::new(SignedEntityLock::default()),
         };
 
         Ok(dependency_manager)

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use mithril_common::entities::SignedEntityConfig;
-use mithril_common::signed_entity_lock::SignedEntityLock;
 use mithril_common::{
     api_version::APIVersionProvider,
     cardano_block_scanner::BlockScanner,
@@ -13,6 +12,7 @@ use mithril_common::{
     entities::{Epoch, ProtocolParameters, SignerWithStake, StakeDistribution},
     era::{EraChecker, EraReader},
     signable_builder::SignableBuilderService,
+    signed_entity_type_lock::SignedEntityTypeLock,
     test_utils::MithrilFixture,
     TickerService,
 };
@@ -159,8 +159,8 @@ pub struct DependencyContainer {
     /// Prover service
     pub prover_service: Arc<dyn ProverService>,
 
-    /// Signed Entity Lock
-    pub signed_entity_lock: Arc<SignedEntityLock>,
+    /// Signed Entity Type Lock
+    pub signed_entity_type_lock: Arc<SignedEntityTypeLock>,
 }
 
 #[doc(hidden)]

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use mithril_common::entities::SignedEntityConfig;
+use mithril_common::signed_entity_lock::SignedEntityLock;
 use mithril_common::{
     api_version::APIVersionProvider,
     cardano_block_scanner::BlockScanner,
@@ -157,6 +158,9 @@ pub struct DependencyContainer {
 
     /// Prover service
     pub prover_service: Arc<dyn ProverService>,
+
+    /// Signed Entity Lock
+    pub signed_entity_lock: Arc<SignedEntityLock>,
 }
 
 #[doc(hidden)]

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -150,7 +150,7 @@ impl AggregatorRunner {
             .signed_entity_config
             .list_allowed_signed_entity_types(time_point);
         self.dependencies
-            .signed_entity_lock
+            .signed_entity_type_lock
             .filter_unlocked_entries(signed_entity_types)
             .await
     }
@@ -500,7 +500,7 @@ pub mod tests {
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
     use mithril_common::entities::{ChainPoint, SignedEntityTypeDiscriminants};
-    use mithril_common::signed_entity_lock::SignedEntityLock;
+    use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
     use mithril_common::{
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
@@ -1164,7 +1164,7 @@ pub mod tests {
             let mut dependencies = initialize_dependencies().await;
             dependencies.signed_entity_config.allowed_discriminants =
                 SignedEntityTypeDiscriminants::all();
-            dependencies.signed_entity_lock = Arc::new(SignedEntityLock::default());
+            dependencies.signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
             AggregatorRunner::new(Arc::new(dependencies))
         };
 
@@ -1186,16 +1186,16 @@ pub mod tests {
 
     #[tokio::test]
     async fn list_available_signed_entity_types_exclude_locked_entities() {
-        let signed_entity_lock = Arc::new(SignedEntityLock::default());
+        let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
         let runner = {
             let mut dependencies = initialize_dependencies().await;
             dependencies.signed_entity_config.allowed_discriminants =
                 SignedEntityTypeDiscriminants::all();
-            dependencies.signed_entity_lock = signed_entity_lock.clone();
+            dependencies.signed_entity_type_lock = signed_entity_type_lock.clone();
             AggregatorRunner::new(Arc::new(dependencies))
         };
 
-        signed_entity_lock
+        signed_entity_type_lock
             .lock(SignedEntityTypeDiscriminants::CardanoTransactions)
             .await;
 

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -140,6 +140,20 @@ impl AggregatorRunner {
     pub fn new(dependencies: Arc<DependencyContainer>) -> Self {
         Self { dependencies }
     }
+
+    async fn list_available_signed_entity_types(
+        &self,
+        time_point: &TimePoint,
+    ) -> Vec<SignedEntityType> {
+        let signed_entity_types = self
+            .dependencies
+            .signed_entity_config
+            .list_allowed_signed_entity_types(time_point);
+        self.dependencies
+            .signed_entity_lock
+            .filter_unlocked_entries(signed_entity_types)
+            .await
+    }
 }
 
 #[cfg_attr(test, automock)]
@@ -179,9 +193,8 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     ) -> StdResult<Option<OpenMessage>> {
         debug!("RUNNER: get_current_non_certified_open_message"; "time_point" => #?current_time_point);
         let signed_entity_types = self
-            .dependencies
-            .signed_entity_config
-            .list_allowed_signed_entity_types(current_time_point);
+            .list_available_signed_entity_types(current_time_point)
+            .await;
         for signed_entity_type in signed_entity_types {
             let current_open_message = self.get_current_open_message_for_signed_entity_type(&signed_entity_type)
                 .await
@@ -486,7 +499,8 @@ pub mod tests {
     };
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
-    use mithril_common::entities::ChainPoint;
+    use mithril_common::entities::{ChainPoint, SignedEntityTypeDiscriminants};
+    use mithril_common::signed_entity_lock::SignedEntityLock;
     use mithril_common::{
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
@@ -1142,5 +1156,58 @@ pub mod tests {
             .get_current_non_certified_open_message(&TimePoint::dummy())
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn list_available_signed_entity_types_list_all_configured_entities_if_none_are_locked() {
+        let runner = {
+            let mut dependencies = initialize_dependencies().await;
+            dependencies.signed_entity_config.allowed_discriminants =
+                SignedEntityTypeDiscriminants::all();
+            dependencies.signed_entity_lock = Arc::new(SignedEntityLock::default());
+            AggregatorRunner::new(Arc::new(dependencies))
+        };
+
+        let time_point = TimePoint::dummy();
+        let signed_entities: Vec<SignedEntityTypeDiscriminants> = runner
+            .list_available_signed_entity_types(&time_point)
+            .await
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        assert_eq!(
+            signed_entities,
+            SignedEntityTypeDiscriminants::all()
+                .into_iter()
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn list_available_signed_entity_types_exclude_locked_entities() {
+        let signed_entity_lock = Arc::new(SignedEntityLock::default());
+        let runner = {
+            let mut dependencies = initialize_dependencies().await;
+            dependencies.signed_entity_config.allowed_discriminants =
+                SignedEntityTypeDiscriminants::all();
+            dependencies.signed_entity_lock = signed_entity_lock.clone();
+            AggregatorRunner::new(Arc::new(dependencies))
+        };
+
+        signed_entity_lock
+            .lock(SignedEntityTypeDiscriminants::CardanoTransactions)
+            .await;
+
+        let time_point = TimePoint::dummy();
+        let signed_entities: Vec<SignedEntityTypeDiscriminants> = runner
+            .list_available_signed_entity_types(&time_point)
+            .await
+            .into_iter()
+            .map(Into::into)
+            .collect();
+
+        assert!(!signed_entities.is_empty());
+        assert!(!signed_entities.contains(&SignedEntityTypeDiscriminants::CardanoTransactions));
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.16"
+version = "0.4.17"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/signed_entity_config.rs
+++ b/mithril-common/src/entities/signed_entity_config.rs
@@ -144,7 +144,7 @@ impl CardanoTransactionsSigningConfig {
         // We can't have a step lower than the block range length.
         let adjusted_step = std::cmp::max(adjusted_step, BlockRange::LENGTH);
 
-        (block_number - self.security_parameter) / adjusted_step * adjusted_step
+        (block_number.saturating_sub(self.security_parameter)) / adjusted_step * adjusted_step
     }
 }
 
@@ -247,6 +247,18 @@ mod tests {
                 step: 30,
             }
             .compute_block_number_to_be_signed(29),
+            0
+        );
+    }
+
+    #[test]
+    fn computing_block_number_to_be_signed_should_not_overlow_on_security_parameter() {
+        assert_eq!(
+            CardanoTransactionsSigningConfig {
+                security_parameter: 100,
+                step: 30,
+            }
+            .compute_block_number_to_be_signed(50),
             0
         );
     }

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -61,6 +61,7 @@ pub mod messages;
 pub mod protocol;
 pub mod resource_pool;
 pub mod signable_builder;
+pub mod signed_entity_lock;
 
 cfg_test_tools! {
     pub mod test_utils;

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -61,7 +61,7 @@ pub mod messages;
 pub mod protocol;
 pub mod resource_pool;
 pub mod signable_builder;
-pub mod signed_entity_lock;
+pub mod signed_entity_type_lock;
 
 cfg_test_tools! {
     pub mod test_utils;

--- a/mithril-common/src/signed_entity_lock.rs
+++ b/mithril-common/src/signed_entity_lock.rs
@@ -24,25 +24,25 @@ impl SignedEntityLock {
     }
 
     /// Check if a signed entity is locked.
-    pub async fn is_locked(&self, entity_type: SignedEntityTypeDiscriminants) -> bool {
+    pub async fn is_locked<T: Into<SignedEntityTypeDiscriminants>>(&self, entity_type: T) -> bool {
         let locked_entities = self.locked_entities.read().await;
-        locked_entities.contains(&entity_type)
+        locked_entities.contains(&entity_type.into())
     }
 
     /// Lock a signed entity.
     ///
     /// If the entity is already locked, this function does nothing.
-    pub async fn lock(&self, entity_type: SignedEntityTypeDiscriminants) {
+    pub async fn lock<T: Into<SignedEntityTypeDiscriminants>>(&self, entity_type: T) {
         let mut locked_entities = self.locked_entities.write().await;
-        locked_entities.insert(entity_type);
+        locked_entities.insert(entity_type.into());
     }
 
     /// Release a locked signed entity.
     ///
     /// If the entity is not locked, this function does nothing.
-    pub async fn release(&self, entity_type: SignedEntityTypeDiscriminants) {
+    pub async fn release<T: Into<SignedEntityTypeDiscriminants>>(&self, entity_type: T) {
         let mut locked_entities = self.locked_entities.write().await;
-        locked_entities.remove(&entity_type);
+        locked_entities.remove(&entity_type.into());
     }
 
     /// List only the unlocked signed entities in the given list.

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.143"
+version = "0.2.144"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -244,7 +244,7 @@ impl Runner for SignerRunner {
         debug!("RUNNER: can_i_sign");
         if self
             .services
-            .signed_entity_lock
+            .signed_entity_type_lock
             .is_locked(&pending_certificate.signed_entity_type)
             .await
         {
@@ -469,7 +469,7 @@ mod tests {
             CardanoTransactionsSignableBuilder, MithrilSignableBuilderService,
             MithrilStakeDistributionSignableBuilder,
         },
-        signed_entity_lock::SignedEntityLock,
+        signed_entity_type_lock::SignedEntityTypeLock,
         test_utils::{fake_data, MithrilFixtureBuilder},
         MithrilTickerService, TickerService,
     };
@@ -582,7 +582,7 @@ mod tests {
             api_version_provider,
             signable_builder_service,
             metrics_service,
-            signed_entity_lock: Arc::new(SignedEntityLock::default()),
+            signed_entity_type_lock: Arc::new(SignedEntityTypeLock::default()),
         }
     }
 
@@ -711,11 +711,11 @@ mod tests {
         let epoch = pending_certificate.epoch;
         let signer = &mut pending_certificate.signers[0];
         // All signed entities are available for signing.
-        let signed_entity_lock = Arc::new(SignedEntityLock::new());
+        let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::new());
         let mut services = init_services().await;
         let protocol_initializer_store = services.protocol_initializer_store.clone();
         services.single_signer = Arc::new(MithrilSingleSigner::new(signer.party_id.to_owned()));
-        services.signed_entity_lock = signed_entity_lock.clone();
+        services.signed_entity_type_lock = signed_entity_type_lock.clone();
         let runner = init_runner(Some(services), None).await;
 
         let protocol_initializer = MithrilProtocolInitializerBuilder::build(
@@ -740,7 +740,7 @@ mod tests {
         assert!(can_i_sign_result);
 
         // Lock the pending certificate signed entity type, the signer should not be able to sign.
-        signed_entity_lock
+        signed_entity_type_lock
             .lock(&pending_certificate.signed_entity_type)
             .await;
 

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -242,6 +242,15 @@ impl Runner for SignerRunner {
 
     async fn can_i_sign(&self, pending_certificate: &CertificatePending) -> StdResult<bool> {
         debug!("RUNNER: can_i_sign");
+        if self
+            .services
+            .signed_entity_lock
+            .is_locked(&pending_certificate.signed_entity_type)
+            .await
+        {
+            debug!(" > signed entity type is locked, can NOT sign");
+            return Ok(false);
+        }
 
         if let Some(signer) =
             pending_certificate.get_signer(self.services.single_signer.get_party_id())
@@ -460,6 +469,7 @@ mod tests {
             CardanoTransactionsSignableBuilder, MithrilSignableBuilderService,
             MithrilStakeDistributionSignableBuilder,
         },
+        signed_entity_lock::SignedEntityLock,
         test_utils::{fake_data, MithrilFixtureBuilder},
         MithrilTickerService, TickerService,
     };
@@ -572,6 +582,7 @@ mod tests {
             api_version_provider,
             signable_builder_service,
             metrics_service,
+            signed_entity_lock: Arc::new(SignedEntityLock::default()),
         }
     }
 
@@ -699,9 +710,12 @@ mod tests {
         let mut pending_certificate = fake_data::certificate_pending();
         let epoch = pending_certificate.epoch;
         let signer = &mut pending_certificate.signers[0];
+        // All signed entities are available for signing.
+        let signed_entity_lock = Arc::new(SignedEntityLock::new());
         let mut services = init_services().await;
         let protocol_initializer_store = services.protocol_initializer_store.clone();
         services.single_signer = Arc::new(MithrilSingleSigner::new(signer.party_id.to_owned()));
+        services.signed_entity_lock = signed_entity_lock.clone();
         let runner = init_runner(Some(services), None).await;
 
         let protocol_initializer = MithrilProtocolInitializerBuilder::build(
@@ -724,6 +738,17 @@ mod tests {
 
         let can_i_sign_result = runner.can_i_sign(&pending_certificate).await.unwrap();
         assert!(can_i_sign_result);
+
+        // Lock the pending certificate signed entity type, the signer should not be able to sign.
+        signed_entity_lock
+            .lock(&pending_certificate.signed_entity_type)
+            .await;
+
+        let can_i_sign_result = runner.can_i_sign(&pending_certificate).await.unwrap();
+        assert!(
+            !can_i_sign_result,
+            "The signer should not be able to sign when the signed entity type is locked."
+        );
     }
 
     #[tokio::test]

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -18,6 +18,7 @@ use mithril_common::{
         MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
         SignableBuilderService,
     },
+    signed_entity_lock::SignedEntityLock,
     MithrilTickerService, StdResult, TickerService,
 };
 use mithril_persistence::{
@@ -307,6 +308,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             api_version_provider,
             signable_builder_service,
             metrics_service,
+            signed_entity_lock: Arc::new(SignedEntityLock::default()),
         };
 
         Ok(services)
@@ -350,6 +352,9 @@ pub struct SignerServices {
 
     /// Metrics service
     pub metrics_service: Arc<MetricsService>,
+
+    /// Signed entity lock
+    pub signed_entity_lock: Arc<SignedEntityLock>,
 }
 
 #[cfg(test)]

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -18,7 +18,7 @@ use mithril_common::{
         MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
         SignableBuilderService,
     },
-    signed_entity_lock::SignedEntityLock,
+    signed_entity_type_lock::SignedEntityTypeLock,
     MithrilTickerService, StdResult, TickerService,
 };
 use mithril_persistence::{
@@ -308,7 +308,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             api_version_provider,
             signable_builder_service,
             metrics_service,
-            signed_entity_lock: Arc::new(SignedEntityLock::default()),
+            signed_entity_type_lock: Arc::new(SignedEntityTypeLock::default()),
         };
 
         Ok(services)
@@ -353,8 +353,8 @@ pub struct SignerServices {
     /// Metrics service
     pub metrics_service: Arc<MetricsService>,
 
-    /// Signed entity lock
-    pub signed_entity_lock: Arc<SignedEntityLock>,
+    /// Signed entity type lock
+    pub signed_entity_type_lock: Arc<SignedEntityTypeLock>,
 }
 
 #[cfg(test)]

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -20,6 +20,7 @@ use mithril_common::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
         MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
     },
+    signed_entity_lock::SignedEntityLock,
     MithrilTickerService, StdError, TickerService,
 };
 use mithril_persistence::database::repository::CardanoTransactionRepository;
@@ -195,6 +196,7 @@ impl StateMachineTester {
             api_version_provider,
             signable_builder_service,
             metrics_service: metrics_service.clone(),
+            signed_entity_lock: Arc::new(SignedEntityLock::default()),
         };
         // set up stake distribution
         chain_observer

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -20,7 +20,7 @@ use mithril_common::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
         MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
     },
-    signed_entity_lock::SignedEntityLock,
+    signed_entity_type_lock::SignedEntityTypeLock,
     MithrilTickerService, StdError, TickerService,
 };
 use mithril_persistence::database::repository::CardanoTransactionRepository;
@@ -196,7 +196,7 @@ impl StateMachineTester {
             api_version_provider,
             signable_builder_service,
             metrics_service: metrics_service.clone(),
-            signed_entity_lock: Arc::new(SignedEntityLock::default()),
+            signed_entity_type_lock: Arc::new(SignedEntityTypeLock::default()),
         };
         // set up stake distribution
         chain_observer


### PR DESCRIPTION
## Content

This PR add a lock mechanism to make our state machines skip a signed entity when needed (ie: when we need to do a costly computation on a signed entity but we still want our state machines to run).

On aggregator the skip is done when it try to create open messages.
On signer the skip is done when it check if it can sign a pending certificate.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1693
