### PR TITLE
Bugfix: Can't generate proof for transactions on the last signed block number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.34"
+version = "0.5.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.14"
+version = "0.2.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.157"
+version = "0.2.158"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.14"
+version = "0.2.15"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/query/block_range_root/delete_block_range_root.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/delete_block_range_root.rs
@@ -49,17 +49,12 @@ mod tests {
     use mithril_common::crypto_helper::MKTreeNode;
     use mithril_common::entities::BlockRange;
 
-    use crate::database::query::{GetBlockRangeRootQuery, InsertBlockRangeRootQuery};
+    use crate::database::query::block_range_root::test_helper::insert_block_range_roots;
+    use crate::database::query::GetBlockRangeRootQuery;
     use crate::database::test_helper::cardano_tx_db_connection;
-    use crate::sqlite::{ConnectionExtensions, SqliteConnection};
+    use crate::sqlite::ConnectionExtensions;
 
     use super::*;
-
-    fn insert_block_range_roots(connection: &SqliteConnection, records: Vec<BlockRangeRootRecord>) {
-        connection
-            .fetch_first(InsertBlockRangeRootQuery::insert_many(records).unwrap())
-            .unwrap();
-    }
 
     fn block_range_root_dataset() -> Vec<BlockRangeRootRecord> {
         [

--- a/internal/mithril-persistence/src/database/query/block_range_root/get_block_range_root.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/get_block_range_root.rs
@@ -1,5 +1,6 @@
-use mithril_common::entities::BlockNumber;
 use sqlite::Value;
+
+use mithril_common::entities::BlockNumber;
 
 use crate::database::record::BlockRangeRootRecord;
 use crate::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
@@ -16,12 +17,9 @@ impl GetBlockRangeRootQuery {
         }
     }
 
-    pub fn up_to_block_number(up_to_or_equal_end_block_number: BlockNumber) -> Self {
+    pub fn contains_or_below_block_number(block_number: BlockNumber) -> Self {
         Self {
-            condition: WhereCondition::new(
-                "end <= ?*",
-                vec![Value::Integer(up_to_or_equal_end_block_number as i64)],
-            ),
+            condition: WhereCondition::new("start < ?*", vec![Value::Integer(block_number as i64)]),
         }
     }
 }
@@ -38,5 +36,102 @@ impl Query for GetBlockRangeRootQuery {
         let projection = Self::Entity::get_projection().expand(aliases);
 
         format!("select {projection} from block_range_root where {condition} order by start, end")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::crypto_helper::MKTreeNode;
+    use mithril_common::entities::BlockRange;
+
+    use crate::database::query::block_range_root::test_helper::insert_block_range_roots;
+    use crate::database::query::GetBlockRangeRootQuery;
+    use crate::database::test_helper::cardano_tx_db_connection;
+    use crate::sqlite::ConnectionExtensions;
+
+    use super::*;
+
+    fn block_range_root_dataset() -> Vec<BlockRangeRootRecord> {
+        [
+            (
+                BlockRange::from_block_number(15),
+                MKTreeNode::from_hex("AAAA").unwrap(),
+            ),
+            (
+                BlockRange::from_block_number(30),
+                MKTreeNode::from_hex("BBBB").unwrap(),
+            ),
+            (
+                BlockRange::from_block_number(45),
+                MKTreeNode::from_hex("CCCC").unwrap(),
+            ),
+        ]
+        .into_iter()
+        .map(BlockRangeRootRecord::from)
+        .collect()
+    }
+
+    #[test]
+    fn test_get_contains_or_below_block_number_with_empty_db() {
+        let connection = cardano_tx_db_connection().unwrap();
+
+        let cursor: Vec<BlockRangeRootRecord> = connection
+            .fetch_collect(GetBlockRangeRootQuery::contains_or_below_block_number(100))
+            .unwrap();
+        assert_eq!(Vec::<BlockRangeRootRecord>::new(), cursor);
+    }
+
+    #[test]
+    fn test_get_contains_or_below_block_number_higher_than_the_highest_stored_block_range() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let dataset = block_range_root_dataset();
+        insert_block_range_roots(&connection, dataset.clone());
+
+        let cursor: Vec<BlockRangeRootRecord> = connection
+            .fetch_collect(GetBlockRangeRootQuery::contains_or_below_block_number(
+                10_000,
+            ))
+            .unwrap();
+
+        assert_eq!(dataset, cursor);
+    }
+
+    #[test]
+    fn test_get_contains_or_below_block_number_below_end_of_the_third_block_range() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let dataset = block_range_root_dataset();
+        insert_block_range_roots(&connection, dataset.clone());
+
+        let cursor: Vec<BlockRangeRootRecord> = connection
+            .fetch_collect(GetBlockRangeRootQuery::contains_or_below_block_number(44))
+            .unwrap();
+
+        assert_eq!(&dataset[0..2], &cursor);
+    }
+
+    #[test]
+    fn test_get_contains_or_below_block_number_equal_to_end_of_the_third_block_range() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let dataset = block_range_root_dataset();
+        insert_block_range_roots(&connection, dataset.clone());
+
+        let cursor: Vec<BlockRangeRootRecord> = connection
+            .fetch_collect(GetBlockRangeRootQuery::contains_or_below_block_number(45))
+            .unwrap();
+
+        assert_eq!(&dataset[0..2], &cursor);
+    }
+
+    #[test]
+    fn test_get_contains_or_below_block_number_after_end_of_the_third_block_range() {
+        let connection = cardano_tx_db_connection().unwrap();
+        let dataset = block_range_root_dataset();
+        insert_block_range_roots(&connection, dataset.clone());
+
+        let cursor: Vec<BlockRangeRootRecord> = connection
+            .fetch_collect(GetBlockRangeRootQuery::contains_or_below_block_number(46))
+            .unwrap();
+
+        assert_eq!(dataset, cursor);
     }
 }

--- a/internal/mithril-persistence/src/database/query/block_range_root/mod.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/mod.rs
@@ -7,3 +7,20 @@ pub use delete_block_range_root::*;
 pub use get_block_range_root::*;
 pub use get_interval_without_block_range::*;
 pub use insert_block_range::*;
+
+#[cfg(test)]
+mod test_helper {
+    use crate::database::record::BlockRangeRootRecord;
+    use crate::sqlite::{ConnectionExtensions, SqliteConnection};
+
+    use super::*;
+
+    pub fn insert_block_range_roots(
+        connection: &SqliteConnection,
+        records: Vec<BlockRangeRootRecord>,
+    ) {
+        connection
+            .fetch_first(InsertBlockRangeRootQuery::insert_many(records).unwrap())
+            .unwrap();
+    }
+}

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.34"
+version = "0.5.35"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -141,7 +141,7 @@ impl ProverService for MithrilProverService {
 
         // 4 - Enrich the Merkle map with the block ranges Merkle trees
         for (block_range, mk_tree) in mk_trees {
-            mk_map.insert(block_range, mk_tree.into())?;
+            mk_map.replace(block_range, mk_tree.into())?;
         }
 
         // 5 - Compute the proof for all transactions
@@ -167,7 +167,8 @@ impl ProverService for MithrilProverService {
         let pool_size = self.mk_map_pool.size();
         info!(
             self.logger,
-            "Prover starts computing the Merkle map pool resource of size {pool_size}"
+            "Prover starts computing the Merkle map pool resource of size {pool_size}";
+            "up_to_block_number" => up_to,
         );
         let mk_map_cache = self
             .block_range_root_retriever

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -142,7 +142,7 @@ async fn create_certificate() {
 
     comment!(
         "Increase cardano chain block number to 185, 
-        the state machine should be signing CardanoTransactions for block 180"
+        the state machine should be signing CardanoTransactions for block 179"
     );
     tester.increase_block_number(85, 185).await.unwrap();
     cycle!(tester, "signing");
@@ -166,7 +166,7 @@ async fn create_certificate() {
                 .map(|s| s.signer_with_stake.clone().into())
                 .collect::<Vec<_>>(),
             fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoTransactions(Epoch(1), 180),
+            SignedEntityType::CardanoTransactions(Epoch(1), 179),
             ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
                 "devnet".to_string(),
                 1,
@@ -201,7 +201,7 @@ async fn create_certificate() {
                 .map(|s| s.signer_with_stake.clone().into())
                 .collect::<Vec<_>>(),
             fixture.compute_and_encode_avk(),
-            SignedEntityType::CardanoTransactions(Epoch(1), 120),
+            SignedEntityType::CardanoTransactions(Epoch(1), 119),
             ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
                 "devnet".to_string(),
                 1,

--- a/mithril-aggregator/tests/prove_transactions.rs
+++ b/mithril-aggregator/tests/prove_transactions.rs
@@ -1,0 +1,149 @@
+use mithril_aggregator::Configuration;
+use mithril_common::{
+    entities::{
+        CardanoDbBeacon, CardanoTransactionsSigningConfig, ChainPoint, Epoch,
+        ProtocolMessagePartKey, ProtocolParameters, SignedEntityType,
+        SignedEntityTypeDiscriminants, TimePoint,
+    },
+    test_utils::MithrilFixtureBuilder,
+};
+use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
+
+use crate::test_extensions::utilities::tx_hash;
+
+mod test_extensions;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn prove_transactions() {
+    let protocol_parameters = ProtocolParameters {
+        k: 5,
+        m: 150,
+        phi_f: 0.95,
+    };
+    let configuration = Configuration {
+        protocol_parameters: protocol_parameters.clone(),
+        signed_entity_types: Some(SignedEntityTypeDiscriminants::CardanoTransactions.to_string()),
+        data_stores_directory: get_test_dir("prove_transactions"),
+        cardano_transactions_signing_config: CardanoTransactionsSigningConfig {
+            security_parameter: 0,
+            step: 30,
+        },
+        ..Configuration::new_sample()
+    };
+    let mut tester = RuntimeTester::build(
+        TimePoint {
+            epoch: Epoch(1),
+            immutable_file_number: 1,
+            chain_point: ChainPoint {
+                slot_number: 10,
+                block_number: 100,
+                block_hash: "block_hash-100".to_string(),
+            },
+        },
+        configuration,
+    )
+    .await;
+    let observer = tester.observer.clone();
+    let prover = tester.dependencies.prover_service.clone();
+
+    comment!("create signers & declare stake distribution");
+    let fixture = MithrilFixtureBuilder::default()
+        .with_signers(10)
+        .with_protocol_parameters(protocol_parameters.clone())
+        .build();
+    let signers = &fixture.signers_fixture();
+
+    tester.init_state_from_fixture(&fixture).await.unwrap();
+
+    comment!("Boostrap the genesis certificate");
+    tester.register_genesis_certificate(&fixture).await.unwrap();
+
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new_genesis(
+            CardanoDbBeacon::new("devnet", 1, 1),
+            fixture.compute_and_encode_avk()
+        )
+    );
+
+    // Lock all signed entity types except CardanoTransactions to limit the scope of the test
+    for entity in SignedEntityTypeDiscriminants::all()
+        .into_iter()
+        .filter(|e| e != &SignedEntityTypeDiscriminants::CardanoTransactions)
+    {
+        tester
+            .dependencies
+            .signed_entity_type_lock
+            .lock(entity)
+            .await;
+    }
+
+    comment!("register signers");
+    cycle!(tester, "ready");
+    tester
+        .register_signers(&fixture.signers_fixture())
+        .await
+        .unwrap();
+
+    comment!(
+        "Increase cardano chain block number to 185, 
+        the state machine should be signing CardanoTransactions up to block 179 included"
+    );
+    tester.increase_block_number(85, 185).await.unwrap();
+    cycle!(tester, "signing");
+    tester
+        .send_single_signatures(SignedEntityTypeDiscriminants::CardanoTransactions, signers)
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the CardanoTransactions");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            CardanoDbBeacon::new("devnet", 1, 1),
+            &signers
+                .iter()
+                .map(|s| s.signer_with_stake.clone().into())
+                .collect::<Vec<_>>(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::CardanoTransactions(Epoch(1), 179),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new("devnet", 1, 1)),
+        )
+    );
+
+    cycle!(tester, "ready");
+
+    comment!("Get the proof for the last transaction, BlockNumber(179), and verify it");
+    let last_transaction_hash = tx_hash(179, 1);
+    let last_tx_snapshot = observer
+        .get_last_cardano_transactions_snapshot()
+        .await
+        .unwrap();
+    let proof_for_last_transaction = prover
+        .compute_transactions_proofs(
+            last_tx_snapshot.artifact.block_number,
+            &[last_transaction_hash.clone()],
+        )
+        .await
+        .unwrap()
+        .pop()
+        .unwrap();
+    assert!(proof_for_last_transaction
+        .transactions_hashes()
+        .contains(&last_transaction_hash));
+
+    proof_for_last_transaction.verify().unwrap();
+
+    comment!("Get the certificate associated with the last transaction and check that it matches the proof");
+    let proof_merkle_root = proof_for_last_transaction.merkle_root();
+    let proof_certificate = observer.get_last_certificate().await.unwrap();
+    assert_eq!(&last_tx_snapshot.certificate_id, &proof_certificate.hash);
+    assert_eq!(
+        proof_certificate
+            .protocol_message
+            .get_message_part(&ProtocolMessagePartKey::CardanoTransactionsMerkleRoot),
+        Some(&proof_merkle_root),
+        "The proof merkle root should match the one in the certificate"
+    );
+}

--- a/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
@@ -1,7 +1,9 @@
 use anyhow::{anyhow, Context};
+use mithril_aggregator::services::SignedEntityService;
 use mithril_aggregator::{
     dependency_injection::DependenciesBuilder, entities::OpenMessage, services::CertifierService,
 };
+use mithril_common::entities::{CardanoTransactionsSnapshot, Certificate, SignedEntity};
 use mithril_common::{
     entities::{
         Epoch, SignedEntityConfig, SignedEntityType, SignedEntityTypeDiscriminants, TimePoint,
@@ -14,6 +16,7 @@ use std::sync::Arc;
 pub struct AggregatorObserver {
     network: CardanoNetwork,
     certifier_service: Arc<dyn CertifierService>,
+    signed_entity_service: Arc<dyn SignedEntityService>,
     ticker_service: Arc<dyn TickerService>,
     signed_entity_config: SignedEntityConfig,
 }
@@ -24,6 +27,7 @@ impl AggregatorObserver {
         Self {
             network: deps_builder.configuration.get_network().unwrap(),
             certifier_service: deps_builder.get_certifier_service().await.unwrap(),
+            signed_entity_service: deps_builder.get_signed_entity_service().await.unwrap(),
             ticker_service: deps_builder.get_ticker_service().await.unwrap(),
             signed_entity_config: deps_builder.get_signed_entity_config().unwrap(),
         }
@@ -52,7 +56,7 @@ impl AggregatorObserver {
             .with_context(|| "Requesting current open message of type CardanoImmutableFilesFull should be not fail")
     }
 
-    // Get the [entity type][SignedEntityType::CardanoImmutableFilesFull] of the current current open message
+    /// Get the [entity type][SignedEntityType::CardanoImmutableFilesFull] of the current current open message
     pub async fn get_current_signed_entity_type(
         &self,
         discriminant: SignedEntityTypeDiscriminants,
@@ -63,6 +67,35 @@ impl AggregatorObserver {
             )),
             Some(message) => Ok(message.signed_entity_type),
         }
+    }
+
+    /// Get the last certificate produced by the aggregator
+    pub async fn get_last_certificate(&self) -> StdResult<Certificate> {
+        let certificate = self
+            .certifier_service
+            .get_latest_certificates(1)
+            .await
+            .with_context(|| "Querying last certificate should not fail")?
+            .pop()
+            .ok_or(anyhow!(
+                "No certificate have been produced by the aggregator"
+            ))?;
+        Ok(certificate)
+    }
+
+    /// Get the last cardano transactions snapshot produced by the aggregator
+    pub async fn get_last_cardano_transactions_snapshot(
+        &self,
+    ) -> StdResult<SignedEntity<CardanoTransactionsSnapshot>> {
+        let last_tx_snapshot = self
+            .signed_entity_service
+            .get_last_cardano_transaction_snapshot()
+            .await
+            .with_context(|| "Querying last cardano transactions snapshot should not fail")?
+            .ok_or(anyhow!(
+                "No cardano transactions snapshot have been produced by the aggregator"
+            ))?;
+        Ok(last_tx_snapshot)
     }
 
     async fn build_current_signed_entity_type(

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -33,7 +33,7 @@ use crate::test_extensions::{AggregatorObserver, ExpectedCertificate};
 #[macro_export]
 macro_rules! cycle {
     ( $tester:expr, $expected_state:expr ) => {{
-        $tester.cycle().await.unwrap();
+        RuntimeTester::cycle(&mut $tester).await.unwrap();
         assert_eq!($expected_state, $tester.runtime.get_state());
     }};
 }
@@ -41,8 +41,7 @@ macro_rules! cycle {
 #[macro_export]
 macro_rules! cycle_err {
     ( $tester:expr, $expected_state:expr ) => {{
-        $tester
-            .cycle()
+        RuntimeTester::cycle(&mut $tester)
             .await
             .expect_err("cycle tick should have returned an error");
         assert_eq!($expected_state, $tester.runtime.get_state());
@@ -52,7 +51,9 @@ macro_rules! cycle_err {
 #[macro_export]
 macro_rules! assert_last_certificate_eq {
     ( $tester:expr, $expected_certificate:expr ) => {{
-        let last_certificate = $tester.get_last_expected_certificate().await.unwrap();
+        let last_certificate = RuntimeTester::get_last_expected_certificate(&mut $tester)
+            .await
+            .unwrap();
         assert_eq!($expected_certificate, last_certificate);
     }};
 }

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -1,3 +1,5 @@
+use crate::test_extensions::utilities::tx_hash;
+use crate::test_extensions::{AggregatorObserver, ExpectedCertificate};
 use anyhow::{anyhow, Context};
 use chrono::Utc;
 use mithril_aggregator::{
@@ -27,8 +29,6 @@ use slog_scope::debug;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc::UnboundedReceiver;
-
-use crate::test_extensions::{AggregatorObserver, ExpectedCertificate};
 
 #[macro_export]
 macro_rules! cycle {
@@ -276,7 +276,7 @@ impl RuntimeTester {
                     block_number,
                     slot_number,
                     current_immutable,
-                    vec![format!("tx_hash-{block_number}-1")],
+                    vec![tx_hash(block_number, 1)],
                 )
             })
             .collect();
@@ -485,17 +485,7 @@ impl RuntimeTester {
     pub async fn get_last_certificate_with_signed_entity(
         &mut self,
     ) -> StdResult<(Certificate, Option<SignedEntityRecord>)> {
-        let certificate = self
-            .dependencies
-            .certifier_service
-            .get_latest_certificates(1)
-            .await
-            .with_context(|| "Querying last certificate should not fail")?
-            .first()
-            .ok_or(anyhow!(
-                "No certificate have been produced by the aggregator"
-            ))?
-            .clone();
+        let certificate = self.observer.get_last_certificate().await?;
 
         let signed_entity = match &certificate.signature {
             CertificateSignature::GenesisSignature(..) => None,

--- a/mithril-aggregator/tests/test_extensions/utilities.rs
+++ b/mithril-aggregator/tests/test_extensions/utilities.rs
@@ -1,3 +1,4 @@
+use mithril_common::entities::BlockNumber;
 use mithril_common::test_utils::TempDir;
 use slog_scope::debug;
 use std::{
@@ -17,6 +18,10 @@ pub fn get_test_dir(subdir_name: &str) -> PathBuf {
 pub fn comment(comment: String) {
     let old_count = COMMENT_COUNT.fetch_add(1, Ordering::SeqCst);
     debug!("COMMENT {:02} 💬 {}", old_count + 1, comment);
+}
+
+pub fn tx_hash(block_number: BlockNumber, tx_index: u64) -> String {
+    format!("tx_hash-{block_number}-{tx_index}")
 }
 
 #[macro_export]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.25"
+version = "0.4.26"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -491,7 +491,7 @@ mod tests {
         MKTree::new(&leaves).unwrap()
     }
 
-    fn join_merkle_tree(block_ranges: &[BlockRange]) -> Vec<(BlockRange, MKTree)> {
+    fn generate_merkle_trees_for_ranges(block_ranges: &[BlockRange]) -> Vec<(BlockRange, MKTree)> {
         block_ranges
             .iter()
             .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
@@ -530,7 +530,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_accept_replacement_with_same_root_value() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_reject_replacement_with_different_root_value() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -572,7 +572,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_replace_should_accept_replacement_with_same_root_value() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -606,7 +606,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_replace_should_reject_replacement_if_key_doesnt_exist() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -630,7 +630,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_replace_should_reject_replacement_with_different_root_value() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -654,7 +654,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_compress_correctly() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -675,7 +675,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_reject_out_of_order_insertion() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -693,7 +693,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_list_keys_correctly() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -716,7 +716,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_list_values_correctly() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -742,7 +742,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_find_value_correctly() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
@@ -755,7 +755,7 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_clone_and_compute_same_root() {
-        let entries = join_merkle_tree(&[
+        let entries = generate_merkle_trees_for_ranges(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -519,21 +519,8 @@ mod tests {
     #[test]
     fn test_mk_map_should_compute_same_root_when_replacing_entry_with_equivalent() {
         let entries = generate_merkle_trees(10, 3);
-        let merkle_tree_node_entries = &entries
-            .iter()
-            .map(|(range, mktree)| {
-                (
-                    range.to_owned(),
-                    MKMapNode::TreeNode(mktree.try_into().unwrap()),
-                )
-            })
-            .collect::<Vec<_>>();
-        let merkle_tree_full_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<(_, MKMapNode<_>)>>();
-        let mk_map_nodes = MKMap::new(merkle_tree_node_entries.as_slice()).unwrap();
-        let mk_map_full = MKMap::new(merkle_tree_full_entries).unwrap();
+        let mk_map_nodes = MKMap::new(&into_mkmap_tree_node_entries(entries.clone())).unwrap();
+        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         let mk_map_nodes_root = mk_map_nodes.compute_root().unwrap();
         let mk_map_full_root = mk_map_full.compute_root().unwrap();
@@ -543,19 +530,12 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_accept_replacement_with_same_root_value() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
-        let merkle_tree_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<(_, MKMapNode<_>)>>();
-        let mut mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        ]);
+        let mut mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
         let mk_map_root_expected = mk_map.compute_root().unwrap();
         let block_range_replacement = BlockRange::new(0, 3);
         let same_root_value = MKMapNode::TreeNode(
@@ -575,19 +555,12 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_reject_replacement_with_different_root_value() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
-        let merkle_tree_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<_>>();
-        let mut mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        ]);
+        let mut mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
         let block_range_replacement = BlockRange::new(0, 3);
         let value_replacement: MKTreeNode = "test-123".to_string().into();
         let different_root_value = MKMapNode::TreeNode(value_replacement);
@@ -681,19 +654,12 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_compress_correctly() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
-        let merkle_tree_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<(_, MKMapNode<_>)>>();
-        let mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        ]);
+        let mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
         let mk_map_root_expected = mk_map.compute_root().unwrap();
         let mk_map_provable_keys = mk_map.get_provable_keys();
         assert!(!mk_map_provable_keys.is_empty());
@@ -709,24 +675,12 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_reject_out_of_order_insertion() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
-        let merkle_tree_entries = &entries
-            .iter()
-            .map(|(range, mktree)| {
-                (
-                    range.to_owned(),
-                    MKMapNode::TreeNode(mktree.try_into().unwrap()),
-                )
-            })
-            .collect::<Vec<_>>();
-        let mut mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        ]);
+        let mut mk_map = MKMap::new(&into_mkmap_tree_node_entries(entries)).unwrap();
         let out_of_order_entry = (
             BlockRange::new(0, 25),
             MKMapNode::TreeNode("test-123".into()),
@@ -739,23 +693,12 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_list_keys_correctly() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
-        let merkle_tree_entries = &entries
-            .iter()
-            .map(|(range, mktree)| {
-                (
-                    range.to_owned(),
-                    MKMapNode::TreeNode(mktree.try_into().unwrap()),
-                )
-            })
-            .collect::<Vec<_>>();
+        ]);
+        let merkle_tree_entries = &into_mkmap_tree_node_entries(entries);
         let mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
 
         let keys = mk_map
@@ -773,23 +716,12 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_list_values_correctly() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
-        let merkle_tree_entries = &entries
-            .iter()
-            .map(|(range, mktree)| {
-                (
-                    range.to_owned(),
-                    MKMapNode::TreeNode(mktree.try_into().unwrap()),
-                )
-            })
-            .collect::<Vec<_>>();
+        ]);
+        let merkle_tree_entries = &into_mkmap_tree_node_entries(entries);
         let mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
 
         let values = mk_map
@@ -810,39 +742,25 @@ mod tests {
 
     #[test]
     fn test_mk_map_should_find_value_correctly() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
+        ]);
         let mktree_node_to_certify = entries[2].1.leaves()[1].clone();
-        let merkle_tree_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<(_, MKMapNode<_>)>>();
-        let mk_map_full = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         mk_map_full.contains(&mktree_node_to_certify).unwrap();
     }
 
     #[test]
     fn test_mk_map_should_clone_and_compute_same_root() {
-        let entries = [
+        let entries = join_merkle_tree(&[
             BlockRange::new(0, 3),
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
-        ]
-        .iter()
-        .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
-        .collect::<Vec<_>>();
-        let merkle_tree_node_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<(_, MKMapNode<_>)>>();
-        let mk_map = MKMap::new(merkle_tree_node_entries.as_slice()).unwrap();
+        ]);
+        let mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         let mk_map_clone = mk_map.clone();
 
@@ -856,11 +774,7 @@ mod tests {
     fn test_mk_map_should_not_compute_proof_for_no_leaves() {
         let entries = generate_merkle_trees(10, 3);
         let mktree_nodes_to_certify: &[MKTreeNode] = &[];
-        let merkle_tree_node_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<(_, MKMapNode<_>)>>();
-        let mk_map_full = MKMap::new(merkle_tree_node_entries.as_slice()).unwrap();
+        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         mk_map_full
             .compute_proof(mktree_nodes_to_certify)
@@ -876,11 +790,7 @@ mod tests {
             entries[1].1.leaves()[1].clone(),
             entries[2].1.leaves()[1].clone(),
         ];
-        let merkle_tree_node_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), mktree.into()))
-            .collect::<Vec<(_, MKMapNode<_>)>>();
-        let mk_map_full = MKMap::new(merkle_tree_node_entries.as_slice()).unwrap();
+        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
         let mk_map_proof = mk_map_full.compute_proof(&mktree_nodes_to_certify).unwrap();
 
         mk_map_proof.verify().unwrap();
@@ -903,10 +813,7 @@ mod tests {
             entries[20].1.leaves()[0].clone(),
             entries[30].1.leaves()[0].clone(),
         ];
-        let merkle_tree_node_entries = &entries
-            .into_iter()
-            .map(|(range, mktree)| (range.to_owned(), MKMapNode::Tree(Arc::new(mktree))))
-            .collect::<Vec<_>>()
+        let merkle_tree_node_entries = &into_mkmap_tree_entries(entries)
             .chunks(10)
             .map(|entries| {
                 (

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -29,7 +29,7 @@ pub trait BlockRangeRootRetriever: Send + Sync {
     /// Returns a Merkle map of the block ranges roots up to a given beacon
     async fn retrieve_block_range_roots<'a>(
         &'a self,
-        up_to_or_equal_beacon: BlockNumber,
+        up_to_beacon: BlockNumber,
     ) -> StdResult<Box<dyn Iterator<Item = (BlockRange, MKTreeNode)> + 'a>>;
 
     /// Returns a Merkle map of the block ranges roots up to a given beacon

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.157"
+version = "0.2.158"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes a fix for #1785, there was several problems:

- The computed block number to be signed was not taking in account the fact that block range ends is exclusive, meaning that it overflowed over the next block range, a block range which end after the block number that we want to sign.
  To solve this we simply subtract one to the computation.
- The request that retrieved block range when computing merkle roots excluded the last block range.

Not directly related to the bug: 
- The prover would add leaf to it's merkle tree in some condition, corrupting it as this changed its merkle root so it no longer matcher the one in the certificate.
  This was worrisome since this corrupted merkle tree is returned to a resource pool after use, meaning that a subsequent requests would also yield invalid proofs.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments
I'm unsure this totally fix the problem as when investing the logs I could see that, in the transaction importer, they were a gap of minus one between the block number of the transaction we asked it to import and the really imported transactions.
We should oversee the testing preview network after merge to ensure that its fixed or if there's still more work needed.

## Issue(s)
Relates to #1785