### PR TITLE
Fix: rename `certificate_total_produced_since_startup` metric name in aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.86"
+version = "0.5.87"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.86"
+version = "0.5.87"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/metrics/service.rs
+++ b/mithril-aggregator/src/metrics/service.rs
@@ -41,7 +41,7 @@ build_metrics_service!(
         "Number of signature registrations received since startup on a Mithril aggregator node"
     ),
     certificate_total_produced_since_startup:MetricCounter(
-        "mithril_aggregator_certificate_detail_total_produced_since_startup_counter",
+        "mithril_aggregator_certificate_total_produced_since_startup_counter",
         "Number of certificates produced since startup on a Mithril aggregator node"
     ),
     artifact_cardano_db_total_produced_since_startup:MetricCounter(


### PR DESCRIPTION
## Content

This PR includes the renaming of `certificate_total_produced_since_startup` metric (leftover related to the original name).

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #1980 
