### PR TITLE
Import transactions in sequence on signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ As a minor extension, we have adopted a slightly different versioning convention
   - Optimize the performances of the computation of the proof with a Merkle map.
   - Handle rollback events from the Cardano chain by removing stale data.
   - Preload Cardano transactions and Block Range Roots at signer & aggregator startup.
+  - Chunk the Cardano transactions import in `mithril-signer` to reduce disk footprint by running the pruning process more frequently.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.146"
+version = "0.2.147"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.146"
+version = "0.2.147"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -108,6 +108,11 @@ pub struct Configuration {
     /// [network_security_parameter][Self::network_security_parameter] blocks after each import
     /// `[default: true]`.
     pub enable_transaction_pruning: bool,
+
+    /// Chunk size for importing transactions, combined with transaction pruning it reduces the
+    /// storage footprint of the signer by reducing the number of transactions stored on disk
+    /// at any given time.
+    pub transactions_import_block_chunk_size: BlockNumber,
 }
 
 impl Configuration {
@@ -143,6 +148,7 @@ impl Configuration {
             metrics_server_port: 9090,
             allow_unparsable_block: false,
             enable_transaction_pruning: false,
+            transactions_import_block_chunk_size: 1000,
         }
     }
 
@@ -212,6 +218,9 @@ pub struct DefaultConfiguration {
 
     /// Preload security parameter
     pub preload_security_parameter: BlockNumber,
+
+    /// Chunk size for importing transactions
+    pub transactions_import_block_chunk_size: BlockNumber,
 }
 
 impl DefaultConfiguration {
@@ -229,6 +238,7 @@ impl Default for DefaultConfiguration {
             network_security_parameter: 2160, // 2160 is the mainnet value
             preload_security_parameter: 3000,
             enable_transaction_pruning: true,
+            transactions_import_block_chunk_size: 1500,
         }
     }
 }
@@ -273,6 +283,11 @@ impl Source for DefaultConfiguration {
         result.insert(
             "enable_transaction_pruning".to_string(),
             into_value(myself.enable_transaction_pruning),
+        );
+
+        result.insert(
+            "transactions_import_block_chunk_size".to_string(),
+            into_value(myself.transactions_import_block_chunk_size),
         );
 
         Ok(result)

--- a/mithril-signer/src/database/repository/cardano_transaction_repository.rs
+++ b/mithril-signer/src/database/repository/cardano_transaction_repository.rs
@@ -7,7 +7,7 @@ use mithril_common::entities::{BlockNumber, BlockRange, CardanoTransaction, Chai
 use mithril_common::StdResult;
 use mithril_persistence::database::repository::CardanoTransactionRepository;
 
-use crate::{TransactionPruner, TransactionStore};
+use crate::{HighestTransactionBlockNumberGetter, TransactionPruner, TransactionStore};
 
 #[async_trait]
 impl TransactionStore for CardanoTransactionRepository {
@@ -59,5 +59,13 @@ impl TransactionStore for CardanoTransactionRepository {
 impl TransactionPruner for CardanoTransactionRepository {
     async fn prune(&self, number_of_blocks_to_keep: BlockNumber) -> StdResult<()> {
         self.prune_transaction(number_of_blocks_to_keep).await
+    }
+}
+
+#[async_trait]
+impl HighestTransactionBlockNumberGetter for CardanoTransactionRepository {
+    async fn get(&self) -> StdResult<Option<BlockNumber>> {
+        let highest_chain_point = self.get_transaction_highest_chain_point().await?;
+        Ok(highest_chain_point.map(|c| c.block_number))
     }
 }

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -15,6 +15,7 @@ pub mod metrics;
 mod protocol_initializer_store;
 mod runtime;
 mod single_signer;
+mod transactions_importer_by_chunk;
 mod transactions_importer_with_pruner;
 
 #[cfg(test)]
@@ -29,6 +30,7 @@ pub use metrics::*;
 pub use protocol_initializer_store::{ProtocolInitializerStore, ProtocolInitializerStorer};
 pub use runtime::*;
 pub use single_signer::*;
+pub use transactions_importer_by_chunk::*;
 pub use transactions_importer_with_pruner::*;
 
 /// HTTP request timeout duration in milliseconds

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -13,7 +13,6 @@ use mithril_common::{
         CardanoImmutableDigester, ImmutableDigester, ImmutableFileObserver,
         ImmutableFileSystemObserver,
     },
-    entities::BlockRange,
     era::{EraChecker, EraReader},
     signable_builder::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
@@ -292,7 +291,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
         let transactions_importer = Arc::new(TransactionsImporterByChunk::new(
             transaction_store.clone(),
             transactions_importer,
-            BlockRange::LENGTH * 10,
+            self.config.transactions_import_block_chunk_size,
             slog_scope::logger(),
         ));
         let block_range_root_retriever = transaction_store.clone();

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -285,6 +285,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
                 .then_some(self.config.network_security_parameter),
             transaction_store.clone(),
             transactions_importer,
+            slog_scope::logger(),
         ));
         // Wrap the transaction importer with decorator to chunk its workload, so it prunes
         // transactions after each chunk, reducing the storage footprint

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -13,6 +13,7 @@ use mithril_common::{
         CardanoImmutableDigester, ImmutableDigester, ImmutableFileObserver,
         ImmutableFileSystemObserver,
     },
+    entities::BlockRange,
     era::{EraChecker, EraReader},
     signable_builder::{
         CardanoImmutableFilesFullSignableBuilder, CardanoTransactionsSignableBuilder,
@@ -31,8 +32,9 @@ use mithril_persistence::{
 use crate::{
     aggregator_client::AggregatorClient, metrics::MetricsService, single_signer::SingleSigner,
     AggregatorHTTPClient, CardanoTransactionsImporter, Configuration, MithrilSingleSigner,
-    ProtocolInitializerStore, ProtocolInitializerStorer, TransactionsImporterWithPruner,
-    HTTP_REQUEST_TIMEOUT_DURATION, SQLITE_FILE, SQLITE_FILE_CARDANO_TRANSACTION,
+    ProtocolInitializerStore, ProtocolInitializerStorer, TransactionsImporterByChunk,
+    TransactionsImporterWithPruner, HTTP_REQUEST_TIMEOUT_DURATION, SQLITE_FILE,
+    SQLITE_FILE_CARDANO_TRANSACTION,
 };
 
 type StakeStoreService = Arc<StakeStore>;
@@ -283,6 +285,14 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
                 .then_some(self.config.network_security_parameter),
             transaction_store.clone(),
             transactions_importer,
+        ));
+        // Wrap the transaction importer with decorator to chunk its workload, so it prunes
+        // transactions after each chunk, reducing the storage footprint
+        let transactions_importer = Arc::new(TransactionsImporterByChunk::new(
+            transaction_store.clone(),
+            transactions_importer,
+            BlockRange::LENGTH * 10,
+            slog_scope::logger(),
         ));
         let block_range_root_retriever = transaction_store.clone();
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(

--- a/mithril-signer/src/transactions_importer_by_chunk.rs
+++ b/mithril-signer/src/transactions_importer_by_chunk.rs
@@ -1,0 +1,209 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use mithril_common::entities::BlockNumber;
+use mithril_common::signable_builder::TransactionsImporter;
+use mithril_common::StdResult;
+
+/// Trait to get the highest transaction block number
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait HighestTransactionBlockNumberGetter: Send + Sync {
+    /// Get the highest known transaction block number
+    async fn get(&self) -> StdResult<Option<BlockNumber>>;
+}
+
+/// A decorator of [TransactionsImporter] that do the import by chunks
+pub struct TransactionsImporterByChunk {
+    highest_transaction_block_number_getter: Arc<dyn HighestTransactionBlockNumberGetter>,
+    wrapped_importer: Arc<dyn TransactionsImporter>,
+    chunk_size: BlockNumber,
+}
+
+impl TransactionsImporterByChunk {
+    /// Create a new instance of `TransactionsImporterByChunk`.
+    pub fn new(
+        highest_transaction_block_number_getter: Arc<dyn HighestTransactionBlockNumberGetter>,
+        wrapped_importer: Arc<dyn TransactionsImporter>,
+        chunk_size: BlockNumber,
+    ) -> Self {
+        Self {
+            highest_transaction_block_number_getter,
+            wrapped_importer,
+            chunk_size,
+        }
+    }
+}
+
+#[async_trait]
+impl TransactionsImporter for TransactionsImporterByChunk {
+    async fn import(&self, up_to_beacon: BlockNumber) -> StdResult<()> {
+        let mut start_block_number = self
+            .highest_transaction_block_number_getter
+            .get()
+            .await?
+            .unwrap_or(0);
+
+        while start_block_number < up_to_beacon {
+            start_block_number += self.chunk_size;
+            self.wrapped_importer
+                .import(start_block_number.min(up_to_beacon))
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::predicate::eq;
+    use mockall::{mock, Sequence};
+
+    use super::*;
+
+    mock! {
+        pub TransactionImporterImpl {}
+
+        #[async_trait]
+        impl TransactionsImporter for TransactionImporterImpl {
+            async fn import(&self, up_to_beacon: BlockNumber) -> StdResult<()>;
+        }
+    }
+
+    fn create_highest_transaction_block_number_getter_mock(
+        highest_block_number: BlockNumber,
+    ) -> Arc<dyn HighestTransactionBlockNumberGetter> {
+        Arc::new({
+            let mut mock = MockHighestTransactionBlockNumberGetter::new();
+            mock.expect_get()
+                .returning(move || Ok(Some(highest_block_number)));
+            mock
+        })
+    }
+
+    fn create_transaction_importer_mock(expected_values: Vec<u64>) -> MockTransactionImporterImpl {
+        let mut seq = Sequence::new();
+        let mut wrapped_importer = MockTransactionImporterImpl::new();
+        for expected_value in expected_values {
+            wrapped_importer
+                .expect_import()
+                .once()
+                .in_sequence(&mut seq)
+                .with(eq(expected_value))
+                .returning(|_| Ok(()));
+        }
+        wrapped_importer
+    }
+
+    #[tokio::test]
+    async fn test_import_nothing_to_do_when_highest_block_number_lower_or_equal_up_to_beacon() {
+        let highest_block_number = 10;
+        let chunk_size = 5;
+
+        let highest_transaction_block_number_getter =
+            create_highest_transaction_block_number_getter_mock(highest_block_number);
+        let mut wrapped_importer = MockTransactionImporterImpl::new();
+        wrapped_importer.expect_import().never();
+
+        let importer = TransactionsImporterByChunk::new(
+            highest_transaction_block_number_getter,
+            Arc::new(wrapped_importer),
+            chunk_size,
+        );
+
+        let up_to_beacon = highest_block_number;
+        importer.import(up_to_beacon).await.unwrap();
+
+        let up_to_beacon = highest_block_number - 1;
+        importer.import(up_to_beacon).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_import_even_when_highest_block_number_is_none() {
+        let highest_block_number = None;
+        let chunk_size = 5;
+        let up_to_beacon = chunk_size - 1;
+
+        let highest_transaction_block_number_getter = Arc::new({
+            let mut mock = MockHighestTransactionBlockNumberGetter::new();
+            mock.expect_get()
+                .returning(move || Ok(highest_block_number));
+            mock
+        });
+        let wrapped_importer = create_transaction_importer_mock(vec![up_to_beacon]);
+
+        let importer = TransactionsImporterByChunk::new(
+            highest_transaction_block_number_getter,
+            Arc::new(wrapped_importer),
+            chunk_size,
+        );
+
+        importer.import(up_to_beacon).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_import_only_once_when_block_delta_less_than_chunk_size() {
+        let highest_block_number = 10;
+        let chunk_size = 5;
+        let up_to_beacon = highest_block_number + chunk_size - 1;
+
+        let highest_transaction_block_number_getter =
+            create_highest_transaction_block_number_getter_mock(highest_block_number);
+        let wrapped_importer = create_transaction_importer_mock(vec![up_to_beacon]);
+
+        let importer = TransactionsImporterByChunk::new(
+            highest_transaction_block_number_getter,
+            Arc::new(wrapped_importer),
+            chunk_size,
+        );
+
+        importer.import(up_to_beacon).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_import_multiple_times_when_block_delta_is_not_a_multiple_of_chunk_size() {
+        let highest_block_number = 10;
+        let chunk_size = 5;
+        let up_to_beacon = highest_block_number + chunk_size * 2 + 1;
+
+        let highest_transaction_block_number_getter =
+            create_highest_transaction_block_number_getter_mock(highest_block_number);
+        let wrapped_importer = create_transaction_importer_mock(vec![
+            highest_block_number + chunk_size,
+            highest_block_number + chunk_size * 2,
+            up_to_beacon,
+        ]);
+
+        let importer = TransactionsImporterByChunk::new(
+            highest_transaction_block_number_getter,
+            Arc::new(wrapped_importer),
+            chunk_size,
+        );
+
+        importer.import(up_to_beacon).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_import_multiple_times_when_block_delta_is_a_multiple_of_chunk_size() {
+        let highest_block_number = 10;
+        let chunk_size = 5;
+        let up_to_beacon = highest_block_number + chunk_size * 2;
+
+        let highest_transaction_block_number_getter =
+            create_highest_transaction_block_number_getter_mock(highest_block_number);
+        let wrapped_importer = create_transaction_importer_mock(vec![
+            highest_block_number + chunk_size,
+            highest_block_number + chunk_size * 2,
+        ]);
+
+        let importer = TransactionsImporterByChunk::new(
+            highest_transaction_block_number_getter,
+            Arc::new(wrapped_importer),
+            chunk_size,
+        );
+
+        importer.import(up_to_beacon).await.unwrap();
+    }
+}

--- a/mithril-signer/src/transactions_importer_by_chunk.rs
+++ b/mithril-signer/src/transactions_importer_by_chunk.rs
@@ -15,7 +15,7 @@ pub trait HighestTransactionBlockNumberGetter: Send + Sync {
     async fn get(&self) -> StdResult<Option<BlockNumber>>;
 }
 
-/// A decorator of [TransactionsImporter] that do the import by chunks
+/// A decorator of [TransactionsImporter] that does the import by chunks
 pub struct TransactionsImporterByChunk {
     highest_transaction_block_number_getter: Arc<dyn HighestTransactionBlockNumberGetter>,
     wrapped_importer: Arc<dyn TransactionsImporter>,

--- a/mithril-signer/src/transactions_importer_with_pruner.rs
+++ b/mithril-signer/src/transactions_importer_with_pruner.rs
@@ -51,7 +51,7 @@ impl TransactionsImporter for TransactionsImporterWithPruner {
         if let Some(number_of_blocks_to_keep) = self.number_of_blocks_to_keep {
             debug!(
                 self.logger,
-                "Transaction Import finished - Pruning transactions included in a block range roots";
+                "Transaction Import finished - Pruning transactions included in block range roots";
                 "number_of_blocks_to_keep" => number_of_blocks_to_keep,
             );
             self.transaction_pruner

--- a/mithril-signer/src/transactions_importer_with_pruner.rs
+++ b/mithril-signer/src/transactions_importer_with_pruner.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use slog::{debug, Logger};
 
 use mithril_common::entities::BlockNumber;
 use mithril_common::signable_builder::TransactionsImporter;
@@ -22,6 +23,7 @@ pub struct TransactionsImporterWithPruner {
     number_of_blocks_to_keep: Option<BlockNumber>,
     transaction_pruner: Arc<dyn TransactionPruner>,
     wrapped_importer: Arc<dyn TransactionsImporter>,
+    logger: Logger,
 }
 
 impl TransactionsImporterWithPruner {
@@ -30,11 +32,13 @@ impl TransactionsImporterWithPruner {
         number_of_blocks_to_keep: Option<BlockNumber>,
         transaction_pruner: Arc<dyn TransactionPruner>,
         wrapped_importer: Arc<dyn TransactionsImporter>,
+        logger: Logger,
     ) -> Self {
         Self {
             number_of_blocks_to_keep,
             transaction_pruner,
             wrapped_importer,
+            logger,
         }
     }
 }
@@ -45,6 +49,11 @@ impl TransactionsImporter for TransactionsImporterWithPruner {
         self.wrapped_importer.import(up_to_beacon).await?;
 
         if let Some(number_of_blocks_to_keep) = self.number_of_blocks_to_keep {
+            debug!(
+                self.logger,
+                "Transaction Import finished - Pruning transactions included in a block range roots";
+                "number_of_blocks_to_keep" => number_of_blocks_to_keep,
+            );
             self.transaction_pruner
                 .prune(number_of_blocks_to_keep)
                 .await?;
@@ -89,6 +98,7 @@ mod tests {
                 number_of_blocks_to_keep,
                 Arc::new(transaction_pruner),
                 Arc::new(transaction_importer),
+                crate::test_tools::logger_for_tests(),
             )
         }
     }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.16"
+version = "0.4.17"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
@@ -69,6 +69,7 @@ impl Signer {
                 signer_config.mithril_era_reader_adapter,
             ),
             ("ERA_READER_ADAPTER_PARAMS", &era_reader_adapter_params),
+            ("TRANSACTIONS_IMPORT_BLOCK_CHUNK_SIZE", "150"),
         ]);
         if signer_config.enable_certification {
             env.insert(


### PR DESCRIPTION
## Content

This PR break up in chunk the `mithril-signer` transactions import process, so the transactions pruning is done more frequently, reducing the number of transactions stored at any given time, reducing the disk footprint.

The chunk size is set to `1500` and is configurable.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1766
