### PR TITLE
Fix: add missing automatically generated release note section for `unstable` releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,19 +607,8 @@ jobs:
           name: Unstable Development Builds
           files: package/*
           generate_release_notes: true
-
-      # We use a separate action to update the body of the release note.
-      # The 'softprops/action-gh-release' action prepends the customized part to the generated note,
-      # which is not the intended behavior.
-      - name: Update unstable release body with release notes addon
-        # specific version since this action does not support giving only the major number
-        uses: tubone24/update_release@v1.3.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG_NAME: unstable
-        with:
-          is_append_body: true
           body_path: ./release-notes-addon.txt
+          append_body: true
 
   deploy-testing:
     if: vars.DEPLOY_NETWORKS_IN_CI == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -606,8 +606,20 @@ jobs:
           prerelease: true
           name: Unstable Development Builds
           files: package/*
+          generate_release_notes: true
+
+      # We use a separate action to update the body of the release note.
+      # The 'softprops/action-gh-release' action prepends the customized part to the generated note,
+      # which is not the intended behavior.
+      - name: Update unstable release body with release notes addon
+        # specific version since this action does not support giving only the major number
+        uses: tubone24/update_release@v1.3.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: unstable
+        with:
+          is_append_body: true
           body_path: ./release-notes-addon.txt
-          append_body: true
 
   deploy-testing:
     if: vars.DEPLOY_NETWORKS_IN_CI == 'true' && (github.event_name == 'push' || github.event_name == 'pull_request')


### PR DESCRIPTION
## Content

This PR includes a fix following the merge of PR #2007.

The auto-generated part of the `unstable` release note, which contains the commit history, is no longer published.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #1691 
