### PR TITLE
Chore: update signer preloader refresh interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.196"
+version = "0.2.197"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.196"
+version = "0.2.197"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/main.rs
+++ b/mithril-signer/src/main.rs
@@ -81,11 +81,10 @@ pub struct Args {
     allow_unparsable_block: bool,
 
     /// Preloading refresh interval in seconds
-    // TODO: Replace the default value to 43200 (12 hours) once the Cardano transactions is activated on mainnet
     #[clap(
         long,
         env = "PRELOADING_REFRESH_INTERVAL_IN_SECONDS",
-        default_value_t = 7200
+        default_value_t = 43200
     )]
     preloading_refresh_interval_in_seconds: u64,
 }


### PR DESCRIPTION
## Content
This PR includes an update to the **default preloader refresh interval of the signer** which has been set to **12 hours instead of 2 hours**.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #1943 