### PR TITLE
Fix: add migration to resolve deserialization issue with `cardano_transactions_signing_config`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.71"
+version = "0.5.72"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.71"
+version = "0.5.72"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -579,6 +579,18 @@ impl DependenciesBuilder {
                 message: "cannot build aggregator runner: no epoch returned.".to_string(),
                 error: None,
             })?;
+
+        {
+            // Temporary fix, should be removed
+            // Replace empty JSON values '{}' injected with Migration #28
+            let cardano_signing_config = self
+                .get_signed_entity_config()?
+                .cardano_transactions_signing_config;
+            #[allow(deprecated)]
+            epoch_settings_store
+                .replace_cardano_signing_config_empty_values(cardano_signing_config)?;
+        }
+
         epoch_settings_store
             .handle_discrepancies_at_startup(
                 current_epoch,


### PR DESCRIPTION
## Content

This PR includes a fix for the issue introduced by the merged PR #1964, which added a migration to the `epoch_setting` table.
The `cardano_transactions_signing_config` column had a JSON default value that was not deserializable by `serde`.
This PR adds a new migration to correct this by providing a deserializable default value.

Error on `testing-preview` aggregator:
```
thread 'main' panicked at /home/runner/work/mithril/mithril/internal/mithril-persistence/src/sqlite/cursor.rs:35:76:
called `Result::unwrap()` on an `Err` value: InvalidData("Could not turn string '{}' to CardanoTransactionsSigningConfig. Error: missing field `security_parameter` at line 1 column 2")
```

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #1924 
