### PR TITLE
Use new GitHub action for creating releases

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -76,23 +76,15 @@ jobs:
           compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "⛔", "testing-sanchonet": "⛔" }'
 
       - name: Create pre-release ${{ github.ref_name }}
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: ${{ github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.ref_name }}
           prerelease: true
-          title: Mithril v${{ github.ref_name }}
+          name: Mithril v${{ github.ref_name }}
           files: package/*
-
-      - name: Update release body with release notes addon
-        # specific version since this action does not support giving only the major number
-        uses: tubone24/update_release@v1.3.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: ${{ github.ref_name }}
-        with:
-          is_append_body: true
           body_path: ./release-notes-addon.txt
+          append_body: true
 
   build-push-docker:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Content

This PR includes updates of the CI jobs that create `pre-release` and `release` to replace the unmaintained `marvinpinto/action-automatic-releases` action.

The https://github.com/softprops/action-gh-release is a suitable replacement for the pre-release job as it can handle the tasks previously managed by both [marvinpinto/action-automatic-releases](https://github.com/marvinpinto/actions/tree/master/packages/automatic-releases) and [tubone24/update_release](https://github.com/tubone24/update_release) , including updating the release notes body.

Examples of releases created from a fork of Mithril using these new GitHub Action: https://github.com/dlachaume/mithril/releases

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1691 
