### PR TITLE
Refactor ChainPoint conversion from pallas Point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.90"
+version = "0.5.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3709,7 +3709,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.204"
+version = "0.2.205"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.90"
+version = "0.5.91"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use slog::{debug, Logger};
 use tokio::{runtime::Handle, sync::Mutex, task};
 
-use mithril_common::cardano_block_scanner::{BlockScanner, ChainScannedBlocks};
+use mithril_common::cardano_block_scanner::{BlockScanner, ChainScannedBlocks, RawCardanoPoint};
 use mithril_common::crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory};
 use mithril_common::entities::{
     BlockNumber, BlockRange, CardanoTransaction, ChainPoint, SlotNumber,
@@ -56,7 +56,7 @@ pub trait TransactionStore: Send + Sync {
 pub struct CardanoTransactionsImporter {
     block_scanner: Arc<dyn BlockScanner>,
     transaction_store: Arc<dyn TransactionStore>,
-    latest_polled_chain_point: Arc<Mutex<Option<ChainPoint>>>,
+    last_polled_point: Arc<Mutex<Option<RawCardanoPoint>>>,
     logger: Logger,
 }
 
@@ -70,47 +70,52 @@ impl CardanoTransactionsImporter {
         Self {
             block_scanner,
             transaction_store,
-            latest_polled_chain_point: Arc::new(Mutex::new(None)),
+            last_polled_point: Arc::new(Mutex::new(None)),
             logger: logger.new_with_component_name::<Self>(),
         }
     }
 
-    async fn start_chain_point(&self) -> StdResult<Option<ChainPoint>> {
-        let last_scanned_chain_point = self.latest_polled_chain_point.lock().await.clone();
-
-        if last_scanned_chain_point.is_none() {
-            self.transaction_store.get_highest_beacon().await
-        } else {
-            Ok(last_scanned_chain_point)
-        }
+    async fn start_point(
+        &self,
+        highest_stored_chain_point: &Option<ChainPoint>,
+    ) -> StdResult<Option<RawCardanoPoint>> {
+        let last_polled_point = self.last_polled_point.lock().await.clone();
+        Ok(last_polled_point.or(highest_stored_chain_point
+            .as_ref()
+            .map(RawCardanoPoint::from)))
     }
 
     async fn import_transactions(&self, up_to_beacon: BlockNumber) -> StdResult<()> {
-        let from = self.start_chain_point().await?;
-        self.parse_and_store_transactions_not_imported_yet(from, up_to_beacon)
-            .await
+        let highest_stored_beacon = self.transaction_store.get_highest_beacon().await?;
+        let from = self.start_point(&highest_stored_beacon).await?;
+
+        if highest_stored_beacon
+            .as_ref()
+            .is_some_and(|f| f.block_number >= up_to_beacon)
+        {
+            debug!(
+                self.logger,
+                "No need to retrieve Cardano transactions, the database is up to date for block_number '{up_to_beacon}'",
+            );
+
+            Ok(())
+        } else {
+            debug!(
+                self.logger, "Retrieving Cardano transactions until block numbered '{up_to_beacon}'";
+                "starting_slot_number" => ?from.as_ref().map(|c| c.slot_number),
+                "highest_stored_block_number" => ?highest_stored_beacon.as_ref().map(|c| c.block_number),
+            );
+
+            self.parse_and_store_transactions_not_imported_yet(from, up_to_beacon)
+                .await
+        }
     }
 
     async fn parse_and_store_transactions_not_imported_yet(
         &self,
-        from: Option<ChainPoint>,
+        from: Option<RawCardanoPoint>,
         until: BlockNumber,
     ) -> StdResult<()> {
-        if from.as_ref().is_some_and(|f| f.block_number >= until) {
-            debug!(
-                self.logger,
-                "No need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
-            );
-            return Ok(());
-        }
-        debug!(
-            self.logger,
-            "Retrieving Cardano transactions between block_number '{}' and '{until}'",
-            from.as_ref()
-                .map(|c| c.block_number)
-                .unwrap_or(BlockNumber(0))
-        );
-
         let mut streamer = self.block_scanner.scan(from, until).await?;
 
         while let Some(blocks) = streamer.poll_next().await? {
@@ -132,7 +137,8 @@ impl CardanoTransactionsImporter {
                 }
             }
         }
-        *self.latest_polled_chain_point.lock().await = streamer.latest_polled_chain_point();
+
+        *self.last_polled_point.lock().await = streamer.last_polled_point();
 
         Ok(())
     }
@@ -229,7 +235,7 @@ mod tests {
         impl BlockScanner for BlockScannerImpl {
             async fn scan(
               &self,
-              from: Option<ChainPoint>,
+              from: Option<RawCardanoPoint>,
               until: BlockNumber,
             ) -> StdResult<Box<dyn BlockStreamer>>;
         }
@@ -446,8 +452,12 @@ mod tests {
             ),
         ]]);
 
-        let last_tx =
-            CardanoTransaction::new("tx-20", BlockNumber(30), SlotNumber(35), "block_hash-3");
+        let last_tx = CardanoTransaction::new(
+            "tx-20",
+            BlockNumber(30),
+            SlotNumber(35),
+            hex::encode("block_hash-3"),
+        );
         repository
             .store_transactions(vec![last_tx.clone()])
             .await
@@ -472,10 +482,13 @@ mod tests {
             SqliteConnectionPool::build_from_connection(connection),
         )));
 
-        let highest_stored_chain_point =
-            ChainPoint::new(SlotNumber(134), BlockNumber(10), "block_hash-1");
+        let highest_stored_chain_point = ChainPoint::new(
+            SlotNumber(134),
+            BlockNumber(10),
+            hex::encode("block_hash-1"),
+        );
         let stored_block = ScannedBlock::new(
-            highest_stored_chain_point.block_hash.clone(),
+            hex::decode(highest_stored_chain_point.block_hash.clone()).unwrap(),
             highest_stored_chain_point.block_number,
             highest_stored_chain_point.slot_number,
             vec!["tx_hash-1", "tx_hash-2"],
@@ -504,7 +517,7 @@ mod tests {
             scanner_mock
                 .expect_scan()
                 .withf(move |from, until| {
-                    from == &Some(highest_stored_chain_point.clone())
+                    from == &Some(highest_stored_chain_point.clone().into())
                         && *until == up_to_block_number
                 })
                 .return_once(move |_, _| {
@@ -797,24 +810,16 @@ mod tests {
     mod transactions_import_start_point {
         use super::*;
 
-        async fn importer_with_highest_stored_transaction_and_last_polled_chain_point(
-            highest_stored_transaction: Option<CardanoTransaction>,
-            last_polled_chain_point: Option<ChainPoint>,
+        async fn importer_with_last_polled_point(
+            last_polled_point: Option<RawCardanoPoint>,
         ) -> CardanoTransactionsImporter {
             let connection = cardano_tx_db_connection().unwrap();
             let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(
                 SqliteConnectionPool::build_from_connection(connection),
             )));
 
-            if let Some(transaction) = highest_stored_transaction {
-                repository
-                    .store_transactions(vec![transaction])
-                    .await
-                    .unwrap();
-            }
-
             CardanoTransactionsImporter {
-                latest_polled_chain_point: Arc::new(Mutex::new(last_polled_chain_point)),
+                last_polled_point: Arc::new(Mutex::new(last_polled_point)),
                 ..CardanoTransactionsImporter::new_for_test(
                     Arc::new(DumbBlockScanner::new()),
                     repository,
@@ -823,110 +828,90 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn cloning_keep_last_polled_chain_point() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                None,
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1",
-                )),
-            )
+        async fn cloning_keep_last_polled_point() {
+            let importer = importer_with_last_polled_point(Some(RawCardanoPoint::new(
+                SlotNumber(15),
+                "block_hash-1",
+            )))
             .await;
 
             let cloned_importer = importer.clone();
-            let start_point = cloned_importer.start_chain_point().await.unwrap();
+            let start_point = cloned_importer.start_point(&None).await.unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(15), "block_hash-1")),
                 start_point
             );
         }
 
         #[tokio::test]
         async fn none_if_nothing_stored_nor_scanned() {
-            let importer =
-                importer_with_highest_stored_transaction_and_last_polled_chain_point(None, None)
-                    .await;
+            let importer = importer_with_last_polled_point(None).await;
+            let highest_stored_block_number = None;
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(None, start_point);
         }
 
         #[tokio::test]
-        async fn start_at_last_stored_chain_point_if_nothing_scanned() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                Some(CardanoTransaction::new(
-                    "tx_hash-2",
-                    BlockNumber(20),
-                    SlotNumber(25),
-                    "block_hash-2",
-                )),
-                None,
-            )
-            .await;
+        async fn start_at_last_stored_point_if_nothing_scanned() {
+            let importer = importer_with_last_polled_point(None).await;
+            let highest_stored_block_number = Some(ChainPoint::new(
+                SlotNumber(25),
+                BlockNumber(20),
+                hex::encode("block_hash-2"),
+            ));
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(25),
-                    BlockNumber(20),
-                    "block_hash-2"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(25), "block_hash-2")),
                 start_point
             );
         }
 
         #[tokio::test]
-        async fn start_at_last_scanned_chain_point_when_nothing_stored() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                None,
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1",
-                )),
-            )
+        async fn start_at_last_scanned_point_when_nothing_stored() {
+            let importer = importer_with_last_polled_point(Some(RawCardanoPoint::new(
+                SlotNumber(15),
+                "block_hash-1",
+            )))
             .await;
+            let highest_stored_block_number = None;
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(15), "block_hash-1")),
                 start_point
             );
         }
 
         #[tokio::test]
-        async fn start_at_last_scanned_chain_point_even_if_something_stored() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                Some(CardanoTransaction::new(
-                    "tx_hash-2",
-                    BlockNumber(20),
-                    SlotNumber(25),
-                    "block_hash-2",
-                )),
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1",
-                )),
-            )
+        async fn start_at_last_scanned_point_even_if_something_stored() {
+            let importer = importer_with_last_polled_point(Some(RawCardanoPoint::new(
+                SlotNumber(15),
+                "block_hash-1",
+            )))
             .await;
+            let highest_stored_block_number = Some(ChainPoint::new(
+                SlotNumber(25),
+                BlockNumber(20),
+                hex::encode("block_hash-2"),
+            ));
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(15), "block_hash-1")),
                 start_point
             );
         }
@@ -935,7 +920,7 @@ mod tests {
         async fn importing_transactions_update_start_point_even_if_no_transactions_are_found() {
             let connection = cardano_tx_db_connection().unwrap();
             let importer = CardanoTransactionsImporter {
-                latest_polled_chain_point: Arc::new(Mutex::new(None)),
+                last_polled_point: Arc::new(Mutex::new(None)),
                 ..CardanoTransactionsImporter::new_for_test(
                     Arc::new(
                         DumbBlockScanner::new()
@@ -945,9 +930,8 @@ mod tests {
                                 SlotNumber(15),
                                 Vec::<&str>::new(),
                             )]])
-                            .latest_polled_chain_point(Some(ChainPoint::new(
+                            .last_polled_point(Some(RawCardanoPoint::new(
                                 SlotNumber(25),
-                                BlockNumber(20),
                                 "block_hash-2",
                             ))),
                     ),
@@ -956,8 +940,12 @@ mod tests {
                     ))),
                 )
             };
+            let highest_stored_block_number = None;
 
-            let start_point_before_import = importer.start_chain_point().await.unwrap();
+            let start_point_before_import = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(None, start_point_before_import);
 
             importer
@@ -965,13 +953,12 @@ mod tests {
                 .await
                 .unwrap();
 
-            let start_point_after_import = importer.start_chain_point().await.unwrap();
+            let start_point_after_import = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(25),
-                    BlockNumber(20),
-                    "block_hash-2"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(25), "block_hash-2")),
                 start_point_after_import
             );
         }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.74"
+version = "0.4.75"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/cardano_block_scanner/block_scanner.rs
+++ b/mithril-common/src/cardano_block_scanner/block_scanner.rs
@@ -4,9 +4,9 @@ use async_trait::async_trait;
 use slog::Logger;
 use tokio::sync::Mutex;
 
-use crate::cardano_block_scanner::{BlockScanner, BlockStreamer};
+use crate::cardano_block_scanner::{BlockScanner, BlockStreamer, RawCardanoPoint};
 use crate::chain_reader::ChainBlockReader;
-use crate::entities::{BlockNumber, ChainPoint};
+use crate::entities::BlockNumber;
 use crate::StdResult;
 
 use super::ChainReaderBlockStreamer;
@@ -39,7 +39,7 @@ impl CardanoBlockScanner {
 impl BlockScanner for CardanoBlockScanner {
     async fn scan(
         &self,
-        from: Option<ChainPoint>,
+        from: Option<RawCardanoPoint>,
         until: BlockNumber,
     ) -> StdResult<Box<dyn BlockStreamer>> {
         Ok(Box::new(

--- a/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
+++ b/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
@@ -4,10 +4,9 @@ use async_trait::async_trait;
 use slog::{debug, trace, Logger};
 use tokio::sync::Mutex;
 
-use crate::cardano_block_scanner::BlockStreamer;
-use crate::cardano_block_scanner::ChainScannedBlocks;
+use crate::cardano_block_scanner::{BlockStreamer, ChainScannedBlocks, RawCardanoPoint};
 use crate::chain_reader::{ChainBlockNextAction, ChainBlockReader};
-use crate::entities::{BlockNumber, ChainPoint};
+use crate::entities::BlockNumber;
 use crate::logging::LoggerExtensions;
 use crate::StdResult;
 
@@ -23,10 +22,10 @@ enum BlockStreamerNextAction {
 /// [Block streamer][BlockStreamer] that streams blocks with a [Chain block reader][ChainBlockReader]
 pub struct ChainReaderBlockStreamer {
     chain_reader: Arc<Mutex<dyn ChainBlockReader>>,
-    from: ChainPoint,
+    from: RawCardanoPoint,
     until: BlockNumber,
     max_roll_forwards_per_poll: usize,
-    last_polled_chain_point: Option<ChainPoint>,
+    last_polled_point: Option<RawCardanoPoint>,
     logger: Logger,
 }
 
@@ -43,7 +42,7 @@ impl BlockStreamer for ChainReaderBlockStreamer {
                 Some(BlockStreamerNextAction::ChainBlockNextAction(
                     ChainBlockNextAction::RollForward { parsed_block },
                 )) => {
-                    self.last_polled_chain_point = Some(ChainPoint::from(&parsed_block));
+                    self.last_polled_point = Some(RawCardanoPoint::from(&parsed_block));
                     let parsed_block_number = parsed_block.block_number;
                     roll_forwards.push(parsed_block);
                     if roll_forwards.len() >= self.max_roll_forwards_per_poll
@@ -54,10 +53,10 @@ impl BlockStreamer for ChainReaderBlockStreamer {
                 }
                 Some(BlockStreamerNextAction::ChainBlockNextAction(
                     ChainBlockNextAction::RollBackward {
-                        chain_point: rollback_chain_point,
+                        point: rollback_chain_point,
                     },
                 )) => {
-                    self.last_polled_chain_point = Some(rollback_chain_point.clone());
+                    self.last_polled_point = Some(rollback_chain_point.clone());
                     let rollback_slot_number = rollback_chain_point.slot_number;
                     let index_rollback = roll_forwards
                         .iter()
@@ -96,8 +95,8 @@ impl BlockStreamer for ChainReaderBlockStreamer {
         }
     }
 
-    fn latest_polled_chain_point(&self) -> Option<ChainPoint> {
-        self.last_polled_chain_point.clone()
+    fn last_polled_point(&self) -> Option<RawCardanoPoint> {
+        self.last_polled_point.clone()
     }
 }
 
@@ -105,12 +104,12 @@ impl ChainReaderBlockStreamer {
     /// Factory
     pub async fn try_new(
         chain_reader: Arc<Mutex<dyn ChainBlockReader>>,
-        from: Option<ChainPoint>,
+        from: Option<RawCardanoPoint>,
         until: BlockNumber,
         max_roll_forwards_per_poll: usize,
         logger: Logger,
     ) -> StdResult<Self> {
-        let from = from.unwrap_or(ChainPoint::origin());
+        let from = from.unwrap_or(RawCardanoPoint::origin());
         {
             let mut chain_reader_inner = chain_reader.try_lock()?;
             chain_reader_inner.set_chain_point(&from).await?;
@@ -120,7 +119,7 @@ impl ChainReaderBlockStreamer {
             from,
             until,
             max_roll_forwards_per_poll,
-            last_polled_chain_point: None,
+            last_polled_point: None,
             logger: logger.new_with_component_name::<Self>(),
         })
     }
@@ -148,7 +147,7 @@ impl ChainReaderBlockStreamer {
                 }
             }
             Some(ChainBlockNextAction::RollBackward {
-                chain_point: rollback_chain_point,
+                point: rollback_chain_point,
             }) => {
                 let rollback_slot_number = rollback_chain_point.slot_number;
                 trace!(
@@ -160,7 +159,7 @@ impl ChainReaderBlockStreamer {
                 } else {
                     BlockStreamerNextAction::ChainBlockNextAction(
                         ChainBlockNextAction::RollBackward {
-                            chain_point: rollback_chain_point,
+                            point: rollback_chain_point,
                         },
                     )
                 };
@@ -219,7 +218,7 @@ mod tests {
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
-        assert_eq!(None, block_streamer.latest_polled_chain_point());
+        assert_eq!(None, block_streamer.last_polled_point());
 
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
             chain_reader,
@@ -242,12 +241,8 @@ mod tests {
             scanned_blocks
         );
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(
-                SlotNumber(100),
-                until_block_number,
-                "hash-2",
-            ))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(100), "hash-2"))
         );
     }
 
@@ -304,8 +299,8 @@ mod tests {
         assert_eq!(1, chain_reader_total_remaining_next_actions);
 
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(20), BlockNumber(2), "hash-2"))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(20), "hash-2"))
         );
     }
 
@@ -350,8 +345,8 @@ mod tests {
             scanned_blocks,
         );
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(20), BlockNumber(2), "hash-2"))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(20), "hash-2"))
         );
     }
 
@@ -403,8 +398,8 @@ mod tests {
             scanned_blocks,
         );
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(20), BlockNumber(2), "hash-2"))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(20), "hash-2"))
         );
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
@@ -418,15 +413,15 @@ mod tests {
             scanned_blocks,
         );
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(30), BlockNumber(3), "hash-3"))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(30), "hash-3"))
         );
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(30), BlockNumber(3), "hash-3"))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(30), "hash-3"))
         );
     }
 
@@ -434,16 +429,12 @@ mod tests {
     async fn test_parse_expected_nothing_when_rollbackward_on_same_point() {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollBackward {
-                chain_point: ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-123"),
+                point: RawCardanoPoint::new(SlotNumber(100), "hash-123"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
             chain_reader,
-            Some(ChainPoint::new(
-                SlotNumber(100),
-                BlockNumber(10),
-                "hash-123",
-            )),
+            Some(RawCardanoPoint::new(SlotNumber(100), "hash-123")),
             BlockNumber(1),
             MAX_ROLL_FORWARDS_PER_POLL,
             TestLogger::stdout(),
@@ -453,7 +444,7 @@ mod tests {
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
-        assert_eq!(block_streamer.latest_polled_chain_point(), None);
+        assert_eq!(block_streamer.last_polled_point(), None);
     }
 
     #[tokio::test]
@@ -461,7 +452,7 @@ mod tests {
     {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollBackward {
-                chain_point: ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-10"),
+                point: RawCardanoPoint::new(SlotNumber(100), "hash-10"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -481,15 +472,15 @@ mod tests {
             scanned_blocks,
         );
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-10"))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(100), "hash-10"))
         );
 
         let scanned_blocks = block_streamer.poll_next().await.expect("poll_next failed");
         assert_eq!(None, scanned_blocks);
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(100), BlockNumber(10), "hash-10"))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(100), "hash-10"))
         );
     }
 
@@ -522,7 +513,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                chain_point: ChainPoint::new(SlotNumber(9), BlockNumber(90), "hash-9"),
+                point: RawCardanoPoint::new(SlotNumber(9), "hash-9"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -545,8 +536,8 @@ mod tests {
             scanned_blocks,
         );
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(9), BlockNumber(90), "hash-9",))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(9), "hash-9"))
         );
     }
 
@@ -571,7 +562,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                chain_point: ChainPoint::new(SlotNumber(3), BlockNumber(30), "hash-3"),
+                point: RawCardanoPoint::new(SlotNumber(3), "hash-3"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -591,8 +582,8 @@ mod tests {
             scanned_blocks,
         );
         assert_eq!(
-            block_streamer.latest_polled_chain_point(),
-            Some(ChainPoint::new(SlotNumber(3), BlockNumber(30), "hash-3",))
+            block_streamer.last_polled_point(),
+            Some(RawCardanoPoint::new(SlotNumber(3), "hash-3"))
         );
     }
 
@@ -615,7 +606,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_latest_polled_chain_point_is_none_if_nothing_was_polled() {
+    async fn test_last_polled_point_is_none_if_nothing_was_polled() {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![])));
         let block_streamer = ChainReaderBlockStreamer::try_new(
             chain_reader,
@@ -627,6 +618,6 @@ mod tests {
         .await
         .unwrap();
 
-        assert_eq!(block_streamer.latest_polled_chain_point(), None);
+        assert_eq!(block_streamer.last_polled_point(), None);
     }
 }

--- a/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
+++ b/mithril-common/src/cardano_block_scanner/chain_reader_block_streamer.rs
@@ -52,12 +52,10 @@ impl BlockStreamer for ChainReaderBlockStreamer {
                     }
                 }
                 Some(BlockStreamerNextAction::ChainBlockNextAction(
-                    ChainBlockNextAction::RollBackward {
-                        point: rollback_chain_point,
-                    },
+                    ChainBlockNextAction::RollBackward { rollback_point },
                 )) => {
-                    self.last_polled_point = Some(rollback_chain_point.clone());
-                    let rollback_slot_number = rollback_chain_point.slot_number;
+                    self.last_polled_point = Some(rollback_point.clone());
+                    let rollback_slot_number = rollback_point.slot_number;
                     let index_rollback = roll_forwards
                         .iter()
                         .position(|block| block.slot_number == rollback_slot_number);
@@ -146,10 +144,8 @@ impl ChainReaderBlockStreamer {
                     )))
                 }
             }
-            Some(ChainBlockNextAction::RollBackward {
-                point: rollback_chain_point,
-            }) => {
-                let rollback_slot_number = rollback_chain_point.slot_number;
+            Some(ChainBlockNextAction::RollBackward { rollback_point }) => {
+                let rollback_slot_number = rollback_point.slot_number;
                 trace!(
                     self.logger,
                     "Received a RollBackward({rollback_slot_number:?})"
@@ -158,9 +154,7 @@ impl ChainReaderBlockStreamer {
                     BlockStreamerNextAction::SkipToNextAction
                 } else {
                     BlockStreamerNextAction::ChainBlockNextAction(
-                        ChainBlockNextAction::RollBackward {
-                            point: rollback_chain_point,
-                        },
+                        ChainBlockNextAction::RollBackward { rollback_point },
                     )
                 };
                 Ok(Some(block_streamer_next_action))
@@ -429,7 +423,7 @@ mod tests {
     async fn test_parse_expected_nothing_when_rollbackward_on_same_point() {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollBackward {
-                point: RawCardanoPoint::new(SlotNumber(100), "hash-123"),
+                rollback_point: RawCardanoPoint::new(SlotNumber(100), "hash-123"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -452,7 +446,7 @@ mod tests {
     {
         let chain_reader = Arc::new(Mutex::new(FakeChainReader::new(vec![
             ChainBlockNextAction::RollBackward {
-                point: RawCardanoPoint::new(SlotNumber(100), "hash-10"),
+                rollback_point: RawCardanoPoint::new(SlotNumber(100), "hash-10"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -513,7 +507,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                point: RawCardanoPoint::new(SlotNumber(9), "hash-9"),
+                rollback_point: RawCardanoPoint::new(SlotNumber(9), "hash-9"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(
@@ -562,7 +556,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                point: RawCardanoPoint::new(SlotNumber(3), "hash-3"),
+                rollback_point: RawCardanoPoint::new(SlotNumber(3), "hash-3"),
             },
         ])));
         let mut block_streamer = ChainReaderBlockStreamer::try_new(

--- a/mithril-common/src/cardano_block_scanner/interface.rs
+++ b/mithril-common/src/cardano_block_scanner/interface.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
-use crate::cardano_block_scanner::ScannedBlock;
-use crate::entities::{BlockNumber, ChainPoint, SlotNumber};
+use crate::cardano_block_scanner::{RawCardanoPoint, ScannedBlock};
+use crate::entities::{BlockNumber, SlotNumber};
 use crate::StdResult;
 
 /// A scanner that can read cardano transactions in a cardano database
@@ -15,8 +15,8 @@ use crate::StdResult;
 ///     use async_trait::async_trait;
 ///     use mockall::mock;
 ///
-///     use mithril_common::cardano_block_scanner::{BlockScanner, BlockStreamer};
-///     use mithril_common::entities::{BlockNumber, ChainPoint};
+///     use mithril_common::cardano_block_scanner::{BlockScanner, BlockStreamer, RawCardanoPoint};
+///     use mithril_common::entities::{BlockNumber};
 ///     use mithril_common::StdResult;
 ///
 ///     mock! {
@@ -26,7 +26,7 @@ use crate::StdResult;
 ///         impl BlockScanner for BlockScannerImpl {
 ///             async fn scan(
 ///               &self,
-///               from: Option<ChainPoint>,
+///               from: Option<RawCardanoPoint>,
 ///               until: BlockNumber,
 ///             ) -> StdResult<Box<dyn BlockStreamer>>;
 ///         }
@@ -46,7 +46,7 @@ pub trait BlockScanner: Sync + Send {
     /// Scan the transactions
     async fn scan(
         &self,
-        from: Option<ChainPoint>,
+        from: Option<RawCardanoPoint>,
         until: BlockNumber,
     ) -> StdResult<Box<dyn BlockStreamer>>;
 }
@@ -66,8 +66,8 @@ pub trait BlockStreamer: Sync + Send {
     /// Stream the next available blocks
     async fn poll_next(&mut self) -> StdResult<Option<ChainScannedBlocks>>;
 
-    /// Get the latest polled chain point
-    fn latest_polled_chain_point(&self) -> Option<ChainPoint>;
+    /// Get the last polled point of the chain
+    fn last_polled_point(&self) -> Option<RawCardanoPoint>;
 }
 
 cfg_test_tools! {

--- a/mithril-common/src/cardano_block_scanner/mod.rs
+++ b/mithril-common/src/cardano_block_scanner/mod.rs
@@ -3,10 +3,12 @@ mod block_scanner;
 mod chain_reader_block_streamer;
 mod dumb_block_scanner;
 mod interface;
+mod raw_cardano_point;
 mod scanned_block;
 
 pub use block_scanner::*;
 pub use chain_reader_block_streamer::*;
 pub use dumb_block_scanner::*;
 pub use interface::*;
+pub use raw_cardano_point::*;
 pub use scanned_block::*;

--- a/mithril-common/src/cardano_block_scanner/raw_cardano_point.rs
+++ b/mithril-common/src/cardano_block_scanner/raw_cardano_point.rs
@@ -5,11 +5,7 @@ use std::fmt::{Debug, Formatter};
 use crate::cardano_block_scanner::ScannedBlock;
 use crate::entities::{ChainPoint, SlotNumber};
 
-/// Point in the chain that can be intersected.
-///
-/// Internally the point used in Cardano doesn't have a block number like our [ChainPoint]
-/// does, so we need to use a different struct to represent it. Else converting from one to the other
-/// would be lossy.
+/// Point internal representation in the Cardano chain.
 #[derive(Clone, PartialEq)]
 pub struct RawCardanoPoint {
     /// The [slot number](https://docs.cardano.org/learn/cardano-node/#slotsandepochs)

--- a/mithril-common/src/cardano_block_scanner/raw_cardano_point.rs
+++ b/mithril-common/src/cardano_block_scanner/raw_cardano_point.rs
@@ -1,0 +1,151 @@
+#[cfg(feature = "fs")]
+use pallas_network::miniprotocols::Point as PallasPoint;
+use std::fmt::{Debug, Formatter};
+
+use crate::cardano_block_scanner::ScannedBlock;
+use crate::entities::{ChainPoint, SlotNumber};
+
+/// Point in the chain that can be intersected.
+///
+/// Internally the point used in Cardano doesn't have a block number like our [ChainPoint]
+/// does, so we need to use a different struct to represent it. Else converting from one to the other
+/// would be lossy.
+#[derive(Clone, PartialEq)]
+pub struct RawCardanoPoint {
+    /// The [slot number](https://docs.cardano.org/learn/cardano-node/#slotsandepochs)
+    pub slot_number: SlotNumber,
+
+    /// Hex array of the block hash
+    pub block_hash: Vec<u8>,
+}
+
+impl RawCardanoPoint {
+    /// Instantiate a new `RawCardanoPoint`
+    pub fn new<T: Into<Vec<u8>>>(slot_number: SlotNumber, block_hash: T) -> Self {
+        RawCardanoPoint {
+            slot_number,
+            block_hash: block_hash.into(),
+        }
+    }
+
+    /// Create a new origin `RawCardanoPoint`
+    pub fn origin() -> Self {
+        RawCardanoPoint {
+            slot_number: SlotNumber(0),
+            block_hash: Vec::new(),
+        }
+    }
+
+    /// Check if origin
+    pub fn is_origin(&self) -> bool {
+        self.slot_number == 0 && self.block_hash.is_empty()
+    }
+}
+
+impl From<&ChainPoint> for RawCardanoPoint {
+    fn from(point: &ChainPoint) -> Self {
+        RawCardanoPoint {
+            slot_number: point.slot_number,
+            block_hash: hex::decode(&point.block_hash).unwrap(),
+        }
+    }
+}
+
+impl From<ChainPoint> for RawCardanoPoint {
+    fn from(point: ChainPoint) -> Self {
+        Self::from(&point)
+    }
+}
+
+impl Debug for RawCardanoPoint {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let mut debug = f.debug_struct("RawCardanoPoint");
+        debug
+            .field("slot_number", &self.slot_number)
+            .field("block_hash", &hex::encode(&self.block_hash))
+            .finish()
+    }
+}
+
+cfg_fs! {
+    impl From<RawCardanoPoint> for PallasPoint {
+        fn from(raw_point: RawCardanoPoint) -> Self {
+            match raw_point.is_origin() {
+                true => Self::Origin,
+                false => Self::Specific(
+                    *raw_point.slot_number,
+                    raw_point.block_hash
+                ),
+            }
+        }
+    }
+
+    impl From<PallasPoint> for RawCardanoPoint {
+        fn from(point: PallasPoint) -> Self {
+            match point {
+                PallasPoint::Specific(slot_number, block_hash) => Self {
+                    slot_number: SlotNumber(slot_number),
+                    block_hash,
+                },
+                PallasPoint::Origin => Self::origin(),
+            }
+        }
+    }
+}
+
+impl From<&ScannedBlock> for RawCardanoPoint {
+    fn from(scanned_block: &ScannedBlock) -> Self {
+        RawCardanoPoint {
+            slot_number: scanned_block.slot_number,
+            block_hash: hex::decode(&scanned_block.block_hash).unwrap(),
+        }
+    }
+}
+
+impl From<ScannedBlock> for RawCardanoPoint {
+    fn from(scanned_block: ScannedBlock) -> Self {
+        Self::from(&scanned_block)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::entities::BlockNumber;
+
+    use super::*;
+
+    #[test]
+    fn from_chain_point_to_raw_cardano_point_conversions() {
+        let expected_hash = vec![4, 2, 12, 9, 7];
+        let chain_point =
+            ChainPoint::new(SlotNumber(8), BlockNumber(23), hex::encode(&expected_hash));
+
+        assert_eq!(
+            RawCardanoPoint::new(SlotNumber(8), expected_hash.clone()),
+            RawCardanoPoint::from(&chain_point)
+        );
+        assert_eq!(
+            RawCardanoPoint::new(SlotNumber(8), expected_hash.clone()),
+            RawCardanoPoint::from(chain_point)
+        );
+    }
+
+    #[test]
+    fn from_scanned_block_to_raw_cardano_point_conversions() {
+        let expected_hash = vec![7, 1, 13, 7, 8];
+        let scanned_block = ScannedBlock::new(
+            hex::encode(&expected_hash),
+            BlockNumber(31),
+            SlotNumber(4),
+            Vec::<&str>::new(),
+        );
+        assert_eq!(
+            RawCardanoPoint::new(SlotNumber(4), expected_hash.clone()),
+            RawCardanoPoint::from(&scanned_block)
+        );
+        assert_eq!(
+            RawCardanoPoint::new(SlotNumber(4), expected_hash.clone()),
+            RawCardanoPoint::from(scanned_block)
+        );
+    }
+}

--- a/mithril-common/src/cardano_block_scanner/raw_cardano_point.rs
+++ b/mithril-common/src/cardano_block_scanner/raw_cardano_point.rs
@@ -97,7 +97,7 @@ impl From<&ScannedBlock> for RawCardanoPoint {
     fn from(scanned_block: &ScannedBlock) -> Self {
         RawCardanoPoint {
             slot_number: scanned_block.slot_number,
-            block_hash: hex::decode(&scanned_block.block_hash).unwrap(),
+            block_hash: scanned_block.block_hash.clone(),
         }
     }
 }
@@ -134,7 +134,7 @@ mod tests {
     fn from_scanned_block_to_raw_cardano_point_conversions() {
         let expected_hash = vec![7, 1, 13, 7, 8];
         let scanned_block = ScannedBlock::new(
-            hex::encode(&expected_hash),
+            expected_hash.clone(),
             BlockNumber(31),
             SlotNumber(4),
             Vec::<&str>::new(),

--- a/mithril-common/src/cardano_block_scanner/scanned_block.rs
+++ b/mithril-common/src/cardano_block_scanner/scanned_block.rs
@@ -18,11 +18,11 @@ pub struct ScannedBlock {
 
 impl ScannedBlock {
     /// Scanned block factory
-    pub fn new<BlkHash: Into<Vec<u8>>, TxHash: Into<TransactionHash>>(
-        block_hash: BlkHash,
+    pub fn new<B: Into<Vec<u8>>, T: Into<TransactionHash>>(
+        block_hash: B,
         block_number: BlockNumber,
         slot_number: SlotNumber,
-        transaction_hashes: Vec<TxHash>,
+        transaction_hashes: Vec<T>,
     ) -> Self {
         Self {
             block_hash: block_hash.into(),

--- a/mithril-common/src/chain_reader/entity.rs
+++ b/mithril-common/src/chain_reader/entity.rs
@@ -1,4 +1,5 @@
-use crate::{cardano_block_scanner::ScannedBlock, entities::ChainPoint};
+use crate::cardano_block_scanner::RawCardanoPoint;
+use crate::cardano_block_scanner::ScannedBlock;
 
 /// The action that indicates what to do next when scanning the chain
 #[derive(Debug, Clone, PartialEq)]
@@ -10,7 +11,7 @@ pub enum ChainBlockNextAction {
     },
     /// RollBackward event (we are on an incorrect fork, we need to get back a point to roll forward again)
     RollBackward {
-        /// The rollback chain point in the chain to read (as a new valid chain point to read from on the main chain, which has already been seen)
-        chain_point: ChainPoint,
+        /// The rollback point in the chain to read (as a new valid chain point to read from on the main chain, which has already been seen)
+        point: RawCardanoPoint,
     },
 }

--- a/mithril-common/src/chain_reader/entity.rs
+++ b/mithril-common/src/chain_reader/entity.rs
@@ -12,6 +12,6 @@ pub enum ChainBlockNextAction {
     /// RollBackward event (we are on an incorrect fork, we need to get back a point to roll forward again)
     RollBackward {
         /// The rollback point in the chain to read (as a new valid chain point to read from on the main chain, which has already been seen)
-        point: RawCardanoPoint,
+        rollback_point: RawCardanoPoint,
     },
 }

--- a/mithril-common/src/chain_reader/fake_chain_reader.rs
+++ b/mithril-common/src/chain_reader/fake_chain_reader.rs
@@ -2,7 +2,8 @@ use std::{collections::VecDeque, sync::Mutex};
 
 use async_trait::async_trait;
 
-use crate::{entities::ChainPoint, StdResult};
+use crate::cardano_block_scanner::RawCardanoPoint;
+use crate::StdResult;
 
 use super::{ChainBlockNextAction, ChainBlockReader};
 
@@ -27,7 +28,7 @@ impl FakeChainReader {
 
 #[async_trait]
 impl ChainBlockReader for FakeChainReader {
-    async fn set_chain_point(&mut self, _point: &ChainPoint) -> StdResult<()> {
+    async fn set_chain_point(&mut self, _point: &RawCardanoPoint) -> StdResult<()> {
         Ok(())
     }
 
@@ -42,14 +43,6 @@ mod tests {
     use crate::entities::{BlockNumber, SlotNumber};
 
     use super::*;
-
-    fn build_chain_point(id: u64) -> ChainPoint {
-        ChainPoint {
-            slot_number: SlotNumber(id),
-            block_number: BlockNumber(id),
-            block_hash: format!("point-hash-{id}"),
-        }
-    }
 
     #[tokio::test]
     async fn test_get_next_chain_block() {
@@ -71,7 +64,7 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                chain_point: build_chain_point(1),
+                point: RawCardanoPoint::new(SlotNumber(1), "point-hash-1".as_bytes()),
             },
         ];
 

--- a/mithril-common/src/chain_reader/fake_chain_reader.rs
+++ b/mithril-common/src/chain_reader/fake_chain_reader.rs
@@ -9,20 +9,20 @@ use super::{ChainBlockNextAction, ChainBlockReader};
 
 /// [FakeChainReader] is a fake implementation of [ChainBlockReader] for testing purposes.
 pub struct FakeChainReader {
-    chain_point_next_actions: Mutex<VecDeque<ChainBlockNextAction>>,
+    chain_block_next_actions: Mutex<VecDeque<ChainBlockNextAction>>,
 }
 
 impl FakeChainReader {
     /// Creates a new [FakeChainReader] instance.
-    pub fn new(chain_point_next_actions: Vec<ChainBlockNextAction>) -> Self {
+    pub fn new(chain_block_next_actions: Vec<ChainBlockNextAction>) -> Self {
         Self {
-            chain_point_next_actions: Mutex::new(chain_point_next_actions.into()),
+            chain_block_next_actions: Mutex::new(chain_block_next_actions.into()),
         }
     }
 
     /// Total remaining next actions
     pub fn get_total_remaining_next_actions(&self) -> usize {
-        self.chain_point_next_actions.lock().unwrap().len()
+        self.chain_block_next_actions.lock().unwrap().len()
     }
 }
 
@@ -33,7 +33,7 @@ impl ChainBlockReader for FakeChainReader {
     }
 
     async fn get_next_chain_block(&mut self) -> StdResult<Option<ChainBlockNextAction>> {
-        Ok(self.chain_point_next_actions.lock().unwrap().pop_front())
+        Ok(self.chain_block_next_actions.lock().unwrap().pop_front())
     }
 }
 
@@ -46,7 +46,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_next_chain_block() {
-        let expected_chain_point_next_actions = vec![
+        let expected_chain_block_next_actions = vec![
             ChainBlockNextAction::RollForward {
                 parsed_block: ScannedBlock::new(
                     "hash-1",
@@ -64,18 +64,18 @@ mod tests {
                 ),
             },
             ChainBlockNextAction::RollBackward {
-                point: RawCardanoPoint::new(SlotNumber(1), "point-hash-1".as_bytes()),
+                rollback_point: RawCardanoPoint::new(SlotNumber(1), "point-hash-1".as_bytes()),
             },
         ];
 
-        let mut chain_reader = FakeChainReader::new(expected_chain_point_next_actions.clone());
+        let mut chain_reader = FakeChainReader::new(expected_chain_block_next_actions.clone());
 
-        let mut chain_point_next_actions = vec![];
+        let mut chain_block_next_actions = vec![];
         while let Some(chain_block_next_action) = chain_reader.get_next_chain_block().await.unwrap()
         {
-            chain_point_next_actions.push(chain_block_next_action);
+            chain_block_next_actions.push(chain_block_next_action);
         }
 
-        assert_eq!(expected_chain_point_next_actions, chain_point_next_actions);
+        assert_eq!(expected_chain_block_next_actions, chain_block_next_actions);
     }
 }

--- a/mithril-common/src/chain_reader/interface.rs
+++ b/mithril-common/src/chain_reader/interface.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
-use crate::{entities::ChainPoint, StdResult};
+use crate::cardano_block_scanner::RawCardanoPoint;
+use crate::StdResult;
 
 use super::ChainBlockNextAction;
 
@@ -11,7 +12,7 @@ use super::ChainBlockNextAction;
 #[async_trait]
 pub trait ChainBlockReader: Send + Sync {
     /// Sets the chain point
-    async fn set_chain_point(&mut self, point: &ChainPoint) -> StdResult<()>;
+    async fn set_chain_point(&mut self, point: &RawCardanoPoint) -> StdResult<()>;
 
     /// Get the next chain block
     async fn get_next_chain_block(&mut self) -> StdResult<Option<ChainBlockNextAction>>;

--- a/mithril-common/src/chain_reader/pallas_chain_reader.rs
+++ b/mithril-common/src/chain_reader/pallas_chain_reader.rs
@@ -88,8 +88,9 @@ impl PallasChainReader {
                 Ok(Some(ChainBlockNextAction::RollForward { parsed_block }))
             }
             NextResponse::RollBackward(rollback_point, _) => {
-                let point = RawCardanoPoint::from(rollback_point);
-                Ok(Some(ChainBlockNextAction::RollBackward { point }))
+                Ok(Some(ChainBlockNextAction::RollBackward {
+                    rollback_point: RawCardanoPoint::from(rollback_point),
+                }))
             }
             NextResponse::Await => Ok(None),
         }
@@ -281,8 +282,8 @@ mod tests {
         let (_, client_res) = tokio::join!(server, client);
         let chain_block = client_res.expect("Client failed to get next chain block");
         match chain_block {
-            ChainBlockNextAction::RollBackward { point: chain_point } => {
-                assert_eq!(chain_point, get_fake_raw_point_backwards());
+            ChainBlockNextAction::RollBackward { rollback_point } => {
+                assert_eq!(rollback_point, get_fake_raw_point_backwards());
             }
             _ => panic!("Unexpected chain block action"),
         }

--- a/mithril-common/src/chain_reader/pallas_chain_reader.rs
+++ b/mithril-common/src/chain_reader/pallas_chain_reader.rs
@@ -10,7 +10,10 @@ use pallas_traverse::MultiEraBlock;
 use slog::{debug, Logger};
 
 use crate::logging::LoggerExtensions;
-use crate::{cardano_block_scanner::ScannedBlock, entities::ChainPoint, CardanoNetwork, StdResult};
+use crate::{
+    cardano_block_scanner::{RawCardanoPoint, ScannedBlock},
+    CardanoNetwork, StdResult,
+};
 
 use super::{ChainBlockNextAction, ChainBlockReader};
 
@@ -55,7 +58,7 @@ impl PallasChainReader {
     }
 
     /// Intersects the point of the chain with the given point.
-    async fn find_intersect_point(&mut self, point: &ChainPoint) -> StdResult<()> {
+    async fn find_intersect_point(&mut self, point: &RawCardanoPoint) -> StdResult<()> {
         let logger = self.logger.clone();
         let client = self.get_client().await?;
         let chainsync = client.chainsync();
@@ -85,8 +88,8 @@ impl PallasChainReader {
                 Ok(Some(ChainBlockNextAction::RollForward { parsed_block }))
             }
             NextResponse::RollBackward(rollback_point, _) => {
-                let chain_point = ChainPoint::from(rollback_point);
-                Ok(Some(ChainBlockNextAction::RollBackward { chain_point }))
+                let point = RawCardanoPoint::from(rollback_point);
+                Ok(Some(ChainBlockNextAction::RollBackward { point }))
             }
             NextResponse::Await => Ok(None),
         }
@@ -105,7 +108,7 @@ impl Drop for PallasChainReader {
 
 #[async_trait]
 impl ChainBlockReader for PallasChainReader {
-    async fn set_chain_point(&mut self, point: &ChainPoint) -> StdResult<()> {
+    async fn set_chain_point(&mut self, point: &RawCardanoPoint) -> StdResult<()> {
         self.find_intersect_point(point).await
     }
 
@@ -167,9 +170,9 @@ mod tests {
         BlockNumber(1337)
     }
 
-    /// Returns a fake chain point for testing purposes.
-    fn get_fake_chain_point_backwards() -> ChainPoint {
-        ChainPoint::from(get_fake_specific_point())
+    /// Returns a fake cardano raw point for testing purposes.
+    fn get_fake_raw_point_backwards() -> RawCardanoPoint {
+        RawCardanoPoint::from(get_fake_specific_point())
     }
 
     /// Creates a new work directory in the system's temporary folder.
@@ -268,7 +271,7 @@ mod tests {
             );
 
             chain_reader
-                .set_chain_point(&ChainPoint::from(known_point.clone()))
+                .set_chain_point(&RawCardanoPoint::from(known_point.clone()))
                 .await
                 .unwrap();
 
@@ -278,8 +281,8 @@ mod tests {
         let (_, client_res) = tokio::join!(server, client);
         let chain_block = client_res.expect("Client failed to get next chain block");
         match chain_block {
-            ChainBlockNextAction::RollBackward { chain_point } => {
-                assert_eq!(chain_point, get_fake_chain_point_backwards());
+            ChainBlockNextAction::RollBackward { point: chain_point } => {
+                assert_eq!(chain_point, get_fake_raw_point_backwards());
             }
             _ => panic!("Unexpected chain block action"),
         }
@@ -303,7 +306,7 @@ mod tests {
             );
 
             chain_reader
-                .set_chain_point(&ChainPoint::from(known_point.clone()))
+                .set_chain_point(&RawCardanoPoint::from(known_point.clone()))
                 .await
                 .unwrap();
 
@@ -338,7 +341,7 @@ mod tests {
             );
 
             chain_reader
-                .set_chain_point(&ChainPoint::from(known_point.clone()))
+                .set_chain_point(&RawCardanoPoint::from(known_point.clone()))
                 .await
                 .unwrap();
 
@@ -355,7 +358,7 @@ mod tests {
 
             // make sure that setting the chain point is harmless when the chainsync client does not have agency
             chain_reader
-                .set_chain_point(&ChainPoint::from(known_point.clone()))
+                .set_chain_point(&RawCardanoPoint::from(known_point.clone()))
                 .await
                 .unwrap();
 

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.204"
+version = "0.2.205"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/services/cardano_transactions/importer/service.rs
+++ b/mithril-signer/src/services/cardano_transactions/importer/service.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use slog::{debug, Logger};
 use tokio::{runtime::Handle, sync::Mutex, task};
 
-use mithril_common::cardano_block_scanner::{BlockScanner, ChainScannedBlocks};
+use mithril_common::cardano_block_scanner::{BlockScanner, ChainScannedBlocks, RawCardanoPoint};
 use mithril_common::crypto_helper::{MKTree, MKTreeNode, MKTreeStoreInMemory};
 use mithril_common::entities::{
     BlockNumber, BlockRange, CardanoTransaction, ChainPoint, SlotNumber,
@@ -56,7 +56,7 @@ pub trait TransactionStore: Send + Sync {
 pub struct CardanoTransactionsImporter {
     block_scanner: Arc<dyn BlockScanner>,
     transaction_store: Arc<dyn TransactionStore>,
-    latest_polled_chain_point: Arc<Mutex<Option<ChainPoint>>>,
+    last_polled_point: Arc<Mutex<Option<RawCardanoPoint>>>,
     logger: Logger,
 }
 
@@ -70,47 +70,52 @@ impl CardanoTransactionsImporter {
         Self {
             block_scanner,
             transaction_store,
-            latest_polled_chain_point: Arc::new(Mutex::new(None)),
+            last_polled_point: Arc::new(Mutex::new(None)),
             logger: logger.new_with_component_name::<Self>(),
         }
     }
 
-    async fn start_chain_point(&self) -> StdResult<Option<ChainPoint>> {
-        let last_scanned_chain_point = self.latest_polled_chain_point.lock().await.clone();
-
-        if last_scanned_chain_point.is_none() {
-            self.transaction_store.get_highest_beacon().await
-        } else {
-            Ok(last_scanned_chain_point)
-        }
+    async fn start_point(
+        &self,
+        highest_stored_chain_point: &Option<ChainPoint>,
+    ) -> StdResult<Option<RawCardanoPoint>> {
+        let last_polled_point = self.last_polled_point.lock().await.clone();
+        Ok(last_polled_point.or(highest_stored_chain_point
+            .as_ref()
+            .map(RawCardanoPoint::from)))
     }
 
     async fn import_transactions(&self, up_to_beacon: BlockNumber) -> StdResult<()> {
-        let from = self.start_chain_point().await?;
-        self.parse_and_store_transactions_not_imported_yet(from, up_to_beacon)
-            .await
+        let highest_stored_beacon = self.transaction_store.get_highest_beacon().await?;
+        let from = self.start_point(&highest_stored_beacon).await?;
+
+        if highest_stored_beacon
+            .as_ref()
+            .is_some_and(|f| f.block_number >= up_to_beacon)
+        {
+            debug!(
+                self.logger,
+                "No need to retrieve Cardano transactions, the database is up to date for block_number '{up_to_beacon}'",
+            );
+
+            Ok(())
+        } else {
+            debug!(
+                self.logger, "Retrieving Cardano transactions until block numbered '{up_to_beacon}'";
+                "starting_slot_number" => ?from.as_ref().map(|c| c.slot_number),
+                "highest_stored_block_number" => ?highest_stored_beacon.as_ref().map(|c| c.block_number),
+            );
+
+            self.parse_and_store_transactions_not_imported_yet(from, up_to_beacon)
+                .await
+        }
     }
 
     async fn parse_and_store_transactions_not_imported_yet(
         &self,
-        from: Option<ChainPoint>,
+        from: Option<RawCardanoPoint>,
         until: BlockNumber,
     ) -> StdResult<()> {
-        if from.as_ref().is_some_and(|f| f.block_number >= until) {
-            debug!(
-                self.logger,
-                "No need to retrieve Cardano transactions, the database is up to date for block_number '{until}'",
-            );
-            return Ok(());
-        }
-        debug!(
-            self.logger,
-            "Retrieving Cardano transactions between block_number '{}' and '{until}'",
-            from.as_ref()
-                .map(|c| c.block_number)
-                .unwrap_or(BlockNumber(0))
-        );
-
         let mut streamer = self.block_scanner.scan(from, until).await?;
 
         while let Some(blocks) = streamer.poll_next().await? {
@@ -132,7 +137,8 @@ impl CardanoTransactionsImporter {
                 }
             }
         }
-        *self.latest_polled_chain_point.lock().await = streamer.latest_polled_chain_point();
+
+        *self.last_polled_point.lock().await = streamer.last_polled_point();
 
         Ok(())
     }
@@ -229,7 +235,7 @@ mod tests {
         impl BlockScanner for BlockScannerImpl {
             async fn scan(
               &self,
-              from: Option<ChainPoint>,
+              from: Option<RawCardanoPoint>,
               until: BlockNumber,
             ) -> StdResult<Box<dyn BlockStreamer>>;
         }
@@ -446,8 +452,12 @@ mod tests {
             ),
         ]]);
 
-        let last_tx =
-            CardanoTransaction::new("tx-20", BlockNumber(30), SlotNumber(35), "block_hash-3");
+        let last_tx = CardanoTransaction::new(
+            "tx-20",
+            BlockNumber(30),
+            SlotNumber(35),
+            hex::encode("block_hash-3"),
+        );
         repository
             .store_transactions(vec![last_tx.clone()])
             .await
@@ -472,10 +482,13 @@ mod tests {
             SqliteConnectionPool::build_from_connection(connection),
         )));
 
-        let highest_stored_chain_point =
-            ChainPoint::new(SlotNumber(134), BlockNumber(10), "block_hash-1");
+        let highest_stored_chain_point = ChainPoint::new(
+            SlotNumber(134),
+            BlockNumber(10),
+            hex::encode("block_hash-1"),
+        );
         let stored_block = ScannedBlock::new(
-            highest_stored_chain_point.block_hash.clone(),
+            hex::decode(highest_stored_chain_point.block_hash.clone()).unwrap(),
             highest_stored_chain_point.block_number,
             highest_stored_chain_point.slot_number,
             vec!["tx_hash-1", "tx_hash-2"],
@@ -504,7 +517,7 @@ mod tests {
             scanner_mock
                 .expect_scan()
                 .withf(move |from, until| {
-                    from == &Some(highest_stored_chain_point.clone())
+                    from == &Some(highest_stored_chain_point.clone().into())
                         && *until == up_to_block_number
                 })
                 .return_once(move |_, _| {
@@ -797,24 +810,16 @@ mod tests {
     mod transactions_import_start_point {
         use super::*;
 
-        async fn importer_with_highest_stored_transaction_and_last_polled_chain_point(
-            highest_stored_transaction: Option<CardanoTransaction>,
-            last_polled_chain_point: Option<ChainPoint>,
+        async fn importer_with_last_polled_point(
+            last_polled_point: Option<RawCardanoPoint>,
         ) -> CardanoTransactionsImporter {
             let connection = cardano_tx_db_connection().unwrap();
             let repository = Arc::new(CardanoTransactionRepository::new(Arc::new(
                 SqliteConnectionPool::build_from_connection(connection),
             )));
 
-            if let Some(transaction) = highest_stored_transaction {
-                repository
-                    .store_transactions(vec![transaction])
-                    .await
-                    .unwrap();
-            }
-
             CardanoTransactionsImporter {
-                latest_polled_chain_point: Arc::new(Mutex::new(last_polled_chain_point)),
+                last_polled_point: Arc::new(Mutex::new(last_polled_point)),
                 ..CardanoTransactionsImporter::new_for_test(
                     Arc::new(DumbBlockScanner::new()),
                     repository,
@@ -823,110 +828,90 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn cloning_keep_last_polled_chain_point() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                None,
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1",
-                )),
-            )
+        async fn cloning_keep_last_polled_point() {
+            let importer = importer_with_last_polled_point(Some(RawCardanoPoint::new(
+                SlotNumber(15),
+                "block_hash-1",
+            )))
             .await;
 
             let cloned_importer = importer.clone();
-            let start_point = cloned_importer.start_chain_point().await.unwrap();
+            let start_point = cloned_importer.start_point(&None).await.unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(15), "block_hash-1")),
                 start_point
             );
         }
 
         #[tokio::test]
         async fn none_if_nothing_stored_nor_scanned() {
-            let importer =
-                importer_with_highest_stored_transaction_and_last_polled_chain_point(None, None)
-                    .await;
+            let importer = importer_with_last_polled_point(None).await;
+            let highest_stored_block_number = None;
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(None, start_point);
         }
 
         #[tokio::test]
-        async fn start_at_last_stored_chain_point_if_nothing_scanned() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                Some(CardanoTransaction::new(
-                    "tx_hash-2",
-                    BlockNumber(20),
-                    SlotNumber(25),
-                    "block_hash-2",
-                )),
-                None,
-            )
-            .await;
+        async fn start_at_last_stored_point_if_nothing_scanned() {
+            let importer = importer_with_last_polled_point(None).await;
+            let highest_stored_block_number = Some(ChainPoint::new(
+                SlotNumber(25),
+                BlockNumber(20),
+                hex::encode("block_hash-2"),
+            ));
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(25),
-                    BlockNumber(20),
-                    "block_hash-2"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(25), "block_hash-2")),
                 start_point
             );
         }
 
         #[tokio::test]
-        async fn start_at_last_scanned_chain_point_when_nothing_stored() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                None,
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1",
-                )),
-            )
+        async fn start_at_last_scanned_point_when_nothing_stored() {
+            let importer = importer_with_last_polled_point(Some(RawCardanoPoint::new(
+                SlotNumber(15),
+                "block_hash-1",
+            )))
             .await;
+            let highest_stored_block_number = None;
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(15), "block_hash-1")),
                 start_point
             );
         }
 
         #[tokio::test]
-        async fn start_at_last_scanned_chain_point_even_if_something_stored() {
-            let importer = importer_with_highest_stored_transaction_and_last_polled_chain_point(
-                Some(CardanoTransaction::new(
-                    "tx_hash-2",
-                    BlockNumber(20),
-                    SlotNumber(25),
-                    "block_hash-2",
-                )),
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1",
-                )),
-            )
+        async fn start_at_last_scanned_point_even_if_something_stored() {
+            let importer = importer_with_last_polled_point(Some(RawCardanoPoint::new(
+                SlotNumber(15),
+                "block_hash-1",
+            )))
             .await;
+            let highest_stored_block_number = Some(ChainPoint::new(
+                SlotNumber(25),
+                BlockNumber(20),
+                hex::encode("block_hash-2"),
+            ));
 
-            let start_point = importer.start_chain_point().await.unwrap();
+            let start_point = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(15),
-                    BlockNumber(10),
-                    "block_hash-1"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(15), "block_hash-1")),
                 start_point
             );
         }
@@ -935,7 +920,7 @@ mod tests {
         async fn importing_transactions_update_start_point_even_if_no_transactions_are_found() {
             let connection = cardano_tx_db_connection().unwrap();
             let importer = CardanoTransactionsImporter {
-                latest_polled_chain_point: Arc::new(Mutex::new(None)),
+                last_polled_point: Arc::new(Mutex::new(None)),
                 ..CardanoTransactionsImporter::new_for_test(
                     Arc::new(
                         DumbBlockScanner::new()
@@ -945,9 +930,8 @@ mod tests {
                                 SlotNumber(15),
                                 Vec::<&str>::new(),
                             )]])
-                            .latest_polled_chain_point(Some(ChainPoint::new(
+                            .last_polled_point(Some(RawCardanoPoint::new(
                                 SlotNumber(25),
-                                BlockNumber(20),
                                 "block_hash-2",
                             ))),
                     ),
@@ -956,8 +940,12 @@ mod tests {
                     ))),
                 )
             };
+            let highest_stored_block_number = None;
 
-            let start_point_before_import = importer.start_chain_point().await.unwrap();
+            let start_point_before_import = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(None, start_point_before_import);
 
             importer
@@ -965,13 +953,12 @@ mod tests {
                 .await
                 .unwrap();
 
-            let start_point_after_import = importer.start_chain_point().await.unwrap();
+            let start_point_after_import = importer
+                .start_point(&highest_stored_block_number)
+                .await
+                .unwrap();
             assert_eq!(
-                Some(ChainPoint::new(
-                    SlotNumber(25),
-                    BlockNumber(20),
-                    "block_hash-2"
-                )),
+                Some(RawCardanoPoint::new(SlotNumber(25), "block_hash-2")),
                 start_point_after_import
             );
         }


### PR DESCRIPTION
## Content

This PR introduce a new type, `RawCardanoPoint`, that is used in place of our `ChainPoint` in the transaction import process.

The `RawCardanoPoint` doesn't have a block number unlike `ChainPoint`, this allow a lossless conversion from and to the pallas point used in their chainsync implementation, avoiding the creation of `ChainPoint` with a block number of `0`.

Also this PR changes the `ScannedBlock` block hash to be a bytes array as this reduce the number of conversion needed when working with pallas types as this type is only used in conjunction with those types (`RawCardanoPoint` also use a bytes array for the same reason).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2037
