### PR TITLE
Refactor client cli command parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3662,7 +3662,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.9.15"
+version = "0.9.16"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/command_context.rs
+++ b/mithril-client-cli/src/command_context.rs
@@ -10,16 +10,27 @@ use crate::configuration::ConfigParameters;
 /// Context for the command execution
 pub struct CommandContext {
     config_builder: ConfigBuilder<DefaultState>,
+    unstable_enabled: bool,
     logger: Logger,
 }
 
 impl CommandContext {
     /// Create a new command context
-    pub fn new(config_builder: ConfigBuilder<DefaultState>, logger: Logger) -> Self {
+    pub fn new(
+        config_builder: ConfigBuilder<DefaultState>,
+        unstable_enabled: bool,
+        logger: Logger,
+    ) -> Self {
         Self {
             config_builder,
+            unstable_enabled,
             logger,
         }
+    }
+
+    /// Check if unstable commands are enabled
+    pub fn is_unstable_enabled(&self) -> bool {
+        self.unstable_enabled
     }
 
     /// Get the configured parameters

--- a/mithril-client-cli/src/command_context.rs
+++ b/mithril-client-cli/src/command_context.rs
@@ -1,0 +1,36 @@
+use config::builder::DefaultState;
+use config::ConfigBuilder;
+use slog::Logger;
+use std::collections::HashMap;
+
+use mithril_client::MithrilResult;
+
+use crate::configuration::ConfigParameters;
+
+/// Context for the command execution
+pub struct CommandContext {
+    config_builder: ConfigBuilder<DefaultState>,
+    logger: Logger,
+}
+
+impl CommandContext {
+    /// Create a new command context
+    pub fn new(config_builder: ConfigBuilder<DefaultState>, logger: Logger) -> Self {
+        Self {
+            config_builder,
+            logger,
+        }
+    }
+
+    /// Get the configured parameters
+    pub fn config_parameters(&self) -> MithrilResult<ConfigParameters> {
+        let config = self.config_builder.clone().build()?;
+        let config_hash_map = config.try_deserialize::<HashMap<String, String>>()?;
+        Ok(ConfigParameters::new(config_hash_map))
+    }
+
+    /// Get the shared logger
+    pub fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -1,7 +1,7 @@
 use anyhow::{anyhow, Context};
 use chrono::Utc;
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
+use config::{builder::DefaultState, ConfigBuilder};
 use slog_scope::{debug, warn};
 use std::{
     collections::HashMap,
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     commands::{client_builder, SharedArgs},
-    configuration::ConfigParameters,
+    configuration::{ConfigError, ConfigParameters, ConfigSource},
     utils::{
         CardanoDbDownloadChecker, CardanoDbUtils, ExpanderUtils, IndicatifFeedbackReceiver,
         ProgressOutputType, ProgressPrinter,
@@ -52,8 +52,9 @@ impl CardanoDbDownloadCommand {
 
     /// Command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.add_source(self.clone()).build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+        let config = config_builder.build()?;
+        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?)
+            .add_source(self)?;
         let download_dir: &String = &params.require("download_dir")?;
         let db_dir = Path::new(download_dir).join("db");
 
@@ -304,34 +305,29 @@ impl CardanoDbDownloadCommand {
     }
 }
 
-impl Source for CardanoDbDownloadCommand {
-    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
-        Box::new(self.clone())
-    }
-
-    fn collect(&self) -> Result<Map<String, Value>, config::ConfigError> {
-        let mut map = Map::new();
-        let namespace = "clap arguments".to_string();
+impl ConfigSource for CardanoDbDownloadCommand {
+    fn collect(&self) -> Result<HashMap<String, String>, ConfigError> {
+        let mut map = HashMap::new();
 
         if let Some(download_dir) = self.download_dir.clone() {
             map.insert(
                 "download_dir".to_string(),
-                Value::new(
-                    Some(&namespace),
-                    ValueKind::from(download_dir.to_str().ok_or_else(|| {
-                        config::ConfigError::Message(format!(
+                download_dir
+                    .to_str()
+                    .ok_or_else(|| {
+                        ConfigError::Conversion(format!(
                             "Could not read download directory: '{}'.",
                             download_dir.display()
                         ))
-                    })?),
-                ),
+                    })?
+                    .to_string(),
             );
         }
 
         if let Some(genesis_verification_key) = self.genesis_verification_key.clone() {
             map.insert(
                 "genesis_verification_key".to_string(),
-                Value::new(Some(&namespace), ValueKind::from(genesis_verification_key)),
+                genesis_verification_key,
             );
         }
 

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context};
 use chrono::Utc;
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder};
 use slog_scope::{debug, warn};
 use std::{
     collections::HashMap,
@@ -12,11 +11,12 @@ use std::{
 
 use crate::{
     commands::{client_builder, SharedArgs},
-    configuration::{ConfigError, ConfigParameters, ConfigSource},
+    configuration::{ConfigError, ConfigSource},
     utils::{
         CardanoDbDownloadChecker, CardanoDbUtils, ExpanderUtils, IndicatifFeedbackReceiver,
         ProgressOutputType, ProgressPrinter,
     },
+    CommandContext,
 };
 use mithril_client::{
     common::ProtocolMessage, Client, MessageBuilder, MithrilCertificate, MithrilResult, Snapshot,
@@ -51,10 +51,8 @@ impl CardanoDbDownloadCommand {
     }
 
     /// Command execution
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?)
-            .add_source(self)?;
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?.add_source(self)?;
         let download_dir: &String = &params.require("download_dir")?;
         let db_dir = Path::new(download_dir).join("db");
 

--- a/mithril-client-cli/src/commands/cardano_db/list.rs
+++ b/mithril-client-cli/src/commands/cardano_db/list.rs
@@ -3,21 +3,23 @@ use cli_table::{format::Justify, print_stdout, Cell, Table};
 use config::{builder::DefaultState, ConfigBuilder};
 use std::collections::HashMap;
 
-use crate::{commands::client_builder_with_fallback_genesis_key, configuration::ConfigParameters};
+use crate::{
+    commands::{client_builder_with_fallback_genesis_key, SharedArgs},
+    configuration::ConfigParameters,
+};
 use mithril_client::MithrilResult;
 
 /// Clap command to list existing cardano dbs
 #[derive(Parser, Debug, Clone)]
 pub struct CardanoDbListCommand {
-    /// Enable JSON output.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    shared_args: SharedArgs,
 }
 
 impl CardanoDbListCommand {
     /// Is JSON output enabled
     pub fn is_json_output_enabled(&self) -> bool {
-        self.json
+        self.shared_args.json
     }
 
     /// Main command execution
@@ -27,7 +29,7 @@ impl CardanoDbListCommand {
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let items = client.snapshot().list().await?;
 
-        if self.json {
+        if self.is_json_output_enabled() {
             println!("{}", serde_json::to_string(&items)?);
         } else {
             let items = items

--- a/mithril-client-cli/src/commands/cardano_db/list.rs
+++ b/mithril-client-cli/src/commands/cardano_db/list.rs
@@ -1,11 +1,9 @@
 use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Table};
-use config::{builder::DefaultState, ConfigBuilder};
-use std::collections::HashMap;
 
 use crate::{
     commands::{client_builder_with_fallback_genesis_key, SharedArgs},
-    configuration::ConfigParameters,
+    CommandContext,
 };
 use mithril_client::MithrilResult;
 
@@ -23,9 +21,8 @@ impl CardanoDbListCommand {
     }
 
     /// Main command execution
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?;
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let items = client.snapshot().list().await?;
 

--- a/mithril-client-cli/src/commands/cardano_db/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_db/mod.rs
@@ -7,8 +7,8 @@ pub use download::*;
 pub use list::*;
 pub use show::*;
 
+use crate::CommandContext;
 use clap::Subcommand;
-use config::{builder::DefaultState, ConfigBuilder};
 use mithril_client::MithrilResult;
 
 /// Cardano db management (alias: cdb)
@@ -37,7 +37,7 @@ pub enum CardanoDbSnapshotCommands {
 
 impl CardanoDbCommands {
     /// Execute cardano db command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+    pub async fn execute(&self, config_builder: CommandContext) -> MithrilResult<()> {
         match self {
             Self::Download(cmd) => cmd.execute(config_builder).await,
             Self::Snapshot(cmd) => cmd.execute(config_builder).await,
@@ -47,7 +47,7 @@ impl CardanoDbCommands {
 
 impl CardanoDbSnapshotCommands {
     /// Execute Cardano db snapshot command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+    pub async fn execute(&self, config_builder: CommandContext) -> MithrilResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,
             Self::Show(cmd) => cmd.execute(config_builder).await,

--- a/mithril-client-cli/src/commands/cardano_db/show.rs
+++ b/mithril-client-cli/src/commands/cardano_db/show.rs
@@ -5,7 +5,8 @@ use config::{builder::DefaultState, ConfigBuilder};
 use std::collections::HashMap;
 
 use crate::{
-    commands::client_builder_with_fallback_genesis_key, configuration::ConfigParameters,
+    commands::{client_builder_with_fallback_genesis_key, SharedArgs},
+    configuration::ConfigParameters,
     utils::ExpanderUtils,
 };
 use mithril_client::MithrilResult;
@@ -13,9 +14,8 @@ use mithril_client::MithrilResult;
 /// Clap command to show a given cardano db
 #[derive(Parser, Debug, Clone)]
 pub struct CardanoDbShowCommand {
-    /// Enable JSON output.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    shared_args: SharedArgs,
 
     /// Cardano DB digest.
     ///
@@ -26,7 +26,7 @@ pub struct CardanoDbShowCommand {
 impl CardanoDbShowCommand {
     /// Is JSON output enabled
     pub fn is_json_output_enabled(&self) -> bool {
-        self.json
+        self.shared_args.json
     }
 
     /// Cardano DB Show command
@@ -55,7 +55,7 @@ impl CardanoDbShowCommand {
             .await?
             .ok_or_else(|| anyhow!("Cardano DB not found for digest: '{}'", &self.digest))?;
 
-        if self.json {
+        if self.is_json_output_enabled() {
             println!("{}", serde_json::to_string(&cardano_db_message)?);
         } else {
             let cardano_db_table = vec![

--- a/mithril-client-cli/src/commands/cardano_db/show.rs
+++ b/mithril-client-cli/src/commands/cardano_db/show.rs
@@ -1,13 +1,11 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use cli_table::{print_stdout, Cell, Table};
-use config::{builder::DefaultState, ConfigBuilder};
-use std::collections::HashMap;
 
 use crate::{
     commands::{client_builder_with_fallback_genesis_key, SharedArgs},
-    configuration::ConfigParameters,
     utils::ExpanderUtils,
+    CommandContext,
 };
 use mithril_client::MithrilResult;
 
@@ -30,9 +28,8 @@ impl CardanoDbShowCommand {
     }
 
     /// Cardano DB Show command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?;
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
 
         let get_list_of_artifact_ids = || async {

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
+use config::{builder::DefaultState, ConfigBuilder};
 use std::sync::Arc;
 use std::{
     collections::HashMap,
@@ -10,7 +10,7 @@ use std::{
 use crate::utils::{ExpanderUtils, IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter};
 use crate::{
     commands::{client_builder, SharedArgs},
-    configuration::ConfigParameters,
+    configuration::{ConfigError, ConfigParameters, ConfigSource},
 };
 use mithril_client::common::Epoch;
 use mithril_client::Client;
@@ -46,13 +46,11 @@ impl CardanoStakeDistributionDownloadCommand {
 
     /// Main command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder
-            .set_default("download_dir", ".")?
-            .add_source(self.clone())
-            .build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
-        let download_dir = &params.require("download_dir")?;
-        let download_dir = Path::new(download_dir);
+        let config = config_builder.build()?;
+        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?)
+            .add_source(self)?;
+        let download_dir = params.get_or("download_dir", ".");
+        let download_dir = Path::new(&download_dir);
 
         let progress_output_type = if self.is_json_output_enabled() {
             ProgressOutputType::JsonReporter
@@ -224,34 +222,29 @@ impl CardanoStakeDistributionDownloadCommand {
     }
 }
 
-impl Source for CardanoStakeDistributionDownloadCommand {
-    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
-        Box::new(self.clone())
-    }
-
-    fn collect(&self) -> Result<Map<String, Value>, config::ConfigError> {
-        let mut map = Map::new();
-        let namespace = "clap arguments".to_string();
+impl ConfigSource for CardanoStakeDistributionDownloadCommand {
+    fn collect(&self) -> Result<HashMap<String, String>, ConfigError> {
+        let mut map = HashMap::new();
 
         if let Some(download_dir) = self.download_dir.clone() {
             map.insert(
                 "download_dir".to_string(),
-                Value::new(
-                    Some(&namespace),
-                    ValueKind::from(download_dir.to_str().ok_or_else(|| {
-                        config::ConfigError::Message(format!(
+                download_dir
+                    .to_str()
+                    .ok_or_else(|| {
+                        ConfigError::Conversion(format!(
                             "Could not read download directory: '{}'.",
                             download_dir.display()
                         ))
-                    })?),
-                ),
+                    })?
+                    .to_string(),
             );
         }
 
         if let Some(genesis_verification_key) = self.genesis_verification_key.clone() {
             map.insert(
                 "genesis_verification_key".to_string(),
-                Value::new(Some(&namespace), ValueKind::from(genesis_verification_key)),
+                genesis_verification_key,
             );
         }
 

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder};
 use std::sync::Arc;
 use std::{
     collections::HashMap,
@@ -10,7 +9,8 @@ use std::{
 use crate::utils::{ExpanderUtils, IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter};
 use crate::{
     commands::{client_builder, SharedArgs},
-    configuration::{ConfigError, ConfigParameters, ConfigSource},
+    configuration::{ConfigError, ConfigSource},
+    CommandContext,
 };
 use mithril_client::common::Epoch;
 use mithril_client::Client;
@@ -45,10 +45,8 @@ impl CardanoStakeDistributionDownloadCommand {
     }
 
     /// Main command execution
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?)
-            .add_source(self)?;
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?.add_source(self)?;
         let download_dir = params.get_or("download_dir", ".");
         let download_dir = Path::new(&download_dir);
 

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
@@ -3,18 +3,25 @@ use cli_table::{format::Justify, print_stdout, Cell, Table};
 use config::{builder::DefaultState, ConfigBuilder};
 use std::collections::HashMap;
 
-use crate::{commands::client_builder_with_fallback_genesis_key, configuration::ConfigParameters};
+use crate::{
+    commands::{client_builder_with_fallback_genesis_key, SharedArgs},
+    configuration::ConfigParameters,
+};
 use mithril_client::MithrilResult;
 
 /// Cardano stake distribution LIST command
 #[derive(Parser, Debug, Clone)]
 pub struct CardanoStakeDistributionListCommand {
-    /// Enable JSON output.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    shared_args: SharedArgs,
 }
 
 impl CardanoStakeDistributionListCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.shared_args.json
+    }
+
     /// Main command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;
@@ -22,7 +29,7 @@ impl CardanoStakeDistributionListCommand {
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let lines = client.cardano_stake_distribution().list().await?;
 
-        if self.json {
+        if self.is_json_output_enabled() {
             println!("{}", serde_json::to_string(&lines)?);
         } else {
             let lines = lines

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
@@ -1,11 +1,9 @@
 use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Table};
-use config::{builder::DefaultState, ConfigBuilder};
-use std::collections::HashMap;
 
 use crate::{
     commands::{client_builder_with_fallback_genesis_key, SharedArgs},
-    configuration::ConfigParameters,
+    CommandContext,
 };
 use mithril_client::MithrilResult;
 
@@ -23,9 +21,8 @@ impl CardanoStakeDistributionListCommand {
     }
 
     /// Main command execution
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?;
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let lines = client.cardano_stake_distribution().list().await?;
 

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
@@ -5,8 +5,8 @@ mod list;
 pub use download::*;
 pub use list::*;
 
+use crate::CommandContext;
 use clap::Subcommand;
-use config::{builder::DefaultState, ConfigBuilder};
 use mithril_client::MithrilResult;
 
 /// Cardano Stake Distribution management (alias: csd)
@@ -24,7 +24,7 @@ pub enum CardanoStakeDistributionCommands {
 
 impl CardanoStakeDistributionCommands {
     /// Execute Cardano Stake Distribution command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+    pub async fn execute(&self, config_builder: CommandContext) -> MithrilResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,
             Self::Download(cmd) => cmd.execute(config_builder).await,

--- a/mithril-client-cli/src/commands/cardano_transaction/certify.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/certify.rs
@@ -1,7 +1,6 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use cli_table::{print_stdout, Cell, Table};
-use config::{builder::DefaultState, ConfigBuilder};
 use slog_scope::debug;
 use std::{collections::HashMap, sync::Arc};
 
@@ -13,7 +12,8 @@ use mithril_client::{
 use crate::utils::{IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter};
 use crate::{
     commands::{client_builder, SharedArgs},
-    configuration::{ConfigError, ConfigParameters, ConfigSource},
+    configuration::{ConfigError, ConfigSource},
+    CommandContext,
 };
 
 /// Clap command to show a given Cardano transaction sets
@@ -38,10 +38,8 @@ impl CardanoTransactionsCertifyCommand {
     }
 
     /// Cardano transaction certify command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?)
-            .add_source(self)?;
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?.add_source(self)?;
 
         let progress_output_type = if self.is_json_output_enabled() {
             ProgressOutputType::JsonReporter

--- a/mithril-client-cli/src/commands/cardano_transaction/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/mod.rs
@@ -7,9 +7,8 @@ pub use certify::*;
 pub use snapshot_list::*;
 pub use snapshot_show::*;
 
+use crate::CommandContext;
 use clap::Subcommand;
-use config::builder::DefaultState;
-use config::ConfigBuilder;
 use mithril_client::MithrilResult;
 
 /// Cardano transactions management
@@ -39,7 +38,7 @@ pub enum CardanoTransactionSnapshotCommands {
 
 impl CardanoTransactionCommands {
     /// Execute Cardano transaction command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+    pub async fn execute(&self, config_builder: CommandContext) -> MithrilResult<()> {
         match self {
             Self::Snapshot(cmd) => cmd.execute(config_builder).await,
             Self::Certify(cmd) => cmd.execute(config_builder).await,
@@ -49,7 +48,7 @@ impl CardanoTransactionCommands {
 
 impl CardanoTransactionSnapshotCommands {
     /// Execute Cardano transaction snapshot command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+    pub async fn execute(&self, config_builder: CommandContext) -> MithrilResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,
             Self::Show(cmd) => cmd.execute(config_builder).await,

--- a/mithril-client-cli/src/commands/cardano_transaction/snapshot_list.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/snapshot_list.rs
@@ -1,11 +1,9 @@
 use clap::Parser;
 use cli_table::format::Justify;
 use cli_table::{print_stdout, Cell, Table};
-use config::{builder::DefaultState, ConfigBuilder};
-use std::collections::HashMap;
 
 use crate::commands::{client_builder_with_fallback_genesis_key, SharedArgs};
-use crate::configuration::ConfigParameters;
+use crate::CommandContext;
 use mithril_client::MithrilResult;
 
 /// Cardano transaction snapshot list command
@@ -22,9 +20,8 @@ impl CardanoTransactionSnapshotListCommand {
     }
 
     /// Main command execution
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?;
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let lines = client.cardano_transaction().list_snapshots().await?;
 

--- a/mithril-client-cli/src/commands/cardano_transaction/snapshot_list.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/snapshot_list.rs
@@ -4,19 +4,23 @@ use cli_table::{print_stdout, Cell, Table};
 use config::{builder::DefaultState, ConfigBuilder};
 use std::collections::HashMap;
 
-use crate::commands::client_builder_with_fallback_genesis_key;
+use crate::commands::{client_builder_with_fallback_genesis_key, SharedArgs};
 use crate::configuration::ConfigParameters;
 use mithril_client::MithrilResult;
 
 /// Cardano transaction snapshot list command
 #[derive(Parser, Debug, Clone)]
 pub struct CardanoTransactionSnapshotListCommand {
-    /// Enable JSON output.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    shared_args: SharedArgs,
 }
 
 impl CardanoTransactionSnapshotListCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.shared_args.json
+    }
+
     /// Main command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;
@@ -24,7 +28,7 @@ impl CardanoTransactionSnapshotListCommand {
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let lines = client.cardano_transaction().list_snapshots().await?;
 
-        if self.json {
+        if self.is_json_output_enabled() {
             println!("{}", serde_json::to_string(&lines)?);
         } else {
             let lines = lines

--- a/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
@@ -1,13 +1,11 @@
 use anyhow::{anyhow, Context};
 use clap::Parser;
 use cli_table::{print_stdout, Cell, Table};
-use config::{builder::DefaultState, ConfigBuilder};
-use std::collections::HashMap;
 
 use crate::{
     commands::{client_builder_with_fallback_genesis_key, SharedArgs},
-    configuration::ConfigParameters,
     utils::ExpanderUtils,
+    CommandContext,
 };
 use mithril_client::MithrilResult;
 
@@ -31,9 +29,8 @@ impl CardanoTransactionsSnapshotShowCommand {
     }
 
     /// Cardano transaction snapshot Show command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?;
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
 
         let get_list_of_artifact_ids = || async {

--- a/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
@@ -5,7 +5,8 @@ use config::{builder::DefaultState, ConfigBuilder};
 use std::collections::HashMap;
 
 use crate::{
-    commands::client_builder_with_fallback_genesis_key, configuration::ConfigParameters,
+    commands::{client_builder_with_fallback_genesis_key, SharedArgs},
+    configuration::ConfigParameters,
     utils::ExpanderUtils,
 };
 use mithril_client::MithrilResult;
@@ -13,9 +14,8 @@ use mithril_client::MithrilResult;
 /// Clap command to show a given Cardano transaction snapshot
 #[derive(Parser, Debug, Clone)]
 pub struct CardanoTransactionsSnapshotShowCommand {
-    /// Enable JSON output.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    shared_args: SharedArgs,
 
     /// Cardano transaction snapshot hash.
     ///
@@ -25,6 +25,11 @@ pub struct CardanoTransactionsSnapshotShowCommand {
 }
 
 impl CardanoTransactionsSnapshotShowCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.shared_args.json
+    }
+
     /// Cardano transaction snapshot Show command
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;
@@ -56,7 +61,7 @@ impl CardanoTransactionsSnapshotShowCommand {
                 )
             })?;
 
-        if self.json {
+        if self.is_json_output_enabled() {
             println!("{}", serde_json::to_string(&tx_sets)?);
         } else {
             let transaction_sets_table = vec![

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder};
 use std::sync::Arc;
 use std::{
     collections::HashMap,
@@ -10,8 +9,9 @@ use std::{
 use crate::utils::{IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter};
 use crate::{
     commands::{client_builder, SharedArgs},
-    configuration::{ConfigError, ConfigParameters, ConfigSource},
+    configuration::{ConfigError, ConfigSource},
     utils::ExpanderUtils,
+    CommandContext,
 };
 use mithril_client::MessageBuilder;
 use mithril_client::MithrilResult;
@@ -46,10 +46,8 @@ impl MithrilStakeDistributionDownloadCommand {
     }
 
     /// Main command execution
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?)
-            .add_source(self)?;
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?.add_source(self)?;
         let download_dir = params.get_or("download_dir", ".");
         let download_dir = Path::new(&download_dir);
 

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
@@ -8,7 +8,11 @@ use std::{
 };
 
 use crate::utils::{IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter};
-use crate::{commands::client_builder, configuration::ConfigParameters, utils::ExpanderUtils};
+use crate::{
+    commands::{client_builder, SharedArgs},
+    configuration::ConfigParameters,
+    utils::ExpanderUtils,
+};
 use mithril_client::MessageBuilder;
 use mithril_client::MithrilResult;
 
@@ -16,9 +20,8 @@ use mithril_client::MithrilResult;
 /// verification fails, the file is not persisted.
 #[derive(Parser, Debug, Clone)]
 pub struct MithrilStakeDistributionDownloadCommand {
-    /// Enable JSON output.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    shared_args: SharedArgs,
 
     /// Hash of the Mithril Stake Distribution artifact.
     ///
@@ -37,6 +40,11 @@ pub struct MithrilStakeDistributionDownloadCommand {
 }
 
 impl MithrilStakeDistributionDownloadCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.shared_args.json
+    }
+
     /// Main command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder
@@ -47,7 +55,7 @@ impl MithrilStakeDistributionDownloadCommand {
         let download_dir = &params.require("download_dir")?;
         let download_dir = Path::new(download_dir);
 
-        let progress_output_type = if self.json {
+        let progress_output_type = if self.is_json_output_enabled() {
             ProgressOutputType::JsonReporter
         } else {
             ProgressOutputType::Tty
@@ -144,7 +152,7 @@ impl MithrilStakeDistributionDownloadCommand {
             })?,
         )?;
 
-        if self.json {
+        if self.is_json_output_enabled() {
             println!(
                 r#"{{"mithril_stake_distribution_hash": "{}", "filepath": "{}"}}"#,
                 mithril_stake_distribution.hash,

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
@@ -1,11 +1,9 @@
 use clap::Parser;
 use cli_table::{format::Justify, print_stdout, Cell, Table};
-use config::{builder::DefaultState, ConfigBuilder};
-use std::collections::HashMap;
 
 use crate::{
     commands::{client_builder_with_fallback_genesis_key, SharedArgs},
-    configuration::ConfigParameters,
+    CommandContext,
 };
 use mithril_client::MithrilResult;
 
@@ -23,9 +21,8 @@ impl MithrilStakeDistributionListCommand {
     }
 
     /// Main command execution
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
-        let config = config_builder.build()?;
-        let params = ConfigParameters::new(config.try_deserialize::<HashMap<String, String>>()?);
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
+        let params = context.config_parameters()?;
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let lines = client.mithril_stake_distribution().list().await?;
 

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
@@ -3,18 +3,25 @@ use cli_table::{format::Justify, print_stdout, Cell, Table};
 use config::{builder::DefaultState, ConfigBuilder};
 use std::collections::HashMap;
 
-use crate::{commands::client_builder_with_fallback_genesis_key, configuration::ConfigParameters};
+use crate::{
+    commands::{client_builder_with_fallback_genesis_key, SharedArgs},
+    configuration::ConfigParameters,
+};
 use mithril_client::MithrilResult;
 
 /// Mithril stake distribution LIST command
 #[derive(Parser, Debug, Clone)]
 pub struct MithrilStakeDistributionListCommand {
-    /// Enable JSON output.
-    #[clap(long)]
-    json: bool,
+    #[clap(flatten)]
+    shared_args: SharedArgs,
 }
 
 impl MithrilStakeDistributionListCommand {
+    /// Is JSON output enabled
+    pub fn is_json_output_enabled(&self) -> bool {
+        self.shared_args.json
+    }
+
     /// Main command execution
     pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
         let config = config_builder.build()?;
@@ -22,7 +29,7 @@ impl MithrilStakeDistributionListCommand {
         let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
         let lines = client.mithril_stake_distribution().list().await?;
 
-        if self.json {
+        if self.is_json_output_enabled() {
             println!("{}", serde_json::to_string(&lines)?);
         } else {
             let lines = lines

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/mod.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/mod.rs
@@ -5,8 +5,8 @@ mod list;
 pub use download::*;
 pub use list::*;
 
+use crate::CommandContext;
 use clap::Subcommand;
-use config::{builder::DefaultState, ConfigBuilder};
 use mithril_client::MithrilResult;
 
 /// Mithril Stake Distribution management (alias: msd)
@@ -23,7 +23,7 @@ pub enum MithrilStakeDistributionCommands {
 
 impl MithrilStakeDistributionCommands {
     /// Execute Mithril stake distribution command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> MithrilResult<()> {
+    pub async fn execute(&self, config_builder: CommandContext) -> MithrilResult<()> {
         match self {
             Self::List(cmd) => cmd.execute(config_builder).await,
             Self::Download(cmd) => cmd.execute(config_builder).await,

--- a/mithril-client-cli/src/commands/mod.rs
+++ b/mithril-client-cli/src/commands/mod.rs
@@ -11,10 +11,19 @@ pub mod mithril_stake_distribution;
 
 pub use deprecation::{DeprecatedCommand, Deprecation};
 
+use clap::Args;
 use mithril_client::{ClientBuilder, MithrilResult};
 use slog_scope::logger;
 
 use crate::configuration::ConfigParameters;
+
+/// Shared arguments for all commands
+#[derive(Debug, Clone, Args)]
+pub struct SharedArgs {
+    /// Enable JSON output.
+    #[clap(long)]
+    json: bool,
+}
 
 pub(crate) fn client_builder(params: &ConfigParameters) -> MithrilResult<ClientBuilder> {
     let builder = ClientBuilder::aggregator(

--- a/mithril-client-cli/src/lib.rs
+++ b/mithril-client-cli/src/lib.rs
@@ -7,9 +7,11 @@
 //
 //!   You can find more information on how it works reading the [documentation website](https://mithril.network/doc/mithril/mithril-network/client).
 
+mod command_context;
 pub mod commands;
 mod configuration;
 mod utils;
 
+pub use command_context::*;
 /// Error Clap
 pub type ClapError = clap::error::Error;

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -93,9 +93,9 @@ impl Args {
             .add_source(config::File::with_name(&filename).required(false))
             .add_source(self.clone())
             .set_default("download_dir", "")?;
-        let context = CommandContext::new(config, root_logger);
+        let context = CommandContext::new(config, self.unstable, root_logger);
 
-        self.command.execute(self.unstable, context).await
+        self.command.execute(context).await
     }
 
     fn log_level(&self) -> Level {
@@ -200,17 +200,13 @@ enum ArtifactCommands {
 }
 
 impl ArtifactCommands {
-    pub async fn execute(
-        &self,
-        unstable_enabled: bool,
-        context: CommandContext,
-    ) -> MithrilResult<()> {
+    pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
         match self {
             Self::CardanoDb(cmd) => cmd.execute(context).await,
             Self::MithrilStakeDistribution(cmd) => cmd.execute(context).await,
             Self::CardanoTransaction(cmd) => cmd.execute(context).await,
             Self::CardanoStakeDistribution(cmd) => {
-                if !unstable_enabled {
+                if !context.is_unstable_enabled() {
                     Err(anyhow!(Self::unstable_flag_missing_message(
                         "cardano-stake-distribution",
                         "list"


### PR DESCRIPTION
## Content

This PR change how parameters are passed to client-cli commands: Instead of providing a `ConfigBuilder` from the config crate a `CommandContext` new struct is passed so we can provide more than just configuration parameters to sub-commands.

This change is needed in order to remove `slog_scope` so we can share the main logger defined in the bin `main`.

Two others changes are included:
- Introduce a `SharedArgs` struct so to define in one place arguments shared between all commands (only the `--json` option for now). It's flattened so this doesn't change the api.
- Minimize use of the config crate by instead using a "source" system with the `ConfigParameters`. Using both crate to fetch the same thing (parameters) was quite confusing, this is changed so config is only used for its capacity of reading multiple files formats and to provide the initial hasmap of parameters.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
