### PR TITLE
feat: Make `rug-backend` optional for `mithril-client` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - **UNSTABLE** Cardano stake distribution certification:
 
+  - Add feature options `num-integer-backend` and `rug-backend` for `mithril-common` and `mithril-client` crates. Allows to disable `rug-backend` and avoid `LGPL` licence usage.
   - Implement the signable and artifact builders for the signed entity type `CardanoStakeDistribution`.
   - Implement the HTTP routes related to the signed entity type `CardanoStakeDistribution` on the aggregator REST API.
   - Added support in the `mithril-client` library for retrieving `CardanoStakeDistribution` by epoch or by hash, and for listing all available `CardanoStakeDistribution`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.15"
+version = "0.8.16"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.47"
+version = "0.4.48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.27"
+version = "0.3.28"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.15"
+version = "0.8.16"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -50,13 +50,13 @@ uuid = { version = "1.7.0", features = ["v4"] }
 zstd = { version = "0.13.0", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-mithril-common = { path = "../mithril-common", version = "=0.4", features = [
+mithril-common = { path = "../mithril-common", version = "=0.4", default-features = false, features = [
     "fs",
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.12", features = ["js"] }
-mithril-common = { path = "../mithril-common", version = "=0.4" }
+mithril-common = { path = "../mithril-common", version = "=0.4", default-features = false }
 reqwest = { version = "0.12.4", default-features = false, features = [
     "charset",
     "http2",
@@ -68,7 +68,7 @@ reqwest = { version = "0.12.4", default-features = false, features = [
 [dev-dependencies]
 httpmock = "0.7.0"
 indicatif = { version = "0.17.7", features = ["tokio"] }
-mithril-common = { path = "../mithril-common", version = "=0.4", features = [
+mithril-common = { path = "../mithril-common", version = "=0.4", default-features = false, features = [
     "random",
     "test_tools",
 ] }
@@ -81,7 +81,7 @@ warp = "0.3.6"
 
 [features]
 # Include native-tls in reqwest by default
-default = ["native-tls"]
+default = ["native-tls", "rug-backend"]
 
 # Full feature set
 full = ["fs"]
@@ -101,6 +101,12 @@ rustls-tls = ["reqwest/rustls-tls"]
 rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
 rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
 rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
+
+# Enables `rug-backend` features for `mithril-common` dependency
+rug-backend = ["mithril-common/rug-backend"]
+# Enables `num-integer-backend` features for `mithril-common` dependency
+# by default it's `rug-backend`
+num-integer-backend = ["mithril-common/num-integer-backend"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/mithril-client/README.md
+++ b/mithril-client/README.md
@@ -51,6 +51,17 @@ async fn main() -> mithril_client::MithrilResult<()> {
 }
 ```
 
+## Different arithmetic libraries
+
+Under the hood mithril client could use different arithmetic libraries:
+
+- [rug](https://crates.io/crates/rug)
+- [num](https://crates.io/crates/num)
+
+You can switch beetwen them by using `rug-backend` and `num-integer-backend` respectively.
+For Windows and WASM target platforms only `num-integer-backend` is available,
+for others `rug-backend` is a default option.
+
 ## Getting Help
 
 First, check our [Developer documentation](https://mithril.network/doc/manual/developer-docs/nodes/mithril-client-library).

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.47"
+version = "0.4.48"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -47,6 +47,7 @@ kes-summed-ed25519 = { version = "0.2.1", features = [
     "serde_enabled",
     "sk_clone_enabled",
 ] }
+mithril-stm = { path = "../mithril-stm", version = "0.3", default-features = false }
 nom = "7.1.3"
 pallas-addresses = { version = "0.29.0", optional = true }
 pallas-codec = { version = "0.29.0", optional = true }
@@ -73,21 +74,7 @@ typetag = "0.2.15"
 walkdir = "2.4.0"
 warp = { version = "0.3.6", optional = true }
 
-[target.'cfg(target_family = "unix")'.dependencies]
-# only unix supports the default rug backend
-mithril-stm = { path = "../mithril-stm", version = "0.3" }
-
-[target.'cfg(windows)'.dependencies]
-# Windows doesn't support rug backend, fallback to num-integer
-mithril-stm = { path = "../mithril-stm", version = "0.3", default-features = false, features = [
-    "num-integer-backend",
-] }
-
 [target.'cfg(target_family = "wasm")'.dependencies]
-# WASM doesn't support rug backend, fallback to num-integer
-mithril-stm = { path = "../mithril-stm", version = "0.3", default-features = false, features = [
-    "num-integer-backend",
-] }
 wasm-bindgen = "0.2.90"
 
 [dev-dependencies]
@@ -105,7 +92,7 @@ tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "time"] }
 mithril-build-script = { path = "../internal/mithril-build-script", version = "=0.2" }
 
 [features]
-default = []
+default = ["rug-backend"]
 
 # Full feature set
 full = ["random", "fs", "test_tools"]
@@ -120,6 +107,12 @@ fs = [
     "dep:pallas-primitives",
     "dep:pallas-traverse",
 ]
+
+# Enables `rug-backend` features for `mithril-stm` dependency
+rug-backend = ["mithril-stm/rug-backend"]
+# Enables `num-integer-backend` features for `mithril-stm` dependency
+# by default it's `rug-backend`
+num-integer-backend = ["mithril-stm/num-integer-backend"]
 
 # Disable signer certification, to be used only for tests
 allow_skip_signer_certification = []

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.27"
+version = "0.3.28"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -18,14 +18,23 @@ blake2 = "0.10.6"
 # Enforce blst portable feature for runtime detection of Intel ADX instruction set.
 blst = { version = "0.3.11", features = ["portable"] }
 digest = { version = "0.10.7", features = ["alloc"] }
+rand_core = "0.6.4"
+rayon = "1.8.0"
+serde = { version = "1.0.188", features = ["rc", "derive"] }
+thiserror = "1.0.49"
+
+[target.'cfg(not(any(target_family = "wasm", windows)))'.dependencies]
+# only unix supports the rug backend
+rug = { version = "1.22.0", optional = true }
 num-bigint = { version = "0.4.4", optional = true }
 num-rational = { version = "0.4.1", optional = true }
 num-traits = { version = "0.2.16", optional = true }
-rand_core = "0.6.4"
-rayon = "1.8.0"
-rug = { version = "1.22.0", optional = true }
-serde = { version = "1.0.188", features = ["rc", "derive"] }
-thiserror = "1.0.49"
+
+[target.'cfg(any(target_family = "wasm", windows))'.dependencies]
+# WASM and Windows don't support rug backend, fallback to num-integer only
+num-bigint = { version = "0.4.4" }
+num-rational = { version = "0.4.1" }
+num-traits = { version = "0.2.16" }
 
 [dev-dependencies]
 bincode = "1.3.3"

--- a/mithril-stm/src/eligibility_check.rs
+++ b/mithril-stm/src/eligibility_check.rs
@@ -1,5 +1,5 @@
 use crate::stm::Stake;
-#[cfg(feature = "num-integer-backend")]
+#[cfg(any(feature = "num-integer-backend", target_family = "wasm", windows))]
 use {
     num_bigint::{BigInt, Sign},
     num_rational::Ratio,
@@ -7,7 +7,7 @@ use {
     std::ops::Neg,
 };
 
-#[cfg(feature = "num-integer-backend")]
+#[cfg(any(feature = "num-integer-backend", target_family = "wasm", windows))]
 /// Checks that ev is successful in the lottery. In particular, it compares the output of `phi`
 /// (a real) to the output of `ev` (a hash).  It uses the same technique used in the
 /// [Cardano ledger](https://github.com/input-output-hk/cardano-ledger/). In particular,
@@ -49,7 +49,7 @@ pub(crate) fn ev_lt_phi(phi_f: f64, ev: [u8; 64], stake: Stake, total_stake: Sta
     taylor_comparison(1000, q, x)
 }
 
-#[cfg(feature = "num-integer-backend")]
+#[cfg(any(feature = "num-integer-backend", target_family = "wasm", windows))]
 /// Checks if cmp < exp(x). Uses error approximation for an early stop. Whenever the value being
 /// compared, `cmp`, is smaller (or greater) than the current approximation minus an `error_term`
 /// (plus an `error_term` respectively), then we stop approximating. The choice of the `error_term`
@@ -82,7 +82,7 @@ fn taylor_comparison(bound: usize, cmp: Ratio<BigInt>, x: Ratio<BigInt>) -> bool
     false
 }
 
-#[cfg(not(feature = "num-integer-backend"))]
+#[cfg(not(any(feature = "num-integer-backend", target_family = "wasm", windows)))]
 /// The crate `rug` has sufficient optimizations to not require a taylor approximation with early
 /// stop. The difference between the current implementation and the one using the optimization
 /// above is around 10% faster. We perform the computations with 117 significant bits of
@@ -146,7 +146,7 @@ mod tests {
             assert_eq!(quick_result, result);
         }
 
-        #[cfg(feature = "num-integer-backend")]
+        #[cfg(any(feature = "num-integer-backend", target_family = "wasm", windows))]
         #[test]
         /// Checking the early break of Taylor computation
         fn early_break_taylor(


### PR DESCRIPTION
## Content

To allow disable `LGPL` usage which discussed [in](https://github.com/input-output-hk/mithril/issues/1786), added `rug-backend` feature for `mithril-client` and `mithril-common` crates.

## Issue(s)

Closes #1786
