### PR TITLE
Standardize logs in common, signer, and persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.83"
+version = "0.5.84"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3805,7 +3805,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.29"
+version = "0.2.30"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3849,7 +3849,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.200"
+version = "0.2.201"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.29"
+version = "0.2.30"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/version_checker.rs
+++ b/internal/mithril-persistence/src/database/version_checker.rs
@@ -54,7 +54,7 @@ impl<'conn> DatabaseVersionChecker<'conn> {
 
     /// Apply migrations
     pub fn apply(&self) -> StdResult<()> {
-        debug!(&self.logger, "check database version",);
+        debug!(&self.logger, "Check database version",);
         self.create_table_if_not_exists(&self.application_type)
             .with_context(|| "Can not create table 'db_version' while applying migrations")?;
         let db_version = self
@@ -80,7 +80,7 @@ impl<'conn> DatabaseVersionChecker<'conn> {
                 self.apply_migrations(&db_version, self.connection)?;
                 info!(
                     &self.logger,
-                    "database upgraded to version '{}'", migration_version
+                    "Database upgraded to version '{migration_version}'"
                 );
             }
             Ordering::Less => {

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.83"
+version = "0.5.84"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1118,7 +1118,6 @@ impl DependenciesBuilder {
         >::new(
             transactions_importer,
             block_range_root_retriever,
-            self.root_logger(),
         ));
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(self.get_stake_store().await?),
@@ -1131,6 +1130,7 @@ impl DependenciesBuilder {
             immutable_signable_builder,
             cardano_transactions_builder,
             cardano_stake_distribution_builder,
+            self.root_logger(),
         ));
 
         Ok(signable_builder_service)

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.69"
+version = "0.4.70"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
+++ b/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
@@ -32,7 +32,7 @@ pub struct ChainReaderBlockStreamer {
 #[async_trait]
 impl BlockStreamer for ChainReaderBlockStreamer {
     async fn poll_next(&mut self) -> StdResult<Option<ChainScannedBlocks>> {
-        debug!(self.logger, "polls next");
+        debug!(self.logger, ">> poll_next");
 
         let chain_scanned_blocks: ChainScannedBlocks;
         let mut roll_forwards = vec![];
@@ -123,14 +123,14 @@ impl ChainReaderBlockStreamer {
                 if parsed_block.block_number > self.until {
                     trace!(
                         self.logger,
-                        "received a RollForward above threshold block number ({})",
+                        "Received a RollForward above threshold block number ({})",
                         parsed_block.block_number
                     );
                     Ok(None)
                 } else {
                     trace!(
                         self.logger,
-                        "received a RollForward below threshold block number ({})",
+                        "Received a RollForward below threshold block number ({})",
                         parsed_block.block_number
                     );
                     Ok(Some(BlockStreamerNextAction::ChainBlockNextAction(
@@ -143,7 +143,7 @@ impl ChainReaderBlockStreamer {
             }) => {
                 trace!(
                     self.logger,
-                    "received a RollBackward({rollback_slot_number:?})"
+                    "Received a RollBackward({rollback_slot_number:?})"
                 );
                 let block_streamer_next_action = if rollback_slot_number == self.from.slot_number {
                     BlockStreamerNextAction::SkipToNextAction
@@ -157,7 +157,7 @@ impl ChainReaderBlockStreamer {
                 Ok(Some(block_streamer_next_action))
             }
             None => {
-                trace!(self.logger, "received nothing");
+                trace!(self.logger, "Received nothing");
                 Ok(None)
             }
         }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -223,8 +223,8 @@ impl MithrilCertificateVerifier {
             None => Ok(None),
             _ => {
                 debug!(
-                    self.logger,
-                    "Previous certificate {:#?}", previous_certificate
+                    self.logger, "Certificate chain AVK unmatch";
+                    "previous_certificate" => #?previous_certificate
                 );
                 Err(anyhow!(
                     CertificateVerifierError::CertificateChainAVKUnmatch
@@ -265,8 +265,7 @@ impl CertificateVerifier for MithrilCertificateVerifier {
         genesis_verification_key: &ProtocolGenesisVerificationKey,
     ) -> StdResult<Option<Certificate>> {
         debug!(
-            self.logger,
-            "Verifying certificate";
+            self.logger, "Verifying certificate";
             "certificate_hash" => &certificate.hash,
             "certificate_previous_hash" => &certificate.previous_hash,
             "certificate_epoch" => ?certificate.epoch,

--- a/mithril-common/src/chain_reader/pallas_chain_reader.rs
+++ b/mithril-common/src/chain_reader/pallas_chain_reader.rs
@@ -46,7 +46,7 @@ impl PallasChainReader {
     async fn get_client(&mut self) -> StdResult<&mut NodeClient> {
         if self.client.is_none() {
             self.client = Some(self.new_client().await?);
-            debug!(self.logger, "connected to a new client");
+            debug!(self.logger, "Connected to a new client");
         }
 
         self.client
@@ -61,12 +61,12 @@ impl PallasChainReader {
         let chainsync = client.chainsync();
 
         if chainsync.has_agency() {
-            debug!(logger, "has agency, finding intersect point..."; "point" => ?point);
+            debug!(logger, "Has agency, finding intersect point..."; "point" => ?point);
             chainsync
                 .find_intersect(vec![point.to_owned().into()])
                 .await?;
         } else {
-            debug!(logger, "doesn't have agency, no need to find intersect point";);
+            debug!(logger, "Doesn't have agency, no need to find intersect point";);
         }
 
         Ok(())

--- a/mithril-common/src/digesters/cardano_immutable_digester.rs
+++ b/mithril-common/src/digesters/cardano_immutable_digester.rs
@@ -50,6 +50,7 @@ impl ImmutableDigester for CardanoImmutableDigester {
             .into_iter()
             .filter(|f| f.number <= up_to_file_number)
             .collect::<Vec<_>>();
+        info!(self.logger, ">> compute_digest"; "beacon" => #?beacon, "nb_of_immutables" => immutables.len());
 
         match immutables.last() {
             None => Err(ImmutableDigesterError::NotEnoughImmutable {
@@ -65,8 +66,6 @@ impl ImmutableDigester for CardanoImmutableDigester {
                 })
             }
             Some(_) => {
-                info!(self.logger, ">> compute_digest"; "beacon" => #?beacon, "nb_of_immutables" => immutables.len());
-
                 let cached_values = match self.cache_provider.as_ref() {
                     None => BTreeMap::from_iter(immutables.into_iter().map(|i| (i, None))),
                     Some(cache_provider) => match cache_provider.get(immutables.clone()).await {

--- a/mithril-common/src/digesters/cardano_immutable_digester.rs
+++ b/mithril-common/src/digesters/cardano_immutable_digester.rs
@@ -65,7 +65,7 @@ impl ImmutableDigester for CardanoImmutableDigester {
                 })
             }
             Some(_) => {
-                info!(self.logger, "#compute_digest"; "beacon" => #?beacon, "nb_of_immutables" => immutables.len());
+                info!(self.logger, ">> compute_digest"; "beacon" => #?beacon, "nb_of_immutables" => immutables.len());
 
                 let cached_values = match self.cache_provider.as_ref() {
                     None => BTreeMap::from_iter(immutables.into_iter().map(|i| (i, None))),
@@ -73,8 +73,8 @@ impl ImmutableDigester for CardanoImmutableDigester {
                         Ok(values) => values,
                         Err(error) => {
                             warn!(
-                                self.logger,
-                                "Error while getting cached immutable files digests: {}", error
+                                self.logger, "Error while getting cached immutable files digests";
+                                "error" => ?error
                             );
                             BTreeMap::from_iter(immutables.into_iter().map(|i| (i, None)))
                         }
@@ -92,13 +92,13 @@ impl ImmutableDigester for CardanoImmutableDigester {
                     .map_err(|e| ImmutableDigesterError::DigestComputationError(e.into()))??;
                 let digest = hex::encode(hash);
 
-                debug!(self.logger, "#computed digest: {:?}", digest);
+                debug!(self.logger, "Computed digest: {digest:?}");
 
                 if let Some(cache_provider) = self.cache_provider.as_ref() {
                     if let Err(error) = cache_provider.store(new_cache_entries).await {
                         warn!(
-                            self.logger,
-                            "Error while storing new immutable files digests to cache: {}", error
+                            self.logger, "Error while storing new immutable files digests to cache";
+                            "error" => ?error
                         );
                     }
                 }
@@ -136,7 +136,7 @@ fn compute_hash(
         };
 
         if progress.report(ix) {
-            info!(logger, "hashing: {}", &progress);
+            info!(logger, "Hashing: {progress}");
         }
     }
 

--- a/mithril-common/src/messages/cardano_transactions_proof.rs
+++ b/mithril-common/src/messages/cardano_transactions_proof.rs
@@ -322,7 +322,6 @@ mod tests {
             CardanoTransactionsSignableBuilder, MockBlockRangeRootRetriever,
             MockTransactionsImporter, SignableBuilder,
         };
-        use slog::Logger;
         use std::sync::Arc;
 
         use super::*;
@@ -416,7 +415,6 @@ mod tests {
             let cardano_transaction_signable_builder = CardanoTransactionsSignableBuilder::new(
                 Arc::new(transaction_importer),
                 Arc::new(block_range_root_retriever),
-                Logger::root(slog::Discard, slog::o!()),
             );
             cardano_transaction_signable_builder
                 .compute_protocol_message(block_number)

--- a/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
+++ b/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
@@ -52,7 +52,7 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoImmutableFilesFullSignableBuild
                     &self.dirpath.display()
                 )
             })?;
-        info!(self.logger, "digest = '{digest}'.");
+        info!(self.logger, "Computed Digest = '{digest}'.");
         let mut protocol_message = ProtocolMessage::new();
         protocol_message.set_message_part(ProtocolMessagePartKey::SnapshotDigest, digest);
 

--- a/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
+++ b/mithril-common/src/signable_builder/cardano_immutable_full_signable_builder.rs
@@ -12,9 +12,9 @@ use crate::{
 };
 use anyhow::Context;
 use async_trait::async_trait;
-use slog::{debug, info, Logger};
+use slog::{info, Logger};
 
-/// This structure is responsible of calculating the message for Cardano immutable files snapshots.
+/// This structure is responsible for calculating the message for Cardano immutable files snapshots.
 pub struct CardanoImmutableFilesFullSignableBuilder {
     immutable_digester: Arc<dyn ImmutableDigester>,
     logger: Logger,
@@ -42,7 +42,6 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoImmutableFilesFullSignableBuild
         &self,
         beacon: CardanoDbBeacon,
     ) -> StdResult<ProtocolMessage> {
-        debug!(self.logger, "compute_signable({beacon:?})");
         let digest = self
             .immutable_digester
             .compute_digest(&self.dirpath, &beacon)

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.200"
+version = "0.2.201"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -323,7 +323,6 @@ impl<'a> DependenciesBuilder<'a> {
         >::new(
             state_machine_transactions_importer,
             block_range_root_retriever,
-            self.root_logger(),
         ));
         let cardano_stake_distribution_signable_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
@@ -349,6 +348,7 @@ impl<'a> DependenciesBuilder<'a> {
             cardano_immutable_snapshot_builder,
             cardano_transactions_builder,
             cardano_stake_distribution_signable_builder,
+            self.root_logger(),
         ));
         let metrics_service = Arc::new(MetricsService::new(self.root_logger())?);
         let preloader_activation =

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -441,7 +441,6 @@ mod tests {
         let cardano_transactions_builder = Arc::new(CardanoTransactionsSignableBuilder::new(
             transactions_importer.clone(),
             block_range_root_retriever,
-            logger.clone(),
         ));
         let stake_store = Arc::new(StakeStore::new(Box::new(DumbStoreAdapter::new()), None));
         let cardano_stake_distribution_builder = Arc::new(
@@ -470,6 +469,7 @@ mod tests {
             cardano_immutable_signable_builder,
             cardano_transactions_builder,
             cardano_stake_distribution_builder,
+            logger.clone(),
         ));
         let metrics_service = Arc::new(MetricsService::new(logger.clone()).unwrap());
         let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -104,7 +104,7 @@ impl SignerRunner {
 #[async_trait]
 impl Runner for SignerRunner {
     async fn get_epoch_settings(&self) -> StdResult<Option<SignerEpochSettings>> {
-        debug!(self.logger, "get_epoch_settings");
+        debug!(self.logger, ">> get_epoch_settings");
 
         self.services
             .certificate_handler
@@ -114,13 +114,13 @@ impl Runner for SignerRunner {
     }
 
     async fn get_beacon_to_sign(&self) -> StdResult<Option<BeaconToSign>> {
-        debug!(self.logger, "get_beacon_to_sign");
+        debug!(self.logger, ">> get_beacon_to_sign");
 
         self.services.certifier.get_beacon_to_sign().await
     }
 
     async fn get_current_time_point(&self) -> StdResult<TimePoint> {
-        debug!(self.logger, "get_current_time_point");
+        debug!(self.logger, ">> get_current_time_point");
 
         self.services
             .ticker_service
@@ -130,7 +130,7 @@ impl Runner for SignerRunner {
     }
 
     async fn register_signer_to_aggregator(&self) -> StdResult<()> {
-        debug!(self.logger, "register_signer_to_aggregator");
+        debug!(self.logger, ">> register_signer_to_aggregator");
 
         let (epoch, protocol_parameters) = {
             let epoch_service = self.services.epoch_service.read().await;
@@ -206,7 +206,7 @@ impl Runner for SignerRunner {
     }
 
     async fn update_stake_distribution(&self, epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, "update_stake_distribution");
+        debug!(self.logger, ">> update_stake_distribution(epoch: {epoch})");
 
         let exists_stake_distribution = !self
             .services
@@ -239,7 +239,10 @@ impl Runner for SignerRunner {
     }
 
     async fn inform_epoch_settings(&self, epoch_settings: SignerEpochSettings) -> StdResult<()> {
-        debug!(self.logger, "register_epoch");
+        debug!(
+            self.logger,
+            ">> inform_epoch_settings(epoch:{})", epoch_settings.epoch
+        );
         let aggregator_features = self
             .services
             .certificate_handler
@@ -261,7 +264,7 @@ impl Runner for SignerRunner {
         &self,
         signed_entity_type: &SignedEntityType,
     ) -> StdResult<ProtocolMessage> {
-        debug!(self.logger, "compute_message");
+        debug!(self.logger, ">> compute_message({signed_entity_type:?})");
 
         let protocol_message = self
             .services
@@ -278,7 +281,7 @@ impl Runner for SignerRunner {
         beacon_to_sign: &BeaconToSign,
         message: &ProtocolMessage,
     ) -> StdResult<()> {
-        debug!(self.logger, "compute_publish_single_signature");
+        debug!(self.logger, ">> compute_publish_single_signature"; "beacon_to_sign" => ?beacon_to_sign);
         self.services
             .certifier
             .compute_publish_single_signature(beacon_to_sign, message)
@@ -286,7 +289,7 @@ impl Runner for SignerRunner {
     }
 
     async fn update_era_checker(&self, epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, "update_era_checker");
+        debug!(self.logger, ">> update_era_checker(epoch:{epoch})");
 
         let era_token = self
             .services
@@ -314,7 +317,7 @@ impl Runner for SignerRunner {
     }
 
     async fn upkeep(&self, current_epoch: Epoch) -> StdResult<()> {
-        debug!(self.logger, "upkeep");
+        debug!(self.logger, ">> upkeep(current_epoch:{current_epoch})");
         self.services.upkeep_service.run(current_epoch).await?;
         Ok(())
     }

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -109,7 +109,7 @@ impl StateMachine {
 
     /// Launch the state machine until an error occurs or it is interrupted.
     pub async fn run(&self) -> Result<(), RuntimeError> {
-        info!(self.logger, "launching");
+        info!(self.logger, "Launching State Machine");
 
         loop {
             if let Err(e) = self.cycle().await {
@@ -135,7 +135,7 @@ impl StateMachine {
             self.logger,
             "================================================================================"
         );
-        info!(self.logger, "new cycle: {}", *state);
+        info!(self.logger, "New cycle: {}", *state);
 
         self.metrics_service
             .runtime_cycle_total_since_startup_counter_increment();
@@ -164,8 +164,8 @@ impl StateMachine {
                 {
                     info!(self.logger, "→ Epoch settings found");
                     if epoch_settings.epoch >= *epoch {
-                        info!(self.logger, "new Epoch found");
-                        info!(self.logger, " ⋅ transiting to Registered");
+                        info!(self.logger, "New Epoch found");
+                        info!(self.logger, " ⋅ Transiting to Registered");
                         *state = self
                             .transition_from_unregistered_to_one_of_registered_states(
                                 epoch_settings,
@@ -173,8 +173,7 @@ impl StateMachine {
                             .await?;
                     } else {
                         info!(
-                            self.logger,
-                            " ⋅ Epoch settings found, but its epoch is behind the known epoch, waiting…";
+                            self.logger, " ⋅ Epoch settings found, but its epoch is behind the known epoch, waiting…";
                             "epoch_settings" => ?epoch_settings,
                             "known_epoch" => ?epoch,
                         );
@@ -187,7 +186,7 @@ impl StateMachine {
                 if let Some(new_epoch) = self.has_epoch_changed(*epoch).await? {
                     info!(
                         self.logger,
-                        " → new Epoch detected, transiting to Unregistered"
+                        " → New Epoch detected, transiting to Unregistered"
                     );
                     *state = self
                         .transition_from_registered_not_able_to_sign_to_unregistered(new_epoch)
@@ -218,8 +217,7 @@ impl StateMachine {
                     match beacon_to_sign {
                         Some(beacon) => {
                             info!(
-                                self.logger,
-                                "→ Epoch has NOT changed we can sign this beacon, transiting to ReadyToSign";
+                                self.logger, "→ Epoch has NOT changed we can sign this beacon, transiting to ReadyToSign";
                                 "beacon_to_sign" => ?beacon,
                             );
                             *state = self
@@ -227,7 +225,7 @@ impl StateMachine {
                                 .await?;
                         }
                         None => {
-                            info!(self.logger, " ⋅ no beacon to sign, waiting…");
+                            info!(self.logger, " ⋅ No beacon to sign, waiting…");
                         }
                     }
                 }
@@ -373,8 +371,7 @@ impl StateMachine {
         );
 
         debug!(
-            self.logger,
-            " > transition_from_ready_to_sign_to_ready_to_sign";
+            self.logger, ">> transition_from_ready_to_sign_to_ready_to_sign";
             "current_epoch" => ?current_epoch,
             "retrieval_epoch" => ?retrieval_epoch,
             "next_retrieval_epoch" => ?next_retrieval_epoch,

--- a/mithril-signer/src/services/certifier.rs
+++ b/mithril-signer/src/services/certifier.rs
@@ -151,7 +151,7 @@ impl CertifierService for SignerCertifierService {
             .compute_single_signatures(protocol_message)
             .await?
         {
-            debug!(self.logger, " > there is a single signature to send");
+            debug!(self.logger, " > There is a single signature to send");
             self.signature_publisher
                 .publish(
                     &beacon_to_sign.signed_entity_type,
@@ -163,7 +163,7 @@ impl CertifierService for SignerCertifierService {
             debug!(self.logger, " > NO single signature to send");
         }
 
-        debug!(self.logger, " > marking beacon as signed"; "beacon" => ?beacon_to_sign);
+        debug!(self.logger, " > Marking beacon as signed"; "beacon" => ?beacon_to_sign);
         self.signed_beacon_store
             .mark_beacon_as_signed(beacon_to_sign)
             .await?;

--- a/mithril-signer/src/services/epoch_service.rs
+++ b/mithril-signer/src/services/epoch_service.rs
@@ -118,7 +118,10 @@ impl MithrilEpochService {
         epoch: Epoch,
         signers: &[Signer],
     ) -> StdResult<Vec<SignerWithStake>> {
-        debug!(self.logger, "associate_signers_with_stake");
+        debug!(
+            self.logger,
+            ">> associate_signers_with_stake(epoch:{epoch})"
+        );
 
         let stakes = self
             .stake_storer
@@ -143,7 +146,7 @@ impl MithrilEpochService {
             ));
             trace!(
                 self.logger,
-                " > associating signer_id {} with stake {}",
+                " > Associating signer_id {} with stake {}",
                 signer.party_id,
                 *stake
             );
@@ -177,7 +180,7 @@ impl EpochService for MithrilEpochService {
         epoch_settings: SignerEpochSettings,
         allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
     ) -> StdResult<()> {
-        debug!(self.logger, "register_epoch_settings"; "epoch_settings" => ?epoch_settings);
+        debug!(self.logger, ">> inform_epoch_settings"; "epoch_settings" => ?epoch_settings);
 
         let epoch = epoch_settings.epoch;
         let protocol_initializer = self
@@ -259,7 +262,7 @@ impl EpochService for MithrilEpochService {
         if let Some(protocol_initializer) = self.protocol_initializer()? {
             debug!(
                 self.logger,
-                " > got protocol initializer for this epoch ({epoch})"
+                " > Got protocol initializer for this epoch ({epoch})"
             );
             if self
                 .is_signer_included_in_current_stake_distribution(party_id, protocol_initializer)?

--- a/mithril-signer/src/services/single_signer.rs
+++ b/mithril-signer/src/services/single_signer.rs
@@ -153,7 +153,7 @@ impl SingleSigner for MithrilSingleSigner {
             None => {
                 warn!(
                     self.logger,
-                    "no signature computed, all lotteries were lost"
+                    "No signature computed, all lotteries were lost"
                 );
             }
         };

--- a/mithril-signer/src/services/upkeep_service.rs
+++ b/mithril-signer/src/services/upkeep_service.rs
@@ -123,7 +123,7 @@ impl SignerUpkeepService {
 #[async_trait]
 impl UpkeepService for SignerUpkeepService {
     async fn run(&self, current_epoch: Epoch) -> StdResult<()> {
-        info!(self.logger, "start upkeep of the application");
+        info!(self.logger, "Start upkeep of the application");
 
         self.execute_pruning_tasks(current_epoch)
             .await
@@ -133,7 +133,7 @@ impl UpkeepService for SignerUpkeepService {
             .await
             .with_context(|| "Database upkeep failed")?;
 
-        info!(self.logger, "upkeep finished");
+        info!(self.logger, "Upkeep finished");
         Ok(())
     }
 }

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -212,7 +212,6 @@ impl StateMachineTester {
         >::new(
             transactions_importer.clone(),
             block_range_root_retriever,
-            logger.clone(),
         ));
         let cardano_stake_distribution_builder = Arc::new(
             CardanoStakeDistributionSignableBuilder::new(stake_store.clone()),
@@ -238,6 +237,7 @@ impl StateMachineTester {
             cardano_immutable_snapshot_builder,
             cardano_transactions_builder,
             cardano_stake_distribution_builder,
+            logger.clone(),
         ));
         let metrics_service = Arc::new(MetricsService::new(logger.clone()).unwrap());
         let expected_metrics_service = Arc::new(MetricsService::new(logger.clone()).unwrap());


### PR DESCRIPTION
## Content

Following the light rules we decided to applies for logs when working on the aggregator (see #2009), this PR applies those rules on `mithril-signer`, `mithril-common` and `mithril-persistence`:
- Harmonize all "function enter" logs message to be in the form of `>> function_name`. 
- Capitalize the first letters of all "functional" logs.

It also:
- For signer runner function enter logs: add the value of some of the function parameters to the log to provide more context.
- rework where the function entries logs are done when using signable builders: instead of be sent by the child buiders they are sent by the parent (avoiding repetition and making sure that no builders are left out ... as before).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #1981
