### PR TITLE
Remove call to chain observer on pending certificate route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Add prettier configuration to standardize the code formatting in the repository.
 
-- Field `beacon` become optional in `CertificatePendingMessage` response of `/certificate-pending` route.
+- Field `beacon` becomes optional in `CertificatePendingMessage` response of `/certificate-pending` route.
 
 - **UNSTABLE** Cardano transactions certification:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Add prettier configuration to standardize the code formatting in the repository.
 
+- Field `beacon` become optional in `CertificatePendingMessage` response of `/certificate-pending` route.
+
 - **UNSTABLE** Cardano transactions certification:
 
   - Optimize the performances of the computation of the proof with a Merkle map.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.38"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.38"
+version = "0.5.39"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -187,12 +187,6 @@ mod tests {
             &StatusCode::OK,
         )
         .unwrap();
-
-        let message: CertificatePendingMessage = serde_json::from_slice(response.body()).unwrap();
-
-        #[allow(deprecated)]
-        let immutable_file_number = message.beacon.unwrap().immutable_file_number;
-        assert_eq!(0, immutable_file_number);
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -122,7 +122,6 @@ mod tests {
     use anyhow::anyhow;
     use mithril_common::{
         entities::CertificatePending,
-        messages::CertificatePendingMessage,
         test_utils::{apispec::APISpec, fake_data},
     };
     use mithril_persistence::store::adapter::DumbStoreAdapter;

--- a/mithril-aggregator/src/message_adapters/to_certificate_pending_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_pending_message.rs
@@ -10,9 +10,10 @@ pub struct ToCertificatePendingMessageAdapter;
 impl ToCertificatePendingMessageAdapter {
     /// Method to trigger the conversion
     pub fn adapt(certificate_pending: CertificatePending) -> CertificatePendingMessage {
+        #[allow(deprecated)]
         let beacon = match &certificate_pending.signed_entity_type {
             SignedEntityType::CardanoImmutableFilesFull(beacon) => beacon.clone(),
-            _ => CardanoDbBeacon::new("", 0, 0),
+            _ => CardanoDbBeacon::empty(),
         };
 
         #[allow(deprecated)]
@@ -68,7 +69,7 @@ mod tests {
     #[test]
     fn adapt_on_cardano_immutable_files_full_signed_entity_type_ok() {
         let mut certificate_pending = fake_data::certificate_pending();
-        let beacon = CardanoDbBeacon::new("network", 15, 756);
+        let beacon = fake_data::beacon();
         certificate_pending.signed_entity_type =
             SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
 

--- a/mithril-aggregator/src/message_adapters/to_certificate_pending_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_certificate_pending_message.rs
@@ -1,8 +1,7 @@
-use mithril_common::entities::{CardanoDbBeacon, ImmutableFileNumber};
+use mithril_common::entities::CardanoDbBeacon;
 use mithril_common::{
-    entities::{CertificatePending, Signer},
+    entities::{CertificatePending, SignedEntityType, Signer},
     messages::{CertificatePendingMessage, SignerMessagePart},
-    CardanoNetwork,
 };
 
 /// Adapter to turn [CertificatePending] instances into [CertificatePendingMessage].
@@ -10,21 +9,16 @@ pub struct ToCertificatePendingMessageAdapter;
 
 impl ToCertificatePendingMessageAdapter {
     /// Method to trigger the conversion
-    pub fn adapt(
-        certificate_pending: CertificatePending,
-        network: CardanoNetwork,
-        immutable_file_number: ImmutableFileNumber,
-    ) -> CertificatePendingMessage {
-        let beacon = CardanoDbBeacon::new(
-            network.to_string(),
-            *certificate_pending.epoch,
-            immutable_file_number,
-        );
+    pub fn adapt(certificate_pending: CertificatePending) -> CertificatePendingMessage {
+        let beacon = match &certificate_pending.signed_entity_type {
+            SignedEntityType::CardanoImmutableFilesFull(beacon) => beacon.clone(),
+            _ => CardanoDbBeacon::new("", 0, 0),
+        };
 
         #[allow(deprecated)]
         CertificatePendingMessage {
-            epoch: beacon.epoch,
-            beacon,
+            epoch: certificate_pending.epoch,
+            beacon: Some(beacon),
             signed_entity_type: certificate_pending.signed_entity_type,
             protocol_parameters: certificate_pending.protocol_parameters,
             next_protocol_parameters: certificate_pending.next_protocol_parameters,
@@ -55,7 +49,10 @@ impl ToCertificatePendingMessageAdapter {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::test_utils::fake_data;
+    use mithril_common::{
+        entities::{Epoch, SignedEntityType},
+        test_utils::fake_data,
+    };
 
     use super::*;
 
@@ -63,13 +60,37 @@ mod tests {
     fn adapt_ok() {
         let certificate_pending = fake_data::certificate_pending();
         let epoch = certificate_pending.epoch;
-        let message = ToCertificatePendingMessageAdapter::adapt(
-            certificate_pending,
-            fake_data::network(),
-            10,
-        );
+        let message = ToCertificatePendingMessageAdapter::adapt(certificate_pending);
 
         assert_eq!(epoch, message.epoch);
+    }
+
+    #[test]
+    fn adapt_on_cardano_immutable_files_full_signed_entity_type_ok() {
+        let mut certificate_pending = fake_data::certificate_pending();
+        let beacon = CardanoDbBeacon::new("network", 15, 756);
+        certificate_pending.signed_entity_type =
+            SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
+
+        let message = ToCertificatePendingMessageAdapter::adapt(certificate_pending);
+
+        #[allow(deprecated)]
+        let beacon_from_message = message.beacon.unwrap();
+        assert_eq!(beacon, beacon_from_message);
+    }
+
+    #[test]
+    fn adapt_on_other_than_cardano_immutable_files_full_signed_entity_type_ok() {
+        let mut certificate_pending = fake_data::certificate_pending();
+        let beacon = CardanoDbBeacon::new("", 0, 0);
+        certificate_pending.signed_entity_type =
+            SignedEntityType::MithrilStakeDistribution(Epoch(15));
+
+        let message = ToCertificatePendingMessageAdapter::adapt(certificate_pending);
+
+        #[allow(deprecated)]
+        let beacon_from_message = message.beacon.unwrap();
+        assert_eq!(beacon, beacon_from_message);
     }
 
     #[test]
@@ -82,11 +103,7 @@ mod tests {
             next_signers,
             ..fake_data::certificate_pending()
         };
-        let message = ToCertificatePendingMessageAdapter::adapt(
-            certificate_pending,
-            fake_data::network(),
-            10,
-        );
+        let message = ToCertificatePendingMessageAdapter::adapt(certificate_pending);
 
         assert_eq!(2, message.signers.len());
         assert_eq!(3, message.next_signers.len());

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.27"
+version = "0.4.28"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/cardano_db_beacon.rs
+++ b/mithril-common/src/entities/cardano_db_beacon.rs
@@ -61,6 +61,12 @@ impl CardanoDbBeacon {
         }
     }
 
+    /// Value used as a placeholder where a beacon is necessary
+    #[deprecated]
+    pub fn empty() -> Self {
+        Self::new("", 0, 0)
+    }
+
     /// Computes the hash of a CardanoDbBeacon
     pub fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();

--- a/mithril-common/src/messages/certificate_pending.rs
+++ b/mithril-common/src/messages/certificate_pending.rs
@@ -11,7 +11,8 @@ pub struct CertificatePendingMessage {
 
     /// Current Beacon
     #[deprecated(since = "0.3.25", note = "use epoch instead")]
-    pub beacon: CardanoDbBeacon,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub beacon: Option<CardanoDbBeacon>,
 
     /// Signed entity type
     #[serde(rename = "entity_type")]
@@ -41,7 +42,7 @@ impl CertificatePendingMessage {
             #[allow(deprecated)]
             Self {
                 epoch: beacon.epoch,
-                beacon,
+                beacon: None,
                 signed_entity_type: SignedEntityType::dummy(),
                 protocol_parameters: ProtocolParameters {
                     k: 5,
@@ -62,21 +63,141 @@ impl CertificatePendingMessage {
 
 #[cfg(test)]
 mod tests {
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+    pub struct CertificatePendingMessagePreviousVersion {
+        /// Current Epoch
+        pub epoch: Epoch,
+
+        /// Current Beacon
+        #[deprecated(since = "0.3.25", note = "use epoch instead")]
+        pub beacon: CardanoDbBeacon,
+
+        /// Signed entity type
+        #[serde(rename = "entity_type")]
+        pub signed_entity_type: SignedEntityType,
+
+        /// Current Protocol parameters
+        #[serde(rename = "protocol")]
+        pub protocol_parameters: ProtocolParameters,
+
+        /// Next Protocol parameters
+        #[serde(rename = "next_protocol")]
+        pub next_protocol_parameters: ProtocolParameters,
+
+        /// Current Signers
+        pub signers: Vec<SignerMessagePart>,
+
+        /// Signers that will be able to sign on the next epoch
+        pub next_signers: Vec<SignerMessagePart>,
+    }
+
     use crate::entities::Epoch;
 
     use super::*;
 
-    fn golden_message() -> CertificatePendingMessage {
+    fn golden_previous_message() -> CertificatePendingMessagePreviousVersion {
         let beacon = CardanoDbBeacon {
             network: "preview".to_string(),
             epoch: Epoch(86),
             immutable_file_number: 1728,
         };
 
+        let deprecated_beacon = CardanoDbBeacon {
+            network: "".to_string(),
+            epoch: Epoch(0),
+            immutable_file_number: 0,
+        };
+
+        #[allow(deprecated)]
+        CertificatePendingMessagePreviousVersion {
+            epoch: beacon.epoch,
+            beacon: deprecated_beacon,
+            signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(beacon),
+            protocol_parameters: ProtocolParameters {
+                k: 5,
+                m: 100,
+                phi_f: 0.65,
+            },
+            next_protocol_parameters: ProtocolParameters {
+                k: 50,
+                m: 1000,
+                phi_f: 0.65,
+            },
+            signers: vec![
+                SignerMessagePart {
+                    party_id: "123".to_string(),
+                    verification_key: "7b22766b223a5b3134332c3136312c3235352c34382c37382c35372c3230342c3232302c32352c3232312c3136342c3235322c3234382c31342c35362c3132362c3138362c3133352c3232382c3138382c3134352c3138312c35322c3230302c39372c39392c3231332c34362c302c3139392c3139332c38392c3138372c38382c32392c3133352c3137332c3234342c38362c33362c38332c35342c36372c3136342c362c3133372c39342c37322c362c3130352c3132382c3132382c39332c34382c3137362c31312c342c3234362c3133382c34382c3138302c3133332c39302c3134322c3139322c32342c3139332c3131312c3134322c33312c37362c3131312c3131302c3233342c3135332c39302c3230382c3139322c33312c3132342c39352c3130322c34392c3135382c39392c35322c3232302c3136352c39342c3235312c36382c36392c3132312c31362c3232342c3139345d2c22706f70223a5b3136382c35302c3233332c3139332c31352c3133362c36352c37322c3132332c3134382c3132392c3137362c33382c3139382c3230392c34372c32382c3230342c3137362c3134342c35372c3235312c34322c32382c36362c37362c38392c39372c3135382c36332c35342c3139382c3139342c3137362c3133352c3232312c31342c3138352c3139372c3232352c3230322c39382c3234332c37342c3233332c3232352c3134332c3135312c3134372c3137372c3137302c3131372c36362c3136352c36362c36322c33332c3231362c3233322c37352c36382c3131342c3139352c32322c3130302c36352c34342c3139382c342c3136362c3130322c3233332c3235332c3234302c35392c3137352c36302c3131372c3134322c3131342c3134302c3132322c31372c38372c3131302c3138372c312c31372c31302c3139352c3135342c31332c3234392c38362c35342c3232365d7d".to_string(),
+                    verification_key_signature: None,
+                    operational_certificate: None,
+                    kes_period: None
+                }
+            ],
+            next_signers: vec![
+                SignerMessagePart {
+                    party_id: "123".to_string(),
+                    verification_key: "7b22766b223a5b3134332c3136312c3235352c34382c37382c35372c3230342c3232302c32352c3232312c3136342c3235322c3234382c31342c35362c3132362c3138362c3133352c3232382c3138382c3134352c3138312c35322c3230302c39372c39392c3231332c34362c302c3139392c3139332c38392c3138372c38382c32392c3133352c3137332c3234342c38362c33362c38332c35342c36372c3136342c362c3133372c39342c37322c362c3130352c3132382c3132382c39332c34382c3137362c31312c342c3234362c3133382c34382c3138302c3133332c39302c3134322c3139322c32342c3139332c3131312c3134322c33312c37362c3131312c3131302c3233342c3135332c39302c3230382c3139322c33312c3132342c39352c3130322c34392c3135382c39392c35322c3232302c3136352c39342c3235312c36382c36392c3132312c31362c3232342c3139345d2c22706f70223a5b3136382c35302c3233332c3139332c31352c3133362c36352c37322c3132332c3134382c3132392c3137362c33382c3139382c3230392c34372c32382c3230342c3137362c3134342c35372c3235312c34322c32382c36362c37362c38392c39372c3135382c36332c35342c3139382c3139342c3137362c3133352c3232312c31342c3138352c3139372c3232352c3230322c39382c3234332c37342c3233332c3232352c3134332c3135312c3134372c3137372c3137302c3131372c36362c3136352c36362c36322c33332c3231362c3233322c37352c36382c3131342c3139352c32322c3130302c36352c34342c3139382c342c3136362c3130322c3233332c3235332c3234302c35392c3137352c36302c3131372c3134322c3131342c3134302c3132322c31372c38372c3131302c3138372c312c31372c31302c3139352c3135342c31332c3234392c38362c35342c3232365d7d".to_string(),
+                    verification_key_signature: None,
+                    operational_certificate: None,
+                    kes_period: None
+                }
+            ],
+        }
+    }
+
+    const ACTUAL_JSON: &str = r#"{
+            "epoch": 86,
+            "beacon": {
+                "network": "",
+                "epoch": 0,
+                "immutable_file_number": 0
+            },
+            "entity_type": {
+                "CardanoImmutableFilesFull": {
+                    "network": "preview",
+                    "epoch": 86,
+                    "immutable_file_number": 1728
+                }
+            },
+            "protocol": {
+                "k": 5,
+                "m": 100,
+                "phi_f": 0.65
+            },
+            "next_protocol": {
+                "k": 50,
+                "m": 1000,
+                "phi_f": 0.65
+            },
+            "signers": [
+                {
+                    "party_id": "123",
+                    "verification_key": "7b22766b223a5b3134332c3136312c3235352c34382c37382c35372c3230342c3232302c32352c3232312c3136342c3235322c3234382c31342c35362c3132362c3138362c3133352c3232382c3138382c3134352c3138312c35322c3230302c39372c39392c3231332c34362c302c3139392c3139332c38392c3138372c38382c32392c3133352c3137332c3234342c38362c33362c38332c35342c36372c3136342c362c3133372c39342c37322c362c3130352c3132382c3132382c39332c34382c3137362c31312c342c3234362c3133382c34382c3138302c3133332c39302c3134322c3139322c32342c3139332c3131312c3134322c33312c37362c3131312c3131302c3233342c3135332c39302c3230382c3139322c33312c3132342c39352c3130322c34392c3135382c39392c35322c3232302c3136352c39342c3235312c36382c36392c3132312c31362c3232342c3139345d2c22706f70223a5b3136382c35302c3233332c3139332c31352c3133362c36352c37322c3132332c3134382c3132392c3137362c33382c3139382c3230392c34372c32382c3230342c3137362c3134342c35372c3235312c34322c32382c36362c37362c38392c39372c3135382c36332c35342c3139382c3139342c3137362c3133352c3232312c31342c3138352c3139372c3232352c3230322c39382c3234332c37342c3233332c3232352c3134332c3135312c3134372c3137372c3137302c3131372c36362c3136352c36362c36322c33332c3231362c3233322c37352c36382c3131342c3139352c32322c3130302c36352c34342c3139382c342c3136362c3130322c3233332c3235332c3234302c35392c3137352c36302c3131372c3134322c3131342c3134302c3132322c31372c38372c3131302c3138372c312c31372c31302c3139352c3135342c31332c3234392c38362c35342c3232365d7d"
+                }
+            ],
+            "next_signers": [
+                {
+                    "party_id": "123",
+                    "verification_key": "7b22766b223a5b3134332c3136312c3235352c34382c37382c35372c3230342c3232302c32352c3232312c3136342c3235322c3234382c31342c35362c3132362c3138362c3133352c3232382c3138382c3134352c3138312c35322c3230302c39372c39392c3231332c34362c302c3139392c3139332c38392c3138372c38382c32392c3133352c3137332c3234342c38362c33362c38332c35342c36372c3136342c362c3133372c39342c37322c362c3130352c3132382c3132382c39332c34382c3137362c31312c342c3234362c3133382c34382c3138302c3133332c39302c3134322c3139322c32342c3139332c3131312c3134322c33312c37362c3131312c3131302c3233342c3135332c39302c3230382c3139322c33312c3132342c39352c3130322c34392c3135382c39392c35322c3232302c3136352c39342c3235312c36382c36392c3132312c31362c3232342c3139345d2c22706f70223a5b3136382c35302c3233332c3139332c31352c3133362c36352c37322c3132332c3134382c3132392c3137362c33382c3139382c3230392c34372c32382c3230342c3137362c3134342c35372c3235312c34322c32382c36362c37362c38392c39372c3135382c36332c35342c3139382c3139342c3137362c3133352c3232312c31342c3138352c3139372c3232352c3230322c39382c3234332c37342c3233332c3232352c3134332c3135312c3134372c3137372c3137302c3131372c36362c3136352c36362c36322c33332c3231362c3233322c37352c36382c3131342c3139352c32322c3130302c36352c34342c3139382c342c3136362c3130322c3233332c3235332c3234302c35392c3137352c36302c3131372c3134322c3131342c3134302c3132322c31372c38372c3131302c3138372c312c31372c31302c3139352c3135342c31332c3234392c38362c35342c3232365d7d"
+                }
+            ]
+        }"#;
+
+    fn golden_actual_message() -> CertificatePendingMessage {
+        let beacon = CardanoDbBeacon {
+            network: "preview".to_string(),
+            epoch: Epoch(86),
+            immutable_file_number: 1728,
+        };
+        let deprecated_beacon = CardanoDbBeacon {
+            network: "".to_string(),
+            epoch: Epoch(0),
+            immutable_file_number: 0,
+        };
+
         #[allow(deprecated)]
         CertificatePendingMessage {
             epoch: beacon.epoch,
-            beacon: beacon.clone(),
+            beacon: Some(deprecated_beacon),
             signed_entity_type: SignedEntityType::CardanoImmutableFilesFull(beacon),
             protocol_parameters: ProtocolParameters {
                 k: 5,
@@ -110,14 +231,25 @@ mod tests {
     }
 
     #[test]
-    fn test_v1() {
-        let json = r#"{
+    fn test_actual_json_deserialized_into_previous_message() {
+        let json = ACTUAL_JSON;
+        let message: CertificatePendingMessagePreviousVersion = serde_json::from_str(json).unwrap();
+
+        assert_eq!(golden_previous_message(), message);
+    }
+
+    #[test]
+    fn test_actual_json_deserialized_into_actual_message() {
+        let json = ACTUAL_JSON;
+        let message: CertificatePendingMessage = serde_json::from_str(json).unwrap();
+
+        assert_eq!(golden_actual_message(), message);
+    }
+
+    #[test]
+    fn test_json_next_version_deserialized_into_actual_message() {
+        let next_json = r#"{
             "epoch": 86,
-            "beacon": {
-                "network": "preview",
-                "epoch": 86,
-                "immutable_file_number": 1728
-            },
             "entity_type": {
                 "CardanoImmutableFilesFull": {
                     "network": "preview",
@@ -148,8 +280,14 @@ mod tests {
                 }
             ]
         }"#;
-        let message: CertificatePendingMessage = serde_json::from_str(json).unwrap();
+        let message: CertificatePendingMessage = serde_json::from_str(next_json).unwrap();
 
-        assert_eq!(golden_message(), message);
+        #[allow(deprecated)]
+        let golden_message = CertificatePendingMessage {
+            beacon: None,
+            ..golden_actual_message()
+        };
+
+        assert_eq!(golden_message, message);
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.25
+  version: 0.1.26
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -678,7 +678,6 @@ components:
       additionalProperties: false
       required:
         - epoch
-        - beacon
         - entity_type
         - protocol
         - next_protocol


### PR DESCRIPTION
## Content

Improve certificate pending route performance of the aggregator removing the call to the Chain Observer used to retrieve the time point.
The beacon is now optional in the certificate pending route so it could be removed in a future version.

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

Output of `ab` command on `testing-preview` with 1000 requests **before applying changes**:
`ab -n 1000 -c 10 -w https://aggregator.testing-preview.api.mithril.network/aggregator/certificate-pending`

| key                  | value                                          |
| -------------------- | ---------------------------------------------- |
| Server Hostname      | aggregator.testing-preview.api.mithril.network |
| Server Port          | 443                                            |
| Document Path        | /aggregator/certificate-pending                |
| Concurrency Level    | 10                                             |

| run | Requests per second |
| --- | ---------------------- |
| 1  | 27.58                               |
| 2  | 27.89                               |
| 3 | 28.33                              |
| 4  | 27.93                              |
| 5  |  28.02                               |

## Issue(s)
Closes #1804
