### PR TITLE
Fix: discrepancy protocol parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.69"
+version = "0.5.70"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.69"
+version = "0.5.70"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -326,16 +326,15 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         let signers = epoch_service.current_signers_with_stake()?;
         let next_signers = epoch_service.next_signers_with_stake()?;
 
-        let protocol_parameters =
-            epoch_service
-                .current_protocol_parameters()
-                .with_context(|| {
-                    format!("no current protocol parameters found for time point {time_point:?}")
-                })?;
+        let protocol_parameters = epoch_service.next_protocol_parameters().with_context(|| {
+            format!("no current protocol parameters found for time point {time_point:?}")
+        })?;
         let next_protocol_parameters =
-            epoch_service.next_protocol_parameters().with_context(|| {
-                format!("no next protocol parameters found for time point {time_point:?}")
-            })?;
+            epoch_service
+                .upcoming_protocol_parameters()
+                .with_context(|| {
+                    format!("no next protocol parameters found for time point {time_point:?}")
+                })?;
 
         let pending_certificate = CertificatePending::new(
             time_point.epoch,


### PR DESCRIPTION
## Content

This PR includes a fix to the protocol parameters advertised in the `/pending-certificate` which were different from `/epoch-settings` route.

## Pre-submit checklist

- Branch
  - [ ] Crates versions are updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested

## Issue(s)
Closes #1963 
