### PR TITLE
Upgrade mac runner + Fix incorrect param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-14, windows-latest]
+        os: [macos-14, macos-14-large, windows-latest]
 
         include:
           # Only build client on windows & mac
-          - os: macos-12
+          - os: macos-14
             binaries-build-args: --bin mithril-client --features bundle_openssl
             libraries-build-args: --package mithril-stm --package mithril-client --features full,unstable
-          - os: macos-14
+          - os: macos-14-large
             binaries-build-args: --bin mithril-client --features bundle_openssl
             libraries-build-args: --package mithril-stm --package mithril-client --features full,unstable
           - os: windows-latest
@@ -169,15 +169,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-14, windows-latest]
+        os: [ubuntu-22.04, macos-14, macos-14-large, windows-latest]
 
         include:
           - os: ubuntu-22.04
             test-args: --features full,unstable --workspace
           # Only test client on windows & mac (since its the only binaries supported for those os for now)
-          - os: macos-12
-            test-args: --package mithril-client --package mithril-client-cli --features full,unstable
           - os: macos-14
+            test-args: --package mithril-client --package mithril-client-cli --features full,unstable
+          - os: macos-14-large
             test-args: --package mithril-client --package mithril-client-cli --features full,unstable
           - os: windows-latest
             test-args: --package mithril-client --package mithril-client-cli --features full,unstable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,7 +873,7 @@ jobs:
         with:
           output: out/
           spec-file: ./openapi.yaml
-          token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish OpenAPI UI build
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-12, macos-14, windows-latest]
+        os: [ubuntu-22.04, macos-14, macos-14-large, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Content

This PR upgrades x86 mac os runners from macOs 12 to macOs 14 (following their upcoming removal) and fix an incorrect parameter name used with the action that build our open api static website.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

Closes #2016, #2017
