### PR TITLE
Implement Cardano stake distribution commands in `mithril-client` CLI

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -77,7 +77,9 @@ jobs:
         shell: bash
         run: |
           CTX_CAPABILITY=$(wget -q -O - $AGGREGATOR_ENDPOINT | jq '.capabilities.signed_entity_types | contains(["CardanoTransactions"])')
+          CSD_CAPABILITY=$(wget -q -O - $AGGREGATOR_ENDPOINT | jq '.capabilities.signed_entity_types | contains(["CardanoStakeDistribution"])')
           echo "ctx_enabled=$CTX_CAPABILITY" >> $GITHUB_OUTPUT
+          echo "csd_enabled=$CSD_CAPABILITY" >> $GITHUB_OUTPUT
 
       - name: Assessing aggregator capabilities (Windows)
         id: aggregator_capability_windows
@@ -86,7 +88,9 @@ jobs:
         run: |
           aria2c -o aggregator_capabilities.json $AGGREGATOR_ENDPOINT
           CTX_CAPABILITY=$(jq '.capabilities.signed_entity_types | contains(["CardanoTransactions"])' aggregator_capabilities.json)
+          CSD_CAPABILITY=$(jq '.capabilities.signed_entity_types | contains(["CardanoStakeDistribution"])' aggregator_capabilities.json)
           echo "ctx_enabled=$CTX_CAPABILITY" >> $GITHUB_OUTPUT
+          echo "csd_enabled=$CSD_CAPABILITY" >> $GITHUB_OUTPUT
 
       - name: Checkout binary
         uses: dawidd6/action-download-artifact@v3
@@ -152,6 +156,28 @@ jobs:
         working-directory: ./bin
         run: ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-transaction certify $TRANSACTIONS_HASHES_TO_CERTIFY
 
+      - name: Cardano Stake Distribution / list and get last epoch and hash
+        if: steps.aggregator_capability_unix.outputs.csd_enabled == 'true' || steps.aggregator_capability_windows.outputs.csd_enabled == 'true'
+        shell: bash
+        working-directory: ./bin
+        run: |
+          ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution list
+          CMD_OUTPUT=$(./mithril-client --unstable cardano-stake-distribution list --json)
+          echo "CARDANO_STAKE_DISTRIBUTION_EPOCH=$(echo "$CMD_OUTPUT" | jq -r '.[0].epoch')" >> $GITHUB_ENV
+          echo "CARDANO_STAKE_DISTRIBUTION_HASH=$(echo "$CMD_OUTPUT" | jq -r '.[0].hash')" >> $GITHUB_ENV
+
+      - name: Cardano Stake Distribution / download & restore latest by epoch
+        if: steps.aggregator_capability_unix.outputs.csd_enabled == 'true' || steps.aggregator_capability_windows.outputs.csd_enabled == 'true'
+        shell: bash
+        working-directory: ./bin
+        run: ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_EPOCH
+
+      - name: Cardano Stake Distribution / download & restore latest by hash
+        if: steps.aggregator_capability_unix.outputs.csd_enabled == 'true' || steps.aggregator_capability_windows.outputs.csd_enabled == 'true'
+        shell: bash
+        working-directory: ./bin
+        run: ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_HASH
+
   test-docker:
     strategy:
       fail-fast: false
@@ -178,7 +204,9 @@ jobs:
         shell: bash
         run: |
           CTX_CAPABILITY=$(wget -q -O - $AGGREGATOR_ENDPOINT | jq '.capabilities.signed_entity_types | contains(["CardanoTransactions"])')
+          CSD_CAPABILITY=$(wget -q -O - $AGGREGATOR_ENDPOINT | jq '.capabilities.signed_entity_types | contains(["CardanoStakeDistribution"])')
           echo "ctx_enabled=$CTX_CAPABILITY" >> $GITHUB_OUTPUT
+          echo "csd_enabled=$CSD_CAPABILITY" >> $GITHUB_OUTPUT
 
       - name: Prepare Mithril client command
         id: command
@@ -226,6 +254,25 @@ jobs:
         if: steps.aggregator_capability.outputs.ctx_enabled == 'true'
         shell: bash
         run: ${{ steps.command.outputs.mithril_client }} --unstable ${{ steps.prepare.outputs.debug_level }} cardano-transaction certify $TRANSACTIONS_HASHES_TO_CERTIFY
+
+      - name: Cardano Stake Distribution / list and get last epoch and hash
+        if: steps.aggregator_capability.outputs.csd_enabled == 'true'
+        shell: bash
+        run: |
+          ${{ steps.command.outputs.mithril_client }} --unstable cardano-stake-distribution list
+          CMD_OUTPUT=$(${{ steps.command.outputs.mithril_client }} --unstable cardano-stake-distribution list --json)
+          echo "CARDANO_STAKE_DISTRIBUTION_EPOCH=$(echo "$CMD_OUTPUT" | jq -r '.[0].epoch')" >> $GITHUB_ENV
+          echo "CARDANO_STAKE_DISTRIBUTION_HASH=$(echo "$CMD_OUTPUT" | jq -r '.[0].hash')" >> $GITHUB_ENV
+
+      - name: Cardano Stake Distribution / download & restore latest by epoch
+        if: steps.aggregator_capability.outputs.csd_enabled == 'true'
+        shell: bash
+        run: ${{ steps.command.outputs.mithril_client }} --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_EPOCH --download-dir /app
+
+      - name: Cardano Stake Distribution / download & restore latest by hash
+        if: steps.aggregator_capability.outputs.csd_enabled == 'true'
+        shell: bash
+        run: ${{ steps.command.outputs.mithril_client }} --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_HASH --download-dir /app
 
   test-mithril-client-wasm:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ As a minor extension, we have adopted a slightly different versioning convention
   - Implement the signable and artifact builders for the signed entity type `CardanoStakeDistribution`.
   - Implement the HTTP routes related to the signed entity type `CardanoStakeDistribution` on the aggregator REST API.
   - Added support in the `mithril-client` library for retrieving `CardanoStakeDistribution` by epoch or by hash, and for listing all available `CardanoStakeDistribution`.
+  - Implement `CardanoStakeDistribution` commands under the `--unstable` flag in the Mithril client CLI to list all available `CardanoStakeDistribution` and to download artifact by epoch or hash.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,7 +3649,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3767,7 +3767,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.28"
+version = "0.4.29"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.9.10"
+version = "0.9.11"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -257,33 +257,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn is_sha_256_returns_false_with_epoch_as_input() {
-        let input = "501".to_string();
-
+    fn is_sha_256_returns_false_with_len_different_than_64_and_hex_digit() {
+        let len_65_hex_digit = "65aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         assert!(!CardanoStakeDistributionDownloadCommand::is_sha256_hash(
-            &input
+            len_65_hex_digit
+        ));
+
+        let len_63_hex_digit = "63aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        assert!(!CardanoStakeDistributionDownloadCommand::is_sha256_hash(
+            len_63_hex_digit
         ));
     }
 
     #[test]
-    fn is_sha_256_returns_false_with_latest_as_input() {
-        let input = "latest".to_string();
-
+    fn is_sha_256_returns_false_with_len_equal_to_64_and_not_hex_digit() {
+        let len_64_not_hex_digit =
+            "64zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz";
         assert!(!CardanoStakeDistributionDownloadCommand::is_sha256_hash(
-            &input
+            len_64_not_hex_digit
         ));
     }
 
     #[test]
-    fn is_sha_256_returns_true_with_cardano_stake_distribution_hash_as_input() {
-        let input = "aa69be34639b9360fc5d6f9f3402a021568715403dde30dcda6ae6a265b0aba6";
+    fn is_sha_256_returns_true_with_len_equal_to_64_and_hex_digit() {
+        let len_64_hex_digit = "64aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
         assert!(CardanoStakeDistributionDownloadCommand::is_sha256_hash(
-            input
-        ));
-
-        let input = "1234567890123456789012345678901234567890123456789012345678901234";
-        assert!(CardanoStakeDistributionDownloadCommand::is_sha256_hash(
-            input
+            len_64_hex_digit
         ));
     }
 }

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -1,0 +1,183 @@
+use anyhow::{anyhow, Context};
+use clap::Parser;
+use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
+use std::sync::Arc;
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use crate::utils::{IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter};
+use crate::{commands::client_builder, configuration::ConfigParameters};
+use mithril_client::common::Epoch;
+use mithril_client::MessageBuilder;
+use mithril_client::MithrilResult;
+
+/// Download and verify a Cardano stake distribution information.
+#[derive(Parser, Debug, Clone)]
+pub struct CardanoStakeDistributionDownloadCommand {
+    /// Enable JSON output.
+    #[clap(long)]
+    json: bool,
+
+    /// Epoch of the Cardano stake distribution artifact.
+    /// It represents the epoch at the end of which the Cardano stake distribution is computed by the Cardano node
+    epoch: u64,
+
+    /// Directory where the Cardano stake distribution will be downloaded.
+    #[clap(long)]
+    download_dir: Option<PathBuf>,
+
+    /// Genesis Verification Key to check the certificate chain.
+    #[clap(long, env = "GENESIS_VERIFICATION_KEY")]
+    genesis_verification_key: Option<String>,
+}
+
+impl CardanoStakeDistributionDownloadCommand {
+    /// Main command execution
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+        let config = config_builder
+            .set_default("download_dir", ".")?
+            .add_source(self.clone())
+            .build()?;
+        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+        let download_dir = &params.require("download_dir")?;
+        let download_dir = Path::new(download_dir);
+
+        let progress_output_type = if self.json {
+            ProgressOutputType::JsonReporter
+        } else {
+            ProgressOutputType::Tty
+        };
+        let progress_printer = ProgressPrinter::new(progress_output_type, 4);
+        let client = client_builder(&params)?
+            .add_feedback_receiver(Arc::new(IndicatifFeedbackReceiver::new(
+                progress_output_type,
+            )))
+            .build()?;
+
+        progress_printer.report_step(
+            1,
+            &format!(
+                "Fetching Cardano stake distribution for epoch: '{}' …",
+                self.epoch
+            ),
+        )?;
+        let cardano_stake_distribution = client
+            .cardano_stake_distribution()
+            .get_by_epoch(Epoch(self.epoch))
+            .await
+            .with_context(|| {
+                format!(
+                    "Can not download and verify the artifact for epoch: '{}'",
+                    self.epoch
+                )
+            })?
+            .ok_or(anyhow!(
+                "Cardano stake distribution for epoch '{}' not found",
+                self.epoch
+            ))?;
+
+        progress_printer.report_step(
+            2,
+            "Fetching the certificate and verifying the certificate chain…",
+        )?;
+        let certificate = client
+            .certificate()
+            .verify_chain(&cardano_stake_distribution.certificate_hash)
+            .await
+            .with_context(|| {
+                format!(
+                    "Can not verify the certificate chain from certificate_hash: '{}'",
+                    &cardano_stake_distribution.certificate_hash
+                )
+            })?;
+
+        progress_printer.report_step(
+            3,
+            "Verify that the Cardano stake distribution is signed in the associated certificate",
+        )?;
+        let message = MessageBuilder::new()
+            .compute_cardano_stake_distribution_message(&certificate, &cardano_stake_distribution)
+            .with_context(|| {
+                "Can not compute the message for the given Cardano stake distribution"
+            })?;
+
+        if !certificate.match_message(&message) {
+            return Err(anyhow!(
+                    "Certificate and message did not match:\ncertificate_message: '{}'\n computed_message: '{}'",
+                    certificate.signed_message,
+                    message.compute_hash()
+                ));
+        }
+
+        progress_printer.report_step(4, "Writing fetched Cardano stake distribution to a file")?;
+        if !download_dir.is_dir() {
+            std::fs::create_dir_all(download_dir)?;
+        }
+        let filepath = PathBuf::new().join(download_dir).join(format!(
+            "cardano_stake_distribution-{}.json",
+            cardano_stake_distribution.epoch
+        ));
+        std::fs::write(
+            &filepath,
+            serde_json::to_string(&cardano_stake_distribution).with_context(|| {
+                format!(
+                    "Can not serialize Cardano stake distribution artifact '{:?}'",
+                    cardano_stake_distribution
+                )
+            })?,
+        )?;
+
+        if self.json {
+            println!(
+                r#"{{"cardano_stake_distribution_epoch": "{}", "filepath": "{}"}}"#,
+                cardano_stake_distribution.epoch,
+                filepath.display()
+            );
+        } else {
+            println!(
+                "Cardano stake distribution for epoch '{}' has been verified and saved as '{}'.",
+                cardano_stake_distribution.epoch,
+                filepath.display()
+            );
+        }
+
+        Ok(())
+    }
+}
+
+impl Source for CardanoStakeDistributionDownloadCommand {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new(self.clone())
+    }
+
+    fn collect(&self) -> Result<Map<String, Value>, config::ConfigError> {
+        let mut map = Map::new();
+        let namespace = "clap arguments".to_string();
+
+        if let Some(download_dir) = self.download_dir.clone() {
+            map.insert(
+                "download_dir".to_string(),
+                Value::new(
+                    Some(&namespace),
+                    ValueKind::from(download_dir.to_str().ok_or_else(|| {
+                        config::ConfigError::Message(format!(
+                            "Could not read download directory: '{}'.",
+                            download_dir.display()
+                        ))
+                    })?),
+                ),
+            );
+        }
+
+        if let Some(genesis_verification_key) = self.genesis_verification_key.clone() {
+            map.insert(
+                "genesis_verification_key".to_string(),
+                Value::new(Some(&namespace), ValueKind::from(genesis_verification_key)),
+            );
+        }
+
+        Ok(map)
+    }
+}

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
@@ -1,0 +1,51 @@
+use clap::Parser;
+use cli_table::{format::Justify, print_stdout, Cell, Table};
+use config::{builder::DefaultState, ConfigBuilder};
+use std::collections::HashMap;
+
+use crate::{commands::client_builder_with_fallback_genesis_key, configuration::ConfigParameters};
+use mithril_client::MithrilResult;
+
+/// Cardano stake distribution LIST command
+#[derive(Parser, Debug, Clone)]
+pub struct CardanoStakeDistributionListCommand {
+    /// Enable JSON output.
+    #[clap(long)]
+    json: bool,
+}
+
+impl CardanoStakeDistributionListCommand {
+    /// Main command execution
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+        let config = config_builder.build()?;
+        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+        let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
+        let lines = client.cardano_stake_distribution().list().await?;
+
+        if self.json {
+            println!("{}", serde_json::to_string(&lines)?);
+        } else {
+            let lines = lines
+                .into_iter()
+                .map(|item| {
+                    vec![
+                        format!("{}", item.epoch).cell(),
+                        item.hash.cell(),
+                        item.certificate_hash.cell(),
+                        item.created_at.to_string().cell(),
+                    ]
+                })
+                .collect::<Vec<_>>()
+                .table()
+                .title(vec![
+                    "Epoch".cell(),
+                    "Hash".cell(),
+                    "Certificate Hash".cell(),
+                    "Created".cell().justify(Justify::Right),
+                ]);
+            print_stdout(lines)?;
+        }
+
+        Ok(())
+    }
+}

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
@@ -1,6 +1,8 @@
 //! Commands for the Cardano Stake Distribution artifact
+mod download;
 mod list;
 
+pub use download::*;
 pub use list::*;
 
 use clap::Subcommand;
@@ -14,6 +16,10 @@ pub enum CardanoStakeDistributionCommands {
     /// List certified Cardano Stake Distributions
     #[clap(arg_required_else_help = false)]
     List(CardanoStakeDistributionListCommand),
+
+    /// Download and verify the given Cardano Stake Distribution
+    #[clap(arg_required_else_help = true)]
+    Download(CardanoStakeDistributionDownloadCommand),
 }
 
 impl CardanoStakeDistributionCommands {
@@ -21,6 +27,7 @@ impl CardanoStakeDistributionCommands {
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,
+            Self::Download(cmd) => cmd.execute(config_builder).await,
         }
     }
 }

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
@@ -1,0 +1,26 @@
+//! Commands for the Cardano Stake Distribution artifact
+mod list;
+
+pub use list::*;
+
+use clap::Subcommand;
+use config::{builder::DefaultState, ConfigBuilder};
+use mithril_client::MithrilResult;
+
+/// Cardano Stake Distribution management (alias: csd)
+#[derive(Subcommand, Debug, Clone)]
+#[command(about = "[unstable] Cardano stake distribution management (alias: csd)")]
+pub enum CardanoStakeDistributionCommands {
+    /// List certified Cardano Stake Distributions
+    #[clap(arg_required_else_help = false)]
+    List(CardanoStakeDistributionListCommand),
+}
+
+impl CardanoStakeDistributionCommands {
+    /// Execute Cardano Stake Distribution command
+    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+        match self {
+            Self::List(cmd) => cmd.execute(config_builder).await,
+        }
+    }
+}

--- a/mithril-client-cli/src/commands/mod.rs
+++ b/mithril-client-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@
 //!
 
 pub mod cardano_db;
+pub mod cardano_stake_distribution;
 pub mod cardano_transaction;
 mod deprecation;
 pub mod mithril_stake_distribution;

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.28"
+version = "0.4.29"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -145,7 +145,7 @@ impl<'a> Spec<'a> {
         // Verify that Cardano stake distribution artifacts are produced and signed correctly
         if self.infrastructure.is_signing_cardano_stake_distribution() {
             {
-                let hash = assertions::assert_node_producing_cardano_stake_distribution(
+                let (hash, epoch) = assertions::assert_node_producing_cardano_stake_distribution(
                     &aggregator_endpoint,
                 )
                 .await?;
@@ -160,6 +160,14 @@ impl<'a> Spec<'a> {
                     &aggregator_endpoint,
                     &certificate_hash,
                     self.infrastructure.signers().len(),
+                )
+                .await?;
+
+                let mut client = self.infrastructure.build_client()?;
+                assertions::assert_client_can_verify_cardano_stake_distribution(
+                    &mut client,
+                    &hash,
+                    epoch,
                 )
                 .await?;
             }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
@@ -104,10 +104,39 @@ impl CardanoTransactionCommand {
 }
 
 #[derive(Debug)]
+pub enum CardanoStakeDistributionCommand {
+    List,
+    Download { unique_identifier: String },
+}
+
+impl CardanoStakeDistributionCommand {
+    fn name(&self) -> String {
+        match self {
+            CardanoStakeDistributionCommand::List => "list".to_string(),
+            CardanoStakeDistributionCommand::Download { unique_identifier } => {
+                format!("download-{unique_identifier}")
+            }
+        }
+    }
+
+    fn cli_arg(&self) -> Vec<String> {
+        match self {
+            CardanoStakeDistributionCommand::List => {
+                vec!["list".to_string()]
+            }
+            CardanoStakeDistributionCommand::Download { unique_identifier } => {
+                vec!["download".to_string(), unique_identifier.clone()]
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
 pub enum ClientCommand {
     CardanoDb(CardanoDbCommand),
     MithrilStakeDistribution(MithrilStakeDistributionCommand),
     CardanoTransaction(CardanoTransactionCommand),
+    CardanoStakeDistribution(CardanoStakeDistributionCommand),
 }
 
 impl ClientCommand {
@@ -119,6 +148,9 @@ impl ClientCommand {
             }
             ClientCommand::CardanoTransaction(cmd) => {
                 format!("ctx-{}", cmd.name())
+            }
+            ClientCommand::CardanoStakeDistribution(cmd) => {
+                format!("csd-{}", cmd.name())
             }
         }
     }
@@ -135,6 +167,14 @@ impl ClientCommand {
             .concat(),
             ClientCommand::CardanoTransaction(cmd) => [
                 vec!["--unstable".to_string(), "cardano-transaction".to_string()],
+                cmd.cli_arg(),
+            ]
+            .concat(),
+            ClientCommand::CardanoStakeDistribution(cmd) => [
+                vec![
+                    "--unstable".to_string(),
+                    "cardano-stake-distribution".to_string(),
+                ],
                 cmd.cli_arg(),
             ]
             .concat(),

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/mod.rs
@@ -8,8 +8,8 @@ mod signer;
 
 pub use aggregator::{Aggregator, AggregatorConfig};
 pub use client::{
-    CardanoDbCommand, CardanoTransactionCommand, Client, ClientCommand,
-    MithrilStakeDistributionCommand,
+    CardanoDbCommand, CardanoStakeDistributionCommand, CardanoTransactionCommand, Client,
+    ClientCommand, MithrilStakeDistributionCommand,
 };
 pub use infrastructure::{MithrilInfrastructure, MithrilInfrastructureConfig};
 pub use relay_aggregator::RelayAggregator;


### PR DESCRIPTION
## Content

This PR adds support for new commands in the `mithril-client` CLI for `CardanoStakeDistribution`.
These commands are currently unstable and must be used with the `--unstable` option.

- **list**: `./mithril-client --unstable cardano-stake-distribution list`

- **download**: `./mithril-client --unstable cardano-stake-distribution download $UNIQUE_IDENTIFIER`
The `$UNIQUE_IDENTIFIER` can be either the  `hash` or the `epoch` of the `CardanoStakeDistribution`.
The identifier `latest` is also supported.

An alias `csd` has been created for `cardano-stake-distribution`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1880 
