### PR TITLE
fix: `ChainReader` fails on `find_intersect_point` without agency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - `mithril-aggregator` node produces artifact for different signed entity types in parallel.
 
+- Fix `Agency is theirs` error in the `ChainReader` when the underlying `Chain sync` client does not have agency.
+
 - **UNSTABLE** Cardano transactions certification:
 
   - Make Cardano transaction signing settings configurable via the CD.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.34"
+version = "0.4.35"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.34"
+version = "0.4.35"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -89,7 +89,7 @@ impl Aggregator {
             ("CARDANO_TRANSACTIONS_DATABASE_CONNECTION_POOL_SIZE", "5"),
             (
                 "CARDANO_TRANSACTIONS_SIGNING_CONFIG__SECURITY_PARAMETER",
-                "15",
+                "1",
             ),
             ("CARDANO_TRANSACTIONS_SIGNING_CONFIG__STEP", "15"),
         ]);


### PR DESCRIPTION
## Content
This PR includes a fix to the **Chain Reader**: 
when the **Chain Sync** client does not have agency (i.e. is waiting for the server to callback), the find intersect point call to the **Chain Sync** is not allowed and is now skipped in the `find_intersect_point` function of the **Chain Reader**.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1836 
