### PR TITLE
Upkeep service for aggregator & signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Extended CI build and test steps for MacOS `arm64` runners and include pre-built binaries for MacOS `arm64` in the releases.
 
-- Vacuum aggregator & signer SQLite databases at startup to reduce fragmentation and disk space usage.
+- Add a regularly run upkeep task to the `mithril-aggregator` and `mithril-signer` to clean up stale data and optimize their databases.
 
 - **UNSTABLE** Cardano transactions certification:
   - Optimize the performances of the computation of the proof with a Merkle map.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.32"
+version = "0.5.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.155"
+version = "0.2.156"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.13"
+version = "0.2.14"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/sqlite/cleaner.rs
+++ b/internal/mithril-persistence/src/sqlite/cleaner.rs
@@ -2,7 +2,7 @@ use slog::{debug, Logger};
 
 use mithril_common::StdResult;
 
-use crate::sqlite::{vacuum_database, SqliteConnection};
+use crate::sqlite::SqliteConnection;
 
 /// Tasks that can be performed by the SqliteCleaner
 #[derive(Eq, PartialEq, Copy, Clone)]
@@ -68,7 +68,7 @@ impl<'a> SqliteCleaner<'a> {
     pub fn run(self) -> StdResult<()> {
         if self.tasks.contains(&SqliteCleaningTask::Vacuum) {
             debug!(self.logger, "{}", SqliteCleaningTask::Vacuum.log_message());
-            vacuum_database(self.connection)?;
+            self.connection.execute("vacuum")?;
         }
 
         // Important: If wal is enabled Vacuuming the database will not shrink it until a

--- a/internal/mithril-persistence/src/sqlite/cleaner.rs
+++ b/internal/mithril-persistence/src/sqlite/cleaner.rs
@@ -1,0 +1,232 @@
+use slog::Logger;
+
+use mithril_common::StdResult;
+
+use crate::sqlite::{vacuum_database, SqliteConnection};
+
+/// Tasks that can be performed by the SqliteCleaner
+#[derive(Eq, PartialEq, Copy, Clone)]
+pub enum SqliteCleaningTask {
+    /// Reconstruct the database file, repacking it into a minimal amount of disk space.
+    ///
+    /// see: <https://www.sqlite.org/lang_vacuum.html>
+    ///
+    /// ⚠ This operation can be very slow on large databases ⚠
+    Vacuum,
+    /// Run a checkpoint to transfer the data from the WAL file to the main db file and truncate
+    /// it afterward.
+    ///
+    /// see: <https://www.sqlite.org/pragma.html#pragma_wal_checkpoint>
+    WalCheckpointTruncate,
+}
+
+/// The SqliteCleaner is responsible for cleaning up databases by performing tasks defined
+/// in [SqliteCleaningTask].
+pub struct SqliteCleaner<'a> {
+    connection: &'a SqliteConnection,
+    logger: Logger,
+    tasks: Vec<SqliteCleaningTask>,
+}
+
+impl<'a> SqliteCleaner<'a> {
+    /// Create a new instance of the `SqliteCleaner`.
+    pub fn new(connection: &'a SqliteConnection) -> Self {
+        Self {
+            connection,
+            logger: Logger::root(slog::Discard, slog::o!()),
+            tasks: vec![],
+        }
+    }
+
+    /// Set the logger to be used by the cleaner.
+    pub fn with_logger(mut self, logger: Logger) -> Self {
+        self.logger = logger;
+        self
+    }
+
+    /// Set the [SqliteCleaningTask] to be performed by the cleaner.
+    pub fn with_tasks(mut self, tasks: &[SqliteCleaningTask]) -> Self {
+        for option in tasks {
+            self.tasks.push(*option);
+        }
+        self
+    }
+
+    /// Cleanup the database by performing the defined tasks.
+    pub fn run(self) -> StdResult<()> {
+        if self.tasks.contains(&SqliteCleaningTask::Vacuum) {
+            vacuum_database(self.connection)?;
+        }
+
+        // Important: If wal is enabled Vacuuming the database will not shrink it until a
+        // checkpoint is run, so it must be done after vacuuming.
+        // Note: running a checkpoint when the WAL is disabled is harmless.
+        if self
+            .tasks
+            .contains(&SqliteCleaningTask::WalCheckpointTruncate)
+        {
+            self.connection
+                .execute("PRAGMA wal_checkpoint(TRUNCATE);")?;
+        } else {
+            self.connection.execute("PRAGMA wal_checkpoint(PASSIVE);")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+    use std::path::Path;
+
+    use mithril_common::test_utils::TempDir;
+
+    use crate::sqlite::{ConnectionBuilder, ConnectionOptions, SqliteConnection};
+
+    use super::*;
+
+    fn add_test_table(connection: &SqliteConnection) {
+        connection
+            .execute("CREATE TABLE IF NOT EXISTS test (id INTEGER PRIMARY KEY, text TEXT);")
+            .unwrap();
+    }
+
+    fn fill_test_table(connection: &SqliteConnection, ids: Range<u64>) {
+        connection
+            .execute(format!(
+                "INSERT INTO test (id, text) VALUES {}",
+                ids.map(|i| format!("({}, 'some text to fill the db')", i))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ))
+            .unwrap();
+    }
+
+    fn delete_test_rows(connection: &SqliteConnection, ids: Range<u64>) {
+        connection
+            .execute(format!(
+                "DELETE FROM test WHERE id >= {} and id < {}",
+                ids.start, ids.end
+            ))
+            .unwrap();
+    }
+
+    /// Apply migrations, disable auto_vacuum and mangle the database to create some free pages
+    /// for the vacuum to reclaim
+    fn prepare_db_for_vacuum(connection: &SqliteConnection) {
+        // Disable Auto vacuum to allow the test to check if the vacuum was run
+        connection
+            .execute("pragma auto_vacuum = none; vacuum;")
+            .unwrap();
+        add_test_table(connection);
+        fill_test_table(connection, 0..10_000);
+        // Checkpoint before deletion so entries are transferred from the WAL file to the main db
+        connection
+            .execute("PRAGMA wal_checkpoint(PASSIVE)")
+            .unwrap();
+        delete_test_rows(connection, 0..5_000);
+        // Checkpoint after deletion to create free pages in the main db
+        connection
+            .execute("PRAGMA wal_checkpoint(PASSIVE)")
+            .unwrap();
+    }
+
+    fn file_size(path: &Path) -> u64 {
+        path.metadata()
+            .unwrap_or_else(|_| panic!("Failed to read len of '{}'", path.display()))
+            .len()
+    }
+
+    #[test]
+    fn cleanup_empty_in_memory_db_should_not_crash() {
+        let connection = ConnectionBuilder::open_memory().build().unwrap();
+
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::Vacuum])
+            .run()
+            .expect("Vacuum should not fail");
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::WalCheckpointTruncate])
+            .run()
+            .expect("WalCheckpointTruncate should not fail");
+    }
+
+    #[test]
+    fn cleanup_empty_file_without_wal_db_should_not_crash() {
+        let db_path = TempDir::create(
+            "sqlite_cleaner",
+            "cleanup_empty_file_without_wal_db_should_not_crash",
+        )
+        .join("test.db");
+        let connection = ConnectionBuilder::open_file(&db_path).build().unwrap();
+
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::Vacuum])
+            .run()
+            .expect("Vacuum should not fail");
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::WalCheckpointTruncate])
+            .run()
+            .expect("WalCheckpointTruncate should not fail");
+    }
+
+    #[test]
+    fn test_vacuum() {
+        let db_dir = TempDir::create("sqlite_cleaner", "test_vacuum");
+        let (db_path, db_wal_path) = (db_dir.join("test.db"), db_dir.join("test.db-wal"));
+        let connection = ConnectionBuilder::open_file(&db_path)
+            .with_options(&[ConnectionOptions::EnableWriteAheadLog])
+            .build()
+            .unwrap();
+        prepare_db_for_vacuum(&connection);
+
+        let db_initial_size = file_size(&db_path);
+        assert!(db_initial_size > 0);
+
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::Vacuum])
+            .run()
+            .unwrap();
+
+        let db_after_vacuum_size = file_size(&db_path);
+
+        assert!(
+            db_initial_size > db_after_vacuum_size,
+            "db size should have decreased (vacuum enabled)"
+        );
+        assert!(
+            file_size(&db_wal_path) > 0,
+            "db wal file should not have been truncated (truncate disabled)"
+        );
+    }
+
+    #[test]
+    fn test_truncate_wal() {
+        let db_dir = TempDir::create("sqlite_cleaner", "test_truncate_wal");
+        let (db_path, db_wal_path) = (db_dir.join("test.db"), db_dir.join("test.db-wal"));
+        let connection = ConnectionBuilder::open_file(&db_path)
+            .with_options(&[ConnectionOptions::EnableWriteAheadLog])
+            .build()
+            .unwrap();
+
+        // Make "neutral" changes to the db, this will fill the WAL files with some data
+        // but won't change the db size after cleaning up.
+        add_test_table(&connection);
+        fill_test_table(&connection, 0..10_000);
+        delete_test_rows(&connection, 0..10_000);
+
+        assert!(file_size(&db_wal_path) > 0);
+
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::WalCheckpointTruncate])
+            .run()
+            .unwrap();
+
+        assert_eq!(
+            file_size(&db_wal_path),
+            0,
+            "db wal file should have been truncated"
+        );
+    }
+}

--- a/internal/mithril-persistence/src/sqlite/cleaner.rs
+++ b/internal/mithril-persistence/src/sqlite/cleaner.rs
@@ -71,7 +71,7 @@ impl<'a> SqliteCleaner<'a> {
             self.connection.execute("vacuum")?;
         }
 
-        // Important: If wal is enabled Vacuuming the database will not shrink it until a
+        // Important: If WAL is enabled Vacuuming the database will not shrink until a
         // checkpoint is run, so it must be done after vacuuming.
         // Note: running a checkpoint when the WAL is disabled is harmless.
         if self

--- a/internal/mithril-persistence/src/sqlite/mod.rs
+++ b/internal/mithril-persistence/src/sqlite/mod.rs
@@ -2,6 +2,7 @@
 //! This module provides a minimal yet useful Entity framework on top of SQLite
 //! with ability to perform any SQL query possible and hydrate results in Rust
 //! structs.
+mod cleaner;
 mod condition;
 mod connection_builder;
 mod connection_extensions;
@@ -13,6 +14,7 @@ mod query;
 mod source_alias;
 mod transaction;
 
+pub use cleaner::{SqliteCleaner, SqliteCleaningTask};
 pub use condition::{GetAllCondition, WhereCondition};
 pub use connection_builder::{ConnectionBuilder, ConnectionOptions};
 pub use connection_extensions::ConnectionExtensions;

--- a/internal/mithril-persistence/src/sqlite/mod.rs
+++ b/internal/mithril-persistence/src/sqlite/mod.rs
@@ -29,6 +29,17 @@ pub use transaction::Transaction;
 /// Type of the connection used in Mithril
 pub type SqliteConnection = sqlite::ConnectionThreadSafe;
 
+/// Helpers to handle SQLite errors
+pub mod error {
+    /// Sqlite error type used in Mithril
+    pub type SqliteError = sqlite::Error;
+
+    /// SQLITE_BUSY error code
+    ///
+    /// see: <https://www.sqlite.org/rescode.html#busy>
+    pub const SQLITE_BUSY: isize = 5;
+}
+
 #[cfg(test)]
 mod test {
     use sqlite::Connection;

--- a/internal/mithril-persistence/src/sqlite/mod.rs
+++ b/internal/mithril-persistence/src/sqlite/mod.rs
@@ -26,31 +26,12 @@ pub use query::Query;
 pub use source_alias::SourceAlias;
 pub use transaction::Transaction;
 
-use mithril_common::StdResult;
-use sqlite::ConnectionThreadSafe;
-
 /// Type of the connection used in Mithril
-pub type SqliteConnection = ConnectionThreadSafe;
-
-/// Do a [vacuum](https://www.sqlite.org/lang_vacuum.html) on the given connection, this will
-/// reconstruct the database file, repacking it into a minimal amount of disk space.
-pub fn vacuum_database(connection: &SqliteConnection) -> StdResult<()> {
-    connection.execute("vacuum")?;
-
-    Ok(())
-}
+pub type SqliteConnection = sqlite::ConnectionThreadSafe;
 
 #[cfg(test)]
 mod test {
-    use crate::sqlite::vacuum_database;
     use sqlite::Connection;
-
-    #[tokio::test]
-    async fn calling_vacuum_on_an_empty_in_memory_db_should_not_fail() {
-        let connection = Connection::open_thread_safe(":memory:").unwrap();
-
-        vacuum_database(&connection).expect("Vacuum should not fail");
-    }
 
     #[test]
     fn sqlite_version_should_be_3_42_or_more() {

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.32"
+version = "0.5.33"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/tools_command.rs
+++ b/mithril-aggregator/src/commands/tools_command.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::{Parser, Subcommand};
 use config::{builder::DefaultState, ConfigBuilder};
 use mithril_common::StdResult;
-use mithril_persistence::sqlite::vacuum_database;
+use mithril_persistence::sqlite::{SqliteCleaner, SqliteCleaningTask};
 use slog_scope::debug;
 use std::sync::Arc;
 
@@ -74,7 +74,9 @@ impl RecomputeCertificatesHashCommand {
             .await
             .with_context(|| "recompute-certificates-hash: database migration error")?;
 
-        vacuum_database(&connection)
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::Vacuum])
+            .run()
             .with_context(|| "recompute-certificates-hash: database vacuum error")?;
 
         Ok(())

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -267,13 +267,11 @@ impl Configuration {
             .map_err(|e| anyhow!(ConfigError::Message(e.to_string())))
     }
 
-    /// Return the file of the SQLite stores.
-    ///
-    /// If in Production and the directory does not exist, it is created.
+    /// Return the file of the SQLite stores. If the directory does not exist, it is created.
     pub fn get_sqlite_dir(&self) -> PathBuf {
         let store_dir = &self.data_stores_directory;
 
-        if !store_dir.exists() && self.environment == ExecutionEnvironment::Production {
+        if !store_dir.exists() {
             std::fs::create_dir_all(store_dir).unwrap();
         }
 

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -267,11 +267,13 @@ impl Configuration {
             .map_err(|e| anyhow!(ConfigError::Message(e.to_string())))
     }
 
-    /// Return the file of the SQLite stores. If the directory does not exist, it is created.
+    /// Return the file of the SQLite stores.
+    ///
+    /// If in Production and the directory does not exist, it is created.
     pub fn get_sqlite_dir(&self) -> PathBuf {
         let store_dir = &self.data_stores_directory;
 
-        if !store_dir.exists() {
+        if !store_dir.exists() && self.environment == ExecutionEnvironment::Production {
             std::fs::create_dir_all(store_dir).unwrap();
         }
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1256,6 +1256,7 @@ impl DependenciesBuilder {
         let upkeep_service = Arc::new(AggregatorUpkeepService::new(
             main_db_path,
             cardano_tx_db_path,
+            self.get_logger()?,
         ));
 
         Ok(upkeep_service)

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1231,6 +1231,7 @@ impl DependenciesBuilder {
             self.get_sqlite_connection().await?,
             self.get_sqlite_connection_cardano_transaction_pool()
                 .await?,
+            self.get_signed_entity_lock().await?,
             self.get_logger()?,
         ));
 

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -28,7 +28,7 @@ use crate::{
     multi_signer::MultiSigner,
     services::{
         CertifierService, EpochService, MessageService, ProverService, SignedEntityService,
-        StakeDistributionService, TransactionStore,
+        StakeDistributionService, TransactionStore, UpkeepService,
     },
     signer_registerer::SignerRecorder,
     snapshot_uploaders::SnapshotUploader,
@@ -161,6 +161,9 @@ pub struct DependencyContainer {
 
     /// Signed Entity Type Lock
     pub signed_entity_type_lock: Arc<SignedEntityTypeLock>,
+
+    /// Upkeep service
+    pub upkeep_service: Arc<dyn UpkeepService>,
 }
 
 #[doc(hidden)]

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -55,7 +55,7 @@ pub mod handlers {
             Err(err) => {
                 warn!("list_artifacts_cardano_transactions"; "error" => ?err);
 
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -78,7 +78,7 @@ pub mod handlers {
             }
             Err(err) => {
                 warn!("get_cardano_transaction_details::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -55,8 +55,7 @@ pub mod handlers {
             Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
             Err(err) => {
                 warn!("list_artifacts_mithril_stake_distribution"; "error" => ?err);
-
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -79,7 +78,7 @@ pub mod handlers {
             }
             Err(err) => {
                 warn!("get_mithril_stake_distribution_details::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -114,7 +114,7 @@ mod handlers {
             Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
             Err(err) => {
                 warn!("list_artifacts_snapshot"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -136,7 +136,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("snapshot_details::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -212,7 +212,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("snapshot_download::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -86,7 +86,7 @@ mod handlers {
             Ok(None) => Ok(reply::empty(StatusCode::NO_CONTENT)),
             Err(err) => {
                 warn!("certificate_pending::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -104,7 +104,7 @@ mod handlers {
             Ok(certificates) => Ok(reply::json(&certificates, StatusCode::OK)),
             Err(err) => {
                 warn!("certificate_certificates::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -127,7 +127,7 @@ mod handlers {
             Ok(None) => Ok(reply::empty(StatusCode::NOT_FOUND)),
             Err(err) => {
                 warn!("certificate_certificate_hash::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -52,7 +52,7 @@ mod handlers {
             }
             (Err(err), _, _) | (_, Err(err), _) | (_, _, Err(err)) => {
                 warn!("epoch_settings::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -19,7 +19,7 @@ macro_rules! unwrap_to_internal_server_error {
             Ok(res) => res,
             Err(err) => {
                 warn!($($warn_comment)*; "error" => ?err);
-                return Ok($crate::http_server::routes::reply::internal_server_error(
+                return Ok($crate::http_server::routes::reply::server_error(
                     err,
                 ));
             }

--- a/mithril-aggregator/src/http_server/routes/reply.rs
+++ b/mithril-aggregator/src/http_server/routes/reply.rs
@@ -1,6 +1,12 @@
-use mithril_common::entities::{ClientError, InternalServerError};
 use serde::Serialize;
 use warp::http::StatusCode;
+
+use mithril_common::entities::{ClientError, InternalServerError};
+use mithril_common::StdError;
+use mithril_persistence::sqlite::error::{SqliteError, SQLITE_BUSY};
+
+use crate::tools::downcast_check;
+use crate::SignerRegistrationError;
 
 pub fn json<T>(value: &T, status_code: StatusCode) -> Box<dyn warp::Reply>
 where
@@ -20,10 +26,86 @@ pub fn bad_request(label: String, message: String) -> Box<dyn warp::Reply> {
     json(&ClientError::new(label, message), StatusCode::BAD_REQUEST)
 }
 
+pub fn server_error<E: Into<StdError>>(error: E) -> Box<dyn warp::Reply> {
+    let std_error: StdError = error.into();
+    let status_code = {
+        let mut code = StatusCode::INTERNAL_SERVER_ERROR;
+
+        if downcast_check::<SqliteError>(&std_error, |e| {
+            e.code.is_some_and(|code| code == SQLITE_BUSY)
+        }) {
+            code = StatusCode::SERVICE_UNAVAILABLE;
+        }
+
+        if downcast_check::<SignerRegistrationError>(&std_error, |e| {
+            matches!(e, SignerRegistrationError::RegistrationRoundNotYetOpened)
+        }) {
+            code = StatusCode::SERVICE_UNAVAILABLE;
+        }
+
+        code
+    };
+
+    json(
+        &InternalServerError::new(format!("{std_error:?}")),
+        status_code,
+    )
+}
+
 pub fn internal_server_error<T: Into<InternalServerError>>(message: T) -> Box<dyn warp::Reply> {
     json(&message.into(), StatusCode::INTERNAL_SERVER_ERROR)
 }
 
 pub fn service_unavailable<T: Into<InternalServerError>>(message: T) -> Box<dyn warp::Reply> {
     json(&message.into(), StatusCode::SERVICE_UNAVAILABLE)
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+    use warp::Reply;
+
+    use super::*;
+
+    #[test]
+    fn test_server_error_convert_std_error_to_500_by_default() {
+        let error = anyhow!("Some error");
+        let response = server_error(error).into_response();
+
+        assert_eq!(StatusCode::INTERNAL_SERVER_ERROR, response.status());
+    }
+
+    #[test]
+    fn test_server_error_convert_wrapped_sqlite_busy_error_to_503() {
+        let res = sqlite::Error {
+            code: Some(SQLITE_BUSY),
+            message: None,
+        };
+        let response = server_error(res).into_response();
+
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+
+        // Wrapping the error in a StdError should also work
+        let res = anyhow!(sqlite::Error {
+            code: Some(SQLITE_BUSY),
+            message: None,
+        });
+        let response = server_error(res).into_response();
+
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+    }
+
+    #[test]
+    fn test_server_error_convert_signer_registration_round_not_yet_opened_to_503() {
+        let err = SignerRegistrationError::RegistrationRoundNotYetOpened;
+        let response = server_error(err).into_response();
+
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+
+        // Wrapping the error in a StdError should also work
+        let err = anyhow!(SignerRegistrationError::RegistrationRoundNotYetOpened);
+        let response = server_error(err).into_response();
+
+        assert_eq!(StatusCode::SERVICE_UNAVAILABLE, response.status());
+    }
 }

--- a/mithril-aggregator/src/http_server/routes/reply.rs
+++ b/mithril-aggregator/src/http_server/routes/reply.rs
@@ -1,7 +1,7 @@
 use serde::Serialize;
 use warp::http::StatusCode;
 
-use mithril_common::entities::{ClientError, InternalServerError};
+use mithril_common::entities::{ClientError, ServerError};
 use mithril_common::StdError;
 use mithril_persistence::sqlite::error::{SqliteError, SQLITE_BUSY};
 
@@ -46,17 +46,14 @@ pub fn server_error<E: Into<StdError>>(error: E) -> Box<dyn warp::Reply> {
         code
     };
 
-    json(
-        &InternalServerError::new(format!("{std_error:?}")),
-        status_code,
-    )
+    json(&ServerError::new(format!("{std_error:?}")), status_code)
 }
 
-pub fn internal_server_error<T: Into<InternalServerError>>(message: T) -> Box<dyn warp::Reply> {
+pub fn internal_server_error<T: Into<ServerError>>(message: T) -> Box<dyn warp::Reply> {
     json(&message.into(), StatusCode::INTERNAL_SERVER_ERROR)
 }
 
-pub fn service_unavailable<T: Into<InternalServerError>>(message: T) -> Box<dyn warp::Reply> {
+pub fn service_unavailable<T: Into<ServerError>>(message: T) -> Box<dyn warp::Reply> {
     json(&message.into(), StatusCode::SERVICE_UNAVAILABLE)
 }
 

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -89,7 +89,7 @@ mod handlers {
                         }
                         Some(_) | None => {
                             warn!("register_signatures::error"; "error" => ?err);
-                            Ok(reply::internal_server_error(err))
+                            Ok(reply::server_error(err))
                         }
                     },
                     Ok(()) => Ok(reply::empty(StatusCode::CREATED)),
@@ -97,7 +97,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("register_signatures::cant_retrieve_signed_entity_type"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -169,7 +169,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("register_signer::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err.to_string()))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -208,7 +208,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("registered_signers::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }
@@ -237,7 +237,7 @@ mod handlers {
             }
             Err(err) => {
                 warn!("registered_signers::error"; "error" => ?err);
-                Ok(reply::internal_server_error(err))
+                Ok(reply::server_error(err))
             }
         }
     }

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -74,13 +74,30 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[cfg(test)]
 pub(crate) mod test_tools {
-    use slog::Drain;
+    use std::fs::File;
+    use std::io;
     use std::sync::Arc;
 
-    pub fn logger_for_tests() -> slog::Logger {
-        let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
-        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-        slog::Logger::root(Arc::new(drain), slog::o!())
+    use slog::{Drain, Logger};
+    use slog_async::Async;
+    use slog_term::{CompactFormat, PlainDecorator};
+
+    pub struct TestLogger;
+
+    impl TestLogger {
+        fn from_writer<W: io::Write + Send + 'static>(writer: W) -> Logger {
+            let decorator = PlainDecorator::new(writer);
+            let drain = CompactFormat::new(decorator).build().fuse();
+            let drain = Async::new(drain).build().fuse();
+            Logger::root(Arc::new(drain), slog::o!())
+        }
+
+        pub fn stdout() -> Logger {
+            Self::from_writer(slog_term::TestStdoutWriter)
+        }
+
+        pub fn file(filepath: &std::path::Path) -> Logger {
+            Self::from_writer(File::create(filepath).unwrap())
+        }
     }
 }

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -290,6 +290,7 @@ impl AggregatorRuntime {
             self.runner
                 .update_stake_distribution(&new_time_point)
                 .await?;
+            self.runner.upkeep().await?;
             self.runner
                 .open_signer_registration_round(&new_time_point)
                 .await?;
@@ -469,6 +470,7 @@ mod tests {
             .expect_precompute_epoch_data()
             .once()
             .returning(|| Ok(()));
+        runner.expect_upkeep().once().returning(|| Ok(()));
 
         let mut runtime = init_runtime(
             Some(AggregatorState::Idle(IdleState {
@@ -525,6 +527,7 @@ mod tests {
             .expect_precompute_epoch_data()
             .once()
             .returning(|| Ok(()));
+        runner.expect_upkeep().once().returning(|| Ok(()));
 
         let mut runtime = init_runtime(
             Some(AggregatorState::Idle(IdleState {

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -197,6 +197,7 @@ mod tests {
     use mithril_persistence::database::repository::CardanoTransactionRepository;
 
     use crate::database::test_helper::cardano_tx_db_connection;
+    use crate::test_tools::TestLogger;
 
     use super::*;
 
@@ -223,7 +224,7 @@ mod tests {
                 scanner,
                 transaction_store,
                 Path::new(""),
-                crate::test_tools::logger_for_tests(),
+                TestLogger::stdout(),
             )
         }
     }

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -651,9 +651,8 @@ mod tests {
 
         let (importer, repository) = {
             let connection = cardano_tx_db_connection().unwrap();
-            let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(
-                SqliteConnectionPool::build_from_connection(connection),
-            )));
+            let connection_pool = Arc::new(SqliteConnectionPool::build_from_connection(connection));
+            let repository = Arc::new(CardanoTransactionRepository::new(connection_pool));
             let importer = CardanoTransactionsImporter::new_for_test(
                 Arc::new(DumbBlockScanner::new().forwards(vec![blocks.clone()])),
                 repository.clone(),

--- a/mithril-aggregator/src/services/mod.rs
+++ b/mithril-aggregator/src/services/mod.rs
@@ -16,6 +16,7 @@ mod message;
 mod prover;
 mod signed_entity;
 mod stake_distribution;
+mod upkeep;
 
 pub use cardano_transactions_importer::*;
 pub use certifier::*;
@@ -24,3 +25,4 @@ pub use message::*;
 pub use prover::*;
 pub use signed_entity::*;
 pub use stake_distribution::*;
+pub use upkeep::*;

--- a/mithril-aggregator/src/services/upkeep.rs
+++ b/mithril-aggregator/src/services/upkeep.rs
@@ -68,7 +68,6 @@ impl AggregatorUpkeepService {
                 db_upkeep_logger,
                 "UpkeepService::Cleaning cardano transactions database"
             );
-
             let cardano_tx_db_connection = cardano_tx_db_connection_pool.connection()?;
             SqliteCleaner::new(&cardano_tx_db_connection)
                 .with_logger(db_upkeep_logger.clone())
@@ -100,133 +99,53 @@ impl UpkeepService for AggregatorUpkeepService {
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Range;
-    use std::path::Path;
-
     use mithril_common::test_utils::TempDir;
-    use mithril_persistence::sqlite::SqliteConnection;
 
     use crate::database::test_helper::{cardano_tx_db_file_connection, main_db_file_connection};
-    use crate::test_tools::logger_for_tests;
+    use crate::test_tools::TestLogger;
 
     use super::*;
 
-    fn add_test_table(connection: &SqliteConnection) {
-        connection
-            .execute("CREATE TABLE test (id INTEGER PRIMARY KEY, text TEXT);")
-            .unwrap();
-    }
-
-    fn fill_test_table(connection: &SqliteConnection, ids: Range<u64>) {
-        connection
-            .execute(format!(
-                "INSERT INTO test (id, text) VALUES {}",
-                ids.map(|i| format!("({}, 'some text to fill the db')", i))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ))
-            .unwrap();
-    }
-
-    fn delete_test_rows(connection: &SqliteConnection, ids: Range<u64>) {
-        connection
-            .execute(format!(
-                "DELETE FROM test WHERE id >= {} and id < {}",
-                ids.start, ids.end
-            ))
-            .unwrap();
-    }
-
-    /// Apply migrations, disable auto_vacuum and mangle the database to create some free pages
-    /// for the vacuum to reclaim
-    fn prepare_dbs(main_db_path: &Path, ctx_db_path: &Path) {
-        for connection in &[
-            main_db_file_connection(main_db_path).unwrap(),
-            cardano_tx_db_file_connection(ctx_db_path).unwrap(),
-        ] {
-            // Disable Auto vacuum to allow the test to check if the vacuum was run
-            connection
-                .execute("pragma auto_vacuum = none; vacuum;")
-                .unwrap();
-            add_test_table(connection);
-            fill_test_table(connection, 0..10_000);
-            // Checkpoint before deletion so entries are transferred from the WAL file to the main db
-            connection
-                .execute("PRAGMA wal_checkpoint(PASSIVE)")
-                .unwrap();
-            delete_test_rows(connection, 0..5_000);
-            // Checkpoint after deletion to create free pages in the main db
-            connection
-                .execute("PRAGMA wal_checkpoint(PASSIVE)")
-                .unwrap();
-        }
-    }
-
-    fn file_size(path: &Path) -> u64 {
-        path.metadata()
-            .unwrap_or_else(|_| panic!("Failed to read len of '{}'", path.display()))
-            .len()
-    }
-
     #[tokio::test]
     async fn test_cleanup_database() {
-        let (main_db_path, main_db_wal_path, ctx_db_path, ctx_db_wal_path) = {
+        let (main_db_path, ctx_db_path, log_path) = {
             let db_dir = TempDir::create("aggregator_upkeep", "test_cleanup_database");
             (
                 db_dir.join("main.db"),
-                db_dir.join("main.db-wal"),
                 db_dir.join("cardano_tx.db"),
-                db_dir.join("cardano_tx.db-wal"),
+                db_dir.join("upkeep.log"),
             )
         };
-        prepare_dbs(&main_db_path, &ctx_db_path);
-
-        let main_db_initial_size = file_size(&main_db_path);
-        let ctx_db_initial_size = file_size(&ctx_db_path);
 
         let main_db_connection = main_db_file_connection(&main_db_path).unwrap();
         let cardano_tx_connection = cardano_tx_db_file_connection(&ctx_db_path).unwrap();
-        // Make "neutral" changes to the db, this will fill the WAL files with some data
-        // but won't change the db size after cleaning up.
-        for connection in &[&main_db_connection, &cardano_tx_connection] {
-            fill_test_table(connection, 10_000..15_000);
-            delete_test_rows(connection, 10_000..15_000);
-        }
-        assert!(main_db_initial_size > 0);
-        assert!(file_size(&main_db_wal_path) > 0);
-        assert!(ctx_db_initial_size > 0);
-        assert!(file_size(&ctx_db_wal_path) > 0);
 
         let service = AggregatorUpkeepService::new(
             Arc::new(main_db_connection),
             Arc::new(SqliteConnectionPool::build_from_connection(
                 cardano_tx_connection,
             )),
-            logger_for_tests(),
+            TestLogger::file(&log_path),
         );
 
-        service.run().await.expect("Upkeep service failed");
+        // Separate block to ensure the log is flushed after run
+        {
+            service.run().await.expect("Upkeep service failed");
+        }
 
-        let main_db_after_upkeep_size = file_size(&main_db_path);
-        let ctx_db_after_upkeep_size = file_size(&ctx_db_path);
+        let logs = std::fs::read_to_string(&log_path).unwrap();
 
-        assert!(
-            main_db_initial_size > main_db_after_upkeep_size,
-            "Main db size should have decreased (vacuum enabled)"
+        assert_eq!(
+            logs.matches(SqliteCleaningTask::Vacuum.log_message())
+                .count(),
+            1,
+            "Should have run only once since only the main database has a `Vacuum` cleanup"
         );
         assert_eq!(
-            file_size(&main_db_wal_path),
-            0,
-            "Main db wal file should have been truncated"
-        );
-        assert!(
-            ctx_db_initial_size <= ctx_db_after_upkeep_size,
-            "Cardano_tx db size should not have decreased (vacuum disabled)"
-        );
-        assert_eq!(
-            file_size(&ctx_db_wal_path),
-            0,
-            "Cardano_tx db wal file should have been truncated"
+            logs.matches(SqliteCleaningTask::WalCheckpointTruncate.log_message())
+                .count(),
+            2,
+            "Should have run twice since the two databases have a `WalCheckpointTruncate` cleanup"
         );
     }
 }

--- a/mithril-aggregator/src/services/upkeep.rs
+++ b/mithril-aggregator/src/services/upkeep.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use slog::{info, Logger};
 
+use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{
     SqliteCleaner, SqliteCleaningTask, SqliteConnection, SqliteConnectionPool,
@@ -31,6 +32,7 @@ pub trait UpkeepService: Send + Sync {
 pub struct AggregatorUpkeepService {
     main_db_connection: Arc<SqliteConnection>,
     cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
+    signed_entity_type_lock: Arc<SignedEntityTypeLock>,
     logger: Logger,
 }
 
@@ -39,16 +41,26 @@ impl AggregatorUpkeepService {
     pub fn new(
         main_db_connection: Arc<SqliteConnection>,
         cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
+        signed_entity_type_lock: Arc<SignedEntityTypeLock>,
         logger: Logger,
     ) -> Self {
         Self {
             main_db_connection,
             cardano_tx_connection_pool,
+            signed_entity_type_lock,
             logger,
         }
     }
 
     async fn upkeep_all_databases(&self) -> StdResult<()> {
+        if self.signed_entity_type_lock.has_locked_entities().await {
+            info!(
+                self.logger,
+                "UpkeepService::Some entities are locked - Skipping database upkeep"
+            );
+            return Ok(());
+        }
+
         let main_db_connection = self.main_db_connection.clone();
         let cardano_tx_db_connection_pool = self.cardano_tx_connection_pool.clone();
         let db_upkeep_logger = self.logger.clone();
@@ -99,9 +111,13 @@ impl UpkeepService for AggregatorUpkeepService {
 
 #[cfg(test)]
 mod tests {
+    use mithril_common::entities::SignedEntityTypeDiscriminants;
     use mithril_common::test_utils::TempDir;
 
-    use crate::database::test_helper::{cardano_tx_db_file_connection, main_db_file_connection};
+    use crate::database::test_helper::{
+        cardano_tx_db_connection, cardano_tx_db_file_connection, main_db_connection,
+        main_db_file_connection,
+    };
     use crate::test_tools::TestLogger;
 
     use super::*;
@@ -125,6 +141,7 @@ mod tests {
             Arc::new(SqliteConnectionPool::build_from_connection(
                 cardano_tx_connection,
             )),
+            Arc::new(SignedEntityTypeLock::default()),
             TestLogger::file(&log_path),
         );
 
@@ -146,6 +163,44 @@ mod tests {
                 .count(),
             2,
             "Should have run twice since the two databases have a `WalCheckpointTruncate` cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_doesnt_cleanup_db_if_any_entity_is_locked() {
+        let log_path = TempDir::create(
+            "aggregator_upkeep",
+            "test_doesnt_cleanup_db_if_any_entity_is_locked",
+        )
+        .join("upkeep.log");
+
+        let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
+        let service = AggregatorUpkeepService::new(
+            Arc::new(main_db_connection().unwrap()),
+            Arc::new(SqliteConnectionPool::build(1, cardano_tx_db_connection).unwrap()),
+            signed_entity_type_lock.clone(),
+            TestLogger::file(&log_path),
+        );
+
+        // Separate block to ensure the log is flushed after run
+        {
+            signed_entity_type_lock
+                .lock(SignedEntityTypeDiscriminants::CardanoTransactions)
+                .await;
+            service.run().await.expect("Upkeep service failed");
+        }
+
+        let logs = std::fs::read_to_string(&log_path).unwrap();
+
+        assert_eq!(
+            logs.matches(SqliteCleaningTask::Vacuum.log_message())
+                .count(),
+            0,
+        );
+        assert_eq!(
+            logs.matches(SqliteCleaningTask::WalCheckpointTruncate.log_message())
+                .count(),
+            0,
         );
     }
 }

--- a/mithril-aggregator/src/services/upkeep.rs
+++ b/mithril-aggregator/src/services/upkeep.rs
@@ -1,0 +1,210 @@
+//! ## Upkeep Service
+//!
+//! This service is responsible for the upkeep of the application.
+//!
+//! It is in charge of the following tasks:
+//! * free up space by executing vacuum and WAL checkpoint on the database
+
+use std::path::{Path, PathBuf};
+
+use async_trait::async_trait;
+
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{vacuum_database, ConnectionBuilder, ConnectionOptions};
+
+/// Define the service responsible for the upkeep of the application.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait UpkeepService: Send + Sync {
+    /// Run the upkeep service.
+    async fn run(&self) -> StdResult<()>;
+}
+
+/// Implementation of the upkeep service for the aggregator.
+///
+/// To ensure that connections are cleaned up properly, it creates new connections itself
+/// instead of relying on a connection pool or a shared connection.
+pub struct AggregatorUpkeepService {
+    main_db_path: PathBuf,
+    cardano_tx_path: PathBuf,
+}
+
+#[derive(Eq, PartialEq)]
+enum DatabaseUpkeepTask {
+    Vacuum,
+    WalCheckpointTruncate,
+}
+
+impl AggregatorUpkeepService {
+    /// Create a new instance of the aggregator upkeep service.
+    pub fn new<P1: Into<PathBuf>, P2: Into<PathBuf>>(
+        main_db_path: P1,
+        cardano_tx_path: P2,
+    ) -> Self {
+        Self {
+            main_db_path: main_db_path.into(),
+            cardano_tx_path: cardano_tx_path.into(),
+        }
+    }
+
+    fn upkeep_database(db_path: &Path, tasks: &[DatabaseUpkeepTask]) -> StdResult<()> {
+        let connection = ConnectionBuilder::open_file(db_path)
+            .with_options(&[ConnectionOptions::EnableWriteAheadLog])
+            .build()?;
+
+        if tasks.contains(&DatabaseUpkeepTask::Vacuum) {
+            vacuum_database(&connection)?;
+        }
+
+        // Important: Vacuuming the database will not shrink it until a WAL checkpoint is run, so
+        // it must be done after vacuuming.
+        if tasks.contains(&DatabaseUpkeepTask::WalCheckpointTruncate) {
+            connection.execute("PRAGMA wal_checkpoint(TRUNCATE);")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl UpkeepService for AggregatorUpkeepService {
+    async fn run(&self) -> StdResult<()> {
+        Self::upkeep_database(
+            &self.main_db_path,
+            &[
+                DatabaseUpkeepTask::Vacuum,
+                DatabaseUpkeepTask::WalCheckpointTruncate,
+            ],
+        )?;
+        Self::upkeep_database(
+            &self.cardano_tx_path,
+            &[DatabaseUpkeepTask::WalCheckpointTruncate],
+        )?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ops::Range;
+
+    use mithril_common::test_utils::TempDir;
+    use mithril_persistence::sqlite::SqliteConnection;
+
+    use crate::database::test_helper::{cardano_tx_db_file_connection, main_db_file_connection};
+
+    use super::*;
+
+    fn add_test_table(connection: &SqliteConnection) {
+        connection
+            .execute("CREATE TABLE test (id INTEGER PRIMARY KEY, text TEXT);")
+            .unwrap();
+    }
+
+    fn fill_test_table(connection: &SqliteConnection, ids: Range<u64>) {
+        connection
+            .execute(format!(
+                "INSERT INTO test (id, text) VALUES {}",
+                ids.map(|i| format!("({}, 'some text to fill the db')", i))
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            ))
+            .unwrap();
+    }
+
+    fn delete_test_rows(connection: &SqliteConnection, ids: Range<u64>) {
+        connection
+            .execute(format!(
+                "DELETE FROM test WHERE id >= {} and id < {}",
+                ids.start, ids.end
+            ))
+            .unwrap();
+    }
+
+    /// Apply migrations, disable auto_vacuum and mangle the database to create some free pages
+    /// for the vacuum to reclaim
+    fn prepare_dbs(main_db_path: &Path, ctx_db_path: &Path) {
+        for connection in &[
+            main_db_file_connection(main_db_path).unwrap(),
+            cardano_tx_db_file_connection(ctx_db_path).unwrap(),
+        ] {
+            // Disable Auto vacuum to allow the test to check if the vacuum was run
+            connection
+                .execute("pragma auto_vacuum = none; vacuum;")
+                .unwrap();
+            add_test_table(connection);
+            fill_test_table(connection, 0..10_000);
+            // Checkpoint before deletion so entries are transferred from the WAL file to the main db
+            connection
+                .execute("PRAGMA wal_checkpoint(PASSIVE)")
+                .unwrap();
+            delete_test_rows(connection, 0..5_000);
+            // Checkpoint after deletion to create free pages in the main db
+            connection
+                .execute("PRAGMA wal_checkpoint(PASSIVE)")
+                .unwrap();
+        }
+    }
+
+    fn file_size(path: &Path) -> u64 {
+        path.metadata()
+            .unwrap_or_else(|_| panic!("Failed to read len of '{}'", path.display()))
+            .len()
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_database() {
+        let (main_db_path, main_db_wal_path, ctx_db_path, ctx_db_wal_path) = {
+            let db_dir = TempDir::create("aggregator_upkeep", "test_cleanup_database");
+            (
+                db_dir.join("main.db"),
+                db_dir.join("main.db-wal"),
+                db_dir.join("cardano_tx.db"),
+                db_dir.join("cardano_tx.db-wal"),
+            )
+        };
+        prepare_dbs(&main_db_path, &ctx_db_path);
+
+        let main_db_initial_size = file_size(&main_db_path);
+        let ctx_db_initial_size = file_size(&ctx_db_path);
+
+        let main_db_connection = main_db_file_connection(&main_db_path).unwrap();
+        let cardano_tx_connection = cardano_tx_db_file_connection(&ctx_db_path).unwrap();
+        // Make "neutral" changes to the db, this will fill the WAL files with some data
+        // but won't change the db size after cleaning up.
+        for connection in &[&main_db_connection, &cardano_tx_connection] {
+            fill_test_table(connection, 10_000..15_000);
+            delete_test_rows(connection, 10_000..15_000);
+        }
+        assert!(main_db_initial_size > 0);
+        assert!(file_size(&main_db_wal_path) > 0);
+        assert!(ctx_db_initial_size > 0);
+        assert!(file_size(&ctx_db_wal_path) > 0);
+
+        let service = AggregatorUpkeepService::new(&main_db_path, &ctx_db_path);
+
+        service.run().await.expect("Upkeep service failed");
+
+        let main_db_after_upkeep_size = file_size(&main_db_path);
+        let ctx_db_after_upkeep_size = file_size(&ctx_db_path);
+
+        assert!(
+            main_db_initial_size > main_db_after_upkeep_size,
+            "Main db size should have decreased (vacuum enabled)"
+        );
+        assert_eq!(
+            file_size(&main_db_wal_path),
+            0,
+            "Main db wal file should have been truncated"
+        );
+        assert!(
+            ctx_db_initial_size <= ctx_db_after_upkeep_size,
+            "Cardano_tx db size should not have decreased (vacuum disabled)"
+        );
+        assert_eq!(
+            file_size(&ctx_db_wal_path),
+            0,
+            "Cardano_tx db wal file should have been truncated"
+        );
+    }
+}

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -18,3 +18,17 @@ pub use signer_importer::{
 
 #[cfg(test)]
 pub use remote_file_uploader::MockRemoteFileUploader;
+
+/// Downcast the error to the specified error type and check if the error satisfies the condition.
+pub(crate) fn downcast_check<E>(
+    error: &mithril_common::StdError,
+    check: impl Fn(&E) -> bool,
+) -> bool
+where
+    E: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static,
+{
+    if let Some(inner_error) = error.downcast_ref::<E>() {
+        return check(inner_error);
+    }
+    false
+}

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.24"
+version = "0.4.25"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/http_server_error.rs
+++ b/mithril-common/src/entities/http_server_error.rs
@@ -1,35 +1,35 @@
 use crate::StdError;
 use serde::{Deserialize, Serialize};
 
-/// Representation of a Internal Server Error raised by an http server
+/// Representation of a Server Error raised by a http server
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub struct InternalServerError {
+pub struct ServerError {
     /// error message
     pub message: String,
 }
 
-impl InternalServerError {
+impl ServerError {
     /// InternalServerError factory
-    pub fn new(message: String) -> InternalServerError {
-        InternalServerError { message }
+    pub fn new(message: String) -> ServerError {
+        ServerError { message }
     }
 }
 
-impl From<String> for InternalServerError {
+impl From<String> for ServerError {
     fn from(message: String) -> Self {
-        InternalServerError::new(message)
+        ServerError::new(message)
     }
 }
 
-impl From<&str> for InternalServerError {
+impl From<&str> for ServerError {
     fn from(message: &str) -> Self {
-        InternalServerError::new(message.to_string())
+        ServerError::new(message.to_string())
     }
 }
 
-impl From<StdError> for InternalServerError {
+impl From<StdError> for ServerError {
     fn from(error: StdError) -> Self {
-        InternalServerError::new(format!("{error:?}"))
+        ServerError::new(format!("{error:?}"))
     }
 }
 

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -37,7 +37,7 @@ pub use certificate_metadata::{CertificateMetadata, StakeDistributionParty};
 pub use certificate_pending::CertificatePending;
 pub use epoch::{Epoch, EpochError};
 pub use epoch_settings::EpochSettings;
-pub use http_server_error::{ClientError, InternalServerError};
+pub use http_server_error::{ClientError, ServerError};
 pub use mithril_stake_distribution::MithrilStakeDistribution;
 pub use protocol_message::{ProtocolMessage, ProtocolMessagePartKey, ProtocolMessagePartValue};
 pub use protocol_parameters::ProtocolParameters;

--- a/mithril-common/src/signed_entity_type_lock.rs
+++ b/mithril-common/src/signed_entity_type_lock.rs
@@ -45,6 +45,12 @@ impl SignedEntityTypeLock {
         locked_entities.remove(&entity_type.into());
     }
 
+    /// Check if there are any locked signed entities.
+    pub async fn has_locked_entities(&self) -> bool {
+        let locked_entities = self.locked_entities.read().await;
+        !locked_entities.is_empty()
+    }
+
     /// List only the unlocked signed entities in the given list.
     pub async fn filter_unlocked_entries<T: Into<SignedEntityTypeDiscriminants> + Clone>(
         &self,
@@ -188,5 +194,17 @@ mod tests {
                 .await,
             vec![SignedEntityTypeDiscriminants::CardanoTransactions]
         );
+    }
+
+    #[tokio::test]
+    async fn has_locked_entities() {
+        let signed_entity_type_lock = SignedEntityTypeLock::new();
+
+        assert!(!signed_entity_type_lock.has_locked_entities().await);
+
+        signed_entity_type_lock
+            .lock(SignedEntityTypeDiscriminants::MithrilStakeDistribution)
+            .await;
+        assert!(signed_entity_type_lock.has_locked_entities().await);
     }
 }

--- a/mithril-common/src/test_utils/apispec.rs
+++ b/mithril-common/src/test_utils/apispec.rs
@@ -460,7 +460,7 @@ components:
         // for this route, so it's the default response spec that is used.
         let response = build_json_response(
             StatusCode::INTERNAL_SERVER_ERROR.into(),
-            entities::InternalServerError::new("an error occurred".to_string()),
+            entities::ServerError::new("an error occurred".to_string()),
         );
 
         APISpec::from_file(&APISpec::get_default_spec_file())
@@ -474,7 +474,7 @@ components:
     fn test_should_fail_when_the_status_code_is_not_the_expected_one() {
         let response = build_json_response(
             StatusCode::INTERNAL_SERVER_ERROR.into(),
-            entities::InternalServerError::new("an error occurred".to_string()),
+            entities::ServerError::new("an error occurred".to_string()),
         );
 
         let mut api_spec = APISpec::from_file(&APISpec::get_default_spec_file());
@@ -500,7 +500,7 @@ components:
     fn test_should_be_ok_when_the_status_code_is_the_right_one() {
         let response = build_json_response(
             StatusCode::INTERNAL_SERVER_ERROR.into(),
-            entities::InternalServerError::new("an error occurred".to_string()),
+            entities::ServerError::new("an error occurred".to_string()),
         );
 
         APISpec::from_file(&APISpec::get_default_spec_file())

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.155"
+version = "0.2.156"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -196,7 +196,8 @@ mod tests {
     use mithril_common::entities::{BlockNumber, BlockRangesSequence};
     use mithril_persistence::database::repository::CardanoTransactionRepository;
 
-    use crate::database::test_utils::cardano_tx_db_connection;
+    use crate::database::test_helper::cardano_tx_db_connection;
+    use crate::test_tools::TestLogger;
 
     use super::*;
 
@@ -223,7 +224,7 @@ mod tests {
                 scanner,
                 transaction_store,
                 Path::new(""),
-                crate::test_tools::logger_for_tests(),
+                TestLogger::stdout(),
             )
         }
     }

--- a/mithril-signer/src/database/mod.rs
+++ b/mithril-signer/src/database/mod.rs
@@ -3,20 +3,5 @@
 //! representation with their associated providers.
 pub mod migration;
 pub mod repository;
-
 #[cfg(test)]
-pub mod test_utils {
-    use sqlite::ConnectionThreadSafe;
-
-    use mithril_common::StdResult;
-    use mithril_persistence::database::cardano_transaction_migration;
-    use mithril_persistence::sqlite::{ConnectionBuilder, ConnectionOptions};
-
-    pub fn cardano_tx_db_connection() -> StdResult<ConnectionThreadSafe> {
-        let connection = ConnectionBuilder::open_memory()
-            .with_options(&[ConnectionOptions::ForceDisableForeignKeys])
-            .with_migrations(cardano_transaction_migration::get_migrations())
-            .build()?;
-        Ok(connection)
-    }
-}
+pub(crate) mod test_helper;

--- a/mithril-signer/src/database/test_helper.rs
+++ b/mithril-signer/src/database/test_helper.rs
@@ -1,0 +1,44 @@
+use std::path::Path;
+
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{ConnectionBuilder, ConnectionOptions, SqliteConnection};
+
+/// File sqlite database without foreign key support with migrations applied and WAL activated
+pub fn main_db_file_connection(db_path: &Path) -> StdResult<SqliteConnection> {
+    let builder = ConnectionBuilder::open_file(db_path)
+        .with_options(&[ConnectionOptions::EnableWriteAheadLog]);
+    build_main_db_connection(builder)
+}
+
+fn build_main_db_connection(connection_builder: ConnectionBuilder) -> StdResult<SqliteConnection> {
+    let connection = connection_builder
+        .with_options(&[ConnectionOptions::ForceDisableForeignKeys])
+        .with_migrations(crate::database::migration::get_migrations())
+        .build()?;
+    Ok(connection)
+}
+
+/// In-memory sqlite database without foreign key support with cardano db migrations applied
+pub fn cardano_tx_db_connection() -> StdResult<SqliteConnection> {
+    let builder = ConnectionBuilder::open_memory();
+    build_cardano_tx_db_connection(builder)
+}
+
+/// File sqlite database without foreign key support with cardano db migrations applied and WAL activated
+pub fn cardano_tx_db_file_connection(db_path: &Path) -> StdResult<SqliteConnection> {
+    let builder = ConnectionBuilder::open_file(db_path)
+        .with_options(&[ConnectionOptions::EnableWriteAheadLog]);
+    build_cardano_tx_db_connection(builder)
+}
+
+fn build_cardano_tx_db_connection(
+    connection_builder: ConnectionBuilder,
+) -> StdResult<SqliteConnection> {
+    let connection = connection_builder
+        .with_options(&[ConnectionOptions::ForceDisableForeignKeys])
+        .with_migrations(
+            mithril_persistence::database::cardano_transaction_migration::get_migrations(),
+        )
+        .build()?;
+    Ok(connection)
+}

--- a/mithril-signer/src/database/test_helper.rs
+++ b/mithril-signer/src/database/test_helper.rs
@@ -3,6 +3,12 @@ use std::path::Path;
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{ConnectionBuilder, ConnectionOptions, SqliteConnection};
 
+/// In-memory sqlite database without foreign key support with migrations applied
+pub fn main_db_connection() -> StdResult<SqliteConnection> {
+    let builder = ConnectionBuilder::open_memory();
+    build_main_db_connection(builder)
+}
+
 /// File sqlite database without foreign key support with migrations applied and WAL activated
 pub fn main_db_file_connection(db_path: &Path) -> StdResult<SqliteConnection> {
     let builder = ConnectionBuilder::open_file(db_path)

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -52,13 +52,30 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[cfg(test)]
 pub mod test_tools {
-    use slog::Drain;
+    use std::fs::File;
+    use std::io;
     use std::sync::Arc;
 
-    pub fn logger_for_tests() -> slog::Logger {
-        let decorator = slog_term::PlainDecorator::new(slog_term::TestStdoutWriter);
-        let drain = slog_term::CompactFormat::new(decorator).build().fuse();
-        let drain = slog_async::Async::new(drain).build().fuse();
-        slog::Logger::root(Arc::new(drain), slog::o!())
+    use slog::{Drain, Logger};
+    use slog_async::Async;
+    use slog_term::{CompactFormat, PlainDecorator};
+
+    pub struct TestLogger;
+
+    impl TestLogger {
+        fn from_writer<W: io::Write + Send + 'static>(writer: W) -> Logger {
+            let decorator = PlainDecorator::new(writer);
+            let drain = CompactFormat::new(decorator).build().fuse();
+            let drain = Async::new(drain).build().fuse();
+            Logger::root(Arc::new(drain), slog::o!())
+        }
+
+        pub fn stdout() -> Logger {
+            Self::from_writer(slog_term::TestStdoutWriter)
+        }
+
+        pub fn file(filepath: &std::path::Path) -> Logger {
+            Self::from_writer(File::create(filepath).unwrap())
+        }
     }
 }

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -18,6 +18,7 @@ mod single_signer;
 mod transactions_importer_by_chunk;
 mod transactions_importer_with_pruner;
 mod transactions_importer_with_vacuum;
+mod upkeep_service;
 
 #[cfg(test)]
 pub use aggregator_client::dumb::DumbAggregatorClient;
@@ -34,6 +35,7 @@ pub use single_signer::*;
 pub use transactions_importer_by_chunk::*;
 pub use transactions_importer_with_pruner::*;
 pub use transactions_importer_with_vacuum::*;
+pub use upkeep_service::*;
 
 /// HTTP request timeout duration in milliseconds
 const HTTP_REQUEST_TIMEOUT_DURATION: u64 = 30000;

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -336,6 +336,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
         let upkeep_service = Arc::new(SignerUpkeepService::new(
             sqlite_connection.clone(),
             sqlite_connection_cardano_transaction_pool,
+            signed_entity_type_lock.clone(),
             slog_scope::logger(),
         ));
 

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -26,7 +26,7 @@ use mithril_common::{
 };
 use mithril_persistence::{
     database::{repository::CardanoTransactionRepository, ApplicationNodeType, SqlMigration},
-    sqlite::{ConnectionBuilder, ConnectionOptions, SqliteConnection, SqliteConnectionPool},
+    sqlite::{ConnectionBuilder, SqliteConnection, SqliteConnectionPool},
     store::{adapter::SQLiteAdapter, StakeStore},
 };
 
@@ -174,7 +174,6 @@ impl<'a> ProductionServiceBuilder<'a> {
         let logger = slog_scope::logger();
         let connection = ConnectionBuilder::open_file(&sqlite_db_path)
             .with_node_type(ApplicationNodeType::Signer)
-            .with_options(&[ConnectionOptions::Vacuum])
             .with_migrations(migrations)
             .with_logger(logger.clone())
             .build()

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -332,14 +332,6 @@ impl StateMachine {
         self.metrics_service
             .signer_registration_total_since_startup_counter_increment();
 
-        self.runner
-            .upkeep()
-            .await
-            .map_err(|e| RuntimeError::KeepState {
-                message: "Failed to upkeep signer in 'unregistered → registered' phase".to_string(),
-                nested_error: Some(e),
-            })?;
-
         let epoch = self
             .get_current_time_point("unregistered → registered")
             .await?
@@ -367,6 +359,14 @@ impl StateMachine {
             .signer_registration_success_since_startup_counter_increment();
         self.metrics_service
             .signer_registration_success_last_epoch_gauge_set(epoch);
+
+        self.runner
+            .upkeep()
+            .await
+            .map_err(|e| RuntimeError::KeepState {
+                message: "Failed to upkeep signer in 'unregistered → registered' phase".to_string(),
+                nested_error: Some(e),
+            })?;
 
         Ok(SignerState::Registered { epoch })
     }

--- a/mithril-signer/src/transactions_importer_by_chunk.rs
+++ b/mithril-signer/src/transactions_importer_by_chunk.rs
@@ -68,6 +68,8 @@ mod tests {
     use mockall::predicate::eq;
     use mockall::{mock, Sequence};
 
+    use crate::test_tools::TestLogger;
+
     use super::*;
 
     mock! {
@@ -118,7 +120,7 @@ mod tests {
             highest_transaction_block_number_getter,
             Arc::new(wrapped_importer),
             chunk_size,
-            crate::test_tools::logger_for_tests(),
+            TestLogger::stdout(),
         );
 
         let up_to_beacon = highest_block_number;
@@ -146,7 +148,7 @@ mod tests {
             highest_transaction_block_number_getter,
             Arc::new(wrapped_importer),
             chunk_size,
-            crate::test_tools::logger_for_tests(),
+            TestLogger::stdout(),
         );
 
         importer.import(up_to_beacon).await.unwrap();
@@ -166,7 +168,7 @@ mod tests {
             highest_transaction_block_number_getter,
             Arc::new(wrapped_importer),
             chunk_size,
-            crate::test_tools::logger_for_tests(),
+            TestLogger::stdout(),
         );
 
         importer.import(up_to_beacon).await.unwrap();
@@ -190,7 +192,7 @@ mod tests {
             highest_transaction_block_number_getter,
             Arc::new(wrapped_importer),
             chunk_size,
-            crate::test_tools::logger_for_tests(),
+            TestLogger::stdout(),
         );
 
         importer.import(up_to_beacon).await.unwrap();
@@ -213,7 +215,7 @@ mod tests {
             highest_transaction_block_number_getter,
             Arc::new(wrapped_importer),
             chunk_size,
-            crate::test_tools::logger_for_tests(),
+            TestLogger::stdout(),
         );
 
         importer.import(up_to_beacon).await.unwrap();

--- a/mithril-signer/src/transactions_importer_with_pruner.rs
+++ b/mithril-signer/src/transactions_importer_with_pruner.rs
@@ -68,6 +68,8 @@ mod tests {
     use mockall::mock;
     use mockall::predicate::eq;
 
+    use crate::test_tools::TestLogger;
+
     use super::*;
 
     mock! {
@@ -98,7 +100,7 @@ mod tests {
                 number_of_blocks_to_keep,
                 Arc::new(transaction_pruner),
                 Arc::new(transaction_importer),
-                crate::test_tools::logger_for_tests(),
+                TestLogger::stdout(),
             )
         }
     }

--- a/mithril-signer/src/transactions_importer_with_vacuum.rs
+++ b/mithril-signer/src/transactions_importer_with_vacuum.rs
@@ -54,6 +54,8 @@ mod tests {
     use mithril_common::test_utils::TempDir;
     use mithril_persistence::sqlite::SqliteConnection;
 
+    use crate::test_tools::TestLogger;
+
     use super::*;
 
     mock! {
@@ -79,7 +81,7 @@ mod tests {
             Self::new(
                 connection_pool,
                 Arc::new(transaction_importer),
-                crate::test_tools::logger_for_tests(),
+                TestLogger::stdout(),
             )
         }
     }

--- a/mithril-signer/src/transactions_importer_with_vacuum.rs
+++ b/mithril-signer/src/transactions_importer_with_vacuum.rs
@@ -6,7 +6,7 @@ use slog::{debug, Logger};
 use mithril_common::entities::BlockNumber;
 use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
-use mithril_persistence::sqlite::{vacuum_database, SqliteConnectionPool};
+use mithril_persistence::sqlite::{SqliteCleaner, SqliteCleaningTask, SqliteConnectionPool};
 
 /// A decorator of [TransactionsImporter] that vacuums the database after running the import.
 pub struct TransactionsImporterWithVacuum {
@@ -40,7 +40,10 @@ impl TransactionsImporter for TransactionsImporterWithVacuum {
             "Transaction Import finished - Vacuuming database to reclaim disk space"
         );
         let connection = self.connection_pool.connection()?;
-        vacuum_database(&connection)?;
+
+        SqliteCleaner::new(&connection)
+            .with_tasks(&[SqliteCleaningTask::Vacuum])
+            .run()?;
 
         Ok(())
     }

--- a/mithril-signer/src/upkeep_service.rs
+++ b/mithril-signer/src/upkeep_service.rs
@@ -1,0 +1,151 @@
+//! ## Upkeep Service
+//!
+//! This service is responsible for the upkeep of the application.
+//!
+//! It is in charge of the following tasks:
+//! * free up space by executing vacuum and WAL checkpoint on the database
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use async_trait::async_trait;
+use slog::{info, Logger};
+
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{
+    SqliteCleaner, SqliteCleaningTask, SqliteConnection, SqliteConnectionPool,
+};
+
+/// Define the service responsible for the upkeep of the application.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait UpkeepService: Send + Sync {
+    /// Run the upkeep service.
+    async fn run(&self) -> StdResult<()>;
+}
+
+/// Implementation of the upkeep service for the signer.
+///
+/// To ensure that connections are cleaned up properly, it creates new connections itself
+/// instead of relying on a connection pool or a shared connection.
+pub struct SignerUpkeepService {
+    main_db_connection: Arc<SqliteConnection>,
+    cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
+    logger: Logger,
+}
+
+impl SignerUpkeepService {
+    /// Create a new instance of the aggregator upkeep service.
+    pub fn new(
+        main_db_connection: Arc<SqliteConnection>,
+        cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            main_db_connection,
+            cardano_tx_connection_pool,
+            logger,
+        }
+    }
+
+    async fn upkeep_all_databases(&self) -> StdResult<()> {
+        let main_db_connection = self.main_db_connection.clone();
+        let cardano_tx_db_connection_pool = self.cardano_tx_connection_pool.clone();
+        let db_upkeep_logger = self.logger.clone();
+
+        // Run the database upkeep tasks in another thread to avoid blocking the tokio runtime
+        let db_upkeep_thread = tokio::task::spawn_blocking(move || -> StdResult<()> {
+            info!(db_upkeep_logger, "UpkeepService::Cleaning main database");
+            SqliteCleaner::new(&main_db_connection)
+                .with_logger(db_upkeep_logger.clone())
+                .with_tasks(&[
+                    SqliteCleaningTask::Vacuum,
+                    SqliteCleaningTask::WalCheckpointTruncate,
+                ])
+                .run()?;
+
+            info!(
+                db_upkeep_logger,
+                "UpkeepService::Cleaning cardano transactions database"
+            );
+            let cardano_tx_db_connection = cardano_tx_db_connection_pool.connection()?;
+            SqliteCleaner::new(&cardano_tx_db_connection)
+                .with_logger(db_upkeep_logger.clone())
+                .with_tasks(&[SqliteCleaningTask::WalCheckpointTruncate])
+                .run()?;
+
+            Ok(())
+        });
+
+        db_upkeep_thread
+            .await
+            .with_context(|| "Database Upkeep thread crashed")?
+    }
+}
+
+#[async_trait]
+impl UpkeepService for SignerUpkeepService {
+    async fn run(&self) -> StdResult<()> {
+        info!(self.logger, "UpkeepService::start");
+
+        self.upkeep_all_databases()
+            .await
+            .with_context(|| "Database upkeep failed")?;
+
+        info!(self.logger, "UpkeepService::end");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::test_utils::TempDir;
+
+    use crate::database::test_helper::{cardano_tx_db_file_connection, main_db_file_connection};
+    use crate::test_tools::TestLogger;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_cleanup_database() {
+        let (main_db_path, ctx_db_path, log_path) = {
+            let db_dir = TempDir::create("signer_upkeep", "test_cleanup_database");
+            (
+                db_dir.join("main.db"),
+                db_dir.join("cardano_tx.db"),
+                db_dir.join("upkeep.log"),
+            )
+        };
+
+        let main_db_connection = main_db_file_connection(&main_db_path).unwrap();
+        let cardano_tx_connection = cardano_tx_db_file_connection(&ctx_db_path).unwrap();
+
+        let service = SignerUpkeepService::new(
+            Arc::new(main_db_connection),
+            Arc::new(SqliteConnectionPool::build_from_connection(
+                cardano_tx_connection,
+            )),
+            TestLogger::file(&log_path),
+        );
+
+        // Separate block to ensure the log is flushed after run
+        {
+            service.run().await.expect("Upkeep service failed");
+        }
+
+        let logs = std::fs::read_to_string(&log_path).unwrap();
+
+        assert_eq!(
+            logs.matches(SqliteCleaningTask::Vacuum.log_message())
+                .count(),
+            1,
+            "Should have run only once since only the main database has a `Vacuum` cleanup"
+        );
+        assert_eq!(
+            logs.matches(SqliteCleaningTask::WalCheckpointTruncate.log_message())
+                .count(),
+            2,
+            "Should have run twice since the two databases have a `WalCheckpointTruncate` cleanup"
+        );
+    }
+}

--- a/mithril-signer/src/upkeep_service.rs
+++ b/mithril-signer/src/upkeep_service.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use slog::{info, Logger};
 
+use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{
     SqliteCleaner, SqliteCleaningTask, SqliteConnection, SqliteConnectionPool,
@@ -31,6 +32,7 @@ pub trait UpkeepService: Send + Sync {
 pub struct SignerUpkeepService {
     main_db_connection: Arc<SqliteConnection>,
     cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
+    signed_entity_type_lock: Arc<SignedEntityTypeLock>,
     logger: Logger,
 }
 
@@ -39,16 +41,26 @@ impl SignerUpkeepService {
     pub fn new(
         main_db_connection: Arc<SqliteConnection>,
         cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
+        signed_entity_type_lock: Arc<SignedEntityTypeLock>,
         logger: Logger,
     ) -> Self {
         Self {
             main_db_connection,
             cardano_tx_connection_pool,
+            signed_entity_type_lock,
             logger,
         }
     }
 
     async fn upkeep_all_databases(&self) -> StdResult<()> {
+        if self.signed_entity_type_lock.has_locked_entities().await {
+            info!(
+                self.logger,
+                "UpkeepService::Some entities are locked - Skipping database upkeep"
+            );
+            return Ok(());
+        }
+
         let main_db_connection = self.main_db_connection.clone();
         let cardano_tx_db_connection_pool = self.cardano_tx_connection_pool.clone();
         let db_upkeep_logger = self.logger.clone();
@@ -99,9 +111,13 @@ impl UpkeepService for SignerUpkeepService {
 
 #[cfg(test)]
 mod tests {
+    use mithril_common::entities::SignedEntityTypeDiscriminants;
     use mithril_common::test_utils::TempDir;
 
-    use crate::database::test_helper::{cardano_tx_db_file_connection, main_db_file_connection};
+    use crate::database::test_helper::{
+        cardano_tx_db_connection, cardano_tx_db_file_connection, main_db_connection,
+        main_db_file_connection,
+    };
     use crate::test_tools::TestLogger;
 
     use super::*;
@@ -125,6 +141,7 @@ mod tests {
             Arc::new(SqliteConnectionPool::build_from_connection(
                 cardano_tx_connection,
             )),
+            Arc::new(SignedEntityTypeLock::default()),
             TestLogger::file(&log_path),
         );
 
@@ -146,6 +163,44 @@ mod tests {
                 .count(),
             2,
             "Should have run twice since the two databases have a `WalCheckpointTruncate` cleanup"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_doesnt_cleanup_db_if_any_entity_is_locked() {
+        let log_path = TempDir::create(
+            "signer_upkeep",
+            "test_doesnt_cleanup_db_if_any_entity_is_locked",
+        )
+        .join("upkeep.log");
+
+        let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
+        let service = SignerUpkeepService::new(
+            Arc::new(main_db_connection().unwrap()),
+            Arc::new(SqliteConnectionPool::build(1, cardano_tx_db_connection).unwrap()),
+            signed_entity_type_lock.clone(),
+            TestLogger::file(&log_path),
+        );
+
+        // Separate block to ensure the log is flushed after run
+        {
+            signed_entity_type_lock
+                .lock(SignedEntityTypeDiscriminants::CardanoTransactions)
+                .await;
+            service.run().await.expect("Upkeep service failed");
+        }
+
+        let logs = std::fs::read_to_string(&log_path).unwrap();
+
+        assert_eq!(
+            logs.matches(SqliteCleaningTask::Vacuum.log_message())
+                .count(),
+            0,
+        );
+        assert_eq!(
+            logs.matches(SqliteCleaningTask::WalCheckpointTruncate.log_message())
+                .count(),
+            0,
         );
     }
 }

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -213,6 +213,7 @@ impl StateMachineTester {
         let upkeep_service = Arc::new(SignerUpkeepService::new(
             sqlite_connection.clone(),
             sqlite_connection_cardano_transaction_pool,
+            signed_entity_type_lock.clone(),
             slog_scope::logger(),
         ));
 


### PR DESCRIPTION
## Content

This PR add a new service to `mithril-aggregator` and `mithril-signer`, the `UpkeepService`:

- Responsible for upkeep tasks that must be done periodically
- Run at epoch change:
  -  Aggregator:  at the start of the `Idle → Ready` state machine transition, while the registration round is close.
  -  Signer: at the start of the `Unregistered → Registered` state machine transition. 
- It run the following tasks (but more can be added as it should not be limited to database upkeep):
  - Vacuum the main database to compact it and reduce fragmentation.
  - Execute a `pragma wal_checkpoint(TRUNCATE)` on both the main and the cardano transaction database to avoid infinite grow of the wal files.
- Database upkeep tasks are skipped if a signed entity type is locked since there would be a high chance that a database is busy (like when the cardano transation preloader is running). 
- This supersede the startup vacuum that has been added by #1771.

Note: the vacuum is not run on the cardano transaction database as it can be so large that it takes more than an hour on the mainnet.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1707 