### PR TITLE
Signer certifier service sign & send signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.63"
+version = "0.4.64"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3703,7 +3703,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.193"
+version = "0.2.194"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.63"
+version = "0.4.64"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/test_utils/fake_data.rs
+++ b/mithril-common/src/test_utils/fake_data.rs
@@ -52,6 +52,33 @@ pub fn protocol_parameters() -> entities::ProtocolParameters {
     entities::ProtocolParameters::new(k, m, phi_f)
 }
 
+cfg_random! {
+    /// Fake ProtocolInitializer
+    pub fn protocol_initializer<S: Into<String>>(
+        seed: S,
+        stake: entities::Stake,
+    ) -> crypto_helper::ProtocolInitializer {
+        use rand_chacha::ChaCha20Rng;
+        use rand_core::SeedableRng;
+
+        let protocol_parameters = protocol_parameters();
+        let seed: [u8; 32] = format!("{:<032}", seed.into()).as_bytes()[..32]
+            .try_into()
+            .unwrap();
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let kes_secret_key_path: Option<std::path::PathBuf> = None;
+        let kes_period = Some(0);
+
+        crypto_helper::ProtocolInitializer::setup(
+            protocol_parameters.into(),
+            kes_secret_key_path,
+            kes_period,
+            stake,
+            &mut rng,
+        ).unwrap()
+    }
+}
+
 /// Fake CertificatePending
 pub fn certificate_pending() -> entities::CertificatePending {
     // Epoch

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.193"
+version = "0.2.194"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -371,6 +371,8 @@ impl<'a> DependenciesBuilder<'a> {
                 epoch_service.clone(),
             )),
             signed_entity_type_lock.clone(),
+            single_signer.clone(),
+            aggregator_client.clone(),
         ));
 
         let services = SignerDependencyContainer {

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -214,7 +214,6 @@ impl<'a> DependenciesBuilder<'a> {
             )?),
             self.config.store_retention_limit,
         ));
-        let single_signer = Arc::new(MithrilSingleSigner::new(self.compute_protocol_party_id()?));
         let digester = Arc::new(CardanoImmutableDigester::new(
             self.build_digester_cache_provider().await?,
             slog_scope::logger(),
@@ -326,6 +325,10 @@ impl<'a> DependenciesBuilder<'a> {
             stake_store.clone(),
             protocol_initializer_store.clone(),
         )));
+        let single_signer = Arc::new(MithrilSingleSigner::new(
+            self.compute_protocol_party_id()?,
+            epoch_service.clone(),
+        ));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             protocol_initializer_store.clone(),

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -328,7 +328,6 @@ impl<'a> DependenciesBuilder<'a> {
         )));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
-            single_signer.clone(),
             protocol_initializer_store.clone(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -322,7 +322,10 @@ impl<'a> DependenciesBuilder<'a> {
         let cardano_stake_distribution_signable_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
+            stake_store.clone(),
+            protocol_initializer_store.clone(),
+        )));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             single_signer.clone(),

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -528,7 +528,6 @@ mod tests {
         let single_signer = Arc::new(MithrilSingleSigner::new(party_id));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
-            single_signer.clone(),
             protocol_initializer_store.clone(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -53,9 +53,6 @@ pub trait Runner: Send + Sync {
         message: &ProtocolMessage,
     ) -> StdResult<()>;
 
-    /// Mark the beacon as signed.
-    async fn mark_beacon_as_signed(&self, beacon: &BeaconToSign) -> StdResult<()>;
-
     /// Read the current era and update the EraChecker.
     async fn update_era_checker(&self, epoch: Epoch) -> StdResult<()>;
 
@@ -280,12 +277,6 @@ impl Runner for SignerRunner {
             .certifier
             .compute_publish_single_signature(beacon_to_sign, message)
             .await
-    }
-
-    async fn mark_beacon_as_signed(&self, beacon: &BeaconToSign) -> StdResult<()> {
-        debug!("RUNNER: mark_beacon_as_signed"; "beacon" => ?beacon);
-
-        self.services.certifier.mark_beacon_as_signed(beacon).await
     }
 
     async fn update_era_checker(&self, epoch: Epoch) -> StdResult<()> {

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -381,11 +381,6 @@ impl StateMachine {
                 message: format!("Could not compute and publish single signature during 'ready to sign → ready to sign' phase (current epoch {current_epoch:?})"),
                 nested_error: Some(e)
             })?;
-        self.runner.mark_beacon_as_signed(&beacon_to_sign).await
-            .map_err(|e| RuntimeError::KeepState {
-                message: format!("Could not mark beacon as signed during 'ready to sign → ready to sign' phase (current epoch {current_epoch:?})"),
-                nested_error: Some(e)
-            })?;
 
         self.metrics_service
             .signature_registration_success_since_startup_counter_increment();
@@ -723,11 +718,6 @@ mod tests {
             .expect_compute_publish_single_signature()
             .once()
             .returning(|_, _| Ok(()));
-        runner
-            .expect_mark_beacon_as_signed()
-            .once()
-            .with(predicate::eq(beacon_to_sign))
-            .returning(|_| Ok(()));
 
         let state_machine = init_state_machine(
             SignerState::ReadyToSign {

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -377,7 +377,7 @@ impl StateMachine {
 
         let single_signatures = self
             .runner
-            .compute_single_signature(current_epoch, &message)
+            .compute_single_signature(&message)
             .await
             .map_err(|e| RuntimeError::KeepState {
                 message: format!("Could not compute single signature during 'ready to sign → ready to sign' phase (current epoch {current_epoch:?})"),
@@ -725,7 +725,7 @@ mod tests {
         runner
             .expect_compute_single_signature()
             .once()
-            .returning(|_, _| Ok(Some(fake_data::single_signatures(vec![1, 5, 23]))));
+            .returning(|_| Ok(Some(fake_data::single_signatures(vec![1, 5, 23]))));
         runner
             .expect_compute_message()
             .once()

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -375,17 +375,10 @@ impl StateMachine {
                 nested_error: Some(e)
             })?;
 
-        let single_signatures = self
-            .runner
-            .compute_single_signature(&message)
+        self.runner.compute_publish_single_signature(&beacon_to_sign, &message)
             .await
             .map_err(|e| RuntimeError::KeepState {
-                message: format!("Could not compute single signature during 'ready to sign → ready to sign' phase (current epoch {current_epoch:?})"),
-                nested_error: Some(e)
-            })?;
-        self.runner.send_single_signature(&beacon_to_sign.signed_entity_type, single_signatures, &message).await
-            .map_err(|e| RuntimeError::KeepState {
-                message: format!("Could not send single signature during 'ready to sign → ready to sign' phase (current epoch {current_epoch:?})"),
+                message: format!("Could not compute and publish single signature during 'ready to sign → ready to sign' phase (current epoch {current_epoch:?})"),
                 nested_error: Some(e)
             })?;
         self.runner.mark_beacon_as_signed(&beacon_to_sign).await
@@ -723,17 +716,13 @@ mod tests {
             .once()
             .returning(move || Ok(Some(beacon_to_sign_clone.clone())));
         runner
-            .expect_compute_single_signature()
-            .once()
-            .returning(|_| Ok(Some(fake_data::single_signatures(vec![1, 5, 23]))));
-        runner
             .expect_compute_message()
             .once()
             .returning(|_| Ok(ProtocolMessage::new()));
         runner
-            .expect_send_single_signature()
+            .expect_compute_publish_single_signature()
             .once()
-            .returning(|_, _, _| Ok(()));
+            .returning(|_, _| Ok(()));
         runner
             .expect_mark_beacon_as_signed()
             .once()

--- a/mithril-signer/src/services/aggregator_client.rs
+++ b/mithril-signer/src/services/aggregator_client.rs
@@ -11,13 +11,14 @@ use mithril_common::{
     messages::{
         AggregatorFeaturesMessage, EpochSettingsMessage, TryFromMessageAdapter, TryToMessageAdapter,
     },
-    StdError, MITHRIL_API_VERSION_HEADER, MITHRIL_SIGNER_VERSION_HEADER,
+    StdError, StdResult, MITHRIL_API_VERSION_HEADER, MITHRIL_SIGNER_VERSION_HEADER,
 };
 
 use crate::entities::SignerEpochSettings;
 use crate::message_adapters::{
     FromEpochSettingsAdapter, ToRegisterSignatureMessageAdapter, ToRegisterSignerMessageAdapter,
 };
+use crate::services::SignaturePublisher;
 
 /// Error structure for the Aggregator Client.
 #[derive(Error, Debug)]
@@ -95,6 +96,20 @@ pub trait AggregatorClient: Sync + Send {
     async fn retrieve_aggregator_features(
         &self,
     ) -> Result<AggregatorFeaturesMessage, AggregatorClientError>;
+}
+
+#[async_trait]
+impl<T: AggregatorClient> SignaturePublisher for T {
+    async fn publish(
+        &self,
+        signed_entity_type: &SignedEntityType,
+        signatures: &SingleSignatures,
+        protocol_message: &ProtocolMessage,
+    ) -> StdResult<()> {
+        self.register_signatures(signed_entity_type, signatures, protocol_message)
+            .await?;
+        Ok(())
+    }
 }
 
 /// AggregatorHTTPClient is a http client for an aggregator

--- a/mithril-signer/src/services/epoch_service.rs
+++ b/mithril-signer/src/services/epoch_service.rs
@@ -364,43 +364,32 @@ pub mod mock_epoch_service {
 
         #[async_trait]
         impl EpochService for EpochServiceImpl {
-            /// Inform the service a new epoch has been detected, telling it to update its
-            /// internal state for the new epoch.
             async fn inform_epoch_settings(
                 &mut self,
                 epoch_settings: SignerEpochSettings,
                 allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
             ) -> StdResult<()>;
 
-            /// Get the current epoch for which the data stored in this service are computed.
             fn epoch_of_current_data(&self) -> StdResult<Epoch>;
 
-            /// Get next protocol parameters used in next epoch (associated with the actual epoch)
             fn next_protocol_parameters(&self) -> StdResult<&'static ProtocolParameters>;
 
             fn protocol_initializer(&self) -> StdResult<&'static Option<ProtocolInitializer>>;
 
-            /// Get signers for the current epoch
             fn current_signers(&self) -> StdResult<&'static Vec<Signer>>;
 
-            /// Get signers for the next epoch
             fn next_signers(&self) -> StdResult<&'static Vec<Signer>>;
 
-            /// Get the list of signed entity types that are allowed to sign for the current epoch
-            fn allowed_discriminants(&self) -> StdResult<&'static BTreeSet<SignedEntityTypeDiscriminants>>;
-
-            /// Get signers with stake for the current epoch
             async fn current_signers_with_stake(&self) -> StdResult<Vec<SignerWithStake>>;
 
-            /// Get signers with stake for the next epoch
             async fn next_signers_with_stake(&self) -> StdResult<Vec<SignerWithStake>>;
 
-            /// Get the cardano transactions signing configuration for the current epoch
+            fn allowed_discriminants(&self) -> StdResult<&'static BTreeSet<SignedEntityTypeDiscriminants>>;
+
             fn cardano_transactions_signing_config(
                 &self,
             ) -> StdResult<&'static Option<CardanoTransactionsSigningConfig>>;
 
-            /// Get the cardano transactions signing configuration for the next epoch
             fn next_cardano_transactions_signing_config(
                 &self,
             ) -> StdResult<&'static Option<CardanoTransactionsSigningConfig>>;

--- a/mithril-signer/src/services/single_signer.rs
+++ b/mithril-signer/src/services/single_signer.rs
@@ -7,9 +7,9 @@ use thiserror::Error;
 
 use mithril_common::crypto_helper::{KESPeriod, ProtocolInitializer};
 use mithril_common::entities::{
-    PartyId, ProtocolMessage, ProtocolParameters, SignerWithStake, SingleSignatures, Stake,
+    PartyId, ProtocolMessage, ProtocolParameters, SingleSignatures, Stake,
 };
-use mithril_common::protocol::SignerBuilder;
+use mithril_common::protocol::{SignerBuilder, SingleSigner as ProtocolSingleSigner};
 use mithril_common::{StdError, StdResult};
 
 use crate::dependency_injection::EpochServiceWrapper;
@@ -46,7 +46,6 @@ pub trait SingleSigner: Sync + Send {
     async fn compute_single_signatures(
         &self,
         protocol_message: &ProtocolMessage,
-        signers_with_stake: &[SignerWithStake],
     ) -> StdResult<Option<SingleSignatures>>;
 
     /// Get party id
@@ -84,12 +83,35 @@ impl MithrilSingleSigner {
         }
     }
 
-    async fn get_protocol_initializer(&self) -> StdResult<ProtocolInitializer> {
+    async fn build_protocol_single_signer(&self) -> StdResult<ProtocolSingleSigner> {
         let epoch_service = self.epoch_service.read().await;
-        epoch_service.protocol_initializer()?.clone().ok_or(anyhow!(
-            "Can not Sign or Compute AVK, No protocol initializer found for party_id: '{}'",
-            self.party_id.clone()
-        ))
+        let protocol_initializer =
+            epoch_service
+                .protocol_initializer()?
+                .as_ref()
+                .ok_or(anyhow!(
+                    "Can not Sign or Compute AVK, No protocol initializer found for party_id: '{}'",
+                    self.party_id.clone()
+                ))?;
+
+        let builder = SignerBuilder::new(
+            &epoch_service.current_signers_with_stake().await?,
+            &protocol_initializer.get_protocol_parameters().into(),
+        )
+        .with_context(|| "Mithril Single Signer can not build signer")
+        .map_err(SingleSignerError::ProtocolSignerCreationFailure)?;
+
+        let single_signer = builder
+            .restore_signer_from_initializer(self.party_id.clone(), protocol_initializer.clone())
+            .with_context(|| {
+                format!(
+                    "Mithril Single Signer can not restore signer with party_id: '{}'",
+                    self.party_id.clone()
+                )
+            })
+            .map_err(SingleSignerError::ProtocolSignerCreationFailure)?;
+
+        Ok(single_signer)
     }
 }
 
@@ -98,25 +120,11 @@ impl SingleSigner for MithrilSingleSigner {
     async fn compute_single_signatures(
         &self,
         protocol_message: &ProtocolMessage,
-        signers_with_stake: &[SignerWithStake],
     ) -> StdResult<Option<SingleSignatures>> {
-        let protocol_initializer = self.get_protocol_initializer().await?;
-        let builder = SignerBuilder::new(
-            signers_with_stake,
-            &protocol_initializer.get_protocol_parameters().into(),
-        )
-        .with_context(|| "Mithril Single Signer can not build signer")
-        .map_err(|e| SingleSignerError::ProtocolSignerCreationFailure(anyhow!(e)))?;
+        let protocol_single_signer = self.build_protocol_single_signer().await?;
+
         info!("Signing protocol message"; "protocol_message" =>  #?protocol_message, "signed message" => protocol_message.compute_hash().encode_hex::<String>());
-        let signatures = builder
-            .restore_signer_from_initializer(self.party_id.clone(), protocol_initializer.clone())
-            .with_context(|| {
-                format!(
-                    "Mithril Single Signer can not restore signer with party_id: '{}'",
-                    self.party_id.clone()
-                )
-            })
-            .map_err(|e| SingleSignerError::ProtocolSignerCreationFailure(anyhow!(e)))?
+        let signatures = protocol_single_signer
             .sign(protocol_message)
             .with_context(|| {
                 format!(
@@ -156,8 +164,11 @@ mod tests {
     use mithril_common::crypto_helper::ProtocolClerk;
     use mithril_common::entities::{Epoch, ProtocolMessagePartKey};
     use mithril_common::test_utils::MithrilFixtureBuilder;
+    use mithril_persistence::store::adapter::{DumbStoreAdapter, MemoryAdapter};
+    use mithril_persistence::store::StakeStore;
 
     use crate::services::MithrilEpochService;
+    use crate::store::ProtocolInitializerStore;
 
     use super::*;
 
@@ -165,17 +176,28 @@ mod tests {
     async fn compute_single_signature_success() {
         let snapshot_digest = "digest".to_string();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
-        let signers_with_stake = fixture.signers_with_stake();
         let current_signer = &fixture.signers_fixture()[0];
         let clerk = ProtocolClerk::from_signer(&current_signer.protocol_signer);
         let avk = clerk.compute_avk();
-        let mut protocol_message = ProtocolMessage::new();
-        protocol_message.set_message_part(ProtocolMessagePartKey::SnapshotDigest, snapshot_digest);
-        let expected_message = protocol_message.compute_hash().as_bytes().to_vec();
-        let epoch_service = MithrilEpochService::new_with_dumb_dependencies()
+        let stake_store = Arc::new(StakeStore::new(
+            Box::new(
+                MemoryAdapter::new(Some(vec![(
+                    Epoch(10).offset_to_signer_retrieval_epoch().unwrap(),
+                    fixture.stake_distribution(),
+                )]))
+                .unwrap(),
+            ),
+            None,
+        ));
+        let protocol_initializer_store = Arc::new(ProtocolInitializerStore::new(
+            Box::new(DumbStoreAdapter::new()),
+            None,
+        ));
+        let epoch_service = MithrilEpochService::new(stake_store, protocol_initializer_store)
             .set_data_to_default_or_fake(Epoch(10))
             .alter_data(|data| {
-                data.protocol_initializer = Some(current_signer.protocol_initializer.clone())
+                data.protocol_initializer = Some(current_signer.protocol_initializer.clone());
+                data.current_signers = fixture.signers();
             });
 
         let single_signer = MithrilSingleSigner::new(
@@ -183,12 +205,15 @@ mod tests {
             Arc::new(RwLock::new(epoch_service)),
         );
 
+        let mut protocol_message = ProtocolMessage::new();
+        protocol_message.set_message_part(ProtocolMessagePartKey::SnapshotDigest, snapshot_digest);
         let sign_result = single_signer
-            .compute_single_signatures(&protocol_message, &signers_with_stake)
+            .compute_single_signatures(&protocol_message)
             .await
             .expect("single signer should not fail")
             .expect("single signer should produce a signature here");
 
+        let expected_message = protocol_message.compute_hash().as_bytes().to_vec();
         let decoded_sig = sign_result.to_protocol_signature();
         assert!(
             decoded_sig

--- a/mithril-signer/src/store/protocol_initializer_store.rs
+++ b/mithril-signer/src/store/protocol_initializer_store.rs
@@ -100,34 +100,16 @@ impl ProtocolInitializerStorer for ProtocolInitializerStore {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
-    use super::*;
-
     use mithril_common::test_utils::fake_data;
     use mithril_persistence::store::adapter::MemoryAdapter;
 
-    use rand_chacha::ChaCha20Rng;
-    use rand_core::SeedableRng;
+    use super::*;
 
     fn setup_protocol_initializers(nb_epoch: u64) -> Vec<(Epoch, ProtocolInitializer)> {
         let mut values: Vec<(Epoch, ProtocolInitializer)> = Vec::new();
         for epoch in 1..=nb_epoch {
-            let protocol_parameters = fake_data::protocol_parameters();
-            let party_id = format!("{:<032}", 1);
             let stake = (epoch + 1) * 100;
-            let seed: [u8; 32] = party_id.as_bytes()[..32].try_into().unwrap();
-            let mut rng = ChaCha20Rng::from_seed(seed);
-            let kes_secret_key_path: Option<PathBuf> = None;
-            let kes_period = Some(0);
-            let protocol_initializer = ProtocolInitializer::setup(
-                protocol_parameters.into(),
-                kes_secret_key_path,
-                kes_period,
-                stake,
-                &mut rng,
-            )
-            .expect("protocol initializer should not fail");
+            let protocol_initializer = fake_data::protocol_initializer("1", stake);
             values.push((Epoch(epoch), protocol_initializer));
         }
         values

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -222,7 +222,6 @@ impl StateMachineTester {
         )));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
-            single_signer.clone(),
             protocol_initializer_store.clone(),
         ));
         let signable_builder_service = Arc::new(MithrilSignableBuilderService::new(

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -262,6 +262,8 @@ impl StateMachineTester {
                 epoch_service.clone(),
             )),
             signed_entity_type_lock.clone(),
+            single_signer.clone(),
+            certificate_handler.clone(),
         ));
 
         let services = SignerDependencyContainer {

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -163,9 +163,6 @@ impl StateMachineTester {
             ),
             config.store_retention_limit,
         ));
-        let single_signer = Arc::new(MithrilSingleSigner::new(
-            config.party_id.to_owned().unwrap_or_default(),
-        ));
         let stake_store = Arc::new(StakeStore::new(
             Box::new(SQLiteAdapter::new("stake", sqlite_connection.clone()).unwrap()),
             config.store_retention_limit,
@@ -220,6 +217,10 @@ impl StateMachineTester {
             stake_store.clone(),
             protocol_initializer_store.clone(),
         )));
+        let single_signer = Arc::new(MithrilSingleSigner::new(
+            config.party_id.to_owned().unwrap_or_default(),
+            epoch_service.clone(),
+        ));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             protocol_initializer_store.clone(),

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -216,7 +216,10 @@ impl StateMachineTester {
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
         );
-        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(stake_store.clone())));
+        let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
+            stake_store.clone(),
+            protocol_initializer_store.clone(),
+        )));
         let signable_seed_builder_service = Arc::new(SignerSignableSeedBuilder::new(
             epoch_service.clone(),
             single_signer.clone(),


### PR DESCRIPTION
## Content

This PR refactor the `mithril-signer` in order to move the sign & send signatures responsibility from the state machine runner to the signer `Certifier` service.

One of the main concern for this refactor was to minimize the number of new dependencies that needed to be add to the certifier.
Simply moving the code from the runner to the certifier would have result in adding the following dependencies:
- `epoch_service` and `protocol_initializer_store` and `single_signer`: to issue the single signature.
- `certificate_handler`: to send the signatures but we would only need one method of it's whole api.

### Avoiding `protocol_initializer_store` dependency

The protocol initializer of the current epoch is now stored on the epoch service.
It's stored as an option since it's only available if a signer is registered in the Mithril stake distribution of the current epoch.
This is used in the next refactor.

### Refocus single signer service

The `single_signer` service should be able to issue single signatures without needing parameters that must be computed with other dependencies.
To do so the `compute_single_signatures` now only take a protocol message as parameter, the `protocol_initializer` and the list of `signers_with_stake` are fetched from the epoch service.

The `compute_aggregate_verification_key` was only used by the `SignerSignableSeedBuilder` and need not the current protocol_initializer but the next one, a data not available in the epoch service.
I choose to remove this method from the single signer api and instead allow the `SignerSignableSeedBuilder`to do the computation by using the lower level tools since it already had the signers & protocol initializer needed.

### Dependency inversion for signature publishing

By adding a `SignaturePublisher` trait defined for the certifier needs. It's automatically implement it for every `AggregatorClient` trait implemetors.

### Additional refactor

Since the epoch service now hold all data needed for the `can_signer_sign_current_epoch` function, it's code is moved from the signer state machine runner directly to the epoch service.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [ ] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)
Closes #1945
