### PR TITLE
Better folder structure for End to End test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.37"
+version = "0.4.38"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.37"
+version = "0.4.38"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -174,6 +174,11 @@ async fn main() -> StdResult<()> {
             work_dir.canonicalize().unwrap()
         }
     };
+    let artifacts_dir = {
+        let path = work_dir.join("artifacts");
+        fs::create_dir(&path).expect("Artifacts dir creation failure");
+        path
+    };
     let run_only_mode = args.run_only;
     let use_p2p_network_mode = args.use_p2p_network;
     let use_p2p_passive_relays = args.use_p2p_passive_relays;
@@ -193,6 +198,7 @@ async fn main() -> StdResult<()> {
     let mut infrastructure = MithrilInfrastructure::start(&MithrilInfrastructureConfig {
         server_port,
         devnet: devnet.clone(),
+        artifacts_dir,
         work_dir,
         bin_dir: args.bin_directory,
         cardano_node_version: args.cardano_node_version,

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -145,8 +145,11 @@ impl Aggregator {
     }
 
     pub async fn bootstrap_genesis(&mut self) -> StdResult<()> {
-        let exit_status = self
-            .command
+        // Clone the command so we can alter it without affecting the original
+        let mut command = self.command.clone();
+        command.set_log_name("mithril-aggregator-genesis-bootstrap");
+
+        let exit_status = command
             .start(&["genesis".to_string(), "bootstrap".to_string()])?
             .wait()
             .await

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -6,6 +6,7 @@ use crate::{
 use anyhow::{anyhow, Context};
 use mithril_common::era::SupportedEra;
 use mithril_common::{entities, StdResult};
+use slog_scope::info;
 use std::cmp;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -167,10 +168,12 @@ impl Aggregator {
 
     pub async fn stop(&mut self) -> StdResult<()> {
         if let Some(process) = self.process.as_mut() {
+            info!("Stopping aggregator");
             process
                 .kill()
                 .await
                 .with_context(|| "Could not kill aggregator")?;
+            self.process = None;
         }
         Ok(())
     }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -18,6 +18,7 @@ pub struct AggregatorConfig<'a> {
     pub pool_node: &'a PoolNode,
     pub cardano_cli_path: &'a Path,
     pub work_dir: &'a Path,
+    pub artifacts_dir: &'a Path,
     pub bin_dir: &'a Path,
     pub cardano_node_version: &'a str,
     pub mithril_run_interval: u32,
@@ -62,6 +63,10 @@ impl Aggregator {
             ("URL_SNAPSHOT_MANIFEST", ""),
             ("SNAPSHOT_STORE_TYPE", "local"),
             ("SNAPSHOT_UPLOADER_TYPE", "local"),
+            (
+                "SNAPSHOT_DIRECTORY",
+                aggregator_config.artifacts_dir.to_str().unwrap(),
+            ),
             ("NETWORK_MAGIC", &magic_id),
             ("DATA_STORES_DIRECTORY", "./stores/aggregator"),
             (

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -289,6 +289,18 @@ impl MithrilInfrastructure {
         Ok(signers)
     }
 
+    pub async fn stop_nodes(&mut self) -> StdResult<()> {
+        // Note: The aggregator should be stopped *last* since signers depends on it
+        info!("Stopping Mithril infrastructure");
+        for signer in self.signers.as_mut_slice() {
+            signer.stop().await?;
+        }
+
+        self.aggregator.stop().await?;
+
+        Ok(())
+    }
+
     pub fn devnet(&self) -> &Devnet {
         &self.devnet
     }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -1,7 +1,4 @@
-use crate::{
-    assertions, Aggregator, AggregatorConfig, Client, Devnet, PoolNode, RelayAggregator,
-    RelayPassive, RelaySigner, Signer, DEVNET_MAGIC_ID,
-};
+use anyhow::Context;
 use mithril_common::chain_observer::{ChainObserver, PallasChainObserver};
 use mithril_common::entities::{Epoch, PartyId, ProtocolParameters};
 use mithril_common::{CardanoNetwork, StdResult};
@@ -11,12 +8,18 @@ use std::fs;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::{
+    assertions, Aggregator, AggregatorConfig, Client, Devnet, PoolNode, RelayAggregator,
+    RelayPassive, RelaySigner, Signer, DEVNET_MAGIC_ID,
+};
+
 use super::signer::SignerConfig;
 
 pub struct MithrilInfrastructureConfig {
     pub server_port: u64,
     pub devnet: Devnet,
     pub work_dir: PathBuf,
+    pub artifacts_dir: PathBuf,
     pub bin_dir: PathBuf,
     pub cardano_node_version: String,
     pub mithril_run_interval: u32,
@@ -30,7 +33,7 @@ pub struct MithrilInfrastructureConfig {
 }
 
 pub struct MithrilInfrastructure {
-    work_dir: PathBuf,
+    artifacts_dir: PathBuf,
     bin_dir: PathBuf,
     devnet: Devnet,
     aggregator: Aggregator,
@@ -77,8 +80,8 @@ impl MithrilInfrastructure {
         ));
 
         Ok(Self {
-            work_dir: config.work_dir.to_path_buf(),
             bin_dir: config.bin_dir.to_path_buf(),
+            artifacts_dir: config.artifacts_dir.to_path_buf(),
             devnet: config.devnet.clone(),
             aggregator,
             signers,
@@ -137,11 +140,22 @@ impl MithrilInfrastructure {
         pool_node: &PoolNode,
         chain_observer_type: &str,
     ) -> StdResult<Aggregator> {
+        let aggregator_artifacts_directory = config.artifacts_dir.join("mithril-aggregator");
+        if !aggregator_artifacts_directory.exists() {
+            fs::create_dir_all(&aggregator_artifacts_directory).with_context(|| {
+                format!(
+                    "Could not create artifacts directory '{}'",
+                    aggregator_artifacts_directory.display()
+                )
+            })?;
+        }
+
         let mut aggregator = Aggregator::new(&AggregatorConfig {
             server_port: config.server_port,
             pool_node,
             cardano_cli_path: &config.devnet.cardano_cli_path(),
             work_dir: &config.work_dir,
+            artifacts_dir: &aggregator_artifacts_directory,
             bin_dir: &config.bin_dir,
             cardano_node_version: &config.cardano_node_version,
             mithril_run_interval: config.mithril_run_interval,
@@ -312,15 +326,16 @@ impl MithrilInfrastructure {
     }
 
     pub fn build_client(&self) -> StdResult<Client> {
-        let work_dir = if self.use_era_specific_work_dir {
-            let era_work_dir = self.work_dir.join(format!("era.{}", self.current_era));
-            if !era_work_dir.exists() {
-                fs::create_dir(&era_work_dir)?;
+        let work_dir = {
+            let mut artifacts_dir = self.artifacts_dir.join("mithril-client");
+            if self.use_era_specific_work_dir {
+                artifacts_dir = artifacts_dir.join(format!("era.{}", self.current_era));
+            }
+            if !artifacts_dir.exists() {
+                fs::create_dir_all(&artifacts_dir)?;
             }
 
-            era_work_dir
-        } else {
-            self.work_dir.clone()
+            artifacts_dir
         };
 
         Client::new(self.aggregator.endpoint(), &work_dir, &self.bin_dir)

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -23,6 +23,7 @@ pub async fn bootstrap_aggregator(
         pool_node: &args.pool_node,
         cardano_cli_path: &args.cardano_cli_path,
         work_dir: &args.work_dir,
+        artifacts_dir: &args.work_dir,
         bin_dir: &args.bin_dir,
         cardano_node_version: "1.2.3",
         mithril_run_interval: 1000,


### PR DESCRIPTION
## Content

This PR move into sub-directories the artifacts generated during an `mithril-end-to-end` run in order reduce the number of file in the work directory (that became quite packed).

Before a typical run would yield:
```shell
$ tree -L 1 /tmp/mithril-end-to-end/
Downloads/tmp/mithril-e2e-tests-artifacts-run_7180-attempt_1-mode_p2p-era_thales-cardano-9.1.1-fork-0-run_id_#1/
├── devnet
├── devnet-e11-i2.3fbf74bd9da957b719e80b562c7a845c4c87161e530c962c073bf887944865f7.tar.zst
├── devnet-e12-i2.f0b62520d4689fb37c3f8c5f611d357a2f4b0df1387fe845f6a6e67e081e5e73.tar.zst
├── devnet-e13-i2.c811e3d6e4ce658b1207ba131db4aaea2a30c7b2262239c641212d2bf2164d1e.tar.zst
├── devnet-e13-i3.c194fd6096c42dafe4788a82d11b77d26f568370fb78e08370184f80a79ff527.tar.zst
├── devnet-e14-i3.5844223f76f57434f14b2bc8df2286dc70908a89943c8fd95161888039d338c9.tar.zst
├── devnet-e15-i3.def715c7ad26914307e69a8c90e13b2b300e2481dbf75aad9691192037b6ecfa.tar.zst
├── devnet-e16-i3.a5af2e07c5c46fa81a99e587d1c0bc965959347b40d3ad7ad324ad9e975fd3fd.tar.zst
├── devnet-e17-i4.e6d25c2f93b79b749dbc92acbc9618134f79418eba9d0587bb21efd11fb4e247.tar.zst
├── devnet-e18-i4.be0ccc3d7e276a95e7bcc87f208ed58426de44eb1a4d50306c4f0323b863fe90.tar.zst
├── devnet-e19-i4.965d592b4726eed450dba53297642504c087dff486647f1f06ebae510114418b.tar.zst
├── devnet-e20-i5.237d2d827fe96bbcc994f2c02a7ab4d80dbebbed48cbf482031f413c1adbeec4.tar.zst
├── devnet-e21-i5.3f7b131ce3bdf74f36007eb7aade83ade4dbfb122b6991e15a3ae0871dfd2cfe.tar.zst
├── era.Array
├── era.thales
├── mithril-aggregator.log
├── mithril-relay-aggregator.log
├── mithril-relay-passive-1.log
├── mithril-relay-passive-2.log
├── mithril-relay-passive-3.log
├── mithril-relay-signer-pool1jekcezekdagcu7yzdjkfr6lw8727fzw6d8585638q9es7kx7a52.log
├── mithril-relay-signer-pool1snumlq5p70vlz2jmy7zx032hgea9j3t4py8rqe9vp9f52terqpg.log
├── mithril-signer-1-pool1jekcezekdagcu7yzdjkfr6lw8727fzw6d8585638q9es7kx7a52.log
├── mithril-signer-2-pool1snumlq5p70vlz2jmy7zx032hgea9j3t4py8rqe9vp9f52terqpg.log
└── stores

5 directories, 21 file
```

Now it yield far less files since they are moved to a `artifact` sub-folder:
```shell
tree -L 1 /tmp/mithril_end_to_end/
/tmp/mithril_end_to_end/
├── artifacts
├── devnet
├── mithril-aggregator.log
├── mithril-signer-1-pool1r2lney4kcl5qmvmsxsegpysrxnp0u32dngv98evwtqp05cerhaa.log
├── mithril-signer-2-pool1nhvcz4h7d4rstzpk7lnn9zcja6svpun0zrpqetg7wa0ssud0pc9.log
└── stores

4 directories, 3 files
``` 

The artifact subfolder have the following structure:

- Without era switch:
```shell
$ tree /tmp/mithril_end_to_end/artifacts/ -L 2
/tmp/mithril_end_to_end/artifacts/
├── mithril-aggregator
│   ├── devnet-e15-i3.dd0cd5ae8c5cb214f41225e30becc0b9c647ae7d0ffb5328d9ea555f7efac5b5.tar.zst
│   ├── devnet-e16-i3.bba43e5a5ca155ad4404e20083f226fd94f05ce672af15c6b688eaefc40ee72d.tar.zst
│   ├── devnet-e17-i4.37b4a36c87ff8f40bb0d36c1b44bda64243eebfc79c530bed3f0d765e278c54b.tar.zst
│   ├── devnet-e18-i4.6c1bfa476a7dcfdfcb7e17004079aca90974ad3ac88b4848721c33a12c4d7911.tar.zst
│   ├── devnet-e19-i4.2989a9d172612c79b6f535955661fadf2d95fd1e78413c6cd540afc19dbd3fd7.tar.zst
│   ├── devnet-e20-i5.53de4a3ac470f72ba2bcbef7d14b5e8ff9d14dff9794bf06051451cf44abb397.tar.zst
│   ├── devnet-e21-i5.e8739d3b19a76195699a2a4d936eab870b28869cce5e20f0f8632934f61d78ce.tar.zst
│   ├── devnet-e22-i5.d2f4858dbcdbf260e7d6be0f886d70134abdc8bc7a3e77e3ecaf70b99cba7149.tar.zst
│   ├── devnet-e23-i5.95af8cb64ee965017298d0fa6893499e19238ddcdf555c7d5656ba48b3c39e33.tar.zst
│   └── pending_snapshot
└── mithril-client
    ├── cardano_stake_distribution-22.json
    ├── db
    ├── mithril-client-cardano-db-download-d2f4858dbcdbf260e7d6be0f886d70134abdc8bc7a3e77e3ecaf70b99cba7149.out
    ├── mithril-client-csd-download-22.out
    ├── mithril-client-csd-download-478fb0cbb83c5c2f60e1736f43ef08caaa8e8143e5427a2b77f72262220316bf.out
    ├── mithril-client-ctx-certify-39e64f4b72348cc8a177e88c04916b40921343147d9525d18e4073a2d6e64d9f..1acaf6970e908775a81c954f86a931a81220a0e630b2de313b7323162518ac4f.out
    ├── mithril-client.log
    ├── mithril-client-msd-download-b66463919186d577245916a9691c7e48d83fc52811ed13ab84bd52aa70a61754.out
    └── mithril_stake_distribution-b66463919186d577245916a9691c7e48d83fc52811ed13ab84bd52aa70a61754.json

5 directories, 17 files
``` 

- With era switch:
```shell
$tree /tmp/mithril_end_to_end/artifacts/ -L 3
/tmp/mithril_end_to_end/artifacts/
├── mithril-aggregator
│   ├── devnet-e18-i4.3d459838140aa41e89221beb4ef328c5c51cbb793b843b151472bd6c0dee9f82.tar.zst
│   ├── devnet-e19-i4.5640ea8e076ee1e81200ee34651da70f2c32419a0845def4142293a58225343e.tar.zst
│   ├── devnet-e20-i5.baf236715ac8a561a95f77db125349f92719491f0d15fdf105de100c054afa15.tar.zst
│   ├── devnet-e21-i5.63051f9cb894f85efc34dfa504baa19f4b5bb564010c91f849c4760607f116dc.tar.zst
│   ├── devnet-e22-i5.c3f794cd9e7f6ecfe4598c8956479a3ca79ae37d40c0676412398d6e7887513c.tar.zst
│   ├── devnet-e23-i5.5f82771d936cf4cdddda688f230547365e861937f00f1cb0df69423680cbebdb.tar.zst
│   ├── devnet-e23-i6.b4f2b624b3ab3ac5ce36f88a624baa091f16ecf6c17d6603dcc162674a146589.tar.zst
│   ├── devnet-e24-i6.52294b6a3237bd3522c843735d2b9077109c9bd4ec50284b196cbb4ba73c161e.tar.zst
│   ├── devnet-e25-i6.cc99d391b4836f5d4c0f61ecfa933622286587cf2404ffd94964c16fce191bba.tar.zst
│   ├── devnet-e26-i6.dafc50fc70488483e237dcca5d6e1fc1a0735e73c7740b69e1371fbd2c2bf4ad.tar.zst
│   ├── devnet-e27-i7.019a64ec1e5bc72f50ec118648bc72750fd137dc0844c7710c3b31c7cb5cdf2f.tar.zst
│   ├── devnet-e28-i7.83f471370b44f405b363a111e9758a3b6c67512db77704ac63e678532e81df9d.tar.zst
│   ├── devnet-e29-i7.41050f1be662ba9925e82b2a76ab18b6e74a63b474bf4cd276d958144dfc7004.tar.zst
│   ├── devnet-e30-i8.6c6bdcce7e7185384ba78abd668be5553bffcc27b7b9828787fe23f226a0a1ba.tar.zst
│   ├── devnet-e31-i8.94e8220a5837864e5b776fa132d0e3b0c51c0d11a4a02413c093a629270f001a.tar.zst
│   └── pending_snapshot
└── mithril-client
    ├── era.pythagoras
    │   ├── cardano_stake_distribution-30.json
    │   ├── db
    │   ├── mithril-client-cardano-db-download-6c6bdcce7e7185384ba78abd668be5553bffcc27b7b9828787fe23f226a0a1ba.out
    │   ├── mithril-client-csd-download-30.out
    │   ├── mithril-client-csd-download-78cd1ed2f73cd81b573897fbb917ea93405e5a3c45ecb2dc9f8713315d76d6e0.out
    │   ├── mithril-client-ctx-certify-9b93a8daab1c214cfe085fd161d0e96ea5052db3488e189ed676925f3584d23c..fbd0ae5a1611d99da6dd36144990f1f2df1d41179ea67683c54f49d765542bab.out
    │   ├── mithril-client.log
    │   ├── mithril-client-msd-download-8ffe7837e73dcbda87921f96d517ff4bd4cbe8170378526e7ca2a5132189f5d0.out
    │   └── mithril_stake_distribution-8ffe7837e73dcbda87921f96d517ff4bd4cbe8170378526e7ca2a5132189f5d0.json
    └── era.thales
        ├── cardano_stake_distribution-24.json
        ├── db
        ├── mithril-client-cardano-db-download-cc99d391b4836f5d4c0f61ecfa933622286587cf2404ffd94964c16fce191bba.out
        ├── mithril-client-csd-download-24.out
        ├── mithril-client-csd-download-dc8c6d5aaac72bd5fe3814a03a1e431bf49790df383e270a663eaa6d83c1f31a.out
        ├── mithril-client-ctx-certify-9b93a8daab1c214cfe085fd161d0e96ea5052db3488e189ed676925f3584d23c..fbd0ae5a1611d99da6dd36144990f1f2df1d41179ea67683c54f49d765542bab.out
        ├── mithril-client.log
        ├── mithril-client-msd-download-2dc402a566682dfa6e0f136d9f8fa83fe468455c4587df46eb81bfd3d0297ec7.out
        └── mithril_stake_distribution-2dc402a566682dfa6e0f136d9f8fa83fe468455c4587df46eb81bfd3d0297ec7.json

8 directories, 31 files
``` 

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
