### PR TITLE
Retrieve custom signing configuration with epoch settings in Signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Optimizations of the state machine used by the signer to create individual signatures.
 
-- Support for buffering of incoming single signatures by the aggregator if it can not aggregate them yet
+- Support for buffering of incoming single signatures by the aggregator if it can not aggregate them yet.
+
+- Expose the Cardano transactions signing configuration for the current and upcoming epoch via the `/epoch-settings` route.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.64"
+version = "0.5.65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.52"
+version = "0.4.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3704,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.184"
+version = "0.2.185"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.64"
+version = "0.5.65"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -15,24 +15,41 @@ fn epoch_settings(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("epoch-settings")
         .and(warp::get())
-        .and(middlewares::with_epoch_service(dependency_manager))
+        .and(middlewares::with_epoch_service(dependency_manager.clone()))
+        .and(middlewares::with_signed_entity_config(
+            dependency_manager.clone(),
+        ))
+        .and(middlewares::with_config(dependency_manager))
         .and_then(handlers::epoch_settings)
 }
 
 mod handlers {
-    use crate::dependency_injection::EpochServiceWrapper;
-    use crate::http_server::routes::reply;
-    use mithril_common::messages::{EpochSettingsMessage, SignerMessagePart};
-    use slog_scope::{debug, warn};
     use std::convert::Infallible;
+
+    use slog_scope::{debug, warn};
     use warp::http::StatusCode;
+
+    use mithril_common::{
+        entities::{SignedEntityConfig, SignedEntityTypeDiscriminants},
+        messages::{EpochSettingsMessage, SignerMessagePart},
+    };
+
+    use crate::http_server::routes::reply;
+    use crate::{dependency_injection::EpochServiceWrapper, Configuration};
 
     /// Epoch Settings
     pub async fn epoch_settings(
         epoch_service: EpochServiceWrapper,
+        signed_entity_config: SignedEntityConfig,
+        configuration: Configuration,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("⇄ HTTP SERVER: epoch_settings");
         let epoch_service = epoch_service.read().await;
+
+        let current_cardano_transactions_signing_config = signed_entity_config
+            .list_allowed_signed_entity_types_discriminants()
+            .contains(&SignedEntityTypeDiscriminants::CardanoTransactions)
+            .then_some(configuration.cardano_transactions_signing_config);
 
         match (
             epoch_service.epoch_of_current_data(),
@@ -54,6 +71,7 @@ mod handlers {
                     next_protocol_parameters: next_protocol_parameters.clone(),
                     current_signers: SignerMessagePart::from_signers(current_signers.to_vec()),
                     next_signers: SignerMessagePart::from_signers(next_signers.to_vec()),
+                    current_cardano_transactions_signing_config,
                 };
                 Ok(reply::json(&epoch_settings_message, StatusCode::OK))
             }
@@ -71,14 +89,20 @@ mod handlers {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::{
-        entities::Epoch,
-        test_utils::{apispec::APISpec, MithrilFixtureBuilder},
-    };
+    use std::collections::BTreeSet;
+
     use serde_json::Value::Null;
     use tokio::sync::RwLock;
     use warp::http::{Method, StatusCode};
     use warp::test::request;
+
+    use mithril_common::{
+        entities::{
+            BlockNumber, CardanoTransactionsSigningConfig, Epoch, SignedEntityTypeDiscriminants,
+        },
+        messages::EpochSettingsMessage,
+        test_utils::{apispec::APISpec, MithrilFixtureBuilder},
+    };
 
     use crate::http_server::SERVER_BASE_PATH;
     use crate::initialize_dependencies;
@@ -113,6 +137,95 @@ mod tests {
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::OK,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_epoch_settings_get_ok_with_cardano_transactions_enabled() {
+        let method = Method::GET.as_str();
+        let path = "/epoch-settings";
+        let mut dependency_manager = initialize_dependencies().await;
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+        let epoch_service = FakeEpochService::from_fixture(Epoch(5), &fixture);
+        dependency_manager.epoch_service = Arc::new(RwLock::new(epoch_service));
+        dependency_manager
+            .signed_entity_config
+            .allowed_discriminants =
+            BTreeSet::from([SignedEntityTypeDiscriminants::CardanoTransactions]);
+        let signing_config = CardanoTransactionsSigningConfig {
+            security_parameter: BlockNumber(70),
+            step: BlockNumber(15),
+        };
+        dependency_manager
+            .config
+            .cardano_transactions_signing_config = signing_config.clone();
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        let response_body: EpochSettingsMessage = serde_json::from_slice(response.body()).unwrap();
+
+        assert_eq!(
+            response_body.current_cardano_transactions_signing_config,
+            Some(signing_config)
+        );
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::OK,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_epoch_settings_get_ok_with_cardano_transactions_not_enabled() {
+        let method = Method::GET.as_str();
+        let path = "/epoch-settings";
+        let mut dependency_manager = initialize_dependencies().await;
+        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
+        let epoch_service = FakeEpochService::from_fixture(Epoch(5), &fixture);
+        dependency_manager.epoch_service = Arc::new(RwLock::new(epoch_service));
+        dependency_manager
+            .signed_entity_config
+            .allowed_discriminants = BTreeSet::new();
+        let signing_config = CardanoTransactionsSigningConfig {
+            security_parameter: BlockNumber(70),
+            step: BlockNumber(15),
+        };
+        dependency_manager
+            .config
+            .cardano_transactions_signing_config = signing_config.clone();
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(Arc::new(dependency_manager)))
+            .await;
+
+        let response_body: EpochSettingsMessage = serde_json::from_slice(response.body()).unwrap();
+
+        assert_eq!(
+            response_body.current_cardano_transactions_signing_config,
+            None
+        );
 
         APISpec::verify_conformity(
             APISpec::get_all_spec_files(),

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -1,7 +1,15 @@
-use crate::http_server::routes::middlewares;
-use crate::DependencyContainer;
 use std::sync::Arc;
 use warp::Filter;
+
+use mithril_common::{
+    entities::{SignedEntityConfig, SignedEntityTypeDiscriminants},
+    messages::{EpochSettingsMessage, SignerMessagePart},
+    StdResult,
+};
+
+use crate::dependency_injection::EpochServiceWrapper;
+use crate::http_server::routes::middlewares;
+use crate::DependencyContainer;
 
 pub fn routes(
     dependency_manager: Arc<DependencyContainer>,
@@ -16,93 +24,83 @@ fn epoch_settings(
     warp::path!("epoch-settings")
         .and(warp::get())
         .and(middlewares::with_epoch_service(dependency_manager.clone()))
-        .and(middlewares::with_signed_entity_config(
-            dependency_manager.clone(),
-        ))
-        .and(middlewares::with_config(dependency_manager))
+        .and(middlewares::with_signed_entity_config(dependency_manager))
         .and_then(handlers::epoch_settings)
 }
 
-mod handlers {
-    use std::convert::Infallible;
+async fn get_epoch_settings_message(
+    epoch_service: EpochServiceWrapper,
+    signed_entity_config: SignedEntityConfig,
+) -> StdResult<EpochSettingsMessage> {
+    let epoch_service = epoch_service.read().await;
 
-    use slog_scope::{debug, warn};
-    use warp::http::StatusCode;
+    let epoch = epoch_service.epoch_of_current_data()?;
+    let protocol_parameters = epoch_service.next_protocol_parameters()?.clone();
+    let next_protocol_parameters = epoch_service.upcoming_protocol_parameters()?.clone();
+    let current_signers = epoch_service.current_signers()?;
+    let next_signers = epoch_service.next_signers()?;
 
-    use mithril_common::{
-        entities::{SignedEntityConfig, SignedEntityTypeDiscriminants},
-        messages::{EpochSettingsMessage, SignerMessagePart},
+    let cardano_transactions_signing_config = signed_entity_config
+        .list_allowed_signed_entity_types_discriminants()
+        .contains(&SignedEntityTypeDiscriminants::CardanoTransactions)
+        .then_some(signed_entity_config.cardano_transactions_signing_config);
+    let next_cardano_transactions_signing_config = cardano_transactions_signing_config.clone();
+
+    let epoch_settings_message = EpochSettingsMessage {
+        epoch,
+        protocol_parameters,
+        next_protocol_parameters,
+        current_signers: SignerMessagePart::from_signers(current_signers.to_vec()),
+        next_signers: SignerMessagePart::from_signers(next_signers.to_vec()),
+        cardano_transactions_signing_config,
+        next_cardano_transactions_signing_config,
     };
 
+    Ok(epoch_settings_message)
+}
+
+mod handlers {
+    use slog_scope::debug;
+    use std::convert::Infallible;
+    use warp::http::StatusCode;
+
+    use mithril_common::entities::SignedEntityConfig;
+
+    use crate::dependency_injection::EpochServiceWrapper;
+    use crate::http_server::routes::epoch_routes::get_epoch_settings_message;
     use crate::http_server::routes::reply;
-    use crate::{dependency_injection::EpochServiceWrapper, Configuration};
 
     /// Epoch Settings
     pub async fn epoch_settings(
         epoch_service: EpochServiceWrapper,
         signed_entity_config: SignedEntityConfig,
-        configuration: Configuration,
     ) -> Result<impl warp::Reply, Infallible> {
         debug!("⇄ HTTP SERVER: epoch_settings");
-        let epoch_service = epoch_service.read().await;
+        let epoch_settings_message =
+            get_epoch_settings_message(epoch_service, signed_entity_config).await;
 
-        let cardano_transactions_signing_config = signed_entity_config
-            .list_allowed_signed_entity_types_discriminants()
-            .contains(&SignedEntityTypeDiscriminants::CardanoTransactions)
-            .then_some(configuration.cardano_transactions_signing_config);
-
-        match (
-            epoch_service.epoch_of_current_data(),
-            epoch_service.next_protocol_parameters(),
-            epoch_service.upcoming_protocol_parameters(),
-            epoch_service.current_signers(),
-            epoch_service.next_signers(),
-        ) {
-            (
-                Ok(epoch),
-                Ok(protocol_parameters),
-                Ok(next_protocol_parameters),
-                Ok(current_signers),
-                Ok(next_signers),
-            ) => {
-                let epoch_settings_message = EpochSettingsMessage {
-                    epoch,
-                    protocol_parameters: protocol_parameters.clone(),
-                    next_protocol_parameters: next_protocol_parameters.clone(),
-                    current_signers: SignerMessagePart::from_signers(current_signers.to_vec()),
-                    next_signers: SignerMessagePart::from_signers(next_signers.to_vec()),
-                    cardano_transactions_signing_config: cardano_transactions_signing_config
-                        .clone(),
-                    next_cardano_transactions_signing_config: cardano_transactions_signing_config,
-                };
-                Ok(reply::json(&epoch_settings_message, StatusCode::OK))
-            }
-            (Err(err), _, _, _, _)
-            | (_, Err(err), _, _, _)
-            | (_, _, Err(err), _, _)
-            | (_, _, _, Err(err), _)
-            | (_, _, _, _, Err(err)) => {
-                warn!("epoch_settings::error"; "error" => ?err);
-                Ok(reply::server_error(err))
-            }
+        match epoch_settings_message {
+            Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
+            Err(err) => Ok(reply::server_error(err)),
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
-
     use serde_json::Value::Null;
+    use std::collections::BTreeSet;
     use tokio::sync::RwLock;
-    use warp::http::{Method, StatusCode};
-    use warp::test::request;
+    use warp::{
+        http::{Method, StatusCode},
+        test::request,
+    };
 
     use mithril_common::{
         entities::{
-            BlockNumber, CardanoTransactionsSigningConfig, Epoch, SignedEntityTypeDiscriminants,
+            BlockNumber, CardanoTransactionsSigningConfig, Epoch, SignedEntityConfig,
+            SignedEntityTypeDiscriminants,
         },
-        messages::EpochSettingsMessage,
         test_utils::{apispec::APISpec, MithrilFixtureBuilder},
     };
 
@@ -126,6 +124,62 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn get_epoch_settings_message_with_cardano_transactions_enabled() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let epoch_service = FakeEpochService::from_fixture(Epoch(4), &fixture);
+        let epoch_service = Arc::new(RwLock::new(epoch_service));
+
+        let cardano_transactions_signing_config = CardanoTransactionsSigningConfig {
+            security_parameter: BlockNumber(70),
+            step: BlockNumber(15),
+        };
+        let signed_entity_config = SignedEntityConfig {
+            cardano_transactions_signing_config: cardano_transactions_signing_config.clone(),
+            allowed_discriminants: BTreeSet::from([
+                SignedEntityTypeDiscriminants::CardanoTransactions,
+            ]),
+            ..SignedEntityConfig::dummy()
+        };
+
+        let message = get_epoch_settings_message(epoch_service, signed_entity_config)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            message.cardano_transactions_signing_config,
+            Some(cardano_transactions_signing_config.clone())
+        );
+        assert_eq!(
+            message.next_cardano_transactions_signing_config,
+            Some(cardano_transactions_signing_config)
+        );
+    }
+
+    #[tokio::test]
+    async fn get_epoch_settings_message_with_cardano_transactions_not_enabled() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let epoch_service = FakeEpochService::from_fixture(Epoch(4), &fixture);
+        let epoch_service = Arc::new(RwLock::new(epoch_service));
+
+        let cardano_transactions_signing_config = CardanoTransactionsSigningConfig {
+            security_parameter: BlockNumber(70),
+            step: BlockNumber(15),
+        };
+        let signed_entity_config = SignedEntityConfig {
+            cardano_transactions_signing_config,
+            allowed_discriminants: BTreeSet::new(),
+            ..SignedEntityConfig::dummy()
+        };
+
+        let message = get_epoch_settings_message(epoch_service, signed_entity_config)
+            .await
+            .unwrap();
+
+        assert_eq!(message.cardano_transactions_signing_config, None);
+        assert_eq!(message.next_cardano_transactions_signing_config, None);
+    }
+
+    #[tokio::test]
     async fn test_epoch_settings_get_ok() {
         let method = Method::GET.as_str();
         let path = "/epoch-settings";
@@ -139,95 +193,6 @@ mod tests {
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .reply(&setup_router(Arc::new(dependency_manager)))
             .await;
-
-        APISpec::verify_conformity(
-            APISpec::get_all_spec_files(),
-            method,
-            path,
-            "application/json",
-            &Null,
-            &response,
-            &StatusCode::OK,
-        )
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_epoch_settings_get_ok_with_cardano_transactions_enabled() {
-        let method = Method::GET.as_str();
-        let path = "/epoch-settings";
-        let mut dependency_manager = initialize_dependencies().await;
-        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
-        let epoch_service = FakeEpochService::from_fixture(Epoch(5), &fixture);
-        dependency_manager.epoch_service = Arc::new(RwLock::new(epoch_service));
-        dependency_manager
-            .signed_entity_config
-            .allowed_discriminants =
-            BTreeSet::from([SignedEntityTypeDiscriminants::CardanoTransactions]);
-        let signing_config = CardanoTransactionsSigningConfig {
-            security_parameter: BlockNumber(70),
-            step: BlockNumber(15),
-        };
-        dependency_manager
-            .config
-            .cardano_transactions_signing_config = signing_config.clone();
-
-        let response = request()
-            .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
-            .await;
-
-        let response_body: EpochSettingsMessage = serde_json::from_slice(response.body()).unwrap();
-
-        assert_eq!(
-            response_body.current_cardano_transactions_signing_config,
-            Some(signing_config)
-        );
-
-        APISpec::verify_conformity(
-            APISpec::get_all_spec_files(),
-            method,
-            path,
-            "application/json",
-            &Null,
-            &response,
-            &StatusCode::OK,
-        )
-        .unwrap();
-    }
-
-    #[tokio::test]
-    async fn test_epoch_settings_get_ok_with_cardano_transactions_not_enabled() {
-        let method = Method::GET.as_str();
-        let path = "/epoch-settings";
-        let mut dependency_manager = initialize_dependencies().await;
-        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
-        let epoch_service = FakeEpochService::from_fixture(Epoch(5), &fixture);
-        dependency_manager.epoch_service = Arc::new(RwLock::new(epoch_service));
-        dependency_manager
-            .signed_entity_config
-            .allowed_discriminants = BTreeSet::new();
-        let signing_config = CardanoTransactionsSigningConfig {
-            security_parameter: BlockNumber(70),
-            step: BlockNumber(15),
-        };
-        dependency_manager
-            .config
-            .cardano_transactions_signing_config = signing_config.clone();
-
-        let response = request()
-            .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
-            .await;
-
-        let response_body: EpochSettingsMessage = serde_json::from_slice(response.body()).unwrap();
-
-        assert_eq!(
-            response_body.current_cardano_transactions_signing_config,
-            None
-        );
 
         APISpec::verify_conformity(
             APISpec::get_all_spec_files(),

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -46,7 +46,7 @@ mod handlers {
         debug!("⇄ HTTP SERVER: epoch_settings");
         let epoch_service = epoch_service.read().await;
 
-        let current_cardano_transactions_signing_config = signed_entity_config
+        let cardano_transactions_signing_config = signed_entity_config
             .list_allowed_signed_entity_types_discriminants()
             .contains(&SignedEntityTypeDiscriminants::CardanoTransactions)
             .then_some(configuration.cardano_transactions_signing_config);
@@ -71,7 +71,9 @@ mod handlers {
                     next_protocol_parameters: next_protocol_parameters.clone(),
                     current_signers: SignerMessagePart::from_signers(current_signers.to_vec()),
                     next_signers: SignerMessagePart::from_signers(next_signers.to_vec()),
-                    current_cardano_transactions_signing_config,
+                    cardano_transactions_signing_config: cardano_transactions_signing_config
+                        .clone(),
+                    next_cardano_transactions_signing_config: cardano_transactions_signing_config,
                 };
                 Ok(reply::json(&epoch_settings_message, StatusCode::OK))
             }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.52"
+version = "0.4.53"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/epoch_settings.rs
+++ b/mithril-common/src/entities/epoch_settings.rs
@@ -21,5 +21,8 @@ pub struct EpochSettings {
     pub next_signers: Vec<Signer>,
 
     /// Cardano transactions signing configuration for the current epoch
-    pub current_cardano_transactions_signing_config: Option<CardanoTransactionsSigningConfig>,
+    pub cardano_transactions_signing_config: Option<CardanoTransactionsSigningConfig>,
+
+    /// Cardano transactions signing configuration for the next epoch
+    pub next_cardano_transactions_signing_config: Option<CardanoTransactionsSigningConfig>,
 }

--- a/mithril-common/src/entities/epoch_settings.rs
+++ b/mithril-common/src/entities/epoch_settings.rs
@@ -1,4 +1,4 @@
-use crate::entities::{Epoch, ProtocolParameters};
+use crate::entities::{CardanoTransactionsSigningConfig, Epoch, ProtocolParameters};
 
 use super::Signer;
 
@@ -19,4 +19,7 @@ pub struct EpochSettings {
 
     /// Signers that will be able to sign on the next epoch
     pub next_signers: Vec<Signer>,
+
+    /// Cardano transactions signing configuration for the current epoch
+    pub current_cardano_transactions_signing_config: Option<CardanoTransactionsSigningConfig>,
 }

--- a/mithril-common/src/messages/epoch_settings.rs
+++ b/mithril-common/src/messages/epoch_settings.rs
@@ -45,7 +45,7 @@ impl EpochSettingsMessage {
                 },
                 current_signers: [SignerMessagePart::dummy()].to_vec(),
                 next_signers: [SignerMessagePart::dummy()].to_vec(),
-                current_cardano_transactions_signing_config: None,
+                current_cardano_transactions_signing_config: Some(CardanoTransactionsSigningConfig::dummy()),
             }
         }
     }

--- a/mithril-common/src/messages/epoch_settings.rs
+++ b/mithril-common/src/messages/epoch_settings.rs
@@ -24,7 +24,11 @@ pub struct EpochSettingsMessage {
 
     /// Cardano transactions signing configuration for the current epoch
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub current_cardano_transactions_signing_config: Option<CardanoTransactionsSigningConfig>,
+    pub cardano_transactions_signing_config: Option<CardanoTransactionsSigningConfig>,
+
+    /// Cardano transactions signing configuration for the next epoch
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cardano_transactions_signing_config: Option<CardanoTransactionsSigningConfig>,
 }
 
 impl EpochSettingsMessage {
@@ -45,7 +49,8 @@ impl EpochSettingsMessage {
                 },
                 current_signers: [SignerMessagePart::dummy()].to_vec(),
                 next_signers: [SignerMessagePart::dummy()].to_vec(),
-                current_cardano_transactions_signing_config: Some(CardanoTransactionsSigningConfig::dummy()),
+                cardano_transactions_signing_config: Some(CardanoTransactionsSigningConfig::dummy()),
+                next_cardano_transactions_signing_config: Some(CardanoTransactionsSigningConfig::dummy()),
             }
         }
     }
@@ -76,15 +81,20 @@ mod tests {
             "operational_certificate":"certificate_456",
             "kes_period":45
         }],
-        "current_cardano_transactions_signing_config": {
+        "cardano_transactions_signing_config": {
             "security_parameter": 70,
             "step": 20
+        },
+        "next_cardano_transactions_signing_config": {
+            "security_parameter": 50,
+            "step": 10
         }
         
         }"#;
 
+    // Supported structure until OpenAPI version 0.1.28.
     #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-    pub struct EpochSettingsMessageLegacyVersion {
+    pub struct EpochSettingsMessageUntilV0_1_28 {
         /// Current Epoch
         pub epoch: Epoch,
 
@@ -97,8 +107,9 @@ mod tests {
         pub next_protocol_parameters: ProtocolParameters,
     }
 
+    // Supported structure until OpenAPI version 0.1.29.
     #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
-    pub struct EpochSettingsMessagePreviousVersion {
+    pub struct EpochSettingsMessageUntilV0_1_29 {
         /// Current Epoch
         pub epoch: Epoch,
 
@@ -117,8 +128,8 @@ mod tests {
         pub next_signers: Vec<SignerMessagePart>,
     }
 
-    fn golden_legacy_message() -> EpochSettingsMessageLegacyVersion {
-        EpochSettingsMessageLegacyVersion {
+    fn golden_message_until_open_api_0_1_28() -> EpochSettingsMessageUntilV0_1_28 {
+        EpochSettingsMessageUntilV0_1_28 {
             epoch: Epoch(10),
             protocol_parameters: ProtocolParameters {
                 k: 5,
@@ -133,8 +144,8 @@ mod tests {
         }
     }
 
-    fn golden_previous_message() -> EpochSettingsMessagePreviousVersion {
-        EpochSettingsMessagePreviousVersion {
+    fn golden_message_until_open_api_0_1_29() -> EpochSettingsMessageUntilV0_1_29 {
+        EpochSettingsMessageUntilV0_1_29 {
             epoch: Epoch(10),
             protocol_parameters: ProtocolParameters {
                 k: 5,
@@ -190,33 +201,37 @@ mod tests {
                 operational_certificate: Some("certificate_456".to_string()),
                 kes_period: Some(45),
             }],
-            current_cardano_transactions_signing_config: Some(CardanoTransactionsSigningConfig {
+            cardano_transactions_signing_config: Some(CardanoTransactionsSigningConfig {
                 security_parameter: BlockNumber(70),
                 step: BlockNumber(20),
+            }),
+            next_cardano_transactions_signing_config: Some(CardanoTransactionsSigningConfig {
+                security_parameter: BlockNumber(50),
+                step: BlockNumber(10),
             }),
         }
     }
 
-    // Test the backward compatibility with legacy structure.
+    // Test the backward compatibility with the structure supported until OpenAPI version 0.1.28.
     #[test]
-    fn test_actual_json_deserialized_into_legacy_message() {
+    fn test_actual_json_deserialized_into_message_supported_until_open_api_0_1_28() {
         let json = ACTUAL_JSON;
-        let message: EpochSettingsMessageLegacyVersion = serde_json::from_str(json).expect(
-            "This JSON is expected to be successfully parsed into a EpochSettingsMessageLegacyVersion instance.",
+        let message: EpochSettingsMessageUntilV0_1_28 = serde_json::from_str(json).expect(
+            "This JSON is expected to be successfully parsed into a EpochSettingsMessageUntilVersion0_1_28 instance.",
         );
 
-        assert_eq!(golden_legacy_message(), message);
+        assert_eq!(golden_message_until_open_api_0_1_28(), message);
     }
 
-    // Test the backward compatibility with previous structure.
+    // Test the backward compatibility with the structure supported until OpenAPI version 0.1.29.
     #[test]
-    fn test_actual_json_deserialized_into_previous_message() {
+    fn test_actual_json_deserialized_into_message_supported_until_open_api_0_1_29() {
         let json = ACTUAL_JSON;
-        let message: EpochSettingsMessagePreviousVersion = serde_json::from_str(json).expect(
-            "This JSON is expected to be successfully parsed into a EpochSettingsMessagePreviousVersion instance.",
+        let message: EpochSettingsMessageUntilV0_1_29 = serde_json::from_str(json).expect(
+            "This JSON is expected to be successfully parsed into a EpochSettingsMessageUntilVersion0_1_29 instance.",
         );
 
-        assert_eq!(golden_previous_message(), message);
+        assert_eq!(golden_message_until_open_api_0_1_29(), message);
     }
 
     // Test the compatibility with current structure.

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -66,8 +66,10 @@ pub fn epoch_settings() -> entities::EpochSettings {
     let current_signers = signers[1..3].to_vec();
     let next_signers = signers[2..5].to_vec();
 
-    // Cardano transactions signing configuration for the current epoch
-    let current_cardano_transactions_signing_config =
+    // Cardano transactions signing configuration
+    let cardano_transactions_signing_config =
+        Some(entities::CardanoTransactionsSigningConfig::dummy());
+    let next_cardano_transactions_signing_config =
         Some(entities::CardanoTransactionsSigningConfig::dummy());
 
     // Epoch settings
@@ -77,7 +79,8 @@ pub fn epoch_settings() -> entities::EpochSettings {
         next_protocol_parameters,
         current_signers,
         next_signers,
-        current_cardano_transactions_signing_config,
+        cardano_transactions_signing_config,
+        next_cardano_transactions_signing_config,
     }
 }
 

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -66,6 +66,10 @@ pub fn epoch_settings() -> entities::EpochSettings {
     let current_signers = signers[1..3].to_vec();
     let next_signers = signers[2..5].to_vec();
 
+    // Cardano transactions signing configuration for the current epoch
+    let current_cardano_transactions_signing_config =
+        Some(entities::CardanoTransactionsSigningConfig::dummy());
+
     // Epoch settings
     entities::EpochSettings {
         epoch: beacon.epoch,
@@ -73,6 +77,7 @@ pub fn epoch_settings() -> entities::EpochSettings {
         next_protocol_parameters,
         current_signers,
         next_signers,
+        current_cardano_transactions_signing_config,
     }
 }
 

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.184"
+version = "0.2.185"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/message_adapters/from_epoch_settings.rs
+++ b/mithril-signer/src/message_adapters/from_epoch_settings.rs
@@ -19,8 +19,9 @@ impl TryFromMessageAdapter<EpochSettingsMessage, EpochSettings> for FromEpochSet
                 .with_context(|| "'FromMessageAdapter' can not convert the current signers")?,
             next_signers: SignerMessagePart::try_into_signers(message.next_signers)
                 .with_context(|| "'FromMessageAdapter' can not convert the next signers")?,
-            current_cardano_transactions_signing_config: message
-                .current_cardano_transactions_signing_config,
+            cardano_transactions_signing_config: message.cardano_transactions_signing_config,
+            next_cardano_transactions_signing_config: message
+                .next_cardano_transactions_signing_config,
         };
         Ok(epoch_settings)
     }

--- a/mithril-signer/src/message_adapters/from_epoch_settings.rs
+++ b/mithril-signer/src/message_adapters/from_epoch_settings.rs
@@ -19,6 +19,8 @@ impl TryFromMessageAdapter<EpochSettingsMessage, EpochSettings> for FromEpochSet
                 .with_context(|| "'FromMessageAdapter' can not convert the current signers")?,
             next_signers: SignerMessagePart::try_into_signers(message.next_signers)
                 .with_context(|| "'FromMessageAdapter' can not convert the next signers")?,
+            current_cardano_transactions_signing_config: message
+                .current_cardano_transactions_signing_config,
         };
         Ok(epoch_settings)
     }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -458,7 +458,10 @@ mod tests {
             MKMap, MKMapNode, MKTreeNode, MKTreeStoreInMemory, MKTreeStorer, ProtocolInitializer,
         },
         digesters::{DumbImmutableDigester, DumbImmutableFileObserver},
-        entities::{BlockNumber, BlockRange, CardanoDbBeacon, Epoch, ProtocolParameters},
+        entities::{
+            BlockNumber, BlockRange, CardanoDbBeacon, CardanoTransactionsSigningConfig, Epoch,
+            ProtocolParameters,
+        },
         era::{adapters::EraReaderBootstrapAdapter, EraChecker, EraReader},
         signable_builder::{
             BlockRangeRootRetriever, CardanoImmutableFilesFullSignableBuilder,
@@ -544,6 +547,11 @@ mod tests {
         }
         async fn next_signers_with_stake(&self) -> StdResult<Vec<SignerWithStake>> {
             Ok(vec![])
+        }
+        fn current_cardano_transactions_signing_config(
+            &self,
+        ) -> StdResult<&Option<CardanoTransactionsSigningConfig>> {
+            Ok(&None)
         }
 
         fn is_signer_included_in_current_stake_distribution(

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -548,7 +548,12 @@ mod tests {
         async fn next_signers_with_stake(&self) -> StdResult<Vec<SignerWithStake>> {
             Ok(vec![])
         }
-        fn current_cardano_transactions_signing_config(
+        fn cardano_transactions_signing_config(
+            &self,
+        ) -> StdResult<&Option<CardanoTransactionsSigningConfig>> {
+            Ok(&None)
+        }
+        fn next_cardano_transactions_signing_config(
             &self,
         ) -> StdResult<&Option<CardanoTransactionsSigningConfig>> {
             Ok(&None)

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -548,7 +548,8 @@ mod tests {
             next_protocol_parameters: fake_data::protocol_parameters(),
             current_signers: vec![],
             next_signers: vec![],
-            current_cardano_transactions_signing_config: None,
+            cardano_transactions_signing_config: None,
+            next_cardano_transactions_signing_config: None,
         };
         let known_epoch = Epoch(4);
         runner

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -548,6 +548,7 @@ mod tests {
             next_protocol_parameters: fake_data::protocol_parameters(),
             current_signers: vec![],
             next_signers: vec![],
+            current_cardano_transactions_signing_config: None,
         };
         let known_epoch = Epoch(4);
         runner

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.30
+  version: 0.1.31
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -733,6 +733,25 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Signer"
+        current_cardano_transactions_signing_config:
+          description: |
+            Cardano transactions signing configuration for the current epoch
+
+            Mandatory if `signed_entity_types` from the Aggregator configuration contains `CardanoTransactions`.
+          type: object
+          additionalProperties: false
+          required:
+            - security_parameter
+            - step
+          properties:
+            security_parameter:
+              description: Number of blocks to discard from the tip of the chain when importing Cardano transactions
+              type: integer
+              format: int64
+            step:
+              description: Number of blocks between signature of Cardano transactions
+              type: integer
+              format: int64
       example:
         {
           "epoch": 329,
@@ -771,7 +790,9 @@ components:
                 "operational_certificate": "2c38382c3138372c3233332c34302c37322c31362c36365d2c312c3132332c5b31362c3136392c3134312c3138332c32322c3137342c3131312c33322c36342c35322c2c3232382c37392c3137352c32395312c3838282c323030",
                 "kes_period": 876
               }
-            ]
+            ],
+          "current_cardano_transactions_signing_config":
+            { "security_parameter": 100, "step": 10 }
         }
 
     ProtocolParameters:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -55,6 +55,10 @@ paths:
         Returns the information related to the current epoch:
           * protocol parameters for current epoch
           * protocol parameters for next epoch (to setup cryptography, allowing signers to register)
+          * signers for current epoch
+          * signers for next epoch
+          * cardano transactions signing configuration for current epoch
+          * cardano transactions signing configuration for next epoch
       responses:
         "200":
           description: epoch settings found
@@ -733,25 +737,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Signer"
-        current_cardano_transactions_signing_config:
-          description: |
-            Cardano transactions signing configuration for the current epoch
-
-            Mandatory if `signed_entity_types` from the Aggregator configuration contains `CardanoTransactions`.
-          type: object
-          additionalProperties: false
-          required:
-            - security_parameter
-            - step
-          properties:
-            security_parameter:
-              description: Number of blocks to discard from the tip of the chain when importing Cardano transactions
-              type: integer
-              format: int64
-            step:
-              description: Number of blocks between signature of Cardano transactions
-              type: integer
-              format: int64
+        cardano_transactions_signing_config:
+          $ref: "#/components/schemas/CardanoTransactionsSigningConfig"
+        next_cardano_transactions_signing_config:
+          $ref: "#/components/schemas/CardanoTransactionsSigningConfig"
       example:
         {
           "epoch": 329,
@@ -791,8 +780,10 @@ components:
                 "kes_period": 876
               }
             ],
-          "current_cardano_transactions_signing_config":
-            { "security_parameter": 100, "step": 10 }
+          "cardano_transactions_signing_config":
+            { "security_parameter": 100, "step": 10 },
+          "next_cardano_transactions_signing_config":
+            { "security_parameter": 50, "step": 5 }
         }
 
     ProtocolParameters:
@@ -817,6 +808,24 @@ components:
           type: number
           format: double
       example: { "k": 857, "m": 6172, "phi_f": 0.2 }
+
+    CardanoTransactionsSigningConfig:
+      description: Cardano transactions signing configuration
+      type: object
+      additionalProperties: false
+      required:
+        - security_parameter
+        - step
+      properties:
+        security_parameter:
+          description: Number of blocks to discard from the tip of the chain when importing Cardano transactions
+          type: integer
+          format: int64
+        step:
+          description: Number of blocks between signature of Cardano transactions
+          type: integer
+          format: int64
+      example: { "security_parameter": 100, "step": 10 }
 
     CardanoDbBeacon:
       description: A point in the Cardano chain at which a Mithril certificate of the Cardano Database should be produced


### PR DESCRIPTION
## Content

This PR includes  a way for the signer to access the Cardano transaction signing configuration from the aggregator via the `/epoch-settings` route.
The configuration is retrieved by the signer at each epoch transition and stored in its epoch service.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1923 
