### PR TITLE
Make signed_entity_type non optional in RegisterSignatureMessage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.52"
+version = "0.5.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.172"
+version = "0.2.173"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.52"
+version = "0.5.53"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.40"
+version = "0.4.41"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/messages/register_signature.rs
+++ b/mithril-common/src/messages/register_signature.rs
@@ -5,13 +5,12 @@ use crate::entities::{HexEncodedSingleSignature, LotteryIndex, PartyId, SignedEn
 #[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_keys;
 
-era_deprecate!("make signed_entity_type of RegisterSignatureMessage not optional");
 /// Message structure to register single signature.
-#[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RegisterSignatureMessage {
     /// Signed entity type
     #[serde(rename = "entity_type")]
-    pub signed_entity_type: Option<SignedEntityType>,
+    pub signed_entity_type: SignedEntityType,
 
     /// The unique identifier of the signer
     pub party_id: PartyId,
@@ -29,7 +28,7 @@ impl RegisterSignatureMessage {
         /// Return a dummy test entity (test-only).
         pub fn dummy() -> Self {
             Self {
-                signed_entity_type: Some(SignedEntityType::dummy()),
+                signed_entity_type: SignedEntityType::dummy(),
                 party_id: "party_id".to_string(),
                 signature: fake_keys::single_signature()[0].to_string(),
                 won_indexes: vec![1, 3],
@@ -59,11 +58,13 @@ impl Debug for RegisterSignatureMessage {
 
 #[cfg(test)]
 mod tests {
+    use crate::entities::Epoch;
+
     use super::*;
 
     fn golden_message() -> RegisterSignatureMessage {
         RegisterSignatureMessage {
-            signed_entity_type: None,
+            signed_entity_type: SignedEntityType::MithrilStakeDistribution(Epoch(246)),
             party_id: "party_id".to_string(),
             signature: "7b227369676d61223a5b3133302c3137372c31352c3232392c32342c3235312c3234372c3137312c3139362c3231302c3134332c3131332c38362c3138392c39322c35362c3131322c33332c3139332c3231322c35342c3231342c32382c3231362c3232372c3137332c3130302c3132372c3137382c34302c39382c38372c32392c3138312c3235352c3131312c3135372c3232342c3233352c34362c3130302c3136392c3233322c3138392c3235322c38322c3133392c33365d2c22696e6465786573223a5b302c312c332c342c362c382c392c31302c31312c31322c31342c31382c32312c32322c32332c32352c32362c32372c33302c33332c33342c33382c34312c34332c35302c35382c35392c36302c36312c36322c36372c36392c37312c37332c37352c37362c37372c38312c38322c38332c38342c39302c39312c39322c39332c39372c39385d2c227369676e65725f696e646578223a327d".to_string(),
             won_indexes: vec![1, 3],
@@ -74,6 +75,7 @@ mod tests {
     #[test]
     fn test_v1() {
         let json = r#"{
+"entity_type": { "MithrilStakeDistribution": 246 },
 "party_id": "party_id",
 "signature":  "7b227369676d61223a5b3133302c3137372c31352c3232392c32342c3235312c3234372c3137312c3139362c3231302c3134332c3131332c38362c3138392c39322c35362c3131322c33332c3139332c3231322c35342c3231342c32382c3231362c3232372c3137332c3130302c3132372c3137382c34302c39382c38372c32392c3138312c3235352c3131312c3135372c3232342c3233352c34362c3130302c3136392c3233322c3138392c3235322c38322c3133392c33365d2c22696e6465786573223a5b302c312c332c342c362c382c392c31302c31312c31322c31342c31382c32312c32322c32332c32352c32362c32372c33302c33332c33342c33382c34312c34332c35302c35382c35392c36302c36312c36322c36372c36392c37312c37332c37352c37362c37372c38312c38322c38332c38342c39302c39312c39322c39332c39372c39385d2c227369676e65725f696e646578223a327d",
 "indexes": [1, 3]

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.172"
+version = "0.2.173"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/message_adapters/to_register_signature_message.rs
+++ b/mithril-signer/src/message_adapters/to_register_signature_message.rs
@@ -12,7 +12,7 @@ impl TryToMessageAdapter<(SignedEntityType, SingleSignatures), RegisterSignature
         (signed_entity_type, single_signature): (SignedEntityType, SingleSignatures),
     ) -> StdResult<RegisterSignatureMessage> {
         let message = RegisterSignatureMessage {
-            signed_entity_type: Some(signed_entity_type),
+            signed_entity_type,
             party_id: single_signature.party_id,
             signature: single_signature.signature.try_into().with_context(|| {
                 "'ToRegisterSignatureMessageAdapter' can not convert the single signature"

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.26"
+version = "0.4.27"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
@@ -54,7 +54,7 @@ pub fn generate_register_signature_message(
     signatures
         .iter()
         .map(|s| RegisterSignatureMessage {
-            signed_entity_type: Some(signed_entity_type.clone()),
+            signed_entity_type: signed_entity_type.clone(),
             party_id: s.party_id.clone(),
             signature: s.signature.clone().to_json_hex().unwrap(),
             won_indexes: s.won_indexes.clone(),


### PR DESCRIPTION
## Content

This PR makes the `signed_entity_type` non optional in `RegisterSignatureMessage`

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

All the SPOs are now running a version that supports non optional so we do not provide compatibility tests without signed_entity_type.

## Issue(s)

Closes #1863
