### PR TITLE
Refactor(aggregator): simplify http server dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.79"
+version = "0.5.80"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.79"
+version = "0.5.80"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -1,14 +1,13 @@
 use crate::http_server::routes::middlewares;
 use crate::DependencyContainer;
-use std::sync::Arc;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    artifact_cardano_stake_distributions(dependency_manager.clone())
+    artifact_cardano_stake_distributions(dependency_manager)
         .or(artifact_cardano_stake_distribution_by_id(
-            dependency_manager.clone(),
+            dependency_manager,
         ))
         .or(artifact_cardano_stake_distribution_by_epoch(
             dependency_manager,
@@ -17,7 +16,7 @@ pub fn routes(
 
 /// GET /artifact/cardano-stake-distributions
 fn artifact_cardano_stake_distributions(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-stake-distributions")
         .and(warp::get())
@@ -27,7 +26,7 @@ fn artifact_cardano_stake_distributions(
 
 /// GET /artifact/cardano-stake-distribution/:id
 fn artifact_cardano_stake_distribution_by_id(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-stake-distribution" / String)
         .and(warp::get())
@@ -37,7 +36,7 @@ fn artifact_cardano_stake_distribution_by_id(
 
 /// GET /artifact/cardano-stake-distribution/epoch/:epoch
 fn artifact_cardano_stake_distribution_by_epoch(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-stake-distribution" / "epoch" / String)
         .and(warp::get())
@@ -137,6 +136,7 @@ pub mod handlers {
 pub mod tests {
     use anyhow::anyhow;
     use serde_json::Value::Null;
+    use std::sync::Arc;
     use warp::{
         http::{Method, StatusCode},
         test::request,
@@ -163,7 +163,7 @@ pub mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -1,18 +1,17 @@
 use crate::http_server::routes::middlewares;
 use crate::DependencyContainer;
-use std::sync::Arc;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    artifact_cardano_transactions(dependency_manager.clone())
+    artifact_cardano_transactions(dependency_manager)
         .or(artifact_cardano_transaction_by_id(dependency_manager))
 }
 
 /// GET /artifact/cardano-transactions
 fn artifact_cardano_transactions(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-transactions")
         .and(warp::get())
@@ -22,7 +21,7 @@ fn artifact_cardano_transactions(
 
 /// GET /artifact/cardano-transaction/:id
 fn artifact_cardano_transaction_by_id(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-transaction" / String)
         .and(warp::get())
@@ -102,6 +101,7 @@ pub mod tests {
     };
     use mithril_persistence::sqlite::HydrationError;
     use serde_json::Value::Null;
+    use std::sync::Arc;
     use warp::{
         http::{Method, StatusCode},
         test::request,
@@ -119,7 +119,7 @@ pub mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -1,19 +1,18 @@
 use crate::http_server::routes::middlewares;
 use crate::DependencyContainer;
-use std::sync::Arc;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    artifact_mithril_stake_distributions(dependency_manager.clone()).or(
+    artifact_mithril_stake_distributions(dependency_manager).or(
         artifact_mithril_stake_distribution_by_id(dependency_manager),
     )
 }
 
 /// GET /artifact/mithril-stake-distributions
 fn artifact_mithril_stake_distributions(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "mithril-stake-distributions")
         .and(warp::get())
@@ -23,7 +22,7 @@ fn artifact_mithril_stake_distributions(
 
 /// GET /artifact/mithril-stake-distribution/:id
 fn artifact_mithril_stake_distribution_by_id(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "mithril-stake-distribution" / String)
         .and(warp::get())
@@ -102,6 +101,7 @@ pub mod tests {
     };
     use mithril_persistence::sqlite::HydrationError;
     use serde_json::Value::Null;
+    use std::sync::Arc;
     use warp::{
         http::{Method, StatusCode},
         test::request,
@@ -119,7 +119,7 @@ pub mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -1,19 +1,18 @@
 use crate::http_server::routes::middlewares;
 use crate::DependencyContainer;
-use std::sync::Arc;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    certificate_pending(dependency_manager.clone())
-        .or(certificate_certificates(dependency_manager.clone()))
+    certificate_pending(dependency_manager)
+        .or(certificate_certificates(dependency_manager))
         .or(certificate_certificate_hash(dependency_manager))
 }
 
 /// GET /certificate-pending
 fn certificate_pending(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("certificate-pending")
         .and(warp::get())
@@ -25,7 +24,7 @@ fn certificate_pending(
 
 /// GET /certificates
 fn certificate_certificates(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("certificates")
         .and(warp::get())
@@ -35,7 +34,7 @@ fn certificate_certificates(
 
 /// GET /certificate/{certificate_hash}
 fn certificate_certificate_hash(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("certificate" / String)
         .and(warp::get())
@@ -126,6 +125,7 @@ mod tests {
     };
     use mithril_persistence::store::adapter::DumbStoreAdapter;
     use serde_json::Value::Null;
+    use std::sync::Arc;
     use warp::{
         http::{Method, StatusCode},
         test::request,
@@ -148,7 +148,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -1,4 +1,4 @@
-use std::{collections::BTreeSet, sync::Arc};
+use std::collections::BTreeSet;
 use warp::Filter;
 
 use mithril_common::{
@@ -12,18 +12,18 @@ use crate::http_server::routes::middlewares;
 use crate::DependencyContainer;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     epoch_settings(dependency_manager)
 }
 
 /// GET /epoch-settings
 fn epoch_settings(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("epoch-settings")
         .and(warp::get())
-        .and(middlewares::with_epoch_service(dependency_manager.clone()))
+        .and(middlewares::with_epoch_service(dependency_manager))
         .and(middlewares::with_allowed_signed_entity_type_discriminants(
             dependency_manager,
         ))
@@ -99,6 +99,7 @@ mod handlers {
 mod tests {
     use serde_json::Value::Null;
     use std::collections::BTreeSet;
+    use std::sync::Arc;
     use tokio::sync::RwLock;
     use warp::{
         http::{Method, StatusCode},
@@ -129,7 +130,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -18,100 +18,114 @@ use crate::{
 
 /// With certificate pending store
 pub(crate) fn with_certificate_pending_store(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<CertificatePendingStore>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.certificate_pending_store.clone())
+    let certificate_pending_store = dependency_manager.certificate_pending_store.clone();
+    warp::any().map(move || certificate_pending_store.clone())
 }
 
 /// With signer registerer middleware
 pub fn with_signer_registerer(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<dyn SignerRegisterer>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.signer_registerer.clone())
+    let signer_register = dependency_manager.signer_registerer.clone();
+    warp::any().map(move || signer_register.clone())
 }
 
 /// With signer getter middleware
 pub fn with_signer_getter(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<dyn SignerGetter>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.signer_getter.clone())
+    let signer_getter = dependency_manager.signer_getter.clone();
+    warp::any().map(move || signer_getter.clone())
 }
 
 /// With config middleware
 pub fn with_config(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Configuration,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.config.clone())
+    let config = dependency_manager.config.clone();
+    warp::any().map(move || config.clone())
 }
 
 /// With allowed signed entity discriminants middleware
 pub fn with_allowed_signed_entity_type_discriminants(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (BTreeSet<SignedEntityTypeDiscriminants>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.allowed_discriminants.clone())
+    let allowed_discriminants = dependency_manager.allowed_discriminants.clone();
+    warp::any().map(move || allowed_discriminants.clone())
 }
 
 /// With Event transmitter middleware
 pub fn with_event_transmitter(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<TransmitterService<EventMessage>>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.event_transmitter.clone())
+    let event_transmitter = dependency_manager.event_transmitter.clone();
+    warp::any().map(move || event_transmitter.clone())
 }
 
 /// With certifier service middleware
 pub fn with_certifier_service(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<dyn CertifierService>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.certifier_service.clone())
+    let certifier_service = dependency_manager.certifier_service.clone();
+    warp::any().map(move || certifier_service.clone())
 }
 
 /// With epoch service middleware
 pub fn with_epoch_service(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (EpochServiceWrapper,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.epoch_service.clone())
+    let epoch_service = dependency_manager.epoch_service.clone();
+    warp::any().map(move || epoch_service.clone())
 }
 
 /// With signed entity service
 pub fn with_signed_entity_service(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<dyn SignedEntityService>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.signed_entity_service.clone())
+    let signed_entity_service = dependency_manager.signed_entity_service.clone();
+    warp::any().map(move || signed_entity_service.clone())
 }
 
 /// With verification key store
 pub fn with_verification_key_store(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<dyn VerificationKeyStorer>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.verification_key_store.clone())
+    let verification_key_store = dependency_manager.verification_key_store.clone();
+    warp::any().map(move || verification_key_store.clone())
 }
 
 /// With API version provider
 pub fn with_api_version_provider(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<APIVersionProvider>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.api_version_provider.clone())
+    let api_version_provider = dependency_manager.api_version_provider.clone();
+    warp::any().map(move || api_version_provider.clone())
 }
 
 /// With Message service
 pub fn with_http_message_service(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<dyn MessageService>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.message_service.clone())
+    let message_service = dependency_manager.message_service.clone();
+    warp::any().map(move || message_service.clone())
 }
 
 /// With Prover service
 pub fn with_prover_service(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<dyn ProverService>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.prover_service.clone())
+    let prover_service = dependency_manager.prover_service.clone();
+    warp::any().map(move || prover_service.clone())
 }
 
 /// With Single Signature Authenticator
 pub fn with_single_signature_authenticator(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (Arc<SingleSignatureAuthenticator>,), Error = Infallible> + Clone {
-    warp::any().map(move || dependency_manager.single_signer_authenticator.clone())
+    let single_signer_authenticator = dependency_manager.single_signer_authenticator.clone();
+    warp::any().map(move || single_signer_authenticator.clone())
 }
 
 pub mod validators {
@@ -121,7 +135,7 @@ pub mod validators {
 
     /// With Prover Transactions Hash Validator
     pub fn with_prover_transactions_hash_validator(
-        dependency_manager: Arc<DependencyContainer>,
+        dependency_manager: &DependencyContainer,
     ) -> impl Filter<Extract = (ProverTransactionsHashValidator,), Error = Infallible> + Clone {
         let max_hashes = dependency_manager
             .config

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -1,25 +1,22 @@
 use crate::DependencyContainer;
-use std::sync::Arc;
 use warp::Filter;
 
 use super::middlewares;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     root(dependency_manager)
 }
 
 /// GET /
 fn root(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path::end()
-        .and(middlewares::with_api_version_provider(
-            dependency_manager.clone(),
-        ))
+        .and(middlewares::with_api_version_provider(dependency_manager))
         .and(middlewares::with_allowed_signed_entity_type_discriminants(
-            dependency_manager.clone(),
+            dependency_manager,
         ))
         .and(middlewares::with_config(dependency_manager))
         .and_then(handlers::root)
@@ -117,7 +114,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -42,29 +42,27 @@ pub fn routes(
         ))
         .and(warp::path(SERVER_BASE_PATH))
         .and(
-            certificate_routes::routes(dependency_manager.clone())
-                .or(artifact_routes::snapshot::routes(
-                    dependency_manager.clone(),
-                ))
+            certificate_routes::routes(&dependency_manager)
+                .or(artifact_routes::snapshot::routes(&dependency_manager))
                 .or(artifact_routes::mithril_stake_distribution::routes(
-                    dependency_manager.clone(),
+                    &dependency_manager,
                 ))
                 .or(artifact_routes::cardano_stake_distribution::routes(
-                    dependency_manager.clone(),
+                    &dependency_manager,
                 ))
                 .or(artifact_routes::cardano_transaction::routes(
-                    dependency_manager.clone(),
+                    &dependency_manager,
                 ))
-                .or(proof_routes::routes(dependency_manager.clone()))
-                .or(signer_routes::routes(dependency_manager.clone()))
-                .or(signatures_routes::routes(dependency_manager.clone()))
-                .or(epoch_routes::routes(dependency_manager.clone()))
-                .or(statistics_routes::routes(dependency_manager.clone()))
-                .or(root_routes::routes(dependency_manager.clone()))
+                .or(proof_routes::routes(&dependency_manager))
+                .or(signer_routes::routes(&dependency_manager))
+                .or(signatures_routes::routes(&dependency_manager))
+                .or(epoch_routes::routes(&dependency_manager))
+                .or(statistics_routes::routes(&dependency_manager))
+                .or(root_routes::routes(&dependency_manager))
                 .with(cors),
         )
         .recover(handle_custom)
-        .and(middlewares::with_api_version_provider(dependency_manager))
+        .and(middlewares::with_api_version_provider(&dependency_manager))
         .map(|reply, api_version_provider: Arc<APIVersionProvider>| {
             warp::reply::with_header(
                 reply,

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -1,24 +1,21 @@
 use crate::http_server::routes::middlewares;
 use crate::DependencyContainer;
-use std::sync::Arc;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     register_signatures(dependency_manager)
 }
 
 /// POST /register-signatures
 fn register_signatures(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("register-signatures")
         .and(warp::post())
         .and(warp::body::json())
-        .and(middlewares::with_certifier_service(
-            dependency_manager.clone(),
-        ))
+        .and(middlewares::with_certifier_service(dependency_manager))
         .and(middlewares::with_single_signature_authenticator(
             dependency_manager,
         ))
@@ -108,6 +105,7 @@ mod handlers {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
+    use std::sync::Arc;
     use warp::http::{Method, StatusCode};
     use warp::test::request;
 
@@ -135,7 +133,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -1,25 +1,22 @@
-use std::sync::Arc;
 use warp::Filter;
 
 use crate::http_server::routes::middlewares;
 use crate::DependencyContainer;
 
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     post_statistics(dependency_manager)
 }
 
 /// POST /statistics/snapshot
 fn post_statistics(
-    dependency_manager: Arc<DependencyContainer>,
+    dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("statistics" / "snapshot")
         .and(warp::post())
         .and(warp::body::json())
-        .and(middlewares::with_event_transmitter(
-            dependency_manager.clone(),
-        ))
+        .and(middlewares::with_event_transmitter(dependency_manager))
         .and_then(handlers::post_snapshot_statistics)
 }
 
@@ -57,6 +54,7 @@ mod tests {
     use mithril_common::messages::SnapshotDownloadMessage;
     use mithril_common::test_utils::apispec::APISpec;
 
+    use std::sync::Arc;
     use warp::{
         http::{Method, StatusCode},
         test::request,
@@ -76,7 +74,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(dependency_manager).with(cors))
+            .and(routes(&dependency_manager).with(cors))
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Content

This PR simplify the aggregator http server dependencies by providing the dependency container by reference instead of by move, allowing to remove the numerous `.clone()` used before.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
