### PR TITLE
Fix explorer crash when proving transaction & enhance mithril-client error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3687,7 +3687,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "async-trait",
  "futures",

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.3.5"
+version = "0.3.6"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/www-test/package-lock.json
+++ b/mithril-client-wasm/www-test/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.3.4",
+      "version": "0.3.6",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/www/package-lock.json
+++ b/mithril-client-wasm/www/package-lock.json
@@ -19,7 +19,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.3.4",
+      "version": "0.3.6",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.5"
+version = "0.8.6"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/http_server_error.rs
+++ b/mithril-common/src/entities/http_server_error.rs
@@ -1,5 +1,8 @@
-use crate::StdError;
+use std::fmt::Display;
+
 use serde::{Deserialize, Serialize};
+
+use crate::StdError;
 
 /// Representation of a Server Error raised by a http server
 #[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -10,8 +13,16 @@ pub struct ServerError {
 
 impl ServerError {
     /// InternalServerError factory
-    pub fn new(message: String) -> ServerError {
-        ServerError { message }
+    pub fn new<M: Into<String>>(message: M) -> ServerError {
+        ServerError {
+            message: message.into(),
+        }
+    }
+}
+
+impl Display for ServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
     }
 }
 
@@ -50,5 +61,11 @@ impl ClientError {
             label: label.into(),
             message: message.into(),
         }
+    }
+}
+
+impl Display for ClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.label, self.message)
     }
 }

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.2",
+      "version": "0.7.3",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/pkg",
         "@popperjs/core": "^2.11.8",
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm/pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.3.4",
+      "version": "0.3.6",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/components/CertifyCardanoTransactionsModal/index.js
+++ b/mithril-explorer/src/components/CertifyCardanoTransactionsModal/index.js
@@ -37,6 +37,7 @@ export default function CertifyCardanoTransactionsModal({
   const [isCertificateChainValid, setIsCertificateChainValid] = useState(true);
   const [currentStep, setCurrentStep] = useState(validationSteps.ready);
   const [currentTab, setCurrentTab] = useState(getTabForStep(validationSteps.ready));
+  const [currentError, setCurrentError] = useState(undefined);
 
   useEffect(() => {
     setShowLoadingWarning(false);
@@ -124,6 +125,7 @@ export default function CertifyCardanoTransactionsModal({
 
   function handleError(error) {
     console.error("Cardano Transactions Certification Error:", error);
+    setCurrentError(error);
     setCurrentStep(validationSteps.done);
   }
 
@@ -219,13 +221,28 @@ export default function CertifyCardanoTransactionsModal({
                     )}
                   </Tab.Pane>
                   <Tab.Pane eventKey={getTabForStep(validationSteps.done)}>
-                    {currentStep === validationSteps.done && (
+                    {currentStep === validationSteps.done && currentError === undefined && (
                       <TransactionCertificationResult
                         isSuccess={isProofValid && isCertificateChainValid}
                         certificate={certificate}
                         certifiedTransactions={transactionsProofs.transactions_hashes}
                         nonCertifiedTransactions={transactionsProofs.non_certified_transactions}
                       />
+                    )}
+                    {currentStep === validationSteps.done && currentError !== undefined && (
+                      <Alert variant="danger" className="mb-2">
+                        <Alert.Heading>
+                          <i className="text-danger bi bi-shield-slash"></i> Mithril could not
+                          certify the transactions
+                        </Alert.Heading>
+                        <p className="mb-2">
+                          An error occurred during the verification process. Please try again.
+                        </p>
+                        <hr />
+                        <pre className="mb-0">
+                          <code>{currentError.toString()}</code>
+                        </pre>
+                      </Alert>
                     )}
                   </Tab.Pane>
                 </Tab.Content>


### PR DESCRIPTION
## Content
This PR includes:

- Fix explorer crash when an error is returned when proving transaction (#1784)
![image](https://github.com/input-output-hk/mithril/assets/790521/bbace501-8bd9-4361-85db-55430be340de)

- Enhance error transmission from the `mithril-client` when the queried aggregator return a 4xx or a 5xx error.


## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1784 
