### PR TITLE
Signer self compute signed entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Refactor the builder of the protocol messages, and add support for protocol parameters and epoch parts.
 
+- Signer compute what to sign independently of the aggregator.
+
 - Crates versions:
 
 | Crate | Version |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.61"
+version = "0.4.62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.31"
+version = "0.4.32"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "anyhow",
  "clap",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.189"
+version = "0.2.190"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,6 +3708,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "chrono",
  "clap",
  "config",
  "criterion",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.61"
+version = "0.4.62"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/messages/aggregator_features.rs
+++ b/mithril-common/src/messages/aggregator_features.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::entities::{CardanoTransactionsSigningConfig, SignedEntityTypeDiscriminants};
 
 /// Message advertised by an Aggregator to inform about its features
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AggregatorFeaturesMessage {
     /// Version of the OpenAPI specification
     pub open_api_version: String,
@@ -35,7 +35,7 @@ impl AggregatorFeaturesMessage {
 }
 
 /// Capabilities of an Aggregator
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AggregatorCapabilities {
     /// Signed entity types that are signed by the aggregator
     pub signed_entity_types: BTreeSet<SignedEntityTypeDiscriminants>,
@@ -50,7 +50,7 @@ pub struct AggregatorCapabilities {
 }
 
 /// Cardano transactions prover capabilities
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct CardanoTransactionsProverCapabilities {
     /// Maximum number of hashes allowed for a single request
     pub max_hashes_allowed_by_request: usize,

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.23"
+version = "0.1.24"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.189"
+version = "0.2.190"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -17,6 +17,7 @@ harness = false
 anyhow = "1.0.86"
 async-trait = "0.1.82"
 axum = "0.7.5"
+chrono = { version = "0.4.38", features = ["serde"] }
 clap = { version = "4.5.17", features = ["derive", "env"] }
 config = "0.14.0"
 hex = "0.4.3"

--- a/mithril-signer/src/database/migration.rs
+++ b/mithril-signer/src/database/migration.rs
@@ -23,5 +23,42 @@ drop table db_version;
 alter table new_db_version rename to db_version;
             ",
         ),
+        // Migration 2
+        // Add the `signed_entity_type` table and insert first types
+        SqlMigration::new(
+            2,
+            r#"
+create table signed_entity_type (
+    signed_entity_type_id       integer     not null,
+    name                        text        not null,
+    primary key (signed_entity_type_id)
+);
+insert into signed_entity_type (signed_entity_type_id, name)
+    values  (0, 'Mithril Stake Distribution'),
+            (1, 'Cardano Stake Distribution'),
+            (2, 'Full Cardano Immutable Files'),
+            (3, 'Cardano Transactions');
+"#,
+        ),
+        // Migration 3
+        // Create the `signed_beacon` table.
+        SqlMigration::new(
+            3,
+            r"
+create table if not exists signed_beacon (
+    epoch                       integer     not null,
+    beacon                      text        not null,
+    signed_entity_type_id       integer     not null,
+    initiated_at                text        not null,
+    signed_at                   text        not null,
+
+    primary key (epoch, beacon, signed_entity_type_id),
+    foreign key (signed_entity_type_id) references signed_entity_type (signed_entity_type_id)
+);
+
+create index signed_beacon_epoch on signed_beacon(epoch);
+create index signed_beacon_signed_entity_type_id on signed_beacon(signed_entity_type_id);
+            ",
+        ),
     ]
 }

--- a/mithril-signer/src/database/mod.rs
+++ b/mithril-signer/src/database/mod.rs
@@ -2,6 +2,8 @@
 //! This module contains the entities definition tied with database
 //! representation with their associated providers.
 pub mod migration;
+pub(crate) mod query;
+pub mod record;
 pub mod repository;
 #[cfg(test)]
 pub(crate) mod test_helper;

--- a/mithril-signer/src/database/query/mod.rs
+++ b/mithril-signer/src/database/query/mod.rs
@@ -1,0 +1,5 @@
+//! Signer related database queries
+
+mod signed_beacon;
+
+pub use signed_beacon::*;

--- a/mithril-signer/src/database/query/signed_beacon/delete_signed_beacon.rs
+++ b/mithril-signer/src/database/query/signed_beacon/delete_signed_beacon.rs
@@ -1,0 +1,99 @@
+use sqlite::Value;
+
+use mithril_common::entities::Epoch;
+use mithril_persistence::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
+
+use crate::database::record::SignedBeaconRecord;
+
+/// Query to delete old [SignedBeaconRecord] from the sqlite database
+pub struct DeleteSignedBeaconRecordQuery {
+    condition: WhereCondition,
+}
+
+impl Query for DeleteSignedBeaconRecordQuery {
+    type Entity = SignedBeaconRecord;
+
+    fn filters(&self) -> WhereCondition {
+        self.condition.clone()
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        // it is important to alias the fields with the same name as the table
+        // since the table cannot be aliased in a RETURNING statement in SQLite.
+        let projection = Self::Entity::get_projection()
+            .expand(SourceAlias::new(&[("{:signed_beacon:}", "signed_beacon")]));
+
+        format!("delete from signed_beacon where {condition} returning {projection}")
+    }
+}
+
+impl DeleteSignedBeaconRecordQuery {
+    /// Create the SQL query to prune data older than the given Epoch.
+    pub fn below_epoch_threshold(epoch_threshold: Epoch) -> Self {
+        let epoch_threshold = Value::Integer(epoch_threshold.try_into().unwrap());
+
+        Self {
+            condition: WhereCondition::new("epoch < ?*", vec![epoch_threshold]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::entities::{BlockNumber, SignedEntityType};
+    use mithril_persistence::sqlite::ConnectionExtensions;
+
+    use crate::database::query::GetSignedBeaconQuery;
+    use crate::database::test_helper::{insert_signed_beacons, main_db_connection};
+
+    use super::*;
+
+    #[test]
+    fn test_prune_below_epoch_threshold() {
+        let connection = main_db_connection().unwrap();
+        insert_signed_beacons(
+            &connection,
+            SignedBeaconRecord::fakes(&[
+                (
+                    Epoch(7),
+                    vec![
+                        SignedEntityType::MithrilStakeDistribution(Epoch(7)),
+                        SignedEntityType::CardanoTransactions(Epoch(7), BlockNumber(12)),
+                    ],
+                ),
+                (
+                    Epoch(8),
+                    vec![
+                        SignedEntityType::MithrilStakeDistribution(Epoch(8)),
+                        SignedEntityType::CardanoStakeDistribution(Epoch(8)),
+                    ],
+                ),
+                (
+                    Epoch(9),
+                    vec![
+                        SignedEntityType::MithrilStakeDistribution(Epoch(9)),
+                        SignedEntityType::CardanoStakeDistribution(Epoch(9)),
+                        SignedEntityType::CardanoTransactions(Epoch(9), BlockNumber(23)),
+                    ],
+                ),
+            ]),
+        );
+
+        let cursor = connection
+            .fetch(DeleteSignedBeaconRecordQuery::below_epoch_threshold(Epoch(
+                7,
+            )))
+            .unwrap();
+        assert_eq!(0, cursor.count());
+
+        let cursor = connection
+            .fetch(DeleteSignedBeaconRecordQuery::below_epoch_threshold(Epoch(
+                9,
+            )))
+            .unwrap();
+        assert_eq!(4, cursor.count());
+
+        let cursor = connection.fetch(GetSignedBeaconQuery::all()).unwrap();
+        assert_eq!(3, cursor.count());
+    }
+}

--- a/mithril-signer/src/database/query/signed_beacon/delete_signed_beacon.rs
+++ b/mithril-signer/src/database/query/signed_beacon/delete_signed_beacon.rs
@@ -48,8 +48,33 @@ mod tests {
 
     use super::*;
 
+    // Epoch of the signed entities is irrelevant for those tests, only SignedBeacon.epoch matter
+    const WHATEVER_EPOCH: Epoch = Epoch(378);
+
     #[test]
-    fn test_prune_below_epoch_threshold() {
+    fn test_delete_nothing_if_nothing_strictly_below_epoch_threshold() {
+        let connection = main_db_connection().unwrap();
+        insert_signed_beacons(
+            &connection,
+            SignedBeaconRecord::fakes(&[(
+                Epoch(7),
+                vec![SignedEntityType::MithrilStakeDistribution(WHATEVER_EPOCH)],
+            )]),
+        );
+
+        let delete_cursor = connection
+            .fetch(DeleteSignedBeaconRecordQuery::below_epoch_threshold(Epoch(
+                7,
+            )))
+            .unwrap();
+        assert_eq!(0, delete_cursor.count());
+
+        let get_all_cursor = connection.fetch(GetSignedBeaconQuery::all()).unwrap();
+        assert_eq!(1, get_all_cursor.count());
+    }
+
+    #[test]
+    fn test_delete_below_epoch_threshold() {
         let connection = main_db_connection().unwrap();
         insert_signed_beacons(
             &connection,
@@ -57,43 +82,36 @@ mod tests {
                 (
                     Epoch(7),
                     vec![
-                        SignedEntityType::MithrilStakeDistribution(Epoch(7)),
-                        SignedEntityType::CardanoTransactions(Epoch(7), BlockNumber(12)),
+                        SignedEntityType::MithrilStakeDistribution(WHATEVER_EPOCH),
+                        SignedEntityType::CardanoTransactions(WHATEVER_EPOCH, BlockNumber(12)),
                     ],
                 ),
                 (
                     Epoch(8),
                     vec![
-                        SignedEntityType::MithrilStakeDistribution(Epoch(8)),
-                        SignedEntityType::CardanoStakeDistribution(Epoch(8)),
+                        SignedEntityType::MithrilStakeDistribution(WHATEVER_EPOCH),
+                        SignedEntityType::CardanoStakeDistribution(WHATEVER_EPOCH),
                     ],
                 ),
                 (
                     Epoch(9),
                     vec![
-                        SignedEntityType::MithrilStakeDistribution(Epoch(9)),
-                        SignedEntityType::CardanoStakeDistribution(Epoch(9)),
-                        SignedEntityType::CardanoTransactions(Epoch(9), BlockNumber(23)),
+                        SignedEntityType::MithrilStakeDistribution(WHATEVER_EPOCH),
+                        SignedEntityType::CardanoStakeDistribution(WHATEVER_EPOCH),
+                        SignedEntityType::CardanoTransactions(WHATEVER_EPOCH, BlockNumber(23)),
                     ],
                 ),
             ]),
         );
 
-        let cursor = connection
-            .fetch(DeleteSignedBeaconRecordQuery::below_epoch_threshold(Epoch(
-                7,
-            )))
-            .unwrap();
-        assert_eq!(0, cursor.count());
-
-        let cursor = connection
+        let delete_cursor = connection
             .fetch(DeleteSignedBeaconRecordQuery::below_epoch_threshold(Epoch(
                 9,
             )))
             .unwrap();
-        assert_eq!(4, cursor.count());
+        assert_eq!(4, delete_cursor.count());
 
-        let cursor = connection.fetch(GetSignedBeaconQuery::all()).unwrap();
-        assert_eq!(3, cursor.count());
+        let get_all_cursor = connection.fetch(GetSignedBeaconQuery::all()).unwrap();
+        assert_eq!(3, get_all_cursor.count());
     }
 }

--- a/mithril-signer/src/database/query/signed_beacon/get_signed_beacon.rs
+++ b/mithril-signer/src/database/query/signed_beacon/get_signed_beacon.rs
@@ -12,8 +12,8 @@ pub struct GetSignedBeaconQuery {
 }
 
 impl GetSignedBeaconQuery {
-    #[cfg(test)]
-    pub(crate) fn all() -> Self {
+    /// Get all signed beacons.
+    pub fn all() -> Self {
         Self {
             condition: WhereCondition::default(),
         }

--- a/mithril-signer/src/database/query/signed_beacon/get_signed_beacon.rs
+++ b/mithril-signer/src/database/query/signed_beacon/get_signed_beacon.rs
@@ -1,0 +1,243 @@
+use sqlite::Value;
+
+use mithril_common::entities::SignedEntityType;
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
+
+use crate::database::record::SignedBeaconRecord;
+
+/// Simple queries to retrieve [SignedBeacon] from the sqlite database.
+pub struct GetSignedBeaconQuery {
+    condition: WhereCondition,
+}
+
+impl GetSignedBeaconQuery {
+    #[cfg(test)]
+    pub(crate) fn all() -> Self {
+        Self {
+            condition: WhereCondition::default(),
+        }
+    }
+
+    /// Get all signed beacons that match the given signed entity types.
+    pub fn by_signed_entities(signed_entity_types: &[SignedEntityType]) -> StdResult<Self> {
+        fn signed_entity_condition(entity: &SignedEntityType) -> StdResult<WhereCondition> {
+            Ok(WhereCondition::new(
+                "signed_entity_type_id = ?* and beacon = ?*",
+                vec![
+                    Value::Integer(entity.index() as i64),
+                    Value::String(entity.get_json_beacon()?),
+                ],
+            ))
+        }
+
+        let condition = match signed_entity_types {
+            [] => WhereCondition::new("false", vec![]),
+            [first, rest @ ..] => {
+                let mut condition = signed_entity_condition(first)?;
+
+                for entity in rest {
+                    condition = condition.or_where(signed_entity_condition(entity)?);
+                }
+
+                condition
+            }
+        };
+
+        Ok(Self { condition })
+    }
+}
+
+impl Query for GetSignedBeaconQuery {
+    type Entity = SignedBeaconRecord;
+
+    fn filters(&self) -> WhereCondition {
+        self.condition.clone()
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        let aliases = SourceAlias::new(&[("{:signed_beacon:}", "b")]);
+        let projection = Self::Entity::get_projection().expand(aliases);
+        format!("select {projection} from signed_beacon as b where {condition} order by ROWID desc")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::entities::{BlockNumber, Epoch};
+    use mithril_persistence::sqlite::ConnectionExtensions;
+
+    use crate::database::test_helper::{insert_signed_beacons, main_db_connection};
+
+    use super::*;
+
+    #[test]
+    fn test_get_all() {
+        let connection = main_db_connection().unwrap();
+        let records = SignedBeaconRecord::fakes(&[
+            (
+                Epoch(3),
+                vec![SignedEntityType::MithrilStakeDistribution(Epoch(3))],
+            ),
+            (
+                Epoch(4),
+                vec![
+                    SignedEntityType::CardanoStakeDistribution(Epoch(4)),
+                    SignedEntityType::CardanoTransactions(Epoch(4), BlockNumber(124)),
+                ],
+            ),
+        ]);
+        insert_signed_beacons(&connection, records.clone());
+
+        let stored_records: Vec<SignedBeaconRecord> = connection
+            .fetch_collect(GetSignedBeaconQuery::all())
+            .unwrap();
+
+        assert_eq!(
+            records.into_iter().rev().collect::<Vec<_>>(),
+            stored_records
+        );
+    }
+
+    mod get_by_signed_entities {
+        use super::*;
+
+        #[test]
+        fn with_empty_db() {
+            let connection = main_db_connection().unwrap();
+
+            let stored_records: Vec<SignedBeaconRecord> = connection
+                .fetch_collect(
+                    GetSignedBeaconQuery::by_signed_entities(&[
+                        SignedEntityType::MithrilStakeDistribution(Epoch(3)),
+                        SignedEntityType::CardanoTransactions(Epoch(4), BlockNumber(124)),
+                    ])
+                    .unwrap(),
+                )
+                .unwrap();
+
+            assert_eq!(Vec::<SignedBeaconRecord>::new(), stored_records);
+        }
+
+        #[test]
+        fn with_empty_list() {
+            let connection = main_db_connection().unwrap();
+            let records = SignedBeaconRecord::fakes(&[
+                (
+                    Epoch(3),
+                    vec![SignedEntityType::MithrilStakeDistribution(Epoch(3))],
+                ),
+                (
+                    Epoch(4),
+                    vec![SignedEntityType::CardanoStakeDistribution(Epoch(4))],
+                ),
+            ]);
+            insert_signed_beacons(&connection, records.clone());
+
+            let stored_records: Vec<SignedBeaconRecord> = connection
+                .fetch_collect(GetSignedBeaconQuery::by_signed_entities(&[]).unwrap())
+                .unwrap();
+
+            assert_eq!(Vec::<SignedBeaconRecord>::new(), stored_records);
+        }
+
+        #[test]
+        fn with_one_matching() {
+            let connection = main_db_connection().unwrap();
+            let records = SignedBeaconRecord::fakes(&[
+                (
+                    Epoch(3),
+                    vec![SignedEntityType::MithrilStakeDistribution(Epoch(3))],
+                ),
+                (
+                    Epoch(4),
+                    vec![SignedEntityType::CardanoStakeDistribution(Epoch(4))],
+                ),
+            ]);
+            insert_signed_beacons(&connection, records.clone());
+
+            let stored_records: Vec<SignedBeaconRecord> = connection
+                .fetch_collect(
+                    GetSignedBeaconQuery::by_signed_entities(&[
+                        SignedEntityType::MithrilStakeDistribution(Epoch(3)),
+                    ])
+                    .unwrap(),
+                )
+                .unwrap();
+
+            assert_eq!(
+                vec![SignedBeaconRecord::fake(
+                    Epoch(3),
+                    SignedEntityType::MithrilStakeDistribution(Epoch(3))
+                )],
+                stored_records
+            );
+        }
+
+        #[test]
+        fn with_multiple_matchings_over_several_epochs() {
+            let connection = main_db_connection().unwrap();
+            let records = SignedBeaconRecord::fakes(&[
+                (
+                    Epoch(3),
+                    vec![
+                        SignedEntityType::MithrilStakeDistribution(Epoch(3)),
+                        SignedEntityType::CardanoStakeDistribution(Epoch(3)),
+                    ],
+                ),
+                (
+                    Epoch(4),
+                    vec![
+                        SignedEntityType::CardanoStakeDistribution(Epoch(4)),
+                        SignedEntityType::MithrilStakeDistribution(Epoch(4)),
+                        SignedEntityType::CardanoTransactions(Epoch(4), BlockNumber(109)),
+                    ],
+                ),
+                (
+                    Epoch(5),
+                    vec![
+                        SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(124)),
+                        SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(133)),
+                    ],
+                ),
+            ]);
+            insert_signed_beacons(&connection, records.clone());
+
+            let stored_records: Vec<SignedBeaconRecord> = connection
+                .fetch_collect(
+                    GetSignedBeaconQuery::by_signed_entities(&[
+                        SignedEntityType::MithrilStakeDistribution(Epoch(3)),
+                        SignedEntityType::MithrilStakeDistribution(Epoch(4)),
+                        SignedEntityType::CardanoTransactions(Epoch(4), BlockNumber(109)),
+                        SignedEntityType::CardanoTransactions(Epoch(5), BlockNumber(133)),
+                    ])
+                    .unwrap(),
+                )
+                .unwrap();
+
+            assert_eq!(
+                SignedBeaconRecord::fakes(&[
+                    (
+                        Epoch(5),
+                        vec![SignedEntityType::CardanoTransactions(
+                            Epoch(5),
+                            BlockNumber(133)
+                        ),],
+                    ),
+                    (
+                        Epoch(4),
+                        vec![
+                            SignedEntityType::CardanoTransactions(Epoch(4), BlockNumber(109)),
+                            SignedEntityType::MithrilStakeDistribution(Epoch(4)),
+                        ],
+                    ),
+                    (
+                        Epoch(3),
+                        vec![SignedEntityType::MithrilStakeDistribution(Epoch(3)),],
+                    ),
+                ]),
+                stored_records
+            );
+        }
+    }
+}

--- a/mithril-signer/src/database/query/signed_beacon/insert_signed_beacon.rs
+++ b/mithril-signer/src/database/query/signed_beacon/insert_signed_beacon.rs
@@ -1,0 +1,87 @@
+use sqlite::Value;
+
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{Query, SourceAlias, SqLiteEntity, WhereCondition};
+
+use crate::database::record::SignedBeaconRecord;
+
+/// Query to insert or replace [SignedBeaconRecord] in the sqlite database
+pub struct InsertSignedBeaconRecordQuery {
+    condition: WhereCondition,
+}
+
+impl InsertSignedBeaconRecordQuery {
+    pub fn one(record: SignedBeaconRecord) -> StdResult<Self> {
+        let condition =
+        WhereCondition::new(
+            "(epoch, beacon, signed_entity_type_id, initiated_at, signed_at) values (?*, ?*, ?*, ?*, ?*)",
+            vec![
+                Value::Integer(record.epoch.try_into()?),
+                Value::String(record.signed_entity_type.get_json_beacon()?),
+                Value::Integer(record.signed_entity_type.index() as i64),
+                Value::String(record.initiated_at.to_rfc3339()),
+                Value::String(record.signed_at.to_rfc3339()),
+            ],
+        );
+
+        Ok(Self { condition })
+    }
+}
+
+impl Query for InsertSignedBeaconRecordQuery {
+    type Entity = SignedBeaconRecord;
+
+    fn filters(&self) -> WhereCondition {
+        self.condition.clone()
+    }
+
+    fn get_definition(&self, condition: &str) -> String {
+        // it is important to alias the fields with the same name as the table
+        // since the table cannot be aliased in a RETURNING statement in SQLite.
+        let projection = Self::Entity::get_projection()
+            .expand(SourceAlias::new(&[("{:signed_beacon:}", "signed_beacon")]));
+
+        format!("insert into signed_beacon {condition} returning {projection}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::entities::{Epoch, SignedEntityType};
+    use mithril_persistence::sqlite::ConnectionExtensions;
+
+    use crate::database::test_helper::main_db_connection;
+
+    use super::*;
+
+    #[test]
+    fn insert_records_in_empty_db() {
+        let connection = main_db_connection().unwrap();
+
+        let record = SignedBeaconRecord::fake(
+            Epoch(5),
+            SignedEntityType::CardanoStakeDistribution(Epoch(6)),
+        );
+        let inserted_record = connection
+            .fetch_first(InsertSignedBeaconRecordQuery::one(record.clone()).unwrap())
+            .unwrap();
+
+        assert_eq!(Some(record), inserted_record);
+    }
+
+    #[test]
+    #[should_panic]
+    fn inserting_same_record_twice_should_fail() {
+        let connection = main_db_connection().unwrap();
+
+        let record = SignedBeaconRecord::fake(
+            Epoch(13),
+            SignedEntityType::CardanoStakeDistribution(Epoch(17)),
+        );
+
+        connection
+            .fetch_first(InsertSignedBeaconRecordQuery::one(record.clone()).unwrap())
+            .unwrap();
+        let _ = connection.fetch_first(InsertSignedBeaconRecordQuery::one(record.clone()).unwrap());
+    }
+}

--- a/mithril-signer/src/database/query/signed_beacon/mod.rs
+++ b/mithril-signer/src/database/query/signed_beacon/mod.rs
@@ -1,0 +1,5 @@
+mod get_signed_beacon;
+mod insert_signed_beacon;
+
+pub use get_signed_beacon::*;
+pub use insert_signed_beacon::*;

--- a/mithril-signer/src/database/query/signed_beacon/mod.rs
+++ b/mithril-signer/src/database/query/signed_beacon/mod.rs
@@ -1,5 +1,7 @@
+mod delete_signed_beacon;
 mod get_signed_beacon;
 mod insert_signed_beacon;
 
+pub use delete_signed_beacon::*;
 pub use get_signed_beacon::*;
 pub use insert_signed_beacon::*;

--- a/mithril-signer/src/database/record/mod.rs
+++ b/mithril-signer/src/database/record/mod.rs
@@ -1,0 +1,5 @@
+//! Signer related database records
+
+mod signed_beacon_record;
+
+pub use signed_beacon_record::*;

--- a/mithril-signer/src/database/record/signed_beacon_record.rs
+++ b/mithril-signer/src/database/record/signed_beacon_record.rs
@@ -5,7 +5,7 @@ use mithril_common::entities::{Epoch, SignedEntityType};
 use mithril_persistence::database::Hydrator;
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
-use crate::services::BeaconToSign;
+use crate::entities::BeaconToSign;
 
 /// Database record of a beacon signed by the signer
 #[derive(Debug, Clone, PartialEq)]

--- a/mithril-signer/src/database/record/signed_beacon_record.rs
+++ b/mithril-signer/src/database/record/signed_beacon_record.rs
@@ -1,0 +1,154 @@
+use chrono::{DateTime, Utc};
+use sqlite::Row;
+
+use mithril_common::entities::{Epoch, SignedEntityType};
+use mithril_persistence::database::Hydrator;
+use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
+
+use crate::services::BeaconToSign;
+
+/// Database record of a beacon signed by the signer
+#[derive(Debug, Clone, PartialEq)]
+pub struct SignedBeaconRecord {
+    /// The epoch when the beacon was issued
+    pub epoch: Epoch,
+
+    /// The signed entity type to sign
+    pub signed_entity_type: SignedEntityType,
+
+    /// Datetime when the beacon was initiated
+    pub initiated_at: DateTime<Utc>,
+
+    /// Datetime when the beacon was signed
+    pub signed_at: DateTime<Utc>,
+}
+
+impl From<BeaconToSign> for SignedBeaconRecord {
+    fn from(beacon: BeaconToSign) -> Self {
+        Self {
+            epoch: beacon.epoch,
+            signed_entity_type: beacon.signed_entity_type,
+            initiated_at: beacon.initiated_at,
+            signed_at: Utc::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl SignedBeaconRecord {
+    /// Create a fake `SignedBeaconRecord` for testing purposes
+    ///
+    /// The dates fields are set to constant values to make it easier to compare.
+    pub(crate) fn fake(epoch: Epoch, signed_entity_type: SignedEntityType) -> Self {
+        let initiated_at = DateTime::<Utc>::default();
+        Self {
+            epoch,
+            signed_entity_type,
+            initiated_at,
+            signed_at: initiated_at + chrono::TimeDelta::minutes(3),
+        }
+    }
+
+    pub(crate) fn fakes(records: &[(Epoch, Vec<SignedEntityType>)]) -> Vec<Self> {
+        records
+            .iter()
+            .flat_map(|(epoch, signed_entity_types)| {
+                signed_entity_types
+                    .iter()
+                    .map(|se| Self::fake(*epoch, se.clone()))
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+impl PartialEq<BeaconToSign> for SignedBeaconRecord {
+    fn eq(&self, other: &BeaconToSign) -> bool {
+        self.epoch.eq(&other.epoch)
+            && self.signed_entity_type.eq(&other.signed_entity_type)
+            && self.initiated_at.eq(&other.initiated_at)
+    }
+}
+
+#[cfg(test)]
+impl PartialEq<SignedBeaconRecord> for BeaconToSign {
+    fn eq(&self, other: &SignedBeaconRecord) -> bool {
+        other.eq(self)
+    }
+}
+
+impl SqLiteEntity for SignedBeaconRecord {
+    fn hydrate(row: Row) -> Result<Self, HydrationError>
+    where
+        Self: Sized,
+    {
+        let epoch = row.read::<i64, _>(0);
+        let beacon_str = Hydrator::read_signed_entity_beacon_column(&row, 1);
+        let signed_entity_type_id = usize::try_from(row.read::<i64, _>(2)).map_err(|e| {
+            panic!(
+                "Integer field open_message.signed_entity_type_id cannot be turned into usize: {e}"
+            )
+        })?;
+        let initiated_at = &row.read::<&str, _>(3);
+        let signed_at = &row.read::<&str, _>(4);
+
+        let open_message = Self {
+            epoch: Epoch(epoch.try_into().map_err(|e| {
+                HydrationError::InvalidData(format!(
+                    "Could not cast i64 ({epoch}) to u64. Error: '{e}'"
+                ))
+            })?),
+            signed_entity_type: Hydrator::hydrate_signed_entity_type(signed_entity_type_id, &beacon_str)?,
+            initiated_at: DateTime::parse_from_rfc3339(initiated_at).map_err(|e| {
+                HydrationError::InvalidData(format!(
+                    "Could not turn signed_beacon.initiated_at field value '{initiated_at}' to rfc3339 Datetime. Error: {e}"
+                ))
+            })?.with_timezone(&Utc),
+            signed_at:DateTime::parse_from_rfc3339(signed_at).map_err(|e| {
+                HydrationError::InvalidData(format!(
+                    "Could not turn signed_beacon.initiated_at field value '{initiated_at}' to rfc3339 Datetime. Error: {e}"
+                ))
+            })?.with_timezone(&Utc),
+        };
+
+        Ok(open_message)
+    }
+
+    fn get_projection() -> Projection {
+        Projection::from(&[
+            ("epoch", "{:signed_beacon:}.epoch", "int"),
+            ("beacon", "{:signed_beacon:}.beacon", "text"),
+            (
+                "signed_entity_type_id",
+                "{:signed_beacon:}.signed_entity_type_id",
+                "int",
+            ),
+            ("created_at", "{:signed_beacon:}.initiated_at", "text"),
+            ("expires_at", "{:signed_beacon:}.signed_at", "text"),
+        ])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn eq_beacon_to_sign() {
+        let initiated_at = DateTime::<Utc>::default();
+        let beacon_to_sign = BeaconToSign {
+            epoch: Epoch(3),
+            signed_entity_type: SignedEntityType::MithrilStakeDistribution(Epoch(4)),
+            initiated_at,
+        };
+        let signed_beacon = SignedBeaconRecord {
+            epoch: Epoch(3),
+            signed_entity_type: SignedEntityType::MithrilStakeDistribution(Epoch(4)),
+            initiated_at,
+            signed_at: initiated_at + chrono::TimeDelta::minutes(2),
+        };
+
+        assert_eq!(signed_beacon, beacon_to_sign);
+        assert_eq!(beacon_to_sign, signed_beacon);
+    }
+}

--- a/mithril-signer/src/database/record/signed_beacon_record.rs
+++ b/mithril-signer/src/database/record/signed_beacon_record.rs
@@ -148,7 +148,24 @@ mod tests {
             signed_at: initiated_at + chrono::TimeDelta::minutes(2),
         };
 
+        // Check `impl PartialEq<BeaconToSign> for SignedBeaconRecord`
         assert_eq!(signed_beacon, beacon_to_sign);
+        assert_ne!(
+            signed_beacon,
+            BeaconToSign {
+                epoch: beacon_to_sign.epoch + 13,
+                ..beacon_to_sign.clone()
+            }
+        );
+
+        // Check `impl PartialEq<SignedBeaconRecord> for BeaconToSign`
         assert_eq!(beacon_to_sign, signed_beacon);
+        assert_ne!(
+            beacon_to_sign,
+            SignedBeaconRecord {
+                epoch: signed_beacon.epoch + 11,
+                ..signed_beacon.clone()
+            }
+        );
     }
 }

--- a/mithril-signer/src/database/record/signed_beacon_record.rs
+++ b/mithril-signer/src/database/record/signed_beacon_record.rs
@@ -86,13 +86,13 @@ impl SqLiteEntity for SignedBeaconRecord {
         let beacon_str = Hydrator::read_signed_entity_beacon_column(&row, 1);
         let signed_entity_type_id = usize::try_from(row.read::<i64, _>(2)).map_err(|e| {
             panic!(
-                "Integer field open_message.signed_entity_type_id cannot be turned into usize: {e}"
+                "Integer field signed_beacon.signed_entity_type_id cannot be turned into usize: {e}"
             )
         })?;
         let initiated_at = &row.read::<&str, _>(3);
         let signed_at = &row.read::<&str, _>(4);
 
-        let open_message = Self {
+        let signed_beacon = Self {
             epoch: Epoch(epoch.try_into().map_err(|e| {
                 HydrationError::InvalidData(format!(
                     "Could not cast i64 ({epoch}) to u64. Error: '{e}'"
@@ -111,7 +111,7 @@ impl SqLiteEntity for SignedBeaconRecord {
             })?.with_timezone(&Utc),
         };
 
-        Ok(open_message)
+        Ok(signed_beacon)
     }
 
     fn get_projection() -> Projection {

--- a/mithril-signer/src/database/repository/mod.rs
+++ b/mithril-signer/src/database/repository/mod.rs
@@ -1,3 +1,6 @@
 //! Signer related database repositories
 
 mod cardano_transaction_repository;
+mod signed_beacon_repository;
+
+pub use signed_beacon_repository::*;

--- a/mithril-signer/src/database/repository/signed_beacon_repository.rs
+++ b/mithril-signer/src/database/repository/signed_beacon_repository.rs
@@ -56,12 +56,7 @@ impl SignedBeaconStore for SignedBeaconRepository {
     }
 
     async fn mark_beacon_as_signed(&self, entity: &BeaconToSign) -> StdResult<()> {
-        let record = SignedBeaconRecord {
-            epoch: entity.epoch,
-            signed_entity_type: entity.signed_entity_type.clone(),
-            initiated_at: entity.initiated_at,
-            signed_at: chrono::Utc::now(),
-        };
+        let record = entity.clone().into();
         let _ = self
             .connection
             .fetch_first(InsertSignedBeaconRecordQuery::one(record)?)?;

--- a/mithril-signer/src/database/repository/signed_beacon_repository.rs
+++ b/mithril-signer/src/database/repository/signed_beacon_repository.rs
@@ -9,7 +9,8 @@ use crate::database::query::{
     DeleteSignedBeaconRecordQuery, GetSignedBeaconQuery, InsertSignedBeaconRecordQuery,
 };
 use crate::database::record::SignedBeaconRecord;
-use crate::services::{BeaconToSign, EpochPruningTask, SignedBeaconStore};
+use crate::entities::BeaconToSign;
+use crate::services::{EpochPruningTask, SignedBeaconStore};
 
 /// A [SignedBeaconStore] implementation using SQLite.
 pub struct SignedBeaconRepository {

--- a/mithril-signer/src/database/repository/signed_beacon_repository.rs
+++ b/mithril-signer/src/database/repository/signed_beacon_repository.rs
@@ -1,0 +1,201 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+
+use mithril_common::entities::SignedEntityType;
+use mithril_common::StdResult;
+use mithril_persistence::sqlite::{ConnectionExtensions, SqliteConnection};
+
+use crate::database::query::{GetSignedBeaconQuery, InsertSignedBeaconRecordQuery};
+use crate::database::record::SignedBeaconRecord;
+use crate::services::{BeaconToSign, SignedBeaconStore};
+
+/// A [SignedBeaconStore] implementation using SQLite.
+pub struct SignedBeaconRepository {
+    connection: Arc<SqliteConnection>,
+}
+
+impl SignedBeaconRepository {
+    /// Create a new instance of the `SignedBeaconRepository`.
+    pub fn new(connection: Arc<SqliteConnection>) -> Self {
+        Self { connection }
+    }
+}
+
+#[async_trait]
+impl SignedBeaconStore for SignedBeaconRepository {
+    async fn filter_out_already_signed_entities(
+        &self,
+        entities: Vec<SignedEntityType>,
+    ) -> StdResult<Vec<SignedEntityType>> {
+        let already_signed_entities: Vec<SignedEntityType> = self
+            .connection
+            .fetch(GetSignedBeaconQuery::by_signed_entities(&entities)?)?
+            .map(|record| record.signed_entity_type)
+            .collect();
+
+        Ok(entities
+            .into_iter()
+            .filter(|e| !already_signed_entities.contains(e))
+            .collect())
+    }
+
+    async fn mark_beacon_as_signed(&self, entity: &BeaconToSign) -> StdResult<()> {
+        let record = SignedBeaconRecord {
+            epoch: entity.epoch,
+            signed_entity_type: entity.signed_entity_type.clone(),
+            initiated_at: entity.initiated_at,
+            signed_at: chrono::Utc::now(),
+        };
+        let _ = self
+            .connection
+            .fetch_first(InsertSignedBeaconRecordQuery::one(record)?)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use mithril_common::entities::{
+        Epoch, SignedEntityConfig, SignedEntityTypeDiscriminants, TimePoint,
+    };
+    use mithril_persistence::sqlite::ConnectionExtensions;
+
+    use crate::database::query::GetSignedBeaconQuery;
+    use crate::database::record::SignedBeaconRecord;
+    use crate::database::test_helper::{insert_signed_beacons, main_db_connection};
+
+    use super::*;
+
+    fn all_signed_entity_type_for(time_point: &TimePoint) -> Vec<SignedEntityType> {
+        let config = SignedEntityConfig {
+            allowed_discriminants: SignedEntityTypeDiscriminants::all(),
+            ..SignedEntityConfig::dummy()
+        };
+        config.list_allowed_signed_entity_types(time_point).unwrap()
+    }
+
+    #[tokio::test]
+    async fn filter_out_nothing_if_nothing_was_previously_signed() {
+        let connection = Arc::new(main_db_connection().unwrap());
+        let repository = SignedBeaconRepository::new(connection.clone());
+
+        let to_filter = all_signed_entity_type_for(&TimePoint::dummy());
+        let available_entities = repository
+            .filter_out_already_signed_entities(to_filter.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(to_filter, available_entities);
+    }
+
+    #[tokio::test]
+    async fn filter_out_nothing_if_previously_signed_entities_doesnt_match_passed_entities() {
+        let connection = Arc::new(main_db_connection().unwrap());
+        let repository = SignedBeaconRepository::new(connection.clone());
+
+        let time_point = TimePoint::dummy();
+        insert_signed_beacons(
+            &connection,
+            SignedBeaconRecord::fakes(&[(
+                Epoch(1941),
+                vec![SignedEntityType::MithrilStakeDistribution(
+                    time_point.epoch - 2,
+                )],
+            )]),
+        );
+        let to_filter = all_signed_entity_type_for(&time_point);
+
+        let available_entities = repository
+            .filter_out_already_signed_entities(to_filter.clone())
+            .await
+            .unwrap();
+        assert_eq!(to_filter, available_entities);
+    }
+
+    #[tokio::test]
+    async fn filter_out_everything_if_previously_signed_entities_match_all_passed_entities() {
+        let connection = Arc::new(main_db_connection().unwrap());
+        let repository = SignedBeaconRepository::new(connection.clone());
+
+        let to_filter = all_signed_entity_type_for(&TimePoint::dummy());
+        insert_signed_beacons(
+            &connection,
+            to_filter
+                .iter()
+                .map(|entity| SignedBeaconRecord::fake(Epoch(4872), entity.clone()))
+                .collect(),
+        );
+
+        let available_entities = repository
+            .filter_out_already_signed_entities(to_filter.clone())
+            .await
+            .unwrap();
+        assert_eq!(Vec::<SignedEntityType>::new(), available_entities);
+    }
+
+    #[tokio::test]
+    async fn filter_out_partially_if_some_previously_signed_entities_match_passed_entities() {
+        let connection = Arc::new(main_db_connection().unwrap());
+        let repository = SignedBeaconRepository::new(connection.clone());
+
+        let time_point = TimePoint::dummy();
+        let signed_beacons = [
+            SignedEntityType::MithrilStakeDistribution(time_point.epoch),
+            SignedEntityType::CardanoTransactions(
+                time_point.epoch,
+                time_point.chain_point.block_number,
+            ),
+        ];
+        insert_signed_beacons(
+            &connection,
+            signed_beacons
+                .iter()
+                .map(|entity| SignedBeaconRecord::fake(Epoch(4872), entity.clone()))
+                .collect(),
+        );
+
+        let to_filter = all_signed_entity_type_for(&time_point);
+        let available_entities = repository
+            .filter_out_already_signed_entities(to_filter.clone())
+            .await
+            .unwrap();
+
+        let expected: Vec<SignedEntityType> = to_filter
+            .iter()
+            .filter(|entity| !signed_beacons.contains(entity))
+            .cloned()
+            .collect();
+        assert_eq!(expected, available_entities);
+    }
+
+    #[tokio::test]
+    async fn mark_beacon_as_signed() {
+        let connection = Arc::new(main_db_connection().unwrap());
+        let repository = SignedBeaconRepository::new(connection.clone());
+
+        let beacon_to_sign = BeaconToSign {
+            epoch: Epoch(13),
+            signed_entity_type: SignedEntityType::MithrilStakeDistribution(Epoch(13)),
+            initiated_at: Utc::now(),
+        };
+
+        let signed_beacons: Vec<SignedBeaconRecord> = connection
+            .fetch_collect(GetSignedBeaconQuery::all())
+            .unwrap();
+        assert_eq!(Vec::<SignedBeaconRecord>::new(), signed_beacons);
+
+        repository
+            .mark_beacon_as_signed(&beacon_to_sign)
+            .await
+            .unwrap();
+
+        let signed_beacon = connection
+            .fetch_first(GetSignedBeaconQuery::all())
+            .unwrap()
+            .expect("A signed beacon should have been inserted");
+        assert_eq!(beacon_to_sign, signed_beacon);
+    }
+}

--- a/mithril-signer/src/database/repository/signed_beacon_repository.rs
+++ b/mithril-signer/src/database/repository/signed_beacon_repository.rs
@@ -233,18 +233,26 @@ mod tests {
                 .collect(),
         );
 
-        let to_filter = all_signed_entity_type_for(&time_point);
         let available_entities = repository
-            .filter_out_already_signed_entities(to_filter.clone())
+            .filter_out_already_signed_entities(vec![
+                SignedEntityType::MithrilStakeDistribution(time_point.epoch),
+                SignedEntityType::CardanoStakeDistribution(time_point.epoch),
+                SignedEntityType::CardanoTransactions(
+                    time_point.epoch,
+                    time_point.chain_point.block_number,
+                ),
+                SignedEntityType::CardanoStakeDistribution(time_point.epoch + 10),
+            ])
             .await
             .unwrap();
 
-        let expected: Vec<SignedEntityType> = to_filter
-            .iter()
-            .filter(|entity| !signed_beacons.contains(entity))
-            .cloned()
-            .collect();
-        assert_eq!(expected, available_entities);
+        assert_eq!(
+            vec![
+                SignedEntityType::CardanoStakeDistribution(time_point.epoch),
+                SignedEntityType::CardanoStakeDistribution(time_point.epoch + 10),
+            ],
+            available_entities
+        );
     }
 
     #[tokio::test]

--- a/mithril-signer/src/database/test_helper.rs
+++ b/mithril-signer/src/database/test_helper.rs
@@ -1,7 +1,12 @@
 use std::path::Path;
 
 use mithril_common::StdResult;
-use mithril_persistence::sqlite::{ConnectionBuilder, ConnectionOptions, SqliteConnection};
+use mithril_persistence::sqlite::{
+    ConnectionBuilder, ConnectionExtensions, ConnectionOptions, SqliteConnection,
+};
+
+use crate::database::query::InsertSignedBeaconRecordQuery;
+use crate::database::record::SignedBeaconRecord;
 
 /// In-memory sqlite database without foreign key support with migrations applied
 pub fn main_db_connection() -> StdResult<SqliteConnection> {
@@ -47,4 +52,12 @@ fn build_cardano_tx_db_connection(
         )
         .build()?;
     Ok(connection)
+}
+
+pub fn insert_signed_beacons(connection: &SqliteConnection, records: Vec<SignedBeaconRecord>) {
+    for record in records.iter() {
+        connection
+            .fetch_first(InsertSignedBeaconRecordQuery::one(record.clone()).unwrap())
+            .unwrap();
+    }
 }

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -320,10 +320,7 @@ impl<'a> DependenciesBuilder<'a> {
         let cardano_stake_distribution_signable_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
-            stake_store.clone(),
-            network,
-        )));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             single_signer.clone(),

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -35,12 +35,14 @@ use mithril_persistence::sqlite::{ConnectionBuilder, SqliteConnection, SqliteCon
 use mithril_persistence::store::adapter::SQLiteAdapter;
 use mithril_persistence::store::StakeStore;
 
+use crate::database::repository::SignedBeaconRepository;
 use crate::dependency_injection::SignerDependencyContainer;
 use crate::services::{
     AggregatorHTTPClient, CardanoTransactionsImporter,
     CardanoTransactionsPreloaderActivationSigner, MithrilEpochService, MithrilSingleSigner,
-    SignerSignableSeedBuilder, SignerUpkeepService, TransactionsImporterByChunk,
-    TransactionsImporterWithPruner, TransactionsImporterWithVacuum,
+    SignerCertifierService, SignerSignableSeedBuilder, SignerSignedEntityConfigProvider,
+    SignerUpkeepService, TransactionsImporterByChunk, TransactionsImporterWithPruner,
+    TransactionsImporterWithVacuum,
 };
 use crate::store::{MKTreeStoreSqlite, ProtocolInitializerStore};
 use crate::{
@@ -351,6 +353,15 @@ impl<'a> DependenciesBuilder<'a> {
             signed_entity_type_lock.clone(),
             slog_scope::logger(),
         ));
+        let certifier = Arc::new(SignerCertifierService::new(
+            ticker_service.clone(),
+            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone())),
+            Arc::new(SignerSignedEntityConfigProvider::new(
+                network,
+                epoch_service.clone(),
+            )),
+            signed_entity_type_lock.clone(),
+        ));
 
         let services = SignerDependencyContainer {
             ticker_service,
@@ -369,6 +380,7 @@ impl<'a> DependenciesBuilder<'a> {
             cardano_transactions_preloader,
             upkeep_service,
             epoch_service,
+            certifier,
         };
 
         Ok(services)

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -347,15 +347,19 @@ impl<'a> DependenciesBuilder<'a> {
             slog_scope::logger(),
             Arc::new(preloader_activation),
         ));
+        let signed_beacon_repository =
+            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone()));
         let upkeep_service = Arc::new(SignerUpkeepService::new(
             sqlite_connection.clone(),
             sqlite_connection_cardano_transaction_pool,
             signed_entity_type_lock.clone(),
+            vec![signed_beacon_repository.clone()],
+            self.config.store_retention_limit.map(|limit| limit as u64),
             slog_scope::logger(),
         ));
         let certifier = Arc::new(SignerCertifierService::new(
             ticker_service.clone(),
-            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone())),
+            signed_beacon_repository,
             Arc::new(SignerSignedEntityConfigProvider::new(
                 network,
                 epoch_service.clone(),

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -347,14 +347,15 @@ impl<'a> DependenciesBuilder<'a> {
             slog_scope::logger(),
             Arc::new(preloader_activation),
         ));
-        let signed_beacon_repository =
-            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone()));
+        let signed_beacon_repository = Arc::new(SignedBeaconRepository::new(
+            sqlite_connection.clone(),
+            self.config.store_retention_limit.map(|limit| limit as u64),
+        ));
         let upkeep_service = Arc::new(SignerUpkeepService::new(
             sqlite_connection.clone(),
             sqlite_connection_cardano_transaction_pool,
             signed_entity_type_lock.clone(),
             vec![signed_beacon_repository.clone()],
-            self.config.store_retention_limit.map(|limit| limit as u64),
             slog_scope::logger(),
         ));
         let certifier = Arc::new(SignerCertifierService::new(

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -320,7 +320,10 @@ impl<'a> DependenciesBuilder<'a> {
         let cardano_stake_distribution_signable_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
+            stake_store.clone(),
+            network,
+        )));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             single_signer.clone(),

--- a/mithril-signer/src/dependency_injection/containers.rs
+++ b/mithril-signer/src/dependency_injection/containers.rs
@@ -11,7 +11,9 @@ use mithril_common::TickerService;
 use mithril_persistence::store::StakeStore;
 use tokio::sync::RwLock;
 
-use crate::services::{AggregatorClient, EpochService, SingleSigner, UpkeepService};
+use crate::services::{
+    AggregatorClient, CertifierService, EpochService, SingleSigner, UpkeepService,
+};
 use crate::store::ProtocolInitializerStorer;
 use crate::MetricsService;
 
@@ -75,4 +77,7 @@ pub struct SignerDependencyContainer {
 
     /// Epoch service
     pub epoch_service: EpochServiceWrapper,
+
+    /// Certifier service
+    pub certifier: Arc<dyn CertifierService>,
 }

--- a/mithril-signer/src/entities/beacon_to_sign.rs
+++ b/mithril-signer/src/entities/beacon_to_sign.rs
@@ -1,0 +1,31 @@
+use chrono::{DateTime, Utc};
+
+use mithril_common::entities::{Epoch, SignedEntityType};
+
+/// Beacon to sign
+#[derive(Debug, Clone, PartialEq)]
+pub struct BeaconToSign {
+    /// The epoch when the beacon was issued
+    pub epoch: Epoch,
+
+    /// The signed entity type to sign
+    pub signed_entity_type: SignedEntityType,
+
+    /// Datetime when the beacon was initiated
+    pub initiated_at: DateTime<Utc>,
+}
+
+impl BeaconToSign {
+    /// Create a new `BeaconToSign`
+    pub fn new(
+        epoch: Epoch,
+        signed_entity_type: SignedEntityType,
+        initiated_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            epoch,
+            signed_entity_type,
+            initiated_at,
+        }
+    }
+}

--- a/mithril-signer/src/entities/mod.rs
+++ b/mithril-signer/src/entities/mod.rs
@@ -2,6 +2,8 @@
 //!
 //! This module provide domain entities for the services & state machine.
 
+mod beacon_to_sign;
 mod signer_epoch_settings;
 
+pub use beacon_to_sign::*;
 pub use signer_epoch_settings::*;

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -572,6 +572,7 @@ mod tests {
         let adapter: MemoryAdapter<Epoch, ProtocolInitializer> = MemoryAdapter::new(None).unwrap();
         let stake_distribution_signers = fake_data::signers_with_stakes(2);
         let party_id = stake_distribution_signers[1].party_id.clone();
+        let network = fake_data::network();
         let fake_observer = FakeObserver::default();
         fake_observer.set_signers(stake_distribution_signers).await;
         let chain_observer = Arc::new(fake_observer);
@@ -617,7 +618,10 @@ mod tests {
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
+            stake_store.clone(),
+            network,
+        )));
         let single_signer = Arc::new(MithrilSingleSigner::new(party_id));
         let protocol_initializer_store =
             Arc::new(ProtocolInitializerStore::new(Box::new(adapter), None));

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -618,10 +618,7 @@ mod tests {
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
-            stake_store.clone(),
-            network,
-        )));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
         let single_signer = Arc::new(MithrilSingleSigner::new(party_id));
         let protocol_initializer_store =
             Arc::new(ProtocolInitializerStore::new(Box::new(adapter), None));

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -13,8 +13,8 @@ use mithril_common::StdResult;
 use mithril_persistence::store::StakeStorer;
 
 use crate::dependency_injection::SignerDependencyContainer;
-use crate::entities::SignerEpochSettings;
-use crate::services::{BeaconToSign, EpochService, MithrilProtocolInitializerBuilder};
+use crate::entities::{BeaconToSign, SignerEpochSettings};
+use crate::services::{EpochService, MithrilProtocolInitializerBuilder};
 use crate::Configuration;
 
 /// This trait is mainly intended for mocking.

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -642,7 +642,7 @@ mod tests {
         let upkeep_service = Arc::new(MockUpkeepService::new());
         let certifier = Arc::new(SignerCertifierService::new(
             ticker_service.clone(),
-            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone())),
+            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone(), None)),
             Arc::new(SignerSignedEntityConfigProvider::new(
                 network,
                 epoch_service.clone(),

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -361,7 +361,7 @@ impl StateMachine {
             .signer_registration_success_last_epoch_gauge_set(epoch);
 
         self.runner
-            .upkeep()
+            .upkeep(epoch)
             .await
             .map_err(|e| RuntimeError::KeepState {
                 message: "Failed to upkeep signer in 'unregistered → registered' phase".to_string(),
@@ -581,7 +581,7 @@ mod tests {
     #[tokio::test]
     async fn unregistered_to_registered_not_able_to_sign() {
         let mut runner = MockSignerRunner::new();
-        runner.expect_upkeep().returning(|| Ok(())).once();
+        runner.expect_upkeep().returning(|_| Ok(())).once();
         runner
             .expect_get_epoch_settings()
             .once()
@@ -635,7 +635,7 @@ mod tests {
     #[tokio::test]
     async fn unregistered_to_ready_to_sign() {
         let mut runner = MockSignerRunner::new();
-        runner.expect_upkeep().returning(|| Ok(())).once();
+        runner.expect_upkeep().returning(|_| Ok(())).once();
         runner
             .expect_get_epoch_settings()
             .once()

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -7,8 +7,8 @@ use mithril_common::{
     entities::{Epoch, SignedEntityType, TimePoint},
 };
 
-use crate::services::BeaconToSign;
-use crate::{entities::SignerEpochSettings, MetricsService};
+use crate::entities::{BeaconToSign, SignerEpochSettings};
+use crate::MetricsService;
 
 use super::{Runner, RuntimeError};
 
@@ -498,7 +498,6 @@ mod tests {
     use mithril_common::test_utils::fake_data;
 
     use crate::runtime::runner::MockSignerRunner;
-    use crate::services::BeaconToSign;
 
     use super::*;
 

--- a/mithril-signer/src/services/aggregator_client.rs
+++ b/mithril-signer/src/services/aggregator_client.rs
@@ -355,6 +355,7 @@ pub(crate) mod dumb {
         epoch_settings: RwLock<Option<SignerEpochSettings>>,
         certificate_pending: RwLock<Option<CertificatePending>>,
         last_registered_signer: RwLock<Option<Signer>>,
+        aggregator_features: RwLock<AggregatorFeaturesMessage>,
     }
 
     impl DumbAggregatorClient {
@@ -364,6 +365,7 @@ pub(crate) mod dumb {
                 epoch_settings: RwLock::new(None),
                 certificate_pending: RwLock::new(None),
                 last_registered_signer: RwLock::new(None),
+                aggregator_features: RwLock::new(AggregatorFeaturesMessage::dummy()),
             }
         }
 
@@ -389,6 +391,14 @@ pub(crate) mod dumb {
         pub async fn get_last_registered_signer(&self) -> Option<Signer> {
             self.last_registered_signer.read().await.clone()
         }
+
+        pub async fn set_aggregator_features(
+            &self,
+            aggregator_features: AggregatorFeaturesMessage,
+        ) {
+            let mut aggregator_features_writer = self.aggregator_features.write().await;
+            *aggregator_features_writer = aggregator_features;
+        }
     }
 
     impl Default for DumbAggregatorClient {
@@ -397,6 +407,7 @@ pub(crate) mod dumb {
                 epoch_settings: RwLock::new(Some(SignerEpochSettings::dummy())),
                 certificate_pending: RwLock::new(Some(fake_data::certificate_pending())),
                 last_registered_signer: RwLock::new(None),
+                aggregator_features: RwLock::new(AggregatorFeaturesMessage::dummy()),
             }
         }
     }
@@ -445,7 +456,8 @@ pub(crate) mod dumb {
         async fn retrieve_aggregator_features(
             &self,
         ) -> Result<AggregatorFeaturesMessage, AggregatorClientError> {
-            Ok(AggregatorFeaturesMessage::dummy())
+            let aggregator_features = self.aggregator_features.read().await;
+            Ok(aggregator_features.clone())
         }
     }
 }

--- a/mithril-signer/src/services/certifier.rs
+++ b/mithril-signer/src/services/certifier.rs
@@ -36,9 +36,10 @@ pub trait CertifierService: Sync + Send {
 
 /// Trait to provide the current signed entity configuration that can change over time.
 #[cfg_attr(test, mockall::automock)]
+#[async_trait]
 pub trait SignedEntityConfigProvider: Sync + Send {
     /// Get the current signed entity configuration.
-    fn get(&self) -> StdResult<SignedEntityConfig>;
+    async fn get(&self) -> StdResult<SignedEntityConfig>;
 }
 
 /// Trait to store beacons that have been signed in order to avoid signing them twice.
@@ -85,7 +86,8 @@ impl SignerCertifierService {
     ) -> StdResult<Vec<SignedEntityType>> {
         let signed_entity_types = self
             .signed_entity_config_provider
-            .get()?
+            .get()
+            .await?
             .list_allowed_signed_entity_types(time_point)?;
         let unlocked_signed_entities = self
             .signed_entity_type_lock
@@ -334,8 +336,9 @@ mod tests {
             }
         }
 
+        #[async_trait]
         impl SignedEntityConfigProvider for DumbSignedEntityConfigProvider {
-            fn get(&self) -> StdResult<SignedEntityConfig> {
+            async fn get(&self) -> StdResult<SignedEntityConfig> {
                 Ok(self.config.clone())
             }
         }

--- a/mithril-signer/src/services/certifier.rs
+++ b/mithril-signer/src/services/certifier.rs
@@ -1,23 +1,12 @@
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use std::sync::Arc;
 
-use mithril_common::entities::{Epoch, SignedEntityConfig, SignedEntityType, TimePoint};
+use mithril_common::entities::{SignedEntityConfig, SignedEntityType, TimePoint};
 use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
 use mithril_common::{StdResult, TickerService};
 
-/// Beacon to sign
-#[derive(Debug, Clone, PartialEq)]
-pub struct BeaconToSign {
-    /// The epoch when the beacon was issued
-    pub epoch: Epoch,
-
-    /// The signed entity type to sign
-    pub signed_entity_type: SignedEntityType,
-
-    /// Datetime when the beacon was initiated
-    pub initiated_at: DateTime<Utc>,
-}
+use crate::entities::BeaconToSign;
 
 /// Certifier Service
 ///
@@ -114,11 +103,8 @@ impl CertifierService for SignerCertifierService {
             Ok(None)
         } else {
             let signed_entity_type = available_signed_entity_types[0].clone();
-            let beacon_to_sign = BeaconToSign {
-                epoch: time_point.epoch,
-                signed_entity_type,
-                initiated_at: Utc::now(),
-            };
+            let beacon_to_sign =
+                BeaconToSign::new(time_point.epoch, signed_entity_type, Utc::now());
 
             Ok(Some(beacon_to_sign))
         }
@@ -134,7 +120,7 @@ impl CertifierService for SignerCertifierService {
 #[cfg(test)]
 mod tests {
     use mithril_common::entities::{
-        CardanoTransactionsSigningConfig, ChainPoint, SignedEntityTypeDiscriminants,
+        CardanoTransactionsSigningConfig, ChainPoint, Epoch, SignedEntityTypeDiscriminants,
     };
 
     use super::{tests::tests_tooling::*, *};

--- a/mithril-signer/src/services/certifier.rs
+++ b/mithril-signer/src/services/certifier.rs
@@ -1,0 +1,72 @@
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use std::sync::Arc;
+
+use mithril_common::entities::{Epoch, SignedEntityType};
+use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
+use mithril_common::StdResult;
+
+/// Beacon to sign
+#[derive(Debug, Clone, PartialEq)]
+pub struct BeaconToSign {
+    /// The epoch when the beacon was issued
+    pub epoch: Epoch,
+
+    /// The signed entity type to sign
+    pub signed_entity_type: SignedEntityType,
+
+    /// Datetime when the beacon was initiated
+    pub initiated_at: DateTime<Utc>,
+}
+
+/// Certifier Service
+///
+/// This service is responsible for providing the beacons that need to be signed by the signer.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait CertifierService: Sync + Send {
+    /// Get the beacon to sign.
+    ///
+    /// If all available signed entity have already been signed, `None` is returned.
+    async fn get_beacon_to_sign(&self) -> StdResult<Option<BeaconToSign>>;
+}
+
+/// Implementation of the [Certifier Service][CertifierService] for the Mithril Signer.
+pub struct SignerCertifierService {
+    signed_entity_type_lock: Arc<SignedEntityTypeLock>,
+}
+
+impl SignerCertifierService {
+    /// Create a new `SignerCertifierService` instance.
+    pub fn new(signed_entity_type_lock: Arc<SignedEntityTypeLock>) -> Self {
+        Self {
+            signed_entity_type_lock,
+        }
+    }
+}
+
+#[async_trait]
+impl CertifierService for SignerCertifierService {
+    async fn get_beacon_to_sign(&self) -> StdResult<Option<BeaconToSign>> {
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::entities::SignedEntityTypeDiscriminants;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn no_beacon_can_be_signed_if_all_entities_are_locked() {
+        let locker = Arc::new(SignedEntityTypeLock::new());
+        for signed_entity_type in SignedEntityTypeDiscriminants::all() {
+            locker.lock(signed_entity_type).await;
+        }
+        let certifier_service = SignerCertifierService::new(locker);
+
+        let beacon_to_sign = certifier_service.get_beacon_to_sign().await.unwrap();
+        assert_eq!(beacon_to_sign, None);
+    }
+}

--- a/mithril-signer/src/services/certifier.rs
+++ b/mithril-signer/src/services/certifier.rs
@@ -1,10 +1,14 @@
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use mithril_common::entities::{Epoch, SignedEntityType};
+use mithril_common::entities::{
+    CardanoTransactionsSigningConfig, Epoch, SignedEntityConfig, SignedEntityType,
+    SignedEntityTypeDiscriminants, TimePoint,
+};
 use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
-use mithril_common::StdResult;
+use mithril_common::{CardanoNetwork, StdResult, TickerService};
 
 /// Beacon to sign
 #[derive(Debug, Clone, PartialEq)]
@@ -31,32 +35,104 @@ pub trait CertifierService: Sync + Send {
     async fn get_beacon_to_sign(&self) -> StdResult<Option<BeaconToSign>>;
 }
 
+/// Trait to provide the current Cardano transactions signing configuration.
+#[cfg_attr(test, mockall::automock)]
+pub trait CardanoTransactionsSigningConfigProvider: Sync + Send {
+    /// Get the current Cardano transactions signing configuration.
+    fn get(&self) -> StdResult<CardanoTransactionsSigningConfig>;
+}
+
 /// Implementation of the [Certifier Service][CertifierService] for the Mithril Signer.
 pub struct SignerCertifierService {
+    network: CardanoNetwork,
+    ticker_service: Arc<dyn TickerService>,
+    cardano_transactions_signing_config_provider: Arc<dyn CardanoTransactionsSigningConfigProvider>,
     signed_entity_type_lock: Arc<SignedEntityTypeLock>,
 }
 
 impl SignerCertifierService {
     /// Create a new `SignerCertifierService` instance.
-    pub fn new(signed_entity_type_lock: Arc<SignedEntityTypeLock>) -> Self {
+    pub fn new(
+        network: CardanoNetwork,
+        ticker_service: Arc<dyn TickerService>,
+        cardano_transactions_signing_config_provider: Arc<
+            dyn CardanoTransactionsSigningConfigProvider,
+        >,
+        signed_entity_type_lock: Arc<SignedEntityTypeLock>,
+    ) -> Self {
         Self {
+            network,
+            ticker_service,
+            cardano_transactions_signing_config_provider,
             signed_entity_type_lock,
         }
+    }
+
+    async fn compute_signing_config(&self) -> StdResult<SignedEntityConfig> {
+        // Hardcoded list, should we allow to configure this?
+        // Note: we don't use `SignedEntityTypeDiscriminants::all()` to avoid adding entities
+        // that are still in development.
+        let allowed_discriminants = BTreeSet::from([
+            SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            SignedEntityTypeDiscriminants::CardanoStakeDistribution,
+            SignedEntityTypeDiscriminants::CardanoTransactions,
+        ]);
+        let cardano_transactions_signing_config =
+            self.cardano_transactions_signing_config_provider.get()?;
+
+        Ok(SignedEntityConfig {
+            allowed_discriminants,
+            network: self.network,
+            cardano_transactions_signing_config,
+        })
+    }
+
+    async fn list_available_signed_entity_types(
+        &self,
+        time_point: &TimePoint,
+    ) -> StdResult<Vec<SignedEntityType>> {
+        let signed_entity_types = self
+            .compute_signing_config()
+            .await?
+            .list_allowed_signed_entity_types(time_point)?;
+        let unlocked_signed_entities = self
+            .signed_entity_type_lock
+            .filter_unlocked_entries(signed_entity_types)
+            .await;
+
+        Ok(unlocked_signed_entities)
     }
 }
 
 #[async_trait]
 impl CertifierService for SignerCertifierService {
     async fn get_beacon_to_sign(&self) -> StdResult<Option<BeaconToSign>> {
-        Ok(None)
+        let time_point = self.ticker_service.get_current_time_point().await?;
+
+        let available_signed_entity_types =
+            self.list_available_signed_entity_types(&time_point).await?;
+
+        if available_signed_entity_types.is_empty() {
+            Ok(None)
+        } else {
+            let signed_entity_type = available_signed_entity_types[0].clone();
+            let beacon_to_sign = BeaconToSign {
+                epoch: time_point.epoch,
+                signed_entity_type,
+                initiated_at: Utc::now(),
+            };
+
+            Ok(Some(beacon_to_sign))
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::entities::SignedEntityTypeDiscriminants;
+    use mithril_common::entities::ChainPoint;
 
-    use super::*;
+    use super::{tests::tests_tooling::*, *};
 
     #[tokio::test]
     async fn no_beacon_can_be_signed_if_all_entities_are_locked() {
@@ -64,9 +140,80 @@ mod tests {
         for signed_entity_type in SignedEntityTypeDiscriminants::all() {
             locker.lock(signed_entity_type).await;
         }
-        let certifier_service = SignerCertifierService::new(locker);
+        let certifier_service = SignerCertifierService::new(
+            CardanoNetwork::TestNet(42),
+            Arc::new(DumbTickerService::new(TimePoint::dummy())),
+            Arc::new(DumbCardanoTransactionsSigningConfigProvider::new(
+                CardanoTransactionsSigningConfig::dummy(),
+            )),
+            locker,
+        );
 
         let beacon_to_sign = certifier_service.get_beacon_to_sign().await.unwrap();
         assert_eq!(beacon_to_sign, None);
+    }
+
+    #[tokio::test]
+    async fn if_available_mithril_stake_distribution_is_the_first_beacon_to_sign() {
+        let ticker_service = DumbTickerService::new(TimePoint::new(1, 14, ChainPoint::dummy()));
+        let certifier_service = SignerCertifierService::new(
+            CardanoNetwork::TestNet(42),
+            Arc::new(ticker_service),
+            Arc::new(DumbCardanoTransactionsSigningConfigProvider::new(
+                CardanoTransactionsSigningConfig::dummy(),
+            )),
+            Arc::new(SignedEntityTypeLock::new()),
+        );
+
+        let beacon_to_sign = certifier_service.get_beacon_to_sign().await.unwrap();
+
+        assert!(
+            matches!(
+                beacon_to_sign,
+                Some(BeaconToSign {
+                    epoch: Epoch(1),
+                    signed_entity_type: SignedEntityType::MithrilStakeDistribution(Epoch(1)),
+                    ..
+                })
+            ),
+            "expected beacon to sign to be MithrilStakeDistribution(Epoch(1)), got: {beacon_to_sign:?}",
+        );
+    }
+
+    pub mod tests_tooling {
+        use super::*;
+
+        pub struct DumbTickerService {
+            time_point: TimePoint,
+        }
+
+        impl DumbTickerService {
+            pub fn new(time_point: TimePoint) -> Self {
+                Self { time_point }
+            }
+        }
+
+        #[async_trait]
+        impl TickerService for DumbTickerService {
+            async fn get_current_time_point(&self) -> StdResult<TimePoint> {
+                Ok(self.time_point.clone())
+            }
+        }
+
+        pub struct DumbCardanoTransactionsSigningConfigProvider {
+            config: CardanoTransactionsSigningConfig,
+        }
+
+        impl DumbCardanoTransactionsSigningConfigProvider {
+            pub fn new(config: CardanoTransactionsSigningConfig) -> Self {
+                Self { config }
+            }
+        }
+
+        impl CardanoTransactionsSigningConfigProvider for DumbCardanoTransactionsSigningConfigProvider {
+            fn get(&self) -> StdResult<CardanoTransactionsSigningConfig> {
+                Ok(self.config.clone())
+            }
+        }
     }
 }

--- a/mithril-signer/src/services/epoch_service.rs
+++ b/mithril-signer/src/services/epoch_service.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use async_trait::async_trait;
 use slog_scope::{debug, trace};
 use std::collections::BTreeSet;
@@ -15,6 +16,7 @@ use mithril_common::entities::SignerWithStake;
 use mithril_common::StdResult;
 
 use crate::entities::SignerEpochSettings;
+use crate::services::SignedEntityConfigDataProvider;
 use crate::RunnerError;
 
 /// Errors dedicated to the EpochService.
@@ -230,6 +232,21 @@ impl EpochService for MithrilEpochService {
             s.party_id == party_id
                 && s.verification_key == protocol_initializer.verification_key().into()
         }))
+    }
+}
+
+impl SignedEntityConfigDataProvider for MithrilEpochService {
+    fn get_cardano_transaction_signing_config(
+        &self,
+    ) -> StdResult<CardanoTransactionsSigningConfig> {
+        match self.cardano_transactions_signing_config()? {
+            Some(config) => Ok(config.clone()),
+            None => Err(anyhow!("No cardano transaction signing config available")),
+        }
+    }
+
+    fn get_allowed_discriminants(&self) -> StdResult<BTreeSet<SignedEntityTypeDiscriminants>> {
+        self.allowed_discriminants().cloned()
     }
 }
 

--- a/mithril-signer/src/services/mod.rs
+++ b/mithril-signer/src/services/mod.rs
@@ -11,6 +11,7 @@
 
 mod aggregator_client;
 mod cardano_transactions;
+mod certifier;
 mod epoch_service;
 mod signable_builder;
 mod single_signer;
@@ -20,6 +21,7 @@ mod upkeep_service;
 pub use aggregator_client::dumb::DumbAggregatorClient;
 pub use aggregator_client::*;
 pub use cardano_transactions::*;
+pub use certifier::*;
 pub use epoch_service::*;
 pub use signable_builder::*;
 pub use single_signer::*;

--- a/mithril-signer/src/services/upkeep_service.rs
+++ b/mithril-signer/src/services/upkeep_service.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use slog::{info, Logger};
 
+use mithril_common::entities::Epoch;
 use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{
@@ -22,7 +23,7 @@ use mithril_persistence::sqlite::{
 #[async_trait]
 pub trait UpkeepService: Send + Sync {
     /// Run the upkeep service.
-    async fn run(&self) -> StdResult<()>;
+    async fn run(&self, current_epoch: Epoch) -> StdResult<()>;
 }
 
 /// Implementation of the upkeep service for the signer.
@@ -97,7 +98,7 @@ impl SignerUpkeepService {
 
 #[async_trait]
 impl UpkeepService for SignerUpkeepService {
-    async fn run(&self) -> StdResult<()> {
+    async fn run(&self, _current_epoch: Epoch) -> StdResult<()> {
         info!(self.logger, "UpkeepService::start");
 
         self.upkeep_all_databases()
@@ -147,7 +148,7 @@ mod tests {
                 TestLogger::file(&log_path),
             );
 
-            service.run().await.expect("Upkeep service failed");
+            service.run(Epoch(13)).await.expect("Upkeep service failed");
         }
 
         let logs = std::fs::read_to_string(&log_path).unwrap();
@@ -188,7 +189,7 @@ mod tests {
                 TestLogger::file(&log_path),
             );
 
-            service.run().await.expect("Upkeep service failed");
+            service.run(Epoch(13)).await.expect("Upkeep service failed");
         }
 
         let logs = std::fs::read_to_string(&log_path).unwrap();

--- a/mithril-signer/src/services/upkeep_service.rs
+++ b/mithril-signer/src/services/upkeep_service.rs
@@ -33,8 +33,8 @@ pub trait EpochPruningTask: Send + Sync {
     /// Get the name of the data that will be pruned.
     fn pruned_data(&self) -> &'static str;
 
-    /// Prune the datasource below the given epoch threshold.
-    async fn prune_below_epoch_threshold(&self, epoch_threshold: Epoch) -> StdResult<()>;
+    /// Prune the datasource based on the given current epoch.
+    async fn prune(&self, current_epoch: Epoch) -> StdResult<()>;
 }
 
 /// Implementation of the upkeep service for the signer.
@@ -46,7 +46,6 @@ pub struct SignerUpkeepService {
     cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
     signed_entity_type_lock: Arc<SignedEntityTypeLock>,
     pruning_tasks: Vec<Arc<dyn EpochPruningTask>>,
-    store_retention_limit: Option<u64>,
     logger: Logger,
 }
 
@@ -57,7 +56,6 @@ impl SignerUpkeepService {
         cardano_tx_connection_pool: Arc<SqliteConnectionPool>,
         signed_entity_type_lock: Arc<SignedEntityTypeLock>,
         pruning_tasks: Vec<Arc<dyn EpochPruningTask>>,
-        store_retention_limit: Option<u64>,
         logger: Logger,
     ) -> Self {
         Self {
@@ -65,29 +63,20 @@ impl SignerUpkeepService {
             cardano_tx_connection_pool,
             signed_entity_type_lock,
             pruning_tasks,
-            store_retention_limit,
             logger,
         }
     }
 
     async fn execute_pruning_tasks(&self, current_epoch: Epoch) -> StdResult<()> {
-        match self
-            .store_retention_limit
-            .map(|limit| current_epoch - limit)
-        {
-            Some(threshold) if *threshold > 0 => {
-                for task in &self.pruning_tasks {
-                    info!(
-                        self.logger, "UpkeepService::Pruning stale data";
-                        "pruned_data" => task.pruned_data(), "below_epoch_threshold" => ?threshold
-                    );
-
-                    task.prune_below_epoch_threshold(threshold).await?;
-                }
-                Ok(())
-            }
-            _ => Ok(()),
+        for task in &self.pruning_tasks {
+            info!(
+                self.logger, "UpkeepService::Pruning stale data";
+                "pruned_data" => task.pruned_data(), "current_epoch" => ?current_epoch
+            );
+            task.prune(current_epoch).await?;
         }
+
+        Ok(())
     }
 
     async fn upkeep_all_databases(&self) -> StdResult<()> {
@@ -198,7 +187,6 @@ mod tests {
                 )),
                 Arc::new(SignedEntityTypeLock::default()),
                 vec![],
-                None,
                 TestLogger::file(&log_path),
             );
 
@@ -241,7 +229,6 @@ mod tests {
                 Arc::new(SqliteConnectionPool::build(1, cardano_tx_db_connection).unwrap()),
                 signed_entity_type_lock.clone(),
                 vec![],
-                None,
                 TestLogger::file(&log_path),
             );
 
@@ -265,15 +252,15 @@ mod tests {
     #[tokio::test]
     async fn test_execute_all_pruning_tasks() {
         let task1 = mock_epoch_pruning_task(|mock| {
-            mock.expect_prune_below_epoch_threshold()
+            mock.expect_prune()
                 .once()
-                .with(eq(Epoch(4)))
+                .with(eq(Epoch(14)))
                 .returning(|_| Ok(()));
         });
         let task2 = mock_epoch_pruning_task(|mock| {
-            mock.expect_prune_below_epoch_threshold()
+            mock.expect_prune()
                 .once()
-                .with(eq(Epoch(4)))
+                .with(eq(Epoch(14)))
                 .returning(|_| Ok(()));
         });
 
@@ -282,52 +269,9 @@ mod tests {
             Arc::new(SqliteConnectionPool::build(1, cardano_tx_db_connection).unwrap()),
             Arc::new(SignedEntityTypeLock::default()),
             vec![task1, task2],
-            Some(10),
             TestLogger::stdout(),
         );
 
         service.run(Epoch(14)).await.expect("Upkeep service failed");
-    }
-
-    #[tokio::test]
-    async fn test_dont_execute_pruning_tasks_if_current_epoch_minus_retention_limit_is_0() {
-        let task = mock_epoch_pruning_task(|mock| {
-            mock.expect_prune_below_epoch_threshold()
-                .never()
-                .returning(|_| Ok(()));
-        });
-
-        let service = SignerUpkeepService::new(
-            Arc::new(main_db_connection().unwrap()),
-            Arc::new(SqliteConnectionPool::build(1, cardano_tx_db_connection).unwrap()),
-            Arc::new(SignedEntityTypeLock::default()),
-            vec![task],
-            Some(17),
-            TestLogger::stdout(),
-        );
-
-        service.run(Epoch(1)).await.expect("Upkeep service failed");
-        service.run(Epoch(16)).await.expect("Upkeep service failed");
-        service.run(Epoch(17)).await.expect("Upkeep service failed");
-    }
-
-    #[tokio::test]
-    async fn test_dont_execute_pruning_tasks_if_no_retention_limit_set() {
-        let task = mock_epoch_pruning_task(|mock| {
-            mock.expect_prune_below_epoch_threshold()
-                .never()
-                .returning(|_| Ok(()));
-        });
-
-        let service = SignerUpkeepService::new(
-            Arc::new(main_db_connection().unwrap()),
-            Arc::new(SqliteConnectionPool::build(1, cardano_tx_db_connection).unwrap()),
-            Arc::new(SignedEntityTypeLock::default()),
-            vec![task],
-            None,
-            TestLogger::stdout(),
-        );
-
-        service.run(Epoch(29)).await.expect("Upkeep service failed");
     }
 }

--- a/mithril-signer/tests/create_cardano_transaction_single_signature.rs
+++ b/mithril-signer/tests/create_cardano_transaction_single_signature.rs
@@ -3,11 +3,14 @@ mod test_extensions;
 use mithril_common::{
     crypto_helper::tests_setup,
     entities::{
-        BlockNumber, ChainPoint, Epoch, SignedEntityTypeDiscriminants, SlotNumber, TimePoint,
+        BlockNumber, CardanoDbBeacon, ChainPoint, Epoch,
+        SignedEntityType::{
+            CardanoImmutableFilesFull, CardanoTransactions, MithrilStakeDistribution,
+        },
+        SignedEntityTypeDiscriminants, SlotNumber, TimePoint,
     },
     test_utils::MithrilFixtureBuilder,
 };
-
 use test_extensions::StateMachineTester;
 
 #[rustfmt::skip]
@@ -34,12 +37,12 @@ async fn test_create_cardano_transaction_single_signature() {
         .await
         .expect("state machine tester init should not fail");
     let total_signer_registrations_expected = 3;
-    let total_signature_registrations_expected = 2;
+    let total_signature_registrations_expected = 4;
 
     tester
         .comment("state machine starts in Init and transit to Unregistered state.")
         .is_init().await.unwrap()
-        .aggregator_send_signed_entity(SignedEntityTypeDiscriminants::CardanoTransactions).await
+        .aggregator_allow_signed_entities(&[SignedEntityTypeDiscriminants::CardanoTransactions]).await
         .cycle_unregistered().await.unwrap()
 
         .comment("getting an epoch settings changes the state → RegisteredNotAbleToSign")
@@ -59,10 +62,16 @@ async fn test_create_cardano_transaction_single_signature() {
 
         .comment("signer can now create a single signature → ReadyToSign")
         .cycle_ready_to_sign_without_signature_registration().await.unwrap()
-
+        
+        .comment("signer signs a single signature for MithrilStakeDistribution = ReadyToSign")
+        .cycle_ready_to_sign_with_signature_registration(MithrilStakeDistribution(Epoch(3))).await.unwrap()
+        
+        .comment("signer signs a single signature for CardanoImmutableFilesFull = ReadyToSign")
+        .cycle_ready_to_sign_with_signature_registration(CardanoImmutableFilesFull(CardanoDbBeacon::new("devnet", 3, 1))).await.unwrap()
+        
         .comment("creating a new certificate pending with a cardano transaction signed entity → ReadyToSign")
         .increase_block_number_and_slot_number(70, SlotNumber(80), BlockNumber(170)).await.unwrap()
-        .cycle_ready_to_sign_with_signature_registration().await.unwrap()
+        .cycle_ready_to_sign_with_signature_registration(CardanoTransactions(Epoch(3), BlockNumber(149))).await.unwrap()
 
         .comment("more cycles do not change the state = ReadyToSign")
         .cycle_ready_to_sign_without_signature_registration().await.unwrap()
@@ -71,7 +80,7 @@ async fn test_create_cardano_transaction_single_signature() {
         .comment("new blocks means a new signature with the same stake distribution → ReadyToSign")
         .increase_block_number_and_slot_number(125, SlotNumber(205), BlockNumber(295)).await.unwrap()
         .cardano_chain_send_rollback(SlotNumber(205), BlockNumber(230)).await.unwrap()
-        .cycle_ready_to_sign_with_signature_registration().await.unwrap()
+        .cycle_ready_to_sign_with_signature_registration(CardanoTransactions(Epoch(3), BlockNumber(209))).await.unwrap()
 
         .comment("metrics should be correctly computed")
         .check_metrics(total_signer_registrations_expected,total_signature_registrations_expected).await.unwrap()

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -97,6 +97,7 @@ impl StateMachineTester {
         })?;
         let selected_signer_party_id = selected_signer_with_stake.party_id.clone();
         let config = Configuration::new_sample(&selected_signer_party_id);
+        let network = config.get_network()?;
 
         let dependencies_builder = DependenciesBuilder::new(&config);
         let sqlite_connection = Arc::new(
@@ -140,7 +141,7 @@ impl StateMachineTester {
         let certificate_handler = Arc::new(FakeAggregator::new(
             SignedEntityConfig {
                 allowed_discriminants: SignedEntityTypeDiscriminants::all(),
-                network: config.get_network().unwrap(),
+                network,
                 cardano_transactions_signing_config: cardano_transactions_signing_config.clone(),
             },
             ticker_service.clone(),
@@ -205,7 +206,10 @@ impl StateMachineTester {
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
+            stake_store.clone(),
+            network,
+        )));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             single_signer.clone(),

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -206,10 +206,7 @@ impl StateMachineTester {
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
-            stake_store.clone(),
-            network,
-        )));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             single_signer.clone(),

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -246,6 +246,8 @@ impl StateMachineTester {
             sqlite_connection.clone(),
             sqlite_connection_cardano_transaction_pool,
             signed_entity_type_lock.clone(),
+            vec![],
+            None,
             slog_scope::logger(),
         ));
         let signed_beacon_repository =

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -247,11 +247,10 @@ impl StateMachineTester {
             sqlite_connection_cardano_transaction_pool,
             signed_entity_type_lock.clone(),
             vec![],
-            None,
             slog_scope::logger(),
         ));
         let signed_beacon_repository =
-            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone()));
+            Arc::new(SignedBeaconRepository::new(sqlite_connection.clone(), None));
         let certifier = Arc::new(SignerCertifierService::new(
             ticker_service.clone(),
             signed_beacon_repository.clone(),

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.31"
+version = "0.4.32"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
@@ -55,6 +55,7 @@ impl Signer {
                 signer_config.pool_node.db_path.to_str().unwrap(),
             ),
             ("DATA_STORES_DIRECTORY", &data_stores_path),
+            ("STORE_RETENTION_LIMIT", "10"),
             ("NETWORK_MAGIC", &magic_id),
             (
                 "CARDANO_NODE_SOCKET_PATH",


### PR DESCRIPTION
## Content

This PR makes the `mithril-signer` compute what to sign on its own instead of relying on the aggregator `CertificatePending`.

To make this work the signer:
1.  still needs some data from the aggregator to create a `SignedEntityConfig`:
    - The list of allowed signed entity type discriminant, that we can get from the aggregator `/` route.
    - The cardano transaction signing configuration, that's exposed in the aggregator `/epoch-settings` route since #1923
1. use the `SignedEntityConfig` to list all possible `SignedEntityType` for its current time point.
1. filter that list of `SignedEntityType` to remove: locked signed entities, previously signed entities.

Both of the data needed from the aggregator are stored in the signer `EpochService`, meaning that they're fetched once per epoch.
This also mean that if an aggregator is restarted with change to its configured allowed discriminant the signers will take in account this change either at the next epoch or after a restart (since that configuration change is immediately advertised by the aggregator and not constant for an epoch).

Filtering out the previously signed entities mean that we need to persist them, to do so this PR add a new table in the signer database.
Since we don't need to keep those data in the long term (they are mostly useful for the current epoch), stale data of past epoch can be pruned based on the already existing `store_retention_limit` parameter.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #1925