### PR TITLE
Ensemble/1958/fix explorer

### DIFF
--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/pkg",
         "@popperjs/core": "^2.11.8",
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm/pkg": {
       "name": "mithril-client-wasm",
-      "version": "0.5.3",
+      "version": "0.6.0",
       "license": "Apache-2.0"
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/components/Artifacts/CertificatesList/index.js
+++ b/mithril-explorer/src/components/Artifacts/CertificatesList/index.js
@@ -2,8 +2,9 @@ import React, { useEffect, useState } from "react";
 import { useSelector } from "react-redux";
 import { Badge, Button, Card, Col, Container, ListGroup, Row, Stack } from "react-bootstrap";
 import CertificateModal from "#/CertificateModal";
-import RawJsonButton from "#/RawJsonButton";
 import LocalDateTime from "#/LocalDateTime";
+import RawJsonButton from "#/RawJsonButton";
+import SignedEntityType from "#/SignedEntityType";
 import { selectedAggregator } from "@/store/settingsSlice";
 
 export default function CertificatesList(props) {
@@ -77,9 +78,13 @@ export default function CertificatesList(props) {
                             Show
                           </Button>
                         </ListGroup.Item>
-                        <ListGroup.Item>Epoch: {certificate.beacon.epoch}</ListGroup.Item>
+                        <ListGroup.Item>Epoch: {certificate.epoch}</ListGroup.Item>
                         <ListGroup.Item>
-                          Immutable file number: {certificate.beacon.immutable_file_number}
+                          Beacon:{" "}
+                          <SignedEntityType
+                            signedEntityType={certificate.signed_entity_type}
+                            table
+                          />
                         </ListGroup.Item>
                         <ListGroup.Item>
                           Number of signers: {certificate.metadata.total_signers}
@@ -100,7 +105,7 @@ export default function CertificatesList(props) {
                             <Badge bg="primary">Latest</Badge>{" "}
                           </>
                         )}
-                        <Badge bg="secondary">{certificate.beacon.network}</Badge>
+                        <Badge bg="secondary">{certificate.metadata.network}</Badge>
 
                         <RawJsonButton
                           href={`${aggregator}/certificate/${certificate.hash}`}

--- a/mithril-explorer/src/components/CertifyCardanoTransactionsModal/TransactionCertificationResult.js
+++ b/mithril-explorer/src/components/CertifyCardanoTransactionsModal/TransactionCertificationResult.js
@@ -12,11 +12,11 @@ function CertifiedDataBeacon({ certificate }) {
       <ListGroup horizontal>
         <ListGroup.Item>
           <span className="fst-italic">Epoch: </span>
-          {certificate.beacon.epoch}
+          {certificate.epoch}
         </ListGroup.Item>
         <ListGroup.Item>
-          <span className="fst-italic">Immutable File Number: </span>
-          {certificate.beacon.immutable_file_number}
+          <span className="fst-italic">Block number: </span>
+          {certificate.signed_entity_type.CardanoTransactions[1]}
         </ListGroup.Item>
       </ListGroup>
     </>

--- a/mithril-explorer/src/components/VerifyCertificate/CertificateVerifier.js
+++ b/mithril-explorer/src/components/VerifyCertificate/CertificateVerifier.js
@@ -147,7 +147,7 @@ export default function CertificateVerifier({
               linkVariant="primary"
             />
           </div>
-          <div>Epoch: {certificate.beacon.epoch}</div>
+          <div>Epoch: {certificate.epoch}</div>
           <div className="d-flex justify-content-between">
             <div>
               Sealed at: <LocalDateTime datetime={certificate.metadata.sealed_at} />


### PR DESCRIPTION
## Content

This PR includes a fix for the explorer who had `e.beacon is undefined` errors on testing network plus when validating transactions since the merge of #2055.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #1958