### PR TITLE
Enhance logs in client and client-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3649,7 +3649,6 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-async",
- "slog-scope",
  "slog-term",
  "strum",
  "tar",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,7 +3629,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3661,7 +3661,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.9.16"
+version = "0.9.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,7 +3683,6 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-bunyan",
- "slog-scope",
  "slog-term",
  "thiserror",
  "tokio",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -44,7 +44,6 @@ slog = { version = "2.7.0", features = [
 ] }
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
-slog-scope = "4.4.0"
 slog-term = "2.9.1"
 thiserror = "1.0.64"
 tokio = { version = "1.40.0", features = ["full"] }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.9.16"
+version = "0.9.17"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -68,6 +68,7 @@ impl CardanoDbDownloadCommand {
                 progress_output_type,
                 logger.clone(),
             )))
+            .with_logger(logger.clone())
             .build()?;
 
         let get_list_of_artifact_ids = || async {

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -196,14 +196,17 @@ impl CardanoDbDownloadCommand {
         // The cardano db download does not fail if the statistic call fails.
         // It would be nice to implement tests to verify the behavior of `add_statistics`
         if let Err(e) = client.snapshot().add_statistics(cardano_db).await {
-            warn!("Could not increment cardano db download statistics: {e:?}");
+            warn!(
+                "Could not increment cardano db download statistics";
+                "error" => ?e
+            );
         }
 
         // Append 'clean' file to speedup node bootstrap
         if let Err(error) = File::create(db_dir.join("clean")) {
             warn!(
-                "Could not create clean shutdown marker file in directory {}: {error}",
-                db_dir.display()
+                "Could not create clean shutdown marker file in directory '{}'", db_dir.display();
+                "error" => error.to_string()
             );
         };
 
@@ -245,7 +248,10 @@ impl CardanoDbDownloadCommand {
             debug!("Digest verification failed, removing unpacked files & directory.");
 
             if let Err(error) = std::fs::remove_dir_all(db_dir) {
-                warn!("Error while removing unpacked files & directory: {error}.");
+                warn!(
+                    "Error while removing unpacked files & directory";
+                    "error" => error.to_string()
+                );
             }
 
             return Err(anyhow!(

--- a/mithril-client-cli/src/commands/cardano_db/list.rs
+++ b/mithril-client-cli/src/commands/cardano_db/list.rs
@@ -23,7 +23,9 @@ impl CardanoDbListCommand {
     /// Main command execution
     pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
         let params = context.config_parameters()?;
-        let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
+        let client = client_builder_with_fallback_genesis_key(&params)?
+            .with_logger(context.logger().clone())
+            .build()?;
         let items = client.snapshot().list().await?;
 
         if self.is_json_output_enabled() {

--- a/mithril-client-cli/src/commands/cardano_db/show.rs
+++ b/mithril-client-cli/src/commands/cardano_db/show.rs
@@ -30,7 +30,9 @@ impl CardanoDbShowCommand {
     /// Cardano DB Show command
     pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
         let params = context.config_parameters()?;
-        let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
+        let client = client_builder_with_fallback_genesis_key(&params)?
+            .with_logger(context.logger().clone())
+            .build()?;
 
         let get_list_of_artifact_ids = || async {
             let cardano_dbs = client.snapshot().list().await.with_context(|| {

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -49,6 +49,7 @@ impl CardanoStakeDistributionDownloadCommand {
         let params = context.config_parameters()?.add_source(self)?;
         let download_dir = params.get_or("download_dir", ".");
         let download_dir = Path::new(&download_dir);
+        let logger = context.logger();
 
         let progress_output_type = if self.is_json_output_enabled() {
             ProgressOutputType::JsonReporter
@@ -59,6 +60,7 @@ impl CardanoStakeDistributionDownloadCommand {
         let client = client_builder(&params)?
             .add_feedback_receiver(Arc::new(IndicatifFeedbackReceiver::new(
                 progress_output_type,
+                logger.clone(),
             )))
             .build()?;
 

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -62,6 +62,7 @@ impl CardanoStakeDistributionDownloadCommand {
                 progress_output_type,
                 logger.clone(),
             )))
+            .with_logger(logger.clone())
             .build()?;
 
         progress_printer.report_step(

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/list.rs
@@ -23,7 +23,9 @@ impl CardanoStakeDistributionListCommand {
     /// Main command execution
     pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
         let params = context.config_parameters()?;
-        let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
+        let client = client_builder_with_fallback_genesis_key(&params)?
+            .with_logger(context.logger().clone())
+            .build()?;
         let lines = client.cardano_stake_distribution().list().await?;
 
         if self.is_json_output_enabled() {

--- a/mithril-client-cli/src/commands/cardano_transaction/certify.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/certify.rs
@@ -53,6 +53,7 @@ impl CardanoTransactionsCertifyCommand {
                 progress_output_type,
                 logger.clone(),
             )))
+            .with_logger(logger.clone())
             .build()?;
 
         progress_printer.report_step(1, "Fetching a proof for the given transactions…")?;

--- a/mithril-client-cli/src/commands/cardano_transaction/certify.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/certify.rs
@@ -64,10 +64,7 @@ impl CardanoTransactionsCertifyCommand {
                     self.transactions_hashes
                 )
             })?;
-        debug!(
-            "Got Proof from aggregator, proof: {:?}",
-            cardano_transaction_proof
-        );
+        debug!("Got Proof from aggregator"; "proof" => ?cardano_transaction_proof);
 
         let verified_transactions =
             Self::verify_proof_validity(2, &progress_printer, &cardano_transaction_proof)?;

--- a/mithril-client-cli/src/commands/cardano_transaction/snapshot_list.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/snapshot_list.rs
@@ -22,7 +22,9 @@ impl CardanoTransactionSnapshotListCommand {
     /// Main command execution
     pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
         let params = context.config_parameters()?;
-        let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
+        let client = client_builder_with_fallback_genesis_key(&params)?
+            .with_logger(context.logger().clone())
+            .build()?;
         let lines = client.cardano_transaction().list_snapshots().await?;
 
         if self.is_json_output_enabled() {

--- a/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
@@ -31,7 +31,9 @@ impl CardanoTransactionsSnapshotShowCommand {
     /// Cardano transaction snapshot Show command
     pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
         let params = context.config_parameters()?;
-        let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
+        let client = client_builder_with_fallback_genesis_key(&params)?
+            .with_logger(context.logger().clone())
+            .build()?;
 
         let get_list_of_artifact_ids = || async {
             let transactions_sets = client.cardano_transaction().list_snapshots().await.with_context(|| {

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
@@ -50,6 +50,7 @@ impl MithrilStakeDistributionDownloadCommand {
         let params = context.config_parameters()?.add_source(self)?;
         let download_dir = params.get_or("download_dir", ".");
         let download_dir = Path::new(&download_dir);
+        let logger = context.logger();
 
         let progress_output_type = if self.is_json_output_enabled() {
             ProgressOutputType::JsonReporter
@@ -60,6 +61,7 @@ impl MithrilStakeDistributionDownloadCommand {
         let client = client_builder(&params)?
             .add_feedback_receiver(Arc::new(IndicatifFeedbackReceiver::new(
                 progress_output_type,
+                logger.clone(),
             )))
             .build()?;
 

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
@@ -63,6 +63,7 @@ impl MithrilStakeDistributionDownloadCommand {
                 progress_output_type,
                 logger.clone(),
             )))
+            .with_logger(logger.clone())
             .build()?;
 
         let get_list_of_artifact_ids = || async {

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/list.rs
@@ -23,7 +23,9 @@ impl MithrilStakeDistributionListCommand {
     /// Main command execution
     pub async fn execute(&self, context: CommandContext) -> MithrilResult<()> {
         let params = context.config_parameters()?;
-        let client = client_builder_with_fallback_genesis_key(&params)?.build()?;
+        let client = client_builder_with_fallback_genesis_key(&params)?
+            .with_logger(context.logger().clone())
+            .build()?;
         let lines = client.mithril_stake_distribution().list().await?;
 
         if self.is_json_output_enabled() {

--- a/mithril-client-cli/src/commands/mod.rs
+++ b/mithril-client-cli/src/commands/mod.rs
@@ -13,7 +13,6 @@ pub use deprecation::{DeprecatedCommand, Deprecation};
 
 use clap::Args;
 use mithril_client::{ClientBuilder, MithrilResult};
-use slog_scope::logger;
 
 use crate::configuration::ConfigParameters;
 
@@ -29,8 +28,7 @@ pub(crate) fn client_builder(params: &ConfigParameters) -> MithrilResult<ClientB
     let builder = ClientBuilder::aggregator(
         &params.require("aggregator_endpoint")?,
         &params.require("genesis_verification_key")?,
-    )
-    .with_logger(logger());
+    );
 
     Ok(builder)
 }
@@ -50,8 +48,7 @@ pub(crate) fn client_builder_with_fallback_genesis_key(
             "genesis_verification_key",
             fallback_genesis_verification_key,
         ),
-    )
-    .with_logger(logger());
+    );
 
     Ok(builder)
 }

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -241,7 +241,6 @@ async fn main() -> MithrilResult<()> {
         )
     });
     let logger = args.build_logger()?;
-    let _guard = slog_scope::set_global_logger(logger.clone());
 
     #[cfg(feature = "bundle_openssl")]
     openssl_probe::init_ssl_cert_env_vars();

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -87,7 +87,7 @@ impl Args {
     pub async fn execute(&self, root_logger: Logger) -> MithrilResult<()> {
         debug!("Run Mode: {}", self.run_mode);
         let filename = format!("{}/{}.json", self.config_directory.display(), self.run_mode);
-        debug!("Reading configuration file '{}'.", filename);
+        debug!("Reading configuration file '{filename}'.");
         let config: ConfigBuilder<DefaultState> = config::Config::builder()
             .add_source(config::File::with_name(&filename).required(false))
             .add_source(self.clone())

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -3,8 +3,7 @@
 use anyhow::{anyhow, Context};
 use clap::{CommandFactory, Parser, Subcommand};
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
-use slog::{Drain, Fuse, Level, Logger};
-use slog_scope::debug;
+use slog::{debug, Drain, Fuse, Level, Logger};
 use slog_term::Decorator;
 use std::io::Write;
 use std::sync::Arc;
@@ -85,9 +84,9 @@ pub struct Args {
 
 impl Args {
     pub async fn execute(&self, root_logger: Logger) -> MithrilResult<()> {
-        debug!("Run Mode: {}", self.run_mode);
+        debug!(root_logger, "Run Mode: {}", self.run_mode);
         let filename = format!("{}/{}.json", self.config_directory.display(), self.run_mode);
-        debug!("Reading configuration file '{filename}'.");
+        debug!(root_logger, "Reading configuration file '{filename}'.");
         let config: ConfigBuilder<DefaultState> = config::Config::builder()
             .add_source(config::File::with_name(&filename).required(false))
             .add_source(self.clone())

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -140,7 +140,7 @@ impl DownloadProgressReporter {
                 match self.last_json_report_instant.write() {
                     Ok(mut instant) => *instant = Some(Instant::now()),
                     Err(error) => {
-                        warn!("failed to update last json report instant, error: {error:?}")
+                        warn!("failed to update last json report instant"; "error" => ?error)
                     }
                 };
             }

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use indicatif::{MultiProgress, ProgressBar, ProgressDrawTarget};
 use mithril_client::MithrilResult;
-use slog_scope::warn;
+use slog::{warn, Logger};
 use std::{
     ops::Deref,
     sync::RwLock,
@@ -112,15 +112,17 @@ pub struct DownloadProgressReporter {
     progress_bar: ProgressBar,
     output_type: ProgressOutputType,
     last_json_report_instant: RwLock<Option<Instant>>,
+    logger: Logger,
 }
 
 impl DownloadProgressReporter {
     /// Instantiate a new progress reporter
-    pub fn new(progress_bar: ProgressBar, output_type: ProgressOutputType) -> Self {
+    pub fn new(progress_bar: ProgressBar, output_type: ProgressOutputType, logger: Logger) -> Self {
         Self {
             progress_bar,
             output_type,
             last_json_report_instant: RwLock::new(None),
+            logger,
         }
     }
 
@@ -140,7 +142,7 @@ impl DownloadProgressReporter {
                 match self.last_json_report_instant.write() {
                     Ok(mut instant) => *instant = Some(Instant::now()),
                     Err(error) => {
-                        warn!("failed to update last json report instant"; "error" => ?error)
+                        warn!(self.logger, "failed to update last json report instant"; "error" => ?error)
                     }
                 };
             }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.9.2"
+version = "0.9.3"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -74,7 +74,6 @@ mithril-common = { path = "../mithril-common", version = "=0.4", default-feature
 ] }
 mockall = "0.13.0"
 slog-async = "2.8.0"
-slog-scope = "4.4.0"
 slog-term = "2.9.1"
 tokio = { version = "1.40.0", features = ["macros", "rt"] }
 warp = "0.3.7"

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -309,7 +309,7 @@ impl AggregatorHTTPClient {
     #[cfg_attr(target_family = "wasm", async_recursion(?Send))]
     #[cfg_attr(not(target_family = "wasm"), async_recursion)]
     async fn post(&self, url: Url, json: &str) -> Result<Response, AggregatorClientError> {
-        debug!(self.logger, "POST url='{url}' json='{json}'.");
+        debug!(self.logger, "POST url='{url}'"; "json" => json);
         let request_builder = self.http_client.post(url.to_owned()).body(json.to_owned());
         let current_api_version = self
             .compute_current_api_version()

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -20,6 +20,7 @@ use thiserror::Error;
 use tokio::sync::RwLock;
 
 use mithril_common::entities::{ClientError, ServerError};
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::MITHRIL_API_VERSION_HEADER;
 
 #[cfg(feature = "unstable")]
@@ -233,7 +234,7 @@ impl AggregatorHTTPClient {
             http_client,
             aggregator_endpoint,
             api_versions: Arc::new(RwLock::new(api_versions)),
-            logger,
+            logger: logger.new_with_component_name::<Self>(),
             http_headers,
         })
     }

--- a/mithril-client/src/certificate_client.rs
+++ b/mithril-client/src/certificate_client.rs
@@ -59,7 +59,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context};
 use async_trait::async_trait;
-use slog::{crit, debug, Logger};
+use slog::{crit, Logger};
 
 use crate::aggregator_client::{AggregatorClient, AggregatorClientError, AggregatorRequest};
 use crate::feedback::{FeedbackSender, MithrilEvent};
@@ -173,13 +173,12 @@ impl InternalCertificateRetriever {
             Err(e) => Err(e.into()),
             Ok(response) => {
                 let message =
-                    serde_json::from_str::<CertificateMessage>(&response).map_err(|e| {
+                    serde_json::from_str::<CertificateMessage>(&response).inspect_err(|e| {
                         crit!(
-                            self.logger,
-                            "Could not create certificate from API message: {e}."
+                            self.logger, "Could not create certificate from API message";
+                            "error" => e.to_string(),
+                            "raw_message" => response
                         );
-                        debug!(self.logger, "Certificate message = {response}");
-                        e
                     })?;
 
                 Ok(Some(message))

--- a/mithril-client/src/certificate_client.rs
+++ b/mithril-client/src/certificate_client.rs
@@ -61,19 +61,21 @@ use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use slog::{crit, Logger};
 
-use crate::aggregator_client::{AggregatorClient, AggregatorClientError, AggregatorRequest};
-use crate::feedback::{FeedbackSender, MithrilEvent};
-use crate::{MithrilCertificate, MithrilCertificateListItem, MithrilResult};
-use mithril_common::crypto_helper::ProtocolGenesisVerificationKey;
 use mithril_common::{
     certificate_chain::{
         CertificateRetriever, CertificateRetrieverError,
         CertificateVerifier as CommonCertificateVerifier,
         MithrilCertificateVerifier as CommonMithrilCertificateVerifier,
     },
+    crypto_helper::ProtocolGenesisVerificationKey,
     entities::Certificate,
+    logging::LoggerExtensions,
     messages::CertificateMessage,
 };
+
+use crate::aggregator_client::{AggregatorClient, AggregatorClientError, AggregatorRequest};
+use crate::feedback::{FeedbackSender, MithrilEvent};
+use crate::{MithrilCertificate, MithrilCertificateListItem, MithrilResult};
 
 #[cfg(test)]
 use mockall::automock;
@@ -101,6 +103,7 @@ impl CertificateClient {
         verifier: Arc<dyn CertificateVerifier>,
         logger: Logger,
     ) -> Self {
+        let logger = logger.new_with_component_name::<Self>();
         let retriever = Arc::new(InternalCertificateRetriever {
             aggregator_client: aggregator_client.clone(),
             logger,
@@ -203,6 +206,7 @@ impl MithrilCertificateVerifier {
         feedback_sender: FeedbackSender,
         logger: Logger,
     ) -> MithrilResult<MithrilCertificateVerifier> {
+        let logger = logger.new_with_component_name::<Self>();
         let retriever = Arc::new(InternalCertificateRetriever {
             aggregator_client: aggregator_client.clone(),
             logger: logger.clone(),

--- a/mithril-client/src/certificate_client.rs
+++ b/mithril-client/src/certificate_client.rs
@@ -77,9 +77,6 @@ use crate::aggregator_client::{AggregatorClient, AggregatorClientError, Aggregat
 use crate::feedback::{FeedbackSender, MithrilEvent};
 use crate::{MithrilCertificate, MithrilCertificateListItem, MithrilResult};
 
-#[cfg(test)]
-use mockall::automock;
-
 /// Aggregator client for the Certificate
 pub struct CertificateClient {
     aggregator_client: Arc<dyn AggregatorClient>,
@@ -88,7 +85,7 @@ pub struct CertificateClient {
 }
 
 /// API that defines how to validate certificates.
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait CertificateVerifier: Sync + Send {

--- a/mithril-client/src/feedback.rs
+++ b/mithril-client/src/feedback.rs
@@ -191,11 +191,8 @@ impl FeedbackReceiver for SlogFeedbackReceiver {
                 size,
             } => {
                 info!(
-                    self.logger,
-                    "Snapshot download started";
-                    "size" => size,
-                    "digest" => digest,
-                    "download_id" => download_id,
+                    self.logger, "Snapshot download started";
+                    "size" => size, "digest" => digest, "download_id" => download_id,
                 );
             }
             MithrilEvent::SnapshotDownloadProgress {
@@ -204,11 +201,8 @@ impl FeedbackReceiver for SlogFeedbackReceiver {
                 size,
             } => {
                 info!(
-                    self.logger,
-                    "Snapshot download in progress ...";
-                    "downloaded bytes" => downloaded_bytes,
-                    "size" => size,
-                    "download_id" => download_id,
+                    self.logger, "Snapshot download in progress ...";
+                    "downloaded_bytes" => downloaded_bytes, "size" => size, "download_id" => download_id,
                 );
             }
             MithrilEvent::SnapshotDownloadCompleted { download_id } => {
@@ -218,8 +212,7 @@ impl FeedbackReceiver for SlogFeedbackReceiver {
                 certificate_chain_validation_id,
             } => {
                 info!(
-                    self.logger,
-                    "Certificate chain validation started";
+                    self.logger, "Certificate chain validation started";
                     "certificate_chain_validation_id" => certificate_chain_validation_id,
                 );
             }
@@ -228,8 +221,7 @@ impl FeedbackReceiver for SlogFeedbackReceiver {
                 certificate_chain_validation_id,
             } => {
                 info!(
-                    self.logger,
-                    "Certificate validated";
+                    self.logger, "Certificate validated";
                     "certificate_hash" => certificate_hash,
                     "certificate_chain_validation_id" => certificate_chain_validation_id,
                 );
@@ -238,8 +230,7 @@ impl FeedbackReceiver for SlogFeedbackReceiver {
                 certificate_chain_validation_id,
             } => {
                 info!(
-                    self.logger,
-                    "Certificate chain validated";
+                    self.logger, "Certificate chain validated";
                     "certificate_chain_validation_id" => certificate_chain_validation_id,
                 );
             }

--- a/mithril-client/src/message.rs
+++ b/mithril-client/src/message.rs
@@ -1,4 +1,11 @@
 use anyhow::Context;
+use slog::{o, Logger};
+#[cfg(feature = "fs")]
+use std::path::Path;
+#[cfg(feature = "fs")]
+use std::sync::Arc;
+
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::protocol::SignerBuilder;
 #[cfg(feature = "unstable")]
 use mithril_common::signable_builder::CardanoStakeDistributionSignableBuilder;
@@ -7,11 +14,6 @@ use mithril_common::{
     digesters::{CardanoImmutableDigester, ImmutableDigester},
     entities::SignedEntityType,
 };
-use slog::{o, Logger};
-#[cfg(feature = "fs")]
-use std::path::Path;
-#[cfg(feature = "fs")]
-use std::sync::Arc;
 
 use crate::common::{ProtocolMessage, ProtocolMessagePartKey};
 #[cfg(feature = "unstable")]
@@ -40,7 +42,7 @@ impl MessageBuilder {
 
     /// Set the [Logger] to use.
     pub fn with_logger(mut self, logger: Logger) -> Self {
-        self.logger = logger;
+        self.logger = logger.new_with_component_name::<Self>();
         self
     }
 

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -222,8 +222,8 @@ impl SnapshotClient {
                         }
                         Err(e) => {
                             slog::warn!(
-                                self.logger,
-                                "Failed downloading snapshot from '{location}' Error: {e}."
+                                self.logger, "Failed downloading snapshot from '{location}'";
+                                "error" => ?e
                             );
                             Err(e)
                         }

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -144,7 +144,9 @@ impl SnapshotClient {
             #[cfg(feature = "fs")]
             feedback_sender,
             #[cfg(feature = "fs")]
-            logger,
+            logger: mithril_common::logging::LoggerExtensions::new_with_component_name::<Self>(
+                &logger,
+            ),
         }
     }
 

--- a/mithril-client/src/snapshot_downloader.rs
+++ b/mithril-client/src/snapshot_downloader.rs
@@ -25,9 +25,6 @@ use crate::feedback::{FeedbackSender, MithrilEvent};
 use crate::utils::SnapshotUnpacker;
 use crate::MithrilResult;
 
-#[cfg(test)]
-use mockall::automock;
-
 /// API that defines a snapshot downloader
 #[async_trait]
 pub trait SnapshotDownloader: Sync + Send {
@@ -154,7 +151,7 @@ impl HttpSnapshotDownloader {
     }
 }
 
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[async_trait]
 impl SnapshotDownloader for HttpSnapshotDownloader {
     async fn download_unpack(

--- a/mithril-client/src/snapshot_downloader.rs
+++ b/mithril-client/src/snapshot_downloader.rs
@@ -18,13 +18,15 @@ use std::path::Path;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
-#[cfg(test)]
-use mockall::automock;
+use mithril_common::logging::LoggerExtensions;
 
 use crate::common::CompressionAlgorithm;
 use crate::feedback::{FeedbackSender, MithrilEvent};
 use crate::utils::SnapshotUnpacker;
 use crate::MithrilResult;
+
+#[cfg(test)]
+use mockall::automock;
 
 /// API that defines a snapshot downloader
 #[async_trait]
@@ -65,7 +67,7 @@ impl HttpSnapshotDownloader {
         Ok(Self {
             http_client,
             feedback_sender,
-            logger,
+            logger: logger.new_with_component_name::<Self>(),
         })
     }
 


### PR DESCRIPTION
## Content

This PR refactor the log usage in `mithril-client` and `mithril-client-cli`:
- A dedicated child logger is used for each service (only `mithril-client`)
- Each child logger is tagged with its service name in order to identify quickly a log source without the need of a prefix in the log message.
- Change the name property in all logs from the default `slog-rs` to `mithril-client` (only `mithril-client-cli`).
- Capitalize the first letters of all "functional" logs.
- Remove `slog_scope` to enforce the usage of a name tagged child logger.
- Move away from the log message into a property huge structure (ie: some logs joined errors into their message, those errors have been moved to a "error" property).

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #1981
