### PR TITLE
Fix: `clap` arguments are always overriding configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.85"
+version = "0.5.86"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.85"
+version = "0.5.86"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -87,31 +87,30 @@ impl Source for ServeCommand {
                 ),
             );
         }
-        result.insert(
-            "disable_digests_cache".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(self.disable_digests_cache),
-            ),
-        );
-        result.insert(
-            "reset_digests_cache".to_string(),
-            Value::new(Some(&namespace), ValueKind::from(self.reset_digests_cache)),
-        );
-        result.insert(
-            "allow_unparsable_block".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(self.allow_unparsable_block),
-            ),
-        );
-        result.insert(
-            "enable_metrics_server".to_string(),
-            Value::new(
-                Some(&namespace),
-                ValueKind::from(self.enable_metrics_server),
-            ),
-        );
+        if self.disable_digests_cache {
+            result.insert(
+                "disable_digests_cache".to_string(),
+                Value::new(Some(&namespace), ValueKind::from(true)),
+            );
+        };
+        if self.reset_digests_cache {
+            result.insert(
+                "reset_digests_cache".to_string(),
+                Value::new(Some(&namespace), ValueKind::from(true)),
+            );
+        }
+        if self.allow_unparsable_block {
+            result.insert(
+                "allow_unparsable_block".to_string(),
+                Value::new(Some(&namespace), ValueKind::from(true)),
+            );
+        };
+        if self.enable_metrics_server {
+            result.insert(
+                "enable_metrics_server".to_string(),
+                Value::new(Some(&namespace), ValueKind::from(true)),
+            );
+        };
         if let Some(metrics_server_ip) = self.metrics_server_ip.clone() {
             result.insert(
                 "metrics_server_ip".to_string(),


### PR DESCRIPTION
## Content

This PR includes a fix that prevents `clap` arguments from systematically overriding the configuration with boolean arguments.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #1980 
