### PR TITLE
Fix: swagger build step failing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -841,6 +841,7 @@ jobs:
         with:
           output: out/
           spec-file: ./openapi.yaml
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish OpenAPI UI build
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Content

This PR includes a fix to the **Swagger UI build** step in the CI: the missing 'GITHUB_TOKEN' is now required.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

