### PR TITLE
Optimize memory usage of signer for Cardano transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX] - UNRELEASED
 
-- Support for Mithril nodes footprint support in Prometheus monitoring in infrastructure
-- Add support for custom HTTP headers in Mithril client WASM library
-- Support `file://` URLs for snapshot locations
+- Support for Mithril nodes footprint support in Prometheus monitoring in infrastructure.
+
+- Add support for custom HTTP headers in Mithril client WASM library.
+
+- Support `file://` URLs for snapshot locations in Mithril client.
+
+- Support for Mithril signer memory optimization when signing Cardano transactions with multiple Merkle tree storage backends.
 
 - **UNSTABLE** Cardano stake distribution certification:
 
@@ -102,13 +106,9 @@ As a minor extension, we have adopted a slightly different versioning convention
 - **UNSTABLE** Cardano transactions certification:
 
   - Support computation of the Cardano Transactions signature and proving with the pre-computed Block Range Merkle Roots retrieved from the database.
-
   - Prune Cardano Transactions from the signer database after the Block Range Merkle Roots have been computed.
-
   - Implement a Chain Reader which retrieves blocks from the Cardano chain with Pallas through the `chainsync` mini-protocol.
-
   - Implement a Resource Pool and use it for caching Block Range Merkle maps used by the Cardano transactions prover and improving the throughput.
-
   - Change the beacon of the Cardano Transactions to a block number instead of an immutable file number.
 
 - Crates versions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3860,6 +3860,7 @@ dependencies = [
  "axum",
  "clap",
  "config",
+ "criterion",
  "hex",
  "httpmock",
  "mithril-common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.55"
+version = "0.5.56"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.45"
+version = "0.4.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.23"
+version = "0.2.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.173"
+version = "0.2.174"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.23"
+version = "0.2.24"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 
-use mithril_common::crypto_helper::MKTreeNode;
+use mithril_common::crypto_helper::{MKTreeNode, MKTreeStore};
 use mithril_common::entities::{
     BlockHash, BlockNumber, BlockRange, CardanoTransaction, ChainPoint, SlotNumber, TransactionHash,
 };
@@ -296,7 +296,7 @@ impl CardanoTransactionRepository {
 }
 
 #[async_trait]
-impl BlockRangeRootRetriever for CardanoTransactionRepository {
+impl<S: MKTreeStore> BlockRangeRootRetriever<S> for CardanoTransactionRepository {
     async fn retrieve_block_range_roots<'a>(
         &'a self,
         up_to_beacon: BlockNumber,

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use async_trait::async_trait;
 
-use mithril_common::crypto_helper::{MKTreeNode, MKTreeStore};
+use mithril_common::crypto_helper::{MKTreeNode, MKTreeStorer};
 use mithril_common::entities::{
     BlockHash, BlockNumber, BlockRange, CardanoTransaction, ChainPoint, SlotNumber, TransactionHash,
 };
@@ -296,7 +296,7 @@ impl CardanoTransactionRepository {
 }
 
 #[async_trait]
-impl<S: MKTreeStore> BlockRangeRootRetriever<S> for CardanoTransactionRepository {
+impl<S: MKTreeStorer> BlockRangeRootRetriever<S> for CardanoTransactionRepository {
     async fn retrieve_block_range_roots<'a>(
         &'a self,
         up_to_beacon: BlockNumber,

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.55"
+version = "0.5.56"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -21,7 +21,8 @@ use mithril_common::{
     chain_observer::{CardanoCliRunner, ChainObserver, ChainObserverBuilder, FakeObserver},
     chain_reader::{ChainBlockReader, PallasChainReader},
     crypto_helper::{
-        ProtocolGenesisSigner, ProtocolGenesisVerificationKey, ProtocolGenesisVerifier,
+        MKTreeStoreInMemory, ProtocolGenesisSigner, ProtocolGenesisVerificationKey,
+        ProtocolGenesisVerifier,
     },
     digesters::{
         cache::{ImmutableFileDigestCacheProvider, JsonImmutableFileDigestCacheProviderBuilder},
@@ -1085,7 +1086,9 @@ impl DependenciesBuilder {
         ));
         let transactions_importer = self.get_transactions_importer().await?;
         let block_range_root_retriever = self.get_transaction_repository().await?;
-        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::<
+            MKTreeStoreInMemory,
+        >::new(
             transactions_importer,
             block_range_root_retriever,
             self.get_logger()?,
@@ -1487,7 +1490,7 @@ impl DependenciesBuilder {
         let transaction_retriever = self.get_transaction_repository().await?;
         let block_range_root_retriever = self.get_transaction_repository().await?;
         let logger = self.get_logger()?;
-        let prover_service = MithrilProverService::new(
+        let prover_service = MithrilProverService::<MKTreeStoreInMemory>::new(
             transaction_retriever,
             block_range_root_retriever,
             mk_map_pool_size,

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -8,7 +8,7 @@ use slog::{debug, Logger};
 use tokio::{runtime::Handle, task};
 
 use mithril_common::cardano_block_scanner::{BlockScanner, ChainScannedBlocks};
-use mithril_common::crypto_helper::{MKTree, MKTreeNode};
+use mithril_common::crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory};
 use mithril_common::entities::{
     BlockNumber, BlockRange, CardanoTransaction, ChainPoint, SlotNumber,
 };
@@ -152,7 +152,8 @@ impl CardanoTransactionsImporter {
                 continue;
             }
 
-            let merkle_root = MKTree::new(&transactions)?.compute_root()?;
+            let merkle_root =
+                MKTree::<MKTreeStoreInMemory>::new(&transactions)?.compute_root()?;
             block_ranges_with_merkle_root.push((block_range, merkle_root));
 
             if block_ranges_with_merkle_root.len() >= 100 {
@@ -256,7 +257,10 @@ mod tests {
             .iter()
             .flat_map(|br| br.clone().into_transactions())
             .collect();
-        MKTree::new(&tx).unwrap().compute_root().unwrap()
+        MKTree::<MKTreeStoreInMemory>::new(&tx)
+            .unwrap()
+            .compute_root()
+            .unwrap()
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -152,8 +152,7 @@ impl CardanoTransactionsImporter {
                 continue;
             }
 
-            let merkle_root =
-                MKTree::<MKTreeStoreInMemory>::new(&transactions)?.compute_root()?;
+            let merkle_root = MKTree::<MKTreeStoreInMemory>::new(&transactions)?.compute_root()?;
             block_ranges_with_merkle_root.push((block_range, merkle_root));
 
             if block_ranges_with_merkle_root.len() >= 100 {

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -212,7 +212,7 @@ impl<S: MKTreeStorer> ProverService for MithrilProverService<S> {
 mod tests {
     use anyhow::anyhow;
     use mithril_common::crypto_helper::{
-        MKMap, MKMapNode, MKTreeNode, MKTreeStorer, MKTreeStoreInMemory,
+        MKMap, MKMapNode, MKTreeNode, MKTreeStoreInMemory, MKTreeStorer,
     };
     use mithril_common::entities::CardanoTransaction;
     use mithril_common::test_utils::CardanoTransactionsBuilder;
@@ -291,11 +291,8 @@ mod tests {
 
         pub fn compute_mk_map_from_block_ranges_map(
             block_ranges_map: BTreeMap<BlockRange, Vec<CardanoTransaction>>,
-        ) -> MKMap<
-            BlockRange,
-            MKMapNode<BlockRange, MKTreeStoreInMemory>,
-            MKTreeStoreInMemory,
-        > {
+        ) -> MKMap<BlockRange, MKMapNode<BlockRange, MKTreeStoreInMemory>, MKTreeStoreInMemory>
+        {
             MKMap::new_from_iter(
                 block_ranges_map
                     .into_iter()

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.45"
+version = "0.4.46"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/benches/merkle_tree.rs
+++ b/mithril-common/benches/merkle_tree.rs
@@ -5,6 +5,8 @@ use mithril_common::crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory};
 const K: usize = 1_000;
 const M: usize = 1_000 * K;
 const TOTAL_LEAVES_BENCHES: &[usize] = &[K, 10 * K, 100 * K, M, 10 * M];
+const TOTAL_LEAVES_TO_PROVE_BENCHES: &[usize] = &[1, 10, 100];
+const TOTAL_LEAVES_TO_APPEND_BENCHES: &[usize] = &[1, 10, 100];
 
 fn generate_merkle_tree(total_leaves: usize) -> MKTree<MKTreeStoreInMemory> {
     MKTree::new(
@@ -33,39 +35,69 @@ fn create_merkle_tree_root_benches(c: &mut Criterion) {
     group.finish();
 }
 
-fn create_merkle_tree_proof_benches(c: &mut Criterion) {
-    let mut group = c.benchmark_group("create_merkle_tree_proof");
-    for total_leaves in TOTAL_LEAVES_BENCHES.iter() {
-        group.bench_with_input(
-            BenchmarkId::from_parameter(total_leaves),
-            total_leaves,
-            |b, &_total_leaves| {
-                b.iter(|| {
-                    let mk_tree = generate_merkle_tree(*total_leaves);
-                    let leaves_to_prove = mk_tree.leaves();
-                    mk_tree.compute_proof(&leaves_to_prove).unwrap();
-                });
-            },
-        );
+fn append_merkle_tree_benches(c: &mut Criterion) {
+    for total_leaves_to_append in TOTAL_LEAVES_TO_APPEND_BENCHES.iter() {
+        let mut group = c.benchmark_group(format!(
+            "append_merkle_tree[appended_leaves={total_leaves_to_append}]"
+        ));
+        for total_leaves in TOTAL_LEAVES_BENCHES.iter() {
+            let mut mk_tree = generate_merkle_tree(*total_leaves);
+            let leaves_to_append = &mk_tree.leaves()[..*total_leaves_to_append];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(total_leaves),
+                total_leaves,
+                |b, &_total_leaves| {
+                    b.iter(|| {
+                        mk_tree.append(leaves_to_append).unwrap();
+                    });
+                },
+            );
+        }
+        group.finish();
     }
-    group.finish();
+}
+
+fn create_merkle_tree_proof_benches(c: &mut Criterion) {
+    for total_leaves_to_prove in TOTAL_LEAVES_TO_PROVE_BENCHES.iter() {
+        let mut group = c.benchmark_group(format!(
+            "create_merkle_tree_proof[proved_leaves={total_leaves_to_prove}]"
+        ));
+        for total_leaves in TOTAL_LEAVES_BENCHES.iter() {
+            let mk_tree = generate_merkle_tree(*total_leaves);
+            let leaves_to_prove = &mk_tree.leaves()[..*total_leaves_to_prove];
+            group.bench_with_input(
+                BenchmarkId::from_parameter(total_leaves),
+                total_leaves,
+                |b, &_total_leaves| {
+                    b.iter(|| {
+                        mk_tree.compute_proof(leaves_to_prove).unwrap();
+                    });
+                },
+            );
+        }
+        group.finish();
+    }
 }
 
 fn verify_merkle_tree_proof_benches(c: &mut Criterion) {
-    let mut group = c.benchmark_group("verify_merkle_tree_proof");
-    for total_leaves in TOTAL_LEAVES_BENCHES.iter() {
-        let mk_tree = generate_merkle_tree(*total_leaves);
-        let leaves_to_prove = mk_tree.leaves();
-        let mk_proof = mk_tree.compute_proof(&leaves_to_prove).unwrap();
-        group.bench_with_input(
-            BenchmarkId::from_parameter(total_leaves),
-            total_leaves,
-            |b, &_total_leaves| {
-                b.iter(|| mk_proof.verify().unwrap());
-            },
-        );
+    for total_leaves_to_prove in TOTAL_LEAVES_TO_PROVE_BENCHES.iter() {
+        let mut group = c.benchmark_group(format!(
+            "verify_merkle_tree_proof[proved_leaves={total_leaves_to_prove}]"
+        ));
+        for total_leaves in TOTAL_LEAVES_BENCHES.iter() {
+            let mk_tree = generate_merkle_tree(*total_leaves);
+            let leaves_to_prove = &mk_tree.leaves()[..*total_leaves_to_prove];
+            let mk_proof = mk_tree.compute_proof(leaves_to_prove).unwrap();
+            group.bench_with_input(
+                BenchmarkId::from_parameter(total_leaves),
+                total_leaves,
+                |b, &_total_leaves| {
+                    b.iter(|| mk_proof.verify().unwrap());
+                },
+            );
+        }
+        group.finish();
     }
-    group.finish();
 }
 
 criterion_group!(
@@ -73,6 +105,7 @@ criterion_group!(
     config = Criterion::default().sample_size(10);
     targets=
       create_merkle_tree_root_benches,
+      append_merkle_tree_benches,
       create_merkle_tree_proof_benches,
       verify_merkle_tree_proof_benches
 );

--- a/mithril-common/benches/merkle_tree.rs
+++ b/mithril-common/benches/merkle_tree.rs
@@ -1,12 +1,12 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use mithril_common::crypto_helper::{MKTree, MKTreeNode};
+use mithril_common::crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory};
 
 // Shortcuts for magnitudes: K for thousand, M for million
 const K: usize = 1_000;
 const M: usize = 1_000 * K;
 const TOTAL_LEAVES_BENCHES: &[usize] = &[K, 10 * K, 100 * K, M, 10 * M];
 
-fn generate_merkle_tree(total_leaves: usize) -> MKTree {
+fn generate_merkle_tree(total_leaves: usize) -> MKTree<MKTreeStoreInMemory> {
     MKTree::new(
         (0..total_leaves)
             .map(|i| format!("bench-{i}").into())

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -264,7 +264,9 @@ impl<K: MKMapKey, V: MKMapValue<K>, S: MKTreeStorer> Clone for MKMap<K, V, S> {
     }
 }
 
-impl<'a, K: MKMapKey, V: MKMapValue<K>, S: MKTreeStorer> From<&'a MKMap<K, V, S>> for &'a MKTree<S> {
+impl<'a, K: MKMapKey, V: MKMapValue<K>, S: MKTreeStorer> From<&'a MKMap<K, V, S>>
+    for &'a MKTree<S>
+{
     fn from(other: &'a MKMap<K, V, S>) -> Self {
         &other.inner_merkle_tree
     }

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -10,7 +10,7 @@ use std::{
 
 use crate::{resource_pool::Reset, StdError, StdResult};
 
-use super::{MKProof, MKTree, MKTreeNode};
+use super::{MKProof, MKTree, MKTreeNode, MKTreeStore};
 
 /// The trait implemented by the keys of a MKMap
 pub trait MKMapKey: PartialEq + Eq + PartialOrd + Ord + Clone + Hash + Into<MKTreeNode> {}
@@ -34,13 +34,13 @@ pub trait MKMapValue<K: MKMapKey>: Clone + TryInto<MKTreeNode> + TryFrom<MKTreeN
 }
 
 /// A map, where the keys and values are merkelized and provable
-pub struct MKMap<K: MKMapKey, V: MKMapValue<K>> {
+pub struct MKMap<K: MKMapKey, V: MKMapValue<K>, S: MKTreeStore> {
     inner_map_values: BTreeMap<K, V>,
-    inner_merkle_tree: MKTree,
+    inner_merkle_tree: MKTree<S>,
     provable_keys: BTreeSet<K>,
 }
 
-impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
+impl<K: MKMapKey, V: MKMapValue<K>, S: MKTreeStore> MKMap<K, V, S> {
     /// MKMap factory
     pub fn new(entries: &[(K, V)]) -> StdResult<Self> {
         Self::new_from_iter(entries.to_vec())
@@ -49,7 +49,7 @@ impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
     /// MKMap factory
     pub fn new_from_iter<T: IntoIterator<Item = (K, V)>>(entries: T) -> StdResult<Self> {
         let inner_map_values = BTreeMap::default();
-        let inner_merkle_tree = MKTree::new::<MKTreeNode>(&[])?;
+        let inner_merkle_tree = MKTree::<S>::new::<MKTreeNode>(&[])?;
         let can_compute_proof_keys = BTreeSet::default();
         let mut mk_map = Self {
             inner_map_values,
@@ -246,13 +246,13 @@ impl<K: MKMapKey, V: MKMapValue<K>> MKMap<K, V> {
     }
 }
 
-impl<K: MKMapKey, V: MKMapValue<K>> Reset for MKMap<K, V> {
+impl<K: MKMapKey, V: MKMapValue<K>, S: MKTreeStore> Reset for MKMap<K, V, S> {
     fn reset(&mut self) -> StdResult<()> {
         self.compress()
     }
 }
 
-impl<K: MKMapKey, V: MKMapValue<K>> Clone for MKMap<K, V> {
+impl<K: MKMapKey, V: MKMapValue<K>, S: MKTreeStore> Clone for MKMap<K, V, S> {
     fn clone(&self) -> Self {
         // Cloning should never fail so unwrap is safe
         let mut clone = Self::new(&[]).unwrap();
@@ -264,15 +264,15 @@ impl<K: MKMapKey, V: MKMapValue<K>> Clone for MKMap<K, V> {
     }
 }
 
-impl<'a, K: MKMapKey, V: MKMapValue<K>> From<&'a MKMap<K, V>> for &'a MKTree {
-    fn from(other: &'a MKMap<K, V>) -> Self {
+impl<'a, K: MKMapKey, V: MKMapValue<K>, S: MKTreeStore> From<&'a MKMap<K, V, S>> for &'a MKTree<S> {
+    fn from(other: &'a MKMap<K, V, S>) -> Self {
         &other.inner_merkle_tree
     }
 }
 
-impl<K: MKMapKey, V: MKMapValue<K>> TryFrom<MKMap<K, V>> for MKTreeNode {
+impl<K: MKMapKey, V: MKMapValue<K>, S: MKTreeStore> TryFrom<MKMap<K, V, S>> for MKTreeNode {
     type Error = StdError;
-    fn try_from(other: MKMap<K, V>) -> Result<Self, Self::Error> {
+    fn try_from(other: MKMap<K, V, S>) -> Result<Self, Self::Error> {
         other.compute_root()
     }
 }
@@ -365,18 +365,18 @@ impl<K: MKMapKey> From<MKProof> for MKMapProof<K> {
 /// The MKMapNode can be either a MKMap (Merkle map), a MKTree (full Merkle tree) or a MKTreeNode (Merkle tree node, e.g the root of a Merkle tree)
 /// Both MKMap and MKTree can generate proofs of membership for elements that they contain, which allows for recursive proof generation for the multiple layers
 #[derive(Clone)]
-pub enum MKMapNode<K: MKMapKey> {
+pub enum MKMapNode<K: MKMapKey, S: MKTreeStore> {
     /// A Merkle map
-    Map(Arc<MKMap<K, Self>>),
+    Map(Arc<MKMap<K, Self, S>>),
 
     /// A full Merkle tree
-    Tree(Arc<MKTree>),
+    Tree(Arc<MKTree<S>>),
 
     /// A Merkle tree node
     TreeNode(MKTreeNode),
 }
 
-impl<K: MKMapKey> MKMapValue<K> for MKMapNode<K> {
+impl<K: MKMapKey, S: MKTreeStore> MKMapValue<K> for MKMapNode<K, S> {
     fn compute_root(&self) -> StdResult<MKTreeNode> {
         match self {
             MKMapNode::Map(mk_map) => mk_map.compute_root(),
@@ -434,27 +434,27 @@ impl<K: MKMapKey> MKMapValue<K> for MKMapNode<K> {
     }
 }
 
-impl<K: MKMapKey> From<MKMap<K, MKMapNode<K>>> for MKMapNode<K> {
-    fn from(other: MKMap<K, MKMapNode<K>>) -> Self {
+impl<K: MKMapKey, S: MKTreeStore> From<MKMap<K, MKMapNode<K, S>, S>> for MKMapNode<K, S> {
+    fn from(other: MKMap<K, MKMapNode<K, S>, S>) -> Self {
         MKMapNode::Map(Arc::new(other))
     }
 }
 
-impl<K: MKMapKey> From<MKTree> for MKMapNode<K> {
-    fn from(other: MKTree) -> Self {
+impl<K: MKMapKey, S: MKTreeStore> From<MKTree<S>> for MKMapNode<K, S> {
+    fn from(other: MKTree<S>) -> Self {
         MKMapNode::Tree(Arc::new(other))
     }
 }
 
-impl<K: MKMapKey> From<MKTreeNode> for MKMapNode<K> {
+impl<K: MKMapKey, S: MKTreeStore> From<MKTreeNode> for MKMapNode<K, S> {
     fn from(other: MKTreeNode) -> Self {
         MKMapNode::TreeNode(other)
     }
 }
 
-impl<K: MKMapKey> TryFrom<MKMapNode<K>> for MKTreeNode {
+impl<K: MKMapKey, S: MKTreeStore> TryFrom<MKMapNode<K, S>> for MKTreeNode {
     type Error = StdError;
-    fn try_from(other: MKMapNode<K>) -> Result<Self, Self::Error> {
+    fn try_from(other: MKMapNode<K, S>) -> Result<Self, Self::Error> {
         other.compute_root()
     }
 }
@@ -463,14 +463,17 @@ impl<K: MKMapKey> TryFrom<MKMapNode<K>> for MKTreeNode {
 mod tests {
     use std::collections::BTreeSet;
 
-    use crate::entities::{BlockNumber, BlockRange};
+    use crate::{
+        crypto_helper::MKTreeStoreInMemory,
+        entities::{BlockNumber, BlockRange},
+    };
 
     use super::*;
 
     fn generate_merkle_trees(
         total_leaves: u64,
         block_range_length: u64,
-    ) -> Vec<(BlockRange, MKTree)> {
+    ) -> Vec<(BlockRange, MKTree<MKTreeStoreInMemory>)> {
         (0..total_leaves / block_range_length)
             .map(|block_range_index| {
                 let block_range = BlockRange::from_block_number_and_length(
@@ -484,14 +487,16 @@ mod tests {
             .collect::<Vec<_>>()
     }
 
-    fn generate_merkle_tree(block_range: &BlockRange) -> MKTree {
+    fn generate_merkle_tree(block_range: &BlockRange) -> MKTree<MKTreeStoreInMemory> {
         let leaves = (*block_range.start..*block_range.end)
             .map(|leaf_index| leaf_index.to_string())
             .collect::<Vec<_>>();
         MKTree::new(&leaves).unwrap()
     }
 
-    fn generate_merkle_trees_for_ranges(block_ranges: &[BlockRange]) -> Vec<(BlockRange, MKTree)> {
+    fn generate_merkle_trees_for_ranges(
+        block_ranges: &[BlockRange],
+    ) -> Vec<(BlockRange, MKTree<MKTreeStoreInMemory>)> {
         block_ranges
             .iter()
             .map(|block_range| (block_range.to_owned(), generate_merkle_tree(block_range)))
@@ -499,8 +504,8 @@ mod tests {
     }
 
     fn into_mkmap_tree_entries(
-        entries: Vec<(BlockRange, MKTree)>,
-    ) -> Vec<(BlockRange, MKMapNode<BlockRange>)> {
+        entries: Vec<(BlockRange, MKTree<MKTreeStoreInMemory>)>,
+    ) -> Vec<(BlockRange, MKMapNode<BlockRange, MKTreeStoreInMemory>)> {
         entries
             .into_iter()
             .map(|(range, mktree)| (range, MKMapNode::Tree(Arc::new(mktree))))
@@ -508,8 +513,8 @@ mod tests {
     }
 
     fn into_mkmap_tree_node_entries(
-        entries: Vec<(BlockRange, MKTree)>,
-    ) -> Vec<(BlockRange, MKMapNode<BlockRange>)> {
+        entries: Vec<(BlockRange, MKTree<MKTreeStoreInMemory>)>,
+    ) -> Vec<(BlockRange, MKMapNode<BlockRange, MKTreeStoreInMemory>)> {
         entries
             .into_iter()
             .map(|(range, mktree)| (range, MKMapNode::TreeNode(mktree.try_into().unwrap())))
@@ -519,8 +524,11 @@ mod tests {
     #[test]
     fn test_mk_map_should_compute_same_root_when_replacing_entry_with_equivalent() {
         let entries = generate_merkle_trees(10, 3);
-        let mk_map_nodes = MKMap::new(&into_mkmap_tree_node_entries(entries.clone())).unwrap();
-        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mk_map_nodes =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_node_entries(entries.clone()))
+                .unwrap();
+        let mk_map_full =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         let mk_map_nodes_root = mk_map_nodes.compute_root().unwrap();
         let mk_map_full_root = mk_map_full.compute_root().unwrap();
@@ -535,7 +543,8 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mut mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mut mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
         let mk_map_root_expected = mk_map.compute_root().unwrap();
         let block_range_replacement = BlockRange::new(0, 3);
         let same_root_value = MKMapNode::TreeNode(
@@ -560,7 +569,8 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mut mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mut mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
         let block_range_replacement = BlockRange::new(0, 3);
         let value_replacement: MKTreeNode = "test-123".to_string().into();
         let different_root_value = MKMapNode::TreeNode(value_replacement);
@@ -577,7 +587,8 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mut mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mut mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
         let block_range_replacement = BlockRange::new(0, 3);
         let same_root_value = MKMapNode::TreeNode(
             mk_map
@@ -611,7 +622,8 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mut mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mut mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         let error = mk_map
             .replace(
@@ -635,7 +647,8 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mut mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mut mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         let error = mk_map
             .replace(
@@ -659,7 +672,8 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
         let mk_map_root_expected = mk_map.compute_root().unwrap();
         let mk_map_provable_keys = mk_map.get_provable_keys();
         assert!(!mk_map_provable_keys.is_empty());
@@ -680,7 +694,9 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mut mk_map = MKMap::new(&into_mkmap_tree_node_entries(entries)).unwrap();
+        let mut mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_node_entries(entries))
+                .unwrap();
         let out_of_order_entry = (
             BlockRange::new(0, 25),
             MKMapNode::TreeNode("test-123".into()),
@@ -699,7 +715,8 @@ mod tests {
             BlockRange::new(7, 9),
         ]);
         let merkle_tree_entries = &into_mkmap_tree_node_entries(entries);
-        let mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        let mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(merkle_tree_entries.as_slice()).unwrap();
 
         let keys = mk_map
             .iter()
@@ -722,7 +739,8 @@ mod tests {
             BlockRange::new(7, 9),
         ]);
         let merkle_tree_entries = &into_mkmap_tree_node_entries(entries);
-        let mk_map = MKMap::new(merkle_tree_entries.as_slice()).unwrap();
+        let mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(merkle_tree_entries.as_slice()).unwrap();
 
         let values = mk_map
             .iter()
@@ -748,7 +766,8 @@ mod tests {
             BlockRange::new(7, 9),
         ]);
         let mktree_node_to_certify = entries[2].1.leaves()[1].clone();
-        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mk_map_full =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         mk_map_full.contains(&mktree_node_to_certify).unwrap();
     }
@@ -760,7 +779,8 @@ mod tests {
             BlockRange::new(4, 6),
             BlockRange::new(7, 9),
         ]);
-        let mk_map = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mk_map =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         let mk_map_clone = mk_map.clone();
 
@@ -774,7 +794,8 @@ mod tests {
     fn test_mk_map_should_not_compute_proof_for_no_leaves() {
         let entries = generate_merkle_trees(10, 3);
         let mktree_nodes_to_certify: &[MKTreeNode] = &[];
-        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mk_map_full =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
 
         mk_map_full
             .compute_proof(mktree_nodes_to_certify)
@@ -790,7 +811,8 @@ mod tests {
             entries[1].1.leaves()[1].clone(),
             entries[2].1.leaves()[1].clone(),
         ];
-        let mk_map_full = MKMap::new(&into_mkmap_tree_entries(entries)).unwrap();
+        let mk_map_full =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(&into_mkmap_tree_entries(entries)).unwrap();
         let mk_map_proof = mk_map_full.compute_proof(&mktree_nodes_to_certify).unwrap();
 
         mk_map_proof.verify().unwrap();
@@ -827,7 +849,8 @@ mod tests {
             })
             .collect::<Vec<_>>();
 
-        let mk_map_full = MKMap::new(merkle_tree_node_entries.as_slice()).unwrap();
+        let mk_map_full =
+            MKMap::<_, _, MKTreeStoreInMemory>::new(merkle_tree_node_entries.as_slice()).unwrap();
 
         let mk_map_proof = mk_map_full.compute_proof(&mktree_nodes_to_certify).unwrap();
 

--- a/mithril-common/src/crypto_helper/merkle_tree.rs
+++ b/mithril-common/src/crypto_helper/merkle_tree.rs
@@ -14,10 +14,10 @@ use std::{
 use crate::{StdError, StdResult};
 
 /// Alias for a byte
-type Bytes = Vec<u8>;
+pub type Bytes = Vec<u8>;
 
 /// Alias for a Merkle tree leaf position
-type MKTreeLeafPosition = u64;
+pub type MKTreeLeafPosition = u64;
 
 /// A node of a Merkle tree
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Hash, Serialize, Deserialize)]

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -29,7 +29,7 @@ pub use era::{
 pub use genesis::{ProtocolGenesisError, ProtocolGenesisSigner, ProtocolGenesisVerifier};
 pub use merkle_map::{MKMap, MKMapKey, MKMapNode, MKMapProof, MKMapValue};
 pub use merkle_tree::{
-    MKProof, MKTree, MKTreeNode, MKTreeStoreInMemory, MKTreeStoreInMemoryProvider, MKTreeStorer,
+    MKProof, MKTree, MKTreeLeafIndexer, MKTreeNode, MKTreeStoreInMemory, MKTreeStorer,
 };
 pub use types::*;
 

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -21,6 +21,7 @@ pub use cardano::{
     KESPeriod, OpCert, ProtocolInitializerErrorWrapper, ProtocolRegistrationErrorWrapper,
     SerDeShelleyFileFormat, Sum6KesBytes,
 };
+pub use ckb_merkle_mountain_range;
 pub use codec::*;
 pub use era::{
     EraMarkersSigner, EraMarkersVerifier, EraMarkersVerifierError, EraMarkersVerifierSecretKey,
@@ -29,7 +30,8 @@ pub use era::{
 pub use genesis::{ProtocolGenesisError, ProtocolGenesisSigner, ProtocolGenesisVerifier};
 pub use merkle_map::{MKMap, MKMapKey, MKMapNode, MKMapProof, MKMapValue};
 pub use merkle_tree::{
-    MKProof, MKTree, MKTreeLeafIndexer, MKTreeNode, MKTreeStoreInMemory, MKTreeStorer,
+    Bytes, MKProof, MKTree, MKTreeLeafIndexer, MKTreeLeafPosition, MKTreeNode, MKTreeStoreInMemory,
+    MKTreeStorer,
 };
 pub use types::*;
 

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -29,7 +29,7 @@ pub use era::{
 pub use genesis::{ProtocolGenesisError, ProtocolGenesisSigner, ProtocolGenesisVerifier};
 pub use merkle_map::{MKMap, MKMapKey, MKMapNode, MKMapProof, MKMapValue};
 pub use merkle_tree::{
-    MKProof, MKTree, MKTreeNode, MKTreeStore, MKTreeStoreInMemoryProvider, MKTreeStoreInMemory,
+    MKProof, MKTree, MKTreeNode, MKTreeStoreInMemory, MKTreeStoreInMemoryProvider, MKTreeStorer,
 };
 pub use types::*;
 

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -28,7 +28,9 @@ pub use era::{
 };
 pub use genesis::{ProtocolGenesisError, ProtocolGenesisSigner, ProtocolGenesisVerifier};
 pub use merkle_map::{MKMap, MKMapKey, MKMapNode, MKMapProof, MKMapValue};
-pub use merkle_tree::{MKProof, MKTree, MKTreeNode, MKTreeStore};
+pub use merkle_tree::{
+    MKProof, MKTree, MKTreeNode, MKTreeStore, MKTreeStoreInMemoryProvider, MKTreeStoreInMemory,
+};
 pub use types::*;
 
 /// The current protocol version

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -21,7 +21,6 @@ pub use cardano::{
     KESPeriod, OpCert, ProtocolInitializerErrorWrapper, ProtocolRegistrationErrorWrapper,
     SerDeShelleyFileFormat, Sum6KesBytes,
 };
-pub use ckb_merkle_mountain_range;
 pub use codec::*;
 pub use era::{
     EraMarkersSigner, EraMarkersVerifier, EraMarkersVerifierError, EraMarkersVerifierSecretKey,

--- a/mithril-common/src/entities/cardano_transactions_set_proof.rs
+++ b/mithril-common/src/entities/cardano_transactions_set_proof.rs
@@ -6,7 +6,7 @@ use crate::{StdError, StdResult};
 use super::BlockRange;
 
 cfg_test_tools! {
-    use crate::crypto_helper::{MKMap, MKTree, MKTreeNode, MKMapNode, MKTreeStore, MKTreeStoreInMemory};
+    use crate::crypto_helper::{MKMap, MKTree, MKTreeNode, MKMapNode, MKTreeStorer, MKTreeStoreInMemory};
     use crate::entities::BlockNumber;
     use std::collections::HashMap;
 }
@@ -69,7 +69,7 @@ impl CardanoTransactionsSetProof {
         }
 
         /// Helper to create a proof from a list of leaves
-        pub fn from_leaves<S: MKTreeStore>(leaves: &[(BlockNumber, TransactionHash)]) -> StdResult<Self> {
+        pub fn from_leaves<S: MKTreeStorer>(leaves: &[(BlockNumber, TransactionHash)]) -> StdResult<Self> {
             let transactions_hashes: Vec<TransactionHash> =
                 leaves.iter().map(|(_, t)| t.into()).collect();
             let mut transactions_by_block_ranges: HashMap<BlockRange, Vec<TransactionHash>> =

--- a/mithril-common/src/signable_builder/cardano_stake_distribution.rs
+++ b/mithril-common/src/signable_builder/cardano_stake_distribution.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::{
-    crypto_helper::{MKTree, MKTreeNode},
+    crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory},
     entities::{Epoch, ProtocolMessage, ProtocolMessagePartKey, StakeDistribution},
     signable_builder::SignableBuilder,
     StdResult,
@@ -51,7 +51,7 @@ impl CardanoStakeDistributionSignableBuilder {
     /// Compute the Merkle tree of a given [StakeDistribution]
     pub fn compute_merkle_tree_from_stake_distribution(
         pools_with_stake: StakeDistribution,
-    ) -> StdResult<MKTree> {
+    ) -> StdResult<MKTree<MKTreeStoreInMemory>> {
         let leaves: Vec<MKTreeNode> = pools_with_stake
             .iter()
             .map(|(k, v)| StakeDistributionEntry::new(k, *v).into())

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use slog::{debug, Logger};
 
 use crate::{
-    crypto_helper::{MKMap, MKMapNode, MKTreeNode, MKTreeStore},
+    crypto_helper::{MKMap, MKMapNode, MKTreeNode, MKTreeStorer},
     entities::{BlockNumber, BlockRange, ProtocolMessage, ProtocolMessagePartKey},
     signable_builder::SignableBuilder,
     StdResult,
@@ -25,7 +25,7 @@ pub trait TransactionsImporter: Send + Sync {
 /// Block Range Merkle roots retriever
 #[cfg_attr(test, automock)]
 #[async_trait]
-pub trait BlockRangeRootRetriever<S: MKTreeStore>: Send + Sync {
+pub trait BlockRangeRootRetriever<S: MKTreeStorer>: Send + Sync {
     /// Returns a Merkle map of the block ranges roots up to a given beacon
     async fn retrieve_block_range_roots<'a>(
         &'a self,
@@ -49,13 +49,13 @@ pub trait BlockRangeRootRetriever<S: MKTreeStore>: Send + Sync {
 }
 
 /// A [CardanoTransactionsSignableBuilder] builder
-pub struct CardanoTransactionsSignableBuilder<S: MKTreeStore> {
+pub struct CardanoTransactionsSignableBuilder<S: MKTreeStorer> {
     transaction_importer: Arc<dyn TransactionsImporter>,
     block_range_root_retriever: Arc<dyn BlockRangeRootRetriever<S>>,
     logger: Logger,
 }
 
-impl<S: MKTreeStore> CardanoTransactionsSignableBuilder<S> {
+impl<S: MKTreeStorer> CardanoTransactionsSignableBuilder<S> {
     /// Constructor
     pub fn new(
         transaction_importer: Arc<dyn TransactionsImporter>,
@@ -71,7 +71,7 @@ impl<S: MKTreeStore> CardanoTransactionsSignableBuilder<S> {
 }
 
 #[async_trait]
-impl<S: MKTreeStore> SignableBuilder<BlockNumber> for CardanoTransactionsSignableBuilder<S> {
+impl<S: MKTreeStorer> SignableBuilder<BlockNumber> for CardanoTransactionsSignableBuilder<S> {
     async fn compute_protocol_message(&self, beacon: BlockNumber) -> StdResult<ProtocolMessage> {
         debug!(
             self.logger,

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -9,6 +9,10 @@ homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
 
+[[bench]]
+name = "mktree_store_sqlite"
+harness = false
+
 [dependencies]
 anyhow = "1.0.79"
 async-trait = "0.1.77"
@@ -42,6 +46,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 tikv-jemallocator = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
+criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
 httpmock = "0.7.0"
 mithril-common = { path = "../mithril-common" }
 mockall = "0.13.0"

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.173"
+version = "0.2.174"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/benches/mktree_store_sqlite.rs
+++ b/mithril-signer/benches/mktree_store_sqlite.rs
@@ -1,0 +1,43 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use mithril_common::crypto_helper::{MKTree, MKTreeNode};
+use mithril_signer::MKTreeStoreSqlite;
+
+// Shortcuts for magnitudes: K for thousand, M for million
+const K: usize = 1_000;
+const M: usize = 1_000 * K;
+const TOTAL_LEAVES_BENCHES: &[usize] = &[K, 10 * K, 100 * K, M, 10 * M];
+
+fn generate_merkle_tree(total_leaves: usize) -> MKTree<MKTreeStoreSqlite> {
+    MKTree::new(
+        (0..total_leaves)
+            .map(|i| format!("bench-{i}").into())
+            .collect::<Vec<MKTreeNode>>()
+            .as_slice(),
+    )
+    .unwrap()
+}
+
+fn create_merkle_tree_root_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("create_merkle_tree_signer_sqlite");
+    for total_leaves in TOTAL_LEAVES_BENCHES.iter() {
+        group.bench_with_input(
+            BenchmarkId::from_parameter(total_leaves),
+            total_leaves,
+            |b, &total_leaves| {
+                b.iter(|| {
+                    let mk_tree = generate_merkle_tree(total_leaves);
+                    mk_tree.compute_root().unwrap();
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    name=benches;
+    config = Criterion::default().sample_size(10);
+    targets=
+      create_merkle_tree_root_benches,
+);
+criterion_main!(benches);

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -8,7 +8,7 @@ use slog::{debug, Logger};
 use tokio::{runtime::Handle, task};
 
 use mithril_common::cardano_block_scanner::{BlockScanner, ChainScannedBlocks};
-use mithril_common::crypto_helper::{MKTree, MKTreeNode};
+use mithril_common::crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory};
 use mithril_common::entities::{
     BlockNumber, BlockRange, CardanoTransaction, ChainPoint, SlotNumber,
 };
@@ -152,7 +152,8 @@ impl CardanoTransactionsImporter {
                 continue;
             }
 
-            let merkle_root = MKTree::new(&transactions)?.compute_root()?;
+            let merkle_root =
+                MKTree::<MKTreeStoreInMemory>::new(&transactions)?.compute_root()?;
             block_ranges_with_merkle_root.push((block_range, merkle_root));
 
             if block_ranges_with_merkle_root.len() >= 100 {
@@ -256,7 +257,10 @@ mod tests {
             .iter()
             .flat_map(|br| br.clone().into_transactions())
             .collect();
-        MKTree::new(&tx).unwrap().compute_root().unwrap()
+        MKTree::<MKTreeStoreInMemory>::new(&tx)
+            .unwrap()
+            .compute_root()
+            .unwrap()
     }
 
     #[tokio::test]

--- a/mithril-signer/src/cardano_transactions_importer.rs
+++ b/mithril-signer/src/cardano_transactions_importer.rs
@@ -152,8 +152,7 @@ impl CardanoTransactionsImporter {
                 continue;
             }
 
-            let merkle_root =
-                MKTree::<MKTreeStoreInMemory>::new(&transactions)?.compute_root()?;
+            let merkle_root = MKTree::<MKTreeStoreInMemory>::new(&transactions)?.compute_root()?;
             block_ranges_with_merkle_root.push((block_range, merkle_root));
 
             if block_ranges_with_merkle_root.len() >= 100 {

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -13,6 +13,7 @@ mod configuration;
 pub mod database;
 mod message_adapters;
 pub mod metrics;
+mod mktree_store_sqlite;
 mod protocol_initializer_store;
 mod runtime;
 mod single_signer;
@@ -31,6 +32,7 @@ pub use message_adapters::{
     FromEpochSettingsAdapter, FromPendingCertificateMessageAdapter, ToRegisterSignerMessageAdapter,
 };
 pub use metrics::*;
+pub use mktree_store_sqlite::*;
 pub use protocol_initializer_store::{ProtocolInitializerStore, ProtocolInitializerStorer};
 pub use runtime::*;
 pub use single_signer::*;

--- a/mithril-signer/src/mktree_store_sqlite.rs
+++ b/mithril-signer/src/mktree_store_sqlite.rs
@@ -5,12 +5,7 @@ use std::{
 
 use anyhow::Context;
 use mithril_common::{
-    crypto_helper::{
-        ckb_merkle_mountain_range::{
-            Error as MMRError, MMRStoreReadOps, MMRStoreWriteOps, Result as MMRResult,
-        },
-        Bytes, MKTreeLeafIndexer, MKTreeLeafPosition, MKTreeNode, MKTreeStorer,
-    },
+    crypto_helper::{Bytes, MKTreeLeafIndexer, MKTreeLeafPosition, MKTreeNode, MKTreeStorer},
     StdResult,
 };
 
@@ -96,26 +91,6 @@ impl MKTreeStoreSqlite {
     }
 }
 
-impl MMRStoreReadOps<Arc<MKTreeNode>> for MKTreeStoreSqlite {
-    fn get_elem(&self, pos: u64) -> MMRResult<Option<Arc<MKTreeNode>>> {
-        self.get_element_at_position(pos)
-            .with_context(|| {
-                format!("MKTreeStoreSqlite failed to retrieve element at position {pos}")
-            })
-            .map_err(|e| MMRError::StoreError(e.to_string()))
-    }
-}
-
-impl MMRStoreWriteOps<Arc<MKTreeNode>> for MKTreeStoreSqlite {
-    fn append(&mut self, pos: u64, elems: Vec<Arc<MKTreeNode>>) -> MMRResult<()> {
-        self.insert_elements_from_position(pos, elems)
-            .with_context(|| {
-                format!("MKTreeStoreSqlite failed to insert elements from position {pos}")
-            })
-            .map_err(|e| MMRError::StoreError(e.to_string()))
-    }
-}
-
 impl Clone for MKTreeStoreSqlite {
     fn clone(&self) -> Self {
         unimplemented!("Clone is not implemented for MKTreeStoreSqlite")
@@ -143,6 +118,19 @@ impl MKTreeLeafIndexer for MKTreeStoreSqlite {
 impl MKTreeStorer for MKTreeStoreSqlite {
     fn build() -> StdResult<Self> {
         Self::build()
+    }
+
+    fn get_elem(&self, pos: u64) -> StdResult<Option<Arc<MKTreeNode>>> {
+        self.get_element_at_position(pos).with_context(|| {
+            format!("MKTreeStoreSqlite failed to retrieve element at position {pos}")
+        })
+    }
+
+    fn append(&self, pos: u64, elems: Vec<Arc<MKTreeNode>>) -> StdResult<()> {
+        self.insert_elements_from_position(pos, elems)
+            .with_context(|| {
+                format!("MKTreeStoreSqlite failed to insert elements from position {pos}")
+            })
     }
 }
 

--- a/mithril-signer/src/mktree_store_sqlite.rs
+++ b/mithril-signer/src/mktree_store_sqlite.rs
@@ -23,7 +23,7 @@ pub struct MKTreeStoreSqlite {
 }
 
 impl MKTreeStoreSqlite {
-    fn try_new() -> StdResult<Self> {
+    fn build() -> StdResult<Self> {
         Ok(Self {
             inner_store: RwLock::new(Self::create_connection()?),
         })
@@ -116,12 +116,6 @@ impl MMRStoreWriteOps<Arc<MKTreeNode>> for MKTreeStoreSqlite {
     }
 }
 
-impl Default for MKTreeStoreSqlite {
-    fn default() -> Self {
-        Self::try_new().unwrap()
-    }
-}
-
 impl Clone for MKTreeStoreSqlite {
     fn clone(&self) -> Self {
         unimplemented!("Clone is not implemented for MKTreeStoreSqlite")
@@ -146,7 +140,11 @@ impl MKTreeLeafIndexer for MKTreeStoreSqlite {
     }
 }
 
-impl MKTreeStorer for MKTreeStoreSqlite {}
+impl MKTreeStorer for MKTreeStoreSqlite {
+    fn build() -> StdResult<Self> {
+        Self::build()
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/mithril-signer/src/mktree_store_sqlite.rs
+++ b/mithril-signer/src/mktree_store_sqlite.rs
@@ -1,0 +1,171 @@
+use std::{
+    iter::repeat,
+    sync::{Arc, RwLock},
+};
+
+use anyhow::Context;
+use mithril_common::{
+    crypto_helper::{
+        ckb_merkle_mountain_range::{
+            Error as MMRError, MMRStoreReadOps, MMRStoreWriteOps, Result as MMRResult,
+        },
+        Bytes, MKTreeLeafIndexer, MKTreeLeafPosition, MKTreeNode, MKTreeStorer,
+    },
+    StdResult,
+};
+
+/// A Merkle tree store with Sqlite backend
+/// This store is used to store the Merkle tree nodes in a Sqlite database with in memory mode.
+/// This store is not suited for proving, it is only used to store the compute the root of a Merkle tree.
+/// This store is slower than the in memory store but uses less memory which is important to minimize the signer footprint on the SPO infrastructure.
+pub struct MKTreeStoreSqlite {
+    inner_store: RwLock<sqlite::ConnectionThreadSafe>,
+}
+
+impl MKTreeStoreSqlite {
+    fn try_new() -> StdResult<Self> {
+        Ok(Self {
+            inner_store: RwLock::new(Self::create_connection()?),
+        })
+    }
+
+    fn create_connection() -> StdResult<sqlite::ConnectionThreadSafe> {
+        let connection = sqlite::Connection::open_thread_safe(":memory:")?;
+        connection.execute("pragma shrink_memory; pragma temp_store = FILE;")?;
+        connection.execute(
+            "create table merkle_tree (
+                position integer, 
+                element blob, 
+                primary key (position)
+            )",
+        )?;
+
+        Ok(connection)
+    }
+
+    fn get_element_at_position(&self, position: u64) -> StdResult<Option<Arc<MKTreeNode>>> {
+        let inner_store = self.inner_store.read().unwrap();
+        let query = "SELECT element FROM merkle_tree WHERE position = ?";
+        let mut statement = (*inner_store).prepare(query)?;
+        statement.bind((1, position as i64)).unwrap();
+        let result = if let Ok(sqlite::State::Row) = statement.next() {
+            Some(Arc::new(MKTreeNode::new(
+                statement.read::<Bytes, _>("element")?,
+            )))
+        } else {
+            None
+        };
+
+        Ok(result)
+    }
+
+    fn insert_elements_from_position(
+        &self,
+        position: u64,
+        elements: Vec<Arc<MKTreeNode>>,
+    ) -> StdResult<()> {
+        let inner_store = self.inner_store.read().unwrap();
+        let values_columns: Vec<&str> = repeat("(?, ?)").take(elements.len()).collect();
+        let values: Vec<sqlite::Value> =
+            elements
+                .into_iter()
+                .enumerate()
+                .fold(vec![], |mut vec, (i, elem)| {
+                    vec.append(&mut vec![
+                        sqlite::Value::Integer((position + i as u64) as i64),
+                        sqlite::Value::Binary((**elem).to_vec()),
+                    ]);
+                    vec
+                });
+        let query = format!(
+            "INSERT INTO merkle_tree(position, element) VALUES {}",
+            values_columns.join(", ")
+        );
+        let mut statement = (*inner_store).prepare(query)?;
+        statement.bind::<&[(_, sqlite::Value)]>(
+            values
+                .into_iter()
+                .enumerate()
+                .map(|(i, v)| (i + 1, v))
+                .collect::<Vec<_>>()
+                .as_slice(),
+        )?;
+        statement.next()?;
+
+        Ok(())
+    }
+}
+
+impl MMRStoreReadOps<Arc<MKTreeNode>> for MKTreeStoreSqlite {
+    fn get_elem(&self, pos: u64) -> MMRResult<Option<Arc<MKTreeNode>>> {
+        self.get_element_at_position(pos)
+            .with_context(|| {
+                format!("MKTreeStoreSqlite failed to retrieve element at position {pos}")
+            })
+            .map_err(|e| MMRError::StoreError(e.to_string()))
+    }
+}
+
+impl MMRStoreWriteOps<Arc<MKTreeNode>> for MKTreeStoreSqlite {
+    fn append(&mut self, pos: u64, elems: Vec<Arc<MKTreeNode>>) -> MMRResult<()> {
+        self.insert_elements_from_position(pos, elems)
+            .with_context(|| {
+                format!("MKTreeStoreSqlite failed to insert elements from position {pos}")
+            })
+            .map_err(|e| MMRError::StoreError(e.to_string()))
+    }
+}
+
+impl Default for MKTreeStoreSqlite {
+    fn default() -> Self {
+        Self::try_new().unwrap()
+    }
+}
+
+impl Clone for MKTreeStoreSqlite {
+    fn clone(&self) -> Self {
+        unimplemented!("Clone is not implemented for MKTreeStoreSqlite")
+    }
+}
+
+impl MKTreeLeafIndexer for MKTreeStoreSqlite {
+    fn set_leaf_position(&self, _pos: MKTreeLeafPosition, _node: Arc<MKTreeNode>) -> StdResult<()> {
+        Ok(())
+    }
+
+    fn get_leaf_position(&self, _node: &MKTreeNode) -> Option<MKTreeLeafPosition> {
+        unimplemented!("get_leaf_position is not implemented for MKTreeStoreSqlite")
+    }
+
+    fn total_leaves(&self) -> usize {
+        unimplemented!("total_leaves is not implemented for MKTreeStoreSqlite")
+    }
+
+    fn leaves(&self) -> Vec<MKTreeNode> {
+        unimplemented!("leaves is not implemented for MKTreeStoreSqlite")
+    }
+}
+
+impl MKTreeStorer for MKTreeStoreSqlite {}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::crypto_helper::MKTree;
+
+    use super::*;
+
+    #[test]
+    fn test_golden_merkle_root() {
+        let leaves = vec!["golden-1", "golden-2", "golden-3", "golden-4", "golden-5"];
+        let mktree =
+            MKTree::<MKTreeStoreSqlite>::new(&leaves).expect("MKTree creation should not fail");
+        let mkroot = mktree
+            .compute_root()
+            .expect("MKRoot generation should not fail");
+
+        assert_eq!(
+            "3bbced153528697ecde7345a22e50115306478353619411523e804f2323fd921",
+            mkroot.to_hex()
+        );
+    }
+}

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -473,7 +473,7 @@ mod tests {
         },
         chain_observer::{ChainObserver, FakeObserver},
         crypto_helper::{
-            MKMap, MKMapNode, MKTreeNode, MKTreeStore, MKTreeStoreInMemory,
+            MKMap, MKMapNode, MKTreeNode, MKTreeStorer, MKTreeStoreInMemory,
             ProtocolInitializer,
         },
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
@@ -513,10 +513,10 @@ mod tests {
     }
 
     mock! {
-        pub BlockRangeRootRetrieverImpl<S: MKTreeStore> { }
+        pub BlockRangeRootRetrieverImpl<S: MKTreeStorer> { }
 
         #[async_trait]
-        impl<S: MKTreeStore> BlockRangeRootRetriever<S> for BlockRangeRootRetrieverImpl<S> {
+        impl<S: MKTreeStorer> BlockRangeRootRetriever<S> for BlockRangeRootRetrieverImpl<S> {
             async fn retrieve_block_range_roots<'a>(
                 &'a self,
                 up_to_beacon: BlockNumber,

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -473,8 +473,7 @@ mod tests {
         },
         chain_observer::{ChainObserver, FakeObserver},
         crypto_helper::{
-            MKMap, MKMapNode, MKTreeNode, MKTreeStorer, MKTreeStoreInMemory,
-            ProtocolInitializer,
+            MKMap, MKMapNode, MKTreeNode, MKTreeStoreInMemory, MKTreeStorer, ProtocolInitializer,
         },
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
         entities::{BlockNumber, BlockRange, CardanoDbBeacon, Epoch, StakeDistribution},

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -472,7 +472,10 @@ mod tests {
             CardanoTransactionsPreloader, CardanoTransactionsPreloaderActivation,
         },
         chain_observer::{ChainObserver, FakeObserver},
-        crypto_helper::{MKMap, MKMapNode, MKTreeNode, ProtocolInitializer},
+        crypto_helper::{
+            MKMap, MKMapNode, MKTreeNode, MKTreeStore, MKTreeStoreInMemory,
+            ProtocolInitializer,
+        },
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
         entities::{BlockNumber, BlockRange, CardanoDbBeacon, Epoch, StakeDistribution},
         era::{adapters::EraReaderBootstrapAdapter, EraChecker, EraReader},
@@ -510,10 +513,10 @@ mod tests {
     }
 
     mock! {
-        pub BlockRangeRootRetrieverImpl { }
+        pub BlockRangeRootRetrieverImpl<S: MKTreeStore> { }
 
         #[async_trait]
-        impl BlockRangeRootRetriever for BlockRangeRootRetrieverImpl {
+        impl<S: MKTreeStore> BlockRangeRootRetriever<S> for BlockRangeRootRetrieverImpl<S> {
             async fn retrieve_block_range_roots<'a>(
                 &'a self,
                 up_to_beacon: BlockNumber,
@@ -522,7 +525,7 @@ mod tests {
             async fn compute_merkle_map_from_block_range_roots(
                 &self,
                 up_to_beacon: BlockNumber,
-            ) -> StdResult<MKMap<BlockRange, MKMapNode<BlockRange>>>;
+            ) -> StdResult<MKMap<BlockRange, MKMapNode<BlockRange,S>, S>>;
         }
     }
 
@@ -564,7 +567,8 @@ mod tests {
             transaction_store.clone(),
             slog_scope::logger(),
         ));
-        let block_range_root_retriever = Arc::new(MockBlockRangeRootRetrieverImpl::new());
+        let block_range_root_retriever =
+            Arc::new(MockBlockRangeRootRetrieverImpl::<MKTreeStoreInMemory>::new());
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
             transactions_importer.clone(),
             block_range_root_retriever,

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -9,7 +9,7 @@ use mithril_common::{
     cardano_transactions_preloader::CardanoTransactionsPreloader,
     chain_observer::{CardanoCliRunner, ChainObserver, ChainObserverBuilder, ChainObserverType},
     chain_reader::PallasChainReader,
-    crypto_helper::{OpCert, ProtocolPartyId, SerDeShelleyFileFormat},
+    crypto_helper::{MKTreeStoreInMemory, OpCert, ProtocolPartyId, SerDeShelleyFileFormat},
     digesters::{
         cache::{ImmutableFileDigestCacheProvider, JsonImmutableFileDigestCacheProviderBuilder},
         CardanoImmutableDigester, ImmutableDigester, ImmutableFileObserver,
@@ -315,7 +315,9 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
             slog_scope::logger(),
         ));
         let block_range_root_retriever = transaction_store.clone();
-        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::<
+            MKTreeStoreInMemory,
+        >::new(
             state_machine_transactions_importer,
             block_range_root_retriever,
             slog_scope::logger(),

--- a/mithril-signer/src/runtime/signer_services.rs
+++ b/mithril-signer/src/runtime/signer_services.rs
@@ -9,7 +9,7 @@ use mithril_common::{
     cardano_transactions_preloader::CardanoTransactionsPreloader,
     chain_observer::{CardanoCliRunner, ChainObserver, ChainObserverBuilder, ChainObserverType},
     chain_reader::PallasChainReader,
-    crypto_helper::{MKTreeStoreInMemory, OpCert, ProtocolPartyId, SerDeShelleyFileFormat},
+    crypto_helper::{OpCert, ProtocolPartyId, SerDeShelleyFileFormat},
     digesters::{
         cache::{ImmutableFileDigestCacheProvider, JsonImmutableFileDigestCacheProviderBuilder},
         CardanoImmutableDigester, ImmutableDigester, ImmutableFileObserver,
@@ -33,8 +33,8 @@ use mithril_persistence::{
 use crate::{
     aggregator_client::AggregatorClient, metrics::MetricsService, single_signer::SingleSigner,
     AggregatorHTTPClient, CardanoTransactionsImporter,
-    CardanoTransactionsPreloaderActivationSigner, Configuration, MithrilSingleSigner,
-    ProtocolInitializerStore, ProtocolInitializerStorer, SignerUpkeepService,
+    CardanoTransactionsPreloaderActivationSigner, Configuration, MKTreeStoreSqlite,
+    MithrilSingleSigner, ProtocolInitializerStore, ProtocolInitializerStorer, SignerUpkeepService,
     TransactionsImporterByChunk, TransactionsImporterWithPruner, TransactionsImporterWithVacuum,
     UpkeepService, HTTP_REQUEST_TIMEOUT_DURATION, SQLITE_FILE, SQLITE_FILE_CARDANO_TRANSACTION,
 };
@@ -316,7 +316,7 @@ impl<'a> ServiceBuilder for ProductionServiceBuilder<'a> {
         ));
         let block_range_root_retriever = transaction_store.clone();
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::<
-            MKTreeStoreInMemory,
+            MKTreeStoreSqlite,
         >::new(
             state_machine_transactions_importer,
             block_range_root_retriever,

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -13,7 +13,6 @@ use mithril_common::{
         CardanoTransactionsPreloader, CardanoTransactionsPreloaderActivation,
     },
     chain_observer::{ChainObserver, FakeObserver},
-    crypto_helper::MKTreeStoreInMemory,
     digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
     entities::{
         BlockNumber, CardanoTransactionsSigningConfig, ChainPoint, Epoch, SignedEntityConfig,
@@ -35,8 +34,8 @@ use mithril_persistence::{
     store::{StakeStore, StakeStorer},
 };
 use mithril_signer::{
-    metrics::*, AggregatorClient, CardanoTransactionsImporter, Configuration, MetricsService,
-    MithrilSingleSigner, ProductionServiceBuilder, ProtocolInitializerStore,
+    metrics::*, AggregatorClient, CardanoTransactionsImporter, Configuration, MKTreeStoreSqlite,
+    MetricsService, MithrilSingleSigner, ProductionServiceBuilder, ProtocolInitializerStore,
     ProtocolInitializerStorer, RuntimeError, SignerRunner, SignerServices, SignerState,
     SignerUpkeepService, StateMachine,
 };
@@ -193,7 +192,7 @@ impl StateMachineTester {
         ));
         let block_range_root_retriever = transaction_store.clone();
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::<
-            MKTreeStoreInMemory,
+            MKTreeStoreSqlite,
         >::new(
             transactions_importer.clone(),
             block_range_root_retriever,

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -13,6 +13,7 @@ use mithril_common::{
         CardanoTransactionsPreloader, CardanoTransactionsPreloaderActivation,
     },
     chain_observer::{ChainObserver, FakeObserver},
+    crypto_helper::MKTreeStoreInMemory,
     digesters::{DumbImmutableDigester, DumbImmutableFileObserver, ImmutableFileObserver},
     entities::{
         BlockNumber, CardanoTransactionsSigningConfig, ChainPoint, Epoch, SignedEntityConfig,
@@ -191,7 +192,9 @@ impl StateMachineTester {
             slog_scope::logger(),
         ));
         let block_range_root_retriever = transaction_store.clone();
-        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
+        let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::<
+            MKTreeStoreInMemory,
+        >::new(
             transactions_importer.clone(),
             block_range_root_retriever,
             slog_scope::logger(),


### PR DESCRIPTION
## Content
This PR includes the **optimization of the memory usage of the signer** when signing Cardano transactions:
- The capability of the Merkle tree `MKTree` to support multiple `MKTreeStorer` implementations for data storage.
- The implementation of a signing specific Merkle store which is dedicated for the signer and with optimized memory usage.
- The benchmarks of the new signer Merkle store.
- Also some enhancements of the benchmarks of the Merkle tree.

### Signer footprint on the mainnet

The signer memory usage (Resident memory) is **~-67%** less.

![Screenshot from 2024-08-27 18-52-00](https://github.com/user-attachments/assets/e45d5dd8-a6bc-4a72-b174-2ff4d7720516)

### Benchmark

The Merkle tree creation takes **~+50%** longer than with the original in memory store.

- **Merkle tree creation for 100,000 leaves**
![pdf](https://github.com/user-attachments/assets/3d0cf248-f686-419a-9368-8f2cec6064a2)
- **Merkle tree creation for 1,000,000 leaves**
![pdf](https://github.com/user-attachments/assets/528538ba-7726-497e-bd6b-509627752c56)
- **Merkle tree creation for 10,000,000 leaves**
![pdf](https://github.com/user-attachments/assets/d261b406-1e67-4d39-bb11-991be83df902)

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1903 
