### PR TITLE
fix: clippy warnings with Rust `1.80.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-build-script"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "semver",
  "serde_json",
@@ -3624,7 +3624,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.8"
+version = "0.8.9"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.35"
+version = "0.4.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3883,7 +3883,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.24"
+version = "0.3.25"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/internal/mithril-build-script/Cargo.toml
+++ b/internal/mithril-build-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-build-script"
-version = "0.2.6"
+version = "0.2.7"
 description = "A toolbox for Mithril crates build scripts"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-build-script/src/fake_aggregator.rs
+++ b/internal/mithril-build-script/src/fake_aggregator.rs
@@ -36,7 +36,7 @@ impl FakeAggregatorData {
 
         for entry in list_json_files_in_folder(folder) {
             let filename = entry.file_name().to_string_lossy().to_string();
-            let file_content = fs::read_to_string(&entry.path()).unwrap_or_else(|_| {
+            let file_content = fs::read_to_string(entry.path()).unwrap_or_else(|_| {
                 panic!(
                     "Could not read file content, file_path: {}",
                     entry.path().display()

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.9.7"
+version = "0.9.8"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/lib.rs
+++ b/mithril-client-cli/src/lib.rs
@@ -5,7 +5,7 @@
 //! * Cardano DB: List, Show, download and verify
 //! * Mithril Stake Distribution: List, download and verify
 //
-//! You can find more information on how it works reading the [documentation website](https://mithril.network/doc/mithril/mithril-network/client).
+//!   You can find more information on how it works reading the [documentation website](https://mithril.network/doc/mithril/mithril-network/client).
 
 pub mod commands;
 mod configuration;

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.8"
+version = "0.8.9"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/cardano_transaction_client.rs
+++ b/mithril-client/src/cardano_transaction_client.rs
@@ -2,11 +2,11 @@
 //!
 //! In order to do so it defines a [CardanoTransactionClient] which exposes the following features:
 //!  - [get_proofs][CardanoTransactionClient::get_proofs]: get a [cryptographic proof][CardanoTransactionsProofs]
-//! that the transactions with given hash are included in the global Cardano transactions set.
+//!    that the transactions with given hash are included in the global Cardano transactions set.
 //!  - [get][CardanoTransactionClient::get_snapshot]: get a [Cardano transaction snapshot][CardanoTransactionSnapshot]
-//! data from its hash.
+//!    data from its hash.
 //!  - [list][CardanoTransactionClient::list_snapshots]: get the list of the latest available Cardano transaction
-//! snapshot.
+//!    snapshot.
 //!
 //!  **Important:** Verifying a proof **only** means that its cryptography is valid, in order to certify that a Cardano
 //! transactions subset is valid, the associated proof must be tied to a valid Mithril certificate (see the example below).

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -9,7 +9,7 @@
 //! - [Snapshot][snapshot_client] list, get, download tarball and record statistics.
 //! - [Mithril stake distribution][mithril_stake_distribution_client] list and get.
 //! - [Cardano transactions][cardano_transaction_client] list & get snapshot, get proofs
-//! _(available using crate feature_ **unstable**_)_.
+//!   _(available using crate feature_ **unstable**_)_.
 //! - [Certificates][certificate_client] list, get, and chain validation.
 //!
 //! The [Client] aggregates the queries of all of those types.

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.35"
+version = "0.4.36"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -104,7 +104,7 @@ impl Certificate {
             }
             CertificateSignature::MultiSignature(signed_entity_type, signature) => {
                 signed_entity_type.feed_hash(&mut hasher);
-                hasher.update(&signature.to_json_hex().unwrap());
+                hasher.update(signature.to_json_hex().unwrap());
             }
         };
         hex::encode(hasher.finalize())

--- a/mithril-common/src/entities/signed_entity_config.rs
+++ b/mithril-common/src/entities/signed_entity_config.rs
@@ -137,9 +137,9 @@ impl CardanoTransactionsSigningConfig {
     ///
     /// *Notes:*
     /// * *The step is adjusted to be a multiple of the block range length in order
-    /// to guarantee that the block number signed in a certificate is effectively signed.*
+    ///   to guarantee that the block number signed in a certificate is effectively signed.*
     /// * *1 is subtracted to the result because block range end is exclusive (ie: a BlockRange over
-    /// `30..45` finish at 44 included, 45 is included in the next block range).*
+    ///   `30..45` finish at 44 included, 45 is included in the next block range).*
     pub fn compute_block_number_to_be_signed(&self, block_number: BlockNumber) -> BlockNumber {
         // TODO: See if we can remove this adjustment by including a "partial" block range in
         // the signed data.

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -6,7 +6,7 @@
 //! Provide:
 //! - [Digester][digesters] to compute mithril digest from a Cardano database
 //! - Helpers for the [Mithril STM](https://mithril.network/rust-doc/mithril_stm/index.html)
-//! lib with the [crypto_helper].
+//!   lib with the [crypto_helper].
 //! - [certificate chain][certificate_chain] used to validate the Certificate Chain created by an aggregator
 //! - The [entities] used by, and exchanged between, the aggregator, signers and client.
 

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -54,5 +54,7 @@ harness = false
 default = ["rug-backend"]
 rug-backend = ["rug/default"]
 num-integer-backend = ["num-bigint", "num-rational", "num-traits"]
-portable = []                                                      # deprecated, will be removed soon
-benchmark-internals = []                                           # For benchmarking multi_sig
+portable = [] # deprecated, will be removed soon
+benchmark-internals = [] # For benchmarking multi_sig
+batch-verify-aggregates = [
+] # For batch verification of multi-signatures (set automatically by build script)

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.24"
+version = "0.3.25"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/merkle_tree.rs
+++ b/mithril-stm/src/merkle_tree.rs
@@ -367,7 +367,7 @@ impl<D: Clone + Digest> MerkleTreeCommitmentBatchCompat<D> {
                         new_hashes.push(
                             D::new()
                                 .chain(&leaves[i])
-                                .chain(&D::digest([0u8]))
+                                .chain(D::digest([0u8]))
                                 .finalize()
                                 .to_vec(),
                         );

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -774,7 +774,7 @@ impl<D: Clone + Digest + FixedOutput + Send + Sync> StmAggrSig<D> {
     /// * the lottery is indeed won by each one of them,
     /// * the merkle tree path is valid,
     /// * the aggregate signature validates with respect to the aggregate verification key
-    /// (aggregation is computed using functions `MSP.BKey` and `MSP.BSig` as described in Section 2.4 of the paper).
+    ///   (aggregation is computed using functions `MSP.BKey` and `MSP.BSig` as described in Section 2.4 of the paper).
     pub fn verify(
         &self,
         msg: &[u8],


### PR DESCRIPTION
## Content
This PR includes fixes to clippy warnings occurring following the release of Rust `1.80.0`.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

