### PR TITLE
Fix: missing configuration in terraform deployment action in CI/CD

### DIFF
--- a/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
+++ b/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
@@ -196,6 +196,7 @@ runs:
           mithril_aggregator_cexplorer_pools_url                                    = "${{ inputs.mithril_aggregator_cexplorer_pools_url }}"
           mithril_aggregator_allow_unparsable_block                                 = "${{ inputs.mithril_aggregator_allow_unparsable_block }}"
           mithril_aggregator_cardano_transactions_prover_cache_pool_size            = "${{ inputs.mithril_aggregator_cardano_transactions_prover_cache_pool_size }}"
+          mithril_aggregator_cardano_transactions_database_connection_pool_size     = "${{ inputs.mithril_aggregator_cardano_transactions_database_connection_pool_size }}"
           mithril_aggregator_cardano_transactions_signing_config_security_parameter = "${{ inputs.mithril_aggregator_cardano_transactions_signing_config_security_parameter }}"
           mithril_aggregator_cardano_transactions_signing_config_step               = "${{ inputs.mithril_aggregator_cardano_transactions_signing_config_step }}"
           prometheus_auth_username                                                  = "${{ inputs.prometheus_auth_username }}"


### PR DESCRIPTION
## Content
This PR includes a fix to the terraform deployment action in the CI/CD where a configuration parameter was missing

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Issue(s)
Relates to #1814 
