### PR TITLE
Rework & harmonize aggregator log messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.82"
+version = "0.5.83"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.199"
+version = "0.2.200"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.82"
+version = "0.5.83"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -60,7 +60,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         beacon: &CardanoDbBeacon,
         snapshot_digest: &str,
     ) -> StdResult<OngoingSnapshot> {
-        debug!(self.logger, "create snapshot archive");
+        debug!(self.logger, ">> create_snapshot_archive");
 
         let snapshotter = self.snapshotter.clone();
         let snapshot_name = format!(
@@ -87,7 +87,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         &self,
         ongoing_snapshot: &OngoingSnapshot,
     ) -> StdResult<Vec<SnapshotLocation>> {
-        debug!(self.logger, "upload snapshot archive");
+        debug!(self.logger, ">> upload_snapshot_archive");
         let location = self
             .snapshot_uploader
             .upload_snapshot(ongoing_snapshot.get_file_path())
@@ -110,7 +110,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         snapshot_digest: String,
         remote_locations: Vec<String>,
     ) -> StdResult<Snapshot> {
-        debug!(self.logger, "create snapshot");
+        debug!(self.logger, ">> create_snapshot");
 
         let snapshot = Snapshot::new(
             snapshot_digest,

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -95,8 +95,8 @@ impl CardanoImmutableFilesFullArtifactBuilder {
 
         if let Err(error) = tokio::fs::remove_file(ongoing_snapshot.get_file_path()).await {
             warn!(
-                self.logger,
-                " > Post upload ongoing snapshot file removal failure: {error}"
+                self.logger, " > Post upload ongoing snapshot file removal failure";
+                "error" => error
             );
         }
 

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -60,10 +60,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         beacon: &CardanoDbBeacon,
         snapshot_digest: &str,
     ) -> StdResult<OngoingSnapshot> {
-        debug!(
-            self.logger,
-            "CardanoImmutableFilesFullArtifactBuilder: create snapshot archive"
-        );
+        debug!(self.logger, "create snapshot archive");
 
         let snapshotter = self.snapshotter.clone();
         let snapshot_name = format!(
@@ -90,10 +87,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         &self,
         ongoing_snapshot: &OngoingSnapshot,
     ) -> StdResult<Vec<SnapshotLocation>> {
-        debug!(
-            self.logger,
-            "CardanoImmutableFilesFullArtifactBuilder: upload snapshot archive"
-        );
+        debug!(self.logger, "upload snapshot archive");
         let location = self
             .snapshot_uploader
             .upload_snapshot(ongoing_snapshot.get_file_path())
@@ -116,10 +110,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         snapshot_digest: String,
         remote_locations: Vec<String>,
     ) -> StdResult<Snapshot> {
-        debug!(
-            self.logger,
-            "CardanoImmutableFilesFullArtifactBuilder: create snapshot"
-        );
+        debug!(self.logger, "create snapshot");
 
         let snapshot = Snapshot::new(
             snapshot_digest,

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -78,7 +78,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
             })
             .await??;
 
-        debug!(self.logger, " > snapshot created: '{ongoing_snapshot:?}'");
+        debug!(self.logger, " > Snapshot created: '{ongoing_snapshot:?}'");
 
         Ok(ongoing_snapshot)
     }

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -177,10 +177,9 @@ impl ServeCommand {
                 }
                 Err(error) => {
                     warn!(
-                        root_logger,
-                        "Failed to build the `SignersImporter`:\n url to import `{}`\n Error: {:?}",
-                        cexplorer_pools_url,
-                        error
+                        root_logger, "Failed to build the `SignersImporter`";
+                        "url_to_import" => cexplorer_pools_url,
+                        "error" => ?error
                     );
                 }
             }
@@ -190,7 +189,7 @@ impl ServeCommand {
         dependencies_builder.vanish().await;
 
         if let Err(e) = join_set.join_next().await.unwrap()? {
-            crit!(root_logger, "A critical error occurred: {e}");
+            crit!(root_logger, "A critical error occurred"; "error" => e);
         }
 
         // stop servers

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -599,7 +599,8 @@ impl DependenciesBuilder {
         let epoch_settings_configuration = self.get_epoch_settings_configuration()?;
         debug!(
             logger,
-            "Handle discrepancies at startup of epoch settings store, will record epoch settings from the configuration for epoch {current_epoch}: {epoch_settings_configuration:?}"
+            "Handle discrepancies at startup of epoch settings store, will record epoch settings from the configuration for epoch {current_epoch}";
+            "epoch_settings_configuration" => ?epoch_settings_configuration,
         );
         epoch_settings_store
             .handle_discrepancies_at_startup(current_epoch, &epoch_settings_configuration)

--- a/mithril-aggregator/src/event_store/runner.rs
+++ b/mithril-aggregator/src/event_store/runner.rs
@@ -37,7 +37,7 @@ impl EventStore {
         let persister = EventPersister::new(connection);
         info!(
             self.logger,
-            "monitoring: starting event loop to log messages."
+            "Starting monitoring event loop to log messages."
         );
         loop {
             if let Some(message) = self.receiver.recv().await {

--- a/mithril-aggregator/src/event_store/runner.rs
+++ b/mithril-aggregator/src/event_store/runner.rs
@@ -41,7 +41,7 @@ impl EventStore {
         );
         loop {
             if let Some(message) = self.receiver.recv().await {
-                debug!(self.logger, "Event received: {message:?}");
+                debug!(self.logger, "Event received"; "event" => ?message);
                 let event = persister
                     .persist(message)
                     .with_context(|| "event persist failure")?;

--- a/mithril-aggregator/src/event_store/runner.rs
+++ b/mithril-aggregator/src/event_store/runner.rs
@@ -45,7 +45,7 @@ impl EventStore {
                 let event = persister
                     .persist(message)
                     .with_context(|| "event persist failure")?;
-                debug!(self.logger, "event ID={} created", event.event_id);
+                debug!(self.logger, "Event ID={} created", event.event_id);
             } else {
                 info!(self.logger, "No more events to proceed, quitting…");
                 break;

--- a/mithril-aggregator/src/event_store/transmitter_service.rs
+++ b/mithril-aggregator/src/event_store/transmitter_service.rs
@@ -52,7 +52,7 @@ impl TransmitterService<EventMessage> {
     {
         let content = serde_json::to_string(content).map_err(|e| {
             let error_msg = format!("Serialization error while forging event message: {e}");
-            warn!(self.logger, "Event message error => «{error_msg}»");
+            warn!(self.logger, "Event message error"; "error" => &error_msg);
 
             error_msg
         })?;
@@ -68,7 +68,7 @@ impl TransmitterService<EventMessage> {
         self.get_transmitter().send(message.clone()).map_err(|e| {
             let error_msg =
                 format!("An error occurred when sending message {message:?} to monitoring: '{e}'.");
-            warn!(self.logger, "Event message error => «{error_msg}»");
+            warn!(self.logger, "Event message error"; "error" => &error_msg);
 
             error_msg
         })

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -64,7 +64,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifacts");
+        debug!(logger, "GET /artifact/cardano-stake-distributions");
 
         match http_message_service
             .get_cardano_stake_distribution_list_message(LIST_MAX_ITEMS)
@@ -72,7 +72,7 @@ pub mod handlers {
         {
             Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
             Err(err) => {
-                warn!(logger, "list_artifacts_cardano_stake_distribution"; "error" => ?err);
+                warn!(logger, "get_cardano_stake_distribution_list::error"; "error" => ?err);
                 Ok(reply::server_error(err))
             }
         }
@@ -84,7 +84,10 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifact/{signed_entity_id}");
+        debug!(
+            logger,
+            "GET /artifact/cardano-stake-distribution/{signed_entity_id}"
+        );
 
         match http_message_service
             .get_cardano_stake_distribution_message(&signed_entity_id)
@@ -108,7 +111,10 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifact/epoch/{epoch}");
+        debug!(
+            logger,
+            "GET /artifact/cardano-stake-distributions/epoch/{epoch}"
+        );
 
         let artifact_epoch = match epoch.parse::<u64>() {
             Ok(epoch) => Epoch(epoch),

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -64,7 +64,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifacts");
+        debug!(logger, "artifacts");
 
         match http_message_service
             .get_cardano_stake_distribution_list_message(LIST_MAX_ITEMS)
@@ -84,7 +84,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifact/{signed_entity_id}");
+        debug!(logger, "artifact/{signed_entity_id}");
 
         match http_message_service
             .get_cardano_stake_distribution_message(&signed_entity_id)
@@ -108,7 +108,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifact/epoch/{epoch}");
+        debug!(logger, "artifact/epoch/{epoch}");
 
         let artifact_epoch = match epoch.parse::<u64>() {
             Ok(epoch) => Epoch(epoch),

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -52,7 +52,7 @@ pub mod handlers {
     use crate::services::MessageService;
 
     use mithril_common::entities::Epoch;
-    use slog::{debug, warn, Logger};
+    use slog::{warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -64,8 +64,6 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /artifact/cardano-stake-distributions");
-
         match http_message_service
             .get_cardano_stake_distribution_list_message(LIST_MAX_ITEMS)
             .await
@@ -84,11 +82,6 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(
-            logger,
-            "GET /artifact/cardano-stake-distribution/{signed_entity_id}"
-        );
-
         match http_message_service
             .get_cardano_stake_distribution_message(&signed_entity_id)
             .await
@@ -111,11 +104,6 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(
-            logger,
-            "GET /artifact/cardano-stake-distributions/epoch/{epoch}"
-        );
-
         let artifact_epoch = match epoch.parse::<u64>() {
             Ok(epoch) => Epoch(epoch),
             Err(err) => {

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -35,7 +35,7 @@ pub mod handlers {
     use crate::http_server::routes::reply;
     use crate::services::MessageService;
 
-    use slog::{debug, warn, Logger};
+    use slog::{warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -47,8 +47,6 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /artifact/cardano-transactions");
-
         match http_message_service
             .get_cardano_transaction_list_message(LIST_MAX_ITEMS)
             .await
@@ -68,11 +66,6 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(
-            logger,
-            "GET /artifact/cardano-transaction/{signed_entity_id}"
-        );
-
         match http_message_service
             .get_cardano_transaction_message(&signed_entity_id)
             .await

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -47,7 +47,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifacts");
+        debug!(logger, "GET /artifact/cardano-transactions");
 
         match http_message_service
             .get_cardano_transaction_list_message(LIST_MAX_ITEMS)
@@ -68,7 +68,10 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifact/{signed_entity_id}");
+        debug!(
+            logger,
+            "GET /artifact/cardano-transaction/{signed_entity_id}"
+        );
 
         match http_message_service
             .get_cardano_transaction_message(&signed_entity_id)

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -47,7 +47,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifacts");
+        debug!(logger, "artifacts");
 
         match http_message_service
             .get_cardano_transaction_list_message(LIST_MAX_ITEMS)
@@ -68,7 +68,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifact/{signed_entity_id}");
+        debug!(logger, "artifact/{signed_entity_id}");
 
         match http_message_service
             .get_cardano_transaction_message(&signed_entity_id)

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -36,7 +36,7 @@ pub mod handlers {
     use crate::http_server::routes::reply;
     use crate::services::MessageService;
 
-    use slog::{debug, warn, Logger};
+    use slog::{warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -48,8 +48,6 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /artifact/mithril-stake-distributions");
-
         match http_message_service
             .get_mithril_stake_distribution_list_message(LIST_MAX_ITEMS)
             .await
@@ -68,11 +66,6 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(
-            logger,
-            "GET /artifact/mithril-stake-distribution/{signed_entity_id}"
-        );
-
         match http_message_service
             .get_mithril_stake_distribution_message(&signed_entity_id)
             .await

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -48,7 +48,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifacts");
+        debug!(logger, "artifacts");
 
         match http_message_service
             .get_mithril_stake_distribution_list_message(LIST_MAX_ITEMS)
@@ -68,7 +68,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifact/{signed_entity_id}");
+        debug!(logger, "artifact/{signed_entity_id}");
 
         match http_message_service
             .get_mithril_stake_distribution_message(&signed_entity_id)

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -48,7 +48,7 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifacts");
+        debug!(logger, "GET /artifact/mithril-stake-distributions");
 
         match http_message_service
             .get_mithril_stake_distribution_list_message(LIST_MAX_ITEMS)
@@ -68,7 +68,10 @@ pub mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifact/{signed_entity_id}");
+        debug!(
+            logger,
+            "GET /artifact/mithril-stake-distribution/{signed_entity_id}"
+        );
 
         match http_message_service
             .get_mithril_stake_distribution_message(&signed_entity_id)

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -109,7 +109,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifacts");
+        debug!(logger, "artifacts");
 
         match http_message_service
             .get_snapshot_list_message(LIST_MAX_ITEMS)
@@ -129,7 +129,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: artifact/{signed_entity_id}");
+        debug!(logger, "artifact/{signed_entity_id}");
         match http_message_service
             .get_snapshot_message(&signed_entity_id)
             .await
@@ -155,7 +155,7 @@ mod handlers {
         let filepath = reply.path().to_path_buf();
         debug!(
             logger,
-            "⇄ HTTP SERVER: ensure_downloaded_file_is_a_snapshot / file: `{}`",
+            "ensure_downloaded_file_is_a_snapshot / file: `{}`",
             filepath.display()
         );
 
@@ -188,7 +188,7 @@ mod handlers {
         config: Configuration,
         signed_entity_service: Arc<dyn SignedEntityService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: snapshot_download/{}", digest);
+        debug!(logger, "snapshot_download/{}", digest);
 
         match signed_entity_service
             .get_signed_snapshot_by_id(&digest)

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -109,7 +109,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifacts");
+        debug!(logger, "GET /artifact/snapshots");
 
         match http_message_service
             .get_snapshot_list_message(LIST_MAX_ITEMS)
@@ -129,7 +129,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "artifact/{signed_entity_id}");
+        debug!(logger, "GET /artifact/snapshot/{signed_entity_id}");
         match http_message_service
             .get_snapshot_message(&signed_entity_id)
             .await
@@ -155,7 +155,7 @@ mod handlers {
         let filepath = reply.path().to_path_buf();
         debug!(
             logger,
-            "ensure_downloaded_file_is_a_snapshot / file: `{}`",
+            ">> ensure_downloaded_file_is_a_snapshot / file: `{}`",
             filepath.display()
         );
 
@@ -188,7 +188,7 @@ mod handlers {
         config: Configuration,
         signed_entity_service: Arc<dyn SignedEntityService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "snapshot_download/{}", digest);
+        debug!(logger, "GET /snapshot_download/snapshot/{digest}");
 
         match signed_entity_service
             .get_signed_snapshot_by_id(&digest)

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -109,8 +109,6 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /artifact/snapshots");
-
         match http_message_service
             .get_snapshot_list_message(LIST_MAX_ITEMS)
             .await
@@ -129,7 +127,6 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /artifact/snapshot/{signed_entity_id}");
         match http_message_service
             .get_snapshot_message(&signed_entity_id)
             .await
@@ -188,8 +185,6 @@ mod handlers {
         config: Configuration,
         signed_entity_service: Arc<dyn SignedEntityService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /snapshot_download/snapshot/{digest}");
-
         match signed_entity_service
             .get_signed_snapshot_by_id(&digest)
             .await

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -63,7 +63,7 @@ mod handlers {
         logger: Logger,
         certificate_pending_store: Arc<CertificatePendingStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: certificate_pending");
+        debug!(logger, "certificate_pending");
 
         match certificate_pending_store.get().await {
             Ok(Some(certificate_pending)) => Ok(reply::json(
@@ -83,7 +83,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: certificate_certificates",);
+        debug!(logger, "certificate_certificates",);
 
         match http_message_service
             .get_certificate_list_message(LIST_MAX_ITEMS)
@@ -103,10 +103,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(
-            logger,
-            "⇄ HTTP SERVER: certificate_certificate_hash/{}", certificate_hash
-        );
+        debug!(logger, "certificate_certificate_hash/{}", certificate_hash);
 
         match http_message_service
             .get_certificate_message(&certificate_hash)

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -51,7 +51,7 @@ mod handlers {
         ToCertificatePendingMessageAdapter,
     };
 
-    use slog::{debug, warn, Logger};
+    use slog::{warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -63,8 +63,6 @@ mod handlers {
         logger: Logger,
         certificate_pending_store: Arc<CertificatePendingStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /certificate-pending");
-
         match certificate_pending_store.get().await {
             Ok(Some(certificate_pending)) => Ok(reply::json(
                 &ToCertificatePendingMessageAdapter::adapt(certificate_pending),
@@ -83,8 +81,6 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /certificates");
-
         match http_message_service
             .get_certificate_list_message(LIST_MAX_ITEMS)
             .await
@@ -103,8 +99,6 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /certificate/{certificate_hash}");
-
         match http_message_service
             .get_certificate_message(&certificate_hash)
             .await

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -63,7 +63,7 @@ mod handlers {
         logger: Logger,
         certificate_pending_store: Arc<CertificatePendingStore>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "certificate_pending");
+        debug!(logger, "GET /certificate-pending");
 
         match certificate_pending_store.get().await {
             Ok(Some(certificate_pending)) => Ok(reply::json(
@@ -83,7 +83,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "certificate_certificates",);
+        debug!(logger, "GET /certificates");
 
         match http_message_service
             .get_certificate_list_message(LIST_MAX_ITEMS)
@@ -103,7 +103,7 @@ mod handlers {
         logger: Logger,
         http_message_service: Arc<dyn MessageService>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "certificate_certificate_hash/{}", certificate_hash);
+        debug!(logger, "GET /certificate/{certificate_hash}");
 
         match http_message_service
             .get_certificate_message(&certificate_hash)

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -86,7 +86,7 @@ mod handlers {
         epoch_service: EpochServiceWrapper,
         allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "epoch_settings");
+        debug!(logger, "GET /epoch-settings");
         let epoch_settings_message =
             get_epoch_settings_message(epoch_service, allowed_discriminants).await;
 

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -86,7 +86,7 @@ mod handlers {
         epoch_service: EpochServiceWrapper,
         allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: epoch_settings");
+        debug!(logger, "epoch_settings");
         let epoch_settings_message =
             get_epoch_settings_message(epoch_service, allowed_discriminants).await;
 

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -69,7 +69,7 @@ async fn get_epoch_settings_message(
 }
 
 mod handlers {
-    use slog::{debug, Logger};
+    use slog::{warn, Logger};
     use std::collections::BTreeSet;
     use std::convert::Infallible;
     use warp::http::StatusCode;
@@ -86,13 +86,15 @@ mod handlers {
         epoch_service: EpochServiceWrapper,
         allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /epoch-settings");
         let epoch_settings_message =
             get_epoch_settings_message(epoch_service, allowed_discriminants).await;
 
         match epoch_settings_message {
             Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
-            Err(err) => Ok(reply::server_error(err)),
+            Err(err) => {
+                warn!(logger,"epoch_settings::error"; "error" => ?err);
+                Ok(reply::server_error(err))
+            }
         }
     }
 }

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -74,7 +74,7 @@ mod handlers {
         let transaction_hashes = transaction_parameters.split_transactions_hashes();
         debug!(
             logger,
-            "proof_cardano_transaction?transaction_hashes={}",
+            "GET /proof/cardano-transaction?transaction_hashes={}",
             transaction_parameters.transaction_hashes
         );
 

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -74,7 +74,7 @@ mod handlers {
         let transaction_hashes = transaction_parameters.split_transactions_hashes();
         debug!(
             logger,
-            "⇄ HTTP SERVER: proof_cardano_transaction?transaction_hashes={}",
+            "proof_cardano_transaction?transaction_hashes={}",
             transaction_parameters.transaction_hashes
         );
 

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -73,9 +73,8 @@ mod handlers {
     ) -> Result<impl warp::Reply, Infallible> {
         let transaction_hashes = transaction_parameters.split_transactions_hashes();
         debug!(
-            logger,
-            "GET /proof/cardano-transaction?transaction_hashes={}",
-            transaction_parameters.transaction_hashes
+            logger, ">> proof_cardano_transaction";
+            "transaction_hashes" => &transaction_parameters.transaction_hashes
         );
 
         if let Err(error) = validator.validate(&transaction_hashes) {

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -46,7 +46,7 @@ mod handlers {
         allowed_signed_entity_type_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
         configuration: Configuration,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "root");
+        debug!(logger, "GET /");
 
         let open_api_version = unwrap_to_internal_server_error!(
             api_version_provider.compute_current_version(),

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -46,7 +46,7 @@ mod handlers {
         allowed_signed_entity_type_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
         configuration: Configuration,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: root");
+        debug!(logger, "root");
 
         let open_api_version = unwrap_to_internal_server_error!(
             api_version_provider.compute_current_version(),

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -27,7 +27,7 @@ mod handlers {
     use std::collections::BTreeSet;
     use std::{convert::Infallible, sync::Arc};
 
-    use slog::{debug, Logger};
+    use slog::Logger;
     use warp::http::StatusCode;
 
     use mithril_common::api_version::APIVersionProvider;
@@ -46,8 +46,6 @@ mod handlers {
         allowed_signed_entity_type_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
         configuration: Configuration,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "GET /");
-
         let open_api_version = unwrap_to_internal_server_error!(
             api_version_provider.compute_current_version(),
             logger => "root::error"

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -74,6 +74,7 @@ pub fn routes(
                     .to_string(),
             )
         })
+        .with(middlewares::log_route_call(&dependency_manager))
 }
 
 /// API Version verification

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -85,13 +85,16 @@ fn header_must_be(
         .and(warp::any().map(move || api_version_provider.clone()))
         .and(warp::any().map(move || logger.clone()))
         .and_then(
-            move |maybe_header: Option<String>, api_version_provider: Arc<APIVersionProvider>, logger: Logger| async move {
+            move |maybe_header: Option<String>,
+                  api_version_provider: Arc<APIVersionProvider>,
+                  logger: Logger| async move {
                 match maybe_header {
                     None => Ok(()),
                     Some(version) => match semver::Version::parse(&version) {
                         Ok(version)
                             if (api_version_provider
-                                .compute_current_version_requirement().unwrap()
+                                .compute_current_version_requirement()
+                                .unwrap()
                                 .matches(&version))
                             .to_owned() =>
                         {
@@ -99,7 +102,7 @@ fn header_must_be(
                         }
                         Ok(_version) => Err(warp::reject::custom(VersionMismatchError)),
                         Err(err) => {
-                            warn!(logger, "⇄ HTTP SERVER::api_version_check::parse_error"; "error" => ?err);
+                            warn!(logger, "api_version_check::parse_error"; "error" => ?err);
                             Err(warp::reject::custom(VersionParseError))
                         }
                     },

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -45,8 +45,8 @@ mod handlers {
         certifier_service: Arc<dyn CertifierService>,
         single_signer_authenticator: Arc<SingleSignatureAuthenticator>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: register_signatures/{:?}", message);
-        trace!(logger,"⇄ HTTP SERVER: register_signatures"; "complete_message" => #?message );
+        debug!(logger, "register_signatures/{:?}", message);
+        trace!(logger,"register_signatures"; "complete_message" => #?message );
 
         let signed_entity_type = message.signed_entity_type.clone();
         let signed_message = message.signed_message.clone();

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -45,8 +45,8 @@ mod handlers {
         certifier_service: Arc<dyn CertifierService>,
         single_signer_authenticator: Arc<SingleSignatureAuthenticator>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "register_signatures/{:?}", message);
-        trace!(logger,"register_signatures"; "complete_message" => #?message );
+        debug!(logger, "POST /register-signatures/{:?}", message);
+        trace!(logger,"POST /register-signatures"; "complete_message" => #?message );
 
         let signed_entity_type = message.signed_entity_type.clone();
         let signed_message = message.signed_message.clone();

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -45,7 +45,7 @@ mod handlers {
         certifier_service: Arc<dyn CertifierService>,
         single_signer_authenticator: Arc<SingleSignatureAuthenticator>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "POST /register-signatures/{:?}", message);
+        debug!(logger, "POST /register-signatures"; "message" => ?message);
         trace!(logger,"POST /register-signatures"; "complete_message" => #?message );
 
         let signed_entity_type = message.signed_entity_type.clone();

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -24,7 +24,7 @@ fn register_signatures(
 }
 
 mod handlers {
-    use slog::{debug, trace, warn, Logger};
+    use slog::{debug, warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -45,8 +45,7 @@ mod handlers {
         certifier_service: Arc<dyn CertifierService>,
         single_signer_authenticator: Arc<SingleSignatureAuthenticator>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "POST /register-signatures"; "message" => ?message);
-        trace!(logger,"POST /register-signatures"; "complete_message" => #?message );
+        debug!(logger, ">> register_signatures"; "payload" => ?message);
 
         let signed_entity_type = message.signed_entity_type.clone();
         let signed_message = message.signed_message.clone();

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -62,10 +62,7 @@ async fn fetch_epoch_header_value(
     match epoch_service.read().await.epoch_of_current_data() {
         Ok(epoch) => format!("{epoch}"),
         Err(e) => {
-            warn!(
-                logger,
-                "Could not fetch epoch header value from Epoch service: {e}"
-            );
+            warn!(logger, "Could not fetch epoch header value from Epoch service"; "error" => ?e);
             String::new()
         }
     }
@@ -99,11 +96,8 @@ mod handlers {
         event_transmitter: Arc<TransmitterService<EventMessage>>,
         epoch_service: EpochServiceWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "POST /register-signer/{register_signer_message:?}");
-        trace!(logger,
-            "POST /register_signer";
-            "complete_message" => #?register_signer_message
-        );
+        debug!(logger, "POST /register-signer"; "message" => ?register_signer_message);
+        trace!(logger, "POST /register-signer"; "complete_message" => #?register_signer_message);
 
         let registration_epoch = register_signer_message.epoch;
 

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -99,9 +99,9 @@ mod handlers {
         event_transmitter: Arc<TransmitterService<EventMessage>>,
         epoch_service: EpochServiceWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "register_signer/{register_signer_message:?}");
+        debug!(logger, "POST /register-signer/{register_signer_message:?}");
         trace!(logger,
-            "register_signer";
+            "POST /register_signer";
             "complete_message" => #?register_signer_message
         );
 
@@ -178,7 +178,7 @@ mod handlers {
         logger: Logger,
         verification_key_store: Arc<dyn VerificationKeyStorer>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "signers/registered/{:?}", registered_at);
+        debug!(logger, "GET /signers/registered/{registered_at:?}");
 
         let registered_at = match registered_at.parse::<u64>() {
             Ok(epoch) => Epoch(epoch),
@@ -217,7 +217,7 @@ mod handlers {
         configuration: Configuration,
         signer_getter: Arc<dyn SignerGetter>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "signers/tickers");
+        debug!(logger, "GET /signers/tickers");
         let network = configuration.network;
 
         match signer_getter.get_all().await {

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -99,12 +99,9 @@ mod handlers {
         event_transmitter: Arc<TransmitterService<EventMessage>>,
         epoch_service: EpochServiceWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(
-            logger,
-            "⇄ HTTP SERVER: register_signer/{register_signer_message:?}"
-        );
+        debug!(logger, "register_signer/{register_signer_message:?}");
         trace!(logger,
-            "⇄ HTTP SERVER: register_signer";
+            "register_signer";
             "complete_message" => #?register_signer_message
         );
 
@@ -181,10 +178,7 @@ mod handlers {
         logger: Logger,
         verification_key_store: Arc<dyn VerificationKeyStorer>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(
-            logger,
-            "⇄ HTTP SERVER: signers/registered/{:?}", registered_at
-        );
+        debug!(logger, "signers/registered/{:?}", registered_at);
 
         let registered_at = match registered_at.parse::<u64>() {
             Ok(epoch) => Epoch(epoch),
@@ -223,7 +217,7 @@ mod handlers {
         configuration: Configuration,
         signer_getter: Arc<dyn SignerGetter>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "⇄ HTTP SERVER: signers/tickers");
+        debug!(logger, "signers/tickers");
         let network = configuration.network;
 
         match signer_getter.get_all().await {

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -82,7 +82,7 @@ mod handlers {
     use crate::{FromRegisterSignerAdapter, VerificationKeyStorer};
     use mithril_common::entities::Epoch;
     use mithril_common::messages::{RegisterSignerMessage, TryFromMessageAdapter};
-    use slog::{debug, trace, warn, Logger};
+    use slog::{debug, warn, Logger};
     use std::convert::Infallible;
     use std::sync::Arc;
     use warp::http::StatusCode;
@@ -96,8 +96,7 @@ mod handlers {
         event_transmitter: Arc<TransmitterService<EventMessage>>,
         epoch_service: EpochServiceWrapper,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "POST /register-signer"; "message" => ?register_signer_message);
-        trace!(logger, "POST /register-signer"; "complete_message" => #?register_signer_message);
+        debug!(logger, ">> register_signer"; "payload" => ?register_signer_message);
 
         let registration_epoch = register_signer_message.epoch;
 

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -16,13 +16,11 @@ fn post_statistics(
     warp::path!("statistics" / "snapshot")
         .and(warp::post())
         .and(warp::body::json())
-        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_event_transmitter(dependency_manager))
         .and_then(handlers::post_snapshot_statistics)
 }
 
 mod handlers {
-    use slog::{debug, Logger};
     use std::{convert::Infallible, sync::Arc};
     use warp::http::StatusCode;
 
@@ -33,10 +31,8 @@ mod handlers {
 
     pub async fn post_snapshot_statistics(
         snapshot_download_message: SnapshotDownloadMessage,
-        logger: Logger,
         event_transmitter: Arc<TransmitterService<EventMessage>>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "POST /statistics/snapshot");
         let headers: Vec<(&str, &str)> = Vec::new();
 
         match event_transmitter.send_event_message(

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -16,23 +16,27 @@ fn post_statistics(
     warp::path!("statistics" / "snapshot")
         .and(warp::post())
         .and(warp::body::json())
+        .and(middlewares::with_logger(dependency_manager))
         .and(middlewares::with_event_transmitter(dependency_manager))
         .and_then(handlers::post_snapshot_statistics)
 }
 
 mod handlers {
+    use slog::{debug, Logger};
     use std::{convert::Infallible, sync::Arc};
+    use warp::http::StatusCode;
 
     use mithril_common::messages::SnapshotDownloadMessage;
-    use warp::http::StatusCode;
 
     use crate::event_store::{EventMessage, TransmitterService};
     use crate::http_server::routes::reply;
 
     pub async fn post_snapshot_statistics(
         snapshot_download_message: SnapshotDownloadMessage,
+        logger: Logger,
         event_transmitter: Arc<TransmitterService<EventMessage>>,
     ) -> Result<impl warp::Reply, Infallible> {
+        debug!(logger, "POST /statistics/snapshot");
         let headers: Vec<(&str, &str)> = Vec::new();
 
         match event_transmitter.send_event_message(

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -114,7 +114,7 @@ impl MultiSigner for MultiSignerImpl {
         &self,
         open_message: &OpenMessage,
     ) -> StdResult<Option<ProtocolMultiSignature>> {
-        debug!(self.logger, "create_multi_signature({open_message:?})");
+        debug!(self.logger, ">> create_multi_signature({open_message:?})");
 
         let epoch_service = self.epoch_service.read().await;
         let protocol_multi_signer = epoch_service.protocol_multi_signer().with_context(|| {

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -114,7 +114,7 @@ impl MultiSigner for MultiSignerImpl {
         &self,
         open_message: &OpenMessage,
     ) -> StdResult<Option<ProtocolMultiSignature>> {
-        debug!(self.logger, ">> create_multi_signature({open_message:?})");
+        debug!(self.logger, ">> create_multi_signature"; "open_message" => ?open_message);
 
         let epoch_service = self.epoch_service.read().await;
         let protocol_multi_signer = epoch_service.protocol_multi_signer().with_context(|| {

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -114,10 +114,7 @@ impl MultiSigner for MultiSignerImpl {
         &self,
         open_message: &OpenMessage,
     ) -> StdResult<Option<ProtocolMultiSignature>> {
-        debug!(
-            self.logger,
-            "MultiSigner:create_multi_signature({open_message:?})"
-        );
+        debug!(self.logger, "create_multi_signature({open_message:?})");
 
         let epoch_service = self.epoch_service.read().await;
         let protocol_multi_signer = epoch_service.protocol_multi_signer().with_context(|| {

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -1,5 +1,7 @@
-use mithril_common::StdError;
+use slog::{crit, error, Logger};
 use thiserror::Error;
+
+use mithril_common::StdError;
 
 /// Error encountered or produced by the Runtime.
 /// This enum represents the faith of the errors produced during the state
@@ -7,7 +9,7 @@ use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum RuntimeError {
     /// Errors that need the runtime to try again without changing its state.
-    #[error("An error occured: {message}. This runtime cycle will be skipped.")]
+    #[error("An error occurred, runtime state kept. message = '{message}'")]
     KeepState {
         /// error message
         message: String,
@@ -18,7 +20,7 @@ pub enum RuntimeError {
     },
     /// A Critical error means the Runtime stops and the software exits with an
     /// error code.
-    #[error("Critical error:'{message}'.")]
+    #[error("A critical error occurred, aborting runtime. message = '{message}'")]
     Critical {
         /// error message
         message: String,
@@ -28,7 +30,7 @@ pub enum RuntimeError {
         nested_error: Option<StdError>,
     },
     /// An error that needs to re-initialize the state machine.
-    #[error("An error occured: {message}. The state machine will be re-initialized.")]
+    #[error("An error occurred, runtime will be re-initialized. message = '{message}'")]
     ReInit {
         /// error message
         message: String,
@@ -40,6 +42,11 @@ pub enum RuntimeError {
 }
 
 impl RuntimeError {
+    /// Easy matching Critical errors.
+    pub fn is_critical(&self) -> bool {
+        matches!(self, RuntimeError::Critical { .. })
+    }
+
     /// Create a new KeepState error
     pub fn keep_state(message: &str, error: Option<StdError>) -> Self {
         Self::KeepState {
@@ -55,6 +62,22 @@ impl RuntimeError {
             nested_error: error,
         }
     }
+
+    /// Write the error to the given logger.
+    pub fn write_to_log(&self, logger: &Logger) {
+        match self {
+            Self::KeepState { nested_error, .. } | Self::ReInit { nested_error, .. } => {
+                match nested_error {
+                    None => error!(logger, "{self}"),
+                    Some(err) => error!(logger, "{self}"; "nested_error" => ?err),
+                }
+            }
+            Self::Critical { nested_error, .. } => match nested_error {
+                None => crit!(logger, "{self}"),
+                Some(err) => crit!(logger, "{self}"; "nested_error" => ?err),
+            },
+        }
+    }
 }
 
 impl From<StdError> for RuntimeError {
@@ -63,5 +86,158 @@ impl From<StdError> for RuntimeError {
             message: "Error caught, state preserved, will retry to cycle.".to_string(),
             nested_error: Some(value),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::anyhow;
+    use std::path::Path;
+
+    use mithril_common::test_utils::TempDir;
+
+    use crate::test_tools::TestLogger;
+
+    use super::*;
+
+    /// Separate function so the logger is dropped and flushed before the assertion.
+    fn write_log(log_file: &Path, error: &RuntimeError) {
+        let logger = TestLogger::file(log_file);
+        error.write_to_log(&logger);
+    }
+
+    fn nested_error_debug_string(error: &RuntimeError) -> String {
+        let error = match error {
+            RuntimeError::KeepState { nested_error, .. } => nested_error,
+            RuntimeError::Critical { nested_error, .. } => nested_error,
+            RuntimeError::ReInit { nested_error, .. } => nested_error,
+        };
+        match error {
+            None => String::new(),
+            Some(err) => {
+                format!("{err:?}")
+            }
+        }
+    }
+
+    #[test]
+    fn log_critical_without_nested_error() {
+        let log_file = TempDir::create(
+            "aggregator_runtime_error",
+            "log_critical_without_nested_error",
+        )
+        .join("file.log");
+
+        let error = RuntimeError::Critical {
+            message: "Critical error".to_string(),
+            nested_error: None,
+        };
+        write_log(&log_file, &error);
+
+        let log_content = std::fs::read_to_string(&log_file).unwrap();
+        assert!(log_content.contains(&format!("{error}")));
+        assert!(!log_content.contains("nested_error"));
+    }
+
+    #[test]
+    fn log_critical_with_nested_error() {
+        let log_file =
+            TempDir::create("aggregator_runtime_error", "log_critical_with_nested_error")
+                .join("file.log");
+
+        let error = RuntimeError::Critical {
+            message: "Critical error".to_string(),
+            nested_error: Some(
+                anyhow!("Another context error")
+                    .context("Context error")
+                    .context("Critical nested error"),
+            ),
+        };
+        write_log(&log_file, &error);
+
+        let log_content = std::fs::read_to_string(&log_file).unwrap();
+        assert!(log_content.contains(&format!("{error}")));
+        assert!(log_content.contains(&nested_error_debug_string(&error)));
+    }
+
+    #[test]
+    fn log_keep_state_without_nested_error() {
+        let log_file = TempDir::create(
+            "aggregator_runtime_error",
+            "log_keep_state_without_nested_error",
+        )
+        .join("file.log");
+
+        let error = RuntimeError::KeepState {
+            message: "KeepState error".to_string(),
+            nested_error: None,
+        };
+        write_log(&log_file, &error);
+
+        let log_content = std::fs::read_to_string(&log_file).unwrap();
+        assert!(log_content.contains(&format!("{error}")));
+        assert!(!log_content.contains("nested_error"));
+    }
+
+    #[test]
+    fn log_keep_state_with_nested_error() {
+        let log_file = TempDir::create(
+            "aggregator_runtime_error",
+            "log_keep_state_with_nested_error",
+        )
+        .join("file.log");
+
+        let error = RuntimeError::KeepState {
+            message: "KeepState error".to_string(),
+            nested_error: Some(
+                anyhow!("Another context error")
+                    .context("Context error")
+                    .context("KeepState nested error"),
+            ),
+        };
+        write_log(&log_file, &error);
+
+        let log_content = std::fs::read_to_string(&log_file).unwrap();
+        assert!(log_content.contains(&format!("{error}")));
+        assert!(log_content.contains(&nested_error_debug_string(&error)));
+    }
+
+    #[test]
+    fn log_reinit_without_nested_error() {
+        let log_file = TempDir::create(
+            "aggregator_runtime_error",
+            "log_reinit_without_nested_error",
+        )
+        .join("file.log");
+
+        let error = RuntimeError::ReInit {
+            message: "ReInit error".to_string(),
+            nested_error: None,
+        };
+        write_log(&log_file, &error);
+
+        let log_content = std::fs::read_to_string(&log_file).unwrap();
+        assert!(log_content.contains(&format!("{error}")));
+        assert!(!log_content.contains("nested_error"));
+    }
+
+    #[test]
+    fn log_reinit_with_nested_error() {
+        let log_file = TempDir::create("aggregator_runtime_error", "log_reinit_with_nested_error")
+            .join("file.log");
+
+        let error = RuntimeError::ReInit {
+            message: "ReInit error".to_string(),
+            nested_error: Some(
+                anyhow!("Another context error")
+                    .context("Context error")
+                    .context("ReInit nested error"),
+            ),
+        };
+        write_log(&log_file, &error);
+
+        let log_content = std::fs::read_to_string(&log_file).unwrap();
+        assert!(log_content.contains(&format!("{error}")));
+        assert!(log_content.contains(&nested_error_debug_string(&error)));
     }
 }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -438,8 +438,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .change_era(current_era, token.get_current_epoch());
         debug!(
             self.logger,
-            "Current Era is {} (Epoch {}).",
-            current_era,
+            "Current Era is {current_era} (Epoch {}).",
             token.get_current_epoch()
         );
 

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -173,7 +173,7 @@ impl AggregatorRunner {
 impl AggregatorRunnerTrait for AggregatorRunner {
     /// Return the current time point from the chain
     async fn get_time_point_from_chain(&self) -> StdResult<TimePoint> {
-        debug!(self.logger, "get time point from chain");
+        debug!(self.logger, ">> get_time_point_from_chain");
         let time_point = self
             .dependencies
             .ticker_service
@@ -187,7 +187,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!(self.logger,"get_current_open_message_for_signed_entity_type"; "signed_entity_type" => ?signed_entity_type);
+        debug!(self.logger,">> get_current_open_message_for_signed_entity_type"; "signed_entity_type" => ?signed_entity_type);
         self.mark_open_message_if_expired(signed_entity_type)
             .await?;
 
@@ -203,10 +203,11 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         current_time_point: &TimePoint,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!(self.logger,"get_current_non_certified_open_message"; "time_point" => #?current_time_point);
+        debug!(self.logger,">> get_current_non_certified_open_message"; "time_point" => #?current_time_point);
         let signed_entity_types = self
             .list_available_signed_entity_types(current_time_point)
             .await?;
+
         for signed_entity_type in signed_entity_types {
             let current_open_message = self.get_current_open_message_for_signed_entity_type(&signed_entity_type)
                 .await
@@ -232,7 +233,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn is_certificate_chain_valid(&self, time_point: &TimePoint) -> StdResult<()> {
-        debug!(self.logger, "is_certificate_chain_valid");
+        debug!(self.logger, ">> is_certificate_chain_valid");
         self.dependencies
             .certifier_service
             .verify_certificate_chain(time_point.epoch)
@@ -242,7 +243,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn update_stake_distribution(&self, new_time_point: &TimePoint) -> StdResult<()> {
-        debug!(self.logger,"update stake distribution"; "time_point" => #?new_time_point);
+        debug!(self.logger,">> update_stake_distribution"; "time_point" => #?new_time_point);
         self.dependencies
             .stake_distribution_service
             .update_stake_distribution()
@@ -251,7 +252,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn open_signer_registration_round(&self, new_time_point: &TimePoint) -> StdResult<()> {
-        debug!(self.logger,"open signer registration round"; "time_point" => #?new_time_point);
+        debug!(self.logger,">> open_signer_registration_round"; "time_point" => #?new_time_point);
         let registration_epoch = new_time_point.epoch.offset_to_recording_epoch();
 
         let stakes = self
@@ -268,8 +269,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn close_signer_registration_round(&self) -> StdResult<()> {
-        debug!(self.logger, "close signer registration round");
-
+        debug!(self.logger, ">> close_signer_registration_round");
         self.dependencies
             .signer_registration_round_opener
             .close_registration_round()
@@ -277,6 +277,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn update_epoch_settings(&self) -> StdResult<()> {
+        debug!(self.logger, ">> update_epoch_settings");
         self.dependencies
             .epoch_service
             .write()
@@ -289,7 +290,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<ProtocolMessage> {
-        debug!(self.logger, "compute protocol message");
+        debug!(self.logger, ">> compute_protocol_message");
         let protocol_message = self
             .dependencies
             .signable_builder_service
@@ -304,8 +305,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!(self.logger, "mark expired open message");
-
+        debug!(self.logger, ">> mark_open_message_if_expired");
         let expired_open_message = self
             .dependencies
             .certifier_service
@@ -326,7 +326,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         time_point: TimePoint,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<CertificatePending> {
-        debug!(self.logger, "create new pending certificate");
+        debug!(self.logger, ">> create_new_pending_certificate");
         let epoch_service = self.dependencies.epoch_service.read().await;
 
         let signers = epoch_service.current_signers_with_stake()?;
@@ -358,8 +358,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         pending_certificate: CertificatePending,
     ) -> StdResult<()> {
-        debug!(self.logger, "saving pending certificate");
-
+        debug!(self.logger, ">> save_pending_certificate");
         let signed_entity_type = pending_certificate.signed_entity_type.clone();
         self.dependencies
             .certificate_pending_store
@@ -370,8 +369,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn drop_pending_certificate(&self) -> StdResult<Option<CertificatePending>> {
-        debug!(self.logger, "drop pending certificate");
-
+        debug!(self.logger, ">> drop_pending_certificate");
         let certificate_pending = self.dependencies.certificate_pending_store.remove().await?;
         if certificate_pending.is_none() {
             warn!(self.logger," > drop_pending_certificate::no certificate pending in store, did the previous loop crashed ?");
@@ -384,7 +382,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<Certificate>> {
-        debug!(self.logger, "create_certificate");
+        debug!(self.logger, ">> create_certificate");
 
         self.dependencies
             .certifier_service
@@ -402,7 +400,8 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         signed_entity_type: &SignedEntityType,
         certificate: &Certificate,
     ) -> StdResult<()> {
-        debug!(self.logger, "create artifact");
+        debug!(self.logger, ">> create_artifact");
+
         self.dependencies
             .signed_entity_service
             .create_artifact(signed_entity_type.to_owned(), certificate)
@@ -418,6 +417,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn update_era_checker(&self, epoch: Epoch) -> StdResult<()> {
+        debug!(self.logger, ">> update_era_checker");
         let token = self
             .dependencies
             .era_reader
@@ -452,6 +452,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn precompute_epoch_data(&self) -> StdResult<()> {
+        debug!(self.logger, ">> precompute_epoch_data");
         self.dependencies
             .epoch_service
             .write()
@@ -463,6 +464,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn inform_new_epoch(&self, epoch: Epoch) -> StdResult<()> {
+        debug!(self.logger, ">> inform_new_epoch");
         self.dependencies
             .certifier_service
             .inform_epoch(epoch)
@@ -479,7 +481,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn upkeep(&self) -> StdResult<()> {
-        debug!(self.logger, "upkeep");
+        debug!(self.logger, ">> upkeep");
         self.dependencies.upkeep_service.run().await
     }
 
@@ -488,6 +490,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
     ) -> StdResult<OpenMessage> {
+        debug!(self.logger, ">> create_open_message");
         self.dependencies
             .certifier_service
             .create_open_message(signed_entity_type, protocol_message)

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -315,7 +315,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
 
         debug!(
             self.logger,
-            "marked expired open messages: {:#?}", expired_open_message
+            "Marked expired open messages: {:#?}", expired_open_message
         );
 
         Ok(expired_open_message)

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -173,7 +173,7 @@ impl AggregatorRunner {
 impl AggregatorRunnerTrait for AggregatorRunner {
     /// Return the current time point from the chain
     async fn get_time_point_from_chain(&self) -> StdResult<TimePoint> {
-        debug!(self.logger, "RUNNER: get time point from chain");
+        debug!(self.logger, "get time point from chain");
         let time_point = self
             .dependencies
             .ticker_service
@@ -187,7 +187,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!(self.logger,"RUNNER: get_current_open_message_for_signed_entity_type"; "signed_entity_type" => ?signed_entity_type);
+        debug!(self.logger,"get_current_open_message_for_signed_entity_type"; "signed_entity_type" => ?signed_entity_type);
         self.mark_open_message_if_expired(signed_entity_type)
             .await?;
 
@@ -203,7 +203,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         current_time_point: &TimePoint,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!(self.logger,"RUNNER: get_current_non_certified_open_message"; "time_point" => #?current_time_point);
+        debug!(self.logger,"get_current_non_certified_open_message"; "time_point" => #?current_time_point);
         let signed_entity_types = self
             .list_available_signed_entity_types(current_time_point)
             .await?;
@@ -232,7 +232,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn is_certificate_chain_valid(&self, time_point: &TimePoint) -> StdResult<()> {
-        debug!(self.logger, "RUNNER: is_certificate_chain_valid");
+        debug!(self.logger, "is_certificate_chain_valid");
         self.dependencies
             .certifier_service
             .verify_certificate_chain(time_point.epoch)
@@ -242,7 +242,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn update_stake_distribution(&self, new_time_point: &TimePoint) -> StdResult<()> {
-        debug!(self.logger,"RUNNER: update stake distribution"; "time_point" => #?new_time_point);
+        debug!(self.logger,"update stake distribution"; "time_point" => #?new_time_point);
         self.dependencies
             .stake_distribution_service
             .update_stake_distribution()
@@ -251,7 +251,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn open_signer_registration_round(&self, new_time_point: &TimePoint) -> StdResult<()> {
-        debug!(self.logger,"RUNNER: open signer registration round"; "time_point" => #?new_time_point);
+        debug!(self.logger,"open signer registration round"; "time_point" => #?new_time_point);
         let registration_epoch = new_time_point.epoch.offset_to_recording_epoch();
 
         let stakes = self
@@ -268,7 +268,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn close_signer_registration_round(&self) -> StdResult<()> {
-        debug!(self.logger, "RUNNER: close signer registration round");
+        debug!(self.logger, "close signer registration round");
 
         self.dependencies
             .signer_registration_round_opener
@@ -289,7 +289,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<ProtocolMessage> {
-        debug!(self.logger, "RUNNER: compute protocol message");
+        debug!(self.logger, "compute protocol message");
         let protocol_message = self
             .dependencies
             .signable_builder_service
@@ -304,7 +304,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!(self.logger, "RUNNER: mark expired open message");
+        debug!(self.logger, "mark expired open message");
 
         let expired_open_message = self
             .dependencies
@@ -315,7 +315,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
 
         debug!(
             self.logger,
-            "RUNNER: marked expired open messages: {:#?}", expired_open_message
+            "marked expired open messages: {:#?}", expired_open_message
         );
 
         Ok(expired_open_message)
@@ -326,7 +326,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         time_point: TimePoint,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<CertificatePending> {
-        debug!(self.logger, "RUNNER: create new pending certificate");
+        debug!(self.logger, "create new pending certificate");
         let epoch_service = self.dependencies.epoch_service.read().await;
 
         let signers = epoch_service.current_signers_with_stake()?;
@@ -358,7 +358,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         pending_certificate: CertificatePending,
     ) -> StdResult<()> {
-        debug!(self.logger, "RUNNER: saving pending certificate");
+        debug!(self.logger, "saving pending certificate");
 
         let signed_entity_type = pending_certificate.signed_entity_type.clone();
         self.dependencies
@@ -370,7 +370,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn drop_pending_certificate(&self) -> StdResult<Option<CertificatePending>> {
-        debug!(self.logger, "RUNNER: drop pending certificate");
+        debug!(self.logger, "drop pending certificate");
 
         let certificate_pending = self.dependencies.certificate_pending_store.remove().await?;
         if certificate_pending.is_none() {
@@ -384,7 +384,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<Certificate>> {
-        debug!(self.logger, "RUNNER: create_certificate");
+        debug!(self.logger, "create_certificate");
 
         self.dependencies
             .certifier_service
@@ -402,7 +402,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         signed_entity_type: &SignedEntityType,
         certificate: &Certificate,
     ) -> StdResult<()> {
-        debug!(self.logger, "RUNNER: create artifact");
+        debug!(self.logger, "create artifact");
         self.dependencies
             .signed_entity_service
             .create_artifact(signed_entity_type.to_owned(), certificate)
@@ -479,7 +479,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn upkeep(&self) -> StdResult<()> {
-        debug!(self.logger, "RUNNER: upkeep");
+        debug!(self.logger, "upkeep");
         self.dependencies.upkeep_service.run().await
     }
 

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -326,7 +326,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         time_point: TimePoint,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<CertificatePending> {
-        debug!(self.logger, ">> create_new_pending_certificate");
+        debug!(self.logger, ">> create_new_pending_certificate"; "signed_entity_type" => ?signed_entity_type);
         let epoch_service = self.dependencies.epoch_service.read().await;
 
         let signers = epoch_service.current_signers_with_stake()?;
@@ -382,7 +382,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<Certificate>> {
-        debug!(self.logger, ">> create_certificate");
+        debug!(self.logger, ">> create_certificate"; "signed_entity_type" => ?signed_entity_type);
 
         self.dependencies
             .certifier_service
@@ -400,7 +400,11 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         signed_entity_type: &SignedEntityType,
         certificate: &Certificate,
     ) -> StdResult<()> {
-        debug!(self.logger, ">> create_artifact");
+        debug!(
+            self.logger, ">> create_artifact";
+            "signed_entity_type" => ?signed_entity_type,
+            "certificate_hash" => &certificate.hash
+        );
 
         self.dependencies
             .signed_entity_service
@@ -417,7 +421,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn update_era_checker(&self, epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, ">> update_era_checker");
+        debug!(self.logger, ">> update_era_checker({epoch:?})");
         let token = self
             .dependencies
             .era_reader
@@ -463,7 +467,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
     }
 
     async fn inform_new_epoch(&self, epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, ">> inform_new_epoch");
+        debug!(self.logger, ">> inform_new_epoch({epoch:?})");
         self.dependencies
             .certifier_service
             .inform_epoch(epoch)

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -314,8 +314,8 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .with_context(|| "CertifierService can not mark expired open message")?;
 
         debug!(
-            self.logger,
-            "Marked expired open messages: {:#?}", expired_open_message
+            self.logger, "Marked expired open messages";
+            "expired_open_message" => ?expired_open_message
         );
 
         Ok(expired_open_message)

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -73,13 +73,13 @@ impl AggregatorRuntime {
         logger: Logger,
     ) -> Result<Self, RuntimeError> {
         let logger = logger.new_with_component_name::<Self>();
-        info!(logger, "initializing runtime");
+        info!(logger, "Initializing runtime");
 
         let state = if let Some(init_state) = init_state {
-            trace!(logger, "got initial state from caller");
+            trace!(logger, "Got initial state from caller");
             init_state
         } else {
-            trace!(logger, "idle state, no current time point");
+            trace!(logger, "Idle state, no current time point");
             AggregatorState::Idle(IdleState {
                 current_time_point: None,
             })
@@ -104,7 +104,7 @@ impl AggregatorRuntime {
 
     /// Launches an infinite loop ticking the state machine.
     pub async fn run(&mut self) -> Result<(), RuntimeError> {
-        info!(self.logger, "launching");
+        info!(self.logger, "Launching State Machine");
 
         loop {
             if let Err(e) = self.cycle().await {
@@ -115,7 +115,7 @@ impl AggregatorRuntime {
                         message: _,
                         nested_error: _,
                     } => {
-                        crit!(self.logger, "a critical error occurred: {e:?}");
+                        crit!(self.logger, "A critical error occurred: {e:?}");
 
                         return Err(e);
                     }
@@ -174,7 +174,7 @@ impl AggregatorRuntime {
                     || "AggregatorRuntime in the state IDLE can not get current time point from chain",
                 )?;
 
-                info!(self.logger, "→ trying to transition to READY"; "last_time_point" => ?last_time_point);
+                info!(self.logger, "→ Trying to transition to READY"; "last_time_point" => ?last_time_point);
 
                 self.try_transition_from_idle_to_ready(
                     state.current_time_point,
@@ -207,7 +207,7 @@ impl AggregatorRuntime {
                     .with_context(|| "AggregatorRuntime can not get the current open message")?
                 {
                     // transition READY > SIGNING
-                    info!(self.logger, "→ transitioning to SIGNING");
+                    info!(self.logger, "→ Transitioning to SIGNING");
                     let new_state = self
                         .transition_from_ready_to_signing(last_time_point.clone(), open_message.clone())
                         .await.with_context(|| format!("AggregatorRuntime can not perform a transition from READY state to SIGNING with entity_type: '{:?}'", open_message.signed_entity_type))?;
@@ -215,7 +215,7 @@ impl AggregatorRuntime {
                 } else {
                     // READY > READY
                     info!(
-                        self.logger, " ⋅ no open message to certify, waiting…";
+                        self.logger, " ⋅ No open message to certify, waiting…";
                         "time_point" => ?state.current_time_point
                     );
                     self.state = AggregatorState::Ready(ReadyState {
@@ -257,7 +257,7 @@ impl AggregatorRuntime {
                     let new_state = self
                         .transition_from_signing_to_ready_multisignature(state)
                         .await?;
-                    info!(self.logger, "→ a multi-signature has been created, build an artifact & a certificate and transitioning back to READY");
+                    info!(self.logger, "→ A multi-signature has been created, build an artifact & a certificate and transitioning back to READY");
                     self.state = AggregatorState::Ready(new_state);
                 }
             }
@@ -272,7 +272,7 @@ impl AggregatorRuntime {
         maybe_current_time_point: Option<TimePoint>,
         new_time_point: TimePoint,
     ) -> Result<(), RuntimeError> {
-        trace!(self.logger, "trying transition from IDLE to READY state");
+        trace!(self.logger, "Trying transition from IDLE to READY state");
 
         if maybe_current_time_point.is_none()
             || maybe_current_time_point.unwrap().epoch < new_time_point.epoch
@@ -313,7 +313,7 @@ impl AggregatorRuntime {
     ) -> Result<ReadyState, RuntimeError> {
         trace!(
             self.logger,
-            "launching transition from SIGNING to READY state"
+            "Launching transition from SIGNING to READY state"
         );
         let certificate = self
             .runner
@@ -353,7 +353,7 @@ impl AggregatorRuntime {
     ) -> Result<IdleState, RuntimeError> {
         trace!(
             self.logger,
-            "launching transition from SIGNING to IDLE state"
+            "Launching transition from SIGNING to IDLE state"
         );
         self.runner.drop_pending_certificate().await?;
 
@@ -370,7 +370,7 @@ impl AggregatorRuntime {
     ) -> Result<ReadyState, RuntimeError> {
         trace!(
             self.logger,
-            "launching transition from SIGNING to READY state"
+            "Launching transition from SIGNING to READY state"
         );
         self.runner.drop_pending_certificate().await?;
 
@@ -388,7 +388,7 @@ impl AggregatorRuntime {
     ) -> Result<SigningState, RuntimeError> {
         trace!(
             self.logger,
-            "launching transition from READY to SIGNING state"
+            "Launching transition from READY to SIGNING state"
         );
 
         let certificate_pending = self

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -108,14 +108,14 @@ impl AggregatorRuntime {
 
         loop {
             if let Err(e) = self.cycle().await {
-                warn!(self.logger, "State machine issued an error: {e}");
+                warn!(self.logger, "State machine issued an error"; "error" => ?e);
 
                 match &e {
                     RuntimeError::Critical {
                         message: _,
                         nested_error: _,
                     } => {
-                        crit!(self.logger, "A critical error occurred: {e:?}");
+                        crit!(self.logger, "A critical error occurred"; "error" => ?e);
 
                         return Err(e);
                     }

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -104,7 +104,7 @@ impl AggregatorRuntime {
 
     /// Launches an infinite loop ticking the state machine.
     pub async fn run(&mut self) -> Result<(), RuntimeError> {
-        info!(self.logger, "STATE MACHINE: launching");
+        info!(self.logger, "launching");
 
         loop {
             if let Err(e) = self.cycle().await {
@@ -115,10 +115,7 @@ impl AggregatorRuntime {
                         message: _,
                         nested_error: _,
                     } => {
-                        crit!(
-                            self.logger,
-                            "state machine: a critical error occurred: {e:?}"
-                        );
+                        crit!(self.logger, "a critical error occurred: {e:?}");
 
                         return Err(e);
                     }
@@ -169,7 +166,7 @@ impl AggregatorRuntime {
             self.logger,
             "================================================================================"
         );
-        info!(self.logger, "STATE MACHINE: new cycle: {}", self.state);
+        info!(self.logger, "new cycle: {}", self.state);
 
         match self.state.clone() {
             AggregatorState::Idle(state) => {

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -87,13 +87,13 @@ impl CardanoTransactionsImporter {
         if from.as_ref().is_some_and(|f| f.block_number >= until) {
             debug!(
                 self.logger,
-                "Does not need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
+                "No need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
             );
             return Ok(());
         }
         debug!(
             self.logger,
-            "Will retrieve Cardano transactions between block_number '{}' and '{until}'",
+            "Retrieving Cardano transactions between block_number '{}' and '{until}'",
             from.as_ref()
                 .map(|c| c.block_number)
                 .unwrap_or(BlockNumber(0))

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -87,14 +87,16 @@ impl CardanoTransactionsImporter {
         if from.as_ref().is_some_and(|f| f.block_number >= until) {
             debug!(
                 self.logger,
-                "TransactionsImporter does not need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
+                "Does not need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
             );
             return Ok(());
         }
         debug!(
             self.logger,
-            "TransactionsImporter will retrieve Cardano transactions between block_number '{}' and '{until}'",
-            from.as_ref().map(|c|c.block_number).unwrap_or(BlockNumber(0))
+            "Will retrieve Cardano transactions between block_number '{}' and '{until}'",
+            from.as_ref()
+                .map(|c| c.block_number)
+                .unwrap_or(BlockNumber(0))
         );
 
         let mut streamer = self.block_scanner.scan(from, until).await?;
@@ -138,7 +140,7 @@ impl CardanoTransactionsImporter {
         };
 
         debug!(
-            self.logger, "TransactionsImporter - computing Block Range Roots";
+            self.logger, "Computing Block Range Roots";
             "start_block" => *block_ranges.start(), "end_block" => *block_ranges.end(),
         );
 
@@ -198,7 +200,7 @@ mod tests {
         BlockStreamer, DumbBlockScanner, DumbBlockStreamer, ScannedBlock,
     };
     use mithril_common::crypto_helper::MKTree;
-    use mithril_common::entities::{BlockNumber, BlockRangesSequence, SlotNumber};
+    use mithril_common::entities::{BlockNumber, BlockRangesSequence};
     use mithril_persistence::database::repository::CardanoTransactionRepository;
     use mithril_persistence::sqlite::SqliteConnectionPool;
 

--- a/mithril-aggregator/src/services/certifier/buffered_certifier.rs
+++ b/mithril-aggregator/src/services/certifier/buffered_certifier.rs
@@ -102,8 +102,7 @@ impl CertifierService for BufferedCertifierService {
             Err(error) => match error.downcast_ref::<CertifierServiceError>() {
                 Some(CertifierServiceError::NotFound(..)) if signature.is_authenticated() => {
                     debug!(
-                        self.logger,
-                        "No OpenMessage available for signed entity - Buffering single signature";
+                        self.logger, "No OpenMessage available for signed entity - Buffering single signature";
                         "signed_entity_type" => ?signed_entity_type,
                         "party_id" => &signature.party_id
                     );

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -156,7 +156,10 @@ impl CertifierService for MithrilCertifierService {
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
     ) -> StdResult<OpenMessage> {
-        debug!(self.logger, ">> create_open_message(signed_entity_type: {signed_entity_type:?}, protocol_message: {protocol_message:?})");
+        debug!(
+            self.logger, ">> create_open_message(signed_entity_type: {signed_entity_type:?})";
+            "protocol_message" => ?protocol_message
+        );
         let open_message = self
             .open_message_repository
             .create_open_message(

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -73,7 +73,7 @@ impl MithrilCertifierService {
     ) -> StdResult<Option<OpenMessageWithSingleSignaturesRecord>> {
         debug!(
             self.logger,
-            "get_open_message_record(signed_entity_type: {signed_entity_type:?})"
+            ">> get_open_message_record(signed_entity_type: {signed_entity_type:?})"
         );
 
         let open_message_with_single_signatures = self
@@ -89,7 +89,7 @@ impl MithrilCertifierService {
 #[async_trait]
 impl CertifierService for MithrilCertifierService {
     async fn inform_epoch(&self, epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, "inform_epoch(epoch: {epoch:?})");
+        debug!(self.logger, ">> inform_epoch(epoch: {epoch:?})");
         let nb = self
             .open_message_repository
             .clean_epoch(epoch)
@@ -107,8 +107,8 @@ impl CertifierService for MithrilCertifierService {
         signed_entity_type: &SignedEntityType,
         signature: &SingleSignatures,
     ) -> StdResult<SignatureRegistrationStatus> {
-        debug!(self.logger, "register_single_signature(signed_entity_type: {signed_entity_type:?}, single_signatures: {signature:?}");
-        trace!(self.logger, "register_single_signature"; "complete_single_signatures" => #?signature);
+        debug!(self.logger, ">> register_single_signature(signed_entity_type: {signed_entity_type:?}, single_signatures: {signature:?}");
+        trace!(self.logger, ">> register_single_signature"; "complete_single_signatures" => #?signature);
 
         let open_message = self
             .get_open_message_record(signed_entity_type)
@@ -156,7 +156,7 @@ impl CertifierService for MithrilCertifierService {
         signed_entity_type: &SignedEntityType,
         protocol_message: &ProtocolMessage,
     ) -> StdResult<OpenMessage> {
-        debug!(self.logger, "create_open_message(signed_entity_type: {signed_entity_type:?}, protocol_message: {protocol_message:?})");
+        debug!(self.logger, ">> create_open_message(signed_entity_type: {signed_entity_type:?}, protocol_message: {protocol_message:?})");
         let open_message = self
             .open_message_repository
             .create_open_message(
@@ -190,7 +190,7 @@ impl CertifierService for MithrilCertifierService {
     ) -> StdResult<Option<OpenMessage>> {
         debug!(
             self.logger,
-            "get_open_message(signed_entity_type: {signed_entity_type:?})"
+            ">> get_open_message(signed_entity_type: {signed_entity_type:?})"
         );
 
         let open_message = self
@@ -207,7 +207,7 @@ impl CertifierService for MithrilCertifierService {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<Option<OpenMessage>> {
-        debug!(self.logger, "mark_open_message_if_expired");
+        debug!(self.logger, ">> mark_open_message_if_expired");
 
         let mut open_message_record = self
             .open_message_repository
@@ -231,7 +231,7 @@ impl CertifierService for MithrilCertifierService {
     ) -> StdResult<Option<Certificate>> {
         debug!(
             self.logger,
-            "create_certificate(signed_entity_type: {signed_entity_type:?})"
+            ">> create_certificate(signed_entity_type: {signed_entity_type:?})"
         );
         let open_message_record = self
             .get_open_message_record(signed_entity_type)

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -188,7 +188,7 @@ impl MithrilEpochService {
         let recording_epoch = actual_epoch.offset_to_epoch_settings_recording_epoch();
 
         debug!(
-            self.logger, "inserting epoch settings in epoch {recording_epoch}";
+            self.logger, "Inserting epoch settings in epoch {recording_epoch}";
             "epoch_settings" => ?self.future_epoch_settings
         );
 

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -220,7 +220,7 @@ impl MithrilEpochService {
 #[async_trait]
 impl EpochService for MithrilEpochService {
     async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, "inform_epoch(epoch: {epoch:?})");
+        debug!(self.logger, ">> inform_epoch(epoch: {epoch:?})");
 
         let signer_retrieval_epoch =
             epoch.offset_to_signer_retrieval_epoch().with_context(|| {
@@ -277,7 +277,7 @@ impl EpochService for MithrilEpochService {
     }
 
     async fn update_epoch_settings(&mut self) -> StdResult<()> {
-        debug!(self.logger, "update_epoch_settings");
+        debug!(self.logger, ">> update_epoch_settings");
 
         let data = self.unwrap_data().with_context(|| {
             "can't update epoch settings if inform_epoch has not been called first"
@@ -287,7 +287,7 @@ impl EpochService for MithrilEpochService {
     }
 
     async fn precompute_epoch_data(&mut self) -> StdResult<()> {
-        debug!(self.logger, "precompute_epoch_data");
+        debug!(self.logger, ">> precompute_epoch_data");
 
         let data = self.unwrap_data().with_context(|| {
             "can't precompute epoch data if inform_epoch has not been called first"

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -188,7 +188,7 @@ impl MithrilEpochService {
         let recording_epoch = actual_epoch.offset_to_epoch_settings_recording_epoch();
 
         debug!(
-            self.logger, "EpochService: inserting epoch settings in epoch {recording_epoch}";
+            self.logger, "inserting epoch settings in epoch {recording_epoch}";
             "epoch_settings" => ?self.future_epoch_settings
         );
 
@@ -220,7 +220,7 @@ impl MithrilEpochService {
 #[async_trait]
 impl EpochService for MithrilEpochService {
     async fn inform_epoch(&mut self, epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, "EpochService::inform_epoch(epoch: {epoch:?})");
+        debug!(self.logger, "inform_epoch(epoch: {epoch:?})");
 
         let signer_retrieval_epoch =
             epoch.offset_to_signer_retrieval_epoch().with_context(|| {
@@ -277,7 +277,7 @@ impl EpochService for MithrilEpochService {
     }
 
     async fn update_epoch_settings(&mut self) -> StdResult<()> {
-        debug!(self.logger, "EpochService::update_epoch_settings");
+        debug!(self.logger, "update_epoch_settings");
 
         let data = self.unwrap_data().with_context(|| {
             "can't update epoch settings if inform_epoch has not been called first"
@@ -287,7 +287,7 @@ impl EpochService for MithrilEpochService {
     }
 
     async fn precompute_epoch_data(&mut self) -> StdResult<()> {
-        debug!(self.logger, "EpochService::precompute_epoch_data");
+        debug!(self.logger, "precompute_epoch_data");
 
         let data = self.unwrap_data().with_context(|| {
             "can't precompute epoch data if inform_epoch has not been called first"

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -167,8 +167,7 @@ impl<S: MKTreeStorer> ProverService for MithrilProverService<S> {
     async fn compute_cache(&self, up_to: BlockNumber) -> StdResult<()> {
         let pool_size = self.mk_map_pool.size();
         info!(
-            self.logger,
-            "Starts computing the Merkle map pool resource of size {pool_size}";
+            self.logger, "Starts computing the Merkle map pool resource of size {pool_size}";
             "up_to_block_number" => *up_to,
         );
         let mk_map_cache = self

--- a/mithril-aggregator/src/services/prover.rs
+++ b/mithril-aggregator/src/services/prover.rs
@@ -168,7 +168,7 @@ impl<S: MKTreeStorer> ProverService for MithrilProverService<S> {
         let pool_size = self.mk_map_pool.size();
         info!(
             self.logger,
-            "Prover starts computing the Merkle map pool resource of size {pool_size}";
+            "Starts computing the Merkle map pool resource of size {pool_size}";
             "up_to_block_number" => *up_to,
         );
         let mk_map_cache = self
@@ -180,18 +180,18 @@ impl<S: MKTreeStorer> ProverService for MithrilProverService<S> {
             .map(|i| {
                 debug!(
                     self.logger,
-                    "Prover is computing the Merkle map pool resource {i}/{pool_size}"
+                    "Computing the Merkle map pool resource {i}/{pool_size}"
                 );
                 mk_map_cache.clone()
             })
             .collect::<Vec<MKMap<_, _, _>>>();
-        debug!(self.logger, "Prover is draining the Merkle map pool");
+        debug!(self.logger, "Draining the Merkle map pool");
         let discriminant_new = self.mk_map_pool.discriminant()? + 1;
         self.mk_map_pool.set_discriminant(discriminant_new)?;
         self.mk_map_pool.clear();
         debug!(
             self.logger,
-            "Prover is giving back new resources to the Merkle map pool"
+            "Giving back new resources to the Merkle map pool"
         );
         mk_maps_new
             .into_iter()
@@ -202,7 +202,7 @@ impl<S: MKTreeStorer> ProverService for MithrilProverService<S> {
             .collect::<StdResult<Vec<_>>>()?;
         info!(
             self.logger,
-            "Prover completed computing the Merkle map pool resource of size {pool_size}"
+            "Completed computing the Merkle map pool resource of size {pool_size}"
         );
 
         Ok(())

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -127,7 +127,7 @@ impl MithrilSignedEntityService {
         certificate: &Certificate,
     ) -> StdResult<()> {
         info!(
-            self.logger, "create_artifact";
+            self.logger, ">> create_artifact_task";
             "signed_entity_type" => ?signed_entity_type, "certificate_hash" => &certificate.hash
         );
 

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -127,9 +127,8 @@ impl MithrilSignedEntityService {
         certificate: &Certificate,
     ) -> StdResult<()> {
         info!(
-            self.logger, "MithrilSignedEntityService::create_artifact";
-            "signed_entity_type" => ?signed_entity_type,
-            "certificate_hash" => &certificate.hash
+            self.logger, "create_artifact";
+            "signed_entity_type" => ?signed_entity_type, "certificate_hash" => &certificate.hash
         );
 
         let mut remaining_retries = 2;

--- a/mithril-aggregator/src/services/upkeep.rs
+++ b/mithril-aggregator/src/services/upkeep.rs
@@ -57,7 +57,7 @@ impl AggregatorUpkeepService {
         if self.signed_entity_type_lock.has_locked_entities().await {
             info!(
                 self.logger,
-                "UpkeepService::Some entities are locked - Skipping database upkeep"
+                "Some entities are locked - Skipping database upkeep"
             );
             return Ok(());
         }
@@ -68,7 +68,7 @@ impl AggregatorUpkeepService {
 
         // Run the database upkeep tasks in another thread to avoid blocking the tokio runtime
         let db_upkeep_thread = tokio::task::spawn_blocking(move || -> StdResult<()> {
-            info!(db_upkeep_logger, "UpkeepService::Cleaning main database");
+            info!(db_upkeep_logger, "Cleaning main database");
             SqliteCleaner::new(&main_db_connection)
                 .with_logger(db_upkeep_logger.clone())
                 .with_tasks(&[
@@ -77,10 +77,7 @@ impl AggregatorUpkeepService {
                 ])
                 .run()?;
 
-            info!(
-                db_upkeep_logger,
-                "UpkeepService::Cleaning cardano transactions database"
-            );
+            info!(db_upkeep_logger, "Cleaning cardano transactions database");
             let cardano_tx_db_connection = cardano_tx_db_connection_pool.connection()?;
             SqliteCleaner::new(&cardano_tx_db_connection)
                 .with_logger(db_upkeep_logger.clone())
@@ -99,13 +96,13 @@ impl AggregatorUpkeepService {
 #[async_trait]
 impl UpkeepService for AggregatorUpkeepService {
     async fn run(&self) -> StdResult<()> {
-        info!(self.logger, "UpkeepService::start");
+        info!(self.logger, "start upkeep of the application");
 
         self.upkeep_all_databases()
             .await
             .with_context(|| "Database upkeep failed")?;
 
-        info!(self.logger, "UpkeepService::end");
+        info!(self.logger, "upkeep finished");
         Ok(())
     }
 }

--- a/mithril-aggregator/src/services/upkeep.rs
+++ b/mithril-aggregator/src/services/upkeep.rs
@@ -96,13 +96,13 @@ impl AggregatorUpkeepService {
 #[async_trait]
 impl UpkeepService for AggregatorUpkeepService {
     async fn run(&self) -> StdResult<()> {
-        info!(self.logger, "start upkeep of the application");
+        info!(self.logger, "Start upkeep of the application");
 
         self.upkeep_all_databases()
             .await
             .with_context(|| "Database upkeep failed")?;
 
-        info!(self.logger, "upkeep finished");
+        info!(self.logger, "Upkeep finished");
         Ok(())
     }
 }

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -101,8 +101,8 @@ impl Snapshotter for CompressedArchiveSnapshotter {
         let filesize = self.create_and_verify_archive(&archive_path).inspect_err(|_err| {
             if archive_path.exists() {
                 if let Err(remove_error) = fs::remove_file(&archive_path) {
-                    warn!(self.logger,
-                        " > Post snapshotter.snapshot failure, could not remove temporary archive";
+                    warn!(
+                        self.logger, " > Post snapshotter.snapshot failure, could not remove temporary archive";
                         "archive_path" => archive_path.display(),
                         "error" => remove_error
                     );

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -102,9 +102,9 @@ impl Snapshotter for CompressedArchiveSnapshotter {
             if archive_path.exists() {
                 if let Err(remove_error) = fs::remove_file(&archive_path) {
                     warn!(self.logger,
-                        " > Post snapshotter.snapshot failure, could not remove temporary archive at path: path:{}, err: {}",
-                        archive_path.display(),
-                        remove_error
+                        " > Post snapshotter.snapshot failure, could not remove temporary archive";
+                        "archive_path" => archive_path.display(),
+                        "error" => remove_error
                     );
                 }
             }

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -162,7 +162,7 @@ impl CompressedArchiveSnapshotter {
     fn create_archive(&self, archive_path: &Path) -> StdResult<u64> {
         info!(
             self.logger,
-            "compressing {} into {}",
+            "Compressing {} into {}",
             self.db_directory.display(),
             archive_path.display()
         );
@@ -247,7 +247,7 @@ impl CompressedArchiveSnapshotter {
 
     // Verify if an archive is corrupted (i.e. at least one entry is invalid)
     fn verify_archive(&self, archive_path: &Path) -> StdResult<()> {
-        info!(self.logger, "verifying archive: {}", archive_path.display());
+        info!(self.logger, "Verifying archive: {}", archive_path.display());
 
         let mut snapshot_file_tar = File::open(archive_path)
             .map_err(|e| SnapshotError::InvalidArchiveError(e.to_string()))?;

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -31,7 +31,7 @@ impl CertificatesHashMigrator {
 
     /// Recompute all the certificates hashes the database.
     pub async fn migrate(&self) -> StdResult<()> {
-        info!(self.logger, "starting migration");
+        info!(self.logger, "Starting migration");
         let (old_certificates, old_and_new_hashes) =
             self.create_certificates_with_updated_hash().await?;
 
@@ -42,7 +42,7 @@ impl CertificatesHashMigrator {
 
         info!(
             self.logger,
-            "all certificates have been migrated successfully"
+            "All certificates have been migrated successfully"
         );
         Ok(())
     }
@@ -52,7 +52,7 @@ impl CertificatesHashMigrator {
     async fn create_certificates_with_updated_hash(
         &self,
     ) -> StdResult<(Vec<Certificate>, HashMap<String, String>)> {
-        info!(self.logger, "recomputing all certificates hash");
+        info!(self.logger, "Recomputing all certificates hash");
         let old_certificates = self
             .certificate_repository
             // arbitrary high value to get all existing certificates
@@ -67,7 +67,7 @@ impl CertificatesHashMigrator {
         // Note: get_latest_certificates retrieve certificates from the earliest to the older,
         // in order to have a strong guarantee that when inserting a certificate in the db its
         // previous_hash exist we have to work in the reverse order.
-        debug!(self.logger, "computing new hash for all certificates");
+        debug!(self.logger, "Computing new hash for all certificates");
         for mut certificate in old_certificates.into_iter().rev() {
             let old_previous_hash = if certificate.is_genesis() {
                 certificate.previous_hash.clone()
@@ -92,14 +92,14 @@ impl CertificatesHashMigrator {
 
                 if certificate.is_genesis() {
                     trace!(
-                        self.logger, "new hash computed for genesis certificate {:?}",
+                        self.logger, "New hash computed for genesis certificate {:?}",
                         certificate.signed_entity_type();
                         "old_hash" => &certificate.hash,
                         "new_hash" => &new_hash,
                     );
                 } else {
                     trace!(
-                        self.logger, "new hash computed for certificate {:?}",
+                        self.logger, "New hash computed for certificate {:?}",
                         certificate.signed_entity_type();
                         "old_hash" => &certificate.hash,
                         "new_hash" => &new_hash,
@@ -120,7 +120,7 @@ impl CertificatesHashMigrator {
         // (we do this by chunks in order to avoid reaching the limit of 32766 variables in a single query)
         debug!(
             self.logger,
-            "inserting migrated certificates in the database"
+            "Inserting migrated certificates in the database"
         );
         let migrated_certificates_chunk_size = 250;
         for migrated_certificates_chunk in
@@ -141,7 +141,7 @@ impl CertificatesHashMigrator {
         &self,
         old_and_new_certificate_hashes: HashMap<String, String>,
     ) -> StdResult<()> {
-        info!(self.logger, "updating signed entities certificate ids");
+        info!(self.logger, "Updating signed entities certificate ids");
         let old_hashes: Vec<&str> = old_and_new_certificate_hashes
             .keys()
             .map(|k| k.as_str())
@@ -158,7 +158,7 @@ impl CertificatesHashMigrator {
 
         debug!(
             self.logger,
-            "updating signed entities certificate_ids to new computed hash"
+            "Updating signed entities certificate_ids to new computed hash"
         );
         for signed_entity_record in records_to_migrate.iter_mut() {
             let new_certificate_hash =
@@ -171,7 +171,7 @@ impl CertificatesHashMigrator {
                     .to_owned();
 
             trace!(
-                self.logger, "migrating signed entity {} certificate hash computed for certificate",
+                self.logger, "Migrating signed entity {} certificate hash computed for certificate",
                 signed_entity_record.signed_entity_id;
                 "old_certificate_hash" => &signed_entity_record.certificate_id,
                 "new_certificate_hash" => &new_certificate_hash
@@ -181,7 +181,7 @@ impl CertificatesHashMigrator {
 
         debug!(
             self.logger,
-            "updating migrated signed entities in the database"
+            "Updating migrated signed entities in the database"
         );
         self.signed_entity_storer
             .update_signed_entities(records_to_migrate)
@@ -192,7 +192,7 @@ impl CertificatesHashMigrator {
     }
 
     async fn cleanup(&self, old_certificates: Vec<Certificate>) -> StdResult<()> {
-        info!(self.logger, "deleting old certificates in the database");
+        info!(self.logger, "Deleting old certificates in the database");
         self.certificate_repository
             .delete_certificates(&old_certificates.iter().collect::<Vec<_>>())
             .await

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -31,7 +31,7 @@ impl CertificatesHashMigrator {
 
     /// Recompute all the certificates hashes the database.
     pub async fn migrate(&self) -> StdResult<()> {
-        info!(self.logger, "🔧 Certificate Hash Migrator: starting");
+        info!(self.logger, "starting migration");
         let (old_certificates, old_and_new_hashes) =
             self.create_certificates_with_updated_hash().await?;
 
@@ -42,7 +42,7 @@ impl CertificatesHashMigrator {
 
         info!(
             self.logger,
-            "🔧 Certificate Hash Migrator: all certificates have been migrated successfully"
+            "all certificates have been migrated successfully"
         );
         Ok(())
     }
@@ -52,10 +52,7 @@ impl CertificatesHashMigrator {
     async fn create_certificates_with_updated_hash(
         &self,
     ) -> StdResult<(Vec<Certificate>, HashMap<String, String>)> {
-        info!(
-            self.logger,
-            "🔧 Certificate Hash Migrator: recomputing all certificates hash"
-        );
+        info!(self.logger, "recomputing all certificates hash");
         let old_certificates = self
             .certificate_repository
             // arbitrary high value to get all existing certificates
@@ -70,10 +67,7 @@ impl CertificatesHashMigrator {
         // Note: get_latest_certificates retrieve certificates from the earliest to the older,
         // in order to have a strong guarantee that when inserting a certificate in the db its
         // previous_hash exist we have to work in the reverse order.
-        debug!(
-            self.logger,
-            "🔧 Certificate Hash Migrator: computing new hash for all certificates"
-        );
+        debug!(self.logger, "computing new hash for all certificates");
         for mut certificate in old_certificates.into_iter().rev() {
             let old_previous_hash = if certificate.is_genesis() {
                 certificate.previous_hash.clone()
@@ -98,14 +92,14 @@ impl CertificatesHashMigrator {
 
                 if certificate.is_genesis() {
                     trace!(
-                        self.logger, "🔧 Certificate Hash Migrator: new hash computed for genesis certificate {:?}",
+                        self.logger, "new hash computed for genesis certificate {:?}",
                         certificate.signed_entity_type();
                         "old_hash" => &certificate.hash,
                         "new_hash" => &new_hash,
                     );
                 } else {
                     trace!(
-                        self.logger, "🔧 Certificate Hash Migrator: new hash computed for certificate {:?}",
+                        self.logger, "new hash computed for certificate {:?}",
                         certificate.signed_entity_type();
                         "old_hash" => &certificate.hash,
                         "new_hash" => &new_hash,
@@ -126,7 +120,7 @@ impl CertificatesHashMigrator {
         // (we do this by chunks in order to avoid reaching the limit of 32766 variables in a single query)
         debug!(
             self.logger,
-            "🔧 Certificate Hash Migrator: inserting migrated certificates in the database"
+            "inserting migrated certificates in the database"
         );
         let migrated_certificates_chunk_size = 250;
         for migrated_certificates_chunk in
@@ -147,10 +141,7 @@ impl CertificatesHashMigrator {
         &self,
         old_and_new_certificate_hashes: HashMap<String, String>,
     ) -> StdResult<()> {
-        info!(
-            self.logger,
-            "🔧 Certificate Hash Migrator: updating signed entities certificate ids"
-        );
+        info!(self.logger, "updating signed entities certificate ids");
         let old_hashes: Vec<&str> = old_and_new_certificate_hashes
             .keys()
             .map(|k| k.as_str())
@@ -165,7 +156,10 @@ impl CertificatesHashMigrator {
                 )
             )?;
 
-        debug!(self.logger,"🔧 Certificate Hash Migrator: updating signed entities certificate_ids to new computed hash");
+        debug!(
+            self.logger,
+            "updating signed entities certificate_ids to new computed hash"
+        );
         for signed_entity_record in records_to_migrate.iter_mut() {
             let new_certificate_hash =
                 old_and_new_certificate_hashes
@@ -177,7 +171,7 @@ impl CertificatesHashMigrator {
                     .to_owned();
 
             trace!(
-                self.logger, "🔧 Certificate Hash Migrator: migrating signed entity {} certificate hash computed for certificate",
+                self.logger, "migrating signed entity {} certificate hash computed for certificate",
                 signed_entity_record.signed_entity_id;
                 "old_certificate_hash" => &signed_entity_record.certificate_id,
                 "new_certificate_hash" => &new_certificate_hash
@@ -187,7 +181,7 @@ impl CertificatesHashMigrator {
 
         debug!(
             self.logger,
-            "🔧 Certificate Hash Migrator: updating migrated signed entities in the database"
+            "updating migrated signed entities in the database"
         );
         self.signed_entity_storer
             .update_signed_entities(records_to_migrate)
@@ -198,10 +192,7 @@ impl CertificatesHashMigrator {
     }
 
     async fn cleanup(&self, old_certificates: Vec<Certificate>) -> StdResult<()> {
-        info!(
-            self.logger,
-            "🔧 Certificate Hash Migrator: deleting old certificates in the database"
-        );
+        info!(self.logger, "deleting old certificates in the database");
         self.certificate_repository
             .delete_certificates(&old_certificates.iter().collect::<Vec<_>>())
             .await

--- a/mithril-aggregator/src/tools/remote_file_uploader.rs
+++ b/mithril-aggregator/src/tools/remote_file_uploader.rs
@@ -46,7 +46,7 @@ impl RemoteFileUploader for GcpFileUploader {
 
         let filename = filepath.file_name().unwrap().to_str().unwrap();
 
-        info!(self.logger, "uploading {filename}");
+        info!(self.logger, "Uploading {filename}");
         let client = Client::default();
         let file = tokio::fs::File::open(filepath).await.unwrap();
         let stream = FramedRead::new(file, BytesCodec::new());
@@ -62,7 +62,7 @@ impl RemoteFileUploader for GcpFileUploader {
             .await
             .with_context(|| "remote uploading failure")?;
 
-        info!(self.logger, "uploaded {filename}");
+        info!(self.logger, "Uploaded {filename}");
 
         // ensure the uploaded file as public read access
         // when a file is uploaded to Google cloud storage its permissions are overwritten so
@@ -74,7 +74,7 @@ impl RemoteFileUploader for GcpFileUploader {
 
         info!(
             self.logger,
-            "updating acl for {filename}: {new_bucket_access_control:?}"
+            "Updating acl for {filename}: {new_bucket_access_control:?}"
         );
 
         client
@@ -83,7 +83,7 @@ impl RemoteFileUploader for GcpFileUploader {
             .await
             .with_context(|| "updating acl failure")?;
 
-        info!(self.logger, "updated acl for {filename}");
+        info!(self.logger, "Updated acl for {filename}");
 
         Ok(())
     }

--- a/mithril-aggregator/src/tools/signer_importer.rs
+++ b/mithril-aggregator/src/tools/signer_importer.rs
@@ -38,7 +38,7 @@ impl SignersImporter {
 
     /// Import and persist the signers
     pub async fn run(&self) -> StdResult<()> {
-        info!(self.logger, "🔧 Signer Importer: starting");
+        info!(self.logger, "starting importation");
         let items = self
             .retriever
             .retrieve()
@@ -46,7 +46,7 @@ impl SignersImporter {
             .with_context(|| "Failed to retrieve signers from remote service")?;
 
         info!(self.logger,
-            "🔧 Signer Importer: persisting retrieved data in the database";
+            "persisting retrieved data in the database";
             "number_of_signer_to_insert" => items.len()
         );
         self.persister
@@ -69,7 +69,7 @@ impl SignersImporter {
             }
             info!(
                 self.logger,
-                "🔧 Signer Importer: Cycle finished, Sleeping for {} min",
+                "Cycle finished, Sleeping for {} min",
                 run_interval.as_secs() / 60
             );
         }
@@ -139,7 +139,7 @@ impl CExplorerSignerRetriever {
 impl SignersImporterRetriever for CExplorerSignerRetriever {
     async fn retrieve(&self) -> StdResult<HashMap<PartyId, Option<PoolTicker>>> {
         info!(
-            self.logger, "🔧 Signer Importer: retrieving data from source";
+            self.logger, "retrieving data from source";
             "source_url" => &self.source_url.as_str()
         );
         let response = self

--- a/mithril-aggregator/src/tools/signer_importer.rs
+++ b/mithril-aggregator/src/tools/signer_importer.rs
@@ -38,7 +38,7 @@ impl SignersImporter {
 
     /// Import and persist the signers
     pub async fn run(&self) -> StdResult<()> {
-        info!(self.logger, "starting importation");
+        info!(self.logger, "Starting importation");
         let items = self
             .retriever
             .retrieve()
@@ -46,7 +46,7 @@ impl SignersImporter {
             .with_context(|| "Failed to retrieve signers from remote service")?;
 
         info!(self.logger,
-            "persisting retrieved data in the database";
+            "Persisting retrieved data in the database";
             "number_of_signer_to_insert" => items.len()
         );
         self.persister
@@ -139,7 +139,7 @@ impl CExplorerSignerRetriever {
 impl SignersImporterRetriever for CExplorerSignerRetriever {
     async fn retrieve(&self) -> StdResult<HashMap<PartyId, Option<PoolTicker>>> {
         info!(
-            self.logger, "retrieving data from source";
+            self.logger, "Retrieving data from source";
             "source_url" => &self.source_url.as_str()
         );
         let response = self

--- a/mithril-aggregator/src/tools/signer_importer.rs
+++ b/mithril-aggregator/src/tools/signer_importer.rs
@@ -38,7 +38,7 @@ impl SignersImporter {
 
     /// Import and persist the signers
     pub async fn run(&self) -> StdResult<()> {
-        info!(self.logger, "Starting importation");
+        info!(self.logger, "Starting import");
         let items = self
             .retriever
             .retrieve()

--- a/mithril-aggregator/src/tools/signer_importer.rs
+++ b/mithril-aggregator/src/tools/signer_importer.rs
@@ -45,8 +45,8 @@ impl SignersImporter {
             .await
             .with_context(|| "Failed to retrieve signers from remote service")?;
 
-        info!(self.logger,
-            "Persisting retrieved data in the database";
+        info!(
+            self.logger, "Persisting retrieved data in the database";
             "number_of_signer_to_insert" => items.len()
         );
         self.persister

--- a/mithril-aggregator/src/tools/signer_importer.rs
+++ b/mithril-aggregator/src/tools/signer_importer.rs
@@ -62,10 +62,7 @@ impl SignersImporter {
         loop {
             interval.tick().await;
             if let Err(error) = self.run().await {
-                warn!(
-                    self.logger,
-                    "Signer retriever failed: Error: «{:?}».", error
-                );
+                warn!(self.logger, "Signer retriever failed"; "error" => ?error);
             }
             info!(
                 self.logger,

--- a/mithril-aggregator/src/tools/single_signature_authenticator.rs
+++ b/mithril-aggregator/src/tools/single_signature_authenticator.rs
@@ -35,8 +35,7 @@ impl SingleSignatureAuthenticator {
         {
             Ok(()) => {
                 debug!(
-                    self.logger,
-                    "Single signature party authenticated for current stake distribution";
+                    self.logger, "Single signature party authenticated for current stake distribution";
                     "party_id" => &single_signature.party_id,
                 );
                 true
@@ -54,15 +53,13 @@ impl SingleSignatureAuthenticator {
                     .is_ok()
                 {
                     debug!(
-                        self.logger,
-                        "Single signature party authenticated for next stake distribution";
+                        self.logger, "Single signature party authenticated for next stake distribution";
                         "party_id" => &single_signature.party_id,
                     );
                     true
                 } else {
                     debug!(
-                        self.logger,
-                        "Single signature party not authenticated";
+                        self.logger, "Single signature party not authenticated";
                         "party_id" => &single_signature.party_id,
                     );
                     false

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.199"
+version = "0.2.200"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/services/cardano_transactions/importer/service.rs
+++ b/mithril-signer/src/services/cardano_transactions/importer/service.rs
@@ -87,13 +87,13 @@ impl CardanoTransactionsImporter {
         if from.as_ref().is_some_and(|f| f.block_number >= until) {
             debug!(
                 self.logger,
-                "Does not need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
+                "No need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
             );
             return Ok(());
         }
         debug!(
             self.logger,
-            "Will retrieve Cardano transactions between block_number '{}' and '{until}'",
+            "Retrieving Cardano transactions between block_number '{}' and '{until}'",
             from.as_ref()
                 .map(|c| c.block_number)
                 .unwrap_or(BlockNumber(0))


### PR DESCRIPTION
## Content

This PR:

- Harmonize all  "function enter" logs message to be in the form of `>> function_name`.
  - Excepted in the http server where they are in the form of `HTTP_VERB /path/to/endpoint`.
- Remove all prefixes previously used to help find the log of a component since they logs are tagged with their source component since #2002.
- Capitalize the first letters of all "functional" logs.
- Move away from the log message into a property huge structure (ie: some logs joined errors into their message, those errors have been moved to a "error" property).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #1981
