### PR TITLE
Feat: sign epoch in genesis certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.75"
+version = "0.5.76"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.65"
+version = "0.4.66"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.75"
+version = "0.5.76"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -110,6 +110,7 @@ impl GenesisTools {
         let protocol_message = CertificateGenesisProducer::create_genesis_protocol_message(
             &self.genesis_protocol_parameters,
             &self.genesis_avk,
+            &self.time_point.epoch,
         )?;
         target_file.write_all(protocol_message.compute_hash().as_bytes())?;
         Ok(())
@@ -135,6 +136,7 @@ impl GenesisTools {
         let genesis_protocol_message = CertificateGenesisProducer::create_genesis_protocol_message(
             &self.genesis_protocol_parameters,
             &self.genesis_avk,
+            &self.time_point.epoch,
         )?;
         let genesis_signature =
             genesis_producer.sign_genesis_protocol_message(genesis_protocol_message)?;

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.65"
+version = "0.4.66"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -179,7 +179,8 @@ pub fn setup_certificate_chain(
     let genesis_verifier = genesis_signer.create_genesis_verifier();
     let genesis_producer = CertificateGenesisProducer::new(Some(Arc::new(genesis_signer)));
     let protocol_parameters = setup_protocol_parameters();
-    let mut epochs = (1..total_certificates + 2)
+    let genesis_epoch = Epoch(1);
+    let mut epochs = (genesis_epoch.0..total_certificates + 2)
         .map(|i| match certificates_per_epoch {
             0 => panic!("expected at least 1 certificate per epoch"),
             1 => Epoch(i),
@@ -250,6 +251,7 @@ pub fn setup_certificate_chain(
                         CertificateGenesisProducer::create_genesis_protocol_message(
                             next_protocol_parameters,
                             &next_avk,
+                            &genesis_epoch,
                         )
                         .unwrap();
                     let genesis_signature = genesis_producer

--- a/mithril-common/src/test_utils/mithril_fixture.rs
+++ b/mithril-common/src/test_utils/mithril_fixture.rs
@@ -183,6 +183,7 @@ impl MithrilFixture {
         let genesis_protocol_message = CertificateGenesisProducer::create_genesis_protocol_message(
             &self.protocol_parameters,
             &genesis_avk,
+            &epoch,
         )
         .unwrap();
         let genesis_signature = genesis_producer


### PR DESCRIPTION
## Content
This PR includes the **signature of the genesis epoch in the genesis certificate**.

### Enhancements to `CertificateGenesisProducer`:

* [`mithril-common/src/certificate_chain/certificate_genesis.rs`](diffhunk://#diff-d08972d7d55a30e9dab9426e7b031c0a4b786ac050b30c707fe34dcf3af464c7R46): Added `genesis_epoch` parameter to the `create_genesis_protocol_message` method and updated the method to include the `CurrentEpoch` part in the protocol message. [[1]](diffhunk://#diff-d08972d7d55a30e9dab9426e7b031c0a4b786ac050b30c707fe34dcf3af464c7R46) [[2]](diffhunk://#diff-d08972d7d55a30e9dab9426e7b031c0a4b786ac050b30c707fe34dcf3af464c7R58-R61) [[3]](diffhunk://#diff-d08972d7d55a30e9dab9426e7b031c0a4b786ac050b30c707fe34dcf3af464c7L97-R102)

### Updates to `GenesisTools`:

* [`mithril-aggregator/src/tools/genesis.rs`](diffhunk://#diff-0e9381b29a84023643030c84795d59ebf49e69a048f9afc37623d7b5a785adf7R113): Updated calls to `create_genesis_protocol_message` to include the `epoch` parameter. [[1]](diffhunk://#diff-0e9381b29a84023643030c84795d59ebf49e69a048f9afc37623d7b5a785adf7R113) [[2]](diffhunk://#diff-0e9381b29a84023643030c84795d59ebf49e69a048f9afc37623d7b5a785adf7R139)

### Test updates:

* [`mithril-common/src/certificate_chain/certificate_genesis.rs`](diffhunk://#diff-d08972d7d55a30e9dab9426e7b031c0a4b786ac050b30c707fe34dcf3af464c7R125-R129): Added `genesis_epoch` parameter to test cases and verified the `CurrentEpoch` part in the protocol message. [[1]](diffhunk://#diff-d08972d7d55a30e9dab9426e7b031c0a4b786ac050b30c707fe34dcf3af464c7R125-R129) [[2]](diffhunk://#diff-d08972d7d55a30e9dab9426e7b031c0a4b786ac050b30c707fe34dcf3af464c7R145-R150)
* [`mithril-common/src/crypto_helper/tests_setup.rs`](diffhunk://#diff-4094c208406c63faa7b6f2a16ce233c60f6660019cec13f15deb943868ae716bL182-R183): Updated `setup_certificate_chain` function to include `genesis_epoch`. [[1]](diffhunk://#diff-4094c208406c63faa7b6f2a16ce233c60f6660019cec13f15deb943868ae716bL182-R183) [[2]](diffhunk://#diff-4094c208406c63faa7b6f2a16ce233c60f6660019cec13f15deb943868ae716bR254)
* [`mithril-common/src/test_utils/mithril_fixture.rs`](diffhunk://#diff-3c3de15a3d70857577cc9b88b4ed32175ee062f47f634b76e3a9b3aeb2081cb9R186): Updated `MithrilFixture` to include `epoch` in the `create_genesis_protocol_message` call.

### Version updates:

* [`mithril-aggregator/Cargo.toml`](diffhunk://#diff-5ae504281312c194e5e8cf6aa890f49508756041db9dbce0fd89fbf04438f90dL3-R3): Bumped version from `0.5.75` to `0.5.76`.
* [`mithril-common/Cargo.toml`](diffhunk://#diff-0b137373460b5fa18b029b657531df061019d3ce8efadc17b522b1a104971d65L3-R3): Bumped version from `0.4.65` to `0.4.66`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
