### PR TITLE
Ensemble/1792/non blocking artifact production in aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX.X] - UNRELEASED
 
+- `mithril-aggregator` node produces artifact for different signed entity types in parallel.
+
 - **UNSTABLE** Cardano transactions certification:
 
   - Make Cardano transaction signing settings configurable via the CD.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.42"
+version = "0.5.43"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.42"
+version = "0.5.43"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1135,6 +1135,7 @@ impl DependenciesBuilder {
             mithril_stake_distribution_artifact_builder,
             cardano_immutable_files_full_artifact_builder,
             cardano_transactions_artifact_builder,
+            self.get_signed_entity_lock().await?,
         ));
 
         // Compute the cache pool for prover service

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -2,7 +2,7 @@
 //!
 //! This service is responsible for dealing with [SignedEntity] type.
 //! It creates [Artifact] that can be accessed by clients.
-use anyhow::Context;
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use chrono::Utc;
 use slog_scope::info;
@@ -16,6 +16,7 @@ use mithril_common::{
         Snapshot,
     },
     signable_builder::Artifact,
+    signed_entity_type_lock::SignedEntityTypeLock,
     StdResult,
 };
 
@@ -79,6 +80,7 @@ pub struct MithrilSignedEntityService {
         Arc<dyn ArtifactBuilder<CardanoDbBeacon, Snapshot>>,
     cardano_transactions_artifact_builder:
         Arc<dyn ArtifactBuilder<BlockNumber, CardanoTransactionsSnapshot>>,
+    signed_entity_type_lock: Arc<SignedEntityTypeLock>,
 }
 
 impl MithrilSignedEntityService {
@@ -94,29 +96,56 @@ impl MithrilSignedEntityService {
         cardano_transactions_artifact_builder: Arc<
             dyn ArtifactBuilder<BlockNumber, CardanoTransactionsSnapshot>,
         >,
+        signed_entity_type_lock: Arc<SignedEntityTypeLock>,
     ) -> Self {
         Self {
             signed_entity_storer,
             mithril_stake_distribution_artifact_builder,
             cardano_immutable_files_full_artifact_builder,
             cardano_transactions_artifact_builder,
+            signed_entity_type_lock,
         }
     }
 
-    fn create_artifact_return_join_handle(
+    async fn create_artifact_return_join_handle(
         &self,
         signed_entity_type: SignedEntityType,
         certificate: &Certificate,
-    ) -> JoinHandle<StdResult<()>> {
+    ) -> StdResult<JoinHandle<StdResult<()>>> {
+        if self
+            .signed_entity_type_lock
+            .is_locked(&signed_entity_type)
+            .await
+        {
+            return Err(anyhow!(
+                "Signed entity type '{:?}' is already locked",
+                signed_entity_type
+            ));
+        }
+
         let service = self.clone();
         let certificate_cloned = certificate.clone();
-        tokio::task::spawn_blocking(|| {
-            Handle::current().block_on(async move {
-                service
-                    .create_artifact(signed_entity_type, &certificate_cloned)
+        service
+            .signed_entity_type_lock
+            .lock(&signed_entity_type)
+            .await;
+
+        Ok(tokio::task::spawn(async move {
+            let signed_entity_type_clone = signed_entity_type.clone();
+            let service_clone = service.clone();
+            let result = tokio::task::spawn(async move {
+                service_clone
+                    .create_artifact(signed_entity_type_clone, &certificate_cloned)
                     .await
             })
-        })
+            .await;
+            service
+                .signed_entity_type_lock
+                .release(signed_entity_type)
+                .await;
+
+            result.unwrap()
+        }))
     }
 
     /// Compute artifact from signed entity type
@@ -188,6 +217,11 @@ impl SignedEntityService for MithrilSignedEntityService {
             "MithrilSignedEntityService::create_artifact";
             "signed_entity_type" => ?signed_entity_type,
             "certificate_hash" => &certificate.hash
+        );
+
+        println!(
+            "MithrilSignedEntityService::create_artifact: signed_entity_type: {:?}, certificate_hash: {}",
+            signed_entity_type, certificate.hash
         );
 
         let mut remaining_retries = 2;
@@ -317,7 +351,7 @@ impl SignedEntityService for MithrilSignedEntityService {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
+    use std::{sync::atomic::Ordering, time::Duration};
 
     use mithril_common::{
         entities::{CardanoTransactionsSnapshot, Epoch},
@@ -325,6 +359,7 @@ mod tests {
         test_utils::fake_data,
     };
     use serde::{de::DeserializeOwned, Serialize};
+    use std::sync::atomic::AtomicBool;
 
     use crate::artifact_builder::MockArtifactBuilder;
     use crate::database::repository::MockSignedEntityStorer;
@@ -386,6 +421,58 @@ mod tests {
                 Arc::new(self.mock_mithril_stake_distribution_artifact_builder),
                 Arc::new(self.mock_cardano_immutable_files_full_artifact_builder),
                 Arc::new(self.mock_cardano_transactions_artifact_builder),
+                Arc::new(SignedEntityTypeLock::default()),
+            )
+        }
+
+        fn build_artifact_builder_service_with_time_consuming_process(
+            mut self,
+            atomic_stop: Arc<AtomicBool>,
+        ) -> MithrilSignedEntityService {
+            struct LongArtifactBuilder {
+                atomic_stop: Arc<AtomicBool>,
+                snapshot: Snapshot,
+            }
+            impl LongArtifactBuilder {}
+
+            let snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
+
+            #[async_trait]
+            impl ArtifactBuilder<CardanoDbBeacon, Snapshot> for LongArtifactBuilder {
+                async fn compute_artifact(
+                    &self,
+                    _beacon: CardanoDbBeacon,
+                    _certificate: &Certificate,
+                ) -> StdResult<Snapshot> {
+                    let mut max_iteration = 100;
+                    while !self.atomic_stop.load(Ordering::Relaxed) {
+                        max_iteration -= 1;
+                        if max_iteration <= 0 {
+                            return Err(anyhow!("Test should handle the stop"));
+                        }
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                    }
+                    Ok(self.snapshot.clone())
+                }
+            }
+            let cardano_immutable_files_full_long_artifact_builder = LongArtifactBuilder {
+                atomic_stop: atomic_stop.clone(),
+                snapshot: snapshot.clone(),
+            };
+
+            let artifact_clone: Arc<dyn Artifact> = Arc::new(snapshot);
+            let signed_entity_artifact = serde_json::to_string(&artifact_clone).unwrap();
+            self.mock_signed_entity_storer
+                .expect_store_signed_entity()
+                .withf(move |signed_entity| signed_entity.artifact == signed_entity_artifact)
+                .return_once(|_| Ok(()));
+
+            MithrilSignedEntityService::new(
+                Arc::new(self.mock_signed_entity_storer),
+                Arc::new(self.mock_mithril_stake_distribution_artifact_builder),
+                Arc::new(cardano_immutable_files_full_long_artifact_builder),
+                Arc::new(self.mock_cardano_transactions_artifact_builder),
+                Arc::new(SignedEntityTypeLock::default()),
             )
         }
 
@@ -585,7 +672,7 @@ mod tests {
     // TODO: Verify the relevance of this test
     #[tokio::test]
     async fn create_artifact_for_two_signed_entity_types_in_sequence() {
-        let artifact_builder_service = {
+        let signed_entity_type_service = {
             let mut mock_container = MockDependencyInjector::new();
             mock_container.mock_immutable_files_processing(
                 fake_data::snapshots(1).first().unwrap().to_owned(),
@@ -599,13 +686,13 @@ mod tests {
 
         let signed_entity_type_immutable =
             SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
-        artifact_builder_service
+        signed_entity_type_service
             .create_artifact(signed_entity_type_immutable, &certificate)
             .await
             .unwrap();
 
         let signed_entity_type_msd = SignedEntityType::MithrilStakeDistribution(Epoch(1));
-        artifact_builder_service
+        signed_entity_type_service
             .create_artifact(signed_entity_type_msd, &certificate)
             .await
             .unwrap();
@@ -613,35 +700,153 @@ mod tests {
 
     #[tokio::test]
     async fn create_artifact_for_two_signed_entity_types_in_sequence_not_blocking() {
-        let artifact_builder_service = {
+        let atomic_stop = Arc::new(AtomicBool::new(false));
+        let signed_entity_type_service = {
             let mut mock_container = MockDependencyInjector::new();
-            let snapshot = fake_data::snapshots(1).first().unwrap().to_owned();
-            mock_container
-                .mock_cardano_immutable_files_full_artifact_builder
-                .expect_compute_artifact()
-                .times(1)
-                .return_once(|_, _| {
-                    std::thread::sleep(Duration::from_millis(1000));
-                    Ok(snapshot)
-                });
 
             let msd = create_stake_distribution(Epoch(1), 5);
             mock_container.mock_stake_distribution_processing(msd);
 
-            Arc::new(mock_container.build_artifact_builder_service())
+            mock_container
+                .build_artifact_builder_service_with_time_consuming_process(atomic_stop.clone())
         };
         let certificate = fake_data::certificate("hash".to_string());
 
         let signed_entity_type_immutable =
             SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
-        let first_task_that_never_finished = artifact_builder_service
-            .create_artifact_return_join_handle(signed_entity_type_immutable, &certificate);
+        let first_task_that_never_finished = signed_entity_type_service
+            .create_artifact_return_join_handle(signed_entity_type_immutable, &certificate)
+            .await
+            .unwrap();
 
         let signed_entity_type_msd = SignedEntityType::MithrilStakeDistribution(Epoch(1));
-        let second_task_that_finish_first = artifact_builder_service
-            .create_artifact_return_join_handle(signed_entity_type_msd, &certificate);
+        let second_task_that_finish_first = signed_entity_type_service
+            .create_artifact_return_join_handle(signed_entity_type_msd, &certificate)
+            .await
+            .unwrap();
 
-        let _ = second_task_that_finish_first.await.unwrap();
+        second_task_that_finish_first.await.unwrap().unwrap();
         assert!(!first_task_that_never_finished.is_finished());
+
+        atomic_stop.swap(true, Ordering::Relaxed);
+    }
+
+    #[tokio::test]
+    async fn create_artifact_lock_unlock_signed_entity_type_while_processing() {
+        let atomic_stop = Arc::new(AtomicBool::new(false));
+        let signed_entity_type_service = MockDependencyInjector::new()
+            .build_artifact_builder_service_with_time_consuming_process(atomic_stop.clone());
+        let certificate = fake_data::certificate("hash".to_string());
+
+        let signed_entity_type_immutable =
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
+        assert!(
+            !signed_entity_type_service
+                .signed_entity_type_lock
+                .is_locked(&signed_entity_type_immutable)
+                .await
+        );
+        let join_handle = signed_entity_type_service
+            .create_artifact_return_join_handle(signed_entity_type_immutable.clone(), &certificate)
+            .await
+            .unwrap();
+
+        // Results are stored to finalize the task before assertions,
+        // ensuring 'atomic_stop' is always assigned a new value.
+        let is_locked = signed_entity_type_service
+            .signed_entity_type_lock
+            .is_locked(&signed_entity_type_immutable)
+            .await;
+        let is_finished = join_handle.is_finished();
+
+        atomic_stop.swap(true, Ordering::Relaxed);
+        join_handle.await.unwrap().unwrap();
+
+        assert!(is_locked);
+        assert!(!is_finished);
+
+        assert!(
+            !signed_entity_type_service
+                .signed_entity_type_lock
+                .is_locked(&signed_entity_type_immutable)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn create_artifact_unlock_signed_entity_type_when_error() {
+        let signed_entity_type_service = {
+            let mut mock_container = MockDependencyInjector::new();
+            mock_container
+                .mock_cardano_immutable_files_full_artifact_builder
+                .expect_compute_artifact()
+                .returning(|_, _| Err(anyhow::anyhow!("Error while computing artifact")));
+
+            mock_container.build_artifact_builder_service()
+        };
+        let certificate = fake_data::certificate("hash".to_string());
+
+        let signed_entity_type_immutable =
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
+
+        let join_handle = signed_entity_type_service
+            .create_artifact_return_join_handle(signed_entity_type_immutable.clone(), &certificate)
+            .await
+            .unwrap();
+
+        join_handle.await.unwrap().unwrap_err();
+
+        assert!(
+            !signed_entity_type_service
+                .signed_entity_type_lock
+                .is_locked(&signed_entity_type_immutable)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn create_artifact_unlock_signed_entity_type_when_panic() {
+        let signed_entity_type_service =
+            MockDependencyInjector::new().build_artifact_builder_service();
+        let certificate = fake_data::certificate("hash".to_string());
+
+        let signed_entity_type_immutable =
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
+
+        let join_handle = signed_entity_type_service
+            .create_artifact_return_join_handle(signed_entity_type_immutable.clone(), &certificate)
+            .await
+            .unwrap();
+
+        join_handle.await.unwrap_err();
+
+        assert!(
+            !signed_entity_type_service
+                .signed_entity_type_lock
+                .is_locked(&signed_entity_type_immutable)
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn create_artifact_for_a_signed_entity_type_already_lock_return_error() {
+        let atomic_stop = Arc::new(AtomicBool::new(false));
+        let signed_entity_service = MockDependencyInjector::new()
+            .build_artifact_builder_service_with_time_consuming_process(atomic_stop.clone());
+        let certificate = fake_data::certificate("hash".to_string());
+        let signed_entity_type_immutable =
+            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
+
+        signed_entity_service
+            .create_artifact_return_join_handle(signed_entity_type_immutable.clone(), &certificate)
+            .await
+            .unwrap();
+
+        signed_entity_service
+            .create_artifact_return_join_handle(signed_entity_type_immutable, &certificate)
+            .await
+            .expect_err("Should return error when signed entity type is already locked");
+
+        atomic_stop.swap(true, Ordering::Relaxed);
     }
 }

--- a/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
@@ -112,4 +112,34 @@ impl AggregatorObserver {
             .signed_entity_config
             .time_point_to_signed_entity(discriminant, &time_point))
     }
+
+    pub async fn is_last_signed_entity(
+        &self,
+        signed_entity_type_expected: &SignedEntityType,
+    ) -> StdResult<bool> {
+        match signed_entity_type_expected {
+            SignedEntityType::CardanoImmutableFilesFull(_) => Ok(Some(signed_entity_type_expected)
+                == self
+                    .signed_entity_service
+                    .get_last_signed_snapshots(1)
+                    .await?
+                    .first()
+                    .map(|s| &s.signed_entity_type)),
+            SignedEntityType::MithrilStakeDistribution(_) => Ok(Some(signed_entity_type_expected)
+                == self
+                    .signed_entity_service
+                    .get_last_signed_mithril_stake_distributions(1)
+                    .await?
+                    .first()
+                    .map(|s| &s.signed_entity_type)),
+            SignedEntityType::CardanoTransactions(_, _) => Ok(Some(signed_entity_type_expected)
+                == self
+                    .signed_entity_service
+                    .get_last_cardano_transaction_snapshot()
+                    .await?
+                    .map(|s| s.signed_entity_type)
+                    .as_ref()),
+            _ => Ok(false),
+        }
+    }
 }

--- a/mithril-aggregator/tests/test_extensions/expected_certificate.rs
+++ b/mithril-aggregator/tests/test_extensions/expected_certificate.rs
@@ -50,4 +50,8 @@ impl ExpectedCertificate {
     pub fn genesis_identifier(beacon: &CardanoDbBeacon) -> String {
         format!("genesis-{:?}", beacon)
     }
+
+    pub fn get_signed_type(&self) -> Option<SignedEntityType> {
+        self.signed_type.clone()
+    }
 }

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -9,6 +9,7 @@ use mithril_aggregator::{
     AggregatorRuntime, Configuration, DependencyContainer, DumbSnapshotUploader, DumbSnapshotter,
     SignerRegistrationError,
 };
+use mithril_common::entities::SignedEntityType;
 use mithril_common::{
     cardano_block_scanner::{DumbBlockScanner, ScannedBlock},
     chain_observer::{ChainObserver, FakeObserver},
@@ -51,6 +52,13 @@ macro_rules! cycle_err {
 #[macro_export]
 macro_rules! assert_last_certificate_eq {
     ( $tester:expr, $expected_certificate:expr ) => {{
+        if let Some(signed_type) = $expected_certificate.get_signed_type() {
+            $tester
+                .wait_until_signed_entity(&signed_type)
+                .await
+                .unwrap();
+        }
+
         let last_certificate = RuntimeTester::get_last_expected_certificate(&mut $tester)
             .await
             .unwrap();
@@ -567,5 +575,29 @@ impl RuntimeTester {
         };
 
         Ok(cert_identifier)
+    }
+
+    /// Wait until the last stored signed entity of the given type
+    /// corresponds to the expected signed entity type
+    pub async fn wait_until_signed_entity(
+        &self,
+        signed_entity_type_expected: &SignedEntityType,
+    ) -> StdResult<()> {
+        let mut max_iteration = 100;
+        while !self
+            .observer
+            .is_last_signed_entity(signed_entity_type_expected)
+            .await?
+        {
+            max_iteration -= 1;
+            if max_iteration <= 0 {
+                return Err(anyhow!(
+                    "Signed entity not found: {signed_entity_type_expected}"
+                ));
+            }
+            tokio::time::sleep(Duration::from_millis(1)).await;
+        }
+
+        Ok(())
     }
 }

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -9,7 +9,6 @@ use mithril_aggregator::{
     AggregatorRuntime, Configuration, DependencyContainer, DumbSnapshotUploader, DumbSnapshotter,
     SignerRegistrationError,
 };
-use mithril_common::entities::SignedEntityType;
 use mithril_common::{
     cardano_block_scanner::{DumbBlockScanner, ScannedBlock},
     chain_observer::{ChainObserver, FakeObserver},
@@ -17,7 +16,7 @@ use mithril_common::{
     digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
     entities::{
         BlockNumber, Certificate, CertificateSignature, ChainPoint, Epoch, ImmutableFileNumber,
-        SignedEntityTypeDiscriminants, Snapshot, StakeDistribution, TimePoint,
+        SignedEntityType, SignedEntityTypeDiscriminants, Snapshot, StakeDistribution, TimePoint,
     },
     era::{adapters::EraReaderDummyAdapter, EraMarker, EraReader, SupportedEra},
     test_utils::{


### PR DESCRIPTION
## Content

This PR isolate artifact production in a separate thread to avoid blocking the signature of new open messages when the aggregator is computing the artifact for a signed entity type.

The signed entity type is locked during the operation to prevent to compute two signed entity of the same type at the same time.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1792
