### PR TITLE
Use new GitHub action for creating `unstable` release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,24 +588,26 @@ jobs:
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
           compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "⛔", "testing-preview": "✔", "testing-sanchonet": "✔" }'
 
-      - name: Update unstable release
-        uses: marvinpinto/action-automatic-releases@latest
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          automatic_release_tag: unstable
-          prerelease: true
-          title: Unstable Development Builds
-          files: package/*
-
-      - name: Update unstable release body with release notes addon
-        # specific version since this action does not support giving only the major number
-        uses: tubone24/update_release@v1.3.1
+      - name: Delete unstable release and associated tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: unstable
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view unstable -R ${{ github.repository }} &>/dev/null; then
+            gh release delete unstable --cleanup-tag -y -R ${{ github.repository }}
+          else
+            echo "Release 'unstable' not found, skipping deletion."
+          fi
+
+      - name: Update unstable release
+        uses: softprops/action-gh-release@v2
         with:
-          is_append_body: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: unstable
+          prerelease: true
+          name: Unstable Development Builds
+          files: package/*
           body_path: ./release-notes-addon.txt
+          append_body: true
 
   deploy-testing:
     if: vars.DEPLOY_NETWORKS_IN_CI == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')


### PR DESCRIPTION
## Content

This PR includes updates the CI jobs responsible for creating the `unstable` release release by replacing the unmaintained `marvinpinto/action-automatic-releases` action.

The https://github.com/softprops/action-gh-release now replaces both the [marvinpinto/action-automatic-releases](https://github.com/marvinpinto/actions/tree/master/packages/automatic-releases) [tubone24/update_release](https://github.com/tubone24/update_release) actions.

An additional step has been added to remove the previous `unstable` distribution and tag using the GitHub CLI's dedicated [`gh release delete`](https://cli.github.com/manual/gh_release_delete) command. This task was originally handled by the `marvinpinto/action-automatic-releases` action.

Example of unstable release created from a fork of Mithril using this new GitHub Action can be found here: https://github.com/dlachaume/mithril/releases/tag/unstable

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #1691 
