### PR TITLE
Feat: sign protocol parameters and epoch in certificate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Support for signing the protocol parameters in the Genesis certificate.
 
-- Refactor the builder of the protocol messages to be signed.
+- Refactor the builder of the protocol messages, and add support for protocol parameters and epoch parts.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
 
 [[package]]
 name = "client-mithril-stake-distribution"
-version = "0.1.17"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.68"
+version = "0.5.69"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3480,7 +3480,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.8.18"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.9.12"
+version = "0.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.187"
+version = "0.2.188"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/client-mithril-stake-distribution/Cargo.toml
+++ b/examples/client-mithril-stake-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-mithril-stake-distribution"
 description = "Mithril client stake distribution example"
-version = "0.1.17"
+version = "0.2.0"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-mithril-stake-distribution/src/main.rs
+++ b/examples/client-mithril-stake-distribution/src/main.rs
@@ -82,7 +82,7 @@ async fn main() -> MithrilResult<()> {
     );
 
     let message = MessageBuilder::new()
-        .compute_mithril_stake_distribution_message(&mithril_stake_distribution)?;
+        .compute_mithril_stake_distribution_message(&certificate, &mithril_stake_distribution)?;
 
     if certificate.match_message(&message) {
         info!(

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.68"
+version = "0.5.69"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1104,7 +1104,9 @@ impl DependenciesBuilder {
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(self.get_stake_store().await?),
         );
+        let era_checker = self.get_era_checker().await?;
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(
+            era_checker,
             seed_signable_builder,
             mithril_stake_distribution_builder,
             immutable_signable_builder,

--- a/mithril-aggregator/src/services/signable_builder/signable_seed_builder.rs
+++ b/mithril-aggregator/src/services/signable_builder/signable_seed_builder.rs
@@ -28,9 +28,7 @@ impl AggregatorSignableSeedBuilder {
 
 #[async_trait]
 impl SignableSeedBuilder for AggregatorSignableSeedBuilder {
-    async fn compute_next_aggregate_verification_key_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue> {
+    async fn compute_next_aggregate_verification_key(&self) -> StdResult<ProtocolMessagePartValue> {
         let epoch_service = self.epoch_service.read().await;
         let next_aggregate_verification_key = (*epoch_service)
             .next_aggregate_verification_key()?
@@ -41,18 +39,14 @@ impl SignableSeedBuilder for AggregatorSignableSeedBuilder {
         Ok(next_aggregate_verification_key)
     }
 
-    async fn compute_next_protocol_parameters_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue> {
+    async fn compute_next_protocol_parameters(&self) -> StdResult<ProtocolMessagePartValue> {
         let epoch_service = self.epoch_service.read().await;
         let next_protocol_parameters = epoch_service.next_protocol_parameters()?.compute_hash();
 
         Ok(next_protocol_parameters)
     }
 
-    async fn compute_current_epoch_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue> {
+    async fn compute_current_epoch(&self) -> StdResult<ProtocolMessagePartValue> {
         let epoch_service = self.epoch_service.read().await;
         let current_epoch = epoch_service.epoch_of_current_data()?.to_string();
 
@@ -97,7 +91,7 @@ mod tests {
         let expected_next_aggregate_verification_key = next_fixture.compute_and_encode_avk();
 
         let next_aggregate_verification_key = signable_seed_builder
-            .compute_next_aggregate_verification_key_protocol_message_part_value()
+            .compute_next_aggregate_verification_key()
             .await
             .unwrap();
 
@@ -116,7 +110,7 @@ mod tests {
         let expected_next_protocol_parameters = next_fixture.protocol_parameters().compute_hash();
 
         let next_protocol_parameters = signable_seed_builder
-            .compute_next_protocol_parameters_protocol_message_part_value()
+            .compute_next_protocol_parameters()
             .await
             .unwrap();
 
@@ -131,10 +125,7 @@ mod tests {
         let signable_seed_builder = build_signable_builder_service(epoch, &fixture, &next_fixture);
         let expected_current_epoch = epoch.to_string();
 
-        let current_epoch = signable_seed_builder
-            .compute_current_epoch_protocol_message_part_value()
-            .await
-            .unwrap();
+        let current_epoch = signable_seed_builder.compute_current_epoch().await.unwrap();
 
         assert_eq!(current_epoch, expected_current_epoch);
     }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.9.12"
+version = "0.9.13"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
@@ -113,7 +113,7 @@ impl MithrilStakeDistributionDownloadCommand {
             "Verify that the Mithril stake distribution is signed in the associated certificate",
         )?;
         let message = MessageBuilder::new()
-            .compute_mithril_stake_distribution_message(&mithril_stake_distribution)
+            .compute_mithril_stake_distribution_message(&certificate, &mithril_stake_distribution)
             .with_context(|| {
                 "Can not compute the message for the given Mithril stake distribution"
             })?;

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.4.1"
+version = "0.5.0"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/npm/README.md
+++ b/mithril-client-wasm/npm/README.md
@@ -79,6 +79,7 @@ console.log(
 let mithril_stake_distributions_message =
   await client.compute_mithril_stake_distribution_message(
     last_stake_distribution,
+    last_certificate_from_chain,
   );
 console.log(
   "mithril_stake_distributions_message:",

--- a/mithril-client-wasm/www-test/index.js
+++ b/mithril-client-wasm/www-test/index.js
@@ -100,6 +100,7 @@ let mithril_stake_distribution_message;
 test_number++;
 await run_test("compute_mithril_stake_distribution_message", test_number, async () => {
   mithril_stake_distribution_message = await client.compute_mithril_stake_distribution_message(
+    last_certificate_from_chain,
     mithril_stake_distribution,
   );
   console.log("mithril_stake_distribution_message", mithril_stake_distribution_message);

--- a/mithril-client-wasm/www-test/package.json
+++ b/mithril-client-wasm/www-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www-test",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client-wasm/www/index.js
+++ b/mithril-client-wasm/www/index.js
@@ -116,8 +116,10 @@ console.log(
 );
 
 displayStepInDOM(5, "Computing the Mithril stake distribution message...");
-let mithril_stake_distributions_message =
-  await client.compute_mithril_stake_distribution_message(last_stake_distribution);
+let mithril_stake_distributions_message = await client.compute_mithril_stake_distribution_message(
+  last_stake_distribution,
+  last_certificate_from_chain,
+);
 displayMessageInDOM("Result", "Mithril stake distribution message computed &#x2713;");
 console.log("mithril_stake_distributions_message:", mithril_stake_distributions_message);
 

--- a/mithril-client-wasm/www/package-lock.json
+++ b/mithril-client-wasm/www/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.4.2",
+      "version": "0.4.1",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/www/package.json
+++ b/mithril-client-wasm/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.8.18"
+version = "0.9.0"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/message.rs
+++ b/mithril-client/src/message.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use crate::common::{ProtocolMessage, ProtocolMessagePartKey};
 #[cfg(feature = "unstable")]
 use crate::CardanoStakeDistribution;
-#[cfg(any(feature = "fs", feature = "unstable"))]
 use crate::MithrilCertificate;
 #[cfg(feature = "unstable")]
 use crate::VerifiedCardanoTransactions;
@@ -106,6 +105,7 @@ impl MessageBuilder {
     /// Compute message for a Mithril stake distribution.
     pub fn compute_mithril_stake_distribution_message(
         &self,
+        certificate: &MithrilCertificate,
         mithril_stake_distribution: &MithrilStakeDistribution,
     ) -> MithrilResult<ProtocolMessage> {
         let signers =
@@ -125,7 +125,7 @@ impl MessageBuilder {
                 "Could not compute message: aggregate verification key encoding failed"
             })?;
 
-        let mut message = ProtocolMessage::new();
+        let mut message = certificate.protocol_message.clone();
         message.set_message_part(ProtocolMessagePartKey::NextAggregateVerificationKey, avk);
 
         Ok(message)

--- a/mithril-client/tests/extensions/fake.rs
+++ b/mithril-client/tests/extensions/fake.rs
@@ -91,16 +91,15 @@ impl FakeAggregator {
         ])
         .unwrap();
 
-        let message = MessageBuilder::new()
-            .compute_mithril_stake_distribution_message(&mithril_stake_distribution)
-            .expect("Computing msd message should not fail");
-
-        let certificate_json = serde_json::to_string(&MithrilCertificate {
+        let mut certificate = MithrilCertificate {
             hash: certificate_hash.to_string(),
-            signed_message: message.compute_hash(),
             ..MithrilCertificate::dummy()
-        })
-        .unwrap();
+        };
+        let message = MessageBuilder::new()
+            .compute_mithril_stake_distribution_message(&certificate, &mithril_stake_distribution)
+            .expect("Computing msd message should not fail");
+        certificate.signed_message = message.compute_hash();
+        let certificate_json = serde_json::to_string(&certificate).unwrap();
 
         test_http_server(
             routes::mithril_stake_distribution::routes(

--- a/mithril-client/tests/mithril_stake_distribution_list_get_show_verify.rs
+++ b/mithril-client/tests/mithril_stake_distribution_list_get_show_verify.rs
@@ -67,7 +67,7 @@ async fn mithril_stake_distribution_list_get_show_verify() {
     );
 
     let message = MessageBuilder::new()
-        .compute_mithril_stake_distribution_message(&mithril_stake_distribution)
+        .compute_mithril_stake_distribution_message(&certificate, &mithril_stake_distribution)
         .expect("Computing msd message should not fail");
 
     assert!(

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.59"
+version = "0.4.60"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/protocol_message.rs
+++ b/mithril-common/src/entities/protocol_message.rs
@@ -29,6 +29,12 @@ pub enum ProtocolMessagePartKey {
     #[serde(rename = "next_protocol_parameters")]
     NextProtocolParameters,
 
+    /// The ProtocolMessage part key associated to the current epoch
+    ///
+    /// aka EPOCH(n)
+    #[serde(rename = "current_epoch")]
+    CurrentEpoch,
+
     /// The ProtocolMessage part key associated to the latest block number signed
     #[serde(rename = "latest_block_number")]
     LatestBlockNumber,
@@ -48,6 +54,7 @@ impl Display for ProtocolMessagePartKey {
             Self::SnapshotDigest => write!(f, "snapshot_digest"),
             Self::NextAggregateVerificationKey => write!(f, "next_aggregate_verification_key"),
             Self::NextProtocolParameters => write!(f, "next_protocol_parameters"),
+            Self::CurrentEpoch => write!(f, "current_epoch"),
             Self::CardanoTransactionsMerkleRoot => write!(f, "cardano_transactions_merkle_root"),
             Self::LatestBlockNumber => write!(f, "latest_block_number"),
             Self::CardanoStakeDistributionEpoch => write!(f, "cardano_stake_distribution_epoch"),

--- a/mithril-common/src/signable_builder/interface.rs
+++ b/mithril-common/src/signable_builder/interface.rs
@@ -38,4 +38,9 @@ pub trait SignableSeedBuilder: Send + Sync {
     async fn compute_next_aggregate_verification_key_protocol_message_part_value(
         &self,
     ) -> StdResult<ProtocolMessagePartValue>;
+
+    /// Compute next protocol parameters protocol message part value
+    async fn compute_next_protocol_parameters_protocol_message_part_value(
+        &self,
+    ) -> StdResult<ProtocolMessagePartValue>;
 }

--- a/mithril-common/src/signable_builder/interface.rs
+++ b/mithril-common/src/signable_builder/interface.rs
@@ -43,4 +43,9 @@ pub trait SignableSeedBuilder: Send + Sync {
     async fn compute_next_protocol_parameters_protocol_message_part_value(
         &self,
     ) -> StdResult<ProtocolMessagePartValue>;
+
+    /// Compute current epoch protocol message part value
+    async fn compute_current_epoch_protocol_message_part_value(
+        &self,
+    ) -> StdResult<ProtocolMessagePartValue>;
 }

--- a/mithril-common/src/signable_builder/interface.rs
+++ b/mithril-common/src/signable_builder/interface.rs
@@ -35,17 +35,11 @@ where
 #[async_trait]
 pub trait SignableSeedBuilder: Send + Sync {
     /// Compute next aggregate verification key protocol message part value
-    async fn compute_next_aggregate_verification_key_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue>;
+    async fn compute_next_aggregate_verification_key(&self) -> StdResult<ProtocolMessagePartValue>;
 
     /// Compute next protocol parameters protocol message part value
-    async fn compute_next_protocol_parameters_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue>;
+    async fn compute_next_protocol_parameters(&self) -> StdResult<ProtocolMessagePartValue>;
 
     /// Compute current epoch protocol message part value
-    async fn compute_current_epoch_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue>;
+    async fn compute_current_epoch(&self) -> StdResult<ProtocolMessagePartValue>;
 }

--- a/mithril-common/src/signable_builder/signable_builder_service.rs
+++ b/mithril-common/src/signable_builder/signable_builder_service.rs
@@ -96,7 +96,7 @@ impl MithrilSignableBuilderService {
         let mut protocol_message = protocol_message;
         let next_aggregate_verification_key = self
             .seed_signable_builder
-            .compute_next_aggregate_verification_key_protocol_message_part_value()
+            .compute_next_aggregate_verification_key()
             .await?;
         protocol_message.set_message_part(
             ProtocolMessagePartKey::NextAggregateVerificationKey,
@@ -106,7 +106,7 @@ impl MithrilSignableBuilderService {
         if matches!(self.era_checker.current_era(), SupportedEra::Pythagoras) {
             let next_protocol_parameters = self
                 .seed_signable_builder
-                .compute_next_protocol_parameters_protocol_message_part_value()
+                .compute_next_protocol_parameters()
                 .await?;
             protocol_message.set_message_part(
                 ProtocolMessagePartKey::NextProtocolParameters,
@@ -114,7 +114,7 @@ impl MithrilSignableBuilderService {
             );
             let current_epoch = self
                 .seed_signable_builder
-                .compute_current_epoch_protocol_message_part_value()
+                .compute_current_epoch()
                 .await?;
             protocol_message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, current_epoch);
         }
@@ -210,17 +210,17 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .expect_compute_next_protocol_parameters()
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_current_epoch_protocol_message_part_value()
+                .expect_compute_current_epoch()
                 .once()
                 .return_once(move || Ok("epoch-123".to_string()));
             mock_container
@@ -245,17 +245,17 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .expect_compute_next_protocol_parameters()
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_current_epoch_protocol_message_part_value()
+                .expect_compute_current_epoch()
                 .once()
                 .return_once(move || Ok("epoch-123".to_string()));
             mock_container
@@ -281,17 +281,17 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .expect_compute_next_protocol_parameters()
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_current_epoch_protocol_message_part_value()
+                .expect_compute_current_epoch()
                 .once()
                 .return_once(move || Ok("epoch-123".to_string()));
             mock_container
@@ -318,17 +318,17 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .expect_compute_next_protocol_parameters()
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_current_epoch_protocol_message_part_value()
+                .expect_compute_current_epoch()
                 .once()
                 .return_once(move || Ok("epoch-123".to_string()));
             mock_container
@@ -358,7 +358,7 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container
@@ -383,7 +383,7 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container
@@ -409,7 +409,7 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container
@@ -436,7 +436,7 @@ mod tests {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
             mock_container

--- a/mithril-common/src/signable_builder/signable_builder_service.rs
+++ b/mithril-common/src/signable_builder/signable_builder_service.rs
@@ -7,6 +7,7 @@ use crate::{
         BlockNumber, CardanoDbBeacon, Epoch, ProtocolMessage, ProtocolMessagePartKey,
         SignedEntityType,
     },
+    era::{EraChecker, SupportedEra},
     signable_builder::{SignableBuilder, SignableSeedBuilder},
     StdResult,
 };
@@ -24,6 +25,7 @@ pub trait SignableBuilderService: Send + Sync {
 
 /// Mithril Signable Builder Service
 pub struct MithrilSignableBuilderService {
+    era_checker: Arc<EraChecker>,
     seed_signable_builder: Arc<dyn SignableSeedBuilder>,
     mithril_stake_distribution_builder: Arc<dyn SignableBuilder<Epoch>>,
     immutable_signable_builder: Arc<dyn SignableBuilder<CardanoDbBeacon>>,
@@ -34,6 +36,7 @@ pub struct MithrilSignableBuilderService {
 impl MithrilSignableBuilderService {
     /// MithrilSignableBuilderService factory
     pub fn new(
+        era_checker: Arc<EraChecker>,
         seed_signable_builder: Arc<dyn SignableSeedBuilder>,
         mithril_stake_distribution_builder: Arc<dyn SignableBuilder<Epoch>>,
         immutable_signable_builder: Arc<dyn SignableBuilder<CardanoDbBeacon>>,
@@ -41,6 +44,7 @@ impl MithrilSignableBuilderService {
         cardano_stake_distribution_builder: Arc<dyn SignableBuilder<Epoch>>,
     ) -> Self {
         Self {
+            era_checker,
             seed_signable_builder,
             mithril_stake_distribution_builder,
             immutable_signable_builder,
@@ -89,15 +93,26 @@ impl MithrilSignableBuilderService {
         &self,
         protocol_message: ProtocolMessage,
     ) -> StdResult<ProtocolMessage> {
+        let mut protocol_message = protocol_message;
         let next_aggregate_verification_key = self
             .seed_signable_builder
             .compute_next_aggregate_verification_key_protocol_message_part_value()
             .await?;
-        let mut protocol_message = protocol_message;
         protocol_message.set_message_part(
             ProtocolMessagePartKey::NextAggregateVerificationKey,
             next_aggregate_verification_key,
         );
+
+        if matches!(self.era_checker.current_era(), SupportedEra::Pythagoras) {
+            let next_protocol_parameters = self
+                .seed_signable_builder
+                .compute_next_protocol_parameters_protocol_message_part_value()
+                .await?;
+            protocol_message.set_message_part(
+                ProtocolMessagePartKey::NextProtocolParameters,
+                next_protocol_parameters,
+            );
+        }
 
         Ok(protocol_message)
     }
@@ -126,6 +141,7 @@ mod tests {
 
     use crate::{
         entities::{BlockNumber, Epoch, ProtocolMessage},
+        era::SupportedEra,
         signable_builder::{Beacon as Beaconnable, MockSignableSeedBuilder, SignableBuilder},
         StdResult,
     };
@@ -144,6 +160,7 @@ mod tests {
     }
 
     struct MockDependencyInjector {
+        era_checker: EraChecker,
         mock_signable_seed_builder: MockSignableSeedBuilder,
         mock_mithril_stake_distribution_signable_builder: MockSignableBuilderImpl<Epoch>,
         mock_cardano_immutable_files_full_signable_builder:
@@ -153,8 +170,9 @@ mod tests {
     }
 
     impl MockDependencyInjector {
-        fn new() -> MockDependencyInjector {
+        fn new(current_era: SupportedEra) -> MockDependencyInjector {
             MockDependencyInjector {
+                era_checker: EraChecker::new(current_era, Epoch(1)),
                 mock_signable_seed_builder: MockSignableSeedBuilder::new(),
                 mock_mithril_stake_distribution_signable_builder: MockSignableBuilderImpl::new(),
                 mock_cardano_immutable_files_full_signable_builder: MockSignableBuilderImpl::new(),
@@ -165,6 +183,7 @@ mod tests {
 
         fn build_signable_builder_service(self) -> MithrilSignableBuilderService {
             MithrilSignableBuilderService::new(
+                Arc::new(self.era_checker),
                 Arc::new(self.mock_signable_seed_builder),
                 Arc::new(self.mock_mithril_stake_distribution_signable_builder),
                 Arc::new(self.mock_cardano_immutable_files_full_signable_builder),
@@ -174,102 +193,239 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn build_mithril_stake_distribution_signable_when_given_mithril_stake_distribution_entity_type(
-    ) {
-        let protocol_message = ProtocolMessage::new();
-        let protocol_message_clone = protocol_message.clone();
-        let mut mock_container = MockDependencyInjector::new();
-        mock_container
-            .mock_signable_seed_builder
-            .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
-            .once()
-            .return_once(move || Ok("next-avk-123".to_string()));
-        mock_container
-            .mock_mithril_stake_distribution_signable_builder
-            .expect_compute_protocol_message()
-            .once()
-            .return_once(move |_| Ok(protocol_message_clone));
-        let signable_builder_service = mock_container.build_signable_builder_service();
-        let signed_entity_type = SignedEntityType::MithrilStakeDistribution(Epoch(1));
+    mod pythagoras_era {
+        use super::*;
 
-        signable_builder_service
-            .compute_protocol_message(signed_entity_type)
-            .await
-            .unwrap();
+        #[tokio::test]
+        async fn build_mithril_stake_distribution_signable_when_given_mithril_stake_distribution_entity_type(
+        ) {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Pythagoras;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("protocol-params-hash-123".to_string()));
+            mock_container
+                .mock_mithril_stake_distribution_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type = SignedEntityType::MithrilStakeDistribution(Epoch(1));
+
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn build_snapshot_signable_when_given_cardano_immutable_files_full_entity_type() {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Pythagoras;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("protocol-params-hash-123".to_string()));
+            mock_container
+                .mock_cardano_immutable_files_full_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type =
+                SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
+
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn build_transactions_signable_when_given_cardano_transactions_entity_type() {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Pythagoras;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("protocol-params-hash-123".to_string()));
+            mock_container
+                .mock_cardano_transactions_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type =
+                SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(1000));
+
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn build_cardano_stake_distribution_signable_when_given_cardano_stake_distribution_entity_type(
+        ) {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Pythagoras;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_protocol_parameters_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("protocol-params-hash-123".to_string()));
+            mock_container
+                .mock_cardano_stake_distribution_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type = SignedEntityType::CardanoStakeDistribution(Epoch(5));
+
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
     }
 
-    #[tokio::test]
-    async fn build_snapshot_signable_when_given_cardano_immutable_files_full_entity_type() {
-        let protocol_message = ProtocolMessage::new();
-        let protocol_message_clone = protocol_message.clone();
-        let mut mock_container = MockDependencyInjector::new();
-        mock_container
-            .mock_signable_seed_builder
-            .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
-            .once()
-            .return_once(move || Ok("next-avk-123".to_string()));
-        mock_container
-            .mock_cardano_immutable_files_full_signable_builder
-            .expect_compute_protocol_message()
-            .once()
-            .return_once(move |_| Ok(protocol_message_clone));
-        let signable_builder_service = mock_container.build_signable_builder_service();
-        let signed_entity_type =
-            SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
+    mod thales_era {
+        use super::*;
 
-        signable_builder_service
-            .compute_protocol_message(signed_entity_type)
-            .await
-            .unwrap();
-    }
+        #[tokio::test]
+        async fn build_mithril_stake_distribution_signable_when_given_mithril_stake_distribution_entity_type(
+        ) {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Thales;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_mithril_stake_distribution_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type = SignedEntityType::MithrilStakeDistribution(Epoch(1));
 
-    #[tokio::test]
-    async fn build_transactions_signable_when_given_cardano_transactions_entity_type() {
-        let protocol_message = ProtocolMessage::new();
-        let protocol_message_clone = protocol_message.clone();
-        let mut mock_container = MockDependencyInjector::new();
-        mock_container
-            .mock_signable_seed_builder
-            .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
-            .once()
-            .return_once(move || Ok("next-avk-123".to_string()));
-        mock_container
-            .mock_cardano_transactions_signable_builder
-            .expect_compute_protocol_message()
-            .once()
-            .return_once(move |_| Ok(protocol_message_clone));
-        let signable_builder_service = mock_container.build_signable_builder_service();
-        let signed_entity_type = SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(1000));
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
 
-        signable_builder_service
-            .compute_protocol_message(signed_entity_type)
-            .await
-            .unwrap();
-    }
+        #[tokio::test]
+        async fn build_snapshot_signable_when_given_cardano_immutable_files_full_entity_type() {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Thales;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_cardano_immutable_files_full_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type =
+                SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
 
-    #[tokio::test]
-    async fn build_cardano_stake_distribution_signable_when_given_cardano_stake_distribution_entity_type(
-    ) {
-        let protocol_message = ProtocolMessage::new();
-        let protocol_message_clone = protocol_message.clone();
-        let mut mock_container = MockDependencyInjector::new();
-        mock_container
-            .mock_signable_seed_builder
-            .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
-            .once()
-            .return_once(move || Ok("next-avk-123".to_string()));
-        mock_container
-            .mock_cardano_stake_distribution_signable_builder
-            .expect_compute_protocol_message()
-            .once()
-            .return_once(move |_| Ok(protocol_message_clone));
-        let signable_builder_service = mock_container.build_signable_builder_service();
-        let signed_entity_type = SignedEntityType::CardanoStakeDistribution(Epoch(5));
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
 
-        signable_builder_service
-            .compute_protocol_message(signed_entity_type)
-            .await
-            .unwrap();
+        #[tokio::test]
+        async fn build_transactions_signable_when_given_cardano_transactions_entity_type() {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Thales;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_cardano_transactions_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type =
+                SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(1000));
+
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
+
+        #[tokio::test]
+        async fn build_cardano_stake_distribution_signable_when_given_cardano_stake_distribution_entity_type(
+        ) {
+            let protocol_message = ProtocolMessage::new();
+            let protocol_message_clone = protocol_message.clone();
+            let current_era = SupportedEra::Thales;
+            let mut mock_container = MockDependencyInjector::new(current_era);
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_next_aggregate_verification_key_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("next-avk-123".to_string()));
+            mock_container
+                .mock_cardano_stake_distribution_signable_builder
+                .expect_compute_protocol_message()
+                .once()
+                .return_once(move |_| Ok(protocol_message_clone));
+            let signable_builder_service = mock_container.build_signable_builder_service();
+            let signed_entity_type = SignedEntityType::CardanoStakeDistribution(Epoch(5));
+
+            signable_builder_service
+                .compute_protocol_message(signed_entity_type)
+                .await
+                .unwrap();
+        }
     }
 }

--- a/mithril-common/src/signable_builder/signable_builder_service.rs
+++ b/mithril-common/src/signable_builder/signable_builder_service.rs
@@ -112,10 +112,7 @@ impl MithrilSignableBuilderService {
                 ProtocolMessagePartKey::NextProtocolParameters,
                 next_protocol_parameters,
             );
-            let current_epoch = self
-                .seed_signable_builder
-                .compute_current_epoch()
-                .await?;
+            let current_epoch = self.seed_signable_builder.compute_current_epoch().await?;
             protocol_message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, current_epoch);
         }
 
@@ -201,12 +198,7 @@ mod tests {
     mod pythagoras_era {
         use super::*;
 
-        #[tokio::test]
-        async fn build_mithril_stake_distribution_signable_when_given_mithril_stake_distribution_entity_type(
-        ) {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
-            let current_era = SupportedEra::Pythagoras;
+        fn build_mock_container(current_era: SupportedEra) -> MockDependencyInjector {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
@@ -223,11 +215,20 @@ mod tests {
                 .expect_compute_current_epoch()
                 .once()
                 .return_once(move || Ok("epoch-123".to_string()));
+
+            mock_container
+        }
+
+        #[tokio::test]
+        async fn build_mithril_stake_distribution_signable_when_given_mithril_stake_distribution_entity_type(
+        ) {
+            let current_era = SupportedEra::Pythagoras;
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_mithril_stake_distribution_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type = SignedEntityType::MithrilStakeDistribution(Epoch(1));
 
@@ -239,30 +240,13 @@ mod tests {
 
         #[tokio::test]
         async fn build_snapshot_signable_when_given_cardano_immutable_files_full_entity_type() {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
             let current_era = SupportedEra::Pythagoras;
-            let mut mock_container = MockDependencyInjector::new(current_era);
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key()
-                .once()
-                .return_once(move || Ok("next-avk-123".to_string()));
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_protocol_parameters()
-                .once()
-                .return_once(move || Ok("protocol-params-hash-123".to_string()));
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_current_epoch()
-                .once()
-                .return_once(move || Ok("epoch-123".to_string()));
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_cardano_immutable_files_full_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type =
                 SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
@@ -275,30 +259,13 @@ mod tests {
 
         #[tokio::test]
         async fn build_transactions_signable_when_given_cardano_transactions_entity_type() {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
             let current_era = SupportedEra::Pythagoras;
-            let mut mock_container = MockDependencyInjector::new(current_era);
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key()
-                .once()
-                .return_once(move || Ok("next-avk-123".to_string()));
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_protocol_parameters()
-                .once()
-                .return_once(move || Ok("protocol-params-hash-123".to_string()));
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_current_epoch()
-                .once()
-                .return_once(move || Ok("epoch-123".to_string()));
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_cardano_transactions_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type =
                 SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(1000));
@@ -312,30 +279,13 @@ mod tests {
         #[tokio::test]
         async fn build_cardano_stake_distribution_signable_when_given_cardano_stake_distribution_entity_type(
         ) {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
             let current_era = SupportedEra::Pythagoras;
-            let mut mock_container = MockDependencyInjector::new(current_era);
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key()
-                .once()
-                .return_once(move || Ok("next-avk-123".to_string()));
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_protocol_parameters()
-                .once()
-                .return_once(move || Ok("protocol-params-hash-123".to_string()));
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_current_epoch()
-                .once()
-                .return_once(move || Ok("epoch-123".to_string()));
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_cardano_stake_distribution_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type = SignedEntityType::CardanoStakeDistribution(Epoch(5));
 
@@ -349,23 +299,27 @@ mod tests {
     mod thales_era {
         use super::*;
 
-        #[tokio::test]
-        async fn build_mithril_stake_distribution_signable_when_given_mithril_stake_distribution_entity_type(
-        ) {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
-            let current_era = SupportedEra::Thales;
+        fn build_mock_container(current_era: SupportedEra) -> MockDependencyInjector {
             let mut mock_container = MockDependencyInjector::new(current_era);
             mock_container
                 .mock_signable_seed_builder
                 .expect_compute_next_aggregate_verification_key()
                 .once()
                 .return_once(move || Ok("next-avk-123".to_string()));
+
+            mock_container
+        }
+
+        #[tokio::test]
+        async fn build_mithril_stake_distribution_signable_when_given_mithril_stake_distribution_entity_type(
+        ) {
+            let current_era = SupportedEra::Thales;
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_mithril_stake_distribution_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type = SignedEntityType::MithrilStakeDistribution(Epoch(1));
 
@@ -377,20 +331,13 @@ mod tests {
 
         #[tokio::test]
         async fn build_snapshot_signable_when_given_cardano_immutable_files_full_entity_type() {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
             let current_era = SupportedEra::Thales;
-            let mut mock_container = MockDependencyInjector::new(current_era);
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key()
-                .once()
-                .return_once(move || Ok("next-avk-123".to_string()));
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_cardano_immutable_files_full_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type =
                 SignedEntityType::CardanoImmutableFilesFull(CardanoDbBeacon::default());
@@ -403,20 +350,13 @@ mod tests {
 
         #[tokio::test]
         async fn build_transactions_signable_when_given_cardano_transactions_entity_type() {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
             let current_era = SupportedEra::Thales;
-            let mut mock_container = MockDependencyInjector::new(current_era);
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key()
-                .once()
-                .return_once(move || Ok("next-avk-123".to_string()));
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_cardano_transactions_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type =
                 SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(1000));
@@ -430,20 +370,13 @@ mod tests {
         #[tokio::test]
         async fn build_cardano_stake_distribution_signable_when_given_cardano_stake_distribution_entity_type(
         ) {
-            let protocol_message = ProtocolMessage::new();
-            let protocol_message_clone = protocol_message.clone();
             let current_era = SupportedEra::Thales;
-            let mut mock_container = MockDependencyInjector::new(current_era);
-            mock_container
-                .mock_signable_seed_builder
-                .expect_compute_next_aggregate_verification_key()
-                .once()
-                .return_once(move || Ok("next-avk-123".to_string()));
+            let mut mock_container = build_mock_container(current_era);
             mock_container
                 .mock_cardano_stake_distribution_signable_builder
                 .expect_compute_protocol_message()
                 .once()
-                .return_once(move |_| Ok(protocol_message_clone));
+                .return_once(|_| Ok(ProtocolMessage::new()));
             let signable_builder_service = mock_container.build_signable_builder_service();
             let signed_entity_type = SignedEntityType::CardanoStakeDistribution(Epoch(5));
 

--- a/mithril-common/src/signable_builder/signable_builder_service.rs
+++ b/mithril-common/src/signable_builder/signable_builder_service.rs
@@ -112,6 +112,11 @@ impl MithrilSignableBuilderService {
                 ProtocolMessagePartKey::NextProtocolParameters,
                 next_protocol_parameters,
             );
+            let current_epoch = self
+                .seed_signable_builder
+                .compute_current_epoch_protocol_message_part_value()
+                .await?;
+            protocol_message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, current_epoch);
         }
 
         Ok(protocol_message)
@@ -214,6 +219,11 @@ mod tests {
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
             mock_container
+                .mock_signable_seed_builder
+                .expect_compute_current_epoch_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("epoch-123".to_string()));
+            mock_container
                 .mock_mithril_stake_distribution_signable_builder
                 .expect_compute_protocol_message()
                 .once()
@@ -243,6 +253,11 @@ mod tests {
                 .expect_compute_next_protocol_parameters_protocol_message_part_value()
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_current_epoch_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("epoch-123".to_string()));
             mock_container
                 .mock_cardano_immutable_files_full_signable_builder
                 .expect_compute_protocol_message()
@@ -275,6 +290,11 @@ mod tests {
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
             mock_container
+                .mock_signable_seed_builder
+                .expect_compute_current_epoch_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("epoch-123".to_string()));
+            mock_container
                 .mock_cardano_transactions_signable_builder
                 .expect_compute_protocol_message()
                 .once()
@@ -306,6 +326,11 @@ mod tests {
                 .expect_compute_next_protocol_parameters_protocol_message_part_value()
                 .once()
                 .return_once(move || Ok("protocol-params-hash-123".to_string()));
+            mock_container
+                .mock_signable_seed_builder
+                .expect_compute_current_epoch_protocol_message_part_value()
+                .once()
+                .return_once(move || Ok("epoch-123".to_string()));
             mock_container
                 .mock_cardano_stake_distribution_signable_builder
                 .expect_compute_protocol_message()

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.187"
+version = "0.2.188"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -327,6 +327,7 @@ impl<'a> DependenciesBuilder<'a> {
             protocol_initializer_store.clone(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(
+            era_checker.clone(),
             signable_seed_builder_service,
             mithril_stake_distribution_signable_builder,
             cardano_immutable_snapshot_builder,

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -611,6 +611,7 @@ mod tests {
             protocol_initializer_store.clone(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(
+            era_checker.clone(),
             signable_seed_builder_service,
             mithril_stake_distribution_signable_builder,
             cardano_immutable_signable_builder,

--- a/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
+++ b/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
@@ -181,9 +181,9 @@ mod tests {
         let protocol_initializer = next_fixture.signers_fixture()[0]
             .protocol_initializer
             .clone();
-        let expected_next_protocol_parameters =
-            Into::<ProtocolParameters>::into(protocol_initializer.get_protocol_parameters())
-                .compute_hash();
+        let protocol_parameters: ProtocolParameters =
+            protocol_initializer.get_protocol_parameters().into();
+        let expected_next_protocol_parameters = protocol_parameters.compute_hash();
         let mut mock_container = MockDependencyInjector::new();
         mock_container.mock_epoch_service =
             MockEpochServiceImpl::new_with_config(|mock_epoch_service| {

--- a/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
+++ b/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
@@ -67,7 +67,6 @@ impl SignableSeedBuilder for SignerSignableSeedBuilder {
         Ok(next_aggregate_verification_key)
     }
 
-    /// Compute next protocol parameters protocol message part value
     async fn compute_next_protocol_parameters_protocol_message_part_value(
         &self,
     ) -> StdResult<ProtocolMessagePartValue> {
@@ -75,6 +74,15 @@ impl SignableSeedBuilder for SignerSignableSeedBuilder {
         let next_protocol_parameters = epoch_service.next_protocol_parameters()?.compute_hash();
 
         Ok(next_protocol_parameters)
+    }
+
+    async fn compute_current_epoch_protocol_message_part_value(
+        &self,
+    ) -> StdResult<ProtocolMessagePartValue> {
+        let epoch_service = self.epoch_service.read().await;
+        let current_epoch = epoch_service.epoch_of_current_data()?.to_string();
+
+        Ok(current_epoch)
     }
 }
 
@@ -184,5 +192,27 @@ mod tests {
             .unwrap();
 
         assert_eq!(next_protocol_parameters, expected_next_protocol_parameters);
+    }
+
+    #[tokio::test]
+    async fn test_compute_current_epoch_protocol_message_value() {
+        let epoch = Epoch(5);
+        let expected_current_epoch = epoch.to_string();
+        let mut mock_container = MockDependencyInjector::new();
+        mock_container.mock_epoch_service =
+            MockEpochServiceImpl::new_with_config(|mock_epoch_service| {
+                mock_epoch_service
+                    .expect_epoch_of_current_data()
+                    .return_once(move || Ok(epoch))
+                    .once();
+            });
+        let signable_seed_builder = mock_container.build_signable_builder_service();
+
+        let current_epoch = signable_seed_builder
+            .compute_current_epoch_protocol_message_part_value()
+            .await
+            .unwrap();
+
+        assert_eq!(current_epoch, expected_current_epoch);
     }
 }

--- a/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
+++ b/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
@@ -9,7 +9,9 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use mithril_common::{
-    entities::ProtocolMessagePartValue, signable_builder::SignableSeedBuilder, StdResult,
+    entities::{ProtocolMessagePartValue, ProtocolParameters},
+    signable_builder::SignableSeedBuilder,
+    StdResult,
 };
 
 use crate::{
@@ -54,7 +56,6 @@ impl SignableSeedBuilder for SignerSignableSeedBuilder {
             .ok_or_else(|| {
                 anyhow!("can not get protocol_initializer at epoch {next_signer_retrieval_epoch}")
             })?;
-
         let next_signers_with_stake = epoch_service.next_signers_with_stake().await?;
         let next_aggregate_verification_key = self
             .single_signer
@@ -71,9 +72,19 @@ impl SignableSeedBuilder for SignerSignableSeedBuilder {
         &self,
     ) -> StdResult<ProtocolMessagePartValue> {
         let epoch_service = self.epoch_service.read().await;
-        let next_protocol_parameters = epoch_service.next_protocol_parameters()?.compute_hash();
+        let epoch = (*epoch_service).epoch_of_current_data()?;
+        let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
+        let next_protocol_initializer = self
+            .protocol_initializer_store
+            .get_protocol_initializer(next_signer_retrieval_epoch)
+            .await?
+            .ok_or_else(|| {
+                anyhow!("can not get protocol_initializer at epoch {next_signer_retrieval_epoch}")
+            })?;
+        let next_protocol_parameters: ProtocolParameters =
+            next_protocol_initializer.get_protocol_parameters().into();
 
-        Ok(next_protocol_parameters)
+        Ok(next_protocol_parameters.compute_hash())
     }
 
     async fn compute_current_epoch_protocol_message_part_value(
@@ -127,12 +138,13 @@ mod tests {
     #[tokio::test]
     async fn test_compute_next_aggregate_verification_key_protocol_message_value() {
         let epoch = Epoch(5);
-        let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let next_fixture = MithrilFixtureBuilder::default().with_signers(4).build();
+        let protocol_initializer = next_fixture.signers_fixture()[0]
+            .protocol_initializer
+            .clone();
         let expected_next_aggregate_verification_key = next_fixture.compute_and_encode_avk();
         let expected_next_aggregate_verification_key_clone =
             expected_next_aggregate_verification_key.clone();
-        let protocol_initializer = fixture.signers_fixture()[0].protocol_initializer.clone();
         let mut mock_container = MockDependencyInjector::new();
         mock_container.mock_epoch_service =
             MockEpochServiceImpl::new_with_config(|mock_epoch_service| {
@@ -170,20 +182,27 @@ mod tests {
 
     #[tokio::test]
     async fn test_compute_next_protocol_parameters_protocol_message_value() {
-        const NEXT_PROTOCOL_PARAMETERS: ProtocolParameters = ProtocolParameters {
-            k: 10,
-            m: 10,
-            phi_f: 1.0,
-        };
-        let expected_next_protocol_parameters = NEXT_PROTOCOL_PARAMETERS.compute_hash();
+        let epoch = Epoch(5);
+        let next_fixture = MithrilFixtureBuilder::default().with_signers(4).build();
+        let protocol_initializer = next_fixture.signers_fixture()[0]
+            .protocol_initializer
+            .clone();
+        let expected_next_protocol_parameters =
+            Into::<ProtocolParameters>::into(protocol_initializer.get_protocol_parameters())
+                .compute_hash();
         let mut mock_container = MockDependencyInjector::new();
         mock_container.mock_epoch_service =
             MockEpochServiceImpl::new_with_config(|mock_epoch_service| {
                 mock_epoch_service
-                    .expect_next_protocol_parameters()
-                    .return_once(|| Ok(&NEXT_PROTOCOL_PARAMETERS))
+                    .expect_epoch_of_current_data()
+                    .return_once(move || Ok(epoch))
                     .once();
             });
+        mock_container
+            .mock_protocol_initializer_store
+            .expect_get_protocol_initializer()
+            .return_once(move |_| Ok(Some(protocol_initializer)))
+            .once();
         let signable_seed_builder = mock_container.build_signable_builder_service();
 
         let next_protocol_parameters = signable_seed_builder

--- a/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
+++ b/mithril-signer/src/services/signable_builder/signable_seed_builder.rs
@@ -43,9 +43,7 @@ impl SignerSignableSeedBuilder {
 
 #[async_trait]
 impl SignableSeedBuilder for SignerSignableSeedBuilder {
-    async fn compute_next_aggregate_verification_key_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue> {
+    async fn compute_next_aggregate_verification_key(&self) -> StdResult<ProtocolMessagePartValue> {
         let epoch_service = self.epoch_service.read().await;
         let epoch = (*epoch_service).epoch_of_current_data()?;
         let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
@@ -68,9 +66,7 @@ impl SignableSeedBuilder for SignerSignableSeedBuilder {
         Ok(next_aggregate_verification_key)
     }
 
-    async fn compute_next_protocol_parameters_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue> {
+    async fn compute_next_protocol_parameters(&self) -> StdResult<ProtocolMessagePartValue> {
         let epoch_service = self.epoch_service.read().await;
         let epoch = (*epoch_service).epoch_of_current_data()?;
         let next_signer_retrieval_epoch = epoch.offset_to_next_signer_retrieval_epoch();
@@ -87,9 +83,7 @@ impl SignableSeedBuilder for SignerSignableSeedBuilder {
         Ok(next_protocol_parameters.compute_hash())
     }
 
-    async fn compute_current_epoch_protocol_message_part_value(
-        &self,
-    ) -> StdResult<ProtocolMessagePartValue> {
+    async fn compute_current_epoch(&self) -> StdResult<ProtocolMessagePartValue> {
         let epoch_service = self.epoch_service.read().await;
         let current_epoch = epoch_service.epoch_of_current_data()?.to_string();
 
@@ -154,7 +148,7 @@ mod tests {
                     .once();
                 mock_epoch_service
                     .expect_next_signers_with_stake()
-                    .return_once(move || Ok(Vec::new()))
+                    .return_once(|| Ok(Vec::new()))
                     .once();
             });
         mock_container
@@ -170,7 +164,7 @@ mod tests {
         let signable_seed_builder = mock_container.build_signable_builder_service();
 
         let next_aggregate_verification_key = signable_seed_builder
-            .compute_next_aggregate_verification_key_protocol_message_part_value()
+            .compute_next_aggregate_verification_key()
             .await
             .unwrap();
 
@@ -206,7 +200,7 @@ mod tests {
         let signable_seed_builder = mock_container.build_signable_builder_service();
 
         let next_protocol_parameters = signable_seed_builder
-            .compute_next_protocol_parameters_protocol_message_part_value()
+            .compute_next_protocol_parameters()
             .await
             .unwrap();
 
@@ -227,10 +221,7 @@ mod tests {
             });
         let signable_seed_builder = mock_container.build_signable_builder_service();
 
-        let current_epoch = signable_seed_builder
-            .compute_current_epoch_protocol_message_part_value()
-            .await
-            .unwrap();
+        let current_epoch = signable_seed_builder.compute_current_epoch().await.unwrap();
 
         assert_eq!(current_epoch, expected_current_epoch);
     }

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -212,6 +212,7 @@ impl StateMachineTester {
             protocol_initializer_store.clone(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(
+            era_checker.clone(),
             signable_seed_builder_service,
             mithril_stake_distribution_signable_builder,
             cardano_immutable_snapshot_builder,


### PR DESCRIPTION
## Content

This PR includes a **new computation of the protocol message** in the `Pythagoras` Mithril era:
- The **next protocol parameters** are appended to the protocol message
- The **current epoch** is appended to the protocol message

### Version Updates:

> [!IMPORTANT]
> :fire: This PR introduces a breaking-change in the `mithril-client` and `mithril-client-wasm` crates.

* [`examples/client-mithril-stake-distribution/Cargo.toml`](diffhunk://#diff-887fc60a9b9bc268630f88ffb4746333e0f8c76d0a2dc8800abe456fd8c2ce39L4-R4): Updated the version from `0.1.17` to `0.2.0`.
* [`mithril-aggregator/Cargo.toml`](diffhunk://#diff-5ae504281312c194e5e8cf6aa890f49508756041db9dbce0fd89fbf04438f90dL3-R3): Updated the version from `0.5.68` to `0.5.69`.
* [`mithril-client-cli/Cargo.toml`](diffhunk://#diff-2a39f2159ddf8206fa697498383f3b5c626c184d3da53ac7417e4fb1b22351f0L3-R3): Updated the version from `0.9.12` to `0.9.13`.
* [`mithril-client-wasm/Cargo.toml`](diffhunk://#diff-72ad6e1c1356d0f73e50d9e7970bd2defe29e80296db55ad0c0ad44362a6ea84L3-R3): Updated the version from `0.4.1` to `0.5.0`.
* [`mithril-client/Cargo.toml`](diffhunk://#diff-a272fa86be295b0d30ea31b0ca6a5f7b915a4f52677bd575843152082b15a4beL3-R3): Updated the version from `0.8.18` to `0.9.0`.
* [`mithril-common/Cargo.toml`](diffhunk://#diff-0b137373460b5fa18b029b657531df061019d3ce8efadc17b522b1a104971d65L3-R3): Updated the version from `0.4.59` to `0.4.60`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
