### PR TITLE
Fix: aggregator panics in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.78"
+version = "0.5.79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.38"
+version = "0.4.39"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.78"
+version = "0.5.79"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1451,6 +1451,9 @@ impl DependenciesBuilder {
             "Dependencies Builder can not get Cardano network while building genesis container"
         })?;
 
+        // Disable store pruning for genesis commands
+        self.configuration.store_retention_limit = None;
+
         let dependencies = GenesisToolsDependency {
             network,
             ticker_service: self.get_ticker_service().await?,

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.38"
+version = "0.4.39"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -147,7 +147,8 @@ impl Aggregator {
     pub async fn bootstrap_genesis(&mut self) -> StdResult<()> {
         // Clone the command so we can alter it without affecting the original
         let mut command = self.command.clone();
-        command.set_log_name("mithril-aggregator-genesis-bootstrap");
+        let process_name = "mithril-aggregator-genesis-bootstrap";
+        command.set_log_name(process_name);
 
         let exit_status = command
             .start(&["genesis".to_string(), "bootstrap".to_string()])?
@@ -158,6 +159,8 @@ impl Aggregator {
         if exit_status.success() {
             Ok(())
         } else {
+            self.command.tail_logs(Some(process_name), 40).await?;
+
             Err(match exit_status.code() {
                 Some(c) => {
                     anyhow!("`mithril-aggregator genesis bootstrap` exited with code: {c}")


### PR DESCRIPTION
## Content

This PR includes a modification that disables store pruning for genesis commands, an operation that is unnecessary in this context.
An issue was identified through E2E tests and was causing a panic during the pruning of the epoch setting table: https://github.com/input-output-hk/mithril/actions/runs/11146785295/job/30979818861#step:6:642

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1983 
