### PR TITLE
Only save rust cache on main branch

### DIFF
--- a/.github/workflows/actions/toolchain-and-cache/action.yml
+++ b/.github/workflows/actions/toolchain-and-cache/action.yml
@@ -21,14 +21,16 @@ runs:
     - name: Rust Cache
       uses: Swatinem/rust-cache@v2
       with:
+        # only save the cache on the main branch to limit github actions total cache size
+        save-if: ${{ github.ref == 'refs/heads/main' }}
         key: ${{ runner.os }}-cache-v${{ inputs.cache-version }}
-    
+
     - name: Install cargo tools installer
       uses: taiki-e/install-action@v2
       if: inputs.cargo-tools != ''
       with:
         tool: cargo-binstall
-    
+
     - name: Install cargo tools
       if: inputs.cargo-tools != ''
       shell: bash


### PR DESCRIPTION
## Content

This PR limit the cache generation for rust code to only the `main` branch.
 
As of `2024-06-21` our cache size is more than `6Gb`, since github only allow up to `10Gb` that means that we can't allow caches to be generated for non main branches, else it means that the cache from the `main` branch maybe be pruned automatically, slowing down drastically ou builds.

## Pre-submit checklist

- Branch
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
