### PR TITLE
Add Cardano transactions signing configuration in Aggregator '/' route

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 demo/protocol-demo/artifacts/
 docs/website/.docusaurus/
+docs/website/build/
 mithril-client-wasm/pkg/
 mithril-explorer/font.css.hbs
 mithril-explorer/out/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.56"
+version = "0.5.57"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.46"
+version = "0.4.47"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.56"
+version = "0.5.57"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -70,6 +70,7 @@ mod handlers {
                 capabilities: AggregatorCapabilities {
                     signed_entity_types,
                     cardano_transactions_prover: cardano_transactions_prover_capabilities,
+                    cardano_transactions_signing_config: None,
                 },
             },
             StatusCode::OK,
@@ -150,7 +151,8 @@ mod tests {
                         SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
                         SignedEntityTypeDiscriminants::MithrilStakeDistribution,
                     ]),
-                    cardano_transactions_prover: None
+                    cardano_transactions_prover: None,
+                    cardano_transactions_signing_config: None,
                 },
             }
         );

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.46"
+version = "0.4.47"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/messages/aggregator_features.rs
+++ b/mithril-common/src/messages/aggregator_features.rs
@@ -76,7 +76,7 @@ mod tests {
         pub cardano_transactions_prover: Option<CardanoTransactionsProverCapabilities>,
     }
 
-    fn golden_message_v1() -> AggregatorFeaturesMessagePrevious {
+    fn golden_message_previous() -> AggregatorFeaturesMessagePrevious {
         AggregatorFeaturesMessagePrevious {
             open_api_version: "0.0.1".to_string(),
             documentation_url: "https://example.com".to_string(),
@@ -91,7 +91,7 @@ mod tests {
         }
     }
 
-    fn golden_message_v2() -> AggregatorFeaturesMessage {
+    fn golden_message_actual() -> AggregatorFeaturesMessage {
         AggregatorFeaturesMessage {
             open_api_version: "0.0.1".to_string(),
             documentation_url: "https://example.com".to_string(),
@@ -110,44 +110,35 @@ mod tests {
         }
     }
 
+    const ACTUAL_JSON: &str = r#"{
+        "open_api_version": "0.0.1",
+        "documentation_url": "https://example.com",
+        "capabilities": {
+            "signed_entity_types": ["CardanoTransactions"],
+            "cardano_transactions_prover": {
+                "max_hashes_allowed_by_request": 100
+            },
+            "cardano_transactions_signing_config": {
+                "security_parameter": 70,
+                "step": 20
+            }
+        }
+    }"#;
+
     // Test the retro compatibility with possible future upgrades.
     #[test]
-    fn test_v1() {
-        let json = r#"{
-            "open_api_version": "0.0.1",
-            "documentation_url": "https://example.com",
-            "capabilities": {
-                "signed_entity_types": ["CardanoTransactions"],
-                "cardano_transactions_prover": {
-                    "max_hashes_allowed_by_request": 100
-                }
-            }
-        }"#;
-
+    fn test_actual_json_deserialized_into_previous_message() {
+        let json = ACTUAL_JSON;
         let message: AggregatorFeaturesMessagePrevious = serde_json::from_str(json).unwrap();
 
-        assert_eq!(golden_message_v1(), message);
+        assert_eq!(golden_message_previous(), message);
     }
 
     #[test]
-    fn test_v2() {
-        let json = r#"{
-            "open_api_version": "0.0.1",
-            "documentation_url": "https://example.com",
-            "capabilities": {
-                "signed_entity_types": ["CardanoTransactions"],
-                "cardano_transactions_prover": {
-                    "max_hashes_allowed_by_request": 100
-                },
-                "cardano_transactions_signing_config": {
-                    "security_parameter": 70,
-                    "step": 20
-                }
-            }
-        }"#;
-
+    fn test_actual_json_deserialized_into_actual_message() {
+        let json = ACTUAL_JSON;
         let message: AggregatorFeaturesMessage = serde_json::from_str(json).unwrap();
 
-        assert_eq!(golden_message_v2(), message);
+        assert_eq!(golden_message_actual(), message);
     }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -663,6 +663,25 @@ components:
                   description: Maximum number of hashes allowed for a single request
                   type: integer
                   format: int64
+            cardano_transactions_signing_config:
+              description: |
+                Cardano transactions signing configuration
+                
+                Mandatory if `signed_entity_types` contains `CardanoTransactions`.
+              type: object
+              additionalProperties: false
+              required:
+                - security_parameter
+                - step
+              properties:
+                security_parameter:
+                  description: Number of blocks to discard from the tip of the chain when importing Cardano transactions
+                  type: integer
+                  format: int64
+                step:
+                  description: Number of blocks between signature of Cardano transactions
+                  type: integer
+                  format: int64
       example:
         {
           "open_api_version": "0.1.17",
@@ -676,7 +695,12 @@ components:
                   "CardanoTransactions"
                 ],
               "cardano_transactions_prover":
-                { "max_hashes_allowed_by_request": 100 }
+                { "max_hashes_allowed_by_request": 100 },
+              "cardano_transactions_signing_config":
+                {
+                  "security_parameter": 100,
+                  "step": 10
+                }
             }
         }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.27
+  version: 0.1.28
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -666,7 +666,7 @@ components:
             cardano_transactions_signing_config:
               description: |
                 Cardano transactions signing configuration
-                
+
                 Mandatory if `signed_entity_types` contains `CardanoTransactions`.
               type: object
               additionalProperties: false
@@ -697,10 +697,7 @@ components:
               "cardano_transactions_prover":
                 { "max_hashes_allowed_by_request": 100 },
               "cardano_transactions_signing_config":
-                {
-                  "security_parameter": 100,
-                  "step": 10
-                }
+                { "security_parameter": 100, "step": 10 }
             }
         }
 


### PR DESCRIPTION
## Content

This PR enhance add Cardano transactions signing configuration to the message returned by the Aggregator '/' route if the Cardano transactions are enabled on said Aggregator, else it's omitted.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Closes #1898
