### PR TITLE
Make upper bound of `ChainReaderBlockStreamer` inclusive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.43"
+version = "0.5.44"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.30"
+version = "0.4.31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3848,7 +3848,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.165"
+version = "0.2.166"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.43"
+version = "0.5.44"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.30"
+version = "0.4.31"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
+++ b/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
@@ -109,7 +109,7 @@ impl ChainReaderBlockStreamer {
         let mut chain_reader = self.chain_reader.try_lock()?;
         match chain_reader.get_next_chain_block().await? {
             Some(ChainBlockNextAction::RollForward { parsed_block }) => {
-                if parsed_block.block_number >= self.until {
+                if parsed_block.block_number > self.until {
                     trace!(
                         self.logger,
                         "ChainReaderBlockStreamer received a RollForward above threshold block number ({})",
@@ -165,7 +165,7 @@ mod tests {
     const MAX_ROLL_FORWARDS_PER_POLL: usize = 100;
 
     #[tokio::test]
-    async fn test_parse_expected_nothing_above_block_number_threshold() {
+    async fn test_parse_expected_nothing_strictly_above_block_number_threshold() {
         let until_block_number = 10;
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollForward {
@@ -190,7 +190,7 @@ mod tests {
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
             chain_reader.clone(),
             None,
-            until_block_number,
+            until_block_number - 1,
             MAX_ROLL_FORWARDS_PER_POLL,
             TestLogger::stdout(),
         )
@@ -203,7 +203,7 @@ mod tests {
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
             chain_reader,
             None,
-            until_block_number + 1,
+            until_block_number,
             MAX_ROLL_FORWARDS_PER_POLL,
             TestLogger::stdout(),
         )

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.165"
+version = "0.2.166"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.21"
+version = "0.4.22"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -89,7 +89,7 @@ impl Aggregator {
             ("CARDANO_TRANSACTIONS_DATABASE_CONNECTION_POOL_SIZE", "5"),
             (
                 "CARDANO_TRANSACTIONS_SIGNING_CONFIG__SECURITY_PARAMETER",
-                "1",
+                "15",
             ),
             ("CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP", "15"),
         ]);


### PR DESCRIPTION
## Content

This PR changes how the `ChainReaderBlockStreamer` handle it's upper bound (its `until` parameter): 
Before its upper bound was exclusive, this was fine when others subsystems were also exclusive but this changed with the fixes for #1785: now the `until` parameter is the last block to include in the signature instead of being the block where to stop polling.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

Should this parameter be still named `until` ?

## Issue(s)

Relates to #1785
