### PR TITLE
Fix: `ChainReaderBlockStreamer` skips `RollForward` blocks at the tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.41"
+version = "0.4.42"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/chain_reader/fake_chain_reader.rs
+++ b/mithril-common/src/chain_reader/fake_chain_reader.rs
@@ -18,6 +18,11 @@ impl FakeChainReader {
             chain_point_next_actions: Mutex::new(chain_point_next_actions.into()),
         }
     }
+
+    /// Total remaining next actions
+    pub fn get_total_remaining_next_actions(&self) -> usize {
+        self.chain_point_next_actions.lock().unwrap().len()
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Content
This PR includes a fix to the `ChainReaderBlockStreamer` which skips `RollForward` blocks at the tip of the chain.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1875 
