### PR TITLE
Fix: data inconsistency in Cardano transactions stores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.62"
+version = "0.5.63"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.26"
+version = "0.2.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.181"
+version = "0.2.182"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.26"
+version = "0.2.27"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/cardano_transaction_migration.rs
+++ b/internal/mithril-persistence/src/database/cardano_transaction_migration.rs
@@ -108,5 +108,16 @@ drop index cardano_tx_immutable_file_number_index;
 alter table cardano_tx drop column immutable_file_number;
  "#,
         ),
+        // Migration 9
+        // Truncate Cardano transaction related tables to avoid data inconsistency
+        // with previous versions of the nodes.
+        SqlMigration::new(
+            9,
+            r#"
+delete from cardano_tx;
+delete from block_range_root;
+vacuum;
+ "#,
+        ),
     ]
 }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.62"
+version = "0.5.63"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -731,6 +731,7 @@ impl DependenciesBuilder {
         let chain_block_reader = PallasChainReader::new(
             &self.configuration.cardano_node_socket_path,
             self.configuration.get_network()?,
+            self.get_logger()?,
         );
 
         Ok(Arc::new(Mutex::new(chain_block_reader)))

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.181"
+version = "0.2.182"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -264,8 +264,11 @@ impl<'a> DependenciesBuilder<'a> {
         let transaction_store = Arc::new(CardanoTransactionRepository::new(
             sqlite_connection_cardano_transaction_pool.clone(),
         ));
-        let chain_block_reader =
-            PallasChainReader::new(&self.config.cardano_node_socket_path, network);
+        let chain_block_reader = PallasChainReader::new(
+            &self.config.cardano_node_socket_path,
+            network,
+            slog_scope::logger(),
+        );
         let block_scanner = Arc::new(CardanoBlockScanner::new(
             Arc::new(Mutex::new(chain_block_reader)),
             self.config


### PR DESCRIPTION
## Content
This PR includes a fix that prevents **data inconsistency in the Cardano transactions store** if it has been created with stale versions of the signer.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1901 
