### PR TITLE
Enhance end-to-end tests termination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.41"
+version = "0.4.42"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.41"
+version = "0.4.42"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content

This PR rework the termination system of the end to end test runner by doing all stop operation at one unique place and listening to some unix signals (aka "graceful shutdown").

This will limit the possibility of a run finishing without terminating either its devnet or infrastructure (such as when the devnet start failed it was not stopped).

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
