### PR TITLE
Implement Cardano stake distribution HTTP routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - **UNSTABLE** Cardano stake distribution certification:
 
-  - Implement the signable and artifact builders for the signed entity type `CardanoStakeDistribution`
+  - Implement the signable and artifact builders for the signed entity type `CardanoStakeDistribution`.
+  - Implement the HTTP routes related to the signed entity type `CardanoStakeDistribution` on the aggregator REST API.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.53"
+version = "0.5.54"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.27"
+version = "0.4.28"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/internal/mithril-persistence/src/sqlite/condition.rs
+++ b/internal/mithril-persistence/src/sqlite/condition.rs
@@ -2,7 +2,7 @@ use sqlite::Value;
 use std::iter::repeat;
 
 /// Internal Boolean representation
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 enum BooleanCondition {
     /// Empty tree
     None,
@@ -43,7 +43,7 @@ impl BooleanCondition {
 }
 
 /// Where condition builder.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WhereCondition {
     /// Boolean condition internal tree
     condition: BooleanCondition,

--- a/internal/mithril-persistence/src/sqlite/condition.rs
+++ b/internal/mithril-persistence/src/sqlite/condition.rs
@@ -2,7 +2,7 @@ use sqlite::Value;
 use std::iter::repeat;
 
 /// Internal Boolean representation
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 enum BooleanCondition {
     /// Empty tree
     None,
@@ -43,7 +43,7 @@ impl BooleanCondition {
 }
 
 /// Where condition builder.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct WhereCondition {
     /// Boolean condition internal tree
     condition: BooleanCondition,

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.53"
+version = "0.5.54"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -752,5 +752,13 @@ pragma foreign_keys=true;
                 SignedEntityTypeDiscriminants::CardanoTransactions.index()
             ),
         ),
+        // Migration 26
+        // Alter `signed_entity` table, add a unique index on `signed_entity_type_id` and `beacon`
+        SqlMigration::new(
+            26,
+            r#"
+create unique index signed_entity_unique_index on signed_entity(signed_entity_type_id, beacon);
+"#,
+        ),
     ]
 }

--- a/mithril-aggregator/src/database/query/signed_entity/get_signed_entity.rs
+++ b/mithril-aggregator/src/database/query/signed_entity/get_signed_entity.rs
@@ -1,6 +1,6 @@
 use sqlite::Value;
 
-use mithril_common::entities::{Epoch, SignedEntityTypeDiscriminants};
+use mithril_common::entities::{Epoch, SignedEntityType, SignedEntityTypeDiscriminants};
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
 
@@ -62,6 +62,19 @@ impl GetSignedEntityRecordQuery {
         })
     }
 
+    pub fn cardano_stake_distribution_by_epoch(epoch: Epoch) -> Self {
+        let signed_entity_type_id =
+            SignedEntityTypeDiscriminants::CardanoStakeDistribution.index() as i64;
+        let epoch = *epoch as i64;
+
+        Self {
+            condition: WhereCondition::new(
+                "signed_entity_type_id = ?* and beacon = ?*",
+                vec![Value::Integer(signed_entity_type_id), Value::Integer(epoch)],
+            ),
+        }
+    }
+
     pub fn by_signed_entity_type_and_epoch(
         signed_entity_type: &SignedEntityTypeDiscriminants,
         epoch: Epoch,
@@ -106,12 +119,95 @@ impl Query for GetSignedEntityRecordQuery {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::entities::{CardanoDbBeacon, SignedEntityType};
+    use chrono::DateTime;
+    use mithril_common::{
+        entities::{CardanoDbBeacon, SignedEntityType},
+        test_utils::fake_data,
+    };
     use mithril_persistence::sqlite::ConnectionExtensions;
+    use sqlite::ConnectionThreadSafe;
 
     use crate::database::test_helper::{insert_signed_entities, main_db_connection};
 
     use super::*;
+
+    fn create_database_with_cardano_stake_distributions<T: Into<SignedEntityRecord>>(
+        cardano_stake_distributions: Vec<T>,
+    ) -> (ConnectionThreadSafe, Vec<SignedEntityRecord>) {
+        let records = cardano_stake_distributions
+            .into_iter()
+            .map(|cardano_stake_distribution| cardano_stake_distribution.into())
+            .collect::<Vec<_>>();
+
+        let connection = create_database(&records);
+
+        (connection, records)
+    }
+
+    fn create_database(records: &[SignedEntityRecord]) -> ConnectionThreadSafe {
+        let connection = main_db_connection().unwrap();
+        insert_signed_entities(&connection, records.to_vec()).unwrap();
+        connection
+    }
+
+    #[test]
+    fn cardano_stake_distribution_by_epoch_returns_records_filtered_by_epoch() {
+        let mut cardano_stake_distributions = fake_data::cardano_stake_distributions(3);
+        cardano_stake_distributions[0].epoch = Epoch(3);
+        cardano_stake_distributions[1].epoch = Epoch(4);
+        cardano_stake_distributions[2].epoch = Epoch(5);
+
+        let (connection, records) =
+            create_database_with_cardano_stake_distributions(cardano_stake_distributions);
+
+        let records_retrieved: Vec<SignedEntityRecord> = connection
+            .fetch_collect(
+                GetSignedEntityRecordQuery::cardano_stake_distribution_by_epoch(Epoch(4)),
+            )
+            .unwrap();
+
+        assert_eq!(vec![records[1].clone()], records_retrieved);
+    }
+
+    #[test]
+    fn cardano_stake_distribution_by_epoch_returns_records_returns_only_cardano_stake_distribution_records(
+    ) {
+        let cardano_stake_distributions_record: SignedEntityRecord = {
+            let mut cardano_stake_distribution = fake_data::cardano_stake_distribution(Epoch(4));
+            cardano_stake_distribution.hash = "hash-123".to_string();
+            cardano_stake_distribution.into()
+        };
+
+        let snapshots_record = {
+            let mut snapshot = fake_data::snapshots(1)[0].clone();
+            snapshot.beacon.epoch = Epoch(4);
+            SignedEntityRecord::from_snapshot(snapshot, "whatever".to_string(), DateTime::default())
+        };
+
+        let mithril_stake_distribution_record: SignedEntityRecord = {
+            let mithril_stake_distributions = fake_data::mithril_stake_distributions(1);
+            let mut mithril_stake_distribution = mithril_stake_distributions[0].clone();
+            mithril_stake_distribution.epoch = Epoch(4);
+            mithril_stake_distribution.into()
+        };
+
+        let connection = create_database(&[
+            cardano_stake_distributions_record.clone(),
+            snapshots_record,
+            mithril_stake_distribution_record,
+        ]);
+
+        let records_retrieved: Vec<SignedEntityRecord> = connection
+            .fetch_collect(
+                GetSignedEntityRecordQuery::cardano_stake_distribution_by_epoch(Epoch(4)),
+            )
+            .unwrap();
+
+        assert_eq!(
+            vec![cardano_stake_distributions_record.clone()],
+            records_retrieved,
+        );
+    }
 
     #[test]
     fn test_get_signed_entity_records() {

--- a/mithril-aggregator/src/database/query/signed_entity/get_signed_entity.rs
+++ b/mithril-aggregator/src/database/query/signed_entity/get_signed_entity.rs
@@ -1,13 +1,12 @@
 use sqlite::Value;
 
-use mithril_common::entities::{Epoch, SignedEntityType, SignedEntityTypeDiscriminants};
+use mithril_common::entities::{Epoch, SignedEntityTypeDiscriminants};
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
 
 use crate::database::record::SignedEntityRecord;
 
 /// Simple queries to retrieve [SignedEntityRecord] from the sqlite database.
-#[derive(Debug, PartialEq)]
 pub struct GetSignedEntityRecordQuery {
     condition: WhereCondition,
 }
@@ -72,31 +71,6 @@ impl GetSignedEntityRecordQuery {
                 "signed_entity_type_id = ?* and beacon = ?*",
                 vec![Value::Integer(signed_entity_type_id), Value::Integer(epoch)],
             ),
-        }
-    }
-
-    pub fn by_signed_entity_type_and_epoch(
-        signed_entity_type: &SignedEntityTypeDiscriminants,
-        epoch: Epoch,
-    ) -> Self {
-        let signed_entity_type_id: i64 = signed_entity_type.index() as i64;
-        let epoch = *epoch as i64;
-
-        match signed_entity_type {
-            SignedEntityTypeDiscriminants::MithrilStakeDistribution
-            | SignedEntityTypeDiscriminants::CardanoStakeDistribution => Self {
-                condition: WhereCondition::new(
-                    "signed_entity_type_id = ?* and beacon = ?*",
-                    vec![Value::Integer(signed_entity_type_id), Value::Integer(epoch)],
-                ),
-            },
-            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull
-            | SignedEntityTypeDiscriminants::CardanoTransactions => Self {
-                condition: WhereCondition::new(
-                    "signed_entity_type_id = ?* and json_extract(beacon, '$.epoch') = ?*",
-                    vec![Value::Integer(signed_entity_type_id), Value::Integer(epoch)],
-                ),
-            },
         }
     }
 }
@@ -249,89 +223,5 @@ mod tests {
         let expected_signed_entity_records: Vec<SignedEntityRecord> =
             signed_entity_records.iter().map(|c| c.to_owned()).collect();
         assert_eq!(expected_signed_entity_records, signed_entity_records);
-    }
-
-    #[test]
-    fn by_signed_entity_type_and_epoch_with_mithril_stake_distribution() {
-        assert_eq!(
-            0,
-            SignedEntityTypeDiscriminants::MithrilStakeDistribution.index()
-        );
-        let expected = GetSignedEntityRecordQuery {
-            condition: WhereCondition::new(
-                "signed_entity_type_id = ?* and beacon = ?*",
-                vec![Value::Integer(0), Value::Integer(4)],
-            ),
-        };
-
-        let query = GetSignedEntityRecordQuery::by_signed_entity_type_and_epoch(
-            &SignedEntityTypeDiscriminants::MithrilStakeDistribution,
-            Epoch(4),
-        );
-
-        assert_eq!(expected, query);
-    }
-
-    #[test]
-    fn by_signed_entity_type_and_epoch_with_cardano_stake_distribution() {
-        assert_eq!(
-            1,
-            SignedEntityTypeDiscriminants::CardanoStakeDistribution.index()
-        );
-        let expected = GetSignedEntityRecordQuery {
-            condition: WhereCondition::new(
-                "signed_entity_type_id = ?* and beacon = ?*",
-                vec![Value::Integer(1), Value::Integer(4)],
-            ),
-        };
-
-        let query = GetSignedEntityRecordQuery::by_signed_entity_type_and_epoch(
-            &SignedEntityTypeDiscriminants::CardanoStakeDistribution,
-            Epoch(4),
-        );
-
-        assert_eq!(expected, query);
-    }
-
-    #[test]
-    fn by_signed_entity_type_and_epoch_with_cardano_immutable_files_full() {
-        assert_eq!(
-            2,
-            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull.index()
-        );
-        let expected = GetSignedEntityRecordQuery {
-            condition: WhereCondition::new(
-                "signed_entity_type_id = ?* and json_extract(beacon, '$.epoch') = ?*",
-                vec![Value::Integer(2), Value::Integer(4)],
-            ),
-        };
-
-        let query = GetSignedEntityRecordQuery::by_signed_entity_type_and_epoch(
-            &SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
-            Epoch(4),
-        );
-
-        assert_eq!(expected, query);
-    }
-
-    #[test]
-    fn by_signed_entity_type_and_epoch_with_cardano_transactions() {
-        assert_eq!(
-            3,
-            SignedEntityTypeDiscriminants::CardanoTransactions.index()
-        );
-        let expected = GetSignedEntityRecordQuery {
-            condition: WhereCondition::new(
-                "signed_entity_type_id = ?* and json_extract(beacon, '$.epoch') = ?*",
-                vec![Value::Integer(3), Value::Integer(4)],
-            ),
-        };
-
-        let query = GetSignedEntityRecordQuery::by_signed_entity_type_and_epoch(
-            &SignedEntityTypeDiscriminants::CardanoTransactions,
-            Epoch(4),
-        );
-
-        assert_eq!(expected, query);
     }
 }

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -288,13 +288,14 @@ impl TryFrom<SignedEntityRecord> for CardanoStakeDistributionMessage {
     fn try_from(value: SignedEntityRecord) -> Result<Self, Self::Error> {
         #[derive(Deserialize)]
         struct TmpCardanoStakeDistribution {
-            epoch: Epoch,
             hash: String,
             stake_distribution: StakeDistribution,
         }
         let artifact = serde_json::from_str::<TmpCardanoStakeDistribution>(&value.artifact)?;
         let cardano_stake_distribution_message = CardanoStakeDistributionMessage {
-            epoch: artifact.epoch,
+            // The epoch stored in the signed entity type beacon corresponds to epoch
+            // at the end of which the Cardano stake distribution is computed by the Cardano node.
+            epoch: value.signed_entity_type.get_epoch(),
             stake_distribution: artifact.stake_distribution,
             hash: artifact.hash,
             certificate_hash: value.certificate_id,
@@ -311,12 +312,13 @@ impl TryFrom<SignedEntityRecord> for CardanoStakeDistributionListItemMessage {
     fn try_from(value: SignedEntityRecord) -> Result<Self, Self::Error> {
         #[derive(Deserialize)]
         struct TmpCardanoStakeDistribution {
-            epoch: Epoch,
             hash: String,
         }
         let artifact = serde_json::from_str::<TmpCardanoStakeDistribution>(&value.artifact)?;
         let message = CardanoStakeDistributionListItemMessage {
-            epoch: artifact.epoch,
+            // The epoch stored in the signed entity type beacon corresponds to epoch
+            // at the end of which the Cardano stake distribution is computed by the Cardano node.
+            epoch: value.signed_entity_type.get_epoch(),
             hash: artifact.hash,
             certificate_hash: value.certificate_id,
             created_at: value.created_at,

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -2,12 +2,11 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use mithril_common::crypto_helper::ProtocolParameters;
-#[cfg(test)]
-use mithril_common::entities::CardanoStakeDistribution;
 use mithril_common::entities::{
-    BlockNumber, Epoch, MithrilStakeDistribution, SignedEntity, SignedEntityType, Snapshot,
-    StakeDistribution,
+    BlockNumber, Epoch, SignedEntity, SignedEntityType, Snapshot, StakeDistribution,
 };
+#[cfg(test)]
+use mithril_common::entities::{CardanoStakeDistribution, MithrilStakeDistribution};
 use mithril_common::messages::{
     CardanoStakeDistributionListItemMessage, CardanoStakeDistributionMessage,
     CardanoTransactionSnapshotListItemMessage, CardanoTransactionSnapshotMessage,

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -2,6 +2,8 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use mithril_common::crypto_helper::ProtocolParameters;
+#[cfg(test)]
+use mithril_common::entities::CardanoStakeDistribution;
 use mithril_common::entities::{
     BlockNumber, Epoch, SignedEntity, SignedEntityType, Snapshot, StakeDistribution,
 };
@@ -50,6 +52,24 @@ impl SignedEntityRecord {
             certificate_id,
             artifact: entity,
             created_at,
+        }
+    }
+
+    pub(crate) fn from_cardano_stake_distribution(
+        cardano_stake_distribution: CardanoStakeDistribution,
+    ) -> Self {
+        let entity = serde_json::to_string(&cardano_stake_distribution).unwrap();
+
+        SignedEntityRecord {
+            signed_entity_id: cardano_stake_distribution.hash.clone(),
+            signed_entity_type: SignedEntityType::CardanoStakeDistribution(
+                cardano_stake_distribution.epoch,
+            ),
+            certificate_id: format!("certificate-{}", cardano_stake_distribution.hash),
+            artifact: entity,
+            created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
+                .unwrap()
+                .with_timezone(&Utc),
         }
     }
 

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -5,7 +5,8 @@ use mithril_common::crypto_helper::ProtocolParameters;
 #[cfg(test)]
 use mithril_common::entities::CardanoStakeDistribution;
 use mithril_common::entities::{
-    BlockNumber, Epoch, SignedEntity, SignedEntityType, Snapshot, StakeDistribution,
+    BlockNumber, Epoch, MithrilStakeDistribution, SignedEntity, SignedEntityType, Snapshot,
+    StakeDistribution,
 };
 use mithril_common::messages::{
     CardanoStakeDistributionListItemMessage, CardanoStakeDistributionMessage,
@@ -35,6 +36,32 @@ pub struct SignedEntityRecord {
 
     /// Date and time when the signed_entity was created
     pub created_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+impl From<CardanoStakeDistribution> for SignedEntityRecord {
+    fn from(cardano_stake_distribution: CardanoStakeDistribution) -> Self {
+        SignedEntityRecord::from_cardano_stake_distribution(cardano_stake_distribution)
+    }
+}
+
+#[cfg(test)]
+impl From<MithrilStakeDistribution> for SignedEntityRecord {
+    fn from(mithril_stake_distribution: MithrilStakeDistribution) -> Self {
+        let entity = serde_json::to_string(&mithril_stake_distribution).unwrap();
+
+        SignedEntityRecord {
+            signed_entity_id: mithril_stake_distribution.hash.clone(),
+            signed_entity_type: SignedEntityType::MithrilStakeDistribution(
+                mithril_stake_distribution.epoch,
+            ),
+            certificate_id: format!("certificate-{}", mithril_stake_distribution.hash),
+            artifact: entity,
+            created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -6,10 +6,10 @@ use mithril_common::entities::{
     BlockNumber, Epoch, SignedEntity, SignedEntityType, Snapshot, StakeDistribution,
 };
 use mithril_common::messages::{
-    CardanoStakeDistributionMessage, CardanoTransactionSnapshotListItemMessage,
-    CardanoTransactionSnapshotMessage, MithrilStakeDistributionListItemMessage,
-    MithrilStakeDistributionMessage, SignerWithStakeMessagePart, SnapshotListItemMessage,
-    SnapshotMessage,
+    CardanoStakeDistributionListItemMessage, CardanoStakeDistributionMessage,
+    CardanoTransactionSnapshotListItemMessage, CardanoTransactionSnapshotMessage,
+    MithrilStakeDistributionListItemMessage, MithrilStakeDistributionMessage,
+    SignerWithStakeMessagePart, SnapshotListItemMessage, SnapshotMessage,
 };
 use mithril_common::signable_builder::Artifact;
 use mithril_common::StdError;
@@ -256,6 +256,27 @@ impl TryFrom<SignedEntityRecord> for CardanoStakeDistributionMessage {
         };
 
         Ok(cardano_stake_distribution_message)
+    }
+}
+
+impl TryFrom<SignedEntityRecord> for CardanoStakeDistributionListItemMessage {
+    type Error = StdError;
+
+    fn try_from(value: SignedEntityRecord) -> Result<Self, Self::Error> {
+        #[derive(Deserialize)]
+        struct TmpCardanoStakeDistribution {
+            epoch: Epoch,
+            hash: String,
+        }
+        let artifact = serde_json::from_str::<TmpCardanoStakeDistribution>(&value.artifact)?;
+        let message = CardanoStakeDistributionListItemMessage {
+            epoch: artifact.epoch,
+            hash: artifact.hash,
+            certificate_hash: value.certificate_id,
+            created_at: value.created_at,
+        };
+
+        Ok(message)
     }
 }
 

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -1,0 +1,446 @@
+use crate::http_server::routes::middlewares;
+use crate::DependencyContainer;
+use std::sync::Arc;
+use warp::Filter;
+
+pub fn routes(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    artifact_cardano_stake_distributions(dependency_manager.clone())
+        .or(artifact_cardano_stake_distribution_by_id(
+            dependency_manager.clone(),
+        ))
+        .or(artifact_cardano_stake_distribution_by_epoch(
+            dependency_manager,
+        ))
+}
+
+/// GET /artifact/cardano-stake-distributions
+fn artifact_cardano_stake_distributions(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("artifact" / "cardano-stake-distributions")
+        .and(warp::get())
+        .and(middlewares::with_http_message_service(dependency_manager))
+        .and_then(handlers::list_artifacts)
+}
+
+/// GET /artifact/cardano-stake-distribution/:id
+fn artifact_cardano_stake_distribution_by_id(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("artifact" / "cardano-stake-distribution" / String)
+        .and(warp::get())
+        .and(middlewares::with_http_message_service(dependency_manager))
+        .and_then(handlers::get_artifact_by_signed_entity_id)
+}
+
+/// GET /artifact/cardano-stake-distribution/epoch/:epoch
+fn artifact_cardano_stake_distribution_by_epoch(
+    dependency_manager: Arc<DependencyContainer>,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("artifact" / "cardano-stake-distribution" / "epoch" / String)
+        .and(warp::get())
+        .and(middlewares::with_http_message_service(dependency_manager))
+        .and_then(handlers::get_artifact_by_epoch)
+}
+
+pub mod handlers {
+    use crate::http_server::routes::reply;
+    use crate::services::MessageService;
+
+    use mithril_common::entities::Epoch;
+    use slog_scope::{debug, warn};
+    use std::convert::Infallible;
+    use std::sync::Arc;
+    use warp::http::StatusCode;
+
+    pub const LIST_MAX_ITEMS: usize = 20;
+
+    /// List CardanoStakeDistribution artifacts
+    pub async fn list_artifacts(
+        http_message_service: Arc<dyn MessageService>,
+    ) -> Result<impl warp::Reply, Infallible> {
+        debug!("⇄ HTTP SERVER: artifacts");
+
+        match http_message_service
+            .get_cardano_stake_distribution_list_message(LIST_MAX_ITEMS)
+            .await
+        {
+            Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
+            Err(err) => {
+                warn!("list_artifacts_cardano_stake_distribution"; "error" => ?err);
+                Ok(reply::server_error(err))
+            }
+        }
+    }
+
+    /// Get Artifact by signed entity id
+    pub async fn get_artifact_by_signed_entity_id(
+        signed_entity_id: String,
+        http_message_service: Arc<dyn MessageService>,
+    ) -> Result<impl warp::Reply, Infallible> {
+        debug!("⇄ HTTP SERVER: artifact/{signed_entity_id}");
+
+        match http_message_service
+            .get_cardano_stake_distribution_message(&signed_entity_id)
+            .await
+        {
+            Ok(Some(message)) => Ok(reply::json(&message, StatusCode::OK)),
+            Ok(None) => {
+                warn!("get_cardano_stake_distribution_details::not_found");
+                Ok(reply::empty(StatusCode::NOT_FOUND))
+            }
+            Err(err) => {
+                warn!("get_cardano_stake_distribution_details::error"; "error" => ?err);
+                Ok(reply::server_error(err))
+            }
+        }
+    }
+
+    /// Get Artifact by epoch
+    pub async fn get_artifact_by_epoch(
+        epoch: String,
+        http_message_service: Arc<dyn MessageService>,
+    ) -> Result<impl warp::Reply, Infallible> {
+        debug!("⇄ HTTP SERVER: artifact/epoch/{epoch}");
+
+        let artifact_epoch = match epoch.parse::<u64>() {
+            Ok(epoch) => Epoch(epoch),
+            Err(err) => {
+                warn!("get_artifact_by_epoch::invalid_epoch"; "error" => ?err);
+                return Ok(reply::bad_request(
+                    "invalid_epoch".to_string(),
+                    err.to_string(),
+                ));
+            }
+        };
+
+        match http_message_service
+            .get_cardano_stake_distribution_message_by_epoch(artifact_epoch)
+            .await
+        {
+            Ok(Some(message)) => Ok(reply::json(&message, StatusCode::OK)),
+            Ok(None) => {
+                warn!("get_cardano_stake_distribution_details_by_epoch::not_found");
+                Ok(reply::empty(StatusCode::NOT_FOUND))
+            }
+            Err(err) => {
+                warn!("get_cardano_stake_distribution_details_by_epoch::error"; "error" => ?err);
+                Ok(reply::server_error(err))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use anyhow::anyhow;
+    use serde_json::Value::Null;
+    use warp::{
+        http::{Method, StatusCode},
+        test::request,
+    };
+
+    use mithril_common::{
+        messages::{CardanoStakeDistributionListItemMessage, CardanoStakeDistributionMessage},
+        test_utils::apispec::APISpec,
+    };
+
+    use crate::{
+        http_server::SERVER_BASE_PATH, initialize_dependencies, services::MockMessageService,
+    };
+
+    use super::*;
+
+    fn setup_router(
+        dependency_manager: Arc<DependencyContainer>,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        let cors = warp::cors()
+            .allow_any_origin()
+            .allow_headers(vec!["content-type"])
+            .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
+
+        warp::any()
+            .and(warp::path(SERVER_BASE_PATH))
+            .and(routes(dependency_manager).with(cors))
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distributions_returns_ok() {
+        let message = vec![CardanoStakeDistributionListItemMessage::dummy()];
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_list_message()
+            .return_once(|_| Ok(message))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let path = "/artifact/cardano-stake-distributions";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::OK,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distributions_returns_ko_500_when_error() {
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_list_message()
+            .return_once(|_| Err(anyhow!("an error occured")))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let path = "/artifact/cardano-stake-distributions";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distribution_returns_ok() {
+        let message = CardanoStakeDistributionMessage::dummy();
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_message()
+            .return_once(|_| Ok(Some(message)))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let path = "/artifact/cardano-stake-distribution/{hash}";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::OK,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distribution_returns_404_not_found_when_no_record() {
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_message()
+            .return_once(|_| Ok(None))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let path = "/artifact/cardano-stake-distribution/{hash}";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::NOT_FOUND,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distribution_returns_ko_500_when_error() {
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_message()
+            .return_once(|_| Err(anyhow!("an error occured")))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let path = "/artifact/cardano-stake-distribution/{hash}";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distribution_by_epoch_returns_ok() {
+        let message = CardanoStakeDistributionMessage::dummy();
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_message_by_epoch()
+            .return_once(|_| Ok(Some(message)))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let base_path = "/artifact/cardano-stake-distribution/epoch";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{base_path}/123"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            &format!("{base_path}/{{epoch}}"),
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::OK,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distribution_by_epoch_returns_400_bad_request_when_invalid_epoch() {
+        let mock_http_message_service = MockMessageService::new();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let base_path = "/artifact/cardano-stake-distribution/epoch";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{base_path}/invalid-epoch"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            &format!("{base_path}/{{epoch}}"),
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::BAD_REQUEST,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distribution_by_epoch_returns_404_not_found_when_no_record() {
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_message_by_epoch()
+            .return_once(|_| Ok(None))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let base_path = "/artifact/cardano-stake-distribution/epoch";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{base_path}/123"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            &format!("{base_path}/{{epoch}}"),
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::NOT_FOUND,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cardano_stake_distribution_by_epoch_returns_ko_500_when_error() {
+        let mut mock_http_message_service = MockMessageService::new();
+        mock_http_message_service
+            .expect_get_cardano_stake_distribution_message_by_epoch()
+            .return_once(|_| Err(anyhow!("an error occured")))
+            .once();
+        let mut dependency_manager = initialize_dependencies().await;
+        dependency_manager.message_service = Arc::new(mock_http_message_service);
+
+        let method = Method::GET.as_str();
+        let base_path = "/artifact/cardano-stake-distribution/epoch";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{base_path}/123"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            &format!("{base_path}/{{epoch}}"),
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .unwrap();
+    }
+}

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod cardano_stake_distribution;
 pub mod cardano_transaction;
 pub mod mithril_stake_distribution;
 pub mod snapshot;

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -49,6 +49,9 @@ pub fn routes(
                 .or(artifact_routes::mithril_stake_distribution::routes(
                     dependency_manager.clone(),
                 ))
+                .or(artifact_routes::cardano_stake_distribution::routes(
+                    dependency_manager.clone(),
+                ))
                 .or(artifact_routes::cardano_transaction::routes(
                     dependency_manager.clone(),
                 ))

--- a/mithril-aggregator/src/message_adapters/mod.rs
+++ b/mithril-aggregator/src/message_adapters/mod.rs
@@ -1,5 +1,6 @@
 mod from_register_signature;
 mod from_register_signer;
+mod to_cardano_stake_distribution_message;
 mod to_cardano_transaction_list_message;
 mod to_cardano_transaction_message;
 mod to_cardano_transactions_proof_message;
@@ -12,6 +13,8 @@ mod to_snapshot_message;
 
 pub use from_register_signature::FromRegisterSingleSignatureAdapter;
 pub use from_register_signer::FromRegisterSignerAdapter;
+#[cfg(test)]
+pub use to_cardano_stake_distribution_message::ToCardanoStakeDistributionMessageAdapter;
 #[cfg(test)]
 pub use to_cardano_transaction_list_message::ToCardanoTransactionListMessageAdapter;
 #[cfg(test)]

--- a/mithril-aggregator/src/message_adapters/mod.rs
+++ b/mithril-aggregator/src/message_adapters/mod.rs
@@ -1,5 +1,6 @@
 mod from_register_signature;
 mod from_register_signer;
+mod to_cardano_stake_distribution_list_message;
 mod to_cardano_stake_distribution_message;
 mod to_cardano_transaction_list_message;
 mod to_cardano_transaction_message;
@@ -13,6 +14,8 @@ mod to_snapshot_message;
 
 pub use from_register_signature::FromRegisterSingleSignatureAdapter;
 pub use from_register_signer::FromRegisterSignerAdapter;
+#[cfg(test)]
+pub use to_cardano_stake_distribution_list_message::ToCardanoStakeDistributionListMessageAdapter;
 #[cfg(test)]
 pub use to_cardano_stake_distribution_message::ToCardanoStakeDistributionMessageAdapter;
 #[cfg(test)]

--- a/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_list_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_list_message.rs
@@ -1,0 +1,55 @@
+use mithril_common::entities::{CardanoStakeDistribution, SignedEntity};
+use mithril_common::messages::{
+    CardanoStakeDistributionListItemMessage, CardanoStakeDistributionListMessage, ToMessageAdapter,
+};
+
+/// Adapter to convert a list of [CardanoStakeDistribution] to [CardanoStakeDistributionListMessage] instances
+#[allow(dead_code)]
+pub struct ToCardanoStakeDistributionListMessageAdapter;
+
+impl
+    ToMessageAdapter<
+        Vec<SignedEntity<CardanoStakeDistribution>>,
+        CardanoStakeDistributionListMessage,
+    > for ToCardanoStakeDistributionListMessageAdapter
+{
+    /// Method to trigger the conversion
+    fn adapt(
+        snapshots: Vec<SignedEntity<CardanoStakeDistribution>>,
+    ) -> CardanoStakeDistributionListMessage {
+        snapshots
+            .into_iter()
+            .map(|entity| CardanoStakeDistributionListItemMessage {
+                epoch: entity.artifact.epoch,
+                hash: entity.artifact.hash,
+                certificate_hash: entity.certificate_id,
+                created_at: entity.created_at,
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adapt_ok() {
+        let signed_entity = SignedEntity::<CardanoStakeDistribution>::dummy();
+        let cardano_stake_distribution_list_message_expected =
+            vec![CardanoStakeDistributionListItemMessage {
+                epoch: signed_entity.artifact.epoch,
+                hash: signed_entity.artifact.hash.clone(),
+                certificate_hash: signed_entity.certificate_id.clone(),
+                created_at: signed_entity.created_at,
+            }];
+
+        let cardano_stake_distribution_list_message =
+            ToCardanoStakeDistributionListMessageAdapter::adapt(vec![signed_entity]);
+
+        assert_eq!(
+            cardano_stake_distribution_list_message_expected,
+            cardano_stake_distribution_list_message
+        );
+    }
+}

--- a/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_list_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_list_message.rs
@@ -20,7 +20,9 @@ impl
         snapshots
             .into_iter()
             .map(|entity| CardanoStakeDistributionListItemMessage {
-                epoch: entity.artifact.epoch,
+                // The epoch stored in the signed entity type beacon corresponds to epoch
+                // at the end of which the Cardano stake distribution is computed by the Cardano node.
+                epoch: entity.signed_entity_type.get_epoch(),
                 hash: entity.artifact.hash,
                 certificate_hash: entity.certificate_id,
                 created_at: entity.created_at,

--- a/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_message.rs
@@ -1,0 +1,46 @@
+use mithril_common::entities::{CardanoStakeDistribution, SignedEntity};
+use mithril_common::messages::{CardanoStakeDistributionMessage, ToMessageAdapter};
+
+/// Adapter to convert [CardanoStakeDistribution] to [CardanoStakeDistributionMessage] instances
+#[allow(dead_code)]
+pub struct ToCardanoStakeDistributionMessageAdapter;
+
+impl ToMessageAdapter<SignedEntity<CardanoStakeDistribution>, CardanoStakeDistributionMessage>
+    for ToCardanoStakeDistributionMessageAdapter
+{
+    /// Method to trigger the conversion
+    fn adapt(from: SignedEntity<CardanoStakeDistribution>) -> CardanoStakeDistributionMessage {
+        CardanoStakeDistributionMessage {
+            epoch: from.artifact.epoch,
+            hash: from.artifact.hash,
+            certificate_hash: from.certificate_id,
+            stake_distribution: from.artifact.stake_distribution,
+            created_at: from.created_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adapt_ok() {
+        let signed_entity = SignedEntity::<CardanoStakeDistribution>::dummy();
+        let cardano_stake_distribution_message_expected = CardanoStakeDistributionMessage {
+            epoch: signed_entity.artifact.epoch,
+            hash: signed_entity.artifact.hash.clone(),
+            certificate_hash: signed_entity.certificate_id.clone(),
+            stake_distribution: signed_entity.artifact.stake_distribution.clone(),
+            created_at: signed_entity.created_at,
+        };
+
+        let cardano_stake_distribution_message =
+            ToCardanoStakeDistributionMessageAdapter::adapt(signed_entity);
+
+        assert_eq!(
+            cardano_stake_distribution_message_expected,
+            cardano_stake_distribution_message
+        );
+    }
+}

--- a/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_message.rs
+++ b/mithril-aggregator/src/message_adapters/to_cardano_stake_distribution_message.rs
@@ -11,7 +11,9 @@ impl ToMessageAdapter<SignedEntity<CardanoStakeDistribution>, CardanoStakeDistri
     /// Method to trigger the conversion
     fn adapt(from: SignedEntity<CardanoStakeDistribution>) -> CardanoStakeDistributionMessage {
         CardanoStakeDistributionMessage {
-            epoch: from.artifact.epoch,
+            // The epoch stored in the signed entity type beacon corresponds to epoch
+            // at the end of which the Cardano stake distribution is computed by the Cardano node.
+            epoch: from.signed_entity_type.get_epoch(),
             hash: from.artifact.hash,
             certificate_hash: from.certificate_id,
             stake_distribution: from.artifact.stake_distribution,

--- a/mithril-aggregator/src/services/message.rs
+++ b/mithril-aggregator/src/services/message.rs
@@ -222,13 +222,10 @@ impl MessageService for MithrilMessageService {
         &self,
         epoch: Epoch,
     ) -> StdResult<Option<CardanoStakeDistributionMessage>> {
-        let signed_entity_type_id = SignedEntityTypeDiscriminants::CardanoStakeDistribution;
         let signed_entity = self
             .signed_entity_storer
-            .get_signed_entities_by_type_and_epoch(&signed_entity_type_id, epoch)
-            .await?
-            .first()
-            .cloned();
+            .get_cardano_stake_distribution_signed_entity_by_epoch(epoch)
+            .await?;
 
         signed_entity.map(|v| v.try_into()).transpose()
     }
@@ -253,8 +250,7 @@ mod tests {
 
     use mithril_common::entities::{
         CardanoStakeDistribution, CardanoTransactionsSnapshot, Certificate, Epoch,
-        MithrilStakeDistribution, SignedEntity, SignedEntityType, SignedEntityTypeDiscriminants,
-        Snapshot,
+        MithrilStakeDistribution, SignedEntity, SignedEntityType, Snapshot,
     };
     use mithril_common::messages::ToMessageAdapter;
     use mithril_common::test_utils::MithrilFixtureBuilder;
@@ -624,11 +620,8 @@ mod tests {
         let mut dep_builder = DependenciesBuilder::new(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
-            .expect_get_signed_entities_by_type_and_epoch()
-            .withf(|discriminant, _| {
-                discriminant == &SignedEntityTypeDiscriminants::CardanoStakeDistribution
-            })
-            .return_once(|_, _| Ok(vec![record]))
+            .expect_get_cardano_stake_distribution_signed_entity_by_epoch()
+            .return_once(|_| Ok(Some(record)))
             .once();
         dep_builder.signed_entity_storer = Some(Arc::new(storer));
         let service = dep_builder.get_message_service().await.unwrap();
@@ -647,11 +640,8 @@ mod tests {
         let mut dep_builder = DependenciesBuilder::new(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
-            .expect_get_signed_entities_by_type_and_epoch()
-            .withf(|discriminant, _| {
-                discriminant == &SignedEntityTypeDiscriminants::CardanoStakeDistribution
-            })
-            .return_once(|_, _| Ok(vec![]))
+            .expect_get_cardano_stake_distribution_signed_entity_by_epoch()
+            .return_once(|_| Ok(None))
             .once();
         dep_builder.signed_entity_storer = Some(Arc::new(storer));
         let service = dep_builder.get_message_service().await.unwrap();

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -68,6 +68,13 @@ pub trait SignedEntityService: Send + Sync {
         &self,
         signed_entity_id: &str,
     ) -> StdResult<Option<SignedEntity<MithrilStakeDistribution>>>;
+
+    /// Return a list of signed Cardano stake distribution order by creation
+    /// date descending.
+    async fn get_last_signed_cardano_stake_distributions(
+        &self,
+        total: usize,
+    ) -> StdResult<Vec<SignedEntity<CardanoStakeDistribution>>>;
 }
 
 /// Mithril ArtifactBuilder Service
@@ -357,6 +364,25 @@ impl SignedEntityService for MithrilSignedEntityService {
         };
 
         Ok(entity)
+    }
+
+    async fn get_last_signed_cardano_stake_distributions(
+        &self,
+        total: usize,
+    ) -> StdResult<Vec<SignedEntity<CardanoStakeDistribution>>> {
+        let signed_entities_records = self
+            .get_last_signed_entities(
+                total,
+                &SignedEntityTypeDiscriminants::CardanoStakeDistribution,
+            )
+            .await?;
+        let mut signed_entities: Vec<SignedEntity<CardanoStakeDistribution>> = Vec::new();
+
+        for record in signed_entities_records {
+            signed_entities.push(record.try_into()?);
+        }
+
+        Ok(signed_entities)
     }
 }
 

--- a/mithril-aggregator/tests/cardano_stake_distribution_verify_stakes.rs
+++ b/mithril-aggregator/tests/cardano_stake_distribution_verify_stakes.rs
@@ -1,0 +1,184 @@
+mod test_extensions;
+
+use mithril_aggregator::Configuration;
+use mithril_common::entities::SignerWithStake;
+use mithril_common::{
+    entities::{
+        BlockNumber, CardanoDbBeacon, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
+        SignedEntityTypeDiscriminants, SlotNumber, StakeDistribution, StakeDistributionParty,
+        TimePoint,
+    },
+    test_utils::MithrilFixtureBuilder,
+};
+use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
+
+#[tokio::test]
+async fn cardano_stake_distribution_verify_stakes() {
+    let protocol_parameters = ProtocolParameters {
+        k: 5,
+        m: 150,
+        phi_f: 0.95,
+    };
+    let configuration = Configuration {
+        protocol_parameters: protocol_parameters.clone(),
+        signed_entity_types: Some(
+            SignedEntityTypeDiscriminants::CardanoStakeDistribution.to_string(),
+        ),
+        data_stores_directory: get_test_dir("cardano_stake_distribution_verify_stakes"),
+        ..Configuration::new_sample()
+    };
+    let mut tester = RuntimeTester::build(
+        TimePoint::new(
+            2,
+            1,
+            ChainPoint::new(SlotNumber(10), BlockNumber(1), "block_hash-1"),
+        ),
+        configuration,
+    )
+    .await;
+
+    comment!("create signers & declare the initial stake distribution");
+    let fixture = MithrilFixtureBuilder::default()
+        .with_signers(5)
+        .with_protocol_parameters(protocol_parameters.clone())
+        .build();
+    let signers = &fixture.signers_fixture();
+
+    tester.init_state_from_fixture(&fixture).await.unwrap();
+
+    comment!("Bootstrap the genesis certificate");
+    tester.register_genesis_certificate(&fixture).await.unwrap();
+
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new_genesis(
+            CardanoDbBeacon::new("devnet".to_string(), 2, 1),
+            fixture.compute_and_encode_avk()
+        )
+    );
+
+    comment!("Start the runtime state machine and register signers");
+    cycle!(tester, "ready");
+    tester.register_signers(signers).await.unwrap();
+
+    comment!("Increase epoch and register signers with a different stake distribution");
+    tester.increase_epoch().await.unwrap();
+    let signers_with_updated_stake_distribution = fixture
+        .signers_with_stake()
+        .iter()
+        .map(|signer_with_stake| {
+            SignerWithStake::from_signer(
+                signer_with_stake.to_owned().into(),
+                signer_with_stake.stake + 999,
+            )
+        })
+        .collect::<Vec<_>>();
+    let updated_stake_distribution: StakeDistribution = signers_with_updated_stake_distribution
+        .iter()
+        .map(|s| (s.party_id.clone(), s.stake))
+        .collect();
+    tester
+        .chain_observer
+        .set_signers(signers_with_updated_stake_distribution)
+        .await;
+    cycle!(tester, "idle");
+    cycle!(tester, "ready");
+    cycle!(tester, "signing");
+    tester.register_signers(signers).await.unwrap();
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            signers,
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the MithrilStakeDistribution");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            CardanoDbBeacon::new("devnet".to_string(), 3, 1),
+            StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::MithrilStakeDistribution(Epoch(3)),
+            ExpectedCertificate::genesis_identifier(&CardanoDbBeacon::new(
+                "devnet".to_string(),
+                2,
+                1
+            )),
+        )
+    );
+
+    comment!("Increase epoch and register signers with a different stake distribution");
+    let signers_with_updated_stake_distribution = fixture
+        .signers_with_stake()
+        .iter()
+        .map(|signer_with_stake| {
+            SignerWithStake::from_signer(
+                signer_with_stake.to_owned().into(),
+                signer_with_stake.stake + 9999,
+            )
+        })
+        .collect::<Vec<_>>();
+    tester
+        .chain_observer
+        .set_signers(signers_with_updated_stake_distribution)
+        .await;
+    tester.increase_epoch().await.unwrap();
+    cycle!(tester, "idle");
+    cycle!(tester, "ready");
+    cycle!(tester, "signing");
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            signers,
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the MithrilStakeDistribution");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            CardanoDbBeacon::new("devnet".to_string(), 4, 1),
+            StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::MithrilStakeDistribution(Epoch(4)),
+            ExpectedCertificate::identifier(&SignedEntityType::MithrilStakeDistribution(Epoch(3))),
+        )
+    );
+
+    cycle!(tester, "signing");
+    tester
+        .send_single_signatures(
+            SignedEntityTypeDiscriminants::CardanoStakeDistribution,
+            signers,
+        )
+        .await
+        .unwrap();
+
+    comment!("The state machine should issue a certificate for the CardanoStakeDistribution");
+    cycle!(tester, "ready");
+    assert_last_certificate_eq!(
+        tester,
+        ExpectedCertificate::new(
+            CardanoDbBeacon::new("devnet".to_string(), 4, 1),
+            StakeDistributionParty::from_signers(fixture.signers_with_stake()).as_slice(),
+            fixture.compute_and_encode_avk(),
+            SignedEntityType::CardanoStakeDistribution(Epoch(3)),
+            ExpectedCertificate::identifier(&SignedEntityType::MithrilStakeDistribution(Epoch(4))),
+        )
+    );
+
+    comment!("The message service should return the expected stake distribution");
+    let message = tester
+        .dependencies
+        .message_service
+        .get_cardano_stake_distribution_message_by_epoch(Epoch(3))
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(updated_stake_distribution, message.stake_distribution);
+}

--- a/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
@@ -140,7 +140,13 @@ impl AggregatorObserver {
                     .await?
                     .map(|s| s.signed_entity_type)
                     .as_ref()),
-            _ => Ok(false),
+            SignedEntityType::CardanoStakeDistribution(_) => Ok(Some(signed_entity_type_expected)
+                == self
+                    .signed_entity_service
+                    .get_last_signed_cardano_stake_distributions(1)
+                    .await?
+                    .first()
+                    .map(|s| &s.signed_entity_type)),
         }
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.42"
+version = "0.4.43"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/signed_entity.rs
+++ b/mithril-common/src/entities/signed_entity.rs
@@ -7,6 +7,7 @@ use crate::signable_builder::Artifact;
 #[cfg(any(test, feature = "test_tools"))]
 use crate::test_utils::fake_data;
 
+use super::CardanoStakeDistribution;
 #[cfg(any(test, feature = "test_tools"))]
 use super::{CardanoDbBeacon, Epoch};
 
@@ -77,6 +78,23 @@ impl SignedEntity<CardanoTransactionsSnapshot> {
                 certificate_id: "certificate-hash-123".to_string(),
                 artifact: CardanoTransactionsSnapshot::new("mkroot123".to_string(), block_number),
                 created_at: DateTime::parse_from_rfc3339("2023-01-19T13:43:05.618857482Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            }
+        }
+    }
+}
+
+impl SignedEntity<CardanoStakeDistribution> {
+    cfg_test_tools! {
+        /// Create a dummy [SignedEntity] for [CardanoStakeDistribution] entity
+        pub fn dummy() -> Self {
+            SignedEntity {
+                signed_entity_id: "cardano-stake-distribution-id-123".to_string(),
+                signed_entity_type: SignedEntityType::CardanoStakeDistribution(Epoch(1)),
+                certificate_id: "certificate-hash-123".to_string(),
+                artifact: fake_data::cardano_stake_distributions(1)[0].to_owned(),
+                created_at: DateTime::parse_from_rfc3339("2024-07-29T16:15:05.618857482Z")
                     .unwrap()
                     .with_timezone(&Utc),
             }

--- a/mithril-common/src/messages/cardano_stake_distribution.rs
+++ b/mithril-common/src/messages/cardano_stake_distribution.rs
@@ -1,0 +1,81 @@
+use chrono::DateTime;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::entities::Epoch;
+use crate::entities::StakeDistribution;
+
+/// Message structure of a Cardano Stake Distribution
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+pub struct CardanoStakeDistributionMessage {
+    /// Epoch at the end of which the Cardano stake distribution is computed by the Cardano node
+    pub epoch: Epoch,
+
+    /// Hash of the Cardano Stake Distribution
+    pub hash: String,
+
+    /// Hash of the associated certificate
+    pub certificate_hash: String,
+
+    /// Represents the list of participants in the Cardano chain with their associated stake
+    pub stake_distribution: StakeDistribution,
+
+    /// DateTime of creation
+    pub created_at: DateTime<Utc>,
+}
+
+impl CardanoStakeDistributionMessage {
+    cfg_test_tools! {
+        /// Return a dummy test entity (test-only).
+        pub fn dummy() -> Self {
+            Self {
+                epoch: Epoch(1),
+                hash: "hash-123".to_string(),
+                certificate_hash: "cert-hash-123".to_string(),
+                stake_distribution: StakeDistribution::from([
+                    ("pool-123".to_string(), 1000),
+                ]),
+                created_at: DateTime::parse_from_rfc3339("2024-07-29T16:15:05.618857482Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn golden_message() -> CardanoStakeDistributionMessage {
+        CardanoStakeDistributionMessage {
+            epoch: Epoch(1),
+            hash: "hash-123".to_string(),
+            certificate_hash: "cert-hash-123".to_string(),
+            stake_distribution: StakeDistribution::from([
+                ("pool-123".to_string(), 1000),
+                ("pool-456".to_string(), 2000),
+            ]),
+            created_at: DateTime::parse_from_rfc3339("2024-07-29T16:15:05.618857482Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }
+    }
+
+    // Test the backward compatibility with possible future upgrades.
+    #[test]
+    fn test_v1() {
+        let json = r#"{
+            "epoch": 1,
+            "hash": "hash-123",
+            "certificate_hash": "cert-hash-123",
+            "stake_distribution": { "pool-123": 1000, "pool-456": 2000 },
+            "created_at": "2024-07-29T16:15:05.618857482Z"
+        }"#;
+        let message: CardanoStakeDistributionMessage = serde_json::from_str(json).expect(
+            "This JSON is expected to be successfully parsed into a CardanoStakeDistributionMessage instance.",
+        );
+
+        assert_eq!(golden_message(), message);
+    }
+}

--- a/mithril-common/src/messages/cardano_stake_distribution_list.rs
+++ b/mithril-common/src/messages/cardano_stake_distribution_list.rs
@@ -1,0 +1,69 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::entities::Epoch;
+
+/// Message structure of a Cardano Stake Distribution list
+pub type CardanoStakeDistributionListMessage = Vec<CardanoStakeDistributionListItemMessage>;
+
+/// Message structure of a Cardano Stake Distribution list item
+#[derive(Clone, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub struct CardanoStakeDistributionListItemMessage {
+    /// Epoch at the end of which the Cardano stake distribution is computed by the Cardano node
+    pub epoch: Epoch,
+
+    /// Hash of the Cardano Stake Distribution
+    pub hash: String,
+
+    /// Hash of the associated certificate
+    pub certificate_hash: String,
+
+    /// Date and time at which the Cardano Stake Distribution was created
+    pub created_at: DateTime<Utc>,
+}
+
+impl CardanoStakeDistributionListItemMessage {
+    /// Return a dummy test entity (test-only).
+    pub fn dummy() -> Self {
+        Self {
+            epoch: Epoch(1),
+            hash: "hash-123".to_string(),
+            certificate_hash: "certificate-hash-123".to_string(),
+            created_at: DateTime::parse_from_rfc3339("2024-07-29T16:15:05.618857482Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn golden_message() -> CardanoStakeDistributionListMessage {
+        vec![CardanoStakeDistributionListItemMessage {
+            epoch: Epoch(1),
+            hash: "hash-123".to_string(),
+            certificate_hash: "cert-hash-123".to_string(),
+            created_at: DateTime::parse_from_rfc3339("2024-07-29T16:15:05.618857482Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        }]
+    }
+
+    // Test the backward compatibility with possible future upgrades.
+    #[test]
+    fn test_v1() {
+        let json = r#"[{
+            "epoch": 1,
+            "hash": "hash-123",
+            "certificate_hash": "cert-hash-123",
+            "created_at": "2024-07-29T16:15:05.618857482Z"
+        }]"#;
+        let message: CardanoStakeDistributionListMessage = serde_json::from_str(json).expect(
+            "This JSON is expected to be successfully parsed into a CardanoStakeDistributionListMessage instance.",
+        );
+
+        assert_eq!(golden_message(), message);
+    }
+}

--- a/mithril-common/src/messages/mod.rs
+++ b/mithril-common/src/messages/mod.rs
@@ -1,6 +1,7 @@
 //! Messages module
 //! This module aims at providing shared structures for API communications.
 mod aggregator_features;
+mod cardano_stake_distribution;
 mod cardano_transaction_snapshot;
 mod cardano_transaction_snapshot_list;
 mod cardano_transactions_proof;
@@ -21,6 +22,7 @@ mod snapshot_list;
 pub use aggregator_features::{
     AggregatorCapabilities, AggregatorFeaturesMessage, CardanoTransactionsProverCapabilities,
 };
+pub use cardano_stake_distribution::CardanoStakeDistributionMessage;
 pub use cardano_transaction_snapshot::CardanoTransactionSnapshotMessage;
 pub use cardano_transaction_snapshot_list::{
     CardanoTransactionSnapshotListItemMessage, CardanoTransactionSnapshotListMessage,

--- a/mithril-common/src/messages/mod.rs
+++ b/mithril-common/src/messages/mod.rs
@@ -2,6 +2,7 @@
 //! This module aims at providing shared structures for API communications.
 mod aggregator_features;
 mod cardano_stake_distribution;
+mod cardano_stake_distribution_list;
 mod cardano_transaction_snapshot;
 mod cardano_transaction_snapshot_list;
 mod cardano_transactions_proof;
@@ -23,6 +24,9 @@ pub use aggregator_features::{
     AggregatorCapabilities, AggregatorFeaturesMessage, CardanoTransactionsProverCapabilities,
 };
 pub use cardano_stake_distribution::CardanoStakeDistributionMessage;
+pub use cardano_stake_distribution_list::{
+    CardanoStakeDistributionListItemMessage, CardanoStakeDistributionListMessage,
+};
 pub use cardano_transaction_snapshot::CardanoTransactionSnapshotMessage;
 pub use cardano_transaction_snapshot_list::{
     CardanoTransactionSnapshotListItemMessage, CardanoTransactionSnapshotListMessage,

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -7,7 +7,7 @@ use crate::crypto_helper::{self, ProtocolMultiSignature};
 use crate::entities::{
     self, BlockNumber, CertificateMetadata, CertificateSignature, CompressionAlgorithm, Epoch,
     LotteryIndex, ProtocolMessage, ProtocolMessagePartKey, SignedEntityType, SingleSignatures,
-    SlotNumber, StakeDistributionParty,
+    SlotNumber, StakeDistribution, StakeDistributionParty,
 };
 use crate::test_utils::MithrilFixtureBuilder;
 
@@ -257,4 +257,17 @@ pub const fn transaction_hashes<'a>() -> [&'a str; 5] {
         "3f6f3c981c89097f62c9b43632875db7a52183ad3061c822d98259d18cd63dcf",
         "f4fd91dccc25fd63f2caebab3d3452bc4b2944fcc11652214a3e8f1d32b09713",
     ]
+}
+
+/// Fake Cardano Stake Distribution
+pub fn cardano_stake_distributions(total: u64) -> Vec<entities::CardanoStakeDistribution> {
+    let stake_distribution = StakeDistribution::from([("pool-1".to_string(), 100)]);
+
+    (1..total + 1)
+        .map(|epoch_idx| entities::CardanoStakeDistribution {
+            hash: format!("hash-epoch-{epoch_idx}"),
+            epoch: Epoch(epoch_idx),
+            stake_distribution: stake_distribution.clone(),
+        })
+        .collect::<Vec<entities::CardanoStakeDistribution>>()
 }

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -260,15 +260,19 @@ pub const fn transaction_hashes<'a>() -> [&'a str; 5] {
     ]
 }
 
-/// Fake Cardano Stake Distribution
+/// Fake Cardano Stake Distributions
 pub fn cardano_stake_distributions(total: u64) -> Vec<entities::CardanoStakeDistribution> {
-    let stake_distribution = StakeDistribution::from([("pool-1".to_string(), 100)]);
-
     (1..total + 1)
-        .map(|epoch_idx| entities::CardanoStakeDistribution {
-            hash: format!("hash-epoch-{epoch_idx}"),
-            epoch: Epoch(epoch_idx),
-            stake_distribution: stake_distribution.clone(),
-        })
+        .map(|epoch_idx| cardano_stake_distribution(Epoch(epoch_idx)))
         .collect::<Vec<entities::CardanoStakeDistribution>>()
+}
+
+/// Fake Cardano Stake Distribution
+pub fn cardano_stake_distribution(epoch: Epoch) -> entities::CardanoStakeDistribution {
+    let stake_distribution = StakeDistribution::from([("pool-1".to_string(), 100)]);
+    entities::CardanoStakeDistribution {
+        hash: format!("hash-epoch-{epoch}"),
+        epoch,
+        stake_distribution,
+    }
 }

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -202,7 +202,8 @@ pub fn snapshots(total: u64) -> Vec<entities::Snapshot> {
     (1..total + 1)
         .map(|snapshot_id| {
             let digest = format!("1{snapshot_id}").repeat(20);
-            let beacon = beacon();
+            let mut beacon = beacon();
+            beacon.immutable_file_number += snapshot_id;
             let certificate_hash = "123".to_string();
             let size = snapshot_id * 100000;
             let cardano_node_version = Version::parse("1.0.0").unwrap();

--- a/mithril-test-lab/mithril-devnet/mkfiles/mkfiles-mithril-delegation.sh
+++ b/mithril-test-lab/mithril-devnet/mkfiles/mkfiles-mithril-delegation.sh
@@ -85,7 +85,7 @@ done
 # Prepare transactions for delegating to stake pools
 for N in ${POOL_NODES_N}; do
   cat >> delegate.sh <<EOF
-    AMOUNT_STAKED=\$(( $N*1000000 +  DELEGATION_ROUND*1 ))
+    AMOUNT_STAKED=\$(( $N*1000000 +  \$DELEGATION_ROUND*1 ))
 
     # Get the UTxO
     TX_IN=\$(CARDANO_NODE_SOCKET_PATH=node-pool${N}/ipc/node.sock ./cardano-cli query utxo \\

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.27"
+version = "0.4.28"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -41,6 +41,7 @@ pub struct MithrilInfrastructure {
     cardano_chain_observer: Arc<dyn ChainObserver>,
     run_only_mode: bool,
     is_signing_cardano_transactions: bool,
+    is_signing_cardano_stake_distribution: bool,
 }
 
 impl MithrilInfrastructure {
@@ -87,6 +88,11 @@ impl MithrilInfrastructure {
             run_only_mode: config.run_only_mode,
             is_signing_cardano_transactions: config.signed_entity_types.contains(
                 &SignedEntityTypeDiscriminants::CardanoTransactions
+                    .as_ref()
+                    .to_string(),
+            ),
+            is_signing_cardano_stake_distribution: config.signed_entity_types.contains(
+                &SignedEntityTypeDiscriminants::CardanoStakeDistribution
                     .as_ref()
                     .to_string(),
             ),
@@ -283,6 +289,10 @@ impl MithrilInfrastructure {
 
     pub fn is_signing_cardano_transactions(&self) -> bool {
         self.is_signing_cardano_transactions
+    }
+
+    pub fn is_signing_cardano_stake_distribution(&self) -> bool {
+        self.is_signing_cardano_stake_distribution
     }
 
     pub async fn tail_logs(&self, number_of_line: u64) -> StdResult<()> {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -290,6 +290,91 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /artifact/cardano-stake-distributions:
+    get:
+      summary: Get most recent Cardano stake distributions
+      description: |
+        Returns the list of the most recent Cardano stake distributions
+      responses:
+        "200":
+          description: Cardano stake distribution found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardanoStakeDistributionListMessage"
+        "412":
+          description: API version mismatch
+        default:
+          description: Cardano stake distribution retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /artifact/cardano-stake-distribution/{hash}:
+    get:
+      summary: Get Cardano stake distribution information
+      description: |
+        Returns the information of a Cardano stake distribution
+      parameters:
+        - name: hash
+          in: path
+          description: Hash of the Cardano stake distribution to retrieve
+          required: true
+          schema:
+            type: string
+            format: bytes
+          example: "6da2b104ed68481ef829d72d72c2f6a20142916d17985e01774b14ed49f0fea1"
+      responses:
+        "200":
+          description: Cardano stake distribution found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardanoStakeDistributionMessage"
+        "404":
+          description: Cardano stake distribution not found
+        "412":
+          description: API version mismatch
+        default:
+          description: Cardano stake distribution retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
+  /artifact/cardano-stake-distribution/epoch/{epoch}:
+    get:
+      summary: Get Cardano stake distribution information for a specific epoch
+      description: |
+        Returns the information of a Cardano stake distribution at a given epoch
+      parameters:
+        - name: epoch
+          in: path
+          description: Epoch of the Cardano stake distribution to retrieve
+          required: true
+          schema:
+            type: integer
+            format: int64
+          example: 419
+      responses:
+        "200":
+          description: Cardano stake distribution found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CardanoStakeDistributionMessage"
+        "404":
+          description: Cardano stake distribution not found
+        "412":
+          description: API version mismatch
+        default:
+          description: Cardano stake distribution retrieval error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /artifact/cardano-transactions:
     get:
       summary: Get most recent Cardano transactions set snapshots
@@ -1588,6 +1673,96 @@ components:
             ],
           "created_at": "2022-06-14T10:52:31Z",
           "protocol_parameters": { "k": 5, "m": 100, "phi_f": 0.65 }
+        }
+
+    StakeDistribution:
+      description: The list of Stake Pool Operator pool identifiers with their associated stake in the Cardano chain
+      properties:
+        code:
+          type: string
+        text:
+          type: integer
+      example:
+        {
+          "pool15ka28a4a3qxgcgh60wavkylku4vqjg385jezsrqxlafyrhahf02": 1192520901428,
+          "pool1aymf474uv528zafxlpfg3yr55zp267wj5mpu4qt557z5k5frn9p": 1009503382720
+        }
+
+    CardanoStakeDistributionListMessage:
+      description: CardanoStakeDistributionListMessage represents a list of Cardano stake distribution
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        required:
+          - epoch
+          - hash
+          - certificate_hash
+          - created_at
+        properties:
+          epoch:
+            $ref: "#/components/schemas/Epoch"
+          hash:
+            description: Hash of the Cardano stake distribution
+            type: string
+            format: bytes
+          certificate_hash:
+            description: Hash of the associated certificate
+            type: string
+            format: bytes
+          created_at:
+            description: Date and time at which the Cardano stake distribution was created
+            type: string
+            format: date-time,
+        example:
+          {
+            "epoch": 123,
+            "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+            "created_at": "2022-06-14T10:52:31Z"
+          }
+
+    CardanoStakeDistributionMessage:
+      description: This message represents a Cardano stake distribution.
+      type: object
+      additionalProperties: false
+      required:
+        - epoch
+        - hash
+        - certificate_hash
+        - stake_distribution
+        - created_at
+      properties:
+        epoch:
+          $ref: "#/components/schemas/Epoch"
+        hash:
+          description: Hash of the Cardano stake distribution
+          type: string
+          format: bytes
+        certificate_hash:
+          description: Hash of the associated certificate
+          type: string
+          format: bytes
+        stake_distribution:
+          description: The list of Stake Pool Operator pool identifiers with their associated stake in the Cardano chain
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/StakeDistribution"
+        created_at:
+          description: Date and time of the entity creation
+          type: string
+          format: date-time,
+      example:
+        {
+          "epoch": 123,
+          "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+          "stake_distribution":
+            {
+              "pool15ka28a4a3qxgcgh60wavkylku4vqjg385jezsrqxlafyrhahf02": 1192520901428,
+              "pool1aymf474uv528zafxlpfg3yr55zp267wj5mpu4qt557z5k5frn9p": 1009503382720
+            },
+          "created_at": "2022-06-14T10:52:31Z"
         }
 
     CardanoTransactionSnapshotListMessage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1701,6 +1701,7 @@ components:
           - created_at
         properties:
           epoch:
+            description: Epoch at the end of which the Cardano stake distribution is computed by the Cardano node
             $ref: "#/components/schemas/Epoch"
           hash:
             description: Hash of the Cardano stake distribution
@@ -1734,6 +1735,7 @@ components:
         - created_at
       properties:
         epoch:
+          description: Epoch at the end of which the Cardano stake distribution is computed by the Cardano node
           $ref: "#/components/schemas/Epoch"
         hash:
           description: Hash of the Cardano stake distribution


### PR DESCRIPTION
## Content

This PR introduces new HTTP routes in the Aggregator REST API specifically for handling the signed entity type `CardanoStakeDistribution`:
- `/artifact/cardano-stake-distributions`
- `/artifact/cardano-stake-distribution/{hash}`
- `/artifact/cardano-stake-distribution/epoch/{epoch}`

The end to end test has been updated to include the verification of `CardanoStakeDistribution` certification, ensuring that the new routes respond correctly.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1841 
