### PR TITLE
Fix: avoid iterator copy in `BlockRangeRootRetriever`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3538,7 +3538,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.28"
+version = "0.5.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3694,7 +3694,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.11"
+version = "0.2.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.151"
+version = "0.2.152"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.11"
+version = "0.2.12"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -312,15 +312,14 @@ impl CardanoTransactionRepository {
 
 #[async_trait]
 impl BlockRangeRootRetriever for CardanoTransactionRepository {
-    async fn retrieve_block_range_roots(
-        &self,
+    async fn retrieve_block_range_roots<'a>(
+        &'a self,
         up_to_or_equal_beacon: BlockNumber,
-    ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)>>> {
+    ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)> + 'a>> {
         let iterator = self
             .retrieve_block_range_roots_up_to(up_to_or_equal_beacon)
-            .await?
-            .collect::<Vec<_>>() // TODO: remove this collect to return the iterator directly
-            .into_iter();
+            .await?;
+
         Ok(Box::new(iterator))
     }
 }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.28"
+version = "0.5.29"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -212,10 +212,10 @@ mod tests {
 
         #[async_trait]
         impl BlockRangeRootRetriever for BlockRangeRootRetrieverImpl {
-            async fn retrieve_block_range_roots(
-                &self,
+            async fn retrieve_block_range_roots<'a>(
+                &'a self,
                 up_to_beacon: BlockNumber,
-            ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)>>>;
+            ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)> + 'a>>;
 
             async fn compute_merkle_map_from_block_range_roots(
                 &self,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.21"
+version = "0.4.22"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -27,10 +27,10 @@ pub trait TransactionsImporter: Send + Sync {
 #[async_trait]
 pub trait BlockRangeRootRetriever: Send + Sync {
     /// Returns a Merkle map of the block ranges roots up to a given beacon
-    async fn retrieve_block_range_roots(
-        &self,
+    async fn retrieve_block_range_roots<'a>(
+        &'a self,
         up_to_or_equal_beacon: BlockNumber,
-    ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)>>>;
+    ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)> + 'a>>;
 
     /// Returns a Merkle map of the block ranges roots up to a given beacon
     async fn compute_merkle_map_from_block_range_roots(

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.151"
+version = "0.2.152"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -503,10 +503,10 @@ mod tests {
 
         #[async_trait]
         impl BlockRangeRootRetriever for BlockRangeRootRetrieverImpl {
-            async fn retrieve_block_range_roots(
-                &self,
+            async fn retrieve_block_range_roots<'a>(
+                &'a self,
                 up_to_beacon: BlockNumber,
-            ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)>>>;
+            ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)> + 'a>>;
 
             async fn compute_merkle_map_from_block_range_roots(
                 &self,


### PR DESCRIPTION
## Content
This PR includes a fix to avoid copying the iterator in the `retrieve_block_range_roots` function of the `BlockRangeRootRetriever` trait.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1760 
