### PR TITLE
Update CHANGELOG with `2428` distribution release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX.X] - UNRELEASED
 
+- Crates versions:
+
+| Crate | Version |
+| ----- | ------- |
+| N/A   | `-`     |
+
+## Mithril Distribution [2428.0] - UNRELEASED
+
 - Provide a feature to the `mithril-client` crate to allow selection of the TLS implementation used by the dependent `reqwest` crate.
 
 - Implement a reset mechanism for mutable resources returned to a pool (`ResourcePool`) to keep it in a consistent state.


### PR DESCRIPTION
## Content
This PR includes the rotation of the `CHANGELOG` file preparing the release of the `2428` distribution.

## Pre-submit checklist

- Branch
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1810
