### PR TITLE
Fix #1762: CardanoTransactionSnapshot block number is not certified

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.10"
+version = "0.2.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.150"
+version = "0.2.151"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.10"
+version = "0.2.11"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/query/block_range_root/get_block_range_root.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/get_block_range_root.rs
@@ -16,9 +16,12 @@ impl GetBlockRangeRootQuery {
         }
     }
 
-    pub fn up_to_block_number(block_number: BlockNumber) -> Self {
+    pub fn up_to_block_number(up_to_or_equal_end_block_number: BlockNumber) -> Self {
         Self {
-            condition: WhereCondition::new("end < ?*", vec![Value::Integer(block_number as i64)]),
+            condition: WhereCondition::new(
+                "end <= ?*",
+                vec![Value::Integer(up_to_or_equal_end_block_number as i64)],
+            ),
         }
     }
 }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.27"
+version = "0.5.28"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.20"
+version = "0.4.21"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -29,7 +29,7 @@ pub trait BlockRangeRootRetriever: Send + Sync {
     /// Returns a Merkle map of the block ranges roots up to a given beacon
     async fn retrieve_block_range_roots(
         &self,
-        up_to_beacon: BlockNumber,
+        up_to_or_equal_beacon: BlockNumber,
     ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)>>>;
 
     /// Returns a Merkle map of the block ranges roots up to a given beacon

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.150"
+version = "0.2.151"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR fixes #1762:

It was due to the request to retrieve the pre-computed block range roots in database using a exclusive bound comparison instead of an inclusive, leading to the exclusion of the last block range root from the retrieved data.

This means that not only the prover was impacted but the protocol message generation for the single & multi signatures too.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
Even if `mithril-signer` and `mithril-aggregator` are not modified by this PR, their behavior is impacted so their version number should be upgraded.

## Issue(s)
Closes #1762
