### PR TITLE
Fix Signer `make test` command errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.161"
+version = "0.2.162"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.161"
+version = "0.2.162"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/aggregator_client.rs
+++ b/mithril-signer/src/aggregator_client.rs
@@ -492,21 +492,21 @@ mod tests {
         )
     }
 
-    fn set_returning_412(server: MockServer) {
-        let _mock_412 = server.mock(|_, then| {
+    fn set_returning_412(server: &MockServer) {
+        server.mock(|_, then| {
             then.status(412)
                 .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
         });
     }
 
-    fn set_returning_500(server: MockServer) {
-        let _server_mock = server.mock(|_, then| {
+    fn set_returning_500(server: &MockServer) {
+        server.mock(|_, then| {
             then.status(500).body("an error occurred");
         });
     }
 
-    fn set_unparsable_json(server: MockServer) {
-        let _server_mock = server.mock(|_, then| {
+    fn set_unparsable_json(server: &MockServer) {
+        server.mock(|_, then| {
             then.status(200).body("this is not a json");
         });
     }
@@ -528,7 +528,7 @@ mod tests {
     #[tokio::test]
     async fn test_aggregator_features_ko_412() {
         let (server, client) = setup_server_and_client();
-        set_returning_412(server);
+        set_returning_412(&server);
 
         let error = client.retrieve_aggregator_features().await.unwrap_err();
 
@@ -538,7 +538,7 @@ mod tests {
     #[tokio::test]
     async fn test_aggregator_features_ko_500() {
         let (server, client) = setup_server_and_client();
-        set_returning_500(server);
+        set_returning_500(&server);
 
         let error = client.retrieve_aggregator_features().await.unwrap_err();
 
@@ -548,7 +548,7 @@ mod tests {
     #[tokio::test]
     async fn test_aggregator_features_ko_json_serialization() {
         let (server, client) = setup_server_and_client();
-        set_unparsable_json(server);
+        set_unparsable_json(&server);
 
         let error = client.retrieve_aggregator_features().await.unwrap_err();
 


### PR DESCRIPTION
## Content
This PR includes modifications in the `aggregator_client` tests of the `mithril-signer`.
`MockServer` passed as a parameter was being consumed, leading to errors in the tests.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1816 
