### PR TITLE
Fix: update dependencies runbook and script

### DIFF
--- a/docs/runbook/upgrade-repository-dependencies/README.md
+++ b/docs/runbook/upgrade-repository-dependencies/README.md
@@ -88,6 +88,8 @@ By running 'make upgrade' command.
 
 From the root of the repository, run:
 
+[!IMPORTANT]: This command must be run before upgrading `mithril-explorer`.
+
 ```bash
 cd mithril-client-wasm
 make upgrade-www-deps

--- a/docs/runbook/upgrade-repository-dependencies/README.md
+++ b/docs/runbook/upgrade-repository-dependencies/README.md
@@ -84,23 +84,6 @@ chore: upgrade doc dependencies
 By running 'make upgrade' command.
 ```
 
-### Upgrade the explorer dependencies
-
-From the root of the repository, run:
-
-```bash
-cd mithril-explorer
-make upgrade
-```
-
-Create a dedicated commit, e.g.:
-
-```bash
-chore: upgrade explorer dependencies
-
-By running 'make upgrade' command.
-```
-
 ### Upgrade `www/` and `www-test/` dependencies
 
 From the root of the repository, run:
@@ -116,6 +99,23 @@ Create a dedicated commit, e.g.:
 chore: upgrade mithril client wasm 'www' and 'www-test' dependencies
 
 By running 'make upgrade-www-deps' command.
+```
+
+### Upgrade the explorer dependencies
+
+From the root of the repository, run:
+
+```bash
+cd mithril-explorer
+make upgrade
+```
+
+Create a dedicated commit, e.g.:
+
+```bash
+chore: upgrade explorer dependencies
+
+By running 'make upgrade' command.
 ```
 
 ### Bump Javascript packages versions
@@ -142,7 +142,7 @@ make install
 Create a dedicated commit, e.g.:
 
 ```bash
-chore: bump mithril client wasm 'www' and 'www-test' dependencies
+chore: bump javascript packages versions
 
 By running:
 - 'make www-install' command in 'mithril-client-wasm'.

--- a/docs/runbook/upgrade-repository-dependencies/upgrade_dependencies.sh
+++ b/docs/runbook/upgrade-repository-dependencies/upgrade_dependencies.sh
@@ -47,7 +47,7 @@ By running 'make upgrade' command."
 
 # Search all package.json files and bump the version
 # and exclude `package.json` in `node_modules` folder
-for package_json_file in $(find . -name package.json | grep -v "/node_modules/"); do
+for package_json_file in $(find . -name package.json | grep -v "/node_modules/" | grep -v "/pkg/"); do
     folder="$(dirname $package_json_file)"
     pushd "$folder" || exit
     npm version patch

--- a/docs/runbook/upgrade-repository-dependencies/upgrade_dependencies.sh
+++ b/docs/runbook/upgrade-repository-dependencies/upgrade_dependencies.sh
@@ -26,14 +26,6 @@ git commit -am "chore: upgrade doc dependencies
 
 By running 'make upgrade' command."
 
-# Upgrade the explorer dependencies
-pushd mithril-explorer || exit
-make upgrade
-popd || exit
-git commit -am "chore: upgrade explorer dependencies
-
-By running 'make upgrade' command."
-
 # Upgrade www/ and www-test/ dependencies
 pushd mithril-client-wasm || exit
 make upgrade-www-deps
@@ -42,6 +34,14 @@ popd || exit
 git commit -am "chore: upgrade mithril client wasm 'www' and 'www-test' dependencies
 
 By running 'make upgrade-www-deps' command."
+
+# Upgrade the explorer dependencies
+pushd mithril-explorer || exit
+make upgrade
+popd || exit
+git commit -am "chore: upgrade explorer dependencies
+
+By running 'make upgrade' command."
 
 # Bump Javascript packages versions
 
@@ -66,7 +66,7 @@ pushd docs/website || exit
 make install
 popd || exit
 
-git commit -am "chore: bump mithril client wasm 'www' and 'www-test' dependencies
+git commit -am "chore: bump javascript packages versions
 
 By running:
 - 'make www-install' command in 'mithril-client-wasm'.


### PR DESCRIPTION
## Content

This PR includes a fix to the steps in the `Upgrade the project's dependencies in the repository` runbook and the associated script `upgrade_dependencies.sh`:
- Reorder steps to compile `mithril-client-wasm` crate before updating the explorer
- Remove  from the script the npm package version bump (in `/mithril-client-wasm/pkg` file) for `mithril-client-wasm`

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)