### PR TITLE
Enhance logs in mithril-relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.25"
+version = "0.1.26"
 dependencies = [
  "anyhow",
  "clap",

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -43,8 +43,10 @@ slog = { version = "2.7.0", features = [
 ] }
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
-slog-scope = "4.4.0"
 slog-term = "2.9.1"
 thiserror = "1.0.64"
 tokio = { version = "1.40.0", features = ["full"] }
 warp = "0.3.7"
+
+[dev-dependencies]
+slog-scope = "4.4.0"

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -43,10 +43,10 @@ slog = { version = "2.7.0", features = [
 ] }
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
-slog-term = "2.9.1"
 thiserror = "1.0.64"
 tokio = { version = "1.40.0", features = ["full"] }
 warp = "0.3.7"
 
 [dev-dependencies]
 slog-scope = "4.4.0"
+slog-term = "2.9.1"

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.25"
+version = "0.1.26"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/src/commands/aggregator.rs
+++ b/mithril-relay/src/commands/aggregator.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use libp2p::Multiaddr;
 use mithril_common::StdResult;
-use slog_scope::error;
+use slog::error;
 
 use super::CommandContext;
 use crate::AggregatorRelay;
@@ -27,16 +27,16 @@ impl AggregatorCommand {
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
         let aggregator_endpoint = self.aggregator_endpoint.to_owned();
+        let logger = context.logger();
 
-        let mut relay =
-            AggregatorRelay::start(&addr, &aggregator_endpoint, context.logger()).await?;
+        let mut relay = AggregatorRelay::start(&addr, &aggregator_endpoint, logger).await?;
         if let Some(dial_to_address) = dial_to {
             relay.dial_peer(dial_to_address.clone())?;
         }
 
         loop {
             if let Err(err) = relay.tick().await {
-                error!("RelayAggregator: tick error"; "error" => format!("{err:#?}"));
+                error!(logger, "RelayAggregator: tick error"; "error" => format!("{err:#?}"));
             }
         }
     }

--- a/mithril-relay/src/commands/aggregator.rs
+++ b/mithril-relay/src/commands/aggregator.rs
@@ -36,7 +36,7 @@ impl AggregatorCommand {
 
         loop {
             if let Err(err) = relay.tick().await {
-                error!(logger, "RelayAggregator: tick error"; "error" => format!("{err:#?}"));
+                error!(logger, "RelayAggregator: tick error"; "error" => ?err);
             }
         }
     }

--- a/mithril-relay/src/commands/aggregator.rs
+++ b/mithril-relay/src/commands/aggregator.rs
@@ -23,12 +23,13 @@ pub struct AggregatorCommand {
 
 impl AggregatorCommand {
     /// Main command execution
-    pub async fn execute(&self, _context: CommandContext) -> StdResult<()> {
+    pub async fn execute(&self, context: CommandContext) -> StdResult<()> {
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
         let aggregator_endpoint = self.aggregator_endpoint.to_owned();
 
-        let mut relay = AggregatorRelay::start(&addr, &aggregator_endpoint).await?;
+        let mut relay =
+            AggregatorRelay::start(&addr, &aggregator_endpoint, context.logger()).await?;
         if let Some(dial_to_address) = dial_to {
             relay.dial_peer(dial_to_address.clone())?;
         }

--- a/mithril-relay/src/commands/aggregator.rs
+++ b/mithril-relay/src/commands/aggregator.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder};
 use libp2p::Multiaddr;
 use mithril_common::StdResult;
 use slog_scope::error;
 
+use super::CommandContext;
 use crate::AggregatorRelay;
 
 #[derive(Parser, Debug, Clone)]
@@ -23,7 +23,7 @@ pub struct AggregatorCommand {
 
 impl AggregatorCommand {
     /// Main command execution
-    pub async fn execute(&self, _config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(&self, _context: CommandContext) -> StdResult<()> {
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
         let aggregator_endpoint = self.aggregator_endpoint.to_owned();

--- a/mithril-relay/src/commands/context.rs
+++ b/mithril-relay/src/commands/context.rs
@@ -1,0 +1,29 @@
+use config::builder::DefaultState;
+use config::ConfigBuilder;
+use slog::Logger;
+
+/// Context for the command execution
+pub struct CommandContext {
+    config_builder: ConfigBuilder<DefaultState>,
+    logger: Logger,
+}
+
+impl CommandContext {
+    /// Create a new command context
+    pub fn new(config_builder: ConfigBuilder<DefaultState>, logger: Logger) -> Self {
+        Self {
+            config_builder,
+            logger,
+        }
+    }
+
+    /// Get the configured parameters
+    pub fn config_builder(&self) -> ConfigBuilder<DefaultState> {
+        self.config_builder.clone()
+    }
+
+    /// Get the shared logger
+    pub fn logger(&self) -> &Logger {
+        &self.logger
+    }
+}

--- a/mithril-relay/src/commands/mod.rs
+++ b/mithril-relay/src/commands/mod.rs
@@ -13,7 +13,7 @@ use clap::Parser;
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value};
 use context::CommandContext;
 use mithril_common::StdResult;
-use slog::Level;
+use slog::{Level, Logger};
 use slog_scope::debug;
 use std::path::PathBuf;
 
@@ -45,7 +45,7 @@ pub struct Args {
 
 impl Args {
     /// execute command
-    pub async fn execute(&self) -> StdResult<()> {
+    pub async fn execute(&self, logger: Logger) -> StdResult<()> {
         debug!("Run Mode: {}", self.run_mode);
         let filename = format!("{}/{}.json", self.config_directory.display(), self.run_mode);
         debug!("Reading configuration file '{}'.", filename);
@@ -53,7 +53,7 @@ impl Args {
             .add_source(config::File::with_name(&filename).required(false))
             .add_source(self.clone());
 
-        let context = CommandContext::new(config, slog_scope::logger());
+        let context = CommandContext::new(config, logger);
         self.command.execute(context).await
     }
 

--- a/mithril-relay/src/commands/mod.rs
+++ b/mithril-relay/src/commands/mod.rs
@@ -13,8 +13,7 @@ use clap::Parser;
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value};
 use context::CommandContext;
 use mithril_common::StdResult;
-use slog::{Level, Logger};
-use slog_scope::debug;
+use slog::{debug, Level, Logger};
 use std::path::PathBuf;
 
 /// Relay for Mithril Node
@@ -46,9 +45,9 @@ pub struct Args {
 impl Args {
     /// execute command
     pub async fn execute(&self, logger: Logger) -> StdResult<()> {
-        debug!("Run Mode: {}", self.run_mode);
+        debug!(logger, "Run Mode: {}", self.run_mode);
         let filename = format!("{}/{}.json", self.config_directory.display(), self.run_mode);
-        debug!("Reading configuration file '{}'.", filename);
+        debug!(logger, "Reading configuration file '{filename}'.");
         let config: ConfigBuilder<DefaultState> = config::Config::builder()
             .add_source(config::File::with_name(&filename).required(false))
             .add_source(self.clone());

--- a/mithril-relay/src/commands/mod.rs
+++ b/mithril-relay/src/commands/mod.rs
@@ -1,4 +1,5 @@
 mod aggregator;
+mod context;
 mod passive;
 mod relay;
 mod signer;
@@ -10,6 +11,7 @@ pub use signer::SignerCommand;
 
 use clap::Parser;
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value};
+use context::CommandContext;
 use mithril_common::StdResult;
 use slog::Level;
 use slog_scope::debug;
@@ -51,7 +53,8 @@ impl Args {
             .add_source(config::File::with_name(&filename).required(false))
             .add_source(self.clone());
 
-        self.command.execute(config).await
+        let context = CommandContext::new(config, slog_scope::logger());
+        self.command.execute(context).await
     }
 
     /// get log level from parameters

--- a/mithril-relay/src/commands/passive.rs
+++ b/mithril-relay/src/commands/passive.rs
@@ -19,11 +19,11 @@ pub struct PassiveCommand {
 
 impl PassiveCommand {
     /// Main command execution
-    pub async fn execute(&self, _context: CommandContext) -> StdResult<()> {
+    pub async fn execute(&self, context: CommandContext) -> StdResult<()> {
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
 
-        let mut relay = PassiveRelay::start(&addr).await?;
+        let mut relay = PassiveRelay::start(&addr, context.logger()).await?;
         if let Some(dial_to_address) = dial_to {
             relay.dial_peer(dial_to_address.clone())?;
         }

--- a/mithril-relay/src/commands/passive.rs
+++ b/mithril-relay/src/commands/passive.rs
@@ -1,9 +1,9 @@
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder};
 use libp2p::Multiaddr;
 use mithril_common::StdResult;
 use slog_scope::error;
 
+use super::CommandContext;
 use crate::PassiveRelay;
 
 #[derive(Parser, Debug, Clone)]
@@ -19,7 +19,7 @@ pub struct PassiveCommand {
 
 impl PassiveCommand {
     /// Main command execution
-    pub async fn execute(&self, _config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(&self, _context: CommandContext) -> StdResult<()> {
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
 

--- a/mithril-relay/src/commands/passive.rs
+++ b/mithril-relay/src/commands/passive.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use libp2p::Multiaddr;
 use mithril_common::StdResult;
-use slog_scope::error;
+use slog::error;
 
 use super::CommandContext;
 use crate::PassiveRelay;
@@ -22,14 +22,15 @@ impl PassiveCommand {
     pub async fn execute(&self, context: CommandContext) -> StdResult<()> {
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
+        let logger = context.logger();
 
-        let mut relay = PassiveRelay::start(&addr, context.logger()).await?;
+        let mut relay = PassiveRelay::start(&addr, logger).await?;
         if let Some(dial_to_address) = dial_to {
             relay.dial_peer(dial_to_address.clone())?;
         }
         loop {
             if let Err(err) = relay.tick().await {
-                error!("P2PClient: tick error"; "error" => format!("{err:#?}"));
+                error!(logger, "P2PClient: tick error"; "error" => format!("{err:#?}"));
             }
         }
     }

--- a/mithril-relay/src/commands/passive.rs
+++ b/mithril-relay/src/commands/passive.rs
@@ -30,7 +30,7 @@ impl PassiveCommand {
         }
         loop {
             if let Err(err) = relay.tick().await {
-                error!(logger, "P2PClient: tick error"; "error" => format!("{err:#?}"));
+                error!(logger, "P2PClient: tick error"; "error" => ?err);
             }
         }
     }

--- a/mithril-relay/src/commands/relay.rs
+++ b/mithril-relay/src/commands/relay.rs
@@ -1,9 +1,9 @@
-use super::{AggregatorCommand, Args, PassiveCommand, SignerCommand};
 use anyhow::anyhow;
 use clap::{CommandFactory, Subcommand};
-use config::{builder::DefaultState, ConfigBuilder};
 use mithril_common::StdResult;
 use mithril_doc::GenerateDocCommands;
+
+use super::{AggregatorCommand, Args, CommandContext, PassiveCommand, SignerCommand};
 
 /// The available sub-commands of the relay
 #[derive(Subcommand, Debug, Clone)]
@@ -27,11 +27,11 @@ pub enum RelayCommands {
 
 impl RelayCommands {
     /// Execute the command
-    pub async fn execute(&self, config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(&self, context: CommandContext) -> StdResult<()> {
         match self {
-            Self::Aggregator(cmd) => cmd.execute(config_builder).await,
-            Self::Signer(cmd) => cmd.execute(config_builder).await,
-            Self::Passive(cmd) => cmd.execute(config_builder).await,
+            Self::Aggregator(cmd) => cmd.execute(context).await,
+            Self::Signer(cmd) => cmd.execute(context).await,
+            Self::Passive(cmd) => cmd.execute(context).await,
             Self::GenerateDoc(cmd) => cmd
                 .execute(&mut Args::command())
                 .map_err(|message| anyhow!(message)),

--- a/mithril-relay/src/commands/signer.rs
+++ b/mithril-relay/src/commands/signer.rs
@@ -55,7 +55,7 @@ impl SignerCommand {
 
         loop {
             if let Err(err) = relay.tick().await {
-                error!(logger, "RelaySigner: tick error"; "error" => format!("{err:#?}"));
+                error!(logger, "RelaySigner: tick error"; "error" => ?err);
             }
         }
     }

--- a/mithril-relay/src/commands/signer.rs
+++ b/mithril-relay/src/commands/signer.rs
@@ -1,11 +1,11 @@
 use std::time::Duration;
 
 use clap::Parser;
-use config::{builder::DefaultState, ConfigBuilder};
 use libp2p::Multiaddr;
 use mithril_common::StdResult;
 use slog_scope::error;
 
+use super::CommandContext;
 use crate::SignerRelay;
 
 #[derive(Parser, Debug, Clone)]
@@ -33,7 +33,7 @@ pub struct SignerCommand {
 
 impl SignerCommand {
     /// Main command execution
-    pub async fn execute(&self, _config_builder: ConfigBuilder<DefaultState>) -> StdResult<()> {
+    pub async fn execute(&self, _context: CommandContext) -> StdResult<()> {
         let server_port = self.server_port.to_owned();
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;

--- a/mithril-relay/src/commands/signer.rs
+++ b/mithril-relay/src/commands/signer.rs
@@ -33,7 +33,7 @@ pub struct SignerCommand {
 
 impl SignerCommand {
     /// Main command execution
-    pub async fn execute(&self, _context: CommandContext) -> StdResult<()> {
+    pub async fn execute(&self, context: CommandContext) -> StdResult<()> {
         let server_port = self.server_port.to_owned();
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
@@ -45,6 +45,7 @@ impl SignerCommand {
             &server_port,
             &aggregator_endpoint,
             &signer_repeater_delay,
+            context.logger(),
         )
         .await?;
         if let Some(dial_to_address) = dial_to {

--- a/mithril-relay/src/commands/signer.rs
+++ b/mithril-relay/src/commands/signer.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use clap::Parser;
 use libp2p::Multiaddr;
 use mithril_common::StdResult;
-use slog_scope::error;
+use slog::error;
 
 use super::CommandContext;
 use crate::SignerRelay;
@@ -34,6 +34,7 @@ pub struct SignerCommand {
 impl SignerCommand {
     /// Main command execution
     pub async fn execute(&self, context: CommandContext) -> StdResult<()> {
+        let logger = context.logger();
         let server_port = self.server_port.to_owned();
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
@@ -45,7 +46,7 @@ impl SignerCommand {
             &server_port,
             &aggregator_endpoint,
             &signer_repeater_delay,
-            context.logger(),
+            logger,
         )
         .await?;
         if let Some(dial_to_address) = dial_to {
@@ -54,7 +55,7 @@ impl SignerCommand {
 
         loop {
             if let Err(err) = relay.tick().await {
-                error!("RelaySigner: tick error"; "error" => format!("{err:#?}"));
+                error!(logger, "RelaySigner: tick error"; "error" => format!("{err:#?}"));
             }
         }
     }

--- a/mithril-relay/src/lib.rs
+++ b/mithril-relay/src/lib.rs
@@ -21,3 +21,33 @@ pub mod mithril_p2p_topic {
     /// The topic name where signatures are published
     pub const SIGNATURES: &str = "mithril/signatures";
 }
+
+#[cfg(test)]
+pub mod test_tools {
+    use std::fs::File;
+    use std::io;
+    use std::sync::Arc;
+
+    use slog::{Drain, Logger};
+    use slog_async::Async;
+    use slog_term::{CompactFormat, PlainDecorator};
+
+    pub struct TestLogger;
+
+    impl TestLogger {
+        fn from_writer<W: io::Write + Send + 'static>(writer: W) -> Logger {
+            let decorator = PlainDecorator::new(writer);
+            let drain = CompactFormat::new(decorator).build().fuse();
+            let drain = Async::new(drain).build().fuse();
+            Logger::root(Arc::new(drain), slog::o!())
+        }
+
+        pub fn stdout() -> Logger {
+            Self::from_writer(slog_term::TestStdoutWriter)
+        }
+
+        pub fn file(filepath: &std::path::Path) -> Logger {
+            Self::from_writer(File::create(filepath).unwrap())
+        }
+    }
+}

--- a/mithril-relay/src/main.rs
+++ b/mithril-relay/src/main.rs
@@ -20,7 +20,6 @@ pub fn build_logger(min_level: Level) -> Logger {
 async fn main() -> StdResult<()> {
     let args = Args::parse();
     let logger = build_logger(args.log_level());
-    let _guard = slog_scope::set_global_logger(logger.clone());
 
     args.execute(logger).await
 }

--- a/mithril-relay/src/main.rs
+++ b/mithril-relay/src/main.rs
@@ -19,7 +19,8 @@ pub fn build_logger(min_level: Level) -> Logger {
 #[tokio::main]
 async fn main() -> StdResult<()> {
     let args = Args::parse();
-    let _guard = slog_scope::set_global_logger(build_logger(args.log_level()));
+    let logger = build_logger(args.log_level());
+    let _guard = slog_scope::set_global_logger(logger.clone());
 
-    args.execute().await
+    args.execute(logger).await
 }

--- a/mithril-relay/src/main.rs
+++ b/mithril-relay/src/main.rs
@@ -8,8 +8,10 @@ use mithril_relay::Args;
 use slog::{Drain, Level, Logger};
 
 pub fn build_logger(min_level: Level) -> Logger {
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::CompactFormat::new(decorator).build().fuse();
+    let drain = slog_bunyan::with_name("mithril-relay", std::io::stderr())
+        .set_pretty(false)
+        .build()
+        .fuse();
     let drain = slog::LevelFilter::new(drain, min_level).fuse();
     let drain = slog_async::Async::new(drain).build().fuse();
 

--- a/mithril-relay/src/p2p/peer.rs
+++ b/mithril-relay/src/p2p/peer.rs
@@ -9,10 +9,12 @@ use libp2p::{
     tls, yamux, Multiaddr, PeerId, Swarm, SwarmBuilder,
 };
 use mithril_common::{
+    logging::LoggerExtensions,
     messages::{RegisterSignatureMessage, RegisterSignerMessage},
     StdResult,
 };
 use serde::{Deserialize, Serialize};
+use slog::Logger;
 use slog_scope::{debug, info};
 use std::{collections::HashMap, time::Duration};
 
@@ -75,6 +77,7 @@ pub struct Peer {
     addr: Multiaddr,
     /// Multi address on which the peer is listening
     pub addr_peer: Option<Multiaddr>,
+    logger: Logger,
 }
 
 impl Peer {
@@ -85,6 +88,7 @@ impl Peer {
             swarm: None,
             addr: addr.to_owned(),
             addr_peer: None,
+            logger: Logger::root(slog::Discard, slog::o!()),
         }
     }
 
@@ -99,6 +103,12 @@ impl Peer {
                 gossipsub::IdentTopic::new(mithril_p2p_topic::SIGNERS),
             ),
         ])
+    }
+
+    /// Set the logger for the peer
+    pub fn with_logger(mut self, logger: &Logger) -> Self {
+        self.logger = logger.new_with_component_name::<Self>();
+        self
     }
 
     /// Start the peer

--- a/mithril-relay/src/p2p/peer.rs
+++ b/mithril-relay/src/p2p/peer.rs
@@ -112,7 +112,7 @@ impl Peer {
 
     /// Start the peer
     pub async fn start(mut self) -> StdResult<Self> {
-        debug!(self.logger, "Peer: starting...");
+        debug!(self.logger, "Starting...");
         let mut swarm = SwarmBuilder::with_new_identity()
             .with_tokio()
             .with_tcp(
@@ -150,7 +150,7 @@ impl Peer {
             .build();
 
         for topic in self.topics.values() {
-            debug!(self.logger, "Peer: subscribing to"; "topic" => ?topic, "local_peer_id" => ?self.local_peer_id());
+            debug!(self.logger, "Subscribing to"; "topic" => ?topic, "local_peer_id" => ?self.local_peer_id());
             swarm.behaviour_mut().gossipsub.subscribe(topic)?;
         }
 
@@ -159,7 +159,7 @@ impl Peer {
 
         loop {
             if let Some(PeerEvent::ListeningOnAddr { address }) = self.tick_swarm().await? {
-                info!(self.logger, "Peer: listening on"; "address" => ?address, "local_peer_id" => ?self.local_peer_id());
+                info!(self.logger, "Listening on"; "address" => ?address, "local_peer_id" => ?self.local_peer_id());
                 self.addr_peer = Some(address);
                 break;
             }
@@ -183,7 +183,7 @@ impl Peer {
 
     /// Tick the peer swarm to receive the next event
     pub async fn tick_swarm(&mut self) -> StdResult<Option<PeerEvent>> {
-        debug!(self.logger, "Peer: reading next event"; "local_peer_id" => ?self.local_peer_id());
+        debug!(self.logger, "Reading next event"; "local_peer_id" => ?self.local_peer_id());
         match self
             .swarm
             .as_mut()
@@ -193,23 +193,23 @@ impl Peer {
             .await
         {
             Some(swarm::SwarmEvent::NewListenAddr { address, .. }) => {
-                debug!(self.logger, "Peer: received listening address event"; "address" => ?address, "local_peer_id" => ?self.local_peer_id());
+                debug!(self.logger, "Received listening address event"; "address" => ?address, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::ListeningOnAddr { address }))
             }
             Some(swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. }) => {
-                debug!(self.logger, "Peer: received outgoing connection error event"; "error" => ?error, "remote_peer_id" => ?peer_id, "local_peer_id" => ?self.local_peer_id());
+                debug!(self.logger, "Received outgoing connection error event"; "error" => ?error, "remote_peer_id" => ?peer_id, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::OutgoingConnectionError { peer_id, error }))
             }
             Some(swarm::SwarmEvent::ConnectionEstablished { peer_id, .. }) => {
-                debug!(self.logger, "Peer: received connection established event"; "remote_peer_id" => ?peer_id, "local_peer_id" => ?self.local_peer_id());
+                debug!(self.logger, "Received connection established event"; "remote_peer_id" => ?peer_id, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::ConnectionEstablished { peer_id }))
             }
             Some(swarm::SwarmEvent::Behaviour(event)) => {
-                debug!(self.logger, "Peer: received behaviour event"; "event" => ?event, "local_peer_id" => ?self.local_peer_id());
+                debug!(self.logger, "Received behaviour event"; "event" => ?event, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::Behaviour { event }))
             }
             Some(event) => {
-                debug!(self.logger, "Peer: received other event"; "event" => ?event, "local_peer_id" => ?self.local_peer_id());
+                debug!(self.logger, "Received other event"; "event" => ?event, "local_peer_id" => ?self.local_peer_id());
                 Ok(None)
             }
             _ => Ok(None),
@@ -276,7 +276,7 @@ impl Peer {
 
     /// Connect to a remote peer
     pub fn dial(&mut self, addr: Multiaddr) -> StdResult<()> {
-        debug!(self.logger, "Peer: dialing to"; "address" => ?addr, "local_peer_id" => ?self.local_peer_id());
+        debug!(self.logger, "Dialing to"; "address" => ?addr, "local_peer_id" => ?self.local_peer_id());
         self.swarm
             .as_mut()
             .ok_or(PeerError::UnavailableSwarm())

--- a/mithril-relay/src/p2p/peer.rs
+++ b/mithril-relay/src/p2p/peer.rs
@@ -150,7 +150,7 @@ impl Peer {
             .build();
 
         for topic in self.topics.values() {
-            debug!(self.logger, "Peer: subscribing to"; "topic" => format!("{topic:?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+            debug!(self.logger, "Peer: subscribing to"; "topic" => ?topic, "local_peer_id" => ?self.local_peer_id());
             swarm.behaviour_mut().gossipsub.subscribe(topic)?;
         }
 
@@ -159,7 +159,7 @@ impl Peer {
 
         loop {
             if let Some(PeerEvent::ListeningOnAddr { address }) = self.tick_swarm().await? {
-                info!(self.logger, "Peer: listening on"; "address" => format!("{address:?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+                info!(self.logger, "Peer: listening on"; "address" => ?address, "local_peer_id" => ?self.local_peer_id());
                 self.addr_peer = Some(address);
                 break;
             }
@@ -183,7 +183,7 @@ impl Peer {
 
     /// Tick the peer swarm to receive the next event
     pub async fn tick_swarm(&mut self) -> StdResult<Option<PeerEvent>> {
-        debug!(self.logger, "Peer: reading next event"; "local_peer_id" => format!("{:?}", self.local_peer_id()));
+        debug!(self.logger, "Peer: reading next event"; "local_peer_id" => ?self.local_peer_id());
         match self
             .swarm
             .as_mut()
@@ -193,23 +193,23 @@ impl Peer {
             .await
         {
             Some(swarm::SwarmEvent::NewListenAddr { address, .. }) => {
-                debug!(self.logger, "Peer: received listening address event"; "address" => format!("{address:?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+                debug!(self.logger, "Peer: received listening address event"; "address" => ?address, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::ListeningOnAddr { address }))
             }
             Some(swarm::SwarmEvent::OutgoingConnectionError { peer_id, error, .. }) => {
-                debug!(self.logger, "Peer: received outgoing connection error event"; "error" => format!("{error:#?}"), "remote_peer_id" => format!("{peer_id:?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+                debug!(self.logger, "Peer: received outgoing connection error event"; "error" => ?error, "remote_peer_id" => ?peer_id, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::OutgoingConnectionError { peer_id, error }))
             }
             Some(swarm::SwarmEvent::ConnectionEstablished { peer_id, .. }) => {
-                debug!(self.logger, "Peer: received connection established event"; "remote_peer_id" => format!("{peer_id:?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+                debug!(self.logger, "Peer: received connection established event"; "remote_peer_id" => ?peer_id, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::ConnectionEstablished { peer_id }))
             }
             Some(swarm::SwarmEvent::Behaviour(event)) => {
-                debug!(self.logger, "Peer: received behaviour event"; "event" => format!("{event:#?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+                debug!(self.logger, "Peer: received behaviour event"; "event" => ?event, "local_peer_id" => ?self.local_peer_id());
                 Ok(Some(PeerEvent::Behaviour { event }))
             }
             Some(event) => {
-                debug!(self.logger, "Peer: received other event"; "event" => format!("{event:#?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+                debug!(self.logger, "Peer: received other event"; "event" => ?event, "local_peer_id" => ?self.local_peer_id());
                 Ok(None)
             }
             _ => Ok(None),
@@ -276,7 +276,7 @@ impl Peer {
 
     /// Connect to a remote peer
     pub fn dial(&mut self, addr: Multiaddr) -> StdResult<()> {
-        debug!(self.logger, "Peer: dialing to"; "address" => format!("{addr:?}"), "local_peer_id" => format!("{:?}", self.local_peer_id()));
+        debug!(self.logger, "Peer: dialing to"; "address" => ?addr, "local_peer_id" => ?self.local_peer_id());
         self.swarm
             .as_mut()
             .ok_or(PeerError::UnavailableSwarm())

--- a/mithril-relay/src/relay/aggregator.rs
+++ b/mithril-relay/src/relay/aggregator.rs
@@ -43,16 +43,16 @@ impl AggregatorRelay {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => {
-                    info!(self.logger, "Relay aggregator: sent successfully signature message to aggregator"; "signature_message" => #?signature_message);
+                    info!(self.logger, "Sent successfully signature message to aggregator"; "signature_message" => #?signature_message);
                     Ok(())
                 }
                 status => {
-                    error!(self.logger, "Relay aggregator: Post `/register-signatures` should have returned a 201 status code, got: {status}");
+                    error!(self.logger, "Post `/register-signatures` should have returned a 201 status code, got: {status}");
                     Err(anyhow!("Post `/register-signatures` should have returned a 201 status code, got: {status}"))
                 }
             },
             Err(err) => {
-                error!(self.logger, "Relay aggregator: Post `/register-signatures` failed"; "error" => ?err);
+                error!(self.logger, "Post `/register-signatures` failed"; "error" => ?err);
                 Err(anyhow!(err).context("Post `/register-signatures` failed"))
             }
         }
@@ -71,16 +71,16 @@ impl AggregatorRelay {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => {
-                    info!(self.logger, "Relay aggregator: sent successfully signer registration message to aggregator"; "signer_message" => #?signer_message);
+                    info!(self.logger, "Sent successfully signer registration message to aggregator"; "signer_message" => #?signer_message);
                     Ok(())
                 }
                 status => {
-                    error!(self.logger, "Relay aggregator: Post `/register-signer` should have returned a 201 status code, got: {status}");
+                    error!(self.logger, "Post `/register-signer` should have returned a 201 status code, got: {status}");
                     Err(anyhow!("Post `/register-signer` should have returned a 201 status code, got: {status}"))
                 }
             },
             Err(err) => {
-                error!(self.logger, "Relay aggregator: Post `/register-signer` failed"; "error" => ?err);
+                error!(self.logger, "Post `/register-signer` failed"; "error" => ?err);
                 Err(anyhow!(err).context("Post `/register-signer` failed"))
             }
         }
@@ -99,7 +99,7 @@ impl AggregatorRelay {
                     {
                         retry_count += 1;
                         if retry_count >= retry_max {
-                            error!(self.logger, "Relay aggregator: failed to send signer registration message to aggregator after {retry_count} attempts"; "signer_message" => #?signer_message_received, "error" => ?e);
+                            error!(self.logger, "Failed to send signer registration message to aggregator after {retry_count} attempts"; "signer_message" => #?signer_message_received, "error" => ?e);
                             return Err(e);
                         }
                     }
@@ -113,7 +113,7 @@ impl AggregatorRelay {
                     {
                         retry_count += 1;
                         if retry_count >= retry_max {
-                            error!(self.logger, "Relay aggregator: failed to send signature message to aggregator after {retry_count} attempts"; "signature_message" => #?signature_message_received, "error" => ?e);
+                            error!(self.logger, "Failed to send signature message to aggregator after {retry_count} attempts"; "signature_message" => #?signature_message_received, "error" => ?e);
                             return Err(e);
                         }
                     }

--- a/mithril-relay/src/relay/aggregator.rs
+++ b/mithril-relay/src/relay/aggregator.rs
@@ -43,7 +43,7 @@ impl AggregatorRelay {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => {
-                    info!(self.logger, "Relay aggregator: sent successfully signature message to aggregator"; "signature_message" => format!("{:#?}", signature_message));
+                    info!(self.logger, "Relay aggregator: sent successfully signature message to aggregator"; "signature_message" => #?signature_message);
                     Ok(())
                 }
                 status => {
@@ -74,7 +74,7 @@ impl AggregatorRelay {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => {
-                    info!(self.logger, "Relay aggregator: sent successfully signer registration message to aggregator"; "signer_message" => format!("{:#?}", signer_message));
+                    info!(self.logger, "Relay aggregator: sent successfully signer registration message to aggregator"; "signer_message" => #?signer_message);
                     Ok(())
                 }
                 status => {
@@ -105,7 +105,7 @@ impl AggregatorRelay {
                     {
                         retry_count += 1;
                         if retry_count >= retry_max {
-                            error!(self.logger, "Relay aggregator: failed to send signer registration message to aggregator after {retry_count} attempts"; "signer_message" => format!("{:#?}", signer_message_received), "error" => format!("{e:?}"));
+                            error!(self.logger, "Relay aggregator: failed to send signer registration message to aggregator after {retry_count} attempts"; "signer_message" => #?signer_message_received, "error" => ?e);
                             return Err(e);
                         }
                     }
@@ -119,7 +119,7 @@ impl AggregatorRelay {
                     {
                         retry_count += 1;
                         if retry_count >= retry_max {
-                            error!(self.logger, "Relay aggregator: failed to send signature message to aggregator after {retry_count} attempts"; "signature_message" => format!("{:#?}", signature_message_received), "error" => format!("{e:?}"));
+                            error!(self.logger, "Relay aggregator: failed to send signature message to aggregator after {retry_count} attempts"; "signature_message" => #?signature_message_received, "error" => ?e);
                             return Err(e);
                         }
                     }

--- a/mithril-relay/src/relay/aggregator.rs
+++ b/mithril-relay/src/relay/aggregator.rs
@@ -7,8 +7,7 @@ use mithril_common::{
     StdResult,
 };
 use reqwest::StatusCode;
-use slog::Logger;
-use slog_scope::{error, info};
+use slog::{error, info, Logger};
 
 /// A relay for a Mithril aggregator
 pub struct AggregatorRelay {
@@ -44,16 +43,19 @@ impl AggregatorRelay {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => {
-                    info!("Relay aggregator: sent successfully signature message to aggregator"; "signature_message" => format!("{:#?}", signature_message));
+                    info!(self.logger, "Relay aggregator: sent successfully signature message to aggregator"; "signature_message" => format!("{:#?}", signature_message));
                     Ok(())
                 }
                 status => {
-                    error!("Relay aggregator: Post `/register-signatures` should have returned a 201 status code, got: {status}");
+                    error!(self.logger, "Relay aggregator: Post `/register-signatures` should have returned a 201 status code, got: {status}");
                     Err(anyhow!("Post `/register-signatures` should have returned a 201 status code, got: {status}"))
                 }
             },
             Err(err) => {
-                error!("Relay aggregator: Post `/register-signatures` failed: {err:?}");
+                error!(
+                    self.logger,
+                    "Relay aggregator: Post `/register-signatures` failed: {err:?}"
+                );
                 Err(anyhow!("Post `/register-signatures` failed: {err:?}"))
             }
         }
@@ -72,16 +74,19 @@ impl AggregatorRelay {
         match response {
             Ok(response) => match response.status() {
                 StatusCode::CREATED => {
-                    info!("Relay aggregator: sent successfully signer registration message to aggregator"; "signer_message" => format!("{:#?}", signer_message));
+                    info!(self.logger, "Relay aggregator: sent successfully signer registration message to aggregator"; "signer_message" => format!("{:#?}", signer_message));
                     Ok(())
                 }
                 status => {
-                    error!("Relay aggregator: Post `/register-signer` should have returned a 201 status code, got: {status}");
+                    error!(self.logger, "Relay aggregator: Post `/register-signer` should have returned a 201 status code, got: {status}");
                     Err(anyhow!("Post `/register-signer` should have returned a 201 status code, got: {status}"))
                 }
             },
             Err(err) => {
-                error!("Relay aggregator: Post `/register-signer` failed: {err:?}");
+                error!(
+                    self.logger,
+                    "Relay aggregator: Post `/register-signer` failed: {err:?}"
+                );
                 Err(anyhow!("Post `/register-signer` failed: {err:?}"))
             }
         }
@@ -100,7 +105,7 @@ impl AggregatorRelay {
                     {
                         retry_count += 1;
                         if retry_count >= retry_max {
-                            error!("Relay aggregator: failed to send signer registration message to aggregator after {retry_count} attempts"; "signer_message" => format!("{:#?}", signer_message_received), "error" => format!("{e:?}"));
+                            error!(self.logger, "Relay aggregator: failed to send signer registration message to aggregator after {retry_count} attempts"; "signer_message" => format!("{:#?}", signer_message_received), "error" => format!("{e:?}"));
                             return Err(e);
                         }
                     }
@@ -114,7 +119,7 @@ impl AggregatorRelay {
                     {
                         retry_count += 1;
                         if retry_count >= retry_max {
-                            error!("Relay aggregator: failed to send signature message to aggregator after {retry_count} attempts"; "signature_message" => format!("{:#?}", signature_message_received), "error" => format!("{e:?}"));
+                            error!(self.logger, "Relay aggregator: failed to send signature message to aggregator after {retry_count} attempts"; "signature_message" => format!("{:#?}", signature_message_received), "error" => format!("{e:?}"));
                             return Err(e);
                         }
                     }

--- a/mithril-relay/src/relay/aggregator.rs
+++ b/mithril-relay/src/relay/aggregator.rs
@@ -2,24 +2,32 @@ use crate::p2p::{BroadcastMessage, Peer, PeerEvent};
 use anyhow::anyhow;
 use libp2p::Multiaddr;
 use mithril_common::{
+    logging::LoggerExtensions,
     messages::{RegisterSignatureMessage, RegisterSignerMessage},
     StdResult,
 };
 use reqwest::StatusCode;
+use slog::Logger;
 use slog_scope::{error, info};
 
 /// A relay for a Mithril aggregator
 pub struct AggregatorRelay {
     aggregator_endpoint: String,
     peer: Peer,
+    logger: Logger,
 }
 
 impl AggregatorRelay {
     /// Start a relay for a Mithril aggregator
-    pub async fn start(addr: &Multiaddr, aggregator_endpoint: &str) -> StdResult<Self> {
+    pub async fn start(
+        addr: &Multiaddr,
+        aggregator_endpoint: &str,
+        logger: &Logger,
+    ) -> StdResult<Self> {
         Ok(Self {
             aggregator_endpoint: aggregator_endpoint.to_owned(),
-            peer: Peer::new(addr).start().await?,
+            peer: Peer::new(addr).with_logger(logger).start().await?,
+            logger: logger.new_with_component_name::<Self>(),
         })
     }
 

--- a/mithril-relay/src/relay/aggregator.rs
+++ b/mithril-relay/src/relay/aggregator.rs
@@ -52,11 +52,8 @@ impl AggregatorRelay {
                 }
             },
             Err(err) => {
-                error!(
-                    self.logger,
-                    "Relay aggregator: Post `/register-signatures` failed: {err:?}"
-                );
-                Err(anyhow!("Post `/register-signatures` failed: {err:?}"))
+                error!(self.logger, "Relay aggregator: Post `/register-signatures` failed"; "error" => ?err);
+                Err(anyhow!(err).context("Post `/register-signatures` failed"))
             }
         }
     }
@@ -83,11 +80,8 @@ impl AggregatorRelay {
                 }
             },
             Err(err) => {
-                error!(
-                    self.logger,
-                    "Relay aggregator: Post `/register-signer` failed: {err:?}"
-                );
-                Err(anyhow!("Post `/register-signer` failed: {err:?}"))
+                error!(self.logger, "Relay aggregator: Post `/register-signer` failed"; "error" => ?err);
+                Err(anyhow!(err).context("Post `/register-signer` failed"))
             }
         }
     }

--- a/mithril-relay/src/relay/passive.rs
+++ b/mithril-relay/src/relay/passive.rs
@@ -2,8 +2,7 @@ use crate::p2p::{BroadcastMessage, Peer, PeerEvent};
 use libp2p::Multiaddr;
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
-use slog::Logger;
-use slog_scope::{debug, info};
+use slog::{debug, info, Logger};
 
 /// A passive relay
 pub struct PassiveRelay {
@@ -17,7 +16,7 @@ impl PassiveRelay {
     /// Start a passive relay
     pub async fn start(addr: &Multiaddr, logger: &Logger) -> StdResult<Self> {
         let relay_logger = logger.new_with_component_name::<Self>();
-        debug!("PassiveRelay: starting...");
+        debug!(relay_logger, "PassiveRelay: starting...");
 
         Ok(Self {
             peer: Peer::new(addr).with_logger(logger).start().await?,
@@ -39,10 +38,10 @@ impl PassiveRelay {
         if let Some(peer_event) = self.peer.tick_swarm().await? {
             match self.peer.convert_peer_event_to_message(peer_event) {
                 Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) => {
-                    info!("Relay passive: received signer registration message from P2P network"; "signer_message" => format!("{:#?}", signer_message_received));
+                    info!(self.logger, "Relay passive: received signer registration message from P2P network"; "signer_message" => format!("{:#?}", signer_message_received));
                 }
                 Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) => {
-                    info!("Relay passive: received signature message from P2P network"; "signature_message" => format!("{:#?}", signature_message_received));
+                    info!(self.logger, "Relay passive: received signature message from P2P network"; "signature_message" => format!("{:#?}", signature_message_received));
                 }
                 Ok(None) => {}
                 Err(e) => return Err(e),

--- a/mithril-relay/src/relay/passive.rs
+++ b/mithril-relay/src/relay/passive.rs
@@ -1,6 +1,8 @@
 use crate::p2p::{BroadcastMessage, Peer, PeerEvent};
 use libp2p::Multiaddr;
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
+use slog::Logger;
 use slog_scope::{debug, info};
 
 /// A passive relay
@@ -8,14 +10,18 @@ pub struct PassiveRelay {
     /// Relay peer
     // TODO: should be private
     pub peer: Peer,
+    logger: Logger,
 }
 
 impl PassiveRelay {
     /// Start a passive relay
-    pub async fn start(addr: &Multiaddr) -> StdResult<Self> {
+    pub async fn start(addr: &Multiaddr, logger: &Logger) -> StdResult<Self> {
+        let relay_logger = logger.new_with_component_name::<Self>();
         debug!("PassiveRelay: starting...");
+
         Ok(Self {
-            peer: Peer::new(addr).start().await?,
+            peer: Peer::new(addr).with_logger(logger).start().await?,
+            logger: relay_logger,
         })
     }
 

--- a/mithril-relay/src/relay/passive.rs
+++ b/mithril-relay/src/relay/passive.rs
@@ -16,7 +16,7 @@ impl PassiveRelay {
     /// Start a passive relay
     pub async fn start(addr: &Multiaddr, logger: &Logger) -> StdResult<Self> {
         let relay_logger = logger.new_with_component_name::<Self>();
-        debug!(relay_logger, "PassiveRelay: starting...");
+        debug!(relay_logger, "Starting...");
 
         Ok(Self {
             peer: Peer::new(addr).with_logger(logger).start().await?,
@@ -38,10 +38,10 @@ impl PassiveRelay {
         if let Some(peer_event) = self.peer.tick_swarm().await? {
             match self.peer.convert_peer_event_to_message(peer_event) {
                 Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) => {
-                    info!(self.logger, "Relay passive: received signer registration message from P2P network"; "signer_message" => #?signer_message_received);
+                    info!(self.logger, "Received signer registration message from P2P network"; "signer_message" => #?signer_message_received);
                 }
                 Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) => {
-                    info!(self.logger, "Relay passive: received signature message from P2P network"; "signature_message" => #?signature_message_received);
+                    info!(self.logger, "Received signature message from P2P network"; "signature_message" => #?signature_message_received);
                 }
                 Ok(None) => {}
                 Err(e) => return Err(e),

--- a/mithril-relay/src/relay/passive.rs
+++ b/mithril-relay/src/relay/passive.rs
@@ -38,10 +38,10 @@ impl PassiveRelay {
         if let Some(peer_event) = self.peer.tick_swarm().await? {
             match self.peer.convert_peer_event_to_message(peer_event) {
                 Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) => {
-                    info!(self.logger, "Relay passive: received signer registration message from P2P network"; "signer_message" => format!("{:#?}", signer_message_received));
+                    info!(self.logger, "Relay passive: received signer registration message from P2P network"; "signer_message" => #?signer_message_received);
                 }
                 Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) => {
-                    info!(self.logger, "Relay passive: received signature message from P2P network"; "signature_message" => format!("{:#?}", signature_message_received));
+                    info!(self.logger, "Relay passive: received signature message from P2P network"; "signature_message" => #?signature_message_received);
                 }
                 Ok(None) => {}
                 Err(e) => return Err(e),

--- a/mithril-relay/src/relay/signer.rs
+++ b/mithril-relay/src/relay/signer.rs
@@ -52,7 +52,7 @@ impl SignerRelay {
             logger,
         )
         .await;
-        info!(relay_logger, "SignerRelay: listening on"; "address" => format!("{:?}", server.address()));
+        info!(relay_logger, "SignerRelay: listening on"; "address" => ?server.address());
 
         Ok(Self {
             server,
@@ -118,7 +118,7 @@ impl SignerRelay {
             message = self.signature_rx.recv()  => {
                 match message {
                     Some(signature_message) => {
-                        info!(self.logger, "SignerRelay: publish signature to p2p network"; "message" => format!("{signature_message:#?}"));
+                        info!(self.logger, "SignerRelay: publish signature to p2p network"; "message" => #?signature_message);
                         self.peer.publish_signature(&signature_message)?;
                         Ok(())
                     }
@@ -131,7 +131,7 @@ impl SignerRelay {
             message = self.signer_rx.recv()  => {
                 match message {
                     Some(signer_message) => {
-                        info!(self.logger, "SignerRelay: publish signer-registration to p2p network"; "message" => format!("{signer_message:#?}"));
+                        info!(self.logger, "SignerRelay: publish signer-registration to p2p network"; "message" => #?signer_message);
                         self.peer.publish_signer_registration(&signer_message)?;
                         Ok(())
                     }
@@ -234,7 +234,7 @@ mod handlers {
         tx: UnboundedSender<RegisterSignerMessage>,
         repeater: Arc<repeater::MessageRepeater<RegisterSignerMessage>>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "SignerRelay: serve HTTP route /register-signer"; "register_signer_message" => format!("{register_signer_message:#?}"));
+        debug!(logger, "SignerRelay: serve HTTP route /register-signer"; "register_signer_message" => #?register_signer_message);
 
         repeater.set_message(register_signer_message.clone()).await;
         match tx.send(register_signer_message) {
@@ -254,7 +254,7 @@ mod handlers {
         logger: Logger,
         tx: UnboundedSender<RegisterSignatureMessage>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "SignerRelay: serve HTTP route /register-signatures"; "register_signature_message" => format!("{register_signature_message:#?}"));
+        debug!(logger, "SignerRelay: serve HTTP route /register-signatures"; "register_signature_message" => #?register_signature_message);
         match tx.send(register_signature_message) {
             Ok(_) => Ok(Box::new(warp::reply::with_status(
                 "".to_string(),

--- a/mithril-relay/src/relay/signer.rs
+++ b/mithril-relay/src/relay/signer.rs
@@ -299,14 +299,12 @@ mod handlers {
             Ok(response) => match StatusCode::from_u16(response.status().into()) {
                 Ok(status) => match response.text().await {
                     Ok(content) => {
-                        debug!(
-                            logger, "SignerRelay: received response with status '{status}' and content {content:?}"
-                        );
+                        debug!(logger, "SignerRelay: received response with status '{status}'"; "content" => &content);
 
                         Ok(Box::new(warp::reply::with_status(content, status)))
                     }
                     Err(err) => {
-                        debug!(logger, "SignerRelay: received error '{err:?}'");
+                        debug!(logger, "SignerRelay: received error"; "error" => ?err);
                         Ok(Box::new(warp::reply::with_status(
                             format!("{err:?}"),
                             StatusCode::INTERNAL_SERVER_ERROR,
@@ -314,10 +312,7 @@ mod handlers {
                     }
                 },
                 Err(err) => {
-                    debug!(
-                        logger,
-                        "SignerRelay: failed to parse the returned status '{err:?}'"
-                    );
+                    debug!(logger, "SignerRelay: failed to parse the returned status"; "error" => ?err);
                     Ok(Box::new(warp::reply::with_status(
                         format!("{err:?}"),
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -325,7 +320,7 @@ mod handlers {
                 }
             },
             Err(err) => {
-                debug!(logger, "SignerRelay: received error '{err:?}'");
+                debug!(logger, "SignerRelay: received error"; "error" => ?err);
                 Ok(Box::new(warp::reply::with_status(
                     format!("{err:?}"),
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/mithril-relay/src/relay/signer.rs
+++ b/mithril-relay/src/relay/signer.rs
@@ -34,7 +34,7 @@ impl SignerRelay {
         logger: &Logger,
     ) -> StdResult<Self> {
         let relay_logger = logger.new_with_component_name::<Self>();
-        debug!(relay_logger, "SignerRelay: starting...");
+        debug!(relay_logger, "Starting...");
         let (signature_tx, signature_rx) = unbounded_channel::<RegisterSignatureMessage>();
         let (signer_tx, signer_rx) = unbounded_channel::<RegisterSignerMessage>();
         let signer_repeater = Arc::new(MessageRepeater::new(
@@ -52,7 +52,7 @@ impl SignerRelay {
             logger,
         )
         .await;
-        info!(relay_logger, "SignerRelay: listening on"; "address" => ?server.address());
+        info!(relay_logger, "Listening on"; "address" => ?server.address());
 
         Ok(Self {
             server,
@@ -118,12 +118,12 @@ impl SignerRelay {
             message = self.signature_rx.recv()  => {
                 match message {
                     Some(signature_message) => {
-                        info!(self.logger, "SignerRelay: publish signature to p2p network"; "message" => #?signature_message);
+                        info!(self.logger, "Publish signature to p2p network"; "message" => #?signature_message);
                         self.peer.publish_signature(&signature_message)?;
                         Ok(())
                     }
                     None => {
-                        debug!(self.logger, "SignerRelay: no signature message available");
+                        debug!(self.logger, "No signature message available");
                         Ok(())
                     }
                 }
@@ -131,12 +131,12 @@ impl SignerRelay {
             message = self.signer_rx.recv()  => {
                 match message {
                     Some(signer_message) => {
-                        info!(self.logger, "SignerRelay: publish signer-registration to p2p network"; "message" => #?signer_message);
+                        info!(self.logger, "Publish signer-registration to p2p network"; "message" => #?signer_message);
                         self.peer.publish_signer_registration(&signer_message)?;
                         Ok(())
                     }
                     None => {
-                        debug!(self.logger, "SignerRelay: no signer message available");
+                        debug!(self.logger, "No signer message available");
                         Ok(())
                     }
                 }
@@ -220,7 +220,7 @@ mod handlers {
         logger: Logger,
         aggregator_endpoint: String,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "SignerRelay: serve HTTP route /");
+        debug!(logger, "Serve HTTP route /");
         let response = reqwest::Client::new()
             .get(format!("{aggregator_endpoint}/"))
             .send()
@@ -234,7 +234,7 @@ mod handlers {
         tx: UnboundedSender<RegisterSignerMessage>,
         repeater: Arc<repeater::MessageRepeater<RegisterSignerMessage>>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "SignerRelay: serve HTTP route /register-signer"; "register_signer_message" => #?register_signer_message);
+        debug!(logger, "Serve HTTP route /register-signer"; "register_signer_message" => #?register_signer_message);
 
         repeater.set_message(register_signer_message.clone()).await;
         match tx.send(register_signer_message) {
@@ -254,7 +254,7 @@ mod handlers {
         logger: Logger,
         tx: UnboundedSender<RegisterSignatureMessage>,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "SignerRelay: serve HTTP route /register-signatures"; "register_signature_message" => #?register_signature_message);
+        debug!(logger, "Serve HTTP route /register-signatures"; "register_signature_message" => #?register_signature_message);
         match tx.send(register_signature_message) {
             Ok(_) => Ok(Box::new(warp::reply::with_status(
                 "".to_string(),
@@ -271,7 +271,7 @@ mod handlers {
         logger: Logger,
         aggregator_endpoint: String,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "SignerRelay: serve HTTP route /epoch-settings");
+        debug!(logger, "Serve HTTP route /epoch-settings");
         let response = reqwest::Client::new()
             .get(format!("{aggregator_endpoint}/epoch-settings"))
             .send()
@@ -283,7 +283,7 @@ mod handlers {
         logger: Logger,
         aggregator_endpoint: String,
     ) -> Result<impl warp::Reply, Infallible> {
-        debug!(logger, "SignerRelay: serve HTTP route /certificate-pending");
+        debug!(logger, "Serve HTTP route /certificate-pending");
         let response = reqwest::Client::new()
             .get(format!("{aggregator_endpoint}/certificate-pending"))
             .send()
@@ -299,12 +299,12 @@ mod handlers {
             Ok(response) => match StatusCode::from_u16(response.status().into()) {
                 Ok(status) => match response.text().await {
                     Ok(content) => {
-                        debug!(logger, "SignerRelay: received response with status '{status}'"; "content" => &content);
+                        debug!(logger, "Received response with status '{status}'"; "content" => &content);
 
                         Ok(Box::new(warp::reply::with_status(content, status)))
                     }
                     Err(err) => {
-                        debug!(logger, "SignerRelay: received error"; "error" => ?err);
+                        debug!(logger, "Received error"; "error" => ?err);
                         Ok(Box::new(warp::reply::with_status(
                             format!("{err:?}"),
                             StatusCode::INTERNAL_SERVER_ERROR,
@@ -312,7 +312,7 @@ mod handlers {
                     }
                 },
                 Err(err) => {
-                    debug!(logger, "SignerRelay: failed to parse the returned status"; "error" => ?err);
+                    debug!(logger, "Failed to parse the returned status"; "error" => ?err);
                     Ok(Box::new(warp::reply::with_status(
                         format!("{err:?}"),
                         StatusCode::INTERNAL_SERVER_ERROR,
@@ -320,7 +320,7 @@ mod handlers {
                 }
             },
             Err(err) => {
-                debug!(logger, "SignerRelay: received error"; "error" => ?err);
+                debug!(logger, "Received error"; "error" => ?err);
                 Ok(Box::new(warp::reply::with_status(
                     format!("{err:?}"),
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/mithril-relay/src/repeater.rs
+++ b/mithril-relay/src/repeater.rs
@@ -36,7 +36,7 @@ impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
 
     /// Set the message to repeat
     pub async fn set_message(&self, message: M) {
-        debug!(self.logger, "MessageRepeater: set message"; "message" => format!("{:#?}", message));
+        debug!(self.logger, "MessageRepeater: set message"; "message" => #?message);
         *self.message.lock().await = Some(message);
         self.reset_next_repeat_at().await;
     }
@@ -52,7 +52,7 @@ impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
         tokio::time::sleep(wait_delay).await;
         match self.message.lock().await.as_ref() {
             Some(message) => {
-                debug!(self.logger, "MessageRepeater: repeat message"; "message" => format!("{:#?}", message));
+                debug!(self.logger, "MessageRepeater: repeat message"; "message" => #?message);
                 self.tx_message
                     .send(message.clone())
                     .map_err(|e| anyhow!(e))?

--- a/mithril-relay/src/repeater.rs
+++ b/mithril-relay/src/repeater.rs
@@ -1,5 +1,7 @@
 use anyhow::anyhow;
+use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
+use slog::Logger;
 use slog_scope::debug;
 use std::{fmt::Debug, sync::Arc, time::Duration};
 use tokio::{
@@ -13,16 +15,18 @@ pub struct MessageRepeater<M: Clone + Debug + Sync + Send + 'static> {
     tx_message: UnboundedSender<M>,
     delay: Duration,
     next_repeat_at: Arc<Mutex<Option<Instant>>>,
+    logger: Logger,
 }
 
 impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
     /// Factory for MessageRepeater
-    pub fn new(tx_message: UnboundedSender<M>, delay: Duration) -> Self {
+    pub fn new(tx_message: UnboundedSender<M>, delay: Duration, logger: &Logger) -> Self {
         Self {
             message: Arc::new(Mutex::new(None)),
             tx_message,
             delay,
             next_repeat_at: Arc::new(Mutex::new(None)),
+            logger: logger.new_with_component_name::<Self>(),
         }
     }
 
@@ -68,13 +72,15 @@ impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
 mod tests {
     use tokio::{sync::mpsc, time};
 
+    use crate::test_tools::TestLogger;
+
     use super::*;
 
     #[tokio::test]
     async fn should_repeat_message_when_exists() {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let delay = Duration::from_millis(100);
-        let repeater = MessageRepeater::new(tx, delay);
+        let repeater = MessageRepeater::new(tx, delay, &TestLogger::stdout());
 
         let message = "Hello, world!";
         repeater.set_message(message.to_string()).await;
@@ -88,7 +94,7 @@ mod tests {
     async fn should_repeat_message_when_exists_with_expected_delay() {
         let (tx, _rx) = mpsc::unbounded_channel();
         let delay = Duration::from_secs(1);
-        let repeater = MessageRepeater::new(tx, delay);
+        let repeater = MessageRepeater::new(tx, delay, &TestLogger::stdout());
 
         let message = "Hello, world!";
         repeater.set_message(message.to_string()).await;
@@ -105,7 +111,7 @@ mod tests {
     async fn should_do_nothing_when_message_not_exists() {
         let (tx, rx) = mpsc::unbounded_channel::<String>();
         let delay = Duration::from_millis(100);
-        let repeater = MessageRepeater::new(tx, delay);
+        let repeater = MessageRepeater::new(tx, delay, &TestLogger::stdout());
 
         repeater.repeat_message().await.unwrap();
 
@@ -116,7 +122,7 @@ mod tests {
     async fn should_do_nothing_when_message_not_exists_with_expected_delay() {
         let (tx, _rx) = mpsc::unbounded_channel::<String>();
         let delay = Duration::from_secs(1);
-        let repeater = MessageRepeater::new(tx, delay);
+        let repeater = MessageRepeater::new(tx, delay, &TestLogger::stdout());
 
         let result = tokio::select! {
             _ = time::sleep(delay - Duration::from_millis(100)) => {Err(anyhow!("Timeout"))}

--- a/mithril-relay/src/repeater.rs
+++ b/mithril-relay/src/repeater.rs
@@ -30,13 +30,13 @@ impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
     }
 
     async fn reset_next_repeat_at(&self) {
-        debug!(self.logger, "MessageRepeater: reset next_repeat_at");
+        debug!(self.logger, "Reset next_repeat_at");
         *self.next_repeat_at.lock().await = Some(Instant::now() + self.delay);
     }
 
     /// Set the message to repeat
     pub async fn set_message(&self, message: M) {
-        debug!(self.logger, "MessageRepeater: set message"; "message" => #?message);
+        debug!(self.logger, "Set message"; "message" => #?message);
         *self.message.lock().await = Some(message);
         self.reset_next_repeat_at().await;
     }
@@ -52,13 +52,13 @@ impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
         tokio::time::sleep(wait_delay).await;
         match self.message.lock().await.as_ref() {
             Some(message) => {
-                debug!(self.logger, "MessageRepeater: repeat message"; "message" => #?message);
+                debug!(self.logger, "Repeat message"; "message" => #?message);
                 self.tx_message
                     .send(message.clone())
                     .map_err(|e| anyhow!(e))?
             }
             None => {
-                debug!(self.logger, "MessageRepeater: no message to repeat");
+                debug!(self.logger, "No message to repeat");
             }
         }
         self.reset_next_repeat_at().await;

--- a/mithril-relay/tests/register_signer_signature.rs
+++ b/mithril-relay/tests/register_signer_signature.rs
@@ -140,7 +140,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
             event =  p2p_client1.tick_peer() => {
                 if let Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) = p2p_client1.convert_peer_event_to_message(event.unwrap().unwrap())
                 {
-                    info!("Test: client1 consumed signer registration: {signer_message_received:#?}");
+                    info!("Test: client1 consumed signer registration"; "message" => #?signer_message_received);
                     assert_eq!(signer_message_sent, signer_message_received);
                     total_peers_has_received_message += 1
                 }
@@ -148,7 +148,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
             event =  p2p_client2.tick_peer() => {
                 if let Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) = p2p_client2.convert_peer_event_to_message(event.unwrap().unwrap())
                 {
-                    info!("Test: client2 consumed signer registration: {signer_message_received:#?}");
+                    info!("Test: client2 consumed signer registration"; "message" => #?signer_message_received);
                     assert_eq!(signer_message_sent, signer_message_received);
                     total_peers_has_received_message += 1
                 }
@@ -185,7 +185,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
             event =  p2p_client1.tick_peer() => {
                 if let Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) = p2p_client1.convert_peer_event_to_message(event.unwrap().unwrap())
                 {
-                    info!("Test: client1 consumed signature: {signature_message_received:#?}");
+                    info!("Test: client1 consumed signature"; "message" => #?signature_message_received);
                     assert_eq!(signature_message_sent, signature_message_received);
                     total_peers_has_received_message += 1
                 }
@@ -193,7 +193,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
             event =  p2p_client2.tick_peer() => {
                 if let Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) = p2p_client2.convert_peer_event_to_message(event.unwrap().unwrap())
                 {
-                    info!("Test: client2 consumed signature: {signature_message_received:#?}");
+                    info!("Test: client2 consumed signature"; "message" => #?signature_message_received);
                     assert_eq!(signature_message_sent, signature_message_received);
                     total_peers_has_received_message += 1
                 }

--- a/mithril-relay/tests/register_signer_signature.rs
+++ b/mithril-relay/tests/register_signer_signature.rs
@@ -108,7 +108,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     let signer_relay_thread = tokio::spawn(async move {
         loop {
             if let Err(err) = signer_relay.tick().await {
-                error!("RelaySigner: tick error"; "error" => format!("{err:#?}"));
+                error!("RelaySigner: tick error"; "error" => #?err);
             }
         }
     });

--- a/mithril-relay/tests/register_signer_signature.rs
+++ b/mithril-relay/tests/register_signer_signature.rs
@@ -28,7 +28,8 @@ fn build_logger(log_level: Level) -> Logger {
 #[tokio::test]
 async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     let log_level = Level::Info;
-    let _guard = slog_scope::set_global_logger(build_logger(log_level));
+    let logger = build_logger(log_level);
+    let _guard = slog_scope::set_global_logger(logger.clone());
 
     let total_p2p_client = 2;
     let total_peers = 1 + total_p2p_client;
@@ -41,6 +42,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
         &server_port,
         &aggregator_endpoint,
         &signer_repeater_delay,
+        &logger,
     )
     .await
     .expect("Relay start failed");
@@ -48,7 +50,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     let relay_peer_address = signer_relay.peer_address().unwrap();
     info!("Test: relay_address is '{relay_address:?}'");
 
-    let mut p2p_client1 = PassiveRelay::start(&addr)
+    let mut p2p_client1 = PassiveRelay::start(&addr, &logger)
         .await
         .expect("P2P client start failed");
     p2p_client1
@@ -56,7 +58,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
         .dial(relay_peer_address.clone())
         .expect("P2P client dial to the relay should not fail");
 
-    let mut p2p_client2 = PassiveRelay::start(&addr)
+    let mut p2p_client2 = PassiveRelay::start(&addr, &logger)
         .await
         .expect("P2P client start failed");
     p2p_client2


### PR DESCRIPTION
## Content

This PR refactor the log usage in `mithril-relay`:
- A dedicated child logger is used for each service
- Each child logger is tagged with its service name in order to identify quickly a log source without the need of a prefix in the log message.
- Capitalize the first letters of all "functional" logs.
- Remove `slog_scope` to enforce the usage of a name tagged child logger.
- Move away from the log message into a property huge structure (ie: some logs joined errors into their message, those errors have been moved to a "error" property).

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Closes #1981
