### PR TITLE
Parallelize Cardano Transaction prover

### DIFF
--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -84,11 +84,11 @@ impl MithrilProverService {
             .get_by_hashes(transaction_hashes.to_vec(), up_to)
             .await?;
         let block_ranges = transactions
-            .iter()
+            .par_iter()
             .map(|t| BlockRange::from_block_number(t.block_number))
             .collect::<BTreeSet<_>>();
 
-        Ok(block_ranges.into_iter().collect::<Vec<_>>())
+        Ok(Vec::from_iter(block_ranges.into_iter()))
     }
 
     /// Get all the transactions of the block ranges

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -149,7 +149,7 @@ impl ProverService for MithrilProverService {
             self.mk_map_pool.give_back_resource_pool_item(mk_map)?;
             let mk_proof_leaves = mk_proof.leaves();
             let transaction_hashes_certified: Vec<TransactionHash> = transaction_hashes
-                .iter()
+                .par_iter()
                 .filter(|hash| mk_proof_leaves.contains(&hash.as_str().into()))
                 .cloned()
                 .collect();

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -127,7 +127,7 @@ impl ProverService for MithrilProverService {
 
         // 2 - Compute block ranges sub Merkle trees
         let mk_trees: StdResult<Vec<(BlockRange, MKTree)>> = block_range_transactions
-            .into_iter()
+            .into_par_iter()
             .map(|(block_range, transactions)| {
                 let mk_tree = MKTree::new(&transactions)?;
                 Ok((block_range, mk_tree))


### PR DESCRIPTION
## Content
This PR parallelization of the **Cardano transaction prover**:
- The proof computation by the Merkle map
- The block ranges sub Merkle tree computation

### Benchmarks

![Screenshot from 2024-07-09 18-29-29](https://github.com/input-output-hk/mithril/assets/5566665/64a17f09-f2c8-4558-b194-805e50d056e8)

| Total Requests | Concurrency | Transactions/Request | Pool (x5): Request/s | Pool (x5) + Parallel proof computation: Request/s |
| -------------- | ----------- | -------------------- | -------------------- | ------------------------------------------------- |
| 10000          | 500         | 1                    | **7913.59**              | **7623.6**                                            |
| 10000          | 500         | 2                    | **4851.96**              | **4144.61**                                           |
| 10000          | 500         | 3                    | **3515.48**              | **2779.29**                                           |
| 10000          | 500         | 4                    | **3101.26**              | **2381.42**                                           |
| 10000          | 500         | 5                    | **2017.03**              | **1658.07**                                           |
| 10000          | 500         | 6                    | **1832.84**              | **1524.97**                                           |
| 10000          | 500         | 7                    | **1528.66**              | **1276.15**                                           |
| 10000          | 500         | 8                    | **1398.67**              | **1168.99**                                           |
| 10000          | 500         | 9                    | **1165.36**              | **936.44**                                            |
| 10000          | 500         | 10                   | **1041.9**               | **920.39**                                            |
| 1000           | 100         | 20                   | **512.33**               | **440.4**                                             |
| 1000           | 100         | 30                   | **386.91**               | **313.29**                                            |
| 1000           | 100         | 40                   | **314.65**               | **254.52**                                            |
| 1000           | 100         | 50                   | **243.02**               | **195.74**                                            |
| 1000           | 100         | 60                   | **202.51**               | **163.77**                                            |
| 1000           | 100         | 70                   | **175.14**               | **141**                                               |
| 1000           | 100         | 80                   | **149.35**               | **124.07**                                            |
| 1000           | 100         | 90                   | **129.6**                | **96.62**                                             |
| 1000           | 100         | 100                  | **115.64**               | **102.17**                                            |

> Running on **Linux / 8 cores / 64 GB RAM / 2 TB SSD**

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1756 
