### PR TITLE
Implement Cardano stake distribution in `mithril-client` library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
   - Implement the signable and artifact builders for the signed entity type `CardanoStakeDistribution`.
   - Implement the HTTP routes related to the signed entity type `CardanoStakeDistribution` on the aggregator REST API.
+  - Added support in the `mithril-client` library for retrieving `CardanoStakeDistribution` by epoch or by hash, and for listing all available `CardanoStakeDistribution`.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3616,7 +3616,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.43"
+version = "0.4.44"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.11"
+version = "0.8.12"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -101,6 +101,13 @@ pub enum AggregatorRequest {
         hash: String,
     },
 
+    /// Get a specific [Cardano stake distribution][crate::CardanoStakeDistribution] from the aggregator by epoch
+    #[cfg(feature = "unstable")]
+    GetCardanoStakeDistributionByEpoch {
+        /// Epoch at the end of which the Cardano stake distribution is computed by the Cardano node
+        epoch: Epoch,
+    },
+
     /// Lists the aggregator [Cardano stake distribution][crate::CardanoStakeDistribution]
     #[cfg(feature = "unstable")]
     ListCardanoStakeDistributions,
@@ -145,6 +152,10 @@ impl AggregatorRequest {
             #[cfg(feature = "unstable")]
             AggregatorRequest::GetCardanoStakeDistribution { hash } => {
                 format!("artifact/cardano-stake-distribution/{hash}")
+            }
+            #[cfg(feature = "unstable")]
+            AggregatorRequest::GetCardanoStakeDistributionByEpoch { epoch } => {
+                format!("artifact/cardano-stake-distribution/epoch/{epoch}")
             }
             #[cfg(feature = "unstable")]
             AggregatorRequest::ListCardanoStakeDistributions => {
@@ -569,6 +580,11 @@ mod tests {
                     hash: "abc".to_string()
                 }
                 .route()
+            );
+
+            assert_eq!(
+                "artifact/cardano-stake-distribution/epoch/123".to_string(),
+                AggregatorRequest::GetCardanoStakeDistributionByEpoch { epoch: Epoch(123) }.route()
             );
 
             assert_eq!(

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -22,6 +22,7 @@ use tokio::sync::RwLock;
 use mithril_common::entities::{ClientError, ServerError};
 use mithril_common::MITHRIL_API_VERSION_HEADER;
 
+use crate::common::Epoch;
 use crate::{MithrilError, MithrilResult};
 
 /// Error tied with the Aggregator client
@@ -92,6 +93,13 @@ pub enum AggregatorRequest {
     /// Lists the aggregator [Cardano transaction snapshot][crate::CardanoTransactionSnapshot]
     #[cfg(feature = "unstable")]
     ListCardanoTransactionSnapshots,
+
+    /// Get a specific [Cardano stake distribution][crate::CardanoStakeDistribution] from the aggregator by hash
+    #[cfg(feature = "unstable")]
+    GetCardanoStakeDistribution {
+        /// Hash of the Cardano stake distribution to retrieve
+        hash: String,
+    },
 }
 
 impl AggregatorRequest {
@@ -129,6 +137,10 @@ impl AggregatorRequest {
             #[cfg(feature = "unstable")]
             AggregatorRequest::ListCardanoTransactionSnapshots => {
                 "artifact/cardano-transactions".to_string()
+            }
+            #[cfg(feature = "unstable")]
+            AggregatorRequest::GetCardanoStakeDistribution { hash } => {
+                format!("artifact/cardano-stake-distribution/{hash}")
             }
         }
     }
@@ -541,6 +553,14 @@ mod tests {
             assert_eq!(
                 "artifact/cardano-transactions".to_string(),
                 AggregatorRequest::ListCardanoTransactionSnapshots.route()
+            );
+
+            assert_eq!(
+                "artifact/cardano-stake-distribution/abc".to_string(),
+                AggregatorRequest::GetCardanoStakeDistribution {
+                    hash: "abc".to_string()
+                }
+                .route()
             );
         }
     }

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -100,6 +100,10 @@ pub enum AggregatorRequest {
         /// Hash of the Cardano stake distribution to retrieve
         hash: String,
     },
+
+    /// Lists the aggregator [Cardano stake distribution][crate::CardanoStakeDistribution]
+    #[cfg(feature = "unstable")]
+    ListCardanoStakeDistributions,
 }
 
 impl AggregatorRequest {
@@ -141,6 +145,10 @@ impl AggregatorRequest {
             #[cfg(feature = "unstable")]
             AggregatorRequest::GetCardanoStakeDistribution { hash } => {
                 format!("artifact/cardano-stake-distribution/{hash}")
+            }
+            #[cfg(feature = "unstable")]
+            AggregatorRequest::ListCardanoStakeDistributions => {
+                "artifact/cardano-stake-distributions".to_string()
             }
         }
     }
@@ -561,6 +569,11 @@ mod tests {
                     hash: "abc".to_string()
                 }
                 .route()
+            );
+
+            assert_eq!(
+                "artifact/cardano-stake-distributions".to_string(),
+                AggregatorRequest::ListCardanoStakeDistributions.route()
             );
         }
     }

--- a/mithril-client/src/cardano_stake_distribution_client.rs
+++ b/mithril-client/src/cardano_stake_distribution_client.rs
@@ -98,38 +98,32 @@ impl CardanoStakeDistributionClient {
         Ok(items)
     }
 
-    /// Get the given Cardano stake distribution data. If it cannot be found, a None is returned.
+    /// Get the given Cardano stake distribution data by hash.
     pub async fn get(&self, hash: &str) -> MithrilResult<Option<CardanoStakeDistribution>> {
-        match self
-            .aggregator_client
-            .get_content(AggregatorRequest::GetCardanoStakeDistribution {
-                hash: hash.to_string(),
-            })
-            .await
-        {
-            Ok(content) => {
-                let cardano_stake_distribution: CardanoStakeDistribution =
-                    serde_json::from_str(&content).with_context(|| {
-                        "CardanoStakeDistribution client can not deserialize artifact"
-                    })?;
-
-                Ok(Some(cardano_stake_distribution))
-            }
-            Err(AggregatorClientError::RemoteServerLogical(_)) => Ok(None),
-            Err(e) => Err(e.into()),
-        }
+        self.fetch_with_aggregator_request(AggregatorRequest::GetCardanoStakeDistribution {
+            hash: hash.to_string(),
+        })
+        .await
     }
 
-    /// Get the given Cardano stake distribution data by epoch. If it cannot be found, a None is returned.
+    /// Get the given Cardano stake distribution data by epoch.
     pub async fn get_by_epoch(
         &self,
         epoch: Epoch,
     ) -> MithrilResult<Option<CardanoStakeDistribution>> {
-        match self
-            .aggregator_client
-            .get_content(AggregatorRequest::GetCardanoStakeDistributionByEpoch { epoch })
-            .await
-        {
+        self.fetch_with_aggregator_request(AggregatorRequest::GetCardanoStakeDistributionByEpoch {
+            epoch,
+        })
+        .await
+    }
+
+    /// Fetch the given Cardano stake distribution data with an aggregator request.
+    /// If it cannot be found, a None is returned.
+    async fn fetch_with_aggregator_request(
+        &self,
+        request: AggregatorRequest,
+    ) -> MithrilResult<Option<CardanoStakeDistribution>> {
+        match self.aggregator_client.get_content(request).await {
             Ok(content) => {
                 let cardano_stake_distribution: CardanoStakeDistribution =
                     serde_json::from_str(&content).with_context(|| {

--- a/mithril-client/src/cardano_stake_distribution_client.rs
+++ b/mithril-client/src/cardano_stake_distribution_client.rs
@@ -1,0 +1,155 @@
+//! A client to retrieve Cardano stake distributions data from an Aggregator.
+//!
+//! In order to do so it defines a [CardanoStakeDistributionClient] which exposes the following features:
+//!  - [get][CardanoStakeDistributionClient::get]: get a Cardano stake distribution data from its hash
+//!
+//! # Get a Cardano stake distribution
+//!
+//! To get a Cardano stake distribution using the [ClientBuilder][crate::client::ClientBuilder].
+//!
+//! ```no_run
+//! # async fn run() -> mithril_client::MithrilResult<()> {
+//! use mithril_client::ClientBuilder;
+//!
+//! let client = ClientBuilder::aggregator("YOUR_AGGREGATOR_ENDPOINT", "YOUR_GENESIS_VERIFICATION_KEY").build()?;
+//! let cardano_stake_distribution = client.cardano_stake_distribution().get("CARDANO_STAKE_DISTRIBUTION_HASH").await?.unwrap();
+//!
+//! println!(
+//!     "Cardano stake distribution hash={}, epoch={}, stake_distribution={:?}",
+//!     cardano_stake_distribution.hash,
+//!     cardano_stake_distribution.epoch,
+//!     cardano_stake_distribution.stake_distribution
+//! );
+//! #    Ok(())
+//! # }
+//! ```
+
+use anyhow::Context;
+use std::sync::Arc;
+
+use crate::aggregator_client::{AggregatorClient, AggregatorClientError, AggregatorRequest};
+use crate::{CardanoStakeDistribution, MithrilResult};
+
+/// HTTP client for CardanoStakeDistribution API from the Aggregator
+pub struct CardanoStakeDistributionClient {
+    aggregator_client: Arc<dyn AggregatorClient>,
+}
+
+impl CardanoStakeDistributionClient {
+    /// Constructs a new `CardanoStakeDistribution`.
+    pub fn new(aggregator_client: Arc<dyn AggregatorClient>) -> Self {
+        Self { aggregator_client }
+    }
+
+    /// Get the given Cardano stake distribution data. If it cannot be found, a None is returned.
+    pub async fn get(&self, hash: &str) -> MithrilResult<Option<CardanoStakeDistribution>> {
+        match self
+            .aggregator_client
+            .get_content(AggregatorRequest::GetCardanoStakeDistribution {
+                hash: hash.to_string(),
+            })
+            .await
+        {
+            Ok(content) => {
+                let cardano_stake_distribution: CardanoStakeDistribution =
+                    serde_json::from_str(&content).with_context(|| {
+                        "CardanoStakeDistribution client can not deserialize artifact"
+                    })?;
+
+                Ok(Some(cardano_stake_distribution))
+            }
+            Err(AggregatorClientError::RemoteServerLogical(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+    use chrono::{DateTime, Utc};
+    use mockall::predicate::eq;
+
+    use crate::aggregator_client::MockAggregatorHTTPClient;
+    use crate::common::{Epoch, StakeDistribution};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_returns_message() {
+        let expected_stake_distribution = StakeDistribution::from([("pool123".to_string(), 123)]);
+        let message = CardanoStakeDistribution {
+            epoch: Epoch(3),
+            hash: "hash-123".to_string(),
+            certificate_hash: "certificate-hash-123".to_string(),
+            stake_distribution: expected_stake_distribution.clone(),
+            created_at: DateTime::<Utc>::default(),
+        };
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client
+            .expect_get_content()
+            .with(eq(AggregatorRequest::GetCardanoStakeDistribution {
+                hash: "hash-123".to_string(),
+            }))
+            .return_once(move |_| Ok(serde_json::to_string(&message).unwrap()));
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        let cardano_stake_distribution = client
+            .get("hash-123")
+            .await
+            .unwrap()
+            .expect("This test returns a Cardano stake distribution");
+
+        assert_eq!("hash-123".to_string(), cardano_stake_distribution.hash);
+        assert_eq!(Epoch(3), cardano_stake_distribution.epoch);
+        assert_eq!(
+            expected_stake_distribution,
+            cardano_stake_distribution.stake_distribution
+        );
+    }
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_returns_error_when_invalid_json_structure_in_response()
+    {
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client
+            .expect_get_content()
+            .return_once(move |_| Ok("invalid json structure".to_string()));
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        client
+            .get("hash-123")
+            .await
+            .expect_err("Get Cardano stake distribution should return an error");
+    }
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_returns_none_when_not_found_or_remote_server_logical_error(
+    ) {
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client.expect_get_content().return_once(move |_| {
+            Err(AggregatorClientError::RemoteServerLogical(anyhow!(
+                "not found"
+            )))
+        });
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        let result = client.get("hash-123").await.unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_returns_error() {
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client
+            .expect_get_content()
+            .return_once(move |_| Err(AggregatorClientError::SubsystemError(anyhow!("error"))));
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        client
+            .get("hash-123")
+            .await
+            .expect_err("Get Cardano stake distribution should return an error");
+    }
+}

--- a/mithril-client/src/cardano_stake_distribution_client.rs
+++ b/mithril-client/src/cardano_stake_distribution_client.rs
@@ -2,6 +2,7 @@
 //!
 //! In order to do so it defines a [CardanoStakeDistributionClient] which exposes the following features:
 //!  - [get][CardanoStakeDistributionClient::get]: get a Cardano stake distribution data from its hash
+//!  - [get_by_epoch][CardanoStakeDistributionClient::get_by_epoch]: get a Cardano stake distribution data from its epoch
 //!  - [list][CardanoStakeDistributionClient::list]: get the list of available Cardano stake distribution
 //!
 //! # Get a Cardano stake distribution
@@ -42,11 +43,35 @@
 //! #    Ok(())
 //! # }
 //! ```
+//!
+//! # Get a Cardano stake distribution by epoch
+//!
+//! To get a Cardano stake distribution by epoch using the [ClientBuilder][crate::client::ClientBuilder].
+//! The epoch represents the epoch at the end of which the Cardano stake distribution is computed by the Cardano node
+//!
+//! ```no_run
+//! # async fn run() -> mithril_client::MithrilResult<()> {
+//! use mithril_client::ClientBuilder;
+//! use mithril_client::common::Epoch;
+//!
+//! let client = ClientBuilder::aggregator("YOUR_AGGREGATOR_ENDPOINT", "YOUR_GENESIS_VERIFICATION_KEY").build()?;
+//! let cardano_stake_distribution = client.cardano_stake_distribution().get_by_epoch(Epoch(500)).await?.unwrap();
+//!
+//! println!(
+//!     "Cardano stake distribution hash={}, epoch={}, stake_distribution={:?}",
+//!     cardano_stake_distribution.hash,
+//!     cardano_stake_distribution.epoch,
+//!     cardano_stake_distribution.stake_distribution
+//! );
+//! #    Ok(())
+//! # }
+//! ```
 
 use anyhow::Context;
 use std::sync::Arc;
 
 use crate::aggregator_client::{AggregatorClient, AggregatorClientError, AggregatorRequest};
+use crate::common::Epoch;
 use crate::{CardanoStakeDistribution, CardanoStakeDistributionListItem, MithrilResult};
 
 /// HTTP client for CardanoStakeDistribution API from the Aggregator
@@ -94,6 +119,29 @@ impl CardanoStakeDistributionClient {
             Err(e) => Err(e.into()),
         }
     }
+
+    /// Get the given Cardano stake distribution data by epoch. If it cannot be found, a None is returned.
+    pub async fn get_by_epoch(
+        &self,
+        epoch: Epoch,
+    ) -> MithrilResult<Option<CardanoStakeDistribution>> {
+        match self
+            .aggregator_client
+            .get_content(AggregatorRequest::GetCardanoStakeDistributionByEpoch { epoch })
+            .await
+        {
+            Ok(content) => {
+                let cardano_stake_distribution: CardanoStakeDistribution =
+                    serde_json::from_str(&content).with_context(|| {
+                        "CardanoStakeDistribution client can not deserialize artifact"
+                    })?;
+
+                Ok(Some(cardano_stake_distribution))
+            }
+            Err(AggregatorClientError::RemoteServerLogical(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -103,7 +151,7 @@ mod tests {
     use mockall::predicate::eq;
 
     use crate::aggregator_client::MockAggregatorHTTPClient;
-    use crate::common::{Epoch, StakeDistribution};
+    use crate::common::StakeDistribution;
 
     use super::*;
 
@@ -236,5 +284,83 @@ mod tests {
             .get("hash-123")
             .await
             .expect_err("Get Cardano stake distribution should return an error");
+    }
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_by_epoch_returns_message() {
+        let expected_stake_distribution = StakeDistribution::from([("pool123".to_string(), 123)]);
+        let message = CardanoStakeDistribution {
+            epoch: Epoch(3),
+            hash: "hash-123".to_string(),
+            certificate_hash: "certificate-hash-123".to_string(),
+            stake_distribution: expected_stake_distribution.clone(),
+            created_at: DateTime::<Utc>::default(),
+        };
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client
+            .expect_get_content()
+            .with(eq(AggregatorRequest::GetCardanoStakeDistributionByEpoch {
+                epoch: Epoch(3),
+            }))
+            .return_once(move |_| Ok(serde_json::to_string(&message).unwrap()));
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        let cardano_stake_distribution = client
+            .get_by_epoch(Epoch(3))
+            .await
+            .unwrap()
+            .expect("This test returns a Cardano stake distribution");
+
+        assert_eq!("hash-123".to_string(), cardano_stake_distribution.hash);
+        assert_eq!(Epoch(3), cardano_stake_distribution.epoch);
+        assert_eq!(
+            expected_stake_distribution,
+            cardano_stake_distribution.stake_distribution
+        );
+    }
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_by_epoch_returns_error_when_invalid_json_structure_in_response(
+    ) {
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client
+            .expect_get_content()
+            .return_once(move |_| Ok("invalid json structure".to_string()));
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        client
+            .get_by_epoch(Epoch(3))
+            .await
+            .expect_err("Get Cardano stake distribution by epoch should return an error");
+    }
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_by_epoch_returns_none_when_not_found_or_remote_server_logical_error(
+    ) {
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client.expect_get_content().return_once(move |_| {
+            Err(AggregatorClientError::RemoteServerLogical(anyhow!(
+                "not found"
+            )))
+        });
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        let result = client.get_by_epoch(Epoch(3)).await.unwrap();
+
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn get_cardano_stake_distribution_by_epoch_returns_error() {
+        let mut http_client = MockAggregatorHTTPClient::new();
+        http_client
+            .expect_get_content()
+            .return_once(move |_| Err(AggregatorClientError::SubsystemError(anyhow!("error"))));
+        let client = CardanoStakeDistributionClient::new(Arc::new(http_client));
+
+        client
+            .get_by_epoch(Epoch(3))
+            .await
+            .expect_err("Get Cardano stake distribution by epoch should return an error");
     }
 }

--- a/mithril-client/src/client.rs
+++ b/mithril-client/src/client.rs
@@ -6,6 +6,8 @@ use std::sync::Arc;
 
 use crate::aggregator_client::{AggregatorClient, AggregatorHTTPClient};
 #[cfg(feature = "unstable")]
+use crate::cardano_stake_distribution_client::CardanoStakeDistributionClient;
+#[cfg(feature = "unstable")]
 use crate::cardano_transaction_client::CardanoTransactionClient;
 use crate::certificate_client::{
     CertificateClient, CertificateVerifier, MithrilCertificateVerifier,
@@ -24,6 +26,8 @@ use crate::MithrilResult;
 pub struct Client {
     #[cfg(feature = "unstable")]
     cardano_transaction_client: Arc<CardanoTransactionClient>,
+    #[cfg(feature = "unstable")]
+    cardano_stake_distribution_client: Arc<CardanoStakeDistributionClient>,
     certificate_client: Arc<CertificateClient>,
     mithril_stake_distribution_client: Arc<MithrilStakeDistributionClient>,
     snapshot_client: Arc<SnapshotClient>,
@@ -49,6 +53,12 @@ impl Client {
     /// Get the client that fetches and downloads Mithril snapshots.
     pub fn snapshot(&self) -> Arc<SnapshotClient> {
         self.snapshot_client.clone()
+    }
+
+    /// Get the client that fetches Cardano stake distributions.
+    #[cfg(feature = "unstable")]
+    pub fn cardano_stake_distribution(&self) -> Arc<CardanoStakeDistributionClient> {
+        self.cardano_stake_distribution_client.clone()
     }
 }
 
@@ -165,7 +175,7 @@ impl ClientBuilder {
             aggregator_client.clone(),
         ));
         let snapshot_client = Arc::new(SnapshotClient::new(
-            aggregator_client,
+            aggregator_client.clone(),
             #[cfg(feature = "fs")]
             snapshot_downloader,
             #[cfg(feature = "fs")]
@@ -174,9 +184,15 @@ impl ClientBuilder {
             logger,
         ));
 
+        #[cfg(feature = "unstable")]
+        let cardano_stake_distribution_client =
+            Arc::new(CardanoStakeDistributionClient::new(aggregator_client));
+
         Ok(Client {
             #[cfg(feature = "unstable")]
             cardano_transaction_client,
+            #[cfg(feature = "unstable")]
+            cardano_stake_distribution_client,
             certificate_client,
             mithril_stake_distribution_client,
             snapshot_client,

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -84,6 +84,7 @@ macro_rules! cfg_unstable {
 
 pub mod aggregator_client;
 cfg_unstable! {
+    pub mod cardano_stake_distribution_client;
     pub mod cardano_transaction_client;
 }
 pub mod certificate_client;

--- a/mithril-client/src/type_alias.rs
+++ b/mithril-client/src/type_alias.rs
@@ -37,6 +37,10 @@ pub use mithril_common::messages::CertificateListItemMessageMetadata as MithrilC
 pub use mithril_common::messages::SignerWithStakeMessagePart as MithrilSigner;
 
 cfg_unstable! {
+    /// A Cardano stake distribution.
+    ///
+    pub use mithril_common::messages::CardanoStakeDistributionMessage as CardanoStakeDistribution;
+
     pub use mithril_common::messages::CardanoTransactionsProofsMessage as CardanoTransactionsProofs;
 
     pub use mithril_common::messages::CardanoTransactionsSetProofMessagePart as CardanoTransactionsSetProof;
@@ -62,5 +66,6 @@ pub mod common {
     };
     cfg_unstable! {
         pub use mithril_common::entities::{ChainPoint, TransactionHash, SlotNumber, BlockHash, BlockNumber};
+        pub use mithril_common::entities::{StakeDistribution};
     }
 }

--- a/mithril-client/src/type_alias.rs
+++ b/mithril-client/src/type_alias.rs
@@ -38,13 +38,10 @@ pub use mithril_common::messages::SignerWithStakeMessagePart as MithrilSigner;
 
 cfg_unstable! {
     /// A Cardano stake distribution.
-    ///
     pub use mithril_common::messages::CardanoStakeDistributionMessage as CardanoStakeDistribution;
 
     /// List item of Cardano stake distributions.
-    ///
     pub use mithril_common::messages::CardanoStakeDistributionListItemMessage as CardanoStakeDistributionListItem;
-
 
     pub use mithril_common::messages::CardanoTransactionsProofsMessage as CardanoTransactionsProofs;
 

--- a/mithril-client/src/type_alias.rs
+++ b/mithril-client/src/type_alias.rs
@@ -41,6 +41,11 @@ cfg_unstable! {
     ///
     pub use mithril_common::messages::CardanoStakeDistributionMessage as CardanoStakeDistribution;
 
+    /// List item of Cardano stake distributions.
+    ///
+    pub use mithril_common::messages::CardanoStakeDistributionListItemMessage as CardanoStakeDistributionListItem;
+
+
     pub use mithril_common::messages::CardanoTransactionsProofsMessage as CardanoTransactionsProofs;
 
     pub use mithril_common::messages::CardanoTransactionsSetProofMessagePart as CardanoTransactionsSetProof;
@@ -50,11 +55,9 @@ cfg_unstable! {
     pub use mithril_common::messages::VerifyCardanoTransactionsProofsError;
 
     /// A snapshot that allow to know up to which [point of time][common::CardanoDbBeacon] Mithril have certified Cardano transactions.
-    ///
     pub use mithril_common::messages::CardanoTransactionSnapshotMessage as CardanoTransactionSnapshot;
 
     /// List item of a Cardano transaction snapshot.
-    ///
     pub use mithril_common::messages::CardanoTransactionSnapshotListItemMessage as CardanoTransactionSnapshotListItem;
 }
 

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.43"
+version = "0.4.44"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/signable_builder/cardano_stake_distribution.rs
+++ b/mithril-common/src/signable_builder/cardano_stake_distribution.rs
@@ -48,7 +48,10 @@ impl CardanoStakeDistributionSignableBuilder {
         }
     }
 
-    fn compute_merkle_tree(pools_with_stake: StakeDistribution) -> StdResult<MKTree> {
+    /// Compute the Merkle tree of a given [StakeDistribution]
+    pub fn compute_merkle_tree_from_stake_distribution(
+        pools_with_stake: StakeDistribution,
+    ) -> StdResult<MKTree> {
         let leaves: Vec<MKTreeNode> = pools_with_stake
             .iter()
             .map(|(k, v)| StakeDistributionEntry::new(k, *v).into())
@@ -68,7 +71,7 @@ impl SignableBuilder<Epoch> for CardanoStakeDistributionSignableBuilder {
                 "CardanoStakeDistributionSignableBuilder could not find the stake distribution for epoch: '{epoch}'"
             ))?;
 
-        let mk_tree = Self::compute_merkle_tree(pools_with_stake)?;
+        let mk_tree = Self::compute_merkle_tree_from_stake_distribution(pools_with_stake)?;
 
         let mut protocol_message = ProtocolMessage::new();
         protocol_message.set_message_part(
@@ -97,11 +100,15 @@ mod tests {
         second_pools_with_stake: StakeDistribution,
     ) -> bool {
         let first_merkle_tree =
-            CardanoStakeDistributionSignableBuilder::compute_merkle_tree(first_pools_with_stake)
-                .unwrap();
+            CardanoStakeDistributionSignableBuilder::compute_merkle_tree_from_stake_distribution(
+                first_pools_with_stake,
+            )
+            .unwrap();
         let second_merkle_tree =
-            CardanoStakeDistributionSignableBuilder::compute_merkle_tree(second_pools_with_stake)
-                .unwrap();
+            CardanoStakeDistributionSignableBuilder::compute_merkle_tree_from_stake_distribution(
+                second_pools_with_stake,
+            )
+            .unwrap();
 
         first_merkle_tree.compute_root().unwrap() == second_merkle_tree.compute_root().unwrap()
     }
@@ -172,8 +179,10 @@ mod tests {
             .unwrap();
 
         let expected_mktree =
-            CardanoStakeDistributionSignableBuilder::compute_merkle_tree(stake_distribution_clone)
-                .unwrap();
+            CardanoStakeDistributionSignableBuilder::compute_merkle_tree_from_stake_distribution(
+                stake_distribution_clone,
+            )
+            .unwrap();
         let mut signable_expected = ProtocolMessage::new();
         signable_expected.set_message_part(
             ProtocolMessagePartKey::CardanoStakeDistributionEpoch,


### PR DESCRIPTION
## Content

This PR adds new functionalities to the `mithril-client` crate related to Cardano stake distribution. The library now supports the following features:

- Retrieve a Cardano stake distribution by its hash.
- Retrieve a Cardano stake distribution by its epoch.
- Get a list of available Cardano stake distributions.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1842 