### PR TITLE
Refactor: seamless `unstable` to `stable` transition in WASM client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX] - UNRELEASED
 
+- **BREAKING** changes in Mithril client WASM:
+
+  - Implementation of seamless transition from **unstable** to **stable** features.
+  - A new `unstable` option in the client allows the usage of unstable features.
+  - The previous `client.unstable` implementation is not supported anymore and must be replaced with `client`.
+
 - Support for Mithril nodes footprint support in Prometheus monitoring in infrastructure.
 
 - Add support for custom HTTP headers in Mithril client WASM library.
@@ -19,7 +25,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Add feature options `num-integer-backend` and `rug-backend` for `mithril-common` and `mithril-client` crates. Allows to disable `rug-backend` and avoid `LGPL` license usage.
 
-- Post `Chang` hard fork cleanup of the CI and the devnet.
+- Post `Chang` hard fork cleanup of the CI, devnet and infrastructure.
 
 - **UNSTABLE** Cardano stake distribution certification:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.3.10"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "futures",

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client-library-wasm.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client-library-wasm.md
@@ -94,10 +94,11 @@ broadcast_channel.onmessage = (e) => {
 
 await initMithrilClient();
 
-let client = await new MithrilClient(
-  aggregator_endpoint,
-  genesis_verification_key,
-);
+let client = new MithrilClient(aggregator_endpoint, genesis_verification_key, {
+  // The following option activates the unstable features of the client.
+  // Unstable features will trigger an error if this option is not set.
+  unstable: true,
+});
 let mithril_stake_distributions_list =
   await client.list_mithril_stake_distributions();
 console.log("stake distributions:", mithril_stake_distributions_list);
@@ -187,7 +188,7 @@ wget -q -O - https://aggregator.pre-release-preview.api.mithril.network/aggregat
 :::
 
 ```js
-const proof = await client.unstable.get_cardano_transaction_proofs([
+const proof = await client.get_cardano_transaction_proofs([
   "CARDANO_TRANSACTION_HASH_1",
   "CARDANO_TRANSACTION_HASH_2",
 ]);
@@ -203,7 +204,7 @@ console.log(
 );
 
 let valid_cardano_transaction_proof =
-  await client.unstable.verify_cardano_transaction_proof_then_compute_message(
+  await client.verify_cardano_transaction_proof_then_compute_message(
     proof,
     proof_certificate,
   );
@@ -233,11 +234,11 @@ wget -q -O - https://aggregator.testing-preview.api.mithril.network/aggregator |
 
 ```js
 let cardano_stake_distributions_list =
-  await client.unstable.list_cardano_stake_distributions();
+  await client.list_cardano_stake_distributions();
 console.log("cardano stake distributions:", cardano_stake_distributions_list);
 
 let last_cardano_stake_distribution =
-  await client.unstable.get_cardano_stake_distribution(
+  await client.get_cardano_stake_distribution(
     cardano_stake_distributions_list[0].hash,
   );
 console.log(
@@ -259,7 +260,7 @@ console.log(
 );
 
 let cardano_stake_distribution_message =
-  await client.unstable.compute_cardano_stake_distribution_message(
+  await client.compute_cardano_stake_distribution_message(
     certificate,
     last_cardano_stake_distribution,
   );

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.3.10"
+version = "0.4.0"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/www-test/index.js
+++ b/mithril-client-wasm/www-test/index.js
@@ -46,7 +46,11 @@ console.log("aggregator_endpoint: ", aggregator_endpoint);
 console.log("aggregator_capabilities: ", aggregator_capabilities);
 
 await run_test("constructor", test_number, async () => {
-  client = new MithrilClient(aggregator_endpoint, genesis_verification_key);
+  client = new MithrilClient(aggregator_endpoint, genesis_verification_key, {
+    // The following option activates the unstable features of the client.
+    // Unstable features will trigger an error if this option is not set.
+    unstable: true,
+  });
 });
 
 let snapshots;
@@ -117,13 +121,13 @@ if (aggregator_capabilities.includes("CardanoTransactions")) {
   let ctx_sets;
   test_number++;
   await run_test("list_cardano_transactions_snapshots", test_number, async () => {
-    ctx_sets = await client.unstable.list_cardano_transactions_snapshots();
+    ctx_sets = await client.list_cardano_transactions_snapshots();
     console.log("cardano_transactions_sets", ctx_sets);
   });
 
   test_number++;
   await run_test("get_cardano_transactions_snapshot", test_number, async () => {
-    const ctx_set = await client.unstable.get_cardano_transactions_snapshot(ctx_sets[0].hash);
+    const ctx_set = await client.get_cardano_transactions_snapshot(ctx_sets[0].hash);
     console.log("cardano_transaction_set", ctx_set);
   });
 
@@ -133,9 +137,7 @@ if (aggregator_capabilities.includes("CardanoTransactions")) {
     let ctx_proof;
     test_number++;
     await run_test("get_cardano_transaction_proof", test_number, async () => {
-      ctx_proof = await client.unstable.get_cardano_transaction_proofs(
-        transactions_hashes_to_certify,
-      );
+      ctx_proof = await client.get_cardano_transaction_proofs(transactions_hashes_to_certify);
       console.log(
         "got proof for transactions: ",
         ctx_proof.transactions_hashes,
@@ -157,11 +159,10 @@ if (aggregator_capabilities.includes("CardanoTransactions")) {
       "verify_cardano_transaction_proof_then_compute_message",
       test_number,
       async () => {
-        ctx_proof_message =
-          await client.unstable.verify_cardano_transaction_proof_then_compute_message(
-            ctx_proof,
-            proof_certificate,
-          );
+        ctx_proof_message = await client.verify_cardano_transaction_proof_then_compute_message(
+          ctx_proof,
+          proof_certificate,
+        );
         console.log("verify_cardano_transaction_proof_then_compute_message", ctx_proof_message);
       },
     );
@@ -181,14 +182,14 @@ if (aggregator_capabilities.includes("CardanoStakeDistribution")) {
   let cardano_stake_distributions;
   test_number++;
   await run_test("list_cardano_stake_distributions", test_number, async () => {
-    cardano_stake_distributions = await client.unstable.list_cardano_stake_distributions();
+    cardano_stake_distributions = await client.list_cardano_stake_distributions();
     console.log("cardano_stake_distributions", cardano_stake_distributions);
   });
 
   let cardano_stake_distribution;
   test_number++;
   await run_test("get_cardano_stake_distribution", test_number, async () => {
-    cardano_stake_distribution = await client.unstable.get_cardano_stake_distribution(
+    cardano_stake_distribution = await client.get_cardano_stake_distribution(
       cardano_stake_distributions[0].hash,
     );
     console.log("cardano_stake_distribution", cardano_stake_distribution);
@@ -198,8 +199,7 @@ if (aggregator_capabilities.includes("CardanoStakeDistribution")) {
   await run_test("get_cardano_stake_distribution_by_epoch", test_number, async () => {
     let epoch = BigInt(cardano_stake_distributions[0].epoch);
 
-    cardano_stake_distribution =
-      await client.unstable.get_cardano_stake_distribution_by_epoch(epoch);
+    cardano_stake_distribution = await client.get_cardano_stake_distribution_by_epoch(epoch);
     console.log("cardano_stake_distribution by epoch", cardano_stake_distribution);
   });
 
@@ -220,11 +220,10 @@ if (aggregator_capabilities.includes("CardanoStakeDistribution")) {
   let cardano_stake_distribution_message;
   test_number++;
   await run_test("compute_cardano_stake_distribution_message", test_number, async () => {
-    cardano_stake_distribution_message =
-      await client.unstable.compute_cardano_stake_distribution_message(
-        certificate,
-        cardano_stake_distribution,
-      );
+    cardano_stake_distribution_message = await client.compute_cardano_stake_distribution_message(
+      certificate,
+      cardano_stake_distribution,
+    );
     console.log("cardano_stake_distribution_message", cardano_stake_distribution_message);
   });
 

--- a/mithril-client-wasm/www-test/package.json
+++ b/mithril-client-wasm/www-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www-test",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client-wasm/www-test/webpack.config.js
+++ b/mithril-client-wasm/www-test/webpack.config.js
@@ -18,4 +18,7 @@ module.exports = {
   experiments: {
     asyncWebAssembly: true,
   },
+  watchOptions: {
+    ignored: /node_modules/,
+  },
 };

--- a/mithril-client-wasm/www/index.js
+++ b/mithril-client-wasm/www/index.js
@@ -64,21 +64,16 @@ function format_tx_list(transactions_hashes) {
   return "<ul>" + transactions_hashes.map((tx) => "<li>" + tx + "</li>").join("") + "</ul>";
 }
 
-function client_options_with_custom_headers() {
-  // The following header is set as an example.
-  // It's used to demonstrate how to add headers.
-  let http_headers_map = new Map();
-  http_headers_map.set("Content-Type", "application/json");
-
-  return {
-    http_headers: http_headers_map,
-  };
-}
-
 await initMithrilClient();
 
-let client_options = client_options_with_custom_headers();
-let client = new MithrilClient(aggregator_endpoint, genesis_verification_key, client_options);
+let client = new MithrilClient(aggregator_endpoint, genesis_verification_key, {
+  // The following header is set as an example.
+  // It's used to demonstrate how to add headers.
+  http_headers: new Map([["Content-Type", "application/json"]]),
+  // The following option activates the unstable features of the client.
+  // Unstable features will trigger an error if this option is not set.
+  unstable: true,
+});
 
 displayStepInDOM(1, "Getting stake distributions list...");
 let mithril_stake_distributions_list = await client.list_mithril_stake_distributions();
@@ -135,7 +130,7 @@ displayMessageInDOM("Result", "Mithril stake distribution message validated &#x2
 console.log("valid_stake_distribution_message:", valid_stake_distribution_message);
 
 displayStepInDOM(7, "Getting transaction proof...");
-const proof = await client.unstable.get_cardano_transaction_proofs([
+const proof = await client.get_cardano_transaction_proofs([
   "eac09f970f47ef3ab378db9232914e146773853397e79b904f1a45123a23c21f",
   "81fe7a5dab42867ef309b6d7210158bf99331884ac3c3b6c7188a8c9c18d5974",
   "320c13f4a3e51f6f4f66fcd9007e02bf658aa4ee9a88a509028d867d3b8a8e9a",
@@ -157,7 +152,7 @@ displayMessageInDOM("Result", "certificate chain verified &#x2713;");
 console.log("verify_certificate_chain OK, last_certificate_from_chain:", proof_certificate);
 
 displayStepInDOM(10, "Validating Cardano transaction proof message...");
-let protocol_message = await client.unstable.verify_cardano_transaction_proof_then_compute_message(
+let protocol_message = await client.verify_cardano_transaction_proof_then_compute_message(
   proof,
   proof_certificate,
 );

--- a/mithril-client-wasm/www/package.json
+++ b/mithril-client-wasm/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client-wasm/www/webpack.config.js
+++ b/mithril-client-wasm/www/webpack.config.js
@@ -19,4 +19,7 @@ module.exports = {
   devServer: {
     allowedHosts: [".mithril.network"],
   },
+  watchOptions: {
+    ignored: /node_modules/,
+  },
 };

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.16"
+version = "0.8.17"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/client.rs
+++ b/mithril-client/src/client.rs
@@ -27,12 +27,27 @@ use crate::MithrilResult;
 pub struct ClientOptions {
     /// HTTP headers to include in the client requests.
     pub http_headers: Option<HashMap<String, String>>,
+
+    /// Whether to enable unstable features in the WASM client.
+    #[cfg(target_family = "wasm")]
+    #[cfg_attr(target_family = "wasm", serde(default))]
+    pub unstable: bool,
 }
 
 impl ClientOptions {
     /// Instantiate a new [ClientOptions].
     pub fn new(http_headers: Option<HashMap<String, String>>) -> Self {
-        Self { http_headers }
+        Self {
+            http_headers,
+            #[cfg(target_family = "wasm")]
+            unstable: false,
+        }
+    }
+
+    /// Enable unstable features in the WASM client.
+    #[cfg(target_family = "wasm")]
+    pub fn with_unstable_features(self, unstable: bool) -> Self {
+        Self { unstable, ..self }
     }
 }
 

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/components/CertifyCardanoTransactionsModal/index.js
+++ b/mithril-explorer/src/components/CertifyCardanoTransactionsModal/index.js
@@ -97,13 +97,17 @@ export default function CertifyCardanoTransactionsModal({
   }, [client, currentStep, transactionsProofs, certificate]);
 
   async function buildClient(aggregator, genesisKey) {
-    const client = new MithrilClient(aggregator, genesisKey);
+    const client = new MithrilClient(aggregator, genesisKey, {
+      // The following option activates the unstable features of the client.
+      // Unstable features will trigger an error if this option is not set.
+      unstable: true,
+    });
     setClient(client);
     return client;
   }
 
   async function getTransactionsProofsAndCertificate(client, transactionHashes) {
-    const proofs = await client.unstable.get_cardano_transaction_proofs(transactionHashes);
+    const proofs = await client.get_cardano_transaction_proofs(transactionHashes);
     const certificate = await client.get_mithril_certificate(proofs.certificate_hash);
 
     setTransactionsProofs(proofs);
@@ -112,11 +116,10 @@ export default function CertifyCardanoTransactionsModal({
 
   async function verifyTransactionProofAgainstCertificate(client, transactionsProofs, certificate) {
     // Verify proof validity if so get its protocol message
-    const protocolMessage =
-      await client.unstable.verify_cardano_transaction_proof_then_compute_message(
-        transactionsProofs,
-        certificate,
-      );
+    const protocolMessage = await client.verify_cardano_transaction_proof_then_compute_message(
+      transactionsProofs,
+      certificate,
+    );
     const isProofValid =
       (await client.verify_message_match_certificate(protocolMessage, certificate)) === true;
 


### PR DESCRIPTION
## Content
This PR includes an update of the **support of unstable features in the WASM client**:
- the `unstable` client has been removed
- the client options have a new `unstable` flag (activated for WASM only)
- the WASM client enforces the usage of the `unstable` flag for unstable features 
- when transitioning from `unstable` to `stable` there is no more breaking change for the users

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1911
