### PR TITLE
Fix: avoid pool acquire timeout during Cardano transaction prover cache computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.36"
+version = "0.5.37"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.36"
+version = "0.5.37"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content
This PR includes a fix to avoid some timeout occurring when trying to acquire a Merkle map from the resource pool when it is being refreshed.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1793
