### PR TITLE
Optional signed message in registered signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.57"
+version = "0.5.58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.47"
+version = "0.4.48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.29"
+version = "0.4.30"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.175"
+version = "0.2.176"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.57"
+version = "0.5.58"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/record/single_signature.rs
+++ b/mithril-aggregator/src/database/record/single_signature.rs
@@ -54,6 +54,7 @@ impl TryFrom<SingleSignatureRecord> for SingleSignatures {
             party_id: value.signer_id,
             won_indexes: value.lottery_indexes,
             signature: value.signature.try_into()?,
+            signed_message: None,
         };
 
         Ok(signatures)

--- a/mithril-aggregator/src/message_adapters/from_register_signature.rs
+++ b/mithril-aggregator/src/message_adapters/from_register_signature.rs
@@ -22,6 +22,7 @@ impl TryFromMessageAdapter<RegisterSignatureMessage, SingleSignatures>
                     "'FromRegisterSingleSignatureAdapter' can not convert the single signature"
                 })?,
             won_indexes: register_single_signature_message.won_indexes,
+            signed_message: register_single_signature_message.signed_message,
         };
 
         Ok(signatures)
@@ -34,9 +35,16 @@ mod tests {
 
     #[test]
     fn test_simple_message() {
-        let message = RegisterSignatureMessage::dummy();
-        let signatures = FromRegisterSingleSignatureAdapter::try_adapt(message).unwrap();
+        let signatures = FromRegisterSingleSignatureAdapter::try_adapt(RegisterSignatureMessage {
+            signed_message: Some("signed_message".to_string()),
+            ..RegisterSignatureMessage::dummy()
+        })
+        .unwrap();
 
         assert_eq!("party_id".to_string(), signatures.party_id);
+        assert_eq!(
+            Some("signed_message".to_string()),
+            signatures.signed_message
+        );
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.47"
+version = "0.4.48"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/single_signatures.rs
+++ b/mithril-common/src/entities/single_signatures.rs
@@ -23,7 +23,7 @@ pub struct SingleSignatures {
 
     /// Message that is signed by the signer
     ///
-    /// Used to buffer the signature for later if the Aggregator has yet to create an open message
+    /// Used to buffer the signature for later if the aggregator has yet to create an open message
     /// for the signed entity type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signed_message: Option<String>,

--- a/mithril-common/src/entities/single_signatures.rs
+++ b/mithril-common/src/entities/single_signatures.rs
@@ -20,6 +20,13 @@ pub struct SingleSignatures {
     /// The indexes of the won lotteries that lead to the single signatures
     #[serde(rename = "indexes")]
     pub won_indexes: Vec<LotteryIndex>,
+
+    /// Message that is signed by the signer
+    ///
+    /// Used to buffer the signature for later if the Aggregator has yet to create an open message
+    /// for the signed entity type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signed_message: Option<String>,
 }
 
 impl SingleSignatures {
@@ -33,6 +40,7 @@ impl SingleSignatures {
             party_id,
             signature,
             won_indexes,
+            signed_message: None,
         }
     }
 

--- a/mithril-common/src/entities/single_signatures.rs
+++ b/mithril-common/src/entities/single_signatures.rs
@@ -30,7 +30,7 @@ pub struct SingleSignatures {
 }
 
 impl SingleSignatures {
-    /// SingleSignature factory
+    /// `SingleSignatures` factory
     pub fn new(
         party_id: PartyId,
         signature: ProtocolSingleSignature,
@@ -41,6 +41,21 @@ impl SingleSignatures {
             signature,
             won_indexes,
             signed_message: None,
+        }
+    }
+
+    /// `SingleSignatures` factory including the signed message
+    pub fn new_with_signed_message(
+        party_id: PartyId,
+        signature: ProtocolSingleSignature,
+        won_indexes: Vec<LotteryIndex>,
+        signed_message: String,
+    ) -> SingleSignatures {
+        SingleSignatures {
+            party_id,
+            signature,
+            won_indexes,
+            signed_message: Some(signed_message),
         }
     }
 

--- a/mithril-common/src/messages/register_signature.rs
+++ b/mithril-common/src/messages/register_signature.rs
@@ -21,6 +21,13 @@ pub struct RegisterSignatureMessage {
     /// The indexes of the won lotteries that lead to the single signatures
     #[serde(rename = "indexes")]
     pub won_indexes: Vec<LotteryIndex>,
+
+    /// Message that is signed by the signer
+    ///
+    /// Used to buffer the signature for later if the Aggregator has yet to create an open message
+    /// for the signed entity type.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub signed_message: Option<String>,
 }
 
 impl RegisterSignatureMessage {
@@ -32,6 +39,7 @@ impl RegisterSignatureMessage {
                 party_id: "party_id".to_string(),
                 signature: fake_keys::single_signature()[0].to_string(),
                 won_indexes: vec![1, 3],
+                signed_message: None,
             }
         }
     }
@@ -62,8 +70,18 @@ mod tests {
 
     use super::*;
 
-    fn golden_message() -> RegisterSignatureMessage {
-        RegisterSignatureMessage {
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct RegisterSignatureMessagePrevious {
+        #[serde(rename = "entity_type")]
+        pub signed_entity_type: SignedEntityType,
+        pub party_id: PartyId,
+        pub signature: HexEncodedSingleSignature,
+        #[serde(rename = "indexes")]
+        pub won_indexes: Vec<LotteryIndex>,
+    }
+
+    fn golden_message_previous() -> RegisterSignatureMessagePrevious {
+        RegisterSignatureMessagePrevious {
             signed_entity_type: SignedEntityType::MithrilStakeDistribution(Epoch(246)),
             party_id: "party_id".to_string(),
             signature: "7b227369676d61223a5b3133302c3137372c31352c3232392c32342c3235312c3234372c3137312c3139362c3231302c3134332c3131332c38362c3138392c39322c35362c3131322c33332c3139332c3231322c35342c3231342c32382c3231362c3232372c3137332c3130302c3132372c3137382c34302c39382c38372c32392c3138312c3235352c3131312c3135372c3232342c3233352c34362c3130302c3136392c3233322c3138392c3235322c38322c3133392c33365d2c22696e6465786573223a5b302c312c332c342c362c382c392c31302c31312c31322c31342c31382c32312c32322c32332c32352c32362c32372c33302c33332c33342c33382c34312c34332c35302c35382c35392c36302c36312c36322c36372c36392c37312c37332c37352c37362c37372c38312c38322c38332c38342c39302c39312c39322c39332c39372c39385d2c227369676e65725f696e646578223a327d".to_string(),
@@ -71,19 +89,39 @@ mod tests {
         }
     }
 
-    // Test the retro compatibility with possible future upgrades.
+    fn golden_message_actual() -> RegisterSignatureMessage {
+        RegisterSignatureMessage {
+            signed_entity_type: SignedEntityType::MithrilStakeDistribution(Epoch(246)),
+            party_id: "party_id".to_string(),
+            signature: "7b227369676d61223a5b3133302c3137372c31352c3232392c32342c3235312c3234372c3137312c3139362c3231302c3134332c3131332c38362c3138392c39322c35362c3131322c33332c3139332c3231322c35342c3231342c32382c3231362c3232372c3137332c3130302c3132372c3137382c34302c39382c38372c32392c3138312c3235352c3131312c3135372c3232342c3233352c34362c3130302c3136392c3233322c3138392c3235322c38322c3133392c33365d2c22696e6465786573223a5b302c312c332c342c362c382c392c31302c31312c31322c31342c31382c32312c32322c32332c32352c32362c32372c33302c33332c33342c33382c34312c34332c35302c35382c35392c36302c36312c36322c36372c36392c37312c37332c37352c37362c37372c38312c38322c38332c38342c39302c39312c39322c39332c39372c39385d2c227369676e65725f696e646578223a327d".to_string(),
+            won_indexes: vec![1, 3],
+            signed_message: Some("6a7e737c312972d2346b65ac3075696e04286d046dddaf8004121e3d5e27cc0d".to_string()),
+        }
+    }
+
+    const ACTUAL_JSON: &str = r#"{
+        "entity_type": { "MithrilStakeDistribution": 246 },
+        "party_id": "party_id",
+        "signature": "7b227369676d61223a5b3133302c3137372c31352c3232392c32342c3235312c3234372c3137312c3139362c3231302c3134332c3131332c38362c3138392c39322c35362c3131322c33332c3139332c3231322c35342c3231342c32382c3231362c3232372c3137332c3130302c3132372c3137382c34302c39382c38372c32392c3138312c3235352c3131312c3135372c3232342c3233352c34362c3130302c3136392c3233322c3138392c3235322c38322c3133392c33365d2c22696e6465786573223a5b302c312c332c342c362c382c392c31302c31312c31322c31342c31382c32312c32322c32332c32352c32362c32372c33302c33332c33342c33382c34312c34332c35302c35382c35392c36302c36312c36322c36372c36392c37312c37332c37352c37362c37372c38312c38322c38332c38342c39302c39312c39322c39332c39372c39385d2c227369676e65725f696e646578223a327d",
+        "indexes": [1, 3],
+        "signed_message": "6a7e737c312972d2346b65ac3075696e04286d046dddaf8004121e3d5e27cc0d"
+    }"#;
+
     #[test]
-    fn test_v1() {
-        let json = r#"{
-"entity_type": { "MithrilStakeDistribution": 246 },
-"party_id": "party_id",
-"signature":  "7b227369676d61223a5b3133302c3137372c31352c3232392c32342c3235312c3234372c3137312c3139362c3231302c3134332c3131332c38362c3138392c39322c35362c3131322c33332c3139332c3231322c35342c3231342c32382c3231362c3232372c3137332c3130302c3132372c3137382c34302c39382c38372c32392c3138312c3235352c3131312c3135372c3232342c3233352c34362c3130302c3136392c3233322c3138392c3235322c38322c3133392c33365d2c22696e6465786573223a5b302c312c332c342c362c382c392c31302c31312c31322c31342c31382c32312c32322c32332c32352c32362c32372c33302c33332c33342c33382c34312c34332c35302c35382c35392c36302c36312c36322c36372c36392c37312c37332c37352c37362c37372c38312c38322c38332c38342c39302c39312c39322c39332c39372c39385d2c227369676e65725f696e646578223a327d",
-"indexes": [1, 3]
-}"#;
+    fn test_actual_json_deserialized_into_previous_message() {
+        let json = ACTUAL_JSON;
+        let message: RegisterSignatureMessagePrevious = serde_json::from_str(json).unwrap();
+
+        assert_eq!(golden_message_previous(), message);
+    }
+
+    #[test]
+    fn test_actual_json_deserialized_into_actual_message() {
+        let json = ACTUAL_JSON;
         let message: RegisterSignatureMessage = serde_json::from_str(json).expect(
             "This JSON is expected to be successfully parsed into a RegisterSignatureMessage instance.",
         );
 
-        assert_eq!(golden_message(), message);
+        assert_eq!(golden_message_actual(), message);
     }
 }

--- a/mithril-common/src/messages/register_signature.rs
+++ b/mithril-common/src/messages/register_signature.rs
@@ -24,7 +24,7 @@ pub struct RegisterSignatureMessage {
 
     /// Message that is signed by the signer
     ///
-    /// Used to buffer the signature for later if the Aggregator has yet to create an open message
+    /// Used to buffer the signature for later if the aggregator has yet to create an open message
     /// for the signed entity type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub signed_message: Option<String>,

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.175"
+version = "0.2.176"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/message_adapters/to_register_signature_message.rs
+++ b/mithril-signer/src/message_adapters/to_register_signature_message.rs
@@ -18,6 +18,7 @@ impl TryToMessageAdapter<(SignedEntityType, SingleSignatures), RegisterSignature
                 "'ToRegisterSignatureMessageAdapter' can not convert the single signature"
             })?,
             won_indexes: single_signature.won_indexes,
+            signed_message: None,
         };
 
         Ok(message)

--- a/mithril-signer/src/message_adapters/to_register_signature_message.rs
+++ b/mithril-signer/src/message_adapters/to_register_signature_message.rs
@@ -18,7 +18,7 @@ impl TryToMessageAdapter<(SignedEntityType, SingleSignatures), RegisterSignature
                 "'ToRegisterSignatureMessageAdapter' can not convert the single signature"
             })?,
             won_indexes: single_signature.won_indexes,
-            signed_message: None,
+            signed_message: single_signature.signed_message,
         };
 
         Ok(message)
@@ -33,13 +33,16 @@ mod tests {
 
     #[test]
     fn adapt_ok() {
-        let single_signature = fake_data::single_signatures([1, 3].to_vec());
         let message: RegisterSignatureMessage = ToRegisterSignatureMessageAdapter::try_adapt((
             SignedEntityType::dummy(),
-            single_signature,
+            SingleSignatures {
+                signed_message: Some("signed_message".to_string()),
+                ..fake_data::single_signatures([1, 3].to_vec())
+            },
         ))
         .unwrap();
 
         assert_eq!("party_id".to_string(), message.party_id);
+        assert_eq!(Some("signed_message".to_string()), message.signed_message);
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.29"
+version = "0.4.30"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/payload_builder.rs
@@ -58,6 +58,7 @@ pub fn generate_register_signature_message(
             party_id: s.party_id.clone(),
             signature: s.signature.clone().to_json_hex().unwrap(),
             won_indexes: s.won_indexes.clone(),
+            signed_message: None,
         })
         .collect::<Vec<_>>()
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1068,12 +1068,21 @@ components:
           items:
             type: integer
             format: int64
+        signed_message:
+          description: |
+            Hash of the protocol message that is signed by the signer
+
+            Optional, allow the aggregator to store this signature for later if it has yet to start to work
+            on the message.
+          type: string
+          format: bytes
       example:
         {
           "entity_type": { "MithrilStakeDistribution": 246 },
           "party_id": "1234567890",
           "signature": "7b2c36322c3130352c3232322c31302c3131302c33312c37312c39372c22766b223a5b3136342c2c31393137352c313834",
-          "indexes": [25, 35]
+          "indexes": [25, 35],
+          "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc"
         }
 
     ProtocolMessageParts:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1072,8 +1072,8 @@ components:
           description: |
             Hash of the protocol message that is signed by the signer
 
-            Optional, allow the aggregator to store this signature for later if it has yet to start to work
-            on the message.
+            Optional, allows the aggregator to store this signature for later if it has yet to start aggregating
+            signatures for the message.
           type: string
           format: bytes
       example:


### PR DESCRIPTION
## Content

This PR add an optional field to single signatures: `signed_message`.

In order to decentralize signatures orchestration we will need to buffer incoming single signatures when the Aggregator has yet to create an open message for the signed entity type.
But in that case we won't be able to some validation to reject immediately malicious signatures from bad actors. 
This new field will allow us to do an integrity check of incoming signatures, by checking their validity against their signed message and the current stake distribution, .

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Closes #1899
