### PR TITLE
Make aggregator advertises constant signing configurations for an epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.70"
+version = "0.5.71"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.60"
+version = "0.4.61"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.188"
+version = "0.2.189"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.70"
+version = "0.5.71"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/artifact_builder/mithril_stake_distribution.rs
@@ -44,18 +44,21 @@ mod tests {
 
     use super::*;
 
-    use crate::services::FakeEpochService;
+    use crate::{entities::AggregatorEpochSettings, services::FakeEpochService};
 
     #[tokio::test]
     async fn should_compute_valid_artifact() {
         let signers_with_stake = fake_data::signers_with_stakes(5);
         let certificate = fake_data::certificate("certificate-123".to_string());
-        let protocol_parameters = fake_data::protocol_parameters();
+        let epoch_settings = AggregatorEpochSettings {
+            protocol_parameters: fake_data::protocol_parameters(),
+            ..AggregatorEpochSettings::dummy()
+        };
         let epoch_service = FakeEpochService::with_data(
             Epoch(1),
-            &protocol_parameters,
-            &protocol_parameters,
-            &protocol_parameters,
+            &epoch_settings,
+            &epoch_settings,
+            &epoch_settings,
             &signers_with_stake,
             &signers_with_stake,
         );
@@ -65,8 +68,11 @@ mod tests {
             .compute_artifact(Epoch(1), &certificate)
             .await
             .unwrap();
-        let artifact_expected =
-            MithrilStakeDistribution::new(Epoch(1), signers_with_stake, &protocol_parameters);
+        let artifact_expected = MithrilStakeDistribution::new(
+            Epoch(1),
+            signers_with_stake,
+            &epoch_settings.protocol_parameters,
+        );
         assert_eq!(artifact_expected, artifact);
     }
 

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -249,7 +249,7 @@ impl Configuration {
             cardano_transactions_prover_cache_pool_size: 3,
             cardano_transactions_database_connection_pool_size: 5,
             cardano_transactions_signing_config: CardanoTransactionsSigningConfig {
-                security_parameter: BlockNumber(100),
+                security_parameter: BlockNumber(120),
                 step: BlockNumber(15),
             },
             cardano_transactions_prover_max_hashes_allowed_by_request: 100,

--- a/mithril-aggregator/src/database/query/epoch_settings/get_epoch_settings.rs
+++ b/mithril-aggregator/src/database/query/epoch_settings/get_epoch_settings.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use mithril_common::entities::{CardanoTransactionsSigningConfig, Epoch};
+use mithril_common::entities::Epoch;
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
 use sqlite::Value;
@@ -42,9 +42,8 @@ impl Query for GetEpochSettingsQuery {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::{
-        entities::{BlockNumber, ProtocolParameters},
-        signable_builder::CardanoTransactionsSignableBuilder,
+    use mithril_common::entities::{
+        BlockNumber, CardanoTransactionsSigningConfig, ProtocolParameters,
     };
     use mithril_persistence::sqlite::ConnectionExtensions;
 

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -141,7 +141,11 @@ impl CertificateRecord {
             immutable_file_number,
             signed_entity_type,
             protocol_version: "protocol_version".to_string(),
-            protocol_parameters: Default::default(),
+            protocol_parameters: ProtocolParameters {
+                k: 0,
+                m: 0,
+                phi_f: 0.0,
+            },
             protocol_message: Default::default(),
             signers: vec![],
             initiated_at: DateTime::parse_from_rfc3339("2024-02-12T13:11:47Z")

--- a/mithril-aggregator/src/database/record/epoch_settings.rs
+++ b/mithril-aggregator/src/database/record/epoch_settings.rs
@@ -1,7 +1,7 @@
-use mithril_common::entities::{
-    BlockNumber, CardanoTransactionsSigningConfig, Epoch, ProtocolParameters,
-};
+use mithril_common::entities::{CardanoTransactionsSigningConfig, Epoch, ProtocolParameters};
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
+
+use crate::entities::AggregatorEpochSettings;
 
 /// Settings for an epoch, including the protocol parameters.
 #[derive(Debug, PartialEq)]
@@ -14,6 +14,15 @@ pub struct EpochSettingsRecord {
 
     /// Cardano transactions signing configuration.
     pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
+}
+
+impl From<EpochSettingsRecord> for AggregatorEpochSettings {
+    fn from(other: EpochSettingsRecord) -> Self {
+        Self {
+            protocol_parameters: other.protocol_parameters,
+            cardano_transactions_signing_config: other.cardano_transactions_signing_config,
+        }
+    }
 }
 
 impl SqLiteEntity for EpochSettingsRecord {

--- a/mithril-aggregator/src/database/repository/epoch_settings_store.rs
+++ b/mithril-aggregator/src/database/repository/epoch_settings_store.rs
@@ -56,7 +56,7 @@ impl EpochSettingsStorer for EpochSettingsStore {
                 .count();
         }
 
-        Ok(Some(AggregatorEpochSettings::from(epoch_settings_record)))
+        Ok(Some(epoch_settings_record.into()))
     }
 
     async fn get_protocol_parameters(&self, epoch: Epoch) -> StdResult<Option<ProtocolParameters>> {
@@ -73,7 +73,7 @@ impl EpochSettingsStorer for EpochSettingsStore {
             .map_err(|e| AdapterError::GeneralError(e.context("Could not get epoch settings")))?;
 
         if let Some(epoch_settings_record) = cursor.next() {
-            return Ok(Some(AggregatorEpochSettings::from(epoch_settings_record)));
+            return Ok(Some(epoch_settings_record.into()));
         }
         Ok(None)
     }

--- a/mithril-aggregator/src/database/test_helper.rs
+++ b/mithril-aggregator/src/database/test_helper.rs
@@ -1,5 +1,4 @@
 use chrono::Utc;
-use mithril_persistence::store::adapter::AdapterError;
 use sqlite::{ConnectionThreadSafe, Value};
 use std::path::Path;
 use uuid::Uuid;
@@ -22,6 +21,7 @@ use crate::database::record::{
     BufferedSingleSignatureRecord, CertificateRecord, SignedEntityRecord, SignerRecord,
     SignerRegistrationRecord, SingleSignatureRecord,
 };
+use crate::entities::AggregatorEpochSettings;
 
 /// In-memory sqlite database without foreign key support with migrations applied
 pub fn main_db_connection() -> StdResult<SqliteConnection> {
@@ -198,29 +198,18 @@ pub fn insert_epoch_settings(
     connection: &SqliteConnection,
     epoch_to_insert_settings: &[u64],
 ) -> StdResult<()> {
-    // for (epoch, protocol_parameters) in epoch_to_insert_settings.iter().map(|epoch| {
-    //     (
-    //         Epoch(*epoch),
-    //         ProtocolParameters::new(*epoch, epoch + 1, 1.0),
-    //     )
-    // }) {
-    //     connection.fetch_first(UpdateEpochSettingsQuery::one(epoch, protocol_parameters))?
-    // }
-
-    // for epoch in epoch_to_insert_settings {
-    //     connection.fetch_first(UpdateEpochSettingsQuery::one(
-    //         Epoch(*epoch),
-    //         ProtocolParameters::new(*epoch, epoch + 1, 1.0),
-    //     ))?
-    // }
-
     let query = {
         // leverage the expanded parameter from this query which is unit
         // tested on its own above.
         let (sql_values, _) = UpdateEpochSettingsQuery::one(
             Epoch(1),
-            ProtocolParameters::new(1, 2, 1.0),
-            CardanoTransactionsSigningConfig::new(BlockNumber(0), BlockNumber(0)),
+            AggregatorEpochSettings {
+                protocol_parameters: ProtocolParameters::new(1, 2, 1.0),
+                cardano_transactions_signing_config: CardanoTransactionsSigningConfig::new(
+                    BlockNumber(0),
+                    BlockNumber(0),
+                ),
+            },
         )
         .filters()
         .expand();

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -44,7 +44,7 @@ use mithril_common::{
         TransactionsImporter,
     },
     signed_entity_type_lock::SignedEntityTypeLock,
-    MithrilTickerService, StdResult, TickerService,
+    MithrilTickerService, TickerService,
 };
 use mithril_persistence::{
     database::{repository::CardanoTransactionRepository, ApplicationNodeType, SqlMigration},
@@ -1317,7 +1317,7 @@ impl DependenciesBuilder {
         Ok(self.single_signer_authenticator.as_ref().cloned().unwrap())
     }
 
-    fn get_epoch_settings_configuration(&mut self) -> StdResult<AggregatorEpochSettings> {
+    fn get_epoch_settings_configuration(&mut self) -> Result<AggregatorEpochSettings> {
         let epoch_settings = AggregatorEpochSettings {
             protocol_parameters: self.configuration.protocol_parameters.clone(),
             cardano_transactions_signing_config: self

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -64,6 +64,7 @@ use crate::{
         OpenMessageRepository, SignedEntityStore, SignedEntityStorer, SignerRegistrationStore,
         SignerStore, SingleSignatureRepository, StakePoolStore,
     },
+    entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
     http_server::routes::router,
     services::{
@@ -1206,8 +1207,16 @@ impl DependenciesBuilder {
         let verification_key_store = self.get_verification_key_store().await?;
         let epoch_settings_storer = self.get_epoch_settings_storer().await?;
 
+        let epoch_settings = AggregatorEpochSettings {
+            protocol_parameters: self.configuration.protocol_parameters.clone(),
+            // TODO : complete the final structure
+            // cardano_transactions_signing_config: self
+            //     .get_signed_entity_config()?
+            //     .cardano_transactions_signing_config,
+        };
+
         let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
-            self.configuration.protocol_parameters.clone(),
+            epoch_settings,
             epoch_settings_storer,
             verification_key_store,
         )));

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -24,6 +24,7 @@ use crate::{
         CertificateRepository, OpenMessageRepository, SignedEntityStorer, SignerGetter,
         StakePoolStore,
     },
+    entities::AggregatorEpochSettings,
     event_store::{EventMessage, TransmitterService},
     multi_signer::MultiSigner,
     services::{
@@ -193,7 +194,12 @@ impl DependencyContainer {
     pub async fn init_state_from_fixture(&self, fixture: &MithrilFixture, target_epochs: &[Epoch]) {
         for epoch in target_epochs {
             self.epoch_settings_storer
-                .save_protocol_parameters(*epoch, fixture.protocol_parameters())
+                .save_epoch_settings(
+                    *epoch,
+                    AggregatorEpochSettings {
+                        protocol_parameters: fixture.protocol_parameters(),
+                    },
+                )
                 .await
                 .expect("save_protocol_parameters should not fail");
             self.fill_verification_key_store(*epoch, &fixture.signers_with_stake())
@@ -241,9 +247,14 @@ impl DependencyContainer {
         epochs_to_save.push(epoch_to_sign.next());
         for epoch in epochs_to_save {
             self.epoch_settings_storer
-                .save_protocol_parameters(epoch, protocol_parameters.clone())
+                .save_epoch_settings(
+                    epoch,
+                    AggregatorEpochSettings {
+                        protocol_parameters: protocol_parameters.clone(),
+                    },
+                )
                 .await
-                .expect("save_protocol_parameters should not fail");
+                .expect("save_epoch_settings should not fail");
         }
     }
 

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -9,7 +9,10 @@ use mithril_common::{
     chain_observer::ChainObserver,
     crypto_helper::ProtocolGenesisVerifier,
     digesters::{ImmutableDigester, ImmutableFileObserver},
-    entities::{Epoch, ProtocolParameters, SignedEntityConfig, SignerWithStake, StakeDistribution},
+    entities::{
+        CardanoTransactionsSigningConfig, Epoch, ProtocolParameters, SignedEntityConfig,
+        SignerWithStake, StakeDistribution,
+    },
     era::{EraChecker, EraReader},
     signable_builder::SignableBuilderService,
     signed_entity_type_lock::SignedEntityTypeLock,
@@ -191,13 +194,20 @@ impl DependencyContainer {
     ///
     /// Fill the stores of a [DependencyManager] in a way to simulate an aggregator state
     /// using the data from a precomputed fixture.
-    pub async fn init_state_from_fixture(&self, fixture: &MithrilFixture, target_epochs: &[Epoch]) {
+    pub async fn init_state_from_fixture(
+        &self,
+        fixture: &MithrilFixture,
+        cardano_transactions_signing_config: &CardanoTransactionsSigningConfig,
+        target_epochs: &[Epoch],
+    ) {
         for epoch in target_epochs {
             self.epoch_settings_storer
                 .save_epoch_settings(
                     *epoch,
                     AggregatorEpochSettings {
                         protocol_parameters: fixture.protocol_parameters(),
+                        cardano_transactions_signing_config: cardano_transactions_signing_config
+                            .clone(),
                     },
                 )
                 .await
@@ -222,9 +232,13 @@ impl DependencyContainer {
         genesis_signers: Vec<SignerWithStake>,
         second_epoch_signers: Vec<SignerWithStake>,
         genesis_protocol_parameters: &ProtocolParameters,
+        cardano_transactions_signing_config: &CardanoTransactionsSigningConfig,
     ) {
-        self.init_protocol_parameter_store(genesis_protocol_parameters)
-            .await;
+        self.init_protocol_parameter_store(
+            genesis_protocol_parameters,
+            cardano_transactions_signing_config,
+        )
+        .await;
 
         let (work_epoch, epoch_to_sign) = self.get_genesis_epochs().await;
         for (epoch, signers) in [
@@ -239,7 +253,11 @@ impl DependencyContainer {
     /// `TEST METHOD ONLY`
     ///
     /// Fill up to the first three epochs of the [ProtocolParametersStore] with the given value.
-    pub async fn init_protocol_parameter_store(&self, protocol_parameters: &ProtocolParameters) {
+    pub async fn init_protocol_parameter_store(
+        &self,
+        protocol_parameters: &ProtocolParameters,
+        cardano_transactions_signing_config: &CardanoTransactionsSigningConfig,
+    ) {
         let (work_epoch, epoch_to_sign) = self.get_genesis_epochs().await;
         let mut epochs_to_save = Vec::new();
         epochs_to_save.push(work_epoch);
@@ -251,6 +269,8 @@ impl DependencyContainer {
                     epoch,
                     AggregatorEpochSettings {
                         protocol_parameters: protocol_parameters.clone(),
+                        cardano_transactions_signing_config: cardano_transactions_signing_config
+                            .clone(),
                     },
                 )
                 .await

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -211,7 +211,7 @@ impl DependencyContainer {
                     },
                 )
                 .await
-                .expect("save_protocol_parameters should not fail");
+                .expect("save_epoch_settings should not fail");
             self.fill_verification_key_store(*epoch, &fixture.signers_with_stake())
                 .await;
             self.fill_stakes_store(*epoch, fixture.signers_with_stake())

--- a/mithril-aggregator/src/entities/aggregator_epoch_settings.rs
+++ b/mithril-aggregator/src/entities/aggregator_epoch_settings.rs
@@ -1,10 +1,13 @@
-use mithril_common::entities::ProtocolParameters;
+use mithril_common::entities::{CardanoTransactionsSigningConfig, ProtocolParameters};
 
 /// AggregatorEpochSettings represents the settings of an epoch
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AggregatorEpochSettings {
     /// Protocol parameters
     pub protocol_parameters: ProtocolParameters,
+
+    /// Cardano transactions signing configuration
+    pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
 }
 
 impl AggregatorEpochSettings {
@@ -13,12 +16,13 @@ impl AggregatorEpochSettings {
     pub fn dummy() -> AggregatorEpochSettings {
         use mithril_common::test_utils::fake_data;
 
-        // Protocol parameters
         let protocol_parameters = fake_data::protocol_parameters();
+        let cardano_transactions_signing_config = CardanoTransactionsSigningConfig::dummy();
 
         // Aggregator Epoch settings
         AggregatorEpochSettings {
             protocol_parameters,
+            cardano_transactions_signing_config,
         }
     }
 }

--- a/mithril-aggregator/src/entities/aggregator_epoch_settings.rs
+++ b/mithril-aggregator/src/entities/aggregator_epoch_settings.rs
@@ -6,3 +6,19 @@ pub struct AggregatorEpochSettings {
     /// Protocol parameters
     pub protocol_parameters: ProtocolParameters,
 }
+
+impl AggregatorEpochSettings {
+    #[cfg(test)]
+    /// Create a dummy AggregatorEpochSettings
+    pub fn dummy() -> AggregatorEpochSettings {
+        use mithril_common::test_utils::fake_data;
+
+        // Protocol parameters
+        let protocol_parameters = fake_data::protocol_parameters();
+
+        // Aggregator Epoch settings
+        AggregatorEpochSettings {
+            protocol_parameters,
+        }
+    }
+}

--- a/mithril-aggregator/src/entities/aggregator_epoch_settings.rs
+++ b/mithril-aggregator/src/entities/aggregator_epoch_settings.rs
@@ -1,0 +1,8 @@
+use mithril_common::entities::ProtocolParameters;
+
+/// AggregatorEpochSettings represents the settings of an epoch
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct AggregatorEpochSettings {
+    /// Protocol parameters
+    pub protocol_parameters: ProtocolParameters,
+}

--- a/mithril-aggregator/src/entities/mod.rs
+++ b/mithril-aggregator/src/entities/mod.rs
@@ -1,10 +1,13 @@
 //! Entities module
 //!
 //! This module provide domain entities for the services & state machine.
+//!
+mod aggregator_epoch_settings;
 mod open_message;
 mod signer_registration_message;
 mod signer_ticker_message;
 
+pub use aggregator_epoch_settings::AggregatorEpochSettings;
 pub use open_message::OpenMessage;
 pub use signer_registration_message::{
     SignerRegistrationsListItemMessage, SignerRegistrationsMessage,

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -211,8 +211,6 @@ mod tests {
         .await
         .unwrap();
 
-        // TODO: What we expect  ? see #1963 Discrepancy of protocol parameters in epoch settings and pending certificates routes
-        // https://github.com/input-output-hk/mithril/issues/1963
         assert_eq!(
             message.protocol_parameters,
             next_epoch_settings.protocol_parameters
@@ -256,9 +254,6 @@ mod tests {
         .await
         .unwrap();
 
-        // TODO: What we expect  ? see #1963 Discrepancy of protocol parameters in epoch settings and pending certificates routes
-        // https://github.com/input-output-hk/mithril/issues/1963
-        // TODO if they need to be aligned with protocol parameters, we may assert in the same test
         assert_eq!(
             message.cardano_transactions_signing_config,
             Some(current_epoch_settings.cardano_transactions_signing_config),

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -142,6 +142,7 @@ mod tests {
     use mithril_common::protocol::ToMessage;
     use mithril_common::test_utils::{fake_data, MithrilFixtureBuilder};
 
+    use crate::entities::AggregatorEpochSettings;
     use crate::services::FakeEpochService;
 
     use super::*;
@@ -174,9 +175,18 @@ mod tests {
         let multi_signer =
             MultiSignerImpl::new(Arc::new(RwLock::new(FakeEpochService::with_data(
                 epoch,
-                &fixture.protocol_parameters(),
-                &next_fixture.protocol_parameters(),
-                &next_fixture.protocol_parameters(),
+                &AggregatorEpochSettings {
+                    protocol_parameters: fixture.protocol_parameters(),
+                    ..AggregatorEpochSettings::dummy()
+                },
+                &AggregatorEpochSettings {
+                    protocol_parameters: next_fixture.protocol_parameters(),
+                    ..AggregatorEpochSettings::dummy()
+                },
+                &AggregatorEpochSettings {
+                    protocol_parameters: next_fixture.protocol_parameters(),
+                    ..AggregatorEpochSettings::dummy()
+                },
                 &fixture.signers_with_stake(),
                 &next_fixture.signers_with_stake(),
             ))));

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -501,7 +501,9 @@ pub mod tests {
     };
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
-    use mithril_common::entities::{ChainPoint, SignedEntityTypeDiscriminants};
+    use mithril_common::entities::{
+        CardanoTransactionsSigningConfig, ChainPoint, SignedEntityTypeDiscriminants,
+    };
     use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
     use mithril_common::{
         chain_observer::FakeObserver,
@@ -544,6 +546,7 @@ pub mod tests {
             .unwrap();
         deps.init_state_from_fixture(
             &fixture,
+            &CardanoTransactionsSigningConfig::dummy(),
             &[
                 current_epoch.offset_to_signer_retrieval_epoch().unwrap(),
                 current_epoch,
@@ -798,6 +801,7 @@ pub mod tests {
             current_signers.clone(),
             next_signers.clone(),
             &protocol_parameters.clone(),
+            &CardanoTransactionsSigningConfig::dummy(),
         )
         .await;
         runner.inform_new_epoch(time_point.epoch).await.unwrap();
@@ -934,6 +938,10 @@ pub mod tests {
         let epoch_settings_storer = deps.epoch_settings_storer.clone();
         let expected_epoch_settings = AggregatorEpochSettings {
             protocol_parameters: deps.config.protocol_parameters.clone(),
+            cardano_transactions_signing_config: deps
+                .signed_entity_config
+                .cardano_transactions_signing_config
+                .clone(),
         };
         let current_epoch = deps.ticker_service.get_current_epoch().await.unwrap();
         let insert_epoch = current_epoch.offset_to_epoch_settings_recording_epoch();

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -294,7 +294,7 @@ impl AggregatorRuntime {
             self.runner
                 .open_signer_registration_round(&new_time_point)
                 .await?;
-            self.runner.update_protocol_parameters().await?;
+            self.runner.update_epoch_settings().await?;
             self.runner.precompute_epoch_data().await?;
         }
 
@@ -463,7 +463,7 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
-            .expect_update_protocol_parameters()
+            .expect_update_epoch_settings()
             .once()
             .returning(|| Ok(()));
         runner
@@ -520,7 +520,7 @@ mod tests {
             .once()
             .returning(|_| Ok(()));
         runner
-            .expect_update_protocol_parameters()
+            .expect_update_epoch_settings()
             .once()
             .returning(|| Ok(()));
         runner

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -382,7 +382,7 @@ mod tests {
     };
     use chrono::{DateTime, Days};
     use mithril_common::{
-        entities::{CardanoDbBeacon, ProtocolMessagePartKey},
+        entities::{CardanoDbBeacon, CardanoTransactionsSigningConfig, ProtocolMessagePartKey},
         test_utils::{fake_data, MithrilFixture, MithrilFixtureBuilder},
     };
     use tokio::sync::RwLock;
@@ -442,7 +442,11 @@ mod tests {
             .await
             .unwrap();
         dependency_manager
-            .init_state_from_fixture(fixture, epochs_with_signers)
+            .init_state_from_fixture(
+                fixture,
+                &CardanoTransactionsSigningConfig::dummy(),
+                epochs_with_signers,
+            )
             .await;
 
         MithrilCertifierService::from_deps(network, dependency_builder).await

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -608,6 +608,8 @@ mod tests {
         epoch: Epoch,
         protocol_parameters: ProtocolParameters,
         next_protocol_parameters: ProtocolParameters,
+        cardano_signing_config: CardanoTransactionsSigningConfig,
+        next_cardano_signing_config: CardanoTransactionsSigningConfig,
         upcoming_protocol_parameters: ProtocolParameters,
         current_signers_with_stake: BTreeSet<SignerWithStake>,
         next_signers_with_stake: BTreeSet<SignerWithStake>,
@@ -628,6 +630,12 @@ mod tests {
                 protocol_parameters: service.current_protocol_parameters()?.clone(),
                 next_protocol_parameters: service.next_protocol_parameters()?.clone(),
                 upcoming_protocol_parameters: service.upcoming_protocol_parameters()?.clone(),
+                cardano_signing_config: service
+                    .current_cardano_transactions_signing_config()?
+                    .clone(),
+                next_cardano_signing_config: service
+                    .next_cardano_transactions_signing_config()?
+                    .clone(),
                 current_signers_with_stake: service
                     .current_signers_with_stake()?
                     .clone()
@@ -781,6 +789,8 @@ mod tests {
                 protocol_parameters: current_epoch_fixture.protocol_parameters(),
                 next_protocol_parameters: next_epoch_fixture.protocol_parameters(),
                 upcoming_protocol_parameters,
+                cardano_signing_config: CardanoTransactionsSigningConfig::dummy(),
+                next_cardano_signing_config: CardanoTransactionsSigningConfig::dummy(),
                 current_signers_with_stake: current_epoch_fixture
                     .signers_with_stake()
                     .into_iter()
@@ -980,6 +990,10 @@ mod tests {
         assert!(service.current_protocol_parameters().is_ok());
         assert!(service.next_protocol_parameters().is_ok());
         assert!(service.upcoming_protocol_parameters().is_ok());
+        assert!(service
+            .current_cardano_transactions_signing_config()
+            .is_ok());
+        assert!(service.next_cardano_transactions_signing_config().is_ok());
         assert!(service.current_signers_with_stake().is_ok());
         assert!(service.next_signers_with_stake().is_ok());
         assert!(service.current_signers().is_ok());

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -39,7 +39,7 @@ pub trait EpochService: Sync + Send {
     /// internal state for the new epoch.
     async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()>;
 
-    /// Insert future epoch settings in the store based on this service current epoch.
+    /// Insert future epoch settings in the store based on this service current epoch (epoch offset +2).
     ///
     /// Note: must be called after `inform_epoch`.
     async fn update_epoch_settings(&mut self) -> StdResult<()>;
@@ -61,18 +61,13 @@ pub trait EpochService: Sync + Send {
     /// Get upcoming protocol parameters used in next epoch (associated with the next epoch)
     fn upcoming_protocol_parameters(&self) -> StdResult<&ProtocolParameters>;
 
-    /// Get cardano transactions signing configuration used in current epoch (associated with the previous epoch)
+    /// Get cardano transactions signing configuration used in current epoch
     fn current_cardano_transactions_signing_config(
         &self,
     ) -> StdResult<&CardanoTransactionsSigningConfig>;
 
-    /// Get next cardano transactions signing configuration used in next epoch (associated with the actual epoch)
+    /// Get next cardano transactions signing configuration used in next epoch
     fn next_cardano_transactions_signing_config(
-        &self,
-    ) -> StdResult<&CardanoTransactionsSigningConfig>;
-
-    /// Get upcoming cardano transactions signing configuration used in next epoch (associated with the next epoch)
-    fn upcoming_cardano_transactions_signing_config(
         &self,
     ) -> StdResult<&CardanoTransactionsSigningConfig>;
 
@@ -336,15 +331,6 @@ impl EpochService for MithrilEpochService {
             .cardano_transactions_signing_config)
     }
 
-    fn upcoming_cardano_transactions_signing_config(
-        &self,
-    ) -> StdResult<&CardanoTransactionsSigningConfig> {
-        Ok(&self
-            .unwrap_data()?
-            .upcoming_epoch_settings
-            .cardano_transactions_signing_config)
-    }
-
     fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
         Ok(&self.unwrap_computed_data()?.aggregate_verification_key)
     }
@@ -568,15 +554,6 @@ impl EpochService for FakeEpochService {
         Ok(&self
             .unwrap_data()?
             .next_epoch_settings
-            .cardano_transactions_signing_config)
-    }
-
-    fn upcoming_cardano_transactions_signing_config(
-        &self,
-    ) -> StdResult<&CardanoTransactionsSigningConfig> {
-        Ok(&self
-            .unwrap_data()?
-            .upcoming_epoch_settings
             .cardano_transactions_signing_config)
     }
 

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -5,7 +5,9 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use mithril_common::crypto_helper::ProtocolAggregateVerificationKey;
-use mithril_common::entities::{Epoch, ProtocolParameters, Signer, SignerWithStake};
+use mithril_common::entities::{
+    CardanoTransactionsSigningConfig, Epoch, ProtocolParameters, Signer, SignerWithStake,
+};
 use mithril_common::protocol::{MultiSigner as ProtocolMultiSigner, SignerBuilder};
 use mithril_common::StdResult;
 
@@ -58,6 +60,21 @@ pub trait EpochService: Sync + Send {
 
     /// Get upcoming protocol parameters used in next epoch (associated with the next epoch)
     fn upcoming_protocol_parameters(&self) -> StdResult<&ProtocolParameters>;
+
+    /// Get cardano transactions signing configuration used in current epoch (associated with the previous epoch)
+    fn current_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig>;
+
+    /// Get next cardano transactions signing configuration used in next epoch (associated with the actual epoch)
+    fn next_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig>;
+
+    /// Get upcoming cardano transactions signing configuration used in next epoch (associated with the next epoch)
+    fn upcoming_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig>;
 
     /// Get aggregate verification key for current epoch
     fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey>;
@@ -301,6 +318,33 @@ impl EpochService for MithrilEpochService {
             .protocol_parameters)
     }
 
+    fn current_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig> {
+        Ok(&self
+            .unwrap_data()?
+            .epoch_settings
+            .cardano_transactions_signing_config)
+    }
+
+    fn next_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig> {
+        Ok(&self
+            .unwrap_data()?
+            .next_epoch_settings
+            .cardano_transactions_signing_config)
+    }
+
+    fn upcoming_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig> {
+        Ok(&self
+            .unwrap_data()?
+            .upcoming_epoch_settings
+            .cardano_transactions_signing_config)
+    }
+
     fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {
         Ok(&self.unwrap_computed_data()?.aggregate_verification_key)
     }
@@ -507,6 +551,33 @@ impl EpochService for FakeEpochService {
             .unwrap_data()?
             .upcoming_epoch_settings
             .protocol_parameters)
+    }
+
+    fn current_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig> {
+        Ok(&self
+            .unwrap_data()?
+            .epoch_settings
+            .cardano_transactions_signing_config)
+    }
+
+    fn next_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig> {
+        Ok(&self
+            .unwrap_data()?
+            .next_epoch_settings
+            .cardano_transactions_signing_config)
+    }
+
+    fn upcoming_cardano_transactions_signing_config(
+        &self,
+    ) -> StdResult<&CardanoTransactionsSigningConfig> {
+        Ok(&self
+            .unwrap_data()?
+            .upcoming_epoch_settings
+            .cardano_transactions_signing_config)
     }
 
     fn current_aggregate_verification_key(&self) -> StdResult<&ProtocolAggregateVerificationKey> {

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -641,15 +641,21 @@ mod tests {
         let epoch_settings_storer = FakeEpochSettingsStorer::new(vec![
             (
                 signer_retrieval_epoch,
-                current_epoch_fixture.protocol_parameters(),
+                AggregatorEpochSettings {
+                    protocol_parameters: current_epoch_fixture.protocol_parameters(),
+                },
             ),
             (
                 next_signer_retrieval_epoch,
-                next_epoch_fixture.protocol_parameters(),
+                AggregatorEpochSettings {
+                    protocol_parameters: next_epoch_fixture.protocol_parameters(),
+                },
             ),
             (
                 next_signer_retrieval_epoch.next(),
-                upcoming_protocol_parameters.clone(),
+                AggregatorEpochSettings {
+                    protocol_parameters: upcoming_protocol_parameters.clone(),
+                },
             ),
         ]);
         let vkey_store = VerificationKeyStore::new(Box::new(

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -925,6 +925,14 @@ mod tests {
                 service.upcoming_protocol_parameters().err(),
             ),
             (
+                "current_cardano_transactions_signing_config",
+                service.current_cardano_transactions_signing_config().err(),
+            ),
+            (
+                "next_cardano_transactions_signing_config",
+                service.next_cardano_transactions_signing_config().err(),
+            ),
+            (
                 "current_signers_with_stake",
                 service.current_signers_with_stake().err(),
             ),

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -168,9 +168,11 @@ impl MithrilEpochService {
         );
 
         self.epoch_settings_storer
-            .save_protocol_parameters(
+            .save_epoch_settings(
                 recording_epoch,
-                self.future_protocol_parameters.clone(),
+                AggregatorEpochSettings {
+                    protocol_parameters: self.future_protocol_parameters.clone(),
+                },
             )
             .await
             .with_context(|| format!("Epoch service failed to insert future_protocol_parameters to epoch {recording_epoch}"))

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -887,7 +887,6 @@ mod tests {
     #[tokio::test]
     async fn update_epoch_settings_insert_future_epoch_settings_in_the_store() {
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-        // TODO use epoch_settings
         let future_protocol_parameters = ProtocolParameters::new(6, 89, 0.124);
         let epoch = Epoch(4);
         let mut service = build_service(
@@ -908,21 +907,21 @@ mod tests {
             .await
             .expect("update_epoch_settings should not fail");
 
-        // TODO use epoch_settings
-        let inserted_protocol_parameters = service
+        let inserted_epoch_settings = service
             .epoch_settings_storer
-            .get_protocol_parameters(epoch.offset_to_epoch_settings_recording_epoch())
+            .get_epoch_settings(epoch.offset_to_epoch_settings_recording_epoch())
             .await
             .unwrap_or_else(|_| {
                 panic!(
                     "epoch settings should have been inserted for epoch {}",
                     epoch.offset_to_epoch_settings_recording_epoch()
                 )
-            });
+            })
+            .unwrap();
 
         assert_eq!(
-            inserted_protocol_parameters,
-            Some(future_protocol_parameters)
+            inserted_epoch_settings.protocol_parameters,
+            future_protocol_parameters
         );
     }
 

--- a/mithril-aggregator/src/services/signable_builder/signable_seed_builder.rs
+++ b/mithril-aggregator/src/services/signable_builder/signable_seed_builder.rs
@@ -61,7 +61,7 @@ mod tests {
         test_utils::{MithrilFixture, MithrilFixtureBuilder},
     };
 
-    use crate::services::FakeEpochService;
+    use crate::{entities::AggregatorEpochSettings, services::FakeEpochService};
 
     use super::*;
 
@@ -72,9 +72,18 @@ mod tests {
     ) -> AggregatorSignableSeedBuilder {
         let epoch_service = Arc::new(RwLock::new(FakeEpochService::with_data(
             epoch,
-            &fixture.protocol_parameters(),
-            &next_fixture.protocol_parameters(),
-            &next_fixture.protocol_parameters(),
+            &AggregatorEpochSettings {
+                protocol_parameters: fixture.protocol_parameters(),
+                ..AggregatorEpochSettings::dummy()
+            },
+            &AggregatorEpochSettings {
+                protocol_parameters: next_fixture.protocol_parameters(),
+                ..AggregatorEpochSettings::dummy()
+            },
+            &AggregatorEpochSettings {
+                protocol_parameters: next_fixture.protocol_parameters(),
+                ..AggregatorEpochSettings::dummy()
+            },
             &fixture.signers_with_stake(),
             &next_fixture.signers_with_stake(),
         )));

--- a/mithril-aggregator/src/store/epoch_settings_storer.rs
+++ b/mithril-aggregator/src/store/epoch_settings_storer.rs
@@ -9,7 +9,7 @@ use mithril_common::entities::{Epoch, ProtocolParameters};
 
 use crate::entities::AggregatorEpochSettings;
 
-/// Store and get [protocol parameters][ProtocolParameters] for given epoch.
+/// Store and get [aggregator epoch settings][AggregatorEpochSettings] for given epoch.
 #[async_trait]
 pub trait EpochSettingsStorer: Sync + Send {
     /// Save the given `AggregatorEpochSettings` for the given [Epoch].

--- a/mithril-aggregator/src/store/epoch_settings_storer.rs
+++ b/mithril-aggregator/src/store/epoch_settings_storer.rs
@@ -7,15 +7,17 @@ use tokio::sync::RwLock;
 
 use mithril_common::entities::{Epoch, ProtocolParameters};
 
+use crate::entities::AggregatorEpochSettings;
+
 /// Store and get [protocol parameters][ProtocolParameters] for given epoch.
 #[async_trait]
 pub trait EpochSettingsStorer: Sync + Send {
-    /// Save the given `ProtocolParameter` for the given [Epoch].
-    async fn save_protocol_parameters(
+    /// Save the given `AggregatorEpochSettings` for the given [Epoch].
+    async fn save_epoch_settings(
         &self,
         epoch: Epoch,
-        protocol_parameters: ProtocolParameters,
-    ) -> StdResult<Option<ProtocolParameters>>;
+        epoch_settings: AggregatorEpochSettings,
+    ) -> StdResult<Option<AggregatorEpochSettings>>;
 
     /// Get the saved `ProtocolParameter` for the given [Epoch] if any.
     async fn get_protocol_parameters(&self, epoch: Epoch) -> StdResult<Option<ProtocolParameters>>;
@@ -24,6 +26,7 @@ pub trait EpochSettingsStorer: Sync + Send {
     /// In case an aggregator has been launched after some epochs of not being up or at initial startup,
     /// the discrepancies in the protocol parameters store needs to be fixed.
     /// The protocol parameters needs to be recorded for the working epoch and the next 2 epochs.
+    // TODO: Should we pass a AggegatorEpochSettings instead of ProtocolParameters?
     async fn handle_discrepancies_at_startup(
         &self,
         current_epoch: Epoch,
@@ -33,8 +36,13 @@ pub trait EpochSettingsStorer: Sync + Send {
             let epoch = current_epoch + epoch_offset;
             if self.get_protocol_parameters(epoch).await?.is_none() {
                 debug!("Handle discrepancies at startup of protocol parameters store, will record protocol parameters from the configuration for epoch {epoch}: {configuration_protocol_parameters:?}");
-                self.save_protocol_parameters(epoch, configuration_protocol_parameters.clone())
-                    .await?;
+                self.save_epoch_settings(
+                    epoch,
+                    AggregatorEpochSettings {
+                        protocol_parameters: configuration_protocol_parameters.clone(),
+                    },
+                )
+                .await?;
             }
         }
 
@@ -43,33 +51,42 @@ pub trait EpochSettingsStorer: Sync + Send {
 }
 
 pub struct FakeEpochSettingsStorer {
-    pub protocol_parameters: RwLock<HashMap<Epoch, ProtocolParameters>>,
+    pub epoch_settings: RwLock<HashMap<Epoch, AggregatorEpochSettings>>,
 }
 
 impl FakeEpochSettingsStorer {
     #[cfg(test)]
     pub fn new(data: Vec<(Epoch, ProtocolParameters)>) -> Self {
-        let protocol_parameters = RwLock::new(data.into_iter().collect());
-        Self {
-            protocol_parameters,
-        }
+        let data_epoch_settings = data.into_iter().map(|(epoch, protocol_parameters)| {
+            (
+                epoch,
+                AggregatorEpochSettings {
+                    protocol_parameters,
+                },
+            )
+        });
+        let epoch_settings = RwLock::new(data_epoch_settings.into_iter().collect());
+        Self { epoch_settings }
     }
 }
 
 #[async_trait]
 impl EpochSettingsStorer for FakeEpochSettingsStorer {
-    async fn save_protocol_parameters(
+    async fn save_epoch_settings(
         &self,
         epoch: Epoch,
-        protocol_parameters: ProtocolParameters,
-    ) -> StdResult<Option<ProtocolParameters>> {
-        let mut protocol_parameters_write = self.protocol_parameters.write().await;
-        Ok(protocol_parameters_write.insert(epoch, protocol_parameters))
+        epoch_settings: AggregatorEpochSettings,
+    ) -> StdResult<Option<AggregatorEpochSettings>> {
+        let mut epoch_settings_write = self.epoch_settings.write().await;
+
+        Ok(epoch_settings_write.insert(epoch, epoch_settings))
     }
 
     async fn get_protocol_parameters(&self, epoch: Epoch) -> StdResult<Option<ProtocolParameters>> {
-        let protocol_parameters = self.protocol_parameters.read().await;
-        Ok(protocol_parameters.get(&epoch).cloned())
+        let epoch_settings = self.epoch_settings.read().await;
+        Ok(epoch_settings
+            .get(&epoch)
+            .map(|es| es.protocol_parameters.clone()))
     }
 }
 
@@ -81,33 +98,39 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    async fn test_save_protocol_parameters_do_not_exist_yet() {
-        let protocol_parameters = fake_data::protocol_parameters();
+    async fn test_save_epoch_settings_do_not_exist_yet() {
+        let epoch_settings = AggregatorEpochSettings::dummy();
         let epoch = Epoch(1);
         let store = FakeEpochSettingsStorer::new(vec![]);
-        let protocol_parameters_previous = store
-            .save_protocol_parameters(epoch, protocol_parameters)
+        let epoch_settings_previous = store
+            .save_epoch_settings(epoch, epoch_settings)
             .await
             .unwrap();
 
-        assert!(protocol_parameters_previous.is_none());
+        assert!(epoch_settings_previous.is_none());
     }
 
     #[tokio::test]
-    async fn test_save_protocol_parameters_already_exist() {
-        let protocol_parameters = fake_data::protocol_parameters();
+    async fn test_save_epoch_settings_already_exist() {
+        let epoch_settings = AggregatorEpochSettings::dummy();
         let epoch = Epoch(1);
-        let store = FakeEpochSettingsStorer::new(vec![(epoch, protocol_parameters.clone())]);
+        let store =
+            FakeEpochSettingsStorer::new(vec![(epoch, epoch_settings.protocol_parameters.clone())]);
         let protocol_parameters_new = ProtocolParameters {
-            k: protocol_parameters.k + 1,
-            ..protocol_parameters
+            k: epoch_settings.protocol_parameters.k + 1,
+            ..epoch_settings.protocol_parameters
         };
-        let protocol_parameters_previous = store
-            .save_protocol_parameters(epoch, protocol_parameters_new)
+        let epoch_settings_previous = store
+            .save_epoch_settings(
+                epoch,
+                AggregatorEpochSettings {
+                    protocol_parameters: protocol_parameters_new.clone(),
+                },
+            )
             .await
             .unwrap();
 
-        assert_eq!(Some(protocol_parameters), protocol_parameters_previous);
+        assert_eq!(Some(epoch_settings), epoch_settings_previous);
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/store/epoch_settings_storer.rs
+++ b/mithril-aggregator/src/store/epoch_settings_storer.rs
@@ -80,6 +80,7 @@ impl EpochSettingsStorer for FakeEpochSettingsStorer {
 
     async fn get_epoch_settings(&self, epoch: Epoch) -> StdResult<Option<AggregatorEpochSettings>> {
         let epoch_settings = self.epoch_settings.read().await;
+
         Ok(epoch_settings.get(&epoch).cloned())
     }
 }

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -9,6 +9,7 @@ use mithril_aggregator::{
     AggregatorRuntime, Configuration, DependencyContainer, DumbSnapshotUploader, DumbSnapshotter,
     SignerRegistrationError,
 };
+use mithril_common::entities::CardanoTransactionsSigningConfig;
 use mithril_common::{
     cardano_block_scanner::{DumbBlockScanner, ScannedBlock},
     chain_observer::{ChainObserver, FakeObserver},
@@ -190,7 +191,11 @@ impl RuntimeTester {
         // Init the stores needed for a genesis certificate
         let genesis_epochs = self.dependencies.get_genesis_epochs().await;
         self.dependencies
-            .init_state_from_fixture(fixture, &[genesis_epochs.0, genesis_epochs.1])
+            .init_state_from_fixture(
+                fixture,
+                &CardanoTransactionsSigningConfig::dummy(),
+                &[genesis_epochs.0, genesis_epochs.1],
+            )
             .await;
         Ok(())
     }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.60"
+version = "0.4.61"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/certificate_metadata.rs
+++ b/mithril-common/src/entities/certificate_metadata.rs
@@ -46,7 +46,7 @@ impl StakeDistributionParty {
 
 era_deprecate!("Remove immutable file number as it's here only for message backward-compatibility");
 /// CertificateMetadata represents the metadata associated to a Certificate
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CertificateMetadata {
     /// Cardano network
     pub network: String,

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -27,8 +27,8 @@ impl Epoch {
     /// The epoch offset used for signers stake distribution and verification keys recording.
     pub const SIGNER_RECORDING_OFFSET: u64 = 1;
 
-    /// The epoch offset used for aggregator protocol parameters recording.
-    pub const PROTOCOL_PARAMETERS_RECORDING_OFFSET: u64 = 2;
+    /// The epoch offset used for aggregator epoch settings recording.
+    pub const EPOCH_SETTINGS_RECORDING_OFFSET: u64 = 2;
 
     /// The epoch offset used to retrieve, given the epoch at which a signer registered, the epoch
     /// at which the signer can send single signatures.
@@ -64,9 +64,9 @@ impl Epoch {
         *self + Self::SIGNER_RECORDING_OFFSET
     }
 
-    /// Apply the [protocol parameters recording offset][Self::PROTOCOL_PARAMETERS_RECORDING_OFFSET] to this epoch
-    pub fn offset_to_protocol_parameters_recording_epoch(&self) -> Self {
-        *self + Self::PROTOCOL_PARAMETERS_RECORDING_OFFSET
+    /// Apply the [epoch settings recording offset][Self::EPOCH_SETTINGS_RECORDING_OFFSET] to this epoch
+    pub fn offset_to_epoch_settings_recording_epoch(&self) -> Self {
+        *self + Self::EPOCH_SETTINGS_RECORDING_OFFSET
     }
 
     /// Apply the [signer signing offset][Self::SIGNER_SIGNING_OFFSET] to this epoch

--- a/mithril-common/src/entities/mithril_stake_distribution.rs
+++ b/mithril-common/src/entities/mithril_stake_distribution.rs
@@ -115,7 +115,8 @@ mod tests {
             .signers_with_stake();
         let protocol_parameters = ProtocolParameters {
             k: 100,
-            ..Default::default()
+            m: 0,
+            phi_f: 0.0,
         };
         let stake_distribution =
             MithrilStakeDistribution::new(Epoch(1), signers, &protocol_parameters);

--- a/mithril-common/src/entities/protocol_parameters.rs
+++ b/mithril-common/src/entities/protocol_parameters.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 /// Protocol cryptographic parameters
-// TODO: `Default` should be removed. There is no functional sense in having a default value for this struct.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProtocolParameters {
     /// Quorum parameter
     pub k: u64,

--- a/mithril-common/src/entities/protocol_parameters.rs
+++ b/mithril-common/src/entities/protocol_parameters.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 /// Protocol cryptographic parameters
+// TODO: `Default` should be removed. There is no functional sense in having a default value for this struct.
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct ProtocolParameters {
     /// Quorum parameter

--- a/mithril-common/src/entities/signed_entity_config.rs
+++ b/mithril-common/src/entities/signed_entity_config.rs
@@ -117,6 +117,14 @@ pub struct CardanoTransactionsSigningConfig {
 
 impl CardanoTransactionsSigningConfig {
     cfg_test_tools! {
+        /// Create a new CardanoTransactionsSigningConfig
+        pub fn new(security_parameter: BlockNumber, step: BlockNumber) -> Self {
+            Self {
+                security_parameter,
+                step,
+            }
+        }
+
         /// Create a dummy config
         pub fn dummy() -> Self {
             Self {

--- a/mithril-common/src/messages/epoch_settings.rs
+++ b/mithril-common/src/messages/epoch_settings.rs
@@ -3,7 +3,7 @@ use crate::messages::SignerMessagePart;
 use serde::{Deserialize, Serialize};
 
 /// EpochSettings represents the settings of an epoch
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EpochSettingsMessage {
     /// Current Epoch
     pub epoch: Epoch,
@@ -93,7 +93,7 @@ mod tests {
         }"#;
 
     // Supported structure until OpenAPI version 0.1.28.
-    #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub struct EpochSettingsMessageUntilV0_1_28 {
         /// Current Epoch
         pub epoch: Epoch,
@@ -108,7 +108,7 @@ mod tests {
     }
 
     // Supported structure until OpenAPI version 0.1.29.
-    #[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub struct EpochSettingsMessageUntilV0_1_29 {
         /// Current Epoch
         pub epoch: Epoch,

--- a/mithril-common/src/messages/message_parts/certificate_metadata.rs
+++ b/mithril-common/src/messages/message_parts/certificate_metadata.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 
 /// CertificateMetadata represents the metadata associated to a Certificate
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CertificateMetadataMessagePart {
     /// Cardano network
     /// part of METADATA(p,n)

--- a/mithril-common/src/messages/mithril_stake_distribution.rs
+++ b/mithril-common/src/messages/mithril_stake_distribution.rs
@@ -9,7 +9,7 @@ use crate::test_utils::fake_data;
 
 use super::SignerWithStakeMessagePart;
 /// Message structure of a Mithril Stake Distribution
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MithrilStakeDistributionMessage {
     /// Epoch at which the Mithril Stake Distribution is created
     pub epoch: Epoch,

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.188"
+version = "0.2.189"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/entities/signer_epoch_settings.rs
+++ b/mithril-signer/src/entities/signer_epoch_settings.rs
@@ -3,7 +3,7 @@ use mithril_common::entities::{
 };
 
 /// SignerEpochSettings represents the settings of an epoch
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SignerEpochSettings {
     /// Current Epoch
     pub epoch: Epoch,

--- a/mithril-signer/tests/test_extensions/certificate_handler.rs
+++ b/mithril-signer/tests/test_extensions/certificate_handler.rs
@@ -108,7 +108,10 @@ impl AggregatorClient for FakeAggregator {
                 epoch: time_point.epoch,
                 current_signers,
                 next_signers,
-                ..Default::default()
+                protocol_parameters: fake_data::protocol_parameters(),
+                next_protocol_parameters: fake_data::protocol_parameters(),
+                cardano_transactions_signing_config: None,
+                next_cardano_transactions_signing_config: None,
             }))
         }
     }


### PR DESCRIPTION
## Content

This PR updates the aggregator to ensure the /epoch-settings route consistently exposes constant signing configurations for each epoch.

The Cardano signing configurations are now stored in the aggregator's `epoch_setting` table, ensuring they remain unchanged throughout an epoch.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1924 
