### PR TITLE
Upgrade `release-mainnet` aggregator VM data disk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
             google_compute_instance_boot_disk_size: 250
             google_compute_instance_boot_disk_type: pd-standard
             google_compute_instance_data_disk_size: 1000
-            google_compute_instance_data_disk_type: pd-standard
+            google_compute_instance_data_disk_type: pd-balanced
 
     environment: ${{ matrix.environment }}
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Content
This PR includes an upgrade on the `release-mainnet` aggregator VM data disk from `pd-standard` to `pd-balanced`.


## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1830 