### PR TITLE
feat: support `file://` URLs for snapshot locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ mithril-infra/terraform.tfstate*
 mithril-infra/*.tfvars
 justfile
 
+# Outputs of nix-build:
+result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Support for Mithril nodes footprint support in Prometheus monitoring in infrastructure
 - Add support for custom HTTP headers in Mithril client WASM library
+- Support `file://` URLs for snapshot locations
 
 - **UNSTABLE** Cardano stake distribution certification:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.14"
+version = "0.8.15"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
[LW-11112](https://input-output.atlassian.net/browse/LW-11112)

## Content

This PR includes support for the `file://` scheme in URLs of the snapshots.

This is very useful for live demos, where you don’t want to repeatedly download from Google Cloud Storage because of the wait time and cost.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

It requires a proxy modifying responses from the aggregator, e.g. [this](https://github.com/input-output-hk/lace/pull/1350).

## Issue(s)

[LW-11112](https://input-output.atlassian.net/browse/LW-11112)