### PR TITLE
Fix unneeded rescan when importing transactions in chunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Support for Prometheus metrics endpoint in aggregator
 
+- Fix an issue that caused unnecessary re-scan of the Cardano chain when importing transactions.
+
 - Crates versions:
 
 | Crate | Version |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.72"
+version = "0.4.73"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.202"
+version = "0.2.203"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.87"
+version = "0.5.88"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.72"
+version = "0.4.73"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
+++ b/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
@@ -26,6 +26,7 @@ pub struct ChainReaderBlockStreamer {
     from: ChainPoint,
     until: BlockNumber,
     max_roll_forwards_per_poll: usize,
+    last_polled_chain_point: Option<ChainPoint>,
     logger: Logger,
 }
 
@@ -42,6 +43,7 @@ impl BlockStreamer for ChainReaderBlockStreamer {
                 Some(BlockStreamerNextAction::ChainBlockNextAction(
                     ChainBlockNextAction::RollForward { parsed_block },
                 )) => {
+                    self.last_polled_chain_point = Some(ChainPoint::from(&parsed_block));
                     let parsed_block_number = parsed_block.block_number;
                     roll_forwards.push(parsed_block);
                     if roll_forwards.len() >= self.max_roll_forwards_per_poll
@@ -55,6 +57,7 @@ impl BlockStreamer for ChainReaderBlockStreamer {
                         chain_point: rollback_chain_point,
                     },
                 )) => {
+                    self.last_polled_chain_point = Some(rollback_chain_point.clone());
                     let rollback_slot_number = rollback_chain_point.slot_number;
                     let index_rollback = roll_forwards
                         .iter()
@@ -82,15 +85,19 @@ impl BlockStreamer for ChainReaderBlockStreamer {
                     continue;
                 }
                 None => {
-                    if roll_forwards.is_empty() {
-                        return Ok(None);
+                    return if roll_forwards.is_empty() {
+                        Ok(None)
                     } else {
                         chain_scanned_blocks = ChainScannedBlocks::RollForwards(roll_forwards);
-                        return Ok(Some(chain_scanned_blocks));
+                        Ok(Some(chain_scanned_blocks))
                     }
                 }
             }
         }
+    }
+
+    fn latest_polled_chain_point(&self) -> Option<ChainPoint> {
+        self.last_polled_chain_point.clone()
     }
 }
 
@@ -113,6 +120,7 @@ impl ChainReaderBlockStreamer {
             from,
             until,
             max_roll_forwards_per_poll,
+            last_polled_chain_point: None,
             logger: logger.new_with_component_name::<Self>(),
         })
     }
@@ -211,6 +219,7 @@ mod tests {
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
+        assert_eq!(None, block_streamer.latest_polled_chain_point());
 
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
             chain_reader,
@@ -231,6 +240,14 @@ mod tests {
                 Vec::<&str>::new(),
             )])),
             scanned_blocks
+        );
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(
+                SlotNumber(100),
+                until_block_number,
+                "hash-2",
+            ))
         );
     }
 
@@ -285,6 +302,11 @@ mod tests {
         let chain_reader_total_remaining_next_actions =
             chain_reader.lock().await.get_total_remaining_next_actions();
         assert_eq!(1, chain_reader_total_remaining_next_actions);
+
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(20), BlockNumber(2), "hash-2"))
+        );
     }
 
     #[tokio::test]
@@ -326,6 +348,10 @@ mod tests {
                 ScannedBlock::new("hash-2", BlockNumber(2), SlotNumber(20), Vec::<&str>::new())
             ])),
             scanned_blocks,
+        );
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(20), BlockNumber(2), "hash-2"))
         );
     }
 
@@ -376,6 +402,10 @@ mod tests {
             ])),
             scanned_blocks,
         );
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(20), BlockNumber(2), "hash-2"))
+        );
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(
@@ -387,9 +417,17 @@ mod tests {
             ),])),
             scanned_blocks,
         );
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(30), BlockNumber(3), "hash-3"))
+        );
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(30), BlockNumber(3), "hash-3"))
+        );
     }
 
     #[tokio::test]
@@ -415,6 +453,7 @@ mod tests {
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
+        assert_eq!(block_streamer.latest_polled_chain_point(), None);
     }
 
     #[tokio::test]
@@ -422,7 +461,7 @@ mod tests {
     {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollBackward {
-                chain_point: ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-123"),
+                chain_point: ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-10"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -441,9 +480,17 @@ mod tests {
             Some(ChainScannedBlocks::RollBackward(SlotNumber(100))),
             scanned_blocks,
         );
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-10"))
+        );
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-10"))
+        );
     }
 
     #[tokio::test]
@@ -497,6 +544,10 @@ mod tests {
             ])),
             scanned_blocks,
         );
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(9), BlockNumber(90), "hash-9",))
+        );
     }
 
     #[tokio::test]
@@ -539,6 +590,10 @@ mod tests {
             Some(ChainScannedBlocks::RollBackward(SlotNumber(3))),
             scanned_blocks,
         );
+        assert_eq!(
+            block_streamer.latest_polled_chain_point(),
+            Some(ChainPoint::new(SlotNumber(3), BlockNumber(30), "hash-3",))
+        );
     }
 
     #[tokio::test]
@@ -557,5 +612,21 @@ mod tests {
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
 
         assert_eq!(scanned_blocks, None);
+    }
+
+    #[tokio::test]
+    async fn test_latest_polled_chain_point_is_none_if_nothing_was_polled() {
+        let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![])));
+        let block_streamer = ChainReaderBlockStreamer::try_new(
+            chain_reader,
+            None,
+            BlockNumber(1),
+            MAX_ROLL_FORWARDS_PER_POLL,
+            TestLogger::stdout(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(block_streamer.latest_polled_chain_point(), None);
     }
 }

--- a/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
+++ b/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
@@ -52,9 +52,10 @@ impl BlockStreamer for ChainReaderBlockStreamer {
                 }
                 Some(BlockStreamerNextAction::ChainBlockNextAction(
                     ChainBlockNextAction::RollBackward {
-                        slot_number: rollback_slot_number,
+                        chain_point: rollback_chain_point,
                     },
                 )) => {
+                    let rollback_slot_number = rollback_chain_point.slot_number;
                     let index_rollback = roll_forwards
                         .iter()
                         .position(|block| block.slot_number == rollback_slot_number);
@@ -139,8 +140,9 @@ impl ChainReaderBlockStreamer {
                 }
             }
             Some(ChainBlockNextAction::RollBackward {
-                slot_number: rollback_slot_number,
+                chain_point: rollback_chain_point,
             }) => {
+                let rollback_slot_number = rollback_chain_point.slot_number;
                 trace!(
                     self.logger,
                     "Received a RollBackward({rollback_slot_number:?})"
@@ -150,7 +152,7 @@ impl ChainReaderBlockStreamer {
                 } else {
                     BlockStreamerNextAction::ChainBlockNextAction(
                         ChainBlockNextAction::RollBackward {
-                            slot_number: rollback_slot_number,
+                            chain_point: rollback_chain_point,
                         },
                     )
                 };
@@ -394,7 +396,7 @@ mod tests {
     async fn test_parse_expected_nothing_when_rollbackward_on_same_point() {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollBackward {
-                slot_number: SlotNumber(100),
+                chain_point: ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-123"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -420,7 +422,7 @@ mod tests {
     {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollBackward {
-                slot_number: SlotNumber(100),
+                chain_point: ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-123"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -473,7 +475,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                slot_number: SlotNumber(9),
+                chain_point: ChainPoint::new(SlotNumber(9), BlockNumber(90), "hash-9"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -518,7 +520,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                slot_number: SlotNumber(3),
+                chain_point: ChainPoint::new(SlotNumber(3), BlockNumber(30), "hash-3"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(

--- a/mithril-common/src/cardano_block_scanner/interface.rs
+++ b/mithril-common/src/cardano_block_scanner/interface.rs
@@ -65,6 +65,9 @@ pub enum ChainScannedBlocks {
 pub trait BlockStreamer: Sync + Send {
     /// Stream the next available blocks
     async fn poll_next(&mut self) -> StdResult<Option<ChainScannedBlocks>>;
+
+    /// Get the latest polled chain point
+    fn latest_polled_chain_point(&self) -> Option<ChainPoint>;
 }
 
 cfg_test_tools! {

--- a/mithril-common/src/cardano_block_scanner/scanned_block.rs
+++ b/mithril-common/src/cardano_block_scanner/scanned_block.rs
@@ -1,6 +1,8 @@
 use pallas_traverse::MultiEraBlock;
 
-use crate::entities::{BlockHash, BlockNumber, CardanoTransaction, SlotNumber, TransactionHash};
+use crate::entities::{
+    BlockHash, BlockNumber, CardanoTransaction, ChainPoint, SlotNumber, TransactionHash,
+};
 
 /// A block scanned from a Cardano database
 #[derive(Debug, Clone, PartialEq)]
@@ -65,5 +67,15 @@ impl ScannedBlock {
                 )
             })
             .collect::<Vec<_>>()
+    }
+}
+
+impl From<&ScannedBlock> for ChainPoint {
+    fn from(scanned_block: &ScannedBlock) -> Self {
+        ChainPoint::new(
+            scanned_block.slot_number,
+            scanned_block.block_number,
+            scanned_block.block_hash.clone(),
+        )
     }
 }

--- a/mithril-common/src/chain_reader/entity.rs
+++ b/mithril-common/src/chain_reader/entity.rs
@@ -1,4 +1,4 @@
-use crate::{cardano_block_scanner::ScannedBlock, entities::SlotNumber};
+use crate::{cardano_block_scanner::ScannedBlock, entities::ChainPoint};
 
 /// The action that indicates what to do next when scanning the chain
 #[derive(Debug, Clone, PartialEq)]
@@ -10,7 +10,7 @@ pub enum ChainBlockNextAction {
     },
     /// RollBackward event (we are on an incorrect fork, we need to get back a point to roll forward again)
     RollBackward {
-        /// The rollback slot number in the chain to read (as a new valid slot number to read from on the main chain, which has already been seen)
-        slot_number: SlotNumber,
+        /// The rollback chain point in the chain to read (as a new valid chain point to read from on the main chain, which has already been seen)
+        chain_point: ChainPoint,
     },
 }

--- a/mithril-common/src/chain_reader/fake_chain_reader.rs
+++ b/mithril-common/src/chain_reader/fake_chain_reader.rs
@@ -71,7 +71,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                slot_number: build_chain_point(1).slot_number,
+                chain_point: build_chain_point(1),
             },
         ];
 

--- a/mithril-common/src/chain_reader/pallas_chain_reader.rs
+++ b/mithril-common/src/chain_reader/pallas_chain_reader.rs
@@ -86,9 +86,7 @@ impl PallasChainReader {
             }
             NextResponse::RollBackward(rollback_point, _) => {
                 let chain_point = ChainPoint::from(rollback_point);
-                Ok(Some(ChainBlockNextAction::RollBackward {
-                    slot_number: chain_point.slot_number,
-                }))
+                Ok(Some(ChainBlockNextAction::RollBackward { chain_point }))
             }
             NextResponse::Await => Ok(None),
         }
@@ -280,8 +278,8 @@ mod tests {
         let (_, client_res) = tokio::join!(server, client);
         let chain_block = client_res.expect("Client failed to get next chain block");
         match chain_block {
-            ChainBlockNextAction::RollBackward { slot_number } => {
-                assert_eq!(slot_number, get_fake_chain_point_backwards().slot_number);
+            ChainBlockNextAction::RollBackward { chain_point } => {
+                assert_eq!(chain_point, get_fake_chain_point_backwards());
             }
             _ => panic!("Unexpected chain block action"),
         }

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -17,7 +17,7 @@ use mockall::automock;
 #[cfg_attr(test, automock)]
 #[async_trait]
 pub trait TransactionsImporter: Send + Sync {
-    /// Returns all transactions up to the given beacon
+    /// Import all transactions up to the given beacon into the system
     async fn import(&self, up_to_beacon: BlockNumber) -> StdResult<()>;
 }
 

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.202"
+version = "0.2.203"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR fix the issue described in #2021.

To do so the way that the importer obtains its starting point change:
- Before it would compute it by getting data from the highest stored transactions in database, this caused the issue since in test networks there may be huge ranges of blocks without transactions.
- Now if keep stored the last `ChainPoint` that was polled by its block streamer after each import, so it can be used as the next import start point, solving the issue.

### Curated logs from the e2e before the change

The same start block number is used repeatedly 
```json
{ "msg": "Retrieving Cardano transactions between block_number '0' and '150'" }
{ "msg": "Retrieving Cardano transactions between block_number '0' and '300'" }
{ "msg": "Retrieving Cardano transactions between block_number '254' and '419'" }
{ "msg": "Retrieving Cardano transactions between block_number '341' and '434'" }
{ "msg": "Retrieving Cardano transactions between block_number '341' and '449'" }
{ "msg": "Retrieving Cardano transactions between block_number '341' and '449'" }
{ "msg": "Retrieving Cardano transactions between block_number '341' and '464'" }
```

### Curated logs from the e2e after the change

No start block number is used more than once 
```json
{ "msg": "Retrieving Cardano transactions between block_number '0' and '150'" }
{ "msg": "Retrieving Cardano transactions between block_number '150' and '300'" }
{ "msg": "Retrieving Cardano transactions between block_number '300' and '450'" }
{ "msg": "Retrieving Cardano transactions between block_number '450' and '569'" }
{ "msg": "Retrieving Cardano transactions between block_number '569' and '584'" }
{ "msg": "Retrieving Cardano transactions between block_number '584' and '599'" }
{ "msg": "Retrieving Cardano transactions between block_number '599' and '614'" }
``` 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Closes #2021
