### PR TITLE
Fix signer stuck if signature already aggregated

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.192"
+version = "0.2.193"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.192"
+version = "0.2.193"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/services/aggregator_client.rs
+++ b/mithril-signer/src/services/aggregator_client.rs
@@ -534,7 +534,7 @@ mod tests {
     async fn test_epoch_settings_ok_200() {
         let (server, config, api_version_provider) = setup_test();
         let epoch_settings_expected = EpochSettingsMessage::dummy();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.path("/epoch-settings");
             then.status(200)
                 .body(json!(epoch_settings_expected).to_string());
@@ -556,7 +556,7 @@ mod tests {
     #[tokio::test]
     async fn test_epoch_settings_ko_412() {
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.path("/epoch-settings");
             then.status(412)
                 .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
@@ -578,7 +578,7 @@ mod tests {
     #[tokio::test]
     async fn test_epoch_settings_ko_500() {
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.path("/epoch-settings");
             then.status(500).body("an error occurred");
         });
@@ -602,7 +602,7 @@ mod tests {
     #[tokio::test]
     async fn test_epoch_settings_timeout() {
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.path("/epoch-settings");
             then.delay(Duration::from_millis(200));
         });
@@ -630,7 +630,7 @@ mod tests {
         let single_signers = fake_data::signers(1);
         let single_signer = single_signers.first().unwrap();
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signer");
             then.status(201);
         });
@@ -650,7 +650,7 @@ mod tests {
     async fn test_register_signer_ko_412() {
         let epoch = Epoch(1);
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signer");
             then.status(412)
                 .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
@@ -677,7 +677,7 @@ mod tests {
         let single_signers = fake_data::signers(1);
         let single_signer = single_signers.first().unwrap();
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signer");
             then.status(400).body(
                 serde_json::to_vec(&ClientError::new(
@@ -714,7 +714,7 @@ mod tests {
         let single_signers = fake_data::signers(1);
         let single_signer = single_signers.first().unwrap();
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signer");
             then.status(500).body("an error occurred");
         });
@@ -741,7 +741,7 @@ mod tests {
         let single_signers = fake_data::signers(1);
         let single_signer = single_signers.first().unwrap();
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signer");
             then.delay(Duration::from_millis(200));
         });
@@ -767,7 +767,7 @@ mod tests {
     async fn test_register_signatures_ok_201() {
         let single_signatures = fake_data::single_signatures((1..5).collect());
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
             then.status(201);
         });
@@ -790,7 +790,7 @@ mod tests {
     #[tokio::test]
     async fn test_register_signatures_ko_412() {
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
             then.status(412)
                 .header(MITHRIL_API_VERSION_HEADER, "0.0.999");
@@ -818,7 +818,7 @@ mod tests {
     async fn test_register_signatures_ko_400() {
         let single_signatures = fake_data::single_signatures((1..5).collect());
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
             then.status(400).body(
                 serde_json::to_vec(&ClientError::new(
@@ -852,7 +852,7 @@ mod tests {
     async fn test_register_signatures_ok_410() {
         let single_signatures = fake_data::single_signatures((1..5).collect());
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
             then.status(410).body(
                 serde_json::to_vec(&ClientError::new(
@@ -882,7 +882,7 @@ mod tests {
     async fn test_register_signatures_ko_409() {
         let single_signatures = fake_data::single_signatures((1..5).collect());
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
             then.status(409);
         });
@@ -910,7 +910,7 @@ mod tests {
     async fn test_register_signatures_ko_500() {
         let single_signatures = fake_data::single_signatures((1..5).collect());
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
             then.status(500).body("an error occurred");
         });
@@ -938,7 +938,7 @@ mod tests {
     async fn test_register_signatures_timeout() {
         let single_signatures = fake_data::single_signatures((1..5).collect());
         let (server, config, api_version_provider) = setup_test();
-        let _snapshots_mock = server.mock(|when, then| {
+        let _server_mock = server.mock(|when, then| {
             when.method(POST).path("/register-signatures");
             then.delay(Duration::from_millis(200));
         });


### PR DESCRIPTION
## Content

This PR fix #1976 by making changing to a "ok" the result of an error received when sending a single signature to an aggregator if that aggregator already certified the signature message.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #1976
