### PR TITLE
Feat: add aggregator metric to record the number of restoration of the Cardano database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.92"
+version = "0.5.93"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.92"
+version = "0.5.93"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/metrics/service.rs
+++ b/mithril-aggregator/src/metrics/service.rs
@@ -12,6 +12,10 @@ build_metrics_service!(
         "mithril_aggregator_artifact_detail_cardano_db_total_served_since_startup",
         "Number of Cardano db artifact details served since startup on a Mithril aggregator node"
     ),
+    cardano_db_total_restoration_since_startup:MetricCounter(
+        "mithril_aggregator_cardano_db_total_restoration_since_startup",
+        "Number of Cardano db restorations since startup on a Mithril aggregator node"
+    ),
     artifact_detail_mithril_stake_distribution_total_served_since_startup:MetricCounter(
         "mithril_aggregator_artifact_detail_mithril_stake_distribution_total_served_since_startup",
         "Number of Mithril stake distribution artifact details served since startup on a Mithril aggregator node"


### PR DESCRIPTION
## Content

This PR includes the implementation of a new metric in the Prometheus endpoint of the aggregator, tracking the total number of restorations of the Cardano database.
The `cardano_db_total_restoration_since_startup` counter metric is recorded in the `/statistics/snapshot` route.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2054 
