### PR TITLE
Fix: aggregator and signer blocked during Cardano transactions import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ As a minor extension, we have adopted a slightly different versioning convention
   - Chunk the Cardano transactions import in `mithril-signer` to reduce disk footprint by running the pruning process more frequently.
   - Add a database connection pool on the Cardano transaction repository for increased performances of the prover.
   - Import Cardano transactions with Chain Sync mini protocol and Pallas chain reader.
+  - Avoid aggregator and signer being blocked when importing the Cardano transactions.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.33"
+version = "0.5.34"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.156"
+version = "0.2.157"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.33"
+version = "0.5.34"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -10,7 +10,7 @@ use mithril_common::{
 };
 use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn create_certificate() {
     let protocol_parameters = ProtocolParameters {
         k: 5,

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.156"
+version = "0.2.157"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/tests/create_cardano_transaction_single_signature.rs
+++ b/mithril-signer/tests/create_cardano_transaction_single_signature.rs
@@ -9,7 +9,7 @@ use mithril_common::{
 use test_extensions::StateMachineTester;
 
 #[rustfmt::skip]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 async fn test_create_cardano_transaction_single_signature() {
     let protocol_parameters = tests_setup::setup_protocol_parameters();
     let fixture = MithrilFixtureBuilder::default()


### PR DESCRIPTION
## Content
This PR includes a fix to the aggregator and signer nodes which are blocked during the database insertions of the Cardano transactions: the state machines and the REST API were completely inaccessible.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1797 
