### PR TITLE
Fix: Cardano stake distribution certification epoch discrepancy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.54"
+version = "0.5.55"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.44"
+version = "0.4.45"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.54"
+version = "0.5.55"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_stake_distribution.rs
@@ -33,7 +33,7 @@ impl ArtifactBuilder<Epoch, CardanoStakeDistribution> for CardanoStakeDistributi
     ) -> StdResult<CardanoStakeDistribution> {
         let stake_distribution = self
             .stake_distribution_retriever
-            .retrieve(epoch.offset_to_recording_epoch())
+            .retrieve(epoch.offset_to_cardano_stake_distribution_snapshot_epoch())
             .await?
             .ok_or_else(|| anyhow!("No stake distribution found for epoch '{}'", epoch))?;
 
@@ -60,7 +60,7 @@ mod tests {
     #[tokio::test]
     async fn compute_artifact_returns_valid_artifact_and_retrieve_with_epoch_offset() {
         let epoch = Epoch(1);
-        let epoch_to_retrieve = Epoch(2);
+        let epoch_to_retrieve = Epoch(3);
         let certificate = fake_data::certificate("whatever".to_string());
         let stake_distribution = StakeDistribution::from([("pool-123".to_string(), 123)]);
         let stake_distribution_clone = stake_distribution.clone();
@@ -81,7 +81,7 @@ mod tests {
     #[tokio::test]
     async fn compute_artifact_returns_error_if_no_stakes_found_for_epoch() {
         let epoch = Epoch(1);
-        let epoch_to_retrieve = Epoch(2);
+        let epoch_to_retrieve = Epoch(3);
         let certificate = fake_data::certificate("whatever".to_string());
         let mut mock_storer = MockStakeDistributionRetrieverImpl::new();
         mock_storer

--- a/mithril-aggregator/tests/cardano_stake_distribution_verify_stakes.rs
+++ b/mithril-aggregator/tests/cardano_stake_distribution_verify_stakes.rs
@@ -73,10 +73,6 @@ async fn cardano_stake_distribution_verify_stakes() {
             )
         })
         .collect::<Vec<_>>();
-    let updated_stake_distribution: StakeDistribution = signers_with_updated_stake_distribution
-        .iter()
-        .map(|s| (s.party_id.clone(), s.stake))
-        .collect();
     tester
         .chain_observer
         .set_signers(signers_with_updated_stake_distribution)
@@ -121,6 +117,10 @@ async fn cardano_stake_distribution_verify_stakes() {
             )
         })
         .collect::<Vec<_>>();
+    let updated_stake_distribution: StakeDistribution = signers_with_updated_stake_distribution
+        .iter()
+        .map(|s| (s.party_id.clone(), s.stake))
+        .collect();
     tester
         .chain_observer
         .set_signers(signers_with_updated_stake_distribution)

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.44"
+version = "0.4.45"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -34,6 +34,10 @@ impl Epoch {
     /// at which the signer can send single signatures.
     pub const SIGNER_SIGNING_OFFSET: u64 = 2;
 
+    /// The epoch offset used to retrieve the epoch at the end of which the snapshot of the stake distribution
+    /// was taken by the Cardano node and labeled as 'Mark' snapshot during the following epoch.
+    pub const CARDANO_STAKE_DISTRIBUTION_SNAPSHOT_OFFSET: u64 = 2;
+
     /// Computes a new Epoch by applying an epoch offset.
     ///
     /// Will fail if the computed epoch is negative.
@@ -68,6 +72,11 @@ impl Epoch {
     /// Apply the [signer signing offset][Self::SIGNER_SIGNING_OFFSET] to this epoch
     pub fn offset_to_signer_signing_offset(&self) -> Self {
         *self + Self::SIGNER_SIGNING_OFFSET
+    }
+
+    /// Apply the [cardano stake distribution snapshot epoch offset][Self::CARDANO_STAKE_DISTRIBUTION_SNAPSHOT_OFFSET] to this epoch
+    pub fn offset_to_cardano_stake_distribution_snapshot_epoch(&self) -> Self {
+        *self + Self::CARDANO_STAKE_DISTRIBUTION_SNAPSHOT_OFFSET
     }
 
     /// Computes the next Epoch

--- a/mithril-common/src/signable_builder/cardano_stake_distribution.rs
+++ b/mithril-common/src/signable_builder/cardano_stake_distribution.rs
@@ -66,7 +66,7 @@ impl SignableBuilder<Epoch> for CardanoStakeDistributionSignableBuilder {
     async fn compute_protocol_message(&self, epoch: Epoch) -> StdResult<ProtocolMessage> {
         let pools_with_stake = self
             .cardano_stake_distribution_retriever
-            .retrieve(epoch.offset_to_recording_epoch())
+            .retrieve(epoch.offset_to_cardano_stake_distribution_snapshot_epoch())
             .await?.ok_or(anyhow!(
                 "CardanoStakeDistributionSignableBuilder could not find the stake distribution for epoch: '{epoch}'"
             ))?;
@@ -161,7 +161,7 @@ mod tests {
     #[tokio::test]
     async fn compute_protocol_message_returns_signable_and_retrieve_with_epoch_offset() {
         let epoch = Epoch(1);
-        let epoch_to_retrieve = Epoch(2);
+        let epoch_to_retrieve = Epoch(3);
         let stake_distribution = StakeDistribution::from([("pool-123".to_string(), 100)]);
         let stake_distribution_clone = stake_distribution.clone();
 


### PR DESCRIPTION
## Content
This PR includes a fix to compute the message and the artifact on the correct epoch for the **Cardano stake distribution** signed entity type.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1895 
