### PR TITLE
Feat: implement certificate chain builder for tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.71"
+version = "0.4.72"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.71"
+version = "0.4.72"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -18,7 +18,7 @@ pub struct ProtocolGenesisError(#[source] StdError);
 
 /// A protocol Genesis Signer that is responsible for signing the
 /// [Genesis Certificate](https://mithril.network/doc/mithril/mithril-protocol/certificates#the-certificate-chain-design)
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProtocolGenesisSigner {
     /// Protocol Genesis secret key
     pub(crate) secret_key: ProtocolGenesisSecretKey,

--- a/mithril-common/src/test_utils/certificate_chain_builder.rs
+++ b/mithril-common/src/test_utils/certificate_chain_builder.rs
@@ -1,0 +1,289 @@
+use std::{cmp::min, collections::HashMap, sync::Arc};
+
+use crate::{
+    certificate_chain::CertificateGenesisProducer,
+    crypto_helper::{
+        ProtocolAggregateVerificationKey, ProtocolClerk, ProtocolGenesisSigner,
+        ProtocolGenesisVerifier, ProtocolParameters,
+    },
+    entities::{
+        Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessagePartKey,
+    },
+    test_utils::{fake_data, MithrilFixture, MithrilFixtureBuilder, SignerFixture},
+};
+
+/// Context used while building a certificate chain. For tests only.
+pub struct CertificateChainBuilderContext<'a> {
+    pub index_certificate: usize,
+    #[allow(dead_code)]
+    pub total_certificates: usize,
+    pub epoch: Epoch,
+    pub fixture: &'a MithrilFixture,
+    pub next_fixture: &'a MithrilFixture,
+}
+
+/// A builder for creating a certificate chain. For tests only.
+///
+/// # Example usage
+///
+/// ```
+///     use mithril_common::crypto_helper::ProtocolParameters;
+///     use mithril_common::test_utils::CertificateChainBuilder;
+///
+///     let (certificate_chain, _protocol_genesis_verifier) = CertificateChainBuilder::new()
+///         .with_total_certificates(5)
+///         .with_certificates_per_epoch(2)
+///         .with_protocol_parameters(ProtocolParameters {
+///             m: 100,
+///             k: 5,
+///             phi_f: 0.65,
+///         }).build();
+///
+///     assert_eq!(5, certificate_chain.len());
+/// ```
+pub struct CertificateChainBuilder {
+    total_certificates: u64,
+    certificates_per_epoch: u64,
+    protocol_parameters: ProtocolParameters,
+}
+
+impl CertificateChainBuilder {
+    /// Create a new [CertificateChainBuilder] instance.
+    pub fn new() -> Self {
+        let protocol_parameters = ProtocolParameters {
+            m: 100,
+            k: 5,
+            phi_f: 0.65,
+        };
+        Self {
+            total_certificates: 5,
+            certificates_per_epoch: 1,
+            protocol_parameters,
+        }
+    }
+
+    /// Set the total number of certificates to generate.
+    pub fn with_total_certificates(mut self, total_certificates: u64) -> Self {
+        self.total_certificates = total_certificates;
+
+        self
+    }
+
+    /// Set the number of certificates per epoch.
+    pub fn with_certificates_per_epoch(mut self, certificates_per_epoch: u64) -> Self {
+        self.certificates_per_epoch = certificates_per_epoch;
+
+        self
+    }
+
+    /// Set the protocol parameters.
+    pub fn with_protocol_parameters(mut self, protocol_parameters: ProtocolParameters) -> Self {
+        self.protocol_parameters = protocol_parameters;
+
+        self
+    }
+
+    /// Build the certificate chain.
+    pub fn build(self) -> (Vec<Certificate>, ProtocolGenesisVerifier) {
+        let (genesis_signer, genesis_verifier) = CertificateChainBuilder::setup_genesis();
+        let epochs = Self::setup_epochs(self.total_certificates, self.certificates_per_epoch);
+        let fixtures_per_epoch =
+            Self::setup_fixtures_for_epochs(&epochs, &self.protocol_parameters);
+        let certificate_chain_length = epochs.len() - 1;
+        let certificates = epochs
+            .iter()
+            .take(certificate_chain_length)
+            .enumerate()
+            .map(|(i, epoch)| {
+                let fixture = fixtures_per_epoch.get(epoch).unwrap();
+                let next_fixture = fixtures_per_epoch.get(&(*epoch + 1)).unwrap();
+                let context = CertificateChainBuilderContext {
+                    index_certificate: i,
+                    total_certificates: certificate_chain_length,
+                    epoch: *epoch,
+                    fixture,
+                    next_fixture,
+                };
+                match i {
+                    0 => Self::create_genesis_certificate(&context, &genesis_signer),
+                    _ => Self::create_standard_certificate(&context),
+                }
+            })
+            .collect::<Vec<Certificate>>();
+        let certificates_chained = Self::compute_chained_certificates(certificates);
+
+        (certificates_chained, genesis_verifier)
+    }
+
+    fn compute_clerk_for_signers(signers: &[SignerFixture]) -> ProtocolClerk {
+        let first_signer = &signers[0].protocol_signer;
+
+        ProtocolClerk::from_signer(first_signer)
+    }
+
+    fn compute_avk_for_signers(signers: &[SignerFixture]) -> ProtocolAggregateVerificationKey {
+        let clerk = Self::compute_clerk_for_signers(signers);
+
+        clerk.compute_avk().into()
+    }
+
+    fn setup_genesis() -> (ProtocolGenesisSigner, ProtocolGenesisVerifier) {
+        let genesis_signer = ProtocolGenesisSigner::create_deterministic_genesis_signer();
+        let genesis_verifier = genesis_signer.create_genesis_verifier();
+
+        (genesis_signer, genesis_verifier)
+    }
+
+    fn setup_epochs(total_certificates: u64, certificates_per_epoch: u64) -> Vec<Epoch> {
+        (1..total_certificates + 2)
+            .map(|i| match certificates_per_epoch {
+                0 => panic!("expected at least 1 certificate per epoch"),
+                1 => Epoch(i),
+                _ => Epoch(i / certificates_per_epoch + 1),
+            })
+            .collect::<Vec<_>>()
+    }
+
+    fn setup_fixtures_for_epochs(
+        epochs: &[Epoch],
+        protocol_parameters: &ProtocolParameters,
+    ) -> HashMap<Epoch, MithrilFixture> {
+        let fixtures_per_epoch = epochs
+            .iter()
+            .map(|epoch| {
+                // TODO: set that in the builder configuration?
+                let total_signers = min(2 + **epoch as usize, 5);
+                (
+                    *epoch,
+                    MithrilFixtureBuilder::default()
+                        .with_protocol_parameters(protocol_parameters.to_owned().into())
+                        .with_signers(total_signers)
+                        .build(),
+                )
+            })
+            .collect::<HashMap<_, _>>();
+
+        fixtures_per_epoch
+    }
+
+    fn create_base_certificate(context: &CertificateChainBuilderContext) -> Certificate {
+        let index = context.index_certificate;
+        let epoch = context.epoch;
+        let immutable_file_number = index as u64 * 10;
+        let digest = format!("digest{index}");
+        let certificate_hash = format!("certificate_hash-{index}");
+        let avk = Self::compute_avk_for_signers(&context.fixture.signers_fixture());
+        let next_avk = Self::compute_avk_for_signers(&context.next_fixture.signers_fixture());
+        let next_protocol_parameters = &context.next_fixture.protocol_parameters();
+        let mut base_certificate = fake_data::certificate(certificate_hash);
+        base_certificate
+            .protocol_message
+            .set_message_part(ProtocolMessagePartKey::SnapshotDigest, digest);
+        base_certificate.protocol_message.set_message_part(
+            ProtocolMessagePartKey::NextAggregateVerificationKey,
+            next_avk.to_json_hex().unwrap(),
+        );
+        base_certificate.protocol_message.set_message_part(
+            ProtocolMessagePartKey::NextProtocolParameters,
+            next_protocol_parameters.compute_hash(),
+        );
+        base_certificate
+            .protocol_message
+            .set_message_part(ProtocolMessagePartKey::CurrentEpoch, epoch.to_string());
+
+        Certificate {
+            epoch,
+            aggregate_verification_key: avk.to_owned(),
+            previous_hash: "".to_string(),
+            signed_message: base_certificate.protocol_message.compute_hash(),
+            #[allow(deprecated)]
+            metadata: CertificateMetadata {
+                immutable_file_number,
+                ..base_certificate.metadata
+            },
+            ..base_certificate
+        }
+    }
+
+    fn create_genesis_certificate(
+        context: &CertificateChainBuilderContext,
+        genesis_signer: &ProtocolGenesisSigner,
+    ) -> Certificate {
+        let epoch = context.epoch;
+        let certificate = Self::create_base_certificate(context);
+        let next_avk = Self::compute_avk_for_signers(&context.next_fixture.signers_fixture());
+        let next_protocol_parameters = &context.next_fixture.protocol_parameters();
+        let genesis_producer =
+            CertificateGenesisProducer::new(Some(Arc::new(genesis_signer.to_owned())));
+        let genesis_protocol_message = CertificateGenesisProducer::create_genesis_protocol_message(
+            next_protocol_parameters,
+            &next_avk,
+            &epoch,
+        )
+        .unwrap();
+        let genesis_signature = genesis_producer
+            .sign_genesis_protocol_message(genesis_protocol_message)
+            .unwrap();
+
+        CertificateGenesisProducer::create_genesis_certificate(
+            certificate.metadata.protocol_parameters,
+            certificate.metadata.network,
+            certificate.epoch,
+            #[allow(deprecated)]
+            certificate.metadata.immutable_file_number,
+            next_avk,
+            genesis_signature,
+        )
+        .unwrap()
+    }
+
+    fn create_standard_certificate(context: &CertificateChainBuilderContext) -> Certificate {
+        let fixture = context.fixture;
+        let mut certificate = Self::create_base_certificate(context);
+        certificate.metadata.signers = fixture.stake_distribution_parties();
+        let single_signatures = fixture
+            .signers_fixture()
+            .iter()
+            .filter_map(|s| {
+                s.protocol_signer
+                    .sign(certificate.signed_message.as_bytes())
+            })
+            .collect::<Vec<_>>();
+        let clerk = CertificateChainBuilder::compute_clerk_for_signers(&fixture.signers_fixture());
+        let multi_signature = clerk
+            .aggregate(&single_signatures, certificate.signed_message.as_bytes())
+            .unwrap();
+        certificate.signature = CertificateSignature::MultiSignature(
+            certificate.signed_entity_type(),
+            multi_signature.into(),
+        );
+
+        certificate
+    }
+
+    fn compute_chained_certificates(certificates: Vec<Certificate>) -> Vec<Certificate> {
+        let mut certificates_chained: Vec<Certificate> = Vec::new();
+        certificates
+            .iter()
+            .enumerate()
+            .for_each(|(i, certificate)| {
+                let mut certificate_new = certificate.clone();
+                if i > 0 {
+                    if let Some(previous_certificate) = certificates_chained.get(i - 1) {
+                        certificate_new.previous_hash = previous_certificate.compute_hash();
+                    }
+                }
+                certificate_new.hash = certificate_new.compute_hash();
+                certificates_chained.push(certificate_new);
+            });
+        certificates_chained.reverse();
+
+        certificates_chained
+    }
+}
+
+impl Default for CertificateChainBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/mithril-common/src/test_utils/certificate_chain_builder.rs
+++ b/mithril-common/src/test_utils/certificate_chain_builder.rs
@@ -9,7 +9,11 @@ use crate::{
 };
 
 use crate::entities::CertificateMetadata;
-use std::{cmp::min, collections::HashMap, sync::Arc};
+use std::{
+    cmp::min,
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 /// Genesis certificate processor function type. For tests only.
 pub type GenesisCertificateProcessorFunc =
@@ -268,6 +272,8 @@ impl<'a> CertificateChainBuilder<'a> {
     fn build_fixtures_for_epochs(&self, epochs: &[Epoch]) -> HashMap<Epoch, MithrilFixture> {
         let fixtures_per_epoch = epochs
             .iter()
+            .collect::<BTreeSet<_>>()
+            .into_iter()
             .map(|epoch| {
                 let total_signers = (self.total_signers_per_epoch_processor)(*epoch);
                 let protocol_parameters = self.protocol_parameters.to_owned().into();

--- a/mithril-common/src/test_utils/certificate_chain_builder.rs
+++ b/mithril-common/src/test_utils/certificate_chain_builder.rs
@@ -267,8 +267,12 @@ impl<'a> CertificateChainBuilder<'a> {
         );
         // The total number of epochs in the sequence is the total number of standard certificates (total number of certificates minus one genesis certificate)
         // divided by the number of certificates per epoch plus two (one for the genesis epoch and one to compute the next fixtures of the last epoch)
-        let total_epochs_in_sequence =
-            (total_certificates - 1).div_ceil(certificates_per_epoch) + 2;
+        const TOTAL_GENESIS_CERTIFICATES: u64 = 1;
+        const TOTAL_EXTRA_EPOCHS_FOR_FIXTURES_COMPUTATION: u64 = 1;
+        let total_epochs_in_sequence = (total_certificates - TOTAL_GENESIS_CERTIFICATES)
+            .div_ceil(certificates_per_epoch)
+            + TOTAL_GENESIS_CERTIFICATES
+            + TOTAL_EXTRA_EPOCHS_FOR_FIXTURES_COMPUTATION;
         (1..=total_epochs_in_sequence).map(Epoch)
     }
 

--- a/mithril-common/src/test_utils/certificate_chain_builder.rs
+++ b/mithril-common/src/test_utils/certificate_chain_builder.rs
@@ -49,6 +49,11 @@ impl CertificateChainBuilderContext<'_> {
 
         protocol_message
     }
+
+    /// Checks if the current certificate is the last one.
+    pub fn is_last_certificate(&self) -> bool {
+        self.index_certificate == self.total_certificates - 1
+    }
 }
 
 /// A builder for creating a certificate chain. For tests only.
@@ -100,8 +105,8 @@ impl CertificateChainBuilderContext<'_> {
 ///         .with_certificates_per_epoch(2)
 ///         .with_standard_certificate_processor(&|certificate, context| {
 ///             let mut certificate = certificate;
-///             // Tamper the epoch of the last certificate
-///             if context.index_certificate == context.total_certificates - 1 {
+///             // Alter the epoch of the last certificate
+///             if context.is_last_certificate() {
 ///                 certificate.epoch = Epoch(123);
 ///             }
 ///
@@ -455,6 +460,20 @@ mod test {
         );
 
         assert_eq!(expected_protocol_message, protocol_message);
+    }
+
+    #[test]
+    fn certificate_chain_builder_context_checks_correctly_if_certificate_is_last() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(2).build();
+        let context = CertificateChainBuilderContext {
+            index_certificate: 4,
+            total_certificates: 5,
+            epoch: Epoch(1),
+            fixture: &fixture,
+            next_fixture: &fixture,
+        };
+
+        assert!(context.is_last_certificate());
     }
 
     #[test]

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -14,6 +14,7 @@ pub mod fake_data;
 pub mod fake_keys;
 
 mod cardano_transactions_builder;
+mod certificate_chain_builder;
 mod fixture_builder;
 mod mithril_fixture;
 
@@ -24,6 +25,7 @@ mod temp_dir;
 pub mod test_http_server;
 
 pub use cardano_transactions_builder::CardanoTransactionsBuilder;
+pub use certificate_chain_builder::CertificateChainBuilder;
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};
 pub use mithril_fixture::{MithrilFixture, SignerFixture};
 pub use temp_dir::*;


### PR DESCRIPTION
## Content

This PR includes the implementation of a **Certificate Chain Builder for tests**:
- This part of the code is now more readable and maintainable
- The certificate chains allows alteration of the genesis and standard certificates with closures
- The computation of the number of signers per epoch is now configurable with a closure

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
