### PR TITLE
 Fix clippy warnings from Rust 1.82 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.40"
+version = "0.4.41"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.40"
+version = "0.4.41"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/entities.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/entities.rs
@@ -159,22 +159,19 @@ impl Reporter {
     }
 
     pub fn stop(&mut self) {
-        match &self.current_timing {
-            Some((phase, instant)) => {
-                let phase = if self.number_of_clients == 0 {
-                    format!("{phase} - without clients")
-                } else {
-                    format!("{phase} - with clients")
-                };
-                let timing = Timing {
-                    phase: phase.clone(),
-                    duration: instant.elapsed(),
-                };
+        if let Some((phase, instant)) = &self.current_timing {
+            let phase = if self.number_of_clients == 0 {
+                format!("{phase} - without clients")
+            } else {
+                format!("{phase} - with clients")
+            };
+            let timing = Timing {
+                phase: phase.clone(),
+                duration: instant.elapsed(),
+            };
 
-                self.timings.push(timing);
-                self.current_timing = None;
-            }
-            None => (),
+            self.timings.push(timing);
+            self.current_timing = None;
         }
     }
 


### PR DESCRIPTION
## Content

This PR fixes clippy warning added in [rust 1.82](https://releases.rs/docs/1.82.0/) _(released on: 17 October, 2024)_.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
