### PR TITLE
Add support for custom HTTP Headers in Mithril client WASM library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 ## Mithril Distribution [XXXX] - UNRELEASED
 
 - Support for Mithril nodes footprint support in Prometheus monitoring in infrastructure
+- Add support for custom HTTP headers in Mithril client WASM library
 
 - **UNSTABLE** Cardano stake distribution certification:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.3.9"
+version = "0.3.10"
 dependencies = [
  "async-trait",
  "futures",

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client-library-wasm.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client-library-wasm.md
@@ -146,6 +146,27 @@ console.log(
 );
 ```
 
+:::tip Adding Custom HTTP Headers
+
+You can customize the HTTP headers sent by the Mithril client. This is particularly useful if you need to include headers like **Authorization** or custom headers for specific use cases. Below is an example of how to set custom headers:
+
+```js
+let headers_map = new Map();
+headers_map.set("Authorization", "Bearer YourBearerToken");
+headers_map.set("X-Custom-Header", "YourCustomHeaderValue");
+
+let client_options = new Map();
+client_options.set("http_headers", headers_map);
+
+let client = new MithrilClient(
+  aggregator_endpoint,
+  genesis_verification_key,
+  client_options,
+);
+```
+
+:::
+
 If the aggregator signs **CardanoTransactions**, you can add the code below to the previous example:
 
 :::tip

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client-library-wasm.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client-library-wasm.md
@@ -148,15 +148,16 @@ console.log(
 
 :::tip Adding Custom HTTP Headers
 
-You can customize the HTTP headers sent by the Mithril client. This is particularly useful if you need to include headers like **Authorization** or custom headers for specific use cases. Below is an example of how to set custom headers:
+You can customize the HTTP headers sent by the Mithril client. This is particularly useful in scenarios where the Mithril client is used with a proxy, as it allows you to include headers like **Authorization** or custom headers for specific use cases. Below is an example of how to set custom headers:
 
 ```js
-let headers_map = new Map();
-headers_map.set("Authorization", "Bearer YourBearerToken");
-headers_map.set("X-Custom-Header", "YourCustomHeaderValue");
+let http_headers_map = new Map();
+http_headers_map.set("Authorization", "Bearer YourBearerToken");
+http_headers_map.set("X-Custom-Header", "YourCustomHeaderValue");
 
-let client_options = new Map();
-client_options.set("http_headers", headers_map);
+let client_options = {
+  http_headers: http_headers_map,
+};
 
 let client = new MithrilClient(
   aggregator_endpoint,

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.3.9"
+version = "0.3.10"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -1,12 +1,16 @@
 use async_trait::async_trait;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::sync::Arc;
 use wasm_bindgen::prelude::*;
+use web_sys::js_sys;
+use web_sys::js_sys::Map;
 
 use mithril_client::{
     common::Epoch,
     feedback::{FeedbackReceiver, MithrilEvent},
-    CardanoTransactionsProofs, Client, ClientBuilder, MessageBuilder, MithrilCertificate,
+    CardanoTransactionsProofs, Client, ClientBuilder, ClientOptionValue,
+    ClientOptionValueDiscriminants, ClientOptions, MessageBuilder, MithrilCertificate,
 };
 
 use crate::WasmResult;
@@ -71,15 +75,68 @@ pub struct MithrilUnstableClient {
 impl MithrilClient {
     /// Constructor for wasm client
     #[wasm_bindgen(constructor)]
-    pub fn new(aggregator_endpoint: &str, genesis_verification_key: &str) -> MithrilClient {
+    pub fn new(
+        aggregator_endpoint: &str,
+        genesis_verification_key: &str,
+        options: Option<Map>,
+    ) -> MithrilClient {
         let feedback_receiver = Arc::new(JSBroadcastChannelFeedbackReceiver::new("mithril-client"));
+
+        let client_options = if let Some(options) = options {
+            Self::parse_client_options(options)
+                .map_err(|err| format!("{err:?}"))
+                .unwrap()
+        } else {
+            HashMap::new()
+        };
+
         let client = ClientBuilder::aggregator(aggregator_endpoint, genesis_verification_key)
             .add_feedback_receiver(feedback_receiver)
+            .with_options(client_options)
             .build()
             .map_err(|err| format!("{err:?}"))
             .unwrap();
         let unstable = MithrilUnstableClient::new(client.clone());
         MithrilClient { client, unstable }
+    }
+
+    fn parse_client_options(options: Map) -> Result<ClientOptions, JsValue> {
+        let mut client_options: ClientOptions = HashMap::new();
+
+        for entry in js_sys::try_iter(&options)?
+            .ok_or_else(|| JsValue::from_str("Failed to iterate over options"))?
+        {
+            let entry = entry?.dyn_into::<js_sys::Array>()?;
+            let option_key = entry.get(0);
+            let option_key = option_key.as_string().ok_or_else(|| {
+                JsValue::from_str(&format!(
+                    "Option key should be a string but received: '{option_key:?}'"
+                ))
+            })?;
+            let option_value = entry.get(1);
+
+            if option_key == ClientOptionValueDiscriminants::HTTPHeaders.to_string() {
+                let headers_map = option_value
+                    .dyn_into::<Map>()
+                    .or_else(|_| {
+                        Err(JsValue::from_str(
+                            "Failed to convert http_headers value to Map",
+                        ))
+                    })?
+                    .entries()
+                    .into_iter()
+                    .filter_map(|entry| {
+                        let entry = entry.ok()?.dyn_into::<js_sys::Array>().ok()?;
+                        let header_key = entry.get(0).as_string()?;
+                        let header_value = entry.get(1).as_string()?;
+                        Some((header_key, header_value))
+                    })
+                    .collect();
+                client_options.insert(option_key, ClientOptionValue::HTTPHeaders(headers_map));
+            };
+        }
+
+        Ok(client_options)
     }
 
     /// Call the client to get a snapshot from a digest
@@ -361,15 +418,18 @@ impl MithrilUnstableClient {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::test_data;
     use wasm_bindgen_test::*;
+    use web_sys::js_sys::Map;
 
     use mithril_client::{
         common::ProtocolMessage, CardanoStakeDistribution, CardanoStakeDistributionListItem,
         CardanoTransactionSnapshot, MithrilCertificateListItem, MithrilStakeDistribution,
         MithrilStakeDistributionListItem, Snapshot, SnapshotListItem,
     };
+
+    use crate::test_data;
+
+    use super::*;
 
     const GENESIS_VERIFICATION_KEY: &str = "5b33322c3235332c3138362c3230312c3137372c31312c3131372c3133352c3138372c3136372c3138312c3138382c32322c35392c3230362c3130352c3233312c3135302c3231352c33302c37382c3231322c37362c31362c3235322c3138302c37322c3133342c3133372c3234372c3136312c36385d";
     const FAKE_AGGREGATOR_IP: &str = "127.0.0.1";
@@ -382,10 +442,88 @@ mod tests {
                 FAKE_AGGREGATOR_IP, FAKE_AGGREGATOR_PORT
             ),
             GENESIS_VERIFICATION_KEY,
+            None,
         )
     }
 
     wasm_bindgen_test_configure!(run_in_browser);
+
+    #[wasm_bindgen_test]
+    fn test_parse_client_with_valid_options() {
+        let headers = Map::new();
+        headers.set(
+            &JsValue::from_str("Content-Type"),
+            &JsValue::from_str("application/json"),
+        );
+        headers.set(
+            &JsValue::from_str("Authorization"),
+            &JsValue::from_str("Bearer <token>"),
+        );
+
+        let options = Map::new();
+        options.set(
+            &JsValue::from_str("http_headers"),
+            &JsValue::from(headers.clone()),
+        );
+
+        let client_options = MithrilClient::parse_client_options(options).unwrap();
+
+        if let Some(ClientOptionValue::HTTPHeaders(parsed_headers)) =
+            client_options.get("http_headers")
+        {
+            assert_eq!(
+                parsed_headers.get("Content-Type").unwrap(),
+                "application/json"
+            );
+            assert_eq!(
+                parsed_headers.get("Authorization").unwrap(),
+                "Bearer <token>"
+            );
+        } else {
+            panic!("Headers were not parsed correctly");
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_parse_client_options_with_unknown_option_key() {
+        let options = Map::new();
+        options.set(
+            &JsValue::from_str("unknown_key"),
+            &JsValue::from_str("whatever"),
+        );
+
+        let result = MithrilClient::parse_client_options(options).unwrap();
+
+        assert!(result.is_empty());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_parse_client_options_with_non_string_option_key() {
+        let options = Map::new();
+        options.set(&JsValue::from_f64(123.0), &JsValue::from_str("whatever"));
+
+        let result = MithrilClient::parse_client_options(options)
+            .expect_err("Should fail with non string option key");
+
+        let error_message = result.as_string().unwrap();
+        assert!(error_message.contains("Option key should be a string"),);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_parse_client_options_with_non_map_http_headers_value() {
+        let options = Map::new();
+        options.set(
+            &JsValue::from_str("http_headers"),
+            &JsValue::from_str("not_a_map"),
+        );
+
+        let result = MithrilClient::parse_client_options(options)
+            .expect_err("Should fail with non map http_headers value");
+
+        let error_message = result.as_string().unwrap();
+        assert!(error_message.contains("Failed to convert http_headers value to Map"),);
+    }
+
     #[wasm_bindgen_test]
     async fn list_snapshots_should_return_value_convertible_in_rust_type() {
         let snapshots_list_js_value = get_mithril_client()

--- a/mithril-client-wasm/www-test/package-lock.json
+++ b/mithril-client-wasm/www-test/package-lock.json
@@ -21,7 +21,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/www/index.js
+++ b/mithril-client-wasm/www/index.js
@@ -67,17 +67,12 @@ function format_tx_list(transactions_hashes) {
 function client_options_with_custom_headers() {
   // The following header is set as an example.
   // It's used to demonstrate how to add headers.
-  let headers_map = new Map();
-  headers_map.set("Content-Type", "application/json");
+  let http_headers_map = new Map();
+  http_headers_map.set("Content-Type", "application/json");
 
-  // The headers below are examples of headers that might be used when interacting with a proxy.
-  // They are commented out because aggregators don't allow these headers.
-  // headers_map.set("Authorization", "Bearer YourBearerToken");
-  // headers_map.set("X-My-Custom-Header", "YourCustomHeaderValue");
-  let client_options = new Map();
-  client_options.set("http_headers", headers_map);
-
-  return client_options;
+  return {
+    http_headers: http_headers_map,
+  };
 }
 
 await initMithrilClient();

--- a/mithril-client-wasm/www/index.js
+++ b/mithril-client-wasm/www/index.js
@@ -64,9 +64,26 @@ function format_tx_list(transactions_hashes) {
   return "<ul>" + transactions_hashes.map((tx) => "<li>" + tx + "</li>").join("") + "</ul>";
 }
 
+function client_options_with_custom_headers() {
+  // The following header is set as an example.
+  // It's used to demonstrate how to add headers.
+  let headers_map = new Map();
+  headers_map.set("Content-Type", "application/json");
+
+  // The headers below are examples of headers that might be used when interacting with a proxy.
+  // They are commented out because aggregators don't allow these headers.
+  // headers_map.set("Authorization", "Bearer YourBearerToken");
+  // headers_map.set("X-My-Custom-Header", "YourCustomHeaderValue");
+  let client_options = new Map();
+  client_options.set("http_headers", headers_map);
+
+  return client_options;
+}
+
 await initMithrilClient();
 
-let client = new MithrilClient(aggregator_endpoint, genesis_verification_key);
+let client_options = client_options_with_custom_headers();
+let client = new MithrilClient(aggregator_endpoint, genesis_verification_key, client_options);
 
 displayStepInDOM(1, "Getting stake distributions list...");
 let mithril_stake_distributions_list = await client.list_mithril_stake_distributions();

--- a/mithril-client-wasm/www/package-lock.json
+++ b/mithril-client-wasm/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "www",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "www",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../pkg"
       },
@@ -20,7 +20,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/www/package.json
+++ b/mithril-client-wasm/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.13"
+version = "0.8.14"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm/pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {


### PR DESCRIPTION
## Content

This PR introduces the ability to set custom HTTP headers in the Mithril client WASM.

A new optional parameter for client options has been added to the `MithrilClient` constructor, allowing users to specify custom headers.

This enhancement is backward-compatible. The constructor can still be called without passing any options, ensuring no breaking changes.

```js
// Passing custom HTTP headers
let http_headers_map = new Map();
http_headers_map.set("Authorization", "Bearer YourBearerToken");
http_headers_map.set("X-Custom-Header", "YourCustomHeaderValue");

let client_options = {
  http_headers: http_headers_map,
};

let client = new MithrilClient(
  "YOUR_AGGREGATOR_ENDPOINT",
  "YOUR_GENESIS_VERIFICATION_KEY",
  client_options,
);
```

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1878
Relates to #1720 
