### PR TITLE
CI: add scheduled Docker builds workflow

### DIFF
--- a/.github/workflows/nightly-docker-builds.yml
+++ b/.github/workflows/nightly-docker-builds.yml
@@ -1,4 +1,4 @@
-name: Scheduled Docker Builds
+name: Nightly Docker Builds
 
 on:
   schedule:
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  docker-scheduled-build:
+  nightly-docker-build:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false

--- a/.github/workflows/scheduled-docker-builds.yml
+++ b/.github/workflows/scheduled-docker-builds.yml
@@ -1,0 +1,35 @@
+name: Scheduled Docker Builds
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  docker-scheduled-build:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        project:
+          [
+            mithril-aggregator,
+            mithril-client-cli,
+            mithril-signer,
+            mithril-relay,
+          ]
+
+    env:
+      DOCKER_FILE: ./${{ matrix.project }}/Dockerfile
+      CONTEXT: .
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ env.CONTEXT }}
+          file: ${{ env.DOCKER_FILE }}
+          push: false


### PR DESCRIPTION
## Content

This PR includes the introduction of a scheduled Docker builds workflow, set to run daily at 2:00 AM UTC, with the option to trigger it manually.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2026 
