### PR TITLE
Add a redirection on index.html to clean url

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,6 +909,7 @@ jobs:
         run: |
           echo "mithril.network" > ./github-pages/CNAME
           echo '<!DOCTYPE html><html><head><meta http-equiv="Refresh" content="0; URL=https://mithril.network/doc"></head></html>' > ./github-pages/index.html
+          sed -i '1s/^/<script type="text/javascript"> if (window.location.href.endsWith("/index.html")) { end_of_clean_url = window.location.href.lastIndexOf("/"); window.location.href = window.location.href.substring(0, end_of_clean_url); } </script>\n/' ./github-pages/doc/index.html
 
       - name: Mithril / Publish GitHub Pages
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -909,6 +909,7 @@ jobs:
         run: |
           echo "mithril.network" > ./github-pages/CNAME
           echo '<!DOCTYPE html><html><head><meta http-equiv="Refresh" content="0; URL=https://mithril.network/doc"></head></html>' > ./github-pages/index.html
+          # Remove the index.html from the url to avoid a display issue that duplicates the content of the page
           sed -i '1s/^/<script type="text/javascript"> if (window.location.href.endsWith("/index.html")) { end_of_clean_url = window.location.href.lastIndexOf("/"); window.location.href = window.location.href.substring(0, end_of_clean_url); } </script>\n/' ./github-pages/doc/index.html
 
       - name: Mithril / Publish GitHub Pages


### PR DESCRIPTION
## Content

When we access to the documentation with `index.html` at the end of the url (https://mithril.network/doc/index.html), the page content is displayed twice.

We inject a javascript in the `doc/index.html` to redirect to the clean url without `index.html`at the end.
The script is added at the beginning of the `index.html`.

```
<script type="text/javascript"> 
if (window.location.href.endsWith("/index.html")) {
    end_of_clean_url = window.location.href.lastIndexOf("/");
    window.location.href = window.location.href.substring(0, end_of_clean_url);
}
</script>
```


## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

The issue is referenced in `docusaurus` repository: https://github.com/facebook/docusaurus/pull/10059

## Issue(s)

Closes #1867
