### PR TITLE
Fix: computation of the chaining of the certificates in tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.73"
+version = "0.4.74"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.73"
+version = "0.4.74"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_retriever.rs
+++ b/mithril-common/src/certificate_chain/certificate_retriever.rs
@@ -5,16 +5,13 @@ use thiserror::Error;
 
 use crate::{entities::Certificate, StdError};
 
-#[cfg(test)]
-use mockall::automock;
-
 /// [CertificateRetriever] related errors.
 #[derive(Debug, Error)]
 #[error("Error when retrieving certificate")]
 pub struct CertificateRetrieverError(#[source] pub StdError);
 
 /// CertificateRetriever is in charge of retrieving a [Certificate] given its hash
-#[cfg_attr(test, automock)]
+#[cfg_attr(test, mockall::automock)]
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait CertificateRetriever: Sync + Send {

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -524,7 +524,7 @@ mod tests {
     #[tokio::test]
     async fn test_verify_certificate_chain_ok() {
         let total_certificates = 15;
-        let certificates_per_epoch = 2;
+        let certificates_per_epoch = 1;
         let (fake_certificates, genesis_verifier) =
             setup_certificate_chain(total_certificates, certificates_per_epoch);
         let mut mock_certificate_retriever = MockCertificateRetrieverImpl::new();
@@ -551,7 +551,7 @@ mod tests {
     #[tokio::test]
     async fn test_verify_certificate_chain_ko() {
         let total_certificates = 15;
-        let certificates_per_epoch = 2;
+        let certificates_per_epoch = 1;
         let (mut fake_certificates, genesis_verifier) =
             setup_certificate_chain(total_certificates, certificates_per_epoch);
         let index_certificate_fail = (total_certificates / 2) as usize;

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -524,7 +524,7 @@ mod tests {
     #[tokio::test]
     async fn test_verify_certificate_chain_ok() {
         let total_certificates = 15;
-        let certificates_per_epoch = 1;
+        let certificates_per_epoch = 2;
         let (fake_certificates, genesis_verifier) =
             setup_certificate_chain(total_certificates, certificates_per_epoch);
         let mut mock_certificate_retriever = MockCertificateRetrieverImpl::new();
@@ -551,7 +551,7 @@ mod tests {
     #[tokio::test]
     async fn test_verify_certificate_chain_ko() {
         let total_certificates = 15;
-        let certificates_per_epoch = 1;
+        let certificates_per_epoch = 2;
         let (mut fake_certificates, genesis_verifier) =
             setup_certificate_chain(total_certificates, certificates_per_epoch);
         let index_certificate_fail = (total_certificates / 2) as usize;

--- a/mithril-common/src/certificate_chain/fake_certificate_retriever.rs
+++ b/mithril-common/src/certificate_chain/fake_certificate_retriever.rs
@@ -1,0 +1,77 @@
+//! A module used for a fake implementation of a certificate chain retriever
+//!
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+
+use crate::entities::Certificate;
+
+use super::{CertificateRetriever, CertificateRetrieverError};
+
+/// A fake [CertificateRetriever] that returns a [Certificate] given its hash
+pub struct FakeCertificaterRetriever {
+    certificates_map: RwLock<HashMap<String, Certificate>>,
+}
+
+impl FakeCertificaterRetriever {
+    /// Create a new [FakeCertificaterRetriever]
+    pub fn from_certificates(certificates: &[Certificate]) -> Self {
+        let certificates_map = certificates
+            .iter()
+            .map(|certificate| (certificate.hash.clone(), certificate.clone()))
+            .collect::<HashMap<_, _>>();
+        let certificates_map = RwLock::new(certificates_map);
+
+        Self { certificates_map }
+    }
+}
+
+#[async_trait]
+impl CertificateRetriever for FakeCertificaterRetriever {
+    async fn get_certificate_details(
+        &self,
+        certificate_hash: &str,
+    ) -> Result<Certificate, CertificateRetrieverError> {
+        let certificates_map = self.certificates_map.read().await;
+        certificates_map
+            .get(certificate_hash)
+            .cloned()
+            .ok_or_else(|| CertificateRetrieverError(anyhow!("Certificate not found")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_utils::fake_data;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn fake_certificate_retriever_retrieves_existing_certificate() {
+        let certificate = fake_data::certificate("certificate-hash-123".to_string());
+        let certificate_hash = certificate.hash.clone();
+        let certificate_retriever =
+            FakeCertificaterRetriever::from_certificates(&[certificate.clone()]);
+
+        let retrieved_certificate = certificate_retriever
+            .get_certificate_details(&certificate_hash)
+            .await
+            .expect("Should retrieve certificate");
+
+        assert_eq!(retrieved_certificate, certificate);
+    }
+
+    #[tokio::test]
+    async fn test_fake_certificate_fails_retrieving_unknow_certificate() {
+        let certificate = fake_data::certificate("certificate-hash-123".to_string());
+        let certificate_retriever = FakeCertificaterRetriever::from_certificates(&[certificate]);
+
+        let retrieved_certificate = certificate_retriever
+            .get_certificate_details("certificate-hash-not-found")
+            .await;
+
+        retrieved_certificate.expect_err("get_certificate_details shoudl fail");
+    }
+}

--- a/mithril-common/src/certificate_chain/mod.rs
+++ b/mithril-common/src/certificate_chain/mod.rs
@@ -3,9 +3,16 @@
 mod certificate_genesis;
 mod certificate_retriever;
 mod certificate_verifier;
+cfg_test_tools! {
+    mod fake_certificate_retriever;
+}
 
 pub use certificate_genesis::CertificateGenesisProducer;
 pub use certificate_retriever::{CertificateRetriever, CertificateRetrieverError};
 pub use certificate_verifier::{
     CertificateVerifier, CertificateVerifierError, MithrilCertificateVerifier,
 };
+
+cfg_test_tools! {
+    pub use fake_certificate_retriever::FakeCertificaterRetriever;
+}

--- a/mithril-common/src/test_utils/certificate_chain_builder.rs
+++ b/mithril-common/src/test_utils/certificate_chain_builder.rs
@@ -789,66 +789,59 @@ mod test {
 
     #[test]
     fn builds_certificate_chain_correctly_chained() {
-        fn create_fake_certificate(epoch: Epoch, index: u64) -> Certificate {
+        fn create_fake_certificate(epoch: Epoch, index_in_epoch: u64) -> Certificate {
             Certificate {
                 epoch,
-                signed_message: format!("certificate-{index}"),
+                signed_message: format!("certificate-{}-{index_in_epoch}", *epoch),
                 ..fake_data::certificate("cert-fake".to_string())
             }
         }
 
-        let certificate_1 = create_fake_certificate(Epoch(1), 1);
-        let certificate_2 = create_fake_certificate(Epoch(2), 2);
-        let certificate_3 = create_fake_certificate(Epoch(2), 3);
-        let certificate_4 = create_fake_certificate(Epoch(3), 4);
-        let certificate_5 = create_fake_certificate(Epoch(4), 5);
-        let certificate_6 = create_fake_certificate(Epoch(4), 6);
-        let certificate_7 = create_fake_certificate(Epoch(4), 7);
         let certificates = vec![
-            certificate_1,
-            certificate_2,
-            certificate_3,
-            certificate_4,
-            certificate_5,
-            certificate_6,
-            certificate_7,
+            create_fake_certificate(Epoch(1), 1),
+            create_fake_certificate(Epoch(2), 1),
+            create_fake_certificate(Epoch(2), 2),
+            create_fake_certificate(Epoch(3), 1),
+            create_fake_certificate(Epoch(4), 1),
+            create_fake_certificate(Epoch(4), 2),
+            create_fake_certificate(Epoch(4), 3),
         ];
 
         let mut certificates_chained =
             CertificateChainBuilder::default().compute_chained_certificates(certificates);
         certificates_chained.reverse();
 
-        let certificate_chained_1 = &certificates_chained[0];
-        let certificate_chained_2 = &certificates_chained[1];
-        let certificate_chained_3 = &certificates_chained[2];
-        let certificate_chained_4 = &certificates_chained[3];
-        let certificate_chained_5 = &certificates_chained[4];
-        let certificate_chained_6 = &certificates_chained[5];
-        let certificate_chained_7 = &certificates_chained[6];
-        assert_eq!("", certificate_chained_1.previous_hash);
+        let certificate_chained_1_1 = &certificates_chained[0];
+        let certificate_chained_2_1 = &certificates_chained[1];
+        let certificate_chained_2_2 = &certificates_chained[2];
+        let certificate_chained_3_1 = &certificates_chained[3];
+        let certificate_chained_4_1 = &certificates_chained[4];
+        let certificate_chained_4_2 = &certificates_chained[5];
+        let certificate_chained_4_3 = &certificates_chained[6];
+        assert_eq!("", certificate_chained_1_1.previous_hash);
         assert_eq!(
-            certificate_chained_2.previous_hash,
-            certificate_chained_1.hash
+            certificate_chained_2_1.previous_hash,
+            certificate_chained_1_1.hash
         );
         assert_eq!(
-            certificate_chained_3.previous_hash,
-            certificate_chained_2.hash
+            certificate_chained_2_2.previous_hash,
+            certificate_chained_2_1.hash
         );
         assert_eq!(
-            certificate_chained_4.previous_hash,
-            certificate_chained_2.hash
+            certificate_chained_3_1.previous_hash,
+            certificate_chained_2_1.hash
         );
         assert_eq!(
-            certificate_chained_5.previous_hash,
-            certificate_chained_4.hash
+            certificate_chained_4_1.previous_hash,
+            certificate_chained_3_1.hash
         );
         assert_eq!(
-            certificate_chained_6.previous_hash,
-            certificate_chained_5.hash
+            certificate_chained_4_2.previous_hash,
+            certificate_chained_4_1.hash
         );
         assert_eq!(
-            certificate_chained_7.previous_hash,
-            certificate_chained_5.hash
+            certificate_chained_4_3.previous_hash,
+            certificate_chained_4_1.hash
         );
     }
 


### PR DESCRIPTION
## Content

This PR includes a fix to the chaining computation of the certificate chain in tests:

The previous certificate is either:
- the first certificate of the previous epoch if the certificate is the first of the epoch
- otherwise the first certificate of the epoch

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

