### PR TITLE
Increase timeout for client WASM headless browser tests

### DIFF
--- a/.github/workflows/scripts/run-wasm-tests-browser-headless.py
+++ b/.github/workflows/scripts/run-wasm-tests-browser-headless.py
@@ -26,8 +26,8 @@ def run_headless_test():
     try:
         driver.get('http://localhost:8080/')
 
-        # Adjust the timeout to 3 minutes
-        wait = WebDriverWait(driver, 180)
+        # Adjust the timeout to 10 minutes
+        wait = WebDriverWait(driver, 600)
 
         # Wait until the div with id "tests_finished" is displayed
         tests_finished_element = wait.until(EC.presence_of_element_located((By.ID, "tests_finished")))


### PR DESCRIPTION
## Content

This PR includes a modification to the timeout for the client WASM headless browser tests (executed by Mithril Client multi-platform test).

Since certificate chain verification takes longer on `preview` than on `sanchonet`, the timeout has been increased from `3` minutes to `10` minutes.

Mithril Client multi-platform test results:
https://github.com/input-output-hk/mithril/actions/runs/10141858789/job/28039918080

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested