### PR TITLE
Enhance logs construction and usage in aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,7 +3403,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.80"
+version = "0.5.81"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3559,7 +3559,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.67"
+version = "0.4.68"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -44,7 +44,6 @@ slog = { version = "2.7.0", features = [
 ] }
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
-slog-scope = "4.4.0"
 sqlite = { version = "0.36.1", features = ["bundled"] }
 tar = "0.4.41"
 thiserror = "1.0.63"
@@ -70,6 +69,7 @@ mithril-common = { path = "../mithril-common", features = [
     "test_tools",
 ] }
 mockall = "0.13.0"
+slog-scope = "4.4.0"
 slog-term = "2.9.1"
 tempfile = "3.12.0"
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.80"
+version = "0.5.81"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/interface.rs
+++ b/mithril-aggregator/src/artifact_builder/interface.rs
@@ -5,11 +5,8 @@ use mithril_common::{
     StdResult,
 };
 
-#[cfg(test)]
-use mockall::automock;
-
 /// ArtifactBuilder is trait for building an artifact
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait ArtifactBuilder<U, W>: Send + Sync
 where

--- a/mithril-aggregator/src/commands/era_command.rs
+++ b/mithril-aggregator/src/commands/era_command.rs
@@ -8,7 +8,7 @@ use mithril_common::{
     entities::{Epoch, HexEncodedEraMarkersSecretKey},
     StdResult,
 };
-use slog_scope::debug;
+use slog::{debug, Logger};
 
 use crate::tools::EraTools;
 
@@ -21,8 +21,14 @@ pub struct EraCommand {
 }
 
 impl EraCommand {
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
-        self.era_subcommand.execute(config_builder).await
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
+        self.era_subcommand
+            .execute(root_logger, config_builder)
+            .await
     }
 }
 
@@ -37,10 +43,14 @@ pub enum EraSubCommand {
 }
 
 impl EraSubCommand {
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
         match self {
-            Self::List(cmd) => cmd.execute(config_builder).await,
-            Self::GenerateTxDatum(cmd) => cmd.execute(config_builder).await,
+            Self::List(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::GenerateTxDatum(cmd) => cmd.execute(root_logger, config_builder).await,
         }
     }
 }
@@ -54,8 +64,12 @@ pub struct ListEraSubCommand {
 }
 
 impl ListEraSubCommand {
-    pub async fn execute(&self, _config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
-        debug!("LIST ERA command");
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        _config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
+        debug!(root_logger, "LIST ERA command");
         let era_tools = EraTools::new();
         let eras = era_tools.get_supported_eras_list()?;
 
@@ -91,8 +105,12 @@ pub struct GenerateTxDatumEraSubCommand {
 }
 
 impl GenerateTxDatumEraSubCommand {
-    pub async fn execute(&self, _config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
-        debug!("GENERATETXDATUM ERA command");
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        _config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
+        debug!(root_logger, "GENERATETXDATUM ERA command");
         let era_tools = EraTools::new();
 
         let era_markers_secret_key =

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -6,7 +6,7 @@ use mithril_common::{
     entities::HexEncodedGenesisSecretKey,
     StdResult,
 };
-use slog_scope::debug;
+use slog::{debug, Logger};
 use std::path::PathBuf;
 
 use crate::{dependency_injection::DependenciesBuilder, tools::GenesisTools, Configuration};
@@ -20,8 +20,14 @@ pub struct GenesisCommand {
 }
 
 impl GenesisCommand {
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
-        self.genesis_subcommand.execute(config_builder).await
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
+        self.genesis_subcommand
+            .execute(root_logger, config_builder)
+            .await
     }
 }
 
@@ -42,12 +48,16 @@ pub enum GenesisSubCommand {
 }
 
 impl GenesisSubCommand {
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
         match self {
-            Self::Bootstrap(cmd) => cmd.execute(config_builder).await,
-            Self::Export(cmd) => cmd.execute(config_builder).await,
-            Self::Import(cmd) => cmd.execute(config_builder).await,
-            Self::Sign(cmd) => cmd.execute(config_builder).await,
+            Self::Bootstrap(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::Export(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::Import(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::Sign(cmd) => cmd.execute(root_logger, config_builder).await,
         }
     }
 }
@@ -61,13 +71,17 @@ pub struct ExportGenesisSubCommand {
 }
 
 impl ExportGenesisSubCommand {
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
         let config: Configuration = config_builder
             .build()
             .with_context(|| "configuration build error")?
             .try_deserialize()
             .with_context(|| "configuration deserialize error")?;
-        debug!("EXPORT GENESIS command"; "config" => format!("{config:?}"));
+        debug!(root_logger, "EXPORT GENESIS command"; "config" => format!("{config:?}"));
         println!(
             "Genesis export payload to sign to {}",
             self.target_path.display()
@@ -98,13 +112,17 @@ pub struct ImportGenesisSubCommand {
 }
 
 impl ImportGenesisSubCommand {
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
         let config: Configuration = config_builder
             .build()
             .with_context(|| "configuration build error")?
             .try_deserialize()
             .with_context(|| "configuration deserialize error")?;
-        debug!("IMPORT GENESIS command"; "config" => format!("{config:?}"));
+        debug!(root_logger, "IMPORT GENESIS command"; "config" => format!("{config:?}"));
         println!(
             "Genesis import signed payload from {}",
             self.signed_payload_path.to_string_lossy()
@@ -144,8 +162,12 @@ pub struct SignGenesisSubCommand {
 }
 
 impl SignGenesisSubCommand {
-    pub async fn execute(&self, _config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
-        debug!("SIGN GENESIS command");
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        _config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
+        debug!(root_logger, "SIGN GENESIS command");
         println!(
             "Genesis sign payload from {} to {}",
             self.to_sign_payload_path.to_string_lossy(),
@@ -171,13 +193,17 @@ pub struct BootstrapGenesisSubCommand {
 }
 
 impl BootstrapGenesisSubCommand {
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
         let config: Configuration = config_builder
             .build()
             .with_context(|| "configuration build error")?
             .try_deserialize()
             .with_context(|| "configuration deserialize error")?;
-        debug!("BOOTSTRAP GENESIS command"; "config" => format!("{config:?}"));
+        debug!(root_logger, "BOOTSTRAP GENESIS command"; "config" => format!("{config:?}"));
         println!("Genesis bootstrap for test only!");
         let mut dependencies_builder = DependenciesBuilder::new(config.clone());
         let dependencies = dependencies_builder

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -86,7 +86,8 @@ impl ExportGenesisSubCommand {
             "Genesis export payload to sign to {}",
             self.target_path.display()
         );
-        let mut dependencies_builder = DependenciesBuilder::new(config.clone());
+        let mut dependencies_builder =
+            DependenciesBuilder::new(root_logger.clone(), config.clone());
         let dependencies = dependencies_builder
             .create_genesis_container()
             .await
@@ -127,7 +128,8 @@ impl ImportGenesisSubCommand {
             "Genesis import signed payload from {}",
             self.signed_payload_path.to_string_lossy()
         );
-        let mut dependencies_builder = DependenciesBuilder::new(config.clone());
+        let mut dependencies_builder =
+            DependenciesBuilder::new(root_logger.clone(), config.clone());
         let dependencies = dependencies_builder
             .create_genesis_container()
             .await
@@ -205,7 +207,8 @@ impl BootstrapGenesisSubCommand {
             .with_context(|| "configuration deserialize error")?;
         debug!(root_logger, "BOOTSTRAP GENESIS command"; "config" => format!("{config:?}"));
         println!("Genesis bootstrap for test only!");
-        let mut dependencies_builder = DependenciesBuilder::new(config.clone());
+        let mut dependencies_builder =
+            DependenciesBuilder::new(root_logger.clone(), config.clone());
         let dependencies = dependencies_builder
             .create_genesis_container()
             .await

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -92,7 +92,8 @@ impl ServeCommand {
             .try_deserialize()
             .with_context(|| "configuration deserialize error")?;
         debug!(root_logger, "SERVE command"; "config" => format!("{config:?}"));
-        let mut dependencies_builder = DependenciesBuilder::new(config.clone());
+        let mut dependencies_builder =
+            DependenciesBuilder::new(root_logger.clone(), config.clone());
 
         // start servers
         println!("Starting server...");

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::Parser;
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
 use mithril_common::StdResult;
-use slog_scope::{crit, debug, info, warn};
+use slog::{crit, debug, info, warn, Logger};
 use std::time::Duration;
 use std::{net::IpAddr, path::PathBuf};
 use tokio::{sync::oneshot, task::JoinSet};
@@ -80,14 +80,18 @@ impl Source for ServeCommand {
 }
 
 impl ServeCommand {
-    pub async fn execute(&self, mut config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        mut config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
         config_builder = config_builder.add_source(self.clone());
         let config: Configuration = config_builder
             .build()
             .with_context(|| "configuration build error")?
             .try_deserialize()
             .with_context(|| "configuration deserialize error")?;
-        debug!("SERVE command"; "config" => format!("{config:?}"));
+        debug!(root_logger, "SERVE command"; "config" => format!("{config:?}"));
         let mut dependencies_builder = DependenciesBuilder::new(config.clone());
 
         // start servers
@@ -172,8 +176,10 @@ impl ServeCommand {
                 }
                 Err(error) => {
                     warn!(
+                        root_logger,
                         "Failed to build the `SignersImporter`:\n url to import `{}`\n Error: {:?}",
-                        cexplorer_pools_url, error
+                        cexplorer_pools_url,
+                        error
                     );
                 }
             }
@@ -183,7 +189,7 @@ impl ServeCommand {
         dependencies_builder.vanish().await;
 
         if let Err(e) = join_set.join_next().await.unwrap()? {
-            crit!("A critical error occurred: {e}");
+            crit!(root_logger, "A critical error occurred: {e}");
         }
 
         // stop servers
@@ -194,7 +200,7 @@ impl ServeCommand {
             preload_task.abort();
         }
 
-        info!("Event store is finishing...");
+        info!(root_logger, "Event store is finishing...");
         event_store_thread.await.unwrap();
         println!("Services stopped, exiting.");
 

--- a/mithril-aggregator/src/commands/tools_command.rs
+++ b/mithril-aggregator/src/commands/tools_command.rs
@@ -73,7 +73,8 @@ impl RecomputeCertificatesHashCommand {
             .with_context(|| "configuration deserialize error")?;
         debug!(root_logger, "RECOMPUTE CERTIFICATES HASH command"; "config" => format!("{config:?}"));
         println!("Recomputing all certificate hash",);
-        let mut dependencies_builder = DependenciesBuilder::new(config.clone());
+        let mut dependencies_builder =
+            DependenciesBuilder::new(root_logger.clone(), config.clone());
         let connection = dependencies_builder
             .get_sqlite_connection()
             .await

--- a/mithril-aggregator/src/commands/tools_command.rs
+++ b/mithril-aggregator/src/commands/tools_command.rs
@@ -67,6 +67,7 @@ impl RecomputeCertificatesHashCommand {
         let migrator = CertificatesHashMigrator::new(
             CertificateRepository::new(connection.clone()),
             Arc::new(SignedEntityStore::new(connection.clone())),
+            dependencies_builder.get_logger()?,
         );
 
         migrator

--- a/mithril-aggregator/src/database/repository/certificate_repository.rs
+++ b/mithril-aggregator/src/database/repository/certificate_repository.rs
@@ -130,8 +130,6 @@ mod tests {
     use mithril_common::crypto_helper::tests_setup::setup_certificate_chain;
 
     use crate::database::test_helper::{insert_certificate_records, main_db_connection};
-    use crate::dependency_injection::DependenciesBuilder;
-    use crate::Configuration;
 
     use super::*;
 
@@ -239,8 +237,7 @@ mod tests {
     async fn repository_get_certificate() {
         let (certificates, _) = setup_certificate_chain(5, 2);
         let expected_hash = certificates[0].hash.clone();
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         insert_certificate_records(&connection, certificates.clone());
 
         let repository: CertificateRepository = CertificateRepository::new(connection);
@@ -262,8 +259,7 @@ mod tests {
     #[tokio::test]
     async fn repository_get_latest_certificates() {
         let (certificates, _) = setup_certificate_chain(5, 2);
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         insert_certificate_records(&connection, certificates.clone());
 
         let repository = CertificateRepository::new(connection);
@@ -278,8 +274,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_master_certificate_no_certificate_recorded_returns_none() {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
 
         let repository: CertificateRepository = CertificateRepository::new(connection);
         let certificate = repository
@@ -292,8 +287,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_master_certificate_one_cert_in_current_epoch_recorded_returns_that_one() {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificate = CertificateRecord::dummy_genesis("1", Epoch(1), 1);
         let expected_certificate: Certificate = certificate.clone().into();
         insert_certificate_records(&connection, vec![certificate]);
@@ -311,8 +305,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_current_epoch_returns_first_of_current_epoch()
     {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -334,8 +327,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_previous_epoch_none_in_the_current_returns_first_of_previous_epoch(
     ) {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -357,8 +349,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_previous_one_cert_in_current_epoch_returns_one_in_current_epoch(
     ) {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -381,8 +372,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_previous_multiple_in_current_epoch_returns_first_of_current_epoch(
     ) {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -406,8 +396,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_penultimate_epoch_none_in_previous_returns_none(
     ) {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -427,8 +416,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_second_genesis_after_multiple_cert_in_current_epoch_returns_last_genesis(
     ) {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -451,8 +439,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_second_genesis_after_multiple_cert_in_multiple_epochs_returns_last_genesis(
     ) {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -477,8 +464,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_new_genesis_after_multiple_cert_in_previous_epoch_returns_last_genesis(
     ) {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
             CertificateRecord::dummy_db_snapshot("2", "1", Epoch(1), 2),
@@ -503,8 +489,7 @@ mod tests {
         let (certificates, _) = setup_certificate_chain(3, 1);
         let expected_certificate_id = &certificates[2].hash;
         let epoch = &certificates[2].epoch;
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         insert_certificate_records(&connection, certificates.clone());
 
         let repository: CertificateRepository = CertificateRepository::new(connection);
@@ -520,9 +505,8 @@ mod tests {
     #[tokio::test]
     async fn save_certificate() {
         let (certificates, _) = setup_certificate_chain(5, 3);
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
-        let repository: CertificateRepository = CertificateRepository::new(connection);
+        let connection = Arc::new(main_db_connection().unwrap());
+        let repository: CertificateRepository = CertificateRepository::new(connection.clone());
         let certificate = repository
             .create_certificate(certificates[4].clone())
             .await
@@ -530,7 +514,6 @@ mod tests {
 
         assert_eq!(certificates[4].hash, certificate.hash);
         {
-            let connection = deps.get_sqlite_connection().await.unwrap();
             let cert = connection
                 .fetch_first(GetCertificateRecordQuery::by_certificate_id(
                     &certificates[4].hash,
@@ -544,8 +527,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_only_given_certificates() {
-        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
-        let connection = deps.get_sqlite_connection().await.unwrap();
+        let connection = Arc::new(main_db_connection().unwrap());
         let repository = CertificateRepository::new(connection.clone());
         let records = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),

--- a/mithril-aggregator/src/database/repository/certificate_repository.rs
+++ b/mithril-aggregator/src/database/repository/certificate_repository.rs
@@ -239,7 +239,7 @@ mod tests {
     async fn repository_get_certificate() {
         let (certificates, _) = setup_certificate_chain(5, 2);
         let expected_hash = certificates[0].hash.clone();
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         insert_certificate_records(&connection, certificates.clone());
 
@@ -262,7 +262,7 @@ mod tests {
     #[tokio::test]
     async fn repository_get_latest_certificates() {
         let (certificates, _) = setup_certificate_chain(5, 2);
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         insert_certificate_records(&connection, certificates.clone());
 
@@ -278,7 +278,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_master_certificate_no_certificate_recorded_returns_none() {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
 
         let repository: CertificateRepository = CertificateRepository::new(connection);
@@ -292,7 +292,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_master_certificate_one_cert_in_current_epoch_recorded_returns_that_one() {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificate = CertificateRecord::dummy_genesis("1", Epoch(1), 1);
         let expected_certificate: Certificate = certificate.clone().into();
@@ -311,7 +311,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_current_epoch_returns_first_of_current_epoch()
     {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -334,7 +334,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_previous_epoch_none_in_the_current_returns_first_of_previous_epoch(
     ) {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -357,7 +357,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_previous_one_cert_in_current_epoch_returns_one_in_current_epoch(
     ) {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -381,7 +381,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_previous_multiple_in_current_epoch_returns_first_of_current_epoch(
     ) {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -406,7 +406,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_multiple_cert_in_penultimate_epoch_none_in_previous_returns_none(
     ) {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -427,7 +427,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_second_genesis_after_multiple_cert_in_current_epoch_returns_last_genesis(
     ) {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -451,7 +451,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_second_genesis_after_multiple_cert_in_multiple_epochs_returns_last_genesis(
     ) {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -477,7 +477,7 @@ mod tests {
     #[tokio::test]
     async fn get_master_certificate_new_genesis_after_multiple_cert_in_previous_epoch_returns_last_genesis(
     ) {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let certificates = vec![
             CertificateRecord::dummy_genesis("1", Epoch(1), 1),
@@ -503,7 +503,7 @@ mod tests {
         let (certificates, _) = setup_certificate_chain(3, 1);
         let expected_certificate_id = &certificates[2].hash;
         let epoch = &certificates[2].epoch;
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         insert_certificate_records(&connection, certificates.clone());
 
@@ -520,7 +520,7 @@ mod tests {
     #[tokio::test]
     async fn save_certificate() {
         let (certificates, _) = setup_certificate_chain(5, 3);
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let repository: CertificateRepository = CertificateRepository::new(connection);
         let certificate = repository
@@ -544,7 +544,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_only_given_certificates() {
-        let mut deps = DependenciesBuilder::new(Configuration::new_sample());
+        let mut deps = DependenciesBuilder::new_for_test(Configuration::new_sample());
         let connection = deps.get_sqlite_connection().await.unwrap();
         let repository = CertificateRepository::new(connection.clone());
         let records = vec![

--- a/mithril-aggregator/src/database/repository/signer_store.rs
+++ b/mithril-aggregator/src/database/repository/signer_store.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use chrono::Utc;
-#[cfg(test)]
-use mockall::automock;
 
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{ConnectionExtensions, SqliteConnection};
@@ -16,7 +14,7 @@ use crate::database::record::SignerRecord;
 use crate::SignerRecorder;
 
 /// Service to get [SignerRecord].
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SignerGetter: Sync + Send {
     /// Return all stored records.

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -1,3 +1,4 @@
+use slog::Logger;
 use std::{collections::BTreeSet, sync::Arc};
 use tokio::sync::RwLock;
 
@@ -52,6 +53,9 @@ pub struct DependencyContainer {
 
     /// List of signed entity discriminants that are allowed to be processed
     pub allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
+
+    /// Application root logger
+    pub root_logger: Logger,
 
     /// SQLite database connection
     ///

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -304,7 +304,7 @@ pub mod tests {
 
     pub async fn initialize_dependencies() -> DependencyContainer {
         let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
 
         builder.build_dependency_container().await.unwrap()
     }

--- a/mithril-aggregator/src/event_store/runner.rs
+++ b/mithril-aggregator/src/event_store/runner.rs
@@ -1,22 +1,27 @@
 use anyhow::Context;
+use mithril_common::logging::LoggerExtensions;
+use mithril_common::StdResult;
+use slog::Logger;
 use slog_scope::{debug, info};
 use sqlite::Connection;
 use std::{path::PathBuf, sync::Arc};
 use tokio::sync::mpsc::UnboundedReceiver;
-
-use mithril_common::StdResult;
 
 use super::{EventMessage, EventPersister};
 
 /// EventMessage receiver service.
 pub struct EventStore {
     receiver: UnboundedReceiver<EventMessage>,
+    logger: Logger,
 }
 
 impl EventStore {
     /// Instantiate the EventMessage receiver service.
-    pub fn new(receiver: UnboundedReceiver<EventMessage>) -> Self {
-        Self { receiver }
+    pub fn new(receiver: UnboundedReceiver<EventMessage>, logger: Logger) -> Self {
+        Self {
+            receiver,
+            logger: logger.new_with_component_name::<Self>(),
+        }
     }
 
     /// Launch the service. It runs until all the transmitters are gone and all

--- a/mithril-aggregator/src/event_store/transmitter_service.rs
+++ b/mithril-aggregator/src/event_store/transmitter_service.rs
@@ -1,6 +1,5 @@
 use serde::Serialize;
-use slog::Logger;
-use slog_scope::warn;
+use slog::{warn, Logger};
 use std::fmt::Debug;
 use tokio::sync::mpsc::UnboundedSender;
 
@@ -53,7 +52,7 @@ impl TransmitterService<EventMessage> {
     {
         let content = serde_json::to_string(content).map_err(|e| {
             let error_msg = format!("Serialization error while forging event message: {e}");
-            warn!("Event message error => «{error_msg}»");
+            warn!(self.logger, "Event message error => «{error_msg}»");
 
             error_msg
         })?;
@@ -69,7 +68,7 @@ impl TransmitterService<EventMessage> {
         self.get_transmitter().send(message.clone()).map_err(|e| {
             let error_msg =
                 format!("An error occurred when sending message {message:?} to monitoring: '{e}'.");
-            warn!("Event message error => «{error_msg}»");
+            warn!(self.logger, "Event message error => «{error_msg}»");
 
             error_msg
         })

--- a/mithril-aggregator/src/event_store/transmitter_service.rs
+++ b/mithril-aggregator/src/event_store/transmitter_service.rs
@@ -1,8 +1,10 @@
-use std::fmt::Debug;
-
 use serde::Serialize;
+use slog::Logger;
 use slog_scope::warn;
+use std::fmt::Debug;
 use tokio::sync::mpsc::UnboundedSender;
+
+use mithril_common::logging::LoggerExtensions;
 
 use super::EventMessage;
 
@@ -13,6 +15,7 @@ where
     MSG: Debug + Sync + Send,
 {
     transmitter: UnboundedSender<MSG>,
+    logger: Logger,
 }
 
 impl<MSG> TransmitterService<MSG>
@@ -20,8 +23,11 @@ where
     MSG: Debug + Sync + Send,
 {
     /// Instantiate a new Service by passing a MPSC transmitter.
-    pub fn new(transmitter: UnboundedSender<MSG>) -> Self {
-        Self { transmitter }
+    pub fn new(transmitter: UnboundedSender<MSG>, logger: Logger) -> Self {
+        Self {
+            transmitter,
+            logger: logger.new_with_component_name::<Self>(),
+        }
     }
 
     /// Clone the internal transmitter and return it.

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -20,6 +20,7 @@ fn artifact_cardano_stake_distributions(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-stake-distributions")
         .and(warp::get())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_http_message_service(dependency_manager))
         .and_then(handlers::list_artifacts)
 }
@@ -30,6 +31,7 @@ fn artifact_cardano_stake_distribution_by_id(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-stake-distribution" / String)
         .and(warp::get())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_http_message_service(dependency_manager))
         .and_then(handlers::get_artifact_by_signed_entity_id)
 }
@@ -40,6 +42,7 @@ fn artifact_cardano_stake_distribution_by_epoch(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-stake-distribution" / "epoch" / String)
         .and(warp::get())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_http_message_service(dependency_manager))
         .and_then(handlers::get_artifact_by_epoch)
 }
@@ -49,7 +52,7 @@ pub mod handlers {
     use crate::services::MessageService;
 
     use mithril_common::entities::Epoch;
-    use slog_scope::{debug, warn};
+    use slog::{debug, warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -58,9 +61,10 @@ pub mod handlers {
 
     /// List CardanoStakeDistribution artifacts
     pub async fn list_artifacts(
+        logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: artifacts");
+        debug!(logger, "⇄ HTTP SERVER: artifacts");
 
         match http_message_service
             .get_cardano_stake_distribution_list_message(LIST_MAX_ITEMS)
@@ -68,7 +72,7 @@ pub mod handlers {
         {
             Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
             Err(err) => {
-                warn!("list_artifacts_cardano_stake_distribution"; "error" => ?err);
+                warn!(logger, "list_artifacts_cardano_stake_distribution"; "error" => ?err);
                 Ok(reply::server_error(err))
             }
         }
@@ -77,9 +81,10 @@ pub mod handlers {
     /// Get Artifact by signed entity id
     pub async fn get_artifact_by_signed_entity_id(
         signed_entity_id: String,
+        logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: artifact/{signed_entity_id}");
+        debug!(logger, "⇄ HTTP SERVER: artifact/{signed_entity_id}");
 
         match http_message_service
             .get_cardano_stake_distribution_message(&signed_entity_id)
@@ -87,11 +92,11 @@ pub mod handlers {
         {
             Ok(Some(message)) => Ok(reply::json(&message, StatusCode::OK)),
             Ok(None) => {
-                warn!("get_cardano_stake_distribution_details::not_found");
+                warn!(logger, "get_cardano_stake_distribution_details::not_found");
                 Ok(reply::empty(StatusCode::NOT_FOUND))
             }
             Err(err) => {
-                warn!("get_cardano_stake_distribution_details::error"; "error" => ?err);
+                warn!(logger, "get_cardano_stake_distribution_details::error"; "error" => ?err);
                 Ok(reply::server_error(err))
             }
         }
@@ -100,14 +105,15 @@ pub mod handlers {
     /// Get Artifact by epoch
     pub async fn get_artifact_by_epoch(
         epoch: String,
+        logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: artifact/epoch/{epoch}");
+        debug!(logger, "⇄ HTTP SERVER: artifact/epoch/{epoch}");
 
         let artifact_epoch = match epoch.parse::<u64>() {
             Ok(epoch) => Epoch(epoch),
             Err(err) => {
-                warn!("get_artifact_by_epoch::invalid_epoch"; "error" => ?err);
+                warn!(logger, "get_artifact_by_epoch::invalid_epoch"; "error" => ?err);
                 return Ok(reply::bad_request(
                     "invalid_epoch".to_string(),
                     err.to_string(),
@@ -121,11 +127,14 @@ pub mod handlers {
         {
             Ok(Some(message)) => Ok(reply::json(&message, StatusCode::OK)),
             Ok(None) => {
-                warn!("get_cardano_stake_distribution_details_by_epoch::not_found");
+                warn!(
+                    logger,
+                    "get_cardano_stake_distribution_details_by_epoch::not_found"
+                );
                 Ok(reply::empty(StatusCode::NOT_FOUND))
             }
             Err(err) => {
-                warn!("get_cardano_stake_distribution_details_by_epoch::error"; "error" => ?err);
+                warn!(logger, "get_cardano_stake_distribution_details_by_epoch::error"; "error" => ?err);
                 Ok(reply::server_error(err))
             }
         }

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -23,6 +23,7 @@ fn artifact_cardano_full_immutable_snapshots(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "snapshots")
         .and(warp::get())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_http_message_service(dependency_manager))
         .and_then(handlers::list_artifacts)
 }
@@ -33,6 +34,7 @@ fn artifact_cardano_full_immutable_snapshot_by_id(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "snapshot" / String)
         .and(warp::get())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_http_message_service(dependency_manager))
         .and_then(handlers::get_artifact_by_signed_entity_id)
 }
@@ -43,6 +45,7 @@ fn snapshot_download(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "snapshot" / String / "download")
         .and(warp::get().or(warp::head()).unify())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_config(dependency_manager))
         .and(middlewares::with_signed_entity_service(dependency_manager))
         .and_then(handlers::snapshot_download)
@@ -55,6 +58,7 @@ fn serve_snapshots_dir(
 
     warp::path("snapshot_download")
         .and(warp::fs::dir(config.snapshot_directory))
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_signed_entity_service(dependency_manager))
         .and_then(handlers::ensure_downloaded_file_is_a_snapshot)
 }
@@ -92,7 +96,7 @@ mod handlers {
     use crate::http_server::SERVER_BASE_PATH;
     use crate::services::MessageService;
     use crate::{services::SignedEntityService, Configuration};
-    use slog_scope::{debug, warn};
+    use slog::{debug, warn, Logger};
     use std::convert::Infallible;
     use std::str::FromStr;
     use std::sync::Arc;
@@ -102,9 +106,10 @@ mod handlers {
 
     /// List Snapshot artifacts
     pub async fn list_artifacts(
+        logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: artifacts");
+        debug!(logger, "⇄ HTTP SERVER: artifacts");
 
         match http_message_service
             .get_snapshot_list_message(LIST_MAX_ITEMS)
@@ -112,7 +117,7 @@ mod handlers {
         {
             Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
             Err(err) => {
-                warn!("list_artifacts_snapshot"; "error" => ?err);
+                warn!(logger,"list_artifacts_snapshot"; "error" => ?err);
                 Ok(reply::server_error(err))
             }
         }
@@ -121,20 +126,21 @@ mod handlers {
     /// Get Artifact by signed entity id
     pub async fn get_artifact_by_signed_entity_id(
         signed_entity_id: String,
+        logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: artifact/{signed_entity_id}");
+        debug!(logger, "⇄ HTTP SERVER: artifact/{signed_entity_id}");
         match http_message_service
             .get_snapshot_message(&signed_entity_id)
             .await
         {
             Ok(Some(signed_entity)) => Ok(reply::json(&signed_entity, StatusCode::OK)),
             Ok(None) => {
-                warn!("snapshot_details::not_found");
+                warn!(logger, "snapshot_details::not_found");
                 Ok(reply::empty(StatusCode::NOT_FOUND))
             }
             Err(err) => {
-                warn!("snapshot_details::error"; "error" => ?err);
+                warn!(logger,"snapshot_details::error"; "error" => ?err);
                 Ok(reply::server_error(err))
             }
         }
@@ -143,10 +149,12 @@ mod handlers {
     /// Download a file if and only if it's a snapshot archive
     pub async fn ensure_downloaded_file_is_a_snapshot(
         reply: warp::fs::File,
+        logger: Logger,
         signed_entity_service: Arc<dyn SignedEntityService>,
     ) -> Result<impl warp::Reply, Infallible> {
         let filepath = reply.path().to_path_buf();
         debug!(
+            logger,
             "⇄ HTTP SERVER: ensure_downloaded_file_is_a_snapshot / file: `{}`",
             filepath.display()
         );
@@ -167,7 +175,7 @@ mod handlers {
                 _ => Ok(reply::empty(StatusCode::NOT_FOUND)),
             },
             Err(err) => {
-                warn!("ensure_downloaded_file_is_a_snapshot::error"; "error" => ?err);
+                warn!(logger,"ensure_downloaded_file_is_a_snapshot::error"; "error" => ?err);
                 Ok(reply::empty(StatusCode::NOT_FOUND))
             }
         }
@@ -176,10 +184,11 @@ mod handlers {
     /// Snapshot download
     pub async fn snapshot_download(
         digest: String,
+        logger: Logger,
         config: Configuration,
         signed_entity_service: Arc<dyn SignedEntityService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: snapshot_download/{}", digest);
+        debug!(logger, "⇄ HTTP SERVER: snapshot_download/{}", digest);
 
         match signed_entity_service
             .get_signed_snapshot_by_id(&digest)
@@ -206,11 +215,11 @@ mod handlers {
                 Ok(Box::new(warp::redirect::found(snapshot_uri)) as Box<dyn warp::Reply>)
             }
             Ok(None) => {
-                warn!("snapshot_download::not_found");
+                warn!(logger, "snapshot_download::not_found");
                 Ok(reply::empty(StatusCode::NOT_FOUND))
             }
             Err(err) => {
-                warn!("snapshot_download::error"; "error" => ?err);
+                warn!(logger,"snapshot_download::error"; "error" => ?err);
                 Ok(reply::server_error(err))
             }
         }

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -23,6 +23,7 @@ fn epoch_settings(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("epoch-settings")
         .and(warp::get())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_epoch_service(dependency_manager))
         .and(middlewares::with_allowed_signed_entity_type_discriminants(
             dependency_manager,
@@ -68,7 +69,7 @@ async fn get_epoch_settings_message(
 }
 
 mod handlers {
-    use slog_scope::debug;
+    use slog::{debug, Logger};
     use std::collections::BTreeSet;
     use std::convert::Infallible;
     use warp::http::StatusCode;
@@ -81,10 +82,11 @@ mod handlers {
 
     /// Epoch Settings
     pub async fn epoch_settings(
+        logger: Logger,
         epoch_service: EpochServiceWrapper,
         allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: epoch_settings");
+        debug!(logger, "⇄ HTTP SERVER: epoch_settings");
         let epoch_settings_message =
             get_epoch_settings_message(epoch_service, allowed_discriminants).await;
 

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -1,7 +1,7 @@
+use slog::Logger;
 use std::collections::BTreeSet;
 use std::convert::Infallible;
 use std::sync::Arc;
-
 use warp::Filter;
 
 use mithril_common::api_version::APIVersionProvider;
@@ -10,11 +10,20 @@ use mithril_common::entities::SignedEntityTypeDiscriminants;
 use crate::database::repository::SignerGetter;
 use crate::dependency_injection::EpochServiceWrapper;
 use crate::event_store::{EventMessage, TransmitterService};
+use crate::http_server::routes::http_server_child_logger;
 use crate::services::{CertifierService, MessageService, ProverService, SignedEntityService};
 use crate::{
     CertificatePendingStore, Configuration, DependencyContainer, SignerRegisterer,
     SingleSignatureAuthenticator, VerificationKeyStorer,
 };
+
+/// With logger middleware
+pub(crate) fn with_logger(
+    dependency_manager: &DependencyContainer,
+) -> impl Filter<Extract = (Logger,), Error = Infallible> + Clone {
+    let logger = http_server_child_logger(&dependency_manager.root_logger);
+    warp::any().map(move || logger.clone())
+}
 
 /// With certificate pending store
 pub(crate) fn with_certificate_pending_store(

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -26,3 +26,8 @@ macro_rules! unwrap_to_internal_server_error {
         }
     };
 }
+
+pub(crate) fn http_server_child_logger(logger: &slog::Logger) -> slog::Logger {
+    use mithril_common::logging::LoggerExtensions;
+    logger.new_with_name("http_server")
+}

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -14,11 +14,11 @@ mod statistics_routes;
 /// if it was an Error. Else return the unwrapped value.
 #[macro_export]
 macro_rules! unwrap_to_internal_server_error {
-    ($code:expr, $($warn_comment:tt)*) => {
+    ($code:expr, $logger:expr => $($warn_comment:tt)*) => {
         match $code {
             Ok(res) => res,
             Err(err) => {
-                warn!($($warn_comment)*; "error" => ?err);
+                slog::warn!($logger, $($warn_comment)*; "error" => ?err);
                 return Ok($crate::http_server::routes::reply::server_error(
                     err,
                 ));

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -198,7 +198,7 @@ mod tests {
     #[tokio::test]
     async fn proof_cardano_transaction_ok() {
         let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let mut dependency_manager = builder.build_dependency_container().await.unwrap();
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
@@ -240,7 +240,7 @@ mod tests {
     #[tokio::test]
     async fn proof_cardano_transaction_not_found() {
         let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let dependency_manager = builder.build_dependency_container().await.unwrap();
 
         let method = Method::GET.as_str();
@@ -271,7 +271,7 @@ mod tests {
     #[tokio::test]
     async fn proof_cardano_transaction_ko() {
         let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let mut dependency_manager = builder.build_dependency_container().await.unwrap();
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
@@ -307,7 +307,7 @@ mod tests {
     #[tokio::test]
     async fn proof_cardano_transaction_return_bad_request_with_invalid_hashes() {
         let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let dependency_manager = builder.build_dependency_container().await.unwrap();
 
         let method = Method::GET.as_str();
@@ -337,7 +337,7 @@ mod tests {
     async fn proof_cardano_transaction_route_deduplicate_hashes() {
         let tx = fake_data::transaction_hashes()[0].to_string();
         let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let mut dependency_manager = builder.build_dependency_container().await.unwrap();
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -38,6 +38,7 @@ fn proof_cardano_transaction(
     warp::path!("proof" / "cardano-transaction")
         .and(warp::get())
         .and(warp::query::<CardanoTransactionProofQueryParams>())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_signed_entity_service(dependency_manager))
         .and(middlewares::validators::with_prover_transactions_hash_validator(dependency_manager))
         .and(middlewares::with_prover_service(dependency_manager))
@@ -50,7 +51,7 @@ mod handlers {
         messages::CardanoTransactionsProofsMessage,
         StdResult,
     };
-    use slog_scope::{debug, warn};
+    use slog::{debug, warn, Logger};
     use std::{convert::Infallible, sync::Arc};
     use warp::http::StatusCode;
 
@@ -65,18 +66,20 @@ mod handlers {
 
     pub async fn proof_cardano_transaction(
         transaction_parameters: CardanoTransactionProofQueryParams,
+        logger: Logger,
         signed_entity_service: Arc<dyn SignedEntityService>,
         validator: ProverTransactionsHashValidator,
         prover_service: Arc<dyn ProverService>,
     ) -> Result<impl warp::Reply, Infallible> {
         let transaction_hashes = transaction_parameters.split_transactions_hashes();
         debug!(
+            logger,
             "⇄ HTTP SERVER: proof_cardano_transaction?transaction_hashes={}",
             transaction_parameters.transaction_hashes
         );
 
         if let Err(error) = validator.validate(&transaction_hashes) {
-            warn!("proof_cardano_transaction::bad_request");
+            warn!(logger, "proof_cardano_transaction::bad_request");
             return Ok(reply::bad_request(error.label, error.message));
         }
 
@@ -86,17 +89,17 @@ mod handlers {
             signed_entity_service
                 .get_last_cardano_transaction_snapshot()
                 .await,
-            "proof_cardano_transaction::error"
+            logger => "proof_cardano_transaction::error"
         ) {
             Some(signed_entity) => {
                 let message = unwrap_to_internal_server_error!(
                     build_response_message(prover_service, signed_entity, sanitized_hashes).await,
-                    "proof_cardano_transaction"
+                    logger => "proof_cardano_transaction"
                 );
                 Ok(reply::json(&message, StatusCode::OK))
             }
             None => {
-                warn!("proof_cardano_transaction::not_found");
+                warn!(logger, "proof_cardano_transaction::not_found");
                 Ok(reply::empty(StatusCode::NOT_FOUND))
             }
         }

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -132,7 +132,7 @@ mod tests {
             )),
             ..Configuration::new_sample()
         };
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let dependency_manager = builder.build_dependency_container().await.unwrap();
 
         let expected_open_api_version = dependency_manager
@@ -193,7 +193,7 @@ mod tests {
             )),
             ..Configuration::new_sample()
         };
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let mut dependency_manager = builder.build_dependency_container().await.unwrap();
         dependency_manager
             .config

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -14,6 +14,7 @@ fn root(
     dependency_manager: &DependencyContainer,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path::end()
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_api_version_provider(dependency_manager))
         .and(middlewares::with_allowed_signed_entity_type_discriminants(
             dependency_manager,
@@ -26,7 +27,7 @@ mod handlers {
     use std::collections::BTreeSet;
     use std::{convert::Infallible, sync::Arc};
 
-    use slog_scope::{debug, warn};
+    use slog::{debug, Logger};
     use warp::http::StatusCode;
 
     use mithril_common::api_version::APIVersionProvider;
@@ -40,15 +41,16 @@ mod handlers {
 
     /// Root
     pub async fn root(
+        logger: Logger,
         api_version_provider: Arc<APIVersionProvider>,
         allowed_signed_entity_type_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
         configuration: Configuration,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: root");
+        debug!(logger, "⇄ HTTP SERVER: root");
 
         let open_api_version = unwrap_to_internal_server_error!(
             api_version_provider.compute_current_version(),
-            "root::error"
+            logger => "root::error"
         );
 
         let mut capabilities = AggregatorCapabilities {

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -1,6 +1,6 @@
 use crate::http_server::routes::{
-    artifact_routes, certificate_routes, epoch_routes, root_routes, signatures_routes,
-    signer_routes, statistics_routes,
+    artifact_routes, certificate_routes, epoch_routes, http_server_child_logger, root_routes,
+    signatures_routes, signer_routes, statistics_routes,
 };
 use crate::http_server::SERVER_BASE_PATH;
 use crate::DependencyContainer;
@@ -8,7 +8,7 @@ use crate::DependencyContainer;
 use mithril_common::api_version::APIVersionProvider;
 use mithril_common::MITHRIL_API_VERSION_HEADER;
 
-use slog_scope::warn;
+use slog::{warn, Logger};
 use std::sync::Arc;
 use warp::http::Method;
 use warp::http::StatusCode;
@@ -39,6 +39,7 @@ pub fn routes(
     warp::any()
         .and(header_must_be(
             dependency_manager.api_version_provider.clone(),
+            http_server_child_logger(&dependency_manager.root_logger),
         ))
         .and(warp::path(SERVER_BASE_PATH))
         .and(
@@ -78,11 +79,13 @@ pub fn routes(
 /// API Version verification
 fn header_must_be(
     api_version_provider: Arc<APIVersionProvider>,
+    logger: Logger,
 ) -> impl Filter<Extract = (), Error = Rejection> + Clone {
     warp::header::optional(MITHRIL_API_VERSION_HEADER)
         .and(warp::any().map(move || api_version_provider.clone()))
+        .and(warp::any().map(move || logger.clone()))
         .and_then(
-            move |maybe_header: Option<String>, api_version_provider: Arc<APIVersionProvider>| async move {
+            move |maybe_header: Option<String>, api_version_provider: Arc<APIVersionProvider>, logger: Logger| async move {
                 match maybe_header {
                     None => Ok(()),
                     Some(version) => match semver::Version::parse(&version) {
@@ -96,7 +99,7 @@ fn header_must_be(
                         }
                         Ok(_version) => Err(warp::reject::custom(VersionMismatchError)),
                         Err(err) => {
-                            warn!("⇄ HTTP SERVER::api_version_check::parse_error"; "error" => ?err);
+                            warn!(logger, "⇄ HTTP SERVER::api_version_check::parse_error"; "error" => ?err);
                             Err(warp::reject::custom(VersionParseError))
                         }
                     },
@@ -124,13 +127,15 @@ mod tests {
         era::{EraChecker, SupportedEra},
     };
 
+    use crate::test_tools::TestLogger;
+
     use super::*;
 
     #[tokio::test]
     async fn test_no_version() {
         let era_checker = EraChecker::new(SupportedEra::dummy(), Epoch(1));
         let api_version_provider = Arc::new(APIVersionProvider::new(Arc::new(era_checker)));
-        let filters = header_must_be(api_version_provider);
+        let filters = header_must_be(api_version_provider, TestLogger::stdout());
         warp::test::request()
             .path("/aggregator/whatever")
             .filter(&filters)
@@ -142,7 +147,7 @@ mod tests {
     async fn test_parse_version_error() {
         let era_checker = EraChecker::new(SupportedEra::dummy(), Epoch(1));
         let api_version_provider = Arc::new(APIVersionProvider::new(Arc::new(era_checker)));
-        let filters = header_must_be(api_version_provider);
+        let filters = header_must_be(api_version_provider, TestLogger::stdout());
         warp::test::request()
             .header(MITHRIL_API_VERSION_HEADER, "not_a_version")
             .path("/aggregator/whatever")
@@ -161,7 +166,7 @@ mod tests {
         open_api_versions.insert("openapi.yaml".to_string(), Version::new(1, 0, 0));
         version_provider.update_open_api_versions(open_api_versions);
         let api_version_provider = Arc::new(version_provider);
-        let filters = header_must_be(api_version_provider);
+        let filters = header_must_be(api_version_provider, TestLogger::stdout());
         warp::test::request()
             .header(MITHRIL_API_VERSION_HEADER, "0.0.999")
             .path("/aggregator/whatever")
@@ -178,7 +183,7 @@ mod tests {
         open_api_versions.insert("openapi.yaml".to_string(), Version::new(0, 1, 0));
         version_provider.update_open_api_versions(open_api_versions);
         let api_version_provider = Arc::new(version_provider);
-        let filters = header_must_be(api_version_provider);
+        let filters = header_must_be(api_version_provider, TestLogger::stdout());
         warp::test::request()
             .header(MITHRIL_API_VERSION_HEADER, "0.1.2")
             .path("/aggregator/whatever")

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -15,6 +15,7 @@ fn register_signatures(
     warp::path!("register-signatures")
         .and(warp::post())
         .and(warp::body::json())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_certifier_service(dependency_manager))
         .and(middlewares::with_single_signature_authenticator(
             dependency_manager,
@@ -23,7 +24,7 @@ fn register_signatures(
 }
 
 mod handlers {
-    use slog_scope::{debug, trace, warn};
+    use slog::{debug, trace, warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -40,11 +41,12 @@ mod handlers {
     /// Register Signatures
     pub async fn register_signatures(
         message: RegisterSignatureMessage,
+        logger: Logger,
         certifier_service: Arc<dyn CertifierService>,
         single_signer_authenticator: Arc<SingleSignatureAuthenticator>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!("⇄ HTTP SERVER: register_signatures/{:?}", message);
-        trace!("⇄ HTTP SERVER: register_signatures"; "complete_message" => #?message );
+        debug!(logger, "⇄ HTTP SERVER: register_signatures/{:?}", message);
+        trace!(logger,"⇄ HTTP SERVER: register_signatures"; "complete_message" => #?message );
 
         let signed_entity_type = message.signed_entity_type.clone();
         let signed_message = message.signed_message.clone();
@@ -52,7 +54,7 @@ mod handlers {
         let mut signatures = match FromRegisterSingleSignatureAdapter::try_adapt(message) {
             Ok(signature) => signature,
             Err(err) => {
-                warn!("register_signatures::payload decoding error"; "error" => ?err);
+                warn!(logger,"register_signatures::payload decoding error"; "error" => ?err);
 
                 return Ok(reply::bad_request(
                     "Could not decode signature payload".to_string(),
@@ -66,11 +68,11 @@ mod handlers {
                 single_signer_authenticator
                     .authenticate(&mut signatures, &signed_message)
                     .await,
-                "single_signer_authenticator::error"
+                logger => "single_signer_authenticator::error"
             );
 
             if !signatures.is_authenticated() {
-                debug!("register_signatures::unauthenticated_signature");
+                debug!(logger, "register_signatures::unauthenticated_signature");
                 return Ok(reply::bad_request(
                     "Could not authenticate signature".to_string(),
                     "Signature could not be authenticated".to_string(),
@@ -84,15 +86,15 @@ mod handlers {
         {
             Err(err) => match err.downcast_ref::<CertifierServiceError>() {
                 Some(CertifierServiceError::AlreadyCertified(signed_entity_type)) => {
-                    debug!("register_signatures::open_message_already_certified"; "signed_entity_type" => ?signed_entity_type);
+                    debug!(logger,"register_signatures::open_message_already_certified"; "signed_entity_type" => ?signed_entity_type);
                     Ok(reply::empty(StatusCode::GONE))
                 }
                 Some(CertifierServiceError::NotFound(signed_entity_type)) => {
-                    debug!("register_signatures::not_found"; "signed_entity_type" => ?signed_entity_type);
+                    debug!(logger,"register_signatures::not_found"; "signed_entity_type" => ?signed_entity_type);
                     Ok(reply::empty(StatusCode::NOT_FOUND))
                 }
                 Some(_) | None => {
-                    warn!("register_signatures::error"; "error" => ?err);
+                    warn!(logger,"register_signatures::error"; "error" => ?err);
                     Ok(reply::server_error(err))
                 }
             },

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -80,7 +80,7 @@ mod tests {
     #[tokio::test]
     async fn post_statistics_ok() {
         let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new(config);
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let mut rx = builder.get_event_transmitter_receiver().await.unwrap();
         let dependency_manager = builder.build_dependency_container().await.unwrap();
         let snapshot_download_message = SnapshotDownloadMessage::dummy();

--- a/mithril-aggregator/src/main.rs
+++ b/mithril-aggregator/src/main.rs
@@ -1,17 +1,21 @@
 #![doc = include_str!("../README.md")]
 
 use clap::Parser;
-use mithril_aggregator::{CommandType, MainOpts};
-use mithril_common::StdResult;
 use slog::{Drain, Fuse, Level, Logger};
 use slog_async::Async;
 use std::sync::Arc;
 
+use mithril_aggregator::{CommandType, MainOpts};
+use mithril_common::StdResult;
+
 fn build_io_logger<W: std::io::Write + Send + 'static>(log_level: Level, io: W) -> Fuse<Async> {
-    let drain = slog_bunyan::new(io).set_pretty(false).build().fuse();
+    let drain = slog_bunyan::with_name("mithril-aggregator", io)
+        .set_pretty(false)
+        .build()
+        .fuse();
     let drain = slog::LevelFilter::new(drain, log_level).fuse();
 
-    slog_async::Async::new(drain).build().fuse()
+    Async::new(drain).build().fuse()
 }
 
 /// Build a logger from args.

--- a/mithril-aggregator/src/main.rs
+++ b/mithril-aggregator/src/main.rs
@@ -28,10 +28,10 @@ pub fn build_logger(args: &MainOpts) -> Logger {
 async fn main() -> StdResult<()> {
     // Load args
     let args = MainOpts::parse();
-    let _guard = slog_scope::set_global_logger(build_logger(&args));
+    let root_logger = build_logger(&args);
 
     #[cfg(feature = "bundle_openssl")]
     openssl_probe::init_ssl_cert_env_vars();
 
-    args.execute().await
+    args.execute(root_logger).await
 }

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -12,11 +12,8 @@ use mithril_common::{
 use crate::dependency_injection::EpochServiceWrapper;
 use crate::entities::OpenMessage;
 
-#[cfg(test)]
-use mockall::automock;
-
 /// MultiSigner is the cryptographic engine in charge of producing multi signatures from individual signatures
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait MultiSigner: Sync + Send {
     /// Verify a single signature

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -13,9 +13,6 @@ use mithril_persistence::store::StakeStorer;
 use crate::entities::OpenMessage;
 use crate::DependencyContainer;
 
-#[cfg(test)]
-use mockall::automock;
-
 /// Configuration structure dedicated to the AggregatorRuntime.
 #[derive(Debug, Clone)]
 pub struct AggregatorConfig {
@@ -165,7 +162,7 @@ impl AggregatorRunner {
     }
 }
 
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 impl AggregatorRunnerTrait for AggregatorRunner {
     /// Return the current time point from the chain

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
-use slog::Logger;
-use slog_scope::{debug, warn};
+use slog::{debug, warn, Logger};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -174,7 +173,7 @@ impl AggregatorRunner {
 impl AggregatorRunnerTrait for AggregatorRunner {
     /// Return the current time point from the chain
     async fn get_time_point_from_chain(&self) -> StdResult<TimePoint> {
-        debug!("RUNNER: get time point from chain");
+        debug!(self.logger, "RUNNER: get time point from chain");
         let time_point = self
             .dependencies
             .ticker_service
@@ -188,7 +187,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!("RUNNER: get_current_open_message_for_signed_entity_type"; "signed_entity_type" => ?signed_entity_type);
+        debug!(self.logger,"RUNNER: get_current_open_message_for_signed_entity_type"; "signed_entity_type" => ?signed_entity_type);
         self.mark_open_message_if_expired(signed_entity_type)
             .await?;
 
@@ -204,7 +203,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         current_time_point: &TimePoint,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!("RUNNER: get_current_non_certified_open_message"; "time_point" => #?current_time_point);
+        debug!(self.logger,"RUNNER: get_current_non_certified_open_message"; "time_point" => #?current_time_point);
         let signed_entity_types = self
             .list_available_signed_entity_types(current_time_point)
             .await?;
@@ -233,7 +232,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn is_certificate_chain_valid(&self, time_point: &TimePoint) -> StdResult<()> {
-        debug!("RUNNER: is_certificate_chain_valid");
+        debug!(self.logger, "RUNNER: is_certificate_chain_valid");
         self.dependencies
             .certifier_service
             .verify_certificate_chain(time_point.epoch)
@@ -243,7 +242,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn update_stake_distribution(&self, new_time_point: &TimePoint) -> StdResult<()> {
-        debug!("RUNNER: update stake distribution"; "time_point" => #?new_time_point);
+        debug!(self.logger,"RUNNER: update stake distribution"; "time_point" => #?new_time_point);
         self.dependencies
             .stake_distribution_service
             .update_stake_distribution()
@@ -252,7 +251,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn open_signer_registration_round(&self, new_time_point: &TimePoint) -> StdResult<()> {
-        debug!("RUNNER: open signer registration round"; "time_point" => #?new_time_point);
+        debug!(self.logger,"RUNNER: open signer registration round"; "time_point" => #?new_time_point);
         let registration_epoch = new_time_point.epoch.offset_to_recording_epoch();
 
         let stakes = self
@@ -269,7 +268,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn close_signer_registration_round(&self) -> StdResult<()> {
-        debug!("RUNNER: close signer registration round");
+        debug!(self.logger, "RUNNER: close signer registration round");
 
         self.dependencies
             .signer_registration_round_opener
@@ -290,7 +289,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<ProtocolMessage> {
-        debug!("RUNNER: compute protocol message");
+        debug!(self.logger, "RUNNER: compute protocol message");
         let protocol_message = self
             .dependencies
             .signable_builder_service
@@ -305,7 +304,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!("RUNNER: mark expired open message");
+        debug!(self.logger, "RUNNER: mark expired open message");
 
         let expired_open_message = self
             .dependencies
@@ -315,8 +314,8 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .with_context(|| "CertifierService can not mark expired open message")?;
 
         debug!(
-            "RUNNER: marked expired open messages: {:#?}",
-            expired_open_message
+            self.logger,
+            "RUNNER: marked expired open messages: {:#?}", expired_open_message
         );
 
         Ok(expired_open_message)
@@ -327,7 +326,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         time_point: TimePoint,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<CertificatePending> {
-        debug!("RUNNER: create new pending certificate");
+        debug!(self.logger, "RUNNER: create new pending certificate");
         let epoch_service = self.dependencies.epoch_service.read().await;
 
         let signers = epoch_service.current_signers_with_stake()?;
@@ -359,7 +358,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         pending_certificate: CertificatePending,
     ) -> StdResult<()> {
-        debug!("RUNNER: saving pending certificate");
+        debug!(self.logger, "RUNNER: saving pending certificate");
 
         let signed_entity_type = pending_certificate.signed_entity_type.clone();
         self.dependencies
@@ -371,11 +370,11 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn drop_pending_certificate(&self) -> StdResult<Option<CertificatePending>> {
-        debug!("RUNNER: drop pending certificate");
+        debug!(self.logger, "RUNNER: drop pending certificate");
 
         let certificate_pending = self.dependencies.certificate_pending_store.remove().await?;
         if certificate_pending.is_none() {
-            warn!(" > drop_pending_certificate::no certificate pending in store, did the previous loop crashed ?");
+            warn!(self.logger," > drop_pending_certificate::no certificate pending in store, did the previous loop crashed ?");
         }
 
         Ok(certificate_pending)
@@ -385,7 +384,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<Certificate>> {
-        debug!("RUNNER: create_certificate");
+        debug!(self.logger, "RUNNER: create_certificate");
 
         self.dependencies
             .certifier_service
@@ -403,7 +402,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         signed_entity_type: &SignedEntityType,
         certificate: &Certificate,
     ) -> StdResult<()> {
-        debug!("RUNNER: create artifact");
+        debug!(self.logger, "RUNNER: create artifact");
         self.dependencies
             .signed_entity_service
             .create_artifact(signed_entity_type.to_owned(), certificate)
@@ -438,6 +437,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .era_checker
             .change_era(current_era, token.get_current_epoch());
         debug!(
+            self.logger,
             "Current Era is {} (Epoch {}).",
             current_era,
             token.get_current_epoch()
@@ -445,7 +445,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
 
         if token.get_next_supported_era().is_err() {
             let era_name = &token.get_next_era_marker().unwrap().name;
-            warn!("Upcoming Era '{era_name}' is not supported by this version of the software. Please update!");
+            warn!(self.logger,"Upcoming Era '{era_name}' is not supported by this version of the software. Please update!");
         }
 
         Ok(())
@@ -479,7 +479,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn upkeep(&self) -> StdResult<()> {
-        debug!("RUNNER: upkeep");
+        debug!(self.logger, "RUNNER: upkeep");
         self.dependencies.upkeep_service.run().await
     }
 

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -1,5 +1,6 @@
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
+use slog::Logger;
 use slog_scope::{debug, warn};
 use std::sync::Arc;
 use std::time::Duration;
@@ -7,6 +8,7 @@ use std::time::Duration;
 use mithril_common::entities::{
     Certificate, CertificatePending, Epoch, ProtocolMessage, SignedEntityType, Signer, TimePoint,
 };
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
 use mithril_persistence::store::StakeStorer;
 
@@ -133,12 +135,17 @@ pub trait AggregatorRunnerTrait: Sync + Send {
 /// holds services and configuration.
 pub struct AggregatorRunner {
     dependencies: Arc<DependencyContainer>,
+    logger: Logger,
 }
 
 impl AggregatorRunner {
     /// Create a new instance of the Aggregator Runner.
     pub fn new(dependencies: Arc<DependencyContainer>) -> Self {
-        Self { dependencies }
+        let logger = dependencies.root_logger.new_with_component_name::<Self>();
+        Self {
+            dependencies,
+            logger,
+        }
     }
 
     async fn list_available_signed_entity_types(

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -12,6 +12,7 @@ use mithril_common::crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory};
 use mithril_common::entities::{
     BlockNumber, BlockRange, CardanoTransaction, ChainPoint, SlotNumber,
 };
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::signable_builder::TransactionsImporter;
 use mithril_common::StdResult;
 
@@ -68,7 +69,7 @@ impl CardanoTransactionsImporter {
         Self {
             block_scanner,
             transaction_store,
-            logger,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 

--- a/mithril-aggregator/src/services/certifier/buffered_certifier.rs
+++ b/mithril-aggregator/src/services/certifier/buffered_certifier.rs
@@ -6,6 +6,7 @@ use mithril_common::entities::{
     Certificate, Epoch, ProtocolMessage, SignedEntityType, SignedEntityTypeDiscriminants,
     SingleSignatures,
 };
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
 
 use crate::entities::OpenMessage;
@@ -35,7 +36,7 @@ impl BufferedCertifierService {
         Self {
             certifier_service,
             buffered_single_signature_store,
-            logger,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -11,6 +11,7 @@ use mithril_common::entities::{
     Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessage,
     SignedEntityType, SingleSignatures, StakeDistributionParty,
 };
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::protocol::ToMessage;
 use mithril_common::{CardanoNetwork, StdResult, TickerService};
 
@@ -35,7 +36,7 @@ pub struct MithrilCertifierService {
     // todo: should be removed after removing immutable file number from the certificate metadata
     ticker_service: Arc<dyn TickerService>,
     epoch_service: EpochServiceWrapper,
-    _logger: Logger,
+    logger: Logger,
 }
 
 impl MithrilCertifierService {
@@ -63,7 +64,7 @@ impl MithrilCertifierService {
             genesis_verifier,
             ticker_service,
             epoch_service,
-            _logger: logger,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 
@@ -378,7 +379,7 @@ impl CertifierService for MithrilCertifierService {
 mod tests {
     use crate::{
         dependency_injection::DependenciesBuilder, multi_signer::MockMultiSigner,
-        services::FakeEpochService, Configuration,
+        services::FakeEpochService, test_tools::TestLogger, Configuration,
     };
     use chrono::{DateTime, Days};
     use mithril_common::{
@@ -404,7 +405,6 @@ mod tests {
             let multi_signer = dependency_builder.get_multi_signer().await.unwrap();
             let ticker_service = dependency_builder.get_ticker_service().await.unwrap();
             let epoch_service = dependency_builder.get_epoch_service().await.unwrap();
-            let logger = dependency_builder.get_logger().unwrap();
 
             Self::new(
                 network,
@@ -416,7 +416,7 @@ mod tests {
                 multi_signer,
                 ticker_service,
                 epoch_service,
-                logger,
+                TestLogger::stdout(),
             )
         }
     }

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -442,7 +442,7 @@ mod tests {
         current_epoch: Option<Epoch>,
     ) -> MithrilCertifierService {
         let configuration = Configuration::new_sample();
-        let mut dependency_builder = DependenciesBuilder::new(configuration);
+        let mut dependency_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
 
         if let Some(epoch) = current_epoch {
             dependency_builder.epoch_service = Some(Arc::new(RwLock::new(

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use slog::Logger;
 use slog_scope::debug;
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -10,6 +11,7 @@ use mithril_common::entities::{
     CardanoTransactionsSigningConfig, Epoch, ProtocolParameters, SignedEntityConfig,
     SignedEntityTypeDiscriminants, Signer, SignerWithStake,
 };
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::protocol::{MultiSigner as ProtocolMultiSigner, SignerBuilder};
 use mithril_common::{CardanoNetwork, StdResult};
 
@@ -130,6 +132,7 @@ pub struct MithrilEpochService {
     verification_key_store: Arc<dyn VerificationKeyStorer>,
     network: CardanoNetwork,
     allowed_signed_entity_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
+    logger: Logger,
 }
 
 impl MithrilEpochService {
@@ -140,6 +143,7 @@ impl MithrilEpochService {
         verification_key_store: Arc<dyn VerificationKeyStorer>,
         network: CardanoNetwork,
         allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
+        logger: Logger,
     ) -> Self {
         Self {
             future_epoch_settings,
@@ -149,6 +153,7 @@ impl MithrilEpochService {
             verification_key_store,
             network,
             allowed_signed_entity_discriminants: allowed_discriminants,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 
@@ -648,6 +653,7 @@ mod tests {
     use std::collections::{BTreeSet, HashMap};
 
     use crate::store::FakeEpochSettingsStorer;
+    use crate::test_tools::TestLogger;
     use crate::VerificationKeyStore;
 
     use super::*;
@@ -801,6 +807,7 @@ mod tests {
                 Arc::new(vkey_store),
                 self.network,
                 self.allowed_discriminants,
+                TestLogger::stdout(),
             )
         }
     }

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
-use slog::Logger;
-use slog_scope::debug;
+use slog::{debug, Logger};
 use std::collections::BTreeSet;
 use std::sync::Arc;
 use thiserror::Error;
@@ -189,8 +188,7 @@ impl MithrilEpochService {
         let recording_epoch = actual_epoch.offset_to_epoch_settings_recording_epoch();
 
         debug!(
-            "EpochService: inserting epoch settings in epoch {}",
-            recording_epoch;
+            self.logger, "EpochService: inserting epoch settings in epoch {recording_epoch}";
             "epoch_settings" => ?self.future_epoch_settings
         );
 
@@ -222,7 +220,7 @@ impl MithrilEpochService {
 #[async_trait]
 impl EpochService for MithrilEpochService {
     async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()> {
-        debug!("EpochService::inform_epoch(epoch: {epoch:?})");
+        debug!(self.logger, "EpochService::inform_epoch(epoch: {epoch:?})");
 
         let signer_retrieval_epoch =
             epoch.offset_to_signer_retrieval_epoch().with_context(|| {
@@ -279,7 +277,7 @@ impl EpochService for MithrilEpochService {
     }
 
     async fn update_epoch_settings(&mut self) -> StdResult<()> {
-        debug!("EpochService::update_epoch_settings");
+        debug!(self.logger, "EpochService::update_epoch_settings");
 
         let data = self.unwrap_data().with_context(|| {
             "can't update epoch settings if inform_epoch has not been called first"
@@ -289,7 +287,7 @@ impl EpochService for MithrilEpochService {
     }
 
     async fn precompute_epoch_data(&mut self) -> StdResult<()> {
-        debug!("EpochService::precompute_epoch_data");
+        debug!(self.logger, "EpochService::precompute_epoch_data");
 
         let data = self.unwrap_data().with_context(|| {
             "can't precompute epoch data if inform_epoch has not been called first"

--- a/mithril-aggregator/src/services/message.rs
+++ b/mithril-aggregator/src/services/message.rs
@@ -18,9 +18,6 @@ use mithril_common::{
 
 use crate::database::repository::{CertificateRepository, SignedEntityStorer};
 
-#[cfg(test)]
-use mockall::automock;
-
 /// Error related to the [MessageService]
 #[derive(Debug, Error)]
 pub enum MessageServiceError {
@@ -29,7 +26,7 @@ pub enum MessageServiceError {
     PendingCertificateDoesNotExist,
 }
 /// HTTP Message service trait.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait MessageService: Sync + Send {
     /// Return the message representation of a certificate if it exists.

--- a/mithril-aggregator/src/services/message.rs
+++ b/mithril-aggregator/src/services/message.rs
@@ -267,7 +267,7 @@ mod tests {
     async fn get_no_certificate() {
         // setup
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let service = dep_builder.get_message_service().await.unwrap();
 
         // test
@@ -283,7 +283,7 @@ mod tests {
     async fn get_certificate() {
         // setup
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let repository = dep_builder.get_certificate_repository().await.unwrap();
         let service = dep_builder.get_message_service().await.unwrap();
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
@@ -305,7 +305,7 @@ mod tests {
     #[tokio::test]
     async fn get_last_certificates() {
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let repository = dep_builder.get_certificate_repository().await.unwrap();
         let service = dep_builder.get_message_service().await.unwrap();
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
@@ -330,7 +330,7 @@ mod tests {
     #[tokio::test]
     async fn get_snapshot_not_exist() {
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let service = dep_builder.get_message_service().await.unwrap();
         let snapshot = service.get_snapshot_message("whatever").await.unwrap();
 
@@ -351,7 +351,7 @@ mod tests {
 
         // setup
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_signed_entity()
@@ -383,7 +383,7 @@ mod tests {
 
         // setup
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_last_signed_entities_by_type()
@@ -408,7 +408,7 @@ mod tests {
         };
         let message = ToMithrilStakeDistributionMessageAdapter::adapt(entity);
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_signed_entity()
@@ -428,7 +428,7 @@ mod tests {
     #[tokio::test]
     async fn get_mithril_stake_distribution_not_exist() {
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_signed_entity()
@@ -456,7 +456,7 @@ mod tests {
         }];
         let message = ToMithrilStakeDistributionListMessageAdapter::adapt(vec![entity]);
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_last_signed_entities_by_type()
@@ -487,7 +487,7 @@ mod tests {
         };
         let message = ToCardanoTransactionMessageAdapter::adapt(entity);
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_signed_entity()
@@ -507,7 +507,7 @@ mod tests {
     #[tokio::test]
     async fn get_cardano_transaction_not_exist() {
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_signed_entity()
@@ -538,7 +538,7 @@ mod tests {
         }];
         let message = ToCardanoTransactionListMessageAdapter::adapt(vec![entity]);
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_last_signed_entities_by_type()
@@ -566,7 +566,7 @@ mod tests {
         };
         let message = ToCardanoStakeDistributionMessageAdapter::adapt(entity);
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_signed_entity()
@@ -586,7 +586,7 @@ mod tests {
     #[tokio::test]
     async fn get_cardano_stake_distribution_not_exist() {
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_signed_entity()
@@ -614,7 +614,7 @@ mod tests {
         };
         let message = ToCardanoStakeDistributionMessageAdapter::adapt(entity.clone());
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_cardano_stake_distribution_signed_entity_by_epoch()
@@ -634,7 +634,7 @@ mod tests {
     #[tokio::test]
     async fn get_cardano_stake_distribution_by_epoch_not_exist() {
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_cardano_stake_distribution_signed_entity_by_epoch()
@@ -662,7 +662,7 @@ mod tests {
         }];
         let message = ToCardanoStakeDistributionListMessageAdapter::adapt(vec![entity]);
         let configuration = Configuration::new_sample();
-        let mut dep_builder = DependenciesBuilder::new(configuration);
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         let mut storer = MockSignedEntityStorer::new();
         storer
             .expect_get_last_signed_entities_by_type()

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -12,6 +12,7 @@ use mithril_common::{
     entities::{
         BlockNumber, BlockRange, CardanoTransaction, CardanoTransactionsSetProof, TransactionHash,
     },
+    logging::LoggerExtensions,
     resource_pool::ResourcePool,
     signable_builder::BlockRangeRootRetriever,
     StdResult,
@@ -70,7 +71,7 @@ impl<S: MKTreeStorer> MithrilProverService<S> {
             transaction_retriever,
             block_range_root_retriever,
             mk_map_pool: ResourcePool::new(mk_map_pool_size, vec![]),
-            logger,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 
@@ -219,6 +220,8 @@ mod tests {
     use mockall::mock;
     use mockall::predicate::eq;
 
+    use crate::test_tools::TestLogger;
+
     use super::*;
 
     mock! {
@@ -366,13 +369,12 @@ mod tests {
         let mut block_range_root_retriever = MockBlockRangeRootRetrieverImpl::new();
         block_range_root_retriever_mock_config(&mut block_range_root_retriever);
         let mk_map_pool_size = 1;
-        let logger = slog_scope::logger();
 
         MithrilProverService::new(
             Arc::new(transaction_retriever),
             Arc::new(block_range_root_retriever),
             mk_map_pool_size,
-            logger,
+            TestLogger::stdout(),
         )
     }
 

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -25,11 +25,8 @@ use crate::{
     database::{record::SignedEntityRecord, repository::SignedEntityStorer},
 };
 
-#[cfg(test)]
-use mockall::automock;
-
 /// ArtifactBuilder Service trait
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SignedEntityService: Send + Sync {
     /// Create artifact for a signed entity type and a certificate

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -5,6 +5,7 @@
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use chrono::Utc;
+use slog::Logger;
 use slog_scope::info;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
@@ -15,6 +16,7 @@ use mithril_common::{
         Certificate, Epoch, MithrilStakeDistribution, SignedEntity, SignedEntityType,
         SignedEntityTypeDiscriminants, Snapshot,
     },
+    logging::LoggerExtensions,
     signable_builder::Artifact,
     signed_entity_type_lock::SignedEntityTypeLock,
     StdResult,
@@ -87,6 +89,7 @@ pub struct MithrilSignedEntityService {
     signed_entity_type_lock: Arc<SignedEntityTypeLock>,
     cardano_stake_distribution_artifact_builder:
         Arc<dyn ArtifactBuilder<Epoch, CardanoStakeDistribution>>,
+    logger: Logger,
 }
 
 impl MithrilSignedEntityService {
@@ -106,6 +109,7 @@ impl MithrilSignedEntityService {
         cardano_stake_distribution_artifact_builder: Arc<
             dyn ArtifactBuilder<Epoch, CardanoStakeDistribution>,
         >,
+        logger: Logger,
     ) -> Self {
         Self {
             signed_entity_storer,
@@ -114,6 +118,7 @@ impl MithrilSignedEntityService {
             cardano_transactions_artifact_builder,
             signed_entity_type_lock,
             cardano_stake_distribution_artifact_builder,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 
@@ -397,6 +402,7 @@ mod tests {
 
     use crate::artifact_builder::MockArtifactBuilder;
     use crate::database::repository::MockSignedEntityStorer;
+    use crate::test_tools::TestLogger;
 
     use super::*;
 
@@ -470,6 +476,7 @@ mod tests {
                 Arc::new(self.mock_cardano_transactions_artifact_builder),
                 Arc::new(SignedEntityTypeLock::default()),
                 Arc::new(self.mock_cardano_stake_distribution_artifact_builder),
+                TestLogger::stdout(),
             )
         }
 
@@ -521,6 +528,7 @@ mod tests {
                 Arc::new(self.mock_cardano_transactions_artifact_builder),
                 Arc::new(SignedEntityTypeLock::default()),
                 Arc::new(self.mock_cardano_stake_distribution_artifact_builder),
+                TestLogger::stdout(),
             )
         }
 

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -5,8 +5,7 @@
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use chrono::Utc;
-use slog::Logger;
-use slog_scope::info;
+use slog::{info, Logger};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 
@@ -128,7 +127,7 @@ impl MithrilSignedEntityService {
         certificate: &Certificate,
     ) -> StdResult<()> {
         info!(
-            "MithrilSignedEntityService::create_artifact";
+            self.logger, "MithrilSignedEntityService::create_artifact";
             "signed_entity_type" => ?signed_entity_type,
             "certificate_hash" => &certificate.hash
         );

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -17,9 +17,6 @@ use mithril_persistence::store::StakeStorer;
 
 use crate::database::repository::StakePoolStore;
 
-#[cfg(test)]
-use mockall::automock;
-
 /// Errors related to the [StakeDistributionService].
 #[derive(Debug)]
 pub enum StakePoolDistributionServiceError {
@@ -89,7 +86,7 @@ impl Display for StakePoolDistributionServiceError {
 impl std::error::Error for StakePoolDistributionServiceError {}
 
 /// Responsible of synchronizing with Cardano stake distribution.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait StakeDistributionService: Sync + Send {
     /// Return the stake distribution fot the given epoch.

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -230,7 +230,8 @@ mod tests {
     use super::*;
 
     async fn get_service(chain_observer: MockChainObserver) -> MithrilStakeDistributionService {
-        let mut builder = DependenciesBuilder::new(crate::Configuration::new_sample());
+        let mut builder =
+            DependenciesBuilder::new_with_stdout_logger(crate::Configuration::new_sample());
         let stake_service = MithrilStakeDistributionService::new(
             builder.get_stake_store().await.unwrap(),
             Arc::new(chain_observer),

--- a/mithril-aggregator/src/services/upkeep.rs
+++ b/mithril-aggregator/src/services/upkeep.rs
@@ -11,6 +11,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use slog::{info, Logger};
 
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::signed_entity_type_lock::SignedEntityTypeLock;
 use mithril_common::StdResult;
 use mithril_persistence::sqlite::{
@@ -48,7 +49,7 @@ impl AggregatorUpkeepService {
             main_db_connection,
             cardano_tx_connection_pool,
             signed_entity_type_lock,
-            logger,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 

--- a/mithril-aggregator/src/signer_registerer.rs
+++ b/mithril-aggregator/src/signer_registerer.rs
@@ -14,8 +14,6 @@ use mithril_common::{
 use crate::VerificationKeyStorer;
 
 use mithril_common::chain_observer::ChainObserverError;
-#[cfg(test)]
-use mockall::automock;
 
 /// Error type for signer registerer service.
 #[derive(Error, Debug)]
@@ -74,7 +72,7 @@ impl SignerRegistrationRound {
 }
 
 /// Trait to register a signer
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SignerRegisterer: Sync + Send {
     /// Register a signer
@@ -89,7 +87,7 @@ pub trait SignerRegisterer: Sync + Send {
 }
 
 /// Trait to open a signer registration round
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SignerRegistrationRoundOpener: Sync + Send {
     /// Open a signer registration round
@@ -104,7 +102,7 @@ pub trait SignerRegistrationRoundOpener: Sync + Send {
 }
 
 /// Signer recorder trait
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SignerRecorder: Sync + Send {
     /// Record a signer registration

--- a/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
@@ -1,7 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
-use slog::Logger;
-use slog_scope::debug;
+use slog::{debug, Logger};
 use std::path::{Path, PathBuf};
 
 use mithril_common::logging::LoggerExtensions;
@@ -25,11 +24,12 @@ pub struct LocalSnapshotUploader {
 impl LocalSnapshotUploader {
     /// LocalSnapshotUploader factory
     pub(crate) fn new(snapshot_server_url: String, target_location: &Path, logger: Logger) -> Self {
-        debug!("New LocalSnapshotUploader created"; "snapshot_server_url" => &snapshot_server_url);
+        let logger = logger.new_with_component_name::<Self>();
+        debug!(logger, "New LocalSnapshotUploader created"; "snapshot_server_url" => &snapshot_server_url);
         Self {
             snapshot_server_url,
             target_location: target_location.to_path_buf(),
-            logger: logger.new_with_component_name::<Self>(),
+            logger,
         }
     }
 }

--- a/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/local_snapshot_uploader.rs
@@ -51,6 +51,7 @@ impl SnapshotUploader for LocalSnapshotUploader {
             digest.unwrap()
         );
 
+        debug!(self.logger, "Snapshot 'uploaded' to local storage"; "location" => &location);
         Ok(location)
     }
 }

--- a/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
-use slog::Logger;
-use slog_scope::debug;
+use slog::{debug, Logger};
 use std::path::Path;
 
 use mithril_common::logging::LoggerExtensions;
@@ -25,12 +24,13 @@ impl RemoteSnapshotUploader {
         use_cdn_domain: bool,
         logger: Logger,
     ) -> Self {
-        debug!("New GCPSnapshotUploader created");
+        let logger = logger.new_with_component_name::<Self>();
+        debug!(logger, "New GCPSnapshotUploader created");
         Self {
             bucket,
             file_uploader,
             use_cdn_domain,
-            logger: logger.new_with_component_name::<Self>(),
+            logger,
         }
     }
 }

--- a/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/remote_snapshot_uploader.rs
@@ -48,7 +48,9 @@ impl SnapshotUploader for RemoteSnapshotUploader {
             )
         };
 
+        debug!(self.logger, "Uploading snapshot to remote storage"; "location" => &location);
         self.file_uploader.upload_file(snapshot_filepath).await?;
+        debug!(self.logger, "Snapshot upload to remote storage completed"; "location" => &location);
 
         Ok(location)
     }

--- a/mithril-aggregator/src/snapshot_uploaders/snapshot_uploader.rs
+++ b/mithril-aggregator/src/snapshot_uploaders/snapshot_uploader.rs
@@ -2,13 +2,10 @@ use async_trait::async_trait;
 use mithril_common::StdResult;
 use std::path::Path;
 
-#[cfg(test)]
-use mockall::automock;
-
 pub type SnapshotLocation = String;
 
 /// SnapshotUploader represents a snapshot uploader interactor
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SnapshotUploader: Sync + Send {
     /// Upload a snapshot

--- a/mithril-aggregator/src/store/epoch_settings_storer.rs
+++ b/mithril-aggregator/src/store/epoch_settings_storer.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 
 use async_trait::async_trait;
 use mithril_common::StdResult;
-use slog_scope::debug;
 use tokio::sync::RwLock;
 
 use mithril_common::entities::{Epoch, ProtocolParameters};
@@ -37,7 +36,6 @@ pub trait EpochSettingsStorer: Sync + Send {
         for epoch_offset in 0..=2 {
             let epoch = current_epoch + epoch_offset;
             if self.get_epoch_settings(epoch).await?.is_none() {
-                debug!("Handle discrepancies at startup of epoch settings store, will record epoch settings from the configuration for epoch {epoch}: {epoch_settings_configuration:?}");
                 self.save_epoch_settings(epoch, epoch_settings_configuration.clone())
                     .await?;
             }

--- a/mithril-aggregator/src/store/verification_key_store.rs
+++ b/mithril-aggregator/src/store/verification_key_store.rs
@@ -7,16 +7,13 @@ use tokio::sync::RwLock;
 use mithril_common::entities::{Epoch, PartyId, Signer, SignerWithStake};
 use mithril_persistence::store::adapter::StoreAdapter;
 
-#[cfg(test)]
-use mockall::automock;
-
 type Adapter = Box<dyn StoreAdapter<Key = Epoch, Record = HashMap<PartyId, SignerWithStake>>>;
 
 /// Store and get signers verification keys for given epoch.
 ///
 /// Important note: This store works on the **recording** epoch, the epoch at which the signers
 /// are signed into a certificate so they can sign single signatures at the next epoch.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait VerificationKeyStorer: Sync + Send {
     /// Save the verification key, for the given [Signer] for the given [Epoch], returns the

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -1,8 +1,10 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Context};
+use slog::Logger;
 use slog_scope::{debug, info, trace};
 
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::{entities::Certificate, StdResult};
 
 use crate::database::repository::{CertificateRepository, SignedEntityStorer};
@@ -11,6 +13,7 @@ use crate::database::repository::{CertificateRepository, SignedEntityStorer};
 pub struct CertificatesHashMigrator {
     certificate_repository: CertificateRepository,
     signed_entity_storer: Arc<dyn SignedEntityStorer>,
+    logger: Logger,
 }
 
 impl CertificatesHashMigrator {
@@ -18,10 +21,12 @@ impl CertificatesHashMigrator {
     pub fn new(
         certificate_repository: CertificateRepository,
         signed_entity_storer: Arc<dyn SignedEntityStorer>,
+        logger: Logger,
     ) -> Self {
         Self {
             certificate_repository,
             signed_entity_storer,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 
@@ -198,6 +203,7 @@ mod test {
 
     use crate::database::record::{CertificateRecord, SignedEntityRecord};
     use crate::database::repository::SignedEntityStore;
+    use crate::test_tools::TestLogger;
 
     use super::*;
 
@@ -449,6 +455,7 @@ mod test {
         let migrator = CertificatesHashMigrator::new(
             CertificateRepository::new(sqlite_connection.clone()),
             Arc::new(SignedEntityStore::new(sqlite_connection.clone())),
+            TestLogger::stdout(),
         );
         migrator
             .migrate()
@@ -613,6 +620,7 @@ mod test {
         let migrator = CertificatesHashMigrator::new(
             CertificateRepository::new(connection.clone()),
             Arc::new(SignedEntityStore::new(connection.clone())),
+            TestLogger::stdout(),
         );
         migrator
             .migrate()

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -1,8 +1,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Context};
-use slog::Logger;
-use slog_scope::{debug, info, trace};
+use slog::{debug, info, trace, Logger};
 
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::{entities::Certificate, StdResult};
@@ -32,7 +31,7 @@ impl CertificatesHashMigrator {
 
     /// Recompute all the certificates hashes the database.
     pub async fn migrate(&self) -> StdResult<()> {
-        info!("🔧 Certificate Hash Migrator: starting");
+        info!(self.logger, "🔧 Certificate Hash Migrator: starting");
         let (old_certificates, old_and_new_hashes) =
             self.create_certificates_with_updated_hash().await?;
 
@@ -41,7 +40,10 @@ impl CertificatesHashMigrator {
 
         self.cleanup(old_certificates).await?;
 
-        info!("🔧 Certificate Hash Migrator: all certificates have been migrated successfully");
+        info!(
+            self.logger,
+            "🔧 Certificate Hash Migrator: all certificates have been migrated successfully"
+        );
         Ok(())
     }
 
@@ -50,7 +52,10 @@ impl CertificatesHashMigrator {
     async fn create_certificates_with_updated_hash(
         &self,
     ) -> StdResult<(Vec<Certificate>, HashMap<String, String>)> {
-        info!("🔧 Certificate Hash Migrator: recomputing all certificates hash");
+        info!(
+            self.logger,
+            "🔧 Certificate Hash Migrator: recomputing all certificates hash"
+        );
         let old_certificates = self
             .certificate_repository
             // arbitrary high value to get all existing certificates
@@ -65,7 +70,10 @@ impl CertificatesHashMigrator {
         // Note: get_latest_certificates retrieve certificates from the earliest to the older,
         // in order to have a strong guarantee that when inserting a certificate in the db its
         // previous_hash exist we have to work in the reverse order.
-        debug!("🔧 Certificate Hash Migrator: computing new hash for all certificates");
+        debug!(
+            self.logger,
+            "🔧 Certificate Hash Migrator: computing new hash for all certificates"
+        );
         for mut certificate in old_certificates.into_iter().rev() {
             let old_previous_hash = if certificate.is_genesis() {
                 certificate.previous_hash.clone()
@@ -90,14 +98,14 @@ impl CertificatesHashMigrator {
 
                 if certificate.is_genesis() {
                     trace!(
-                        "🔧 Certificate Hash Migrator: new hash computed for genesis certificate {:?}",
+                        self.logger, "🔧 Certificate Hash Migrator: new hash computed for genesis certificate {:?}",
                         certificate.signed_entity_type();
                         "old_hash" => &certificate.hash,
                         "new_hash" => &new_hash,
                     );
                 } else {
                     trace!(
-                        "🔧 Certificate Hash Migrator: new hash computed for certificate {:?}",
+                        self.logger, "🔧 Certificate Hash Migrator: new hash computed for certificate {:?}",
                         certificate.signed_entity_type();
                         "old_hash" => &certificate.hash,
                         "new_hash" => &new_hash,
@@ -116,7 +124,10 @@ impl CertificatesHashMigrator {
 
         // 2 - Certificates migrated, we can insert them in the db
         // (we do this by chunks in order to avoid reaching the limit of 32766 variables in a single query)
-        debug!("🔧 Certificate Hash Migrator: inserting migrated certificates in the database");
+        debug!(
+            self.logger,
+            "🔧 Certificate Hash Migrator: inserting migrated certificates in the database"
+        );
         let migrated_certificates_chunk_size = 250;
         for migrated_certificates_chunk in
             migrated_certificates.chunks(migrated_certificates_chunk_size)
@@ -136,7 +147,10 @@ impl CertificatesHashMigrator {
         &self,
         old_and_new_certificate_hashes: HashMap<String, String>,
     ) -> StdResult<()> {
-        info!("🔧 Certificate Hash Migrator: updating signed entities certificate ids");
+        info!(
+            self.logger,
+            "🔧 Certificate Hash Migrator: updating signed entities certificate ids"
+        );
         let old_hashes: Vec<&str> = old_and_new_certificate_hashes
             .keys()
             .map(|k| k.as_str())
@@ -151,7 +165,7 @@ impl CertificatesHashMigrator {
                 )
             )?;
 
-        debug!("🔧 Certificate Hash Migrator: updating signed entities certificate_ids to new computed hash");
+        debug!(self.logger,"🔧 Certificate Hash Migrator: updating signed entities certificate_ids to new computed hash");
         for signed_entity_record in records_to_migrate.iter_mut() {
             let new_certificate_hash =
                 old_and_new_certificate_hashes
@@ -163,7 +177,7 @@ impl CertificatesHashMigrator {
                     .to_owned();
 
             trace!(
-                "🔧 Certificate Hash Migrator: migrating signed entity {} certificate hash computed for certificate",
+                self.logger, "🔧 Certificate Hash Migrator: migrating signed entity {} certificate hash computed for certificate",
                 signed_entity_record.signed_entity_id;
                 "old_certificate_hash" => &signed_entity_record.certificate_id,
                 "new_certificate_hash" => &new_certificate_hash
@@ -171,7 +185,10 @@ impl CertificatesHashMigrator {
             signed_entity_record.certificate_id = new_certificate_hash;
         }
 
-        debug!("🔧 Certificate Hash Migrator: updating migrated signed entities in the database");
+        debug!(
+            self.logger,
+            "🔧 Certificate Hash Migrator: updating migrated signed entities in the database"
+        );
         self.signed_entity_storer
             .update_signed_entities(records_to_migrate)
             .await
@@ -181,7 +198,10 @@ impl CertificatesHashMigrator {
     }
 
     async fn cleanup(&self, old_certificates: Vec<Certificate>) -> StdResult<()> {
-        info!("🔧 Certificate Hash Migrator: deleting old certificates in the database");
+        info!(
+            self.logger,
+            "🔧 Certificate Hash Migrator: deleting old certificates in the database"
+        );
         self.certificate_repository
             .delete_certificates(&old_certificates.iter().collect::<Vec<_>>())
             .await

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -206,13 +206,15 @@ impl GenesisTools {
 
 #[cfg(test)]
 mod tests {
-    use crate::database::test_helper::main_db_connection;
     use mithril_common::{
         certificate_chain::MithrilCertificateVerifier,
         crypto_helper::ProtocolGenesisSigner,
         test_utils::{fake_data, MithrilFixtureBuilder, TempDir},
     };
     use std::path::PathBuf;
+
+    use crate::database::test_helper::main_db_connection;
+    use crate::test_tools::TestLogger;
 
     use super::*;
 
@@ -237,7 +239,7 @@ mod tests {
         let connection = main_db_connection().unwrap();
         let certificate_store = Arc::new(CertificateRepository::new(Arc::new(connection)));
         let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(
-            slog_scope::logger(),
+            TestLogger::stdout(),
             certificate_store.clone(),
         ));
         let genesis_avk = create_fake_genesis_avk();

--- a/mithril-aggregator/src/tools/remote_file_uploader.rs
+++ b/mithril-aggregator/src/tools/remote_file_uploader.rs
@@ -4,10 +4,13 @@ use cloud_storage::{
     bucket::Entity, bucket_access_control::Role, object_access_control::NewObjectAccessControl,
     Client,
 };
-use mithril_common::StdResult;
+use slog::Logger;
 use slog_scope::info;
 use std::{env, path::Path};
 use tokio_util::{codec::BytesCodec, codec::FramedRead};
+
+use mithril_common::logging::LoggerExtensions;
+use mithril_common::StdResult;
 
 /// RemoteFileUploader represents a remote file uploader interactor
 #[cfg_attr(test, mockall::automock)]
@@ -20,12 +23,16 @@ pub trait RemoteFileUploader: Sync + Send {
 /// GcpFileUploader represents a Google Cloud Platform file uploader interactor
 pub struct GcpFileUploader {
     bucket: String,
+    logger: Logger,
 }
 
 impl GcpFileUploader {
     /// GcpFileUploader factory
-    pub fn new(bucket: String) -> Self {
-        Self { bucket }
+    pub fn new(bucket: String, logger: Logger) -> Self {
+        Self {
+            bucket,
+            logger: logger.new_with_component_name::<Self>(),
+        }
     }
 }
 

--- a/mithril-aggregator/src/tools/remote_file_uploader.rs
+++ b/mithril-aggregator/src/tools/remote_file_uploader.rs
@@ -9,11 +9,8 @@ use slog_scope::info;
 use std::{env, path::Path};
 use tokio_util::{codec::BytesCodec, codec::FramedRead};
 
-#[cfg(test)]
-use mockall::automock;
-
 /// RemoteFileUploader represents a remote file uploader interactor
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait RemoteFileUploader: Sync + Send {
     /// Upload a snapshot

--- a/mithril-aggregator/src/tools/signer_importer.rs
+++ b/mithril-aggregator/src/tools/signer_importer.rs
@@ -10,8 +10,6 @@ use std::time::Duration;
 
 use crate::database::repository::SignerStore;
 
-#[cfg(test)]
-use mockall::automock;
 use slog_scope::{info, warn};
 
 pub type PoolTicker = String;
@@ -66,7 +64,7 @@ impl SignersImporter {
 }
 
 /// Trait that define how a [SignersImporter] retrieve the signers to import.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SignersImporterRetriever: Sync + Send {
     /// Retrieve the signers list.
@@ -74,7 +72,7 @@ pub trait SignersImporterRetriever: Sync + Send {
 }
 
 /// Trait that define how a [SignersImporter] persist the retrieved signers.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait SignersImporterPersister: Sync + Send {
     /// Persist the given list of signers.

--- a/mithril-aggregator/src/tools/single_signature_authenticator.rs
+++ b/mithril-aggregator/src/tools/single_signature_authenticator.rs
@@ -2,6 +2,7 @@ use slog::{debug, Logger};
 use std::sync::Arc;
 
 use mithril_common::entities::{SingleSignatureAuthenticationStatus, SingleSignatures};
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
 
 use crate::MultiSigner;
@@ -17,7 +18,7 @@ impl SingleSignatureAuthenticator {
     pub fn new(multi_signer: Arc<dyn MultiSigner>, logger: Logger) -> Self {
         Self {
             multi_signer,
-            logger,
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.67"
+version = "0.4.68"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/logging.rs
+++ b/mithril-common/src/logging.rs
@@ -6,11 +6,18 @@ use slog::Logger;
 pub trait LoggerExtensions {
     /// Create a new child logger with a `src` key containing the component name.
     fn new_with_component_name<T>(&self) -> Self;
+
+    /// Create a new child logger with a `src` key containing the provided name.
+    fn new_with_name(&self, name: &str) -> Self;
 }
 
 impl LoggerExtensions for Logger {
     fn new_with_component_name<T>(&self) -> Self {
-        self.new(slog::o!("src" => component_name::<T>()))
+        self.new_with_name(component_name::<T>())
+    }
+
+    fn new_with_name(&self, name: &str) -> Self {
+        self.new(slog::o!("src" => name.to_owned()))
     }
 }
 
@@ -76,6 +83,24 @@ mod tests {
         assert!(
             logs.contains("src") && logs.contains("TestStruct"),
             "log should contain `src` key for `TestStruct` as component name was provided, logs:\n{logs}"
+        );
+    }
+
+    #[test]
+    fn logger_extension_new_with_name() {
+        let expected_name = "my name";
+        let log_path =
+            TempDir::create("common_logging", "logger_extension_new_with_name").join("test.log");
+        {
+            let root_logger = TestLogger::file(&log_path);
+            let child_logger = root_logger.new_with_name(expected_name);
+            info!(child_logger, "Child log");
+        }
+
+        let logs = std::fs::read_to_string(&log_path).unwrap();
+        assert!(
+            logs.contains("src") && logs.contains(expected_name),
+            "log should contain `src` key for `{expected_name}` as a name was provided, logs:\n{logs}"
         );
     }
 }


### PR DESCRIPTION
## Content

This PR refactor the log usage in `mithril-aggregator`:
- A dedicated child logger is used for each service
- Each child logger is tagged with its service name in order to identify quickly a log source.
- Remove `slog_scope` to enforce the usage of a name tagged child logger (only kept in the integration tests).
- Change the name property in all logs from the default `slog-rs` to `mithril-signer`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Comments

As this PR is already quite big, a second PR will come that will pass over all logs in the aggregator to move away from the log message huge structure  into properties, to remove prefixes in message as now all logs are tagged with their source, and to enforce a common style & structure.

## Issue(s)

Relates to #1981