### PR TITLE
Ensure validation of transaction hashes to provide to the prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.25"
+version = "0.5.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.25"
+version = "0.5.26"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -471,7 +471,7 @@ impl Source for DefaultConfiguration {
             into_value(myself.cardano_transactions_prover_cache_pool_size),
         );
         result.insert(
-            "cardano_transactions_prover_cache_pool_size".to_string(),
+            "cardano_transactions_database_connection_pool_size".to_string(),
             into_value(myself.cardano_transactions_database_connection_pool_size),
         );
         result.insert(

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -167,6 +167,9 @@ pub struct Configuration {
     /// Cardano transactions signing configuration
     #[example = "`{ security_parameter: 3000, step: 120 }`"]
     pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
+
+    /// Maximum number of transactions hashes allowed by request to the prover
+    pub cardano_transactions_prover_max_hashes_allowed_by_request: usize,
 }
 
 /// Uploader needed to copy the snapshot once computed.
@@ -245,6 +248,7 @@ impl Configuration {
                 security_parameter: 100,
                 step: 15,
             },
+            cardano_transactions_prover_max_hashes_allowed_by_request: 100,
         }
     }
 
@@ -358,6 +362,9 @@ pub struct DefaultConfiguration {
 
     /// Cardano transactions signing configuration
     pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
+
+    /// Maximum number of transactions hashes allowed by request to the prover
+    pub cardano_transactions_prover_max_hashes_allowed_by_request: u32,
 }
 
 impl Default for DefaultConfiguration {
@@ -384,6 +391,7 @@ impl Default for DefaultConfiguration {
                 security_parameter: 3000,
                 step: 120,
             },
+            cardano_transactions_prover_max_hashes_allowed_by_request: 100,
         }
     }
 }
@@ -482,6 +490,10 @@ impl Source for DefaultConfiguration {
                     ValueKind::from(myself.cardano_transactions_signing_config.step),
                 ),
             ])),
+        );
+        result.insert(
+            "cardano_transactions_prover_max_hashes_allowed_by_request".to_string(),
+            into_value(myself.cardano_transactions_prover_max_hashes_allowed_by_request),
         );
 
         Ok(result)

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -75,6 +75,7 @@ use super::{DependenciesBuilderError, EpochServiceWrapper, Result};
 
 const SQLITE_FILE: &str = "aggregator.sqlite3";
 const SQLITE_FILE_CARDANO_TRANSACTION: &str = "cardano-transaction.sqlite3";
+const PROVER_MAX_COMPUTABLE_TRANSACTIONS_HASHES: usize = 100;
 
 /// ## Dependencies container builder
 ///
@@ -1431,6 +1432,7 @@ impl DependenciesBuilder {
             block_range_root_retriever,
             mk_map_pool_size,
             logger,
+            PROVER_MAX_COMPUTABLE_TRANSACTIONS_HASHES,
         );
 
         Ok(Arc::new(prover_service))

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -75,7 +75,6 @@ use super::{DependenciesBuilderError, EpochServiceWrapper, Result};
 
 const SQLITE_FILE: &str = "aggregator.sqlite3";
 const SQLITE_FILE_CARDANO_TRANSACTION: &str = "cardano-transaction.sqlite3";
-const PROVER_MAX_COMPUTABLE_TRANSACTIONS_HASHES: usize = 100;
 
 /// ## Dependencies container builder
 ///
@@ -1432,7 +1431,6 @@ impl DependenciesBuilder {
             block_range_root_retriever,
             mk_map_pool_size,
             logger,
-            PROVER_MAX_COMPUTABLE_TRANSACTIONS_HASHES,
         );
 
         Ok(Arc::new(prover_service))

--- a/mithril-aggregator/src/http_server/mod.rs
+++ b/mithril-aggregator/src/http_server/mod.rs
@@ -1,3 +1,4 @@
 pub mod routes;
+pub mod validators;
 
 pub const SERVER_BASE_PATH: &str = "aggregator";

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -120,10 +120,11 @@ pub mod validators {
 
     /// With Prover Transactions Hash Validator
     pub fn with_prover_transations_hash_validator(
-        _dependency_manager: Arc<DependencyContainer>,
+        dependency_manager: Arc<DependencyContainer>,
     ) -> impl Filter<Extract = (ProverTransactionsHashValidator,), Error = Infallible> + Clone {
-        // Todo: get this value from the configuration
-        let max_hashes = 100;
+        let max_hashes = dependency_manager
+            .config
+            .cardano_transactions_prover_max_hashes_allowed_by_request;
 
         warp::any().map(move || ProverTransactionsHashValidator::new(max_hashes))
     }

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -112,3 +112,19 @@ pub fn with_prover_service(
 ) -> impl Filter<Extract = (Arc<dyn ProverService>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.prover_service.clone())
 }
+
+pub mod validators {
+    use crate::http_server::validators::ProverTransactionsHashValidator;
+
+    use super::*;
+
+    /// With Prover Transactions Hash Validator
+    pub fn with_prover_transations_hash_validator(
+        _dependency_manager: Arc<DependencyContainer>,
+    ) -> impl Filter<Extract = (ProverTransactionsHashValidator,), Error = Infallible> + Clone {
+        // Todo: get this value from the configuration
+        let max_hashes = 100;
+
+        warp::any().map(move || ProverTransactionsHashValidator::new(max_hashes))
+    }
+}

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -16,6 +16,13 @@ pub struct RootRouteMessage {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct AggregatorCapabilities {
     pub signed_entity_types: BTreeSet<SignedEntityTypeDiscriminants>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cardano_transactions_prover: Option<CardanoTransactionsProverCapabilities>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct CardanoTransactionsProverCapabilities {
+    max_hashes_allowed_by_request: usize,
 }
 
 pub fn routes(
@@ -32,7 +39,10 @@ fn root(
         .and(middlewares::with_api_version_provider(
             dependency_manager.clone(),
         ))
-        .and(middlewares::with_signed_entity_config(dependency_manager))
+        .and(middlewares::with_signed_entity_config(
+            dependency_manager.clone(),
+        ))
+        .and(middlewares::with_config(dependency_manager))
         .and_then(handlers::root)
 }
 
@@ -43,16 +53,19 @@ mod handlers {
     use warp::http::StatusCode;
 
     use mithril_common::api_version::APIVersionProvider;
-    use mithril_common::entities::SignedEntityConfig;
+    use mithril_common::entities::{SignedEntityConfig, SignedEntityTypeDiscriminants};
 
     use crate::http_server::routes::reply::json;
-    use crate::http_server::routes::root_routes::{AggregatorCapabilities, RootRouteMessage};
-    use crate::unwrap_to_internal_server_error;
+    use crate::http_server::routes::root_routes::{
+        AggregatorCapabilities, CardanoTransactionsProverCapabilities, RootRouteMessage,
+    };
+    use crate::{unwrap_to_internal_server_error, Configuration};
 
     /// Root
     pub async fn root(
         api_version_provider: Arc<APIVersionProvider>,
         signed_entity_config: SignedEntityConfig,
+        configuration: Configuration,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("⇄ HTTP SERVER: root");
 
@@ -61,13 +74,23 @@ mod handlers {
             "root::error"
         );
 
+        let signed_entity_types =
+            signed_entity_config.list_allowed_signed_entity_types_discriminants();
+
+        let cardano_transactions_prover_capabilities = signed_entity_types
+            .contains(&SignedEntityTypeDiscriminants::CardanoTransactions)
+            .then_some(CardanoTransactionsProverCapabilities {
+                max_hashes_allowed_by_request: configuration
+                    .cardano_transactions_prover_max_hashes_allowed_by_request,
+            });
+
         Ok(json(
             &RootRouteMessage {
                 open_api_version: open_api_version.to_string(),
                 documentation_url: env!("CARGO_PKG_HOMEPAGE").to_string(),
                 capabilities: AggregatorCapabilities {
-                    signed_entity_types: signed_entity_config
-                        .list_allowed_signed_entity_types_discriminants(),
+                    signed_entity_types,
+                    cardano_transactions_prover: cardano_transactions_prover_capabilities,
                 },
             },
             StatusCode::OK,
@@ -113,7 +136,7 @@ mod tests {
             .allowed_discriminants = BTreeSet::from([
             SignedEntityTypeDiscriminants::MithrilStakeDistribution,
             SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
-            SignedEntityTypeDiscriminants::CardanoTransactions,
+            SignedEntityTypeDiscriminants::CardanoStakeDistribution,
         ]);
         let expected_open_api_version = dependency_manager
             .api_version_provider
@@ -139,12 +162,55 @@ mod tests {
                 documentation_url: env!("CARGO_PKG_HOMEPAGE").to_string(),
                 capabilities: AggregatorCapabilities {
                     signed_entity_types: BTreeSet::from_iter([
-                        SignedEntityTypeDiscriminants::CardanoTransactions,
+                        SignedEntityTypeDiscriminants::CardanoStakeDistribution,
                         SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
                         SignedEntityTypeDiscriminants::MithrilStakeDistribution,
-                    ])
-                }
+                    ]),
+                    cardano_transactions_prover: None
+                },
             }
+        );
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::OK,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_root_route_ok_with_cardano_transactions_prover_capabilities() {
+        let method = Method::GET.as_str();
+        let path = "/";
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager
+            .signed_entity_config
+            .allowed_discriminants =
+            BTreeSet::from([SignedEntityTypeDiscriminants::CardanoTransactions]);
+        dependency_manager
+            .config
+            .cardano_transactions_prover_max_hashes_allowed_by_request = 99;
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        let response_body: RootRouteMessage = serde_json::from_slice(response.body()).unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        assert_eq!(
+            response_body.capabilities.cardano_transactions_prover,
+            Some(CardanoTransactionsProverCapabilities {
+                max_hashes_allowed_by_request: 99
+            })
         );
 
         APISpec::verify_conformity(

--- a/mithril-aggregator/src/http_server/validators/mod.rs
+++ b/mithril-aggregator/src/http_server/validators/mod.rs
@@ -1,0 +1,3 @@
+mod prover_transactions_hash_validator;
+
+pub use prover_transactions_hash_validator::*;

--- a/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
+++ b/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
@@ -16,7 +16,7 @@ impl ProverTransactionsHashValidator {
             return Err(ClientError::new(
                 Self::LABEL,
                 format!(
-                    "Transaction hashes list contains more than maximum allowed hashes: '{}'",
+                    "Transaction hashes list contains more than maximum allowed number of hashes: '{}'",
                     self.max_hashes
                 ),
             ));
@@ -26,21 +26,21 @@ impl ProverTransactionsHashValidator {
             if hash.is_empty() {
                 return Err(ClientError::new(
                     Self::LABEL,
-                    "Transaction hashes cannot be empty",
+                    "Transaction hash cannot be empty",
                 ));
             }
 
             if hash.chars().count() != 64 {
                 return Err(ClientError::new(
                     Self::LABEL,
-                    "Transaction hashes must have 64 characters",
+                    "Transaction hash must have 64 characters",
                 ));
             }
 
             if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
                 return Err(ClientError::new(
                     Self::LABEL,
-                    "Transaction hashes must contain only hexadecimal characters",
+                    "Transaction hash must contain only hexadecimal characters",
                 ));
             }
         }
@@ -70,7 +70,7 @@ mod tests {
             error,
             ClientError::new(
                 "invalid_transaction_hashes",
-                "Transaction hashes cannot be empty"
+                "Transaction hash cannot be empty"
             )
         );
     }
@@ -85,7 +85,7 @@ mod tests {
             error,
             ClientError::new(
                 "invalid_transaction_hashes",
-                "Transaction hashes must have 64 characters"
+                "Transaction hash must have 64 characters"
             )
         );
     }
@@ -102,7 +102,7 @@ mod tests {
                 error,
                 ClientError::new(
                     "invalid_transaction_hashes",
-                    "Transaction hashes must contain only hexadecimal characters"
+                    "Transaction hash must contain only hexadecimal characters"
                 ),
                 "Invalid hash: {}",
                 hash
@@ -131,7 +131,7 @@ mod tests {
             ClientError::new(
                 "invalid_transaction_hashes",
                 format!(
-                    "Transaction hashes list contains more than maximum allowed hashes: '{}'",
+                    "Transaction hashes list contains more than maximum allowed number of hashes: '{}'",
                     validator.max_hashes
                 )
             )

--- a/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
+++ b/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
@@ -1,0 +1,138 @@
+use mithril_common::entities::ClientError;
+
+pub struct ProverTransactionsHashValidator {
+    max_hashes: usize,
+}
+
+impl ProverTransactionsHashValidator {
+    const LABEL: &str = "invalid_transaction_hashes";
+
+    pub fn new(max_hashes: usize) -> Self {
+        Self { max_hashes }
+    }
+
+    pub fn validate(&self, hashes: Vec<String>) -> Result<(), ClientError> {
+        if hashes.len() > self.max_hashes {
+            return Err(ClientError::new(
+                Self::LABEL,
+                format!(
+                    "Transaction hashes list contains more than maximum allowed hashes: '{}'",
+                    self.max_hashes
+                ),
+            ));
+        }
+
+        for hash in hashes {
+            if hash.is_empty() {
+                return Err(ClientError::new(
+                    Self::LABEL,
+                    "Transaction hashes cannot be empty",
+                ));
+            }
+
+            if hash.chars().count() != 64 {
+                return Err(ClientError::new(
+                    Self::LABEL,
+                    "Transaction hashes must have 64 characters",
+                ));
+            }
+
+            if !hash.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(ClientError::new(
+                    Self::LABEL,
+                    "Transaction hashes must contain only hexadecimal characters",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for ProverTransactionsHashValidator {
+    fn default() -> Self {
+        Self::new(usize::MAX)
+    }
+}
+
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prover_transactions_hash_validator_return_error_when_empty_hash() {
+        let error = ProverTransactionsHashValidator::default()
+            .validate(vec!["".to_string()])
+            .expect_err("Should return an error");
+
+        assert_eq!(
+            error,
+            ClientError::new(
+                "invalid_transaction_hashes",
+                "Transaction hashes cannot be empty"
+            )
+        );
+    }
+
+    #[test]
+    fn prover_transactions_hash_validator_return_error_when_hash_size_different_than_64() {
+        let error = ProverTransactionsHashValidator::default()
+            .validate(vec!["abc".to_string()])
+            .expect_err("Should return an error");
+
+        assert_eq!(
+            error,
+            ClientError::new(
+                "invalid_transaction_hashes",
+                "Transaction hashes must have 64 characters"
+            )
+        );
+    }
+
+    #[test]
+    fn prover_transactions_hash_validator_return_error_when_hash_contains_non_hexadecimal_characters(
+    ) {
+        for invalid_char in ["g", "x", ";", " ", "à"].iter() {
+            let hash = format!("{}{}", "a".repeat(63), invalid_char);
+            let error = ProverTransactionsHashValidator::default()
+                .validate(vec![hash.clone()])
+                .expect_err("Should return an error");
+            assert_eq!(
+                error,
+                ClientError::new(
+                    "invalid_transaction_hashes",
+                    "Transaction hashes must contain only hexadecimal characters"
+                ),
+                "Invalid hash: {}",
+                hash
+            );
+        }
+    }
+
+    #[test]
+    fn prover_transactions_hash_validator_when_hash_contains_only_hexadecimal_characters() {
+        ProverTransactionsHashValidator::default()
+            .validate(vec![format!("bcd9{}", "a".repeat(60))])
+            .expect("Should succeed");
+    }
+
+    #[test]
+    fn prover_transactions_hash_validator_return_error_when_more_hashes_than_max_allowed() {
+        let transactions_hashes = vec!["a".repeat(64), "b".repeat(64), "c".repeat(64)];
+        let validator = ProverTransactionsHashValidator::new(2);
+
+        let error = validator
+            .validate(transactions_hashes)
+            .expect_err("Should return an error");
+
+        assert_eq!(
+            error,
+            ClientError::new(
+                "invalid_transaction_hashes",
+                format!(
+                    "Transaction hashes list contains more than maximum allowed hashes: '{}'",
+                    validator.max_hashes
+                )
+            )
+        );
+    }
+}

--- a/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
+++ b/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
@@ -5,13 +5,13 @@ pub struct ProverTransactionsHashValidator {
 }
 
 impl ProverTransactionsHashValidator {
-    const LABEL: &str = "invalid_transaction_hashes";
+    const LABEL: &'static str = "invalid_transaction_hashes";
 
     pub fn new(max_hashes: usize) -> Self {
         Self { max_hashes }
     }
 
-    pub fn validate(&self, hashes: Vec<String>) -> Result<(), ClientError> {
+    pub fn validate(&self, hashes: &[String]) -> Result<(), ClientError> {
         if hashes.len() > self.max_hashes {
             return Err(ClientError::new(
                 Self::LABEL,
@@ -49,19 +49,21 @@ impl ProverTransactionsHashValidator {
     }
 }
 
+#[cfg(test)]
 impl Default for ProverTransactionsHashValidator {
     fn default() -> Self {
         Self::new(usize::MAX)
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn prover_transactions_hash_validator_return_error_when_empty_hash() {
         let error = ProverTransactionsHashValidator::default()
-            .validate(vec!["".to_string()])
+            .validate(&["".to_string()])
             .expect_err("Should return an error");
 
         assert_eq!(
@@ -76,7 +78,7 @@ mod tests {
     #[test]
     fn prover_transactions_hash_validator_return_error_when_hash_size_different_than_64() {
         let error = ProverTransactionsHashValidator::default()
-            .validate(vec!["abc".to_string()])
+            .validate(&["abc".to_string()])
             .expect_err("Should return an error");
 
         assert_eq!(
@@ -94,7 +96,7 @@ mod tests {
         for invalid_char in ["g", "x", ";", " ", "à"].iter() {
             let hash = format!("{}{}", "a".repeat(63), invalid_char);
             let error = ProverTransactionsHashValidator::default()
-                .validate(vec![hash.clone()])
+                .validate(&[hash.clone()])
                 .expect_err("Should return an error");
             assert_eq!(
                 error,
@@ -111,7 +113,7 @@ mod tests {
     #[test]
     fn prover_transactions_hash_validator_when_hash_contains_only_hexadecimal_characters() {
         ProverTransactionsHashValidator::default()
-            .validate(vec![format!("bcd9{}", "a".repeat(60))])
+            .validate(&[format!("bcd9{}", "a".repeat(60))])
             .expect("Should succeed");
     }
 
@@ -121,7 +123,7 @@ mod tests {
         let validator = ProverTransactionsHashValidator::new(2);
 
         let error = validator
-            .validate(transactions_hashes)
+            .validate(&transactions_hashes)
             .expect_err("Should return an error");
 
         assert_eq!(

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -112,7 +112,11 @@ impl MithrilProverService {
     }
 
     fn filter_valid_hashes(&self, transaction_hashes: &[TransactionHash]) -> Vec<TransactionHash> {
-        let mut transaction_hashes = transaction_hashes.to_vec();
+        let mut transaction_hashes: Vec<TransactionHash> = transaction_hashes
+            .iter()
+            .filter(|hash| !hash.is_empty())
+            .cloned()
+            .collect();
         transaction_hashes.sort();
         transaction_hashes.dedup();
         transaction_hashes
@@ -368,6 +372,24 @@ mod tests {
             mk_map_pool_size,
             logger,
         )
+    }
+
+    #[test]
+    fn filter_valid_hashes_remove_empty_hashes() {
+        let transactions_hashes = vec![
+            "tx-hash-123".to_string(),
+            "".to_string(),
+            "tx-hash-789".to_string(),
+        ];
+
+        let mithril_service_prover = build_prover(|_| {}, |_| {});
+
+        let valid_hashes = mithril_service_prover.filter_valid_hashes(&transactions_hashes);
+
+        assert_equivalent(
+            vec!["tx-hash-123".to_string(), "tx-hash-789".to_string()],
+            valid_hashes,
+        );
     }
 
     #[tokio::test]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.19"
+version = "0.4.20"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/http_server_error.rs
+++ b/mithril-common/src/entities/http_server_error.rs
@@ -45,7 +45,10 @@ pub struct ClientError {
 
 impl ClientError {
     /// ClientError factory
-    pub fn new(label: String, message: String) -> ClientError {
-        ClientError { label, message }
+    pub fn new<T1: Into<String>, T2: Into<String>>(label: T1, message: T2) -> ClientError {
+        ClientError {
+            label: label.into(),
+            message: message.into(),
+        }
     }
 }

--- a/mithril-common/src/entities/http_server_error.rs
+++ b/mithril-common/src/entities/http_server_error.rs
@@ -45,7 +45,7 @@ pub struct ClientError {
 
 impl ClientError {
     /// ClientError factory
-    pub fn new<T1: Into<String>, T2: Into<String>>(label: T1, message: T2) -> ClientError {
+    pub fn new<L: Into<String>, M: Into<String>>(label: L, message: M) -> ClientError {
         ClientError {
             label: label.into(),
             message: message.into(),

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -245,3 +245,14 @@ pub fn cardano_transactions_snapshot(total: u64) -> Vec<entities::CardanoTransac
         .map(|idx| entities::CardanoTransactionsSnapshot::new(format!("merkleroot-{idx}"), idx))
         .collect()
 }
+
+/// Fake transaction hashes that have valid length & characters
+pub const fn transaction_hashes<'a>() -> [&'a str; 5] {
+    [
+        "c96809e2cecd9e27499a4379094c4e1f7b59d918c96327bd8daf1bf909dae332",
+        "5b8788784af9c414f18fc1e6161005b13b839fd91130b7c109aeba1792feb843",
+        "8b6ae44edf877ff2ac80cf067809d575ab2bad234b668f91e90decde837b154a",
+        "3f6f3c981c89097f62c9b43632875db7a52183ad3061c822d98259d18cd63dcf",
+        "f4fd91dccc25fd63f2caebab3d3452bc4b2944fcc11652214a3e8f1d32b09713",
+    ]
+}

--- a/mithril-explorer/__tests__/CardanoTransactionsFormInput.test.js
+++ b/mithril-explorer/__tests__/CardanoTransactionsFormInput.test.js
@@ -2,8 +2,10 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import CardanoTransactionsFormInput from "#/CardanoTransactionsFormInput";
 
-function setup() {
-  const utils = [render(<CardanoTransactionsFormInput />)];
+function setup(maxHashesAllowedByRequest = 100) {
+  const utils = [
+    render(<CardanoTransactionsFormInput maxAllowedHashesByRequest={maxHashesAllowedByRequest} />),
+  ];
   return {
     input: screen.getByRole("textbox"),
     ...utils,
@@ -76,6 +78,22 @@ describe("CardanoTransactionsFormInput", () => {
     ],
   ])("Setting invalid transactions: %s", (_, transactions) => {
     const { input } = setup();
+    fireEvent.change(input, {
+      target: { value: transactions },
+    });
+
+    expect(input.checkValidity()).toBeFalsy();
+    expect(input.value).toBe(transactions);
+  });
+
+  it.each([
+    ["Max 'one'", 1],
+    ["Max 'zero' should be equivalent to max 'one'", 0],
+    ["Max 'two'", 2],
+  ])("Setting more than max hashes allowed by request: %s", (_, maxHashesAllowedByRequest) => {
+    const { input } = setup(maxHashesAllowedByRequest);
+    const transactions =
+      "c44d1f8df92bc75fe74d69b236b1c0ebcab1e3c350ee5ac70e8a8ef53c1e5918,b45d2f9df92bc75fe74e69b236b1c0ebcab1e3c350ee5ac71e8a8ef53c1e5918,a60d2f9df92bc75fe74e69b224b1c0bacab1e3c350ee5ac71e8a8ef65c1e5918";
     fireEvent.change(input, {
       target: { value: transactions },
     });

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/pkg",
         "@popperjs/core": "^2.11.8",

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/components/Artifacts/CardanoTransactionsSnapshotsList/index.js
+++ b/mithril-explorer/src/components/Artifacts/CardanoTransactionsSnapshotsList/index.js
@@ -6,7 +6,8 @@ import LocalDateTime from "#/LocalDateTime";
 import CardanoTransactionsFormInput from "#/CardanoTransactionsFormInput";
 import CertificateModal from "#/CertificateModal";
 import CertifyCardanoTransactionsModal from "#/CertifyCardanoTransactionsModal";
-import { selectedAggregator } from "@/store/settingsSlice";
+import { defaultAggregatorCapabilities } from "@/constants";
+import { selectedAggregator, selectedAggregatorCapabilities } from "@/store/settingsSlice";
 
 export default function CardanoTransactionsSnapshotsList(props) {
   const [cardanoTransactionsSnapshots, setCardanoTransactionsSnapshots] = useState([]);
@@ -19,6 +20,9 @@ export default function CardanoTransactionsSnapshotsList(props) {
   );
   const autoUpdate = useSelector((state) => state.settings.autoUpdate);
   const updateInterval = useSelector((state) => state.settings.updateInterval);
+  const currentAggregatorCapabilities = useSelector((state) =>
+    selectedAggregatorCapabilities(state),
+  );
 
   useEffect(() => {
     if (!autoUpdate) {
@@ -96,7 +100,14 @@ export default function CardanoTransactionsSnapshotsList(props) {
               noValidate
               validated={showCertificationFormValidation}>
               <Row>
-                <CardanoTransactionsFormInput />
+                <CardanoTransactionsFormInput
+                  maxAllowedHashesByRequest={
+                    currentAggregatorCapabilities?.cardano_transactions_prover
+                      ?.max_hashes_allowed_by_request ??
+                    defaultAggregatorCapabilities.cardano_transactions_prover
+                      .max_hashes_allowed_by_request
+                  }
+                />
               </Row>
             </Form>
           </Row>

--- a/mithril-explorer/src/components/CardanoTransactionsFormInput.js
+++ b/mithril-explorer/src/components/CardanoTransactionsFormInput.js
@@ -1,7 +1,10 @@
 import { Button, Form, FormGroup, InputGroup } from "react-bootstrap";
 import React from "react";
 
-export default function CardanoTransactionsFormInput() {
+export default function CardanoTransactionsFormInput({ maxAllowedHashesByRequest }) {
+  const maxHashesAllowed = Math.max(maxAllowedHashesByRequest, 1);
+  const validationPattern = ` *(\\w+ *, *){0,${maxHashesAllowed - 1}}\\w+,? *`;
+
   return (
     <FormGroup>
       <InputGroup hasValidation>
@@ -11,7 +14,7 @@ export default function CardanoTransactionsFormInput() {
           type="text"
           placeholder="comma-separated list of transactions hashes"
           required
-          pattern=" *(\w+ *, *)*\w+,? *"
+          pattern={validationPattern}
         />
         <Form.Control.Feedback type="invalid">
           Please provide a comma-separated list of transactions hashes.

--- a/mithril-explorer/src/constants.js
+++ b/mithril-explorer/src/constants.js
@@ -9,4 +9,7 @@ export const signedEntityType = {
 
 export const defaultAggregatorCapabilities = {
   signed_entity_types: [],
+  cardano_transactions_prover: {
+    max_hashes_allowed_by_request: 100,
+  },
 };

--- a/mithril-explorer/src/store/settingsSlice.js
+++ b/mithril-explorer/src/store/settingsSlice.js
@@ -87,6 +87,8 @@ export const {
 } = settingsSlice.actions;
 
 export const selectedAggregator = (state) => state.settings.selectedAggregator;
+export const selectedAggregatorCapabilities = (state) =>
+  state.settings?.aggregatorCapabilities ?? defaultAggregatorCapabilities;
 export const selectedAggregatorSignedEntities = (state) =>
   state.settings?.aggregatorCapabilities?.signed_entity_types ?? [];
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.23
+  version: 0.1.24
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -31,6 +31,7 @@ paths:
           * Open API version
           * URL of Mithril documentation
           * Capabilities of the aggregator
+          * Cardano transactions prover capabilities
       responses:
         "200":
           description: root found
@@ -566,14 +567,29 @@ components:
                   - CardanoStakeDistribution
                   - CardanoImmutableFilesFull
                   - CardanoTransactions
+            cardano_transactions_prover:
+              description: Cardano transactions prover capabilities
+              type: object
+              additionalProperties: false
+              required:
+                - max_hashes_allowed_by_request
+              properties:
+                max_hashes_allowed_by_request:
+                  description: Maximum number of hashes allowed for a single request
+                  type: integer
+                  format: int64
       example:
         {
           "open_api_version": "0.1.17",
           "documentation_url": "https://mithril.network",
           "capabilities":
             {
-              "signed_entity_types": [ "MithrilStakeDistribution", "CardanoImmutableFilesFull", "CardanoTransactions" ]
-            }
+              "signed_entity_types": [ "MithrilStakeDistribution", "CardanoImmutableFilesFull", "CardanoTransactions" ],
+              "cardano_transactions_prover":
+                {
+                  "max_hashes_allowed_by_request": 100
+                }
+            },
         }
 
     Epoch:


### PR DESCRIPTION
## Content
This PR includes a validation step for the transaction hashes transmitted via the HTTP route `/proof/cardano-transaction`. It was implemented with:

- **a new configuration parameter for the aggregator node**: `cardano_transactions_prover_max_hashes_allowed_by_request` that limits the number of hashes accepted as parameters on the `/proof/cardano-transaction` route.
- **a new structure `cardano_transactions_prover`** exposed on the root route `/`.
  This structure is stored within the existing `capabilities` structure and currently contains only the previous configuration parameter value under the property name `max_hashes`.
- **a validator** that returns an error if the hash validation criteria are not met (empty string, length != 64, ASCII hexadecimal digit characters only). In case of an error, a 400 Bad Request is returned on the `/proof/cardano-transaction` route.


## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1757 
