### PR TITLE
Warmup/Preload cardano transactions & block range roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 - **UNSTABLE** Cardano transactions certification:
   - Optimize the performances of the computation of the proof with a Merkle map.
   - Handle rollback events from the Cardano chain by removing stale data.
+  - Preload Cardano transactions and Block Range Roots at signer & aggregator startup.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.22"
+version = "0.5.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3832,7 +3832,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.144"
+version = "0.2.145"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.22"
+version = "0.5.23"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1278,7 +1278,7 @@ impl DependenciesBuilder {
             self.get_transactions_importer().await?,
             self.configuration
                 .cardano_transactions_signing_config
-                .clone(),
+                .security_parameter,
             self.get_chain_observer().await?,
             self.get_logger().await?,
         );

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use mithril_common::entities::SignedEntityConfig;
 use mithril_common::{
     api_version::APIVersionProvider,
     cardano_block_scanner::BlockScanner,
@@ -9,7 +8,7 @@ use mithril_common::{
     chain_observer::ChainObserver,
     crypto_helper::ProtocolGenesisVerifier,
     digesters::{ImmutableDigester, ImmutableFileObserver},
-    entities::{Epoch, ProtocolParameters, SignerWithStake, StakeDistribution},
+    entities::{Epoch, ProtocolParameters, SignedEntityConfig, SignerWithStake, StakeDistribution},
     era::{EraChecker, EraReader},
     signable_builder::SignableBuilderService,
     signed_entity_type_lock::SignedEntityTypeLock,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.17"
+version = "0.4.18"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/cardano_transactions_preloader.rs
+++ b/mithril-common/src/cardano_transactions_preloader.rs
@@ -1,0 +1,212 @@
+//! # Cardano Transaction Preloader
+//!
+//! This module provides a preload mechanism for Cardano Transaction signed entity, allowing
+//! to compute in advance the Transactions & Block Range Root to be signed.
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use slog::{debug, trace, Logger};
+
+use crate::chain_observer::ChainObserver;
+use crate::entities::{CardanoTransactionsSigningConfig, SignedEntityTypeDiscriminants};
+use crate::signable_builder::TransactionsImporter;
+use crate::signed_entity_type_lock::SignedEntityTypeLock;
+use crate::StdResult;
+
+/// Preload mechanism for Cardano Transaction signed entity, allowing
+/// to compute in advance the Transactions & Block Range Root to be signed.
+pub struct CardanoTransactionsPreloader {
+    signed_entity_type_lock: Arc<SignedEntityTypeLock>,
+    importer: Arc<dyn TransactionsImporter>,
+    cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
+    chain_observer: Arc<dyn ChainObserver>,
+    logger: Logger,
+}
+
+impl CardanoTransactionsPreloader {
+    /// Create a new instance of `CardanoTransactionPreloader`.
+    pub fn new(
+        signed_entity_type_lock: Arc<SignedEntityTypeLock>,
+        importer: Arc<dyn TransactionsImporter>,
+        cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
+        chain_observer: Arc<dyn ChainObserver>,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            signed_entity_type_lock,
+            importer,
+            cardano_transactions_signing_config,
+            chain_observer,
+            logger,
+        }
+    }
+
+    /// Preload the Cardano Transactions by running the importer up to the current chain block number.
+    pub async fn preload(&self) -> StdResult<()> {
+        debug!(self.logger, "🔥 Preload Cardano Transactions - Started");
+        trace!(self.logger, "🔥 Locking signed entity type"; "entity_type" => "CardanoTransactions");
+        self.signed_entity_type_lock
+            .lock(SignedEntityTypeDiscriminants::CardanoTransactions)
+            .await;
+
+        let preload_result = self.do_preload().await;
+
+        trace!(self.logger, "🔥 Releasing signed entity type"; "entity_type" => "CardanoTransactions");
+        self.signed_entity_type_lock
+            .release(SignedEntityTypeDiscriminants::CardanoTransactions)
+            .await;
+        debug!(self.logger, "🔥 Preload Cardano Transactions - Finished");
+
+        preload_result
+    }
+
+    async fn do_preload(&self) -> StdResult<()> {
+        let chain_point = self
+            .chain_observer
+            .get_current_chain_point()
+            .await?
+            .with_context(|| {
+                "No chain point yielded by the chain observer, is your cardano node ready?"
+            })?;
+        let up_to_block_number = self
+            .cardano_transactions_signing_config
+            .compute_block_number_to_be_signed(chain_point.block_number);
+        self.importer.import(up_to_block_number).await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use mockall::predicate::eq;
+
+    use crate::chain_observer::FakeObserver;
+    use crate::entities::{BlockNumber, ChainPoint, TimePoint};
+    use crate::signable_builder::MockTransactionsImporter;
+    use crate::test_utils::TestLogger;
+
+    use super::*;
+
+    struct ImporterWithSignedEntityTypeLockCheck {
+        signed_entity_type_lock: Arc<SignedEntityTypeLock>,
+    }
+    #[async_trait]
+    impl TransactionsImporter for ImporterWithSignedEntityTypeLockCheck {
+        async fn import(&self, _up_to_beacon: BlockNumber) -> StdResult<()> {
+            assert!(
+                self.signed_entity_type_lock
+                    .is_locked(SignedEntityTypeDiscriminants::CardanoTransactions)
+                    .await
+            );
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn call_its_inner_importer() {
+        let chain_block_number = 5000;
+        let cardano_transactions_signing_config = CardanoTransactionsSigningConfig::dummy();
+        let chain_observer = FakeObserver::new(Some(TimePoint {
+            chain_point: ChainPoint {
+                block_number: chain_block_number,
+                ..ChainPoint::dummy()
+            },
+            ..TimePoint::dummy()
+        }));
+        let expected_parsed_block_number = cardano_transactions_signing_config
+            .compute_block_number_to_be_signed(chain_block_number);
+
+        let mut importer = MockTransactionsImporter::new();
+        importer
+            .expect_import()
+            .times(1)
+            .with(eq(expected_parsed_block_number))
+            .returning(|_| Ok(()));
+
+        let preloader = CardanoTransactionsPreloader::new(
+            Arc::new(SignedEntityTypeLock::default()),
+            Arc::new(importer),
+            cardano_transactions_signing_config,
+            Arc::new(chain_observer),
+            TestLogger::stdout(),
+        );
+
+        preloader.preload().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn fail_if_chain_point_is_not_available() {
+        let chain_observer = FakeObserver::new(None);
+        let mut importer = MockTransactionsImporter::new();
+        importer.expect_import().never();
+
+        let preloader = CardanoTransactionsPreloader::new(
+            Arc::new(SignedEntityTypeLock::default()),
+            Arc::new(importer),
+            CardanoTransactionsSigningConfig::dummy(),
+            Arc::new(chain_observer),
+            TestLogger::stdout(),
+        );
+
+        preloader
+            .preload()
+            .await
+            .expect_err("should raise an error when chain point is not available");
+    }
+
+    #[tokio::test]
+    async fn should_lock_entity_type_while_preloading() {
+        let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
+
+        let preloader = CardanoTransactionsPreloader::new(
+            signed_entity_type_lock.clone(),
+            Arc::new(ImporterWithSignedEntityTypeLockCheck {
+                signed_entity_type_lock: signed_entity_type_lock.clone(),
+            }),
+            CardanoTransactionsSigningConfig::dummy(),
+            Arc::new(FakeObserver::new(Some(TimePoint::dummy()))),
+            TestLogger::stdout(),
+        );
+
+        assert!(
+            !signed_entity_type_lock
+                .is_locked(SignedEntityTypeDiscriminants::CardanoTransactions)
+                .await
+        );
+
+        preloader.preload().await.unwrap();
+
+        assert!(
+            !signed_entity_type_lock
+                .is_locked(SignedEntityTypeDiscriminants::CardanoTransactions)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn should_release_locked_entity_type_when_preloading_fail() {
+        let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
+        let chain_observer = FakeObserver::new(None);
+
+        let preloader = CardanoTransactionsPreloader::new(
+            signed_entity_type_lock.clone(),
+            Arc::new(ImporterWithSignedEntityTypeLockCheck {
+                signed_entity_type_lock: signed_entity_type_lock.clone(),
+            }),
+            CardanoTransactionsSigningConfig::dummy(),
+            Arc::new(chain_observer),
+            TestLogger::stdout(),
+        );
+
+        preloader.preload().await.unwrap_err();
+
+        assert!(
+            !signed_entity_type_lock
+                .is_locked(SignedEntityTypeDiscriminants::CardanoTransactions)
+                .await
+        );
+    }
+}

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -72,6 +72,7 @@ cfg_fs! {
     pub mod digesters;
     pub mod cardano_block_scanner;
     pub mod chain_reader;
+    pub mod cardano_transactions_preloader;
 
     pub use ticker_service::{TickerService, MithrilTickerService};
 }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.144"
+version = "0.2.145"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -40,6 +40,10 @@ pub struct Configuration {
     /// be considered final, preventing any further rollback `[default: 2160]`.
     pub network_security_parameter: BlockNumber,
 
+    /// Blocks offset, from the tip of the chain, to exclude during the cardano transactions preload
+    /// `[default: 3000]`.
+    pub preload_security_parameter: BlockNumber,
+
     /// Aggregator endpoint
     #[example = "`https://aggregator.pre-release-preview.api.mithril.network/aggregator`"]
     pub aggregator_endpoint: String,
@@ -121,6 +125,7 @@ impl Configuration {
             network: "devnet".to_string(),
             network_magic: Some(42),
             network_security_parameter: 2160,
+            preload_security_parameter: 30,
             party_id: Some(party_id),
             run_interval: 5000,
             data_stores_directory: PathBuf::new(),
@@ -204,6 +209,9 @@ pub struct DefaultConfiguration {
 
     /// Transaction pruning toggle
     pub enable_transaction_pruning: bool,
+
+    /// Preload security parameter
+    pub preload_security_parameter: BlockNumber,
 }
 
 impl DefaultConfiguration {
@@ -219,6 +227,7 @@ impl Default for DefaultConfiguration {
             metrics_server_ip: "0.0.0.0".to_string(),
             metrics_server_port: 9090,
             network_security_parameter: 2160, // 2160 is the mainnet value
+            preload_security_parameter: 3000,
             enable_transaction_pruning: true,
         }
     }
@@ -254,6 +263,11 @@ impl Source for DefaultConfiguration {
         result.insert(
             "network_security_parameter".to_string(),
             into_value(myself.network_security_parameter),
+        );
+
+        result.insert(
+            "preload_security_parameter".to_string(),
+            into_value(myself.preload_security_parameter),
         );
 
         result.insert(

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -463,10 +463,7 @@ mod tests {
         chain_observer::{ChainObserver, FakeObserver},
         crypto_helper::{MKMap, MKMapNode, MKTreeNode, ProtocolInitializer},
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
-        entities::{
-            BlockNumber, BlockRange, CardanoDbBeacon, CardanoTransactionsSigningConfig, Epoch,
-            StakeDistribution,
-        },
+        entities::{BlockNumber, BlockRange, CardanoDbBeacon, Epoch, StakeDistribution},
         era::{adapters::EraReaderBootstrapAdapter, EraChecker, EraReader},
         signable_builder::{
             BlockRangeRootRetriever, CardanoImmutableFilesFullSignableBuilder,
@@ -522,10 +519,6 @@ mod tests {
         let adapter: MemoryAdapter<Epoch, ProtocolInitializer> = MemoryAdapter::new(None).unwrap();
         let stake_distribution_signers = fake_data::signers_with_stakes(2);
         let party_id = stake_distribution_signers[1].party_id.clone();
-        let cardano_transactions_signing_config = CardanoTransactionsSigningConfig {
-            security_parameter: 100,
-            step: 15,
-        };
         let fake_observer = FakeObserver::default();
         fake_observer.set_signers(stake_distribution_signers).await;
         let chain_observer = Arc::new(fake_observer);
@@ -574,10 +567,11 @@ mod tests {
         ));
         let metrics_service = Arc::new(MetricsService::new().unwrap());
         let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
+        let security_parameter = 0;
         let cardano_transactions_preloader = Arc::new(CardanoTransactionsPreloader::new(
             signed_entity_type_lock.clone(),
             transactions_importer.clone(),
-            cardano_transactions_signing_config,
+            security_parameter,
             chain_observer.clone(),
             slog_scope::logger(),
         ));

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -13,7 +13,6 @@ use mithril_common::{
         CardanoImmutableDigester, ImmutableDigester, ImmutableFileObserver,
         ImmutableFileSystemObserver,
     },
-    entities::CardanoTransactionsSigningConfig,
     era::{EraChecker, EraReader},
     signable_builder::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
@@ -300,12 +299,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
         let cardano_transactions_preloader = Arc::new(CardanoTransactionsPreloader::new(
             signed_entity_type_lock.clone(),
             transactions_importer.clone(),
-            // Only relevant for the preloader since the state machine get the block number to import
-            // through the pending certificate, should it be configurable ?
-            CardanoTransactionsSigningConfig {
-                security_parameter: 3000,
-                step: 120,
-            },
+            self.config.preload_security_parameter,
             chain_observer.clone(),
             slog_scope::logger(),
         ));

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -185,10 +185,11 @@ impl StateMachineTester {
         let metrics_service = Arc::new(MetricsService::new().unwrap());
         let expected_metrics_service = Arc::new(MetricsService::new().unwrap());
         let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
+        let security_parameter = 0;
         let cardano_transactions_preloader = Arc::new(CardanoTransactionsPreloader::new(
             signed_entity_type_lock.clone(),
             transactions_importer.clone(),
-            cardano_transactions_signing_config,
+            security_parameter,
             chain_observer.clone(),
             slog_scope::logger(),
         ));


### PR DESCRIPTION
## Content

This PR includes a preload system for `CardanoTransaction` & `BlockRangeRoot`, it's simply a system that is spawned in a separate thread at aggregator & signer startup that run the transaction importer.
The CardanoTransaction signed entity type is lock during the preload and is released when it finish even if the preload fail.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
We designed this system specifically for the Cardano Transactions import first so we have a rough idea of what's needed before we can consider generalizing it to other tasks that need preload (such as immutable file digester cache or even maybe the import of signers pool tickers).

## Issue(s)
Closes #1692
