### PR TITLE
Fix: hydra CI error when `allow` lint attribute specifies a reason

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.58"
+version = "0.4.59"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.58"
+version = "0.4.59"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/logging.rs
+++ b/mithril-common/src/logging.rs
@@ -26,10 +26,8 @@ mod tests {
     use slog::info;
 
     struct TestStruct;
-    #[allow(
-        dead_code,
-        reason = "A field is needed to add the lifetime but is unused"
-    )]
+    // The `allow(dead_code)` is used because a field is needed to add the lifetime but is unused.
+    #[allow(dead_code)]
     struct TestStructWithLifetime<'a>(&'a str);
     enum TestEnum {}
 


### PR DESCRIPTION
## Content

This PR fix an error detailed in the [draft issue](https://github.com/orgs/input-output-hk/projects/26/views/14?pane=issue&itemId=80847117).

The linting reason has been removed, as it's still experimental and cannot be applied yet.

The initial error from Hydra CI: https://github.com/input-output-hk/mithril/pull/1948/checks?check_run_id=30529857732
```
error[E0658]: lint reasons are experimental
  --> mithril-common/src/logging.rs:31:9
   |
31 |         reason = "A field is needed to add the lifetime but is unused"
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #54503 <https://github.com/rust-lang/rust/issues/54503> for more information
```

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested