### PR TITLE
Fix: ensure epoch consistency during epoch changes when signer is signing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.203"
+version = "0.2.204"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.203"
+version = "0.2.204"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -373,7 +373,6 @@ impl<'a> DependenciesBuilder<'a> {
             self.root_logger(),
         ));
         let certifier = Arc::new(SignerCertifierService::new(
-            ticker_service.clone(),
             signed_beacon_repository,
             Arc::new(SignerSignedEntityConfigProvider::new(
                 network,

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -75,6 +75,11 @@ impl Display for SignerState {
     }
 }
 
+enum EpochStatus {
+    NewEpoch(Epoch),
+    Unchanged(TimePoint),
+}
+
 /// The state machine is responsible of the execution of the signer automate.
 pub struct StateMachine {
     state: Mutex<SignerState>,
@@ -146,7 +151,7 @@ impl StateMachine {
                 *state = self.transition_from_init_to_unregistered().await?;
             }
             SignerState::Unregistered { epoch } => {
-                if let Some(new_epoch) = self.has_epoch_changed(*epoch).await? {
+                if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(*epoch).await? {
                     info!(
                         self.logger,
                         "→ Epoch has changed, transiting to Unregistered"
@@ -184,7 +189,7 @@ impl StateMachine {
                 }
             }
             SignerState::RegisteredNotAbleToSign { epoch } => {
-                if let Some(new_epoch) = self.has_epoch_changed(*epoch).await? {
+                if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(*epoch).await? {
                     info!(
                         self.logger,
                         " → New Epoch detected, transiting to Unregistered"
@@ -198,7 +203,7 @@ impl StateMachine {
             }
 
             SignerState::ReadyToSign { epoch } => match self.has_epoch_changed(*epoch).await? {
-                Some(new_epoch) => {
+                EpochStatus::NewEpoch(new_epoch) => {
                     info!(
                         self.logger,
                         "→ Epoch has changed, transiting to Unregistered"
@@ -207,7 +212,7 @@ impl StateMachine {
                         .transition_from_ready_to_sign_to_unregistered(new_epoch)
                         .await?;
                 }
-                None => {
+                EpochStatus::Unchanged(_timepoint) => {
                     let beacon_to_sign = self.runner.get_beacon_to_sign().await.map_err(|e| {
                         RuntimeError::KeepState {
                             message: "could not fetch the beacon to sign".to_string(),
@@ -240,16 +245,16 @@ impl StateMachine {
         Ok(())
     }
 
-    /// Return the new epoch if the epoch is different than the given one.
-    async fn has_epoch_changed(&self, epoch: Epoch) -> Result<Option<Epoch>, RuntimeError> {
+    /// Return the new epoch if the epoch is different than the given one, otherwise return the current time point.
+    async fn has_epoch_changed(&self, epoch: Epoch) -> Result<EpochStatus, RuntimeError> {
         let current_time_point = self
             .get_current_time_point("checking if epoch has changed")
             .await?;
 
         if current_time_point.epoch > epoch {
-            Ok(Some(current_time_point.epoch))
+            Ok(EpochStatus::NewEpoch(current_time_point.epoch))
         } else {
-            Ok(None)
+            Ok(EpochStatus::Unchanged(current_time_point))
         }
     }
 

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -261,7 +261,6 @@ impl StateMachineTester {
         let signed_beacon_repository =
             Arc::new(SignedBeaconRepository::new(sqlite_connection.clone(), None));
         let certifier = Arc::new(SignerCertifierService::new(
-            ticker_service.clone(),
             signed_beacon_repository.clone(),
             Arc::new(SignerSignedEntityConfigProvider::new(
                 network,


### PR DESCRIPTION
## Content

This PR includes a fix that was triggered by flakiness failures on the CI.
The problem occurred when there was an epoch change after the signer had already begun its signature process.
To resolve this, the current epoch is now passed as a parameter when the signer retrieves the beacon to sign, instead of retrieving it with the ticker service, ensuring consistency throughout the signature process.

This fixes all the CI errors such as:
`Mithril End to End test in failed: Minimum expected mithril stake distribution epoch not reached : 18 < 20`

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2044 
