### PR TITLE
Fix: remove `_counter` suffix from aggregator metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.87"
+version = "0.5.89"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.88"
+version = "0.5.89"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/metrics/service.rs
+++ b/mithril-aggregator/src/metrics/service.rs
@@ -5,67 +5,67 @@ use mithril_metric::metric::{MetricCollector, MetricCounter};
 build_metrics_service!(
     MetricsService,
     certificate_detail_total_served_since_startup:MetricCounter(
-        "mithril_aggregator_certificate_detail_total_served_since_startup_counter",
+        "mithril_aggregator_certificate_detail_total_served_since_startup",
         "Number of certificate details served since startup on a Mithril aggregator node"
     ),
     artifact_detail_cardano_db_total_served_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_detail_cardano_db_total_served_since_startup_counter",
+        "mithril_aggregator_artifact_detail_cardano_db_total_served_since_startup",
         "Number of Cardano db artifact details served since startup on a Mithril aggregator node"
     ),
     artifact_detail_mithril_stake_distribution_total_served_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_detail_mithril_stake_distribution_total_served_since_startup_counter",
+        "mithril_aggregator_artifact_detail_mithril_stake_distribution_total_served_since_startup",
         "Number of Mithril stake distribution artifact details served since startup on a Mithril aggregator node"
     ),
     artifact_detail_cardano_stake_distribution_total_served_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_detail_cardano_stake_distribution_total_served_since_startup_counter",
+        "mithril_aggregator_artifact_detail_cardano_stake_distribution_total_served_since_startup",
         "Number of Cardano stake distribution artifact details served since startup on a Mithril aggregator node"
     ),
     artifact_detail_cardano_transaction_total_served_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_detail_cardano_transaction_total_served_since_startup_counter",
+        "mithril_aggregator_artifact_detail_cardano_transaction_total_served_since_startup",
         "Number of Cardano transaction artifact details served since startup on a Mithril aggregator node"
     ),
     proof_cardano_transaction_total_proofs_served_since_startup:MetricCounter(
-        "mithril_aggregator_proof_cardano_transaction_total_proofs_served_since_startup_counter",
+        "mithril_aggregator_proof_cardano_transaction_total_proofs_served_since_startup",
         "Number of Cardano transaction proofs served since startup on a Mithril aggregator node"
     ),
     proof_cardano_transaction_total_transactions_served_since_startup:MetricCounter(
-        "mithril_aggregator_proof_cardano_transaction_total_transactions_served_since_startup_counter",
+        "mithril_aggregator_proof_cardano_transaction_total_transactions_served_since_startup",
         "Number of Cardano transaction hashes requested for proof since startup on a Mithril aggregator node"
     ),
     signer_registration_total_received_since_startup:MetricCounter(
-        "mithril_aggregator_signer_registration_total_received_since_startup_counter",
+        "mithril_aggregator_signer_registration_total_received_since_startup",
         "Number of signer registrations received since startup on a Mithril aggregator node"
     ),
     signature_registration_total_received_since_startup:MetricCounter(
-        "mithril_aggregator_signature_registration_total_received_since_startup_counter",
+        "mithril_aggregator_signature_registration_total_received_since_startup",
         "Number of signature registrations received since startup on a Mithril aggregator node"
     ),
     certificate_total_produced_since_startup:MetricCounter(
-        "mithril_aggregator_certificate_total_produced_since_startup_counter",
+        "mithril_aggregator_certificate_total_produced_since_startup",
         "Number of certificates produced since startup on a Mithril aggregator node"
     ),
     artifact_cardano_db_total_produced_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_cardano_db_total_produced_since_startup_counter",
+        "mithril_aggregator_artifact_cardano_db_total_produced_since_startup",
         "Number of Cardano db artifacts produced since startup on a Mithril aggregator node"
     ),
     artifact_mithril_stake_distribution_total_produced_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_mithril_stake_distribution_total_produced_since_startup_counter",
+        "mithril_aggregator_artifact_mithril_stake_distribution_total_produced_since_startup",
         "Number of Mithril stake distribution artifacts produced since startup on a Mithril aggregator node"
     ),
     artifact_cardano_stake_distribution_total_produced_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_cardano_stake_distribution_total_produced_since_startup_counter",
+        "mithril_aggregator_artifact_cardano_stake_distribution_total_produced_since_startup",
         "Number of Cardano stake distribution artifacts produced since startup on a Mithril aggregator node"
     ),
     artifact_cardano_transaction_total_produced_since_startup:MetricCounter(
-        "mithril_aggregator_artifact_cardano_transaction_total_produced_since_startup_counter",
+        "mithril_aggregator_artifact_cardano_transaction_total_produced_since_startup",
         "Number of Cardano transaction artifacts produced since startup on a Mithril aggregator node"
     ),
     runtime_cycle_success_since_startup:MetricCounter(
-        "mithril_aggregator_runtime_cycle_success_since_startup_counter",
+        "mithril_aggregator_runtime_cycle_success_since_startup",
         "Number of successful runtime cycles since startup on a Mithril aggregator"
     ),
     runtime_cycle_total_since_startup:MetricCounter(
-        "mithril_aggregator_runtime_cycle_total_since_startup_counter",
+        "mithril_aggregator_runtime_cycle_total_since_startup",
         "Number of runtime cycles since startup on a Mithril aggregator"
     )
 


### PR DESCRIPTION
## Content

This PR includes a renaming of aggregator metrics, removing the `_counter` suffix.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #1980 
