### PR TITLE
Feat: Make Cardano stake distribution stable in client

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -161,8 +161,8 @@ jobs:
         shell: bash
         working-directory: ./bin
         run: |
-          ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution list
-          CMD_OUTPUT=$(./mithril-client --unstable cardano-stake-distribution list --json)
+          ./mithril-client ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution list
+          CMD_OUTPUT=$(./mithril-client cardano-stake-distribution list --json)
           echo "CARDANO_STAKE_DISTRIBUTION_EPOCH=$(echo "$CMD_OUTPUT" | jq -r '.[0].epoch')" >> $GITHUB_ENV
           echo "CARDANO_STAKE_DISTRIBUTION_HASH=$(echo "$CMD_OUTPUT" | jq -r '.[0].hash')" >> $GITHUB_ENV
 
@@ -170,13 +170,13 @@ jobs:
         if: steps.aggregator_capability_unix.outputs.csd_enabled == 'true' || steps.aggregator_capability_windows.outputs.csd_enabled == 'true'
         shell: bash
         working-directory: ./bin
-        run: ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_EPOCH
+        run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_EPOCH
 
       - name: Cardano Stake Distribution / download & restore latest by hash
         if: steps.aggregator_capability_unix.outputs.csd_enabled == 'true' || steps.aggregator_capability_windows.outputs.csd_enabled == 'true'
         shell: bash
         working-directory: ./bin
-        run: ./mithril-client --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_HASH
+        run: ./mithril-client ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_HASH
 
   test-docker:
     strategy:
@@ -259,20 +259,20 @@ jobs:
         if: steps.aggregator_capability.outputs.csd_enabled == 'true'
         shell: bash
         run: |
-          ${{ steps.command.outputs.mithril_client }} --unstable cardano-stake-distribution list
-          CMD_OUTPUT=$(${{ steps.command.outputs.mithril_client }} --unstable cardano-stake-distribution list --json)
+          ${{ steps.command.outputs.mithril_client }} cardano-stake-distribution list
+          CMD_OUTPUT=$(${{ steps.command.outputs.mithril_client }} cardano-stake-distribution list --json)
           echo "CARDANO_STAKE_DISTRIBUTION_EPOCH=$(echo "$CMD_OUTPUT" | jq -r '.[0].epoch')" >> $GITHUB_ENV
           echo "CARDANO_STAKE_DISTRIBUTION_HASH=$(echo "$CMD_OUTPUT" | jq -r '.[0].hash')" >> $GITHUB_ENV
 
       - name: Cardano Stake Distribution / download & restore latest by epoch
         if: steps.aggregator_capability.outputs.csd_enabled == 'true'
         shell: bash
-        run: ${{ steps.command.outputs.mithril_client }} --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_EPOCH --download-dir /app
+        run: ${{ steps.command.outputs.mithril_client }} ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_EPOCH --download-dir /app
 
       - name: Cardano Stake Distribution / download & restore latest by hash
         if: steps.aggregator_capability.outputs.csd_enabled == 'true'
         shell: bash
-        run: ${{ steps.command.outputs.mithril_client }} --unstable ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_HASH --download-dir /app
+        run: ${{ steps.command.outputs.mithril_client }} ${{ steps.prepare.outputs.debug_level }} cardano-stake-distribution download $CARDANO_STAKE_DISTRIBUTION_HASH --download-dir /app
 
   test-mithril-client-wasm:
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Fix an issue that caused unnecessary re-scan of the Cardano chain when importing transactions.
 
+- Support for stable Cardano stake distribution client library, CLI and WASM.
+
 - Crates versions:
 
 | Crate | Version |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-stake-distribution"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3632,7 +3632,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3664,7 +3664,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.9.17"
+version = "0.9.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3693,7 +3693,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.42"
+version = "0.4.43"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/docs/website/root/manual/developer-docs/nodes/mithril-client.md
+++ b/docs/website/root/manual/developer-docs/nodes/mithril-client.md
@@ -131,7 +131,7 @@ Commands:
   cardano-db                  Cardano db management (alias: cdb)
   mithril-stake-distribution  Mithril Stake Distribution management (alias: msd)
   cardano-transaction         Cardano transactions management (alias: ctx)
-  cardano-stake-distribution  [unstable] Cardano stake distribution management (alias: csd)
+  cardano-stake-distribution  Cardano stake distribution management (alias: csd)
   help                        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -148,7 +148,7 @@ Options:
       --log-output <LOG_OUTPUT>
           Redirect the logs to a file
       --unstable
-          Enable unstable commands (such as Cardano Stake Distribution)
+          Enable unstable commands
   -h, --help
           Print help
   -V, --version
@@ -262,10 +262,10 @@ mithril_client cardano-transaction snapshot show $CARDANO_TRANSACTION_SNAPSHOT_H
 mithril_client cardano-transaction certify $TRANSACTION_HASH_1,$TRANSACTION_HASH_2
 
 # 10- List Cardano stake distributions
-mithril_client --unstable cardano-stake-distribution list
+mithril_client cardano-stake-distribution list
 
 # 11 - Download and verify the given Cardano stake distribution from its hash or epoch
-mithril_client --unstable cardano-stake-distribution download $UNIQUE_IDENTIFIER
+mithril_client cardano-stake-distribution download $UNIQUE_IDENTIFIER
 ```
 
 ### Local image

--- a/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/website/root/manual/getting-started/bootstrap-cardano-node.md
@@ -118,7 +118,7 @@ Commands:
   cardano-db                  Cardano db management (alias: cdb)
   mithril-stake-distribution  Mithril Stake Distribution management (alias: msd)
   cardano-transaction         Cardano transactions management (alias: ctx)
-  cardano-stake-distribution  [unstable] Cardano stake distribution management (alias: csd)
+  cardano-stake-distribution  Cardano stake distribution management (alias: csd)
   help                        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -135,7 +135,7 @@ Options:
       --log-output <LOG_OUTPUT>
           Redirect the logs to a file
       --unstable
-          Enable unstable commands (such as Cardano Stake Distribution)
+          Enable unstable commands
   -h, --help
           Print help
   -V, --version

--- a/examples/client-cardano-stake-distribution/Cargo.toml
+++ b/examples/client-cardano-stake-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-stake-distribution"
 description = "Mithril client cardano stake distribution example"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-stake-distribution/Cargo.toml
+++ b/examples/client-cardano-stake-distribution/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/input-output-hk/mithril/"
 [dependencies]
 anyhow = "1.0.89"
 clap = { version = "4.5.20", features = ["derive", "env"] }
-mithril-client = { path = "../../mithril-client", features = ["unstable"] }
+mithril-client = { path = "../../mithril-client" }
 slog = "2.7.0"
 slog-async = "2.8.0"
 slog-term = "2.9.1"

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.9.17"
+version = "0.9.18"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/mod.rs
@@ -11,7 +11,7 @@ use mithril_client::MithrilResult;
 
 /// Cardano Stake Distribution management (alias: csd)
 #[derive(Subcommand, Debug, Clone)]
-#[command(about = "[unstable] Cardano stake distribution management (alias: csd)")]
+#[command(about = "Cardano stake distribution management (alias: csd)")]
 pub enum CardanoStakeDistributionCommands {
     /// List certified Cardano Stake Distributions
     #[clap(arg_required_else_help = false)]

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.5.2"
+version = "0.5.3"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/www-test/package-lock.json
+++ b/mithril-client-wasm/www-test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "www-test",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "www-test",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../pkg"
       },
@@ -21,7 +21,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/www-test/package.json
+++ b/mithril-client-wasm/www-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www-test",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client-wasm/www/package-lock.json
+++ b/mithril-client-wasm/www/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "www",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "www",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../pkg"
       },
@@ -20,7 +20,7 @@
     },
     "../pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/www/package.json
+++ b/mithril-client-wasm/www/package.json
@@ -1,6 +1,6 @@
 {
   "name": "www",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.9.3"
+version = "0.9.4"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/README.md
+++ b/mithril-client/README.md
@@ -7,6 +7,8 @@
 - The different types of available data certified by Mithril are:
   - Snapshot: list, get, download tarball and record statistics.
   - Mithril stake distribution: list and get.
+  - Cardano transactions: list & get snapshot, get proofs.
+  - Cardano stake distribution: list, get and get by epoch.
   - Certificate: list, get, and chain validation.
 
 ## Example

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -23,7 +23,6 @@ use mithril_common::entities::{ClientError, ServerError};
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::MITHRIL_API_VERSION_HEADER;
 
-#[cfg(feature = "unstable")]
 use crate::common::Epoch;
 use crate::{MithrilError, MithrilResult};
 
@@ -94,21 +93,18 @@ pub enum AggregatorRequest {
     ListCardanoTransactionSnapshots,
 
     /// Get a specific [Cardano stake distribution][crate::CardanoStakeDistribution] from the aggregator by hash
-    #[cfg(feature = "unstable")]
     GetCardanoStakeDistribution {
         /// Hash of the Cardano stake distribution to retrieve
         hash: String,
     },
 
     /// Get a specific [Cardano stake distribution][crate::CardanoStakeDistribution] from the aggregator by epoch
-    #[cfg(feature = "unstable")]
     GetCardanoStakeDistributionByEpoch {
         /// Epoch at the end of which the Cardano stake distribution is computed by the Cardano node
         epoch: Epoch,
     },
 
     /// Lists the aggregator [Cardano stake distribution][crate::CardanoStakeDistribution]
-    #[cfg(feature = "unstable")]
     ListCardanoStakeDistributions,
 }
 
@@ -145,15 +141,12 @@ impl AggregatorRequest {
             AggregatorRequest::ListCardanoTransactionSnapshots => {
                 "artifact/cardano-transactions".to_string()
             }
-            #[cfg(feature = "unstable")]
             AggregatorRequest::GetCardanoStakeDistribution { hash } => {
                 format!("artifact/cardano-stake-distribution/{hash}")
             }
-            #[cfg(feature = "unstable")]
             AggregatorRequest::GetCardanoStakeDistributionByEpoch { epoch } => {
                 format!("artifact/cardano-stake-distribution/epoch/{epoch}")
             }
-            #[cfg(feature = "unstable")]
             AggregatorRequest::ListCardanoStakeDistributions => {
                 "artifact/cardano-stake-distributions".to_string()
             }
@@ -604,26 +597,23 @@ mod tests {
             AggregatorRequest::ListCardanoTransactionSnapshots.route()
         );
 
-        #[cfg(feature = "unstable")]
-        {
-            assert_eq!(
-                "artifact/cardano-stake-distribution/abc".to_string(),
-                AggregatorRequest::GetCardanoStakeDistribution {
-                    hash: "abc".to_string()
-                }
-                .route()
-            );
+        assert_eq!(
+            "artifact/cardano-stake-distribution/abc".to_string(),
+            AggregatorRequest::GetCardanoStakeDistribution {
+                hash: "abc".to_string()
+            }
+            .route()
+        );
 
-            assert_eq!(
-                "artifact/cardano-stake-distribution/epoch/123".to_string(),
-                AggregatorRequest::GetCardanoStakeDistributionByEpoch { epoch: Epoch(123) }.route()
-            );
+        assert_eq!(
+            "artifact/cardano-stake-distribution/epoch/123".to_string(),
+            AggregatorRequest::GetCardanoStakeDistributionByEpoch { epoch: Epoch(123) }.route()
+        );
 
-            assert_eq!(
-                "artifact/cardano-stake-distributions".to_string(),
-                AggregatorRequest::ListCardanoStakeDistributions.route()
-            );
-        }
+        assert_eq!(
+            "artifact/cardano-stake-distributions".to_string(),
+            AggregatorRequest::ListCardanoStakeDistributions.route()
+        );
     }
 
     #[tokio::test]

--- a/mithril-client/src/client.rs
+++ b/mithril-client/src/client.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use mithril_common::api_version::APIVersionProvider;
 
 use crate::aggregator_client::{AggregatorClient, AggregatorHTTPClient};
-#[cfg(feature = "unstable")]
 use crate::cardano_stake_distribution_client::CardanoStakeDistributionClient;
 use crate::cardano_transaction_client::CardanoTransactionClient;
 use crate::certificate_client::{
@@ -56,7 +55,6 @@ impl ClientOptions {
 #[derive(Clone)]
 pub struct Client {
     cardano_transaction_client: Arc<CardanoTransactionClient>,
-    #[cfg(feature = "unstable")]
     cardano_stake_distribution_client: Arc<CardanoStakeDistributionClient>,
     certificate_client: Arc<CertificateClient>,
     mithril_stake_distribution_client: Arc<MithrilStakeDistributionClient>,
@@ -85,7 +83,6 @@ impl Client {
     }
 
     /// Get the client that fetches Cardano stake distributions.
-    #[cfg(feature = "unstable")]
     pub fn cardano_stake_distribution(&self) -> Arc<CardanoStakeDistributionClient> {
         self.cardano_stake_distribution_client.clone()
     }
@@ -216,13 +213,11 @@ impl ClientBuilder {
             logger,
         ));
 
-        #[cfg(feature = "unstable")]
         let cardano_stake_distribution_client =
             Arc::new(CardanoStakeDistributionClient::new(aggregator_client));
 
         Ok(Client {
             cardano_transaction_client,
-            #[cfg(feature = "unstable")]
             cardano_stake_distribution_client,
             certificate_client,
             mithril_stake_distribution_client,

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -8,8 +8,8 @@
 //!
 //! - [Snapshot][snapshot_client] list, get, download tarball and record statistics.
 //! - [Mithril stake distribution][mithril_stake_distribution_client] list and get.
-//! - [Cardano transactions][cardano_transaction_client] list & get snapshot, get proofs
-//!   _(available using crate feature_ **unstable**_)_.
+//! - [Cardano transactions][cardano_transaction_client] list & get snapshot, get proofs.
+//! - [Cardano stake distribution][cardano_stake_distribution_client] list, get and get by epoch.
 //! - [Certificates][certificate_client] list, get, and chain validation.
 //!
 //! The [Client] aggregates the queries of all of those types.
@@ -72,6 +72,7 @@ macro_rules! cfg_fs {
     }
 }
 
+#[allow(unused_macros)]
 macro_rules! cfg_unstable {
     ($($item:item)*) => {
         $(
@@ -83,9 +84,7 @@ macro_rules! cfg_unstable {
 }
 
 pub mod aggregator_client;
-cfg_unstable! {
-    pub mod cardano_stake_distribution_client;
-}
+pub mod cardano_stake_distribution_client;
 pub mod cardano_transaction_client;
 pub mod certificate_client;
 mod client;

--- a/mithril-client/src/message.rs
+++ b/mithril-client/src/message.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::protocol::SignerBuilder;
-#[cfg(feature = "unstable")]
 use mithril_common::signable_builder::CardanoStakeDistributionSignableBuilder;
 #[cfg(feature = "fs")]
 use mithril_common::{
@@ -15,12 +14,11 @@ use mithril_common::{
     entities::SignedEntityType,
 };
 
-use crate::common::{ProtocolMessage, ProtocolMessagePartKey};
-#[cfg(feature = "unstable")]
-use crate::CardanoStakeDistribution;
-use crate::MithrilCertificate;
-use crate::VerifiedCardanoTransactions;
-use crate::{MithrilResult, MithrilSigner, MithrilStakeDistribution};
+use crate::{
+    common::{ProtocolMessage, ProtocolMessagePartKey},
+    CardanoStakeDistribution, MithrilCertificate, MithrilResult, MithrilSigner,
+    MithrilStakeDistribution, VerifiedCardanoTransactions,
+};
 
 /// A [MessageBuilder] can be used to compute the message of Mithril artifacts.
 pub struct MessageBuilder {
@@ -143,29 +141,28 @@ impl MessageBuilder {
         message
     }
 
-    cfg_unstable! {
-        /// Compute message for a Cardano stake distribution.
-        pub fn compute_cardano_stake_distribution_message(
-            &self,
-            certificate: &MithrilCertificate,
-            cardano_stake_distribution: &CardanoStakeDistribution,
-        ) -> MithrilResult<ProtocolMessage> {
-            let mk_tree = CardanoStakeDistributionSignableBuilder::compute_merkle_tree_from_stake_distribution(
+    /// Compute message for a Cardano stake distribution.
+    pub fn compute_cardano_stake_distribution_message(
+        &self,
+        certificate: &MithrilCertificate,
+        cardano_stake_distribution: &CardanoStakeDistribution,
+    ) -> MithrilResult<ProtocolMessage> {
+        let mk_tree =
+            CardanoStakeDistributionSignableBuilder::compute_merkle_tree_from_stake_distribution(
                 cardano_stake_distribution.stake_distribution.clone(),
             )?;
 
-            let mut message = certificate.protocol_message.clone();
-            message.set_message_part(
-                ProtocolMessagePartKey::CardanoStakeDistributionEpoch,
-                cardano_stake_distribution.epoch.to_string(),
-            );
-            message.set_message_part(
-                ProtocolMessagePartKey::CardanoStakeDistributionMerkleRoot,
-                mk_tree.compute_root()?.to_hex(),
-            );
+        let mut message = certificate.protocol_message.clone();
+        message.set_message_part(
+            ProtocolMessagePartKey::CardanoStakeDistributionEpoch,
+            cardano_stake_distribution.epoch.to_string(),
+        );
+        message.set_message_part(
+            ProtocolMessagePartKey::CardanoStakeDistributionMerkleRoot,
+            mk_tree.compute_root()?.to_hex(),
+        );
 
-            Ok(message)
-        }
+        Ok(message)
     }
 }
 

--- a/mithril-client/src/type_alias.rs
+++ b/mithril-client/src/type_alias.rs
@@ -50,22 +50,17 @@ pub use mithril_common::messages::CardanoTransactionSnapshotMessage as CardanoTr
 /// List item of a Cardano transaction snapshot.
 pub use mithril_common::messages::CardanoTransactionSnapshotListItemMessage as CardanoTransactionSnapshotListItem;
 
-cfg_unstable! {
-    /// A Cardano stake distribution.
-    pub use mithril_common::messages::CardanoStakeDistributionMessage as CardanoStakeDistribution;
+/// A Cardano stake distribution.
+pub use mithril_common::messages::CardanoStakeDistributionMessage as CardanoStakeDistribution;
 
-    /// List item of Cardano stake distributions.
-    pub use mithril_common::messages::CardanoStakeDistributionListItemMessage as CardanoStakeDistributionListItem;
-}
+/// List item of Cardano stake distributions.
+pub use mithril_common::messages::CardanoStakeDistributionListItemMessage as CardanoStakeDistributionListItem;
 
 /// `mithril-common` re-exports
 pub mod common {
     pub use mithril_common::entities::{
         BlockHash, BlockNumber, CardanoDbBeacon, ChainPoint, CompressionAlgorithm, Epoch,
         ImmutableFileNumber, ProtocolMessage, ProtocolMessagePartKey, ProtocolParameters,
-        SlotNumber, TransactionHash,
+        SlotNumber, StakeDistribution, TransactionHash,
     };
-    cfg_unstable! {
-        pub use mithril_common::entities::{StakeDistribution};
-    }
 }

--- a/mithril-client/tests/extensions/fake.rs
+++ b/mithril-client/tests/extensions/fake.rs
@@ -140,7 +140,6 @@ impl FakeAggregator {
     }
 }
 
-#[cfg(feature = "unstable")]
 mod proof {
     use mithril_client::common::{BlockNumber, ProtocolMessagePartKey};
     use mithril_client::{CardanoTransactionsProofs, CardanoTransactionsSetProof};

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.10",
+      "version": "0.7.11",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/pkg",
         "@popperjs/core": "^2.11.8",
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm/pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "Apache-2.0"
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.42"
+version = "0.4.43"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
@@ -169,10 +169,7 @@ impl ClientCommand {
                 [vec!["cardano-transaction".to_string()], cmd.cli_arg()].concat()
             }
             ClientCommand::CardanoStakeDistribution(cmd) => [
-                vec![
-                    "--unstable".to_string(),
-                    "cardano-stake-distribution".to_string(),
-                ],
+                vec!["cardano-stake-distribution".to_string()],
                 cmd.cli_arg(),
             ]
             .concat(),


### PR DESCRIPTION
## Content

This PR includes the release of Cardano stake distribution in a `stable` version, previously available as an `unstable` feature.

This update ensures the Cardano stake distribution client is now stable using `mithril-client`, `mithril-client-cli` and `mithril-client-wasm`.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2024 
