### PR TITLE
Optimize `/register-signer` route by replacing ticker service with epoch service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.76"
+version = "0.5.77"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.76"
+version = "0.5.77"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 
 use warp::Filter;
 
+use mithril_common::api_version::APIVersionProvider;
 use mithril_common::entities::SignedEntityConfig;
-use mithril_common::{api_version::APIVersionProvider, TickerService};
 
 use crate::database::repository::SignerGetter;
 use crate::dependency_injection::EpochServiceWrapper;
@@ -62,13 +62,6 @@ pub fn with_certifier_service(
     dependency_manager: Arc<DependencyContainer>,
 ) -> impl Filter<Extract = (Arc<dyn CertifierService>,), Error = Infallible> + Clone {
     warp::any().map(move || dependency_manager.certifier_service.clone())
-}
-
-/// With ticker service middleware
-pub fn with_ticker_service(
-    dependency_manager: Arc<DependencyContainer>,
-) -> impl Filter<Extract = (Arc<dyn TickerService>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.ticker_service.clone())
 }
 
 /// With epoch service middleware


### PR DESCRIPTION
## Content

This PR includes the following changes to improve throughput in the `/register-signer` route:

- Replaces direct calls to the chain observer (via the ticker service) with calls to the epoch service.
- Removes the `with_ticker_service` middleware since it's not used anymore.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1982 
