### PR TITLE
Streamline configurations usage in aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3552,7 +3552,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.98"
+version = "0.5.99"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.98"
+version = "0.5.99"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -63,7 +63,10 @@ use crate::{
     },
     entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
-    http_server::routes::router,
+    http_server::routes::{
+        router,
+        router::{RouterConfig, RouterState},
+    },
     services::{
         AggregatorSignableSeedBuilder, AggregatorUpkeepService, BufferedCertifierService,
         CardanoTransactionsImporter, CertifierService, MessageService, MithrilCertifierService,
@@ -1491,8 +1494,9 @@ impl DependenciesBuilder {
         &mut self,
     ) -> Result<impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone> {
         let dependency_container = Arc::new(self.build_dependency_container().await?);
+        let router_state = RouterState::new(dependency_container.clone(), RouterConfig {});
 
-        Ok(router::routes(dependency_container))
+        Ok(router::routes(Arc::new(router_state)))
     }
 
     /// Create a [CardanoTransactionsPreloader] instance.

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1408,6 +1408,7 @@ impl DependenciesBuilder {
 
     /// Return an unconfigured [DependencyContainer]
     pub async fn build_dependency_container(&mut self) -> Result<DependencyContainer> {
+        #[allow(deprecated)]
         let dependency_manager = DependencyContainer {
             config: self.configuration.clone(),
             root_logger: self.root_logger(),

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -1,5 +1,5 @@
 use slog::Logger;
-use std::{collections::BTreeSet, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use mithril_common::{
@@ -10,8 +10,8 @@ use mithril_common::{
     crypto_helper::ProtocolGenesisVerifier,
     digesters::{ImmutableDigester, ImmutableFileObserver},
     entities::{
-        CardanoTransactionsSigningConfig, Epoch, ProtocolParameters, SignedEntityTypeDiscriminants,
-        SignerWithStake, StakeDistribution,
+        CardanoTransactionsSigningConfig, Epoch, ProtocolParameters, SignerWithStake,
+        StakeDistribution,
     },
     era::{EraChecker, EraReader},
     signable_builder::SignableBuilderService,
@@ -51,9 +51,6 @@ pub type EpochServiceWrapper = Arc<RwLock<dyn EpochService>>;
 pub struct DependencyContainer {
     /// Configuration structure.
     pub config: Configuration,
-
-    /// List of signed entity discriminants that are allowed to be processed
-    pub allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
 
     /// Application root logger
     pub root_logger: Logger,

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -50,6 +50,8 @@ pub type EpochServiceWrapper = Arc<RwLock<dyn EpochService>>;
 /// DependencyManager handles the dependencies
 pub struct DependencyContainer {
     /// Configuration structure.
+    // TODO: remove this field and only use the `Configuration` in the dependencies builder
+    #[deprecated]
     pub config: Configuration,
 
     /// Application root logger
@@ -206,6 +208,7 @@ impl DependencyContainer {
             self.epoch_settings_storer
                 .save_epoch_settings(
                     *epoch,
+                    #[allow(deprecated)]
                     AggregatorEpochSettings {
                         protocol_parameters: fixture.protocol_parameters(),
                         cardano_transactions_signing_config: self

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -1,34 +1,33 @@
 use crate::http_server::routes::middlewares;
-use crate::DependencyContainer;
+use crate::http_server::routes::router::RouterState;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    artifact_cardano_transactions(dependency_manager)
-        .or(artifact_cardano_transaction_by_id(dependency_manager))
+    artifact_cardano_transactions(router_state).or(artifact_cardano_transaction_by_id(router_state))
 }
 
 /// GET /artifact/cardano-transactions
 fn artifact_cardano_transactions(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-transactions")
         .and(warp::get())
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_http_message_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_http_message_service(router_state))
         .and_then(handlers::list_artifacts)
 }
 
 /// GET /artifact/cardano-transaction/:id
 fn artifact_cardano_transaction_by_id(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "cardano-transaction" / String)
         .and(warp::get())
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_http_message_service(dependency_manager))
-        .and(middlewares::with_metrics_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_http_message_service(router_state))
+        .and(middlewares::with_metrics_service(router_state))
         .and_then(handlers::get_artifact_by_signed_entity_id)
 }
 
@@ -117,7 +116,7 @@ pub mod tests {
     use super::*;
 
     fn setup_router(
-        dependency_manager: Arc<DependencyContainer>,
+        state: RouterState,
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
@@ -126,7 +125,7 @@ pub mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&dependency_manager).with(cors))
+            .and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -150,7 +149,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -181,7 +182,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -210,7 +213,9 @@ pub mod tests {
         request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(dependency_manager.clone()))
+            .reply(&setup_router(RouterState::new_with_dummy_config(
+                dependency_manager.clone(),
+            )))
             .await;
 
         assert_eq!(
@@ -246,7 +251,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -277,7 +284,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -308,7 +317,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -1,35 +1,34 @@
 use crate::http_server::routes::middlewares;
-use crate::DependencyContainer;
+use crate::http_server::routes::router::RouterState;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    artifact_mithril_stake_distributions(dependency_manager).or(
-        artifact_mithril_stake_distribution_by_id(dependency_manager),
-    )
+    artifact_mithril_stake_distributions(router_state)
+        .or(artifact_mithril_stake_distribution_by_id(router_state))
 }
 
 /// GET /artifact/mithril-stake-distributions
 fn artifact_mithril_stake_distributions(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "mithril-stake-distributions")
         .and(warp::get())
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_http_message_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_http_message_service(router_state))
         .and_then(handlers::list_artifacts)
 }
 
 /// GET /artifact/mithril-stake-distribution/:id
 fn artifact_mithril_stake_distribution_by_id(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "mithril-stake-distribution" / String)
         .and(warp::get())
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_http_message_service(dependency_manager))
-        .and(middlewares::with_metrics_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_http_message_service(router_state))
+        .and(middlewares::with_metrics_service(router_state))
         .and_then(handlers::get_artifact_by_signed_entity_id)
 }
 
@@ -117,7 +116,7 @@ pub mod tests {
     use super::*;
 
     fn setup_router(
-        dependency_manager: Arc<DependencyContainer>,
+        state: RouterState,
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
@@ -126,7 +125,7 @@ pub mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&dependency_manager).with(cors))
+            .and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -150,7 +149,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -181,7 +182,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -210,7 +213,9 @@ pub mod tests {
         request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(dependency_manager.clone()))
+            .reply(&setup_router(RouterState::new_with_dummy_config(
+                dependency_manager.clone(),
+            )))
             .await;
 
         assert_eq!(
@@ -246,7 +251,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -277,7 +284,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -308,7 +317,9 @@ pub mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -1,36 +1,34 @@
 use crate::http_server::routes::middlewares;
+use crate::http_server::routes::router::RouterState;
 use crate::http_server::SERVER_BASE_PATH;
-use crate::DependencyContainer;
 use warp::hyper::Uri;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    artifact_cardano_full_immutable_snapshots(dependency_manager)
-        .or(artifact_cardano_full_immutable_snapshot_by_id(
-            dependency_manager,
-        ))
-        .or(serve_snapshots_dir(dependency_manager))
-        .or(snapshot_download(dependency_manager))
+    artifact_cardano_full_immutable_snapshots(router_state)
+        .or(artifact_cardano_full_immutable_snapshot_by_id(router_state))
+        .or(serve_snapshots_dir(router_state))
+        .or(snapshot_download(router_state))
         .or(artifact_cardano_full_immutable_snapshots_legacy())
         .or(artifact_cardano_full_immutable_snapshot_by_id_legacy())
 }
 
 /// GET /artifact/snapshots
 fn artifact_cardano_full_immutable_snapshots(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "snapshots")
         .and(warp::get())
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_http_message_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_http_message_service(router_state))
         .and_then(handlers::list_artifacts)
 }
 
 /// GET /artifact/snapshot/:id
 fn artifact_cardano_full_immutable_snapshot_by_id(
-    dependency_manager: &DependencyContainer,
+    dependency_manager: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "snapshot" / String)
         .and(warp::get())
@@ -42,25 +40,25 @@ fn artifact_cardano_full_immutable_snapshot_by_id(
 
 /// GET /artifact/snapshots/{digest}/download
 fn snapshot_download(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("artifact" / "snapshot" / String / "download")
         .and(warp::get().or(warp::head()).unify())
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_config(dependency_manager))
-        .and(middlewares::with_signed_entity_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_config(router_state))
+        .and(middlewares::with_signed_entity_service(router_state))
         .and_then(handlers::snapshot_download)
 }
 
 fn serve_snapshots_dir(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    let config = dependency_manager.config.clone();
+    let config = router_state.dependencies.config.clone();
 
     warp::path("snapshot_download")
         .and(warp::fs::dir(config.snapshot_directory))
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_signed_entity_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_signed_entity_service(router_state))
         .and_then(handlers::ensure_downloaded_file_is_a_snapshot)
 }
 
@@ -253,7 +251,7 @@ mod tests {
     use super::*;
 
     fn setup_router(
-        dependency_manager: Arc<DependencyContainer>,
+        state: RouterState,
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
@@ -262,7 +260,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&dependency_manager).with(cors))
+            .and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -286,7 +284,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -317,7 +317,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -345,7 +347,9 @@ mod tests {
         request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(dependency_manager.clone()))
+            .reply(&setup_router(RouterState::new_with_dummy_config(
+                dependency_manager.clone(),
+            )))
             .await;
 
         assert_eq!(
@@ -381,7 +385,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -412,7 +418,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -443,7 +451,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -482,7 +492,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         assert_eq!(response.status(), StatusCode::FOUND);
@@ -511,7 +523,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -542,7 +556,9 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -25,9 +25,9 @@ fn epoch_settings(
         .and(warp::get())
         .and(middlewares::with_logger(router_state))
         .and(middlewares::with_epoch_service(router_state))
-        .and(middlewares::with_allowed_signed_entity_type_discriminants(
-            router_state,
-        ))
+        .and(middlewares::extract_config(router_state, |config| {
+            config.allowed_discriminants.clone()
+        }))
         .and_then(handlers::epoch_settings)
 }
 

--- a/mithril-aggregator/src/http_server/routes/middlewares.rs
+++ b/mithril-aggregator/src/http_server/routes/middlewares.rs
@@ -11,17 +11,18 @@ use crate::database::repository::SignerGetter;
 use crate::dependency_injection::EpochServiceWrapper;
 use crate::event_store::{EventMessage, TransmitterService};
 use crate::http_server::routes::http_server_child_logger;
+use crate::http_server::routes::router::RouterState;
 use crate::services::{CertifierService, MessageService, ProverService, SignedEntityService};
 use crate::{
-    CertificatePendingStore, Configuration, DependencyContainer, MetricsService, SignerRegisterer,
+    CertificatePendingStore, Configuration, MetricsService, SignerRegisterer,
     SingleSignatureAuthenticator, VerificationKeyStorer,
 };
 
 /// With logger middleware
 pub(crate) fn with_logger(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Logger,), Error = Infallible> + Clone {
-    let logger = http_server_child_logger(&dependency_manager.root_logger);
+    let logger = http_server_child_logger(&router_state.dependencies.root_logger);
     warp::any().map(move || logger.clone())
 }
 
@@ -29,9 +30,9 @@ pub(crate) fn with_logger(
 ///
 /// Example of log produced: `POST /aggregator/register-signatures 202 Accepted`
 pub(crate) fn log_route_call(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> warp::log::Log<impl Fn(warp::log::Info<'_>) + Clone> {
-    let logger = http_server_child_logger(&dependency_manager.root_logger);
+    let logger = http_server_child_logger(&router_state.dependencies.root_logger);
     warp::log::custom(move |info| {
         debug!(
             logger,
@@ -45,121 +46,124 @@ pub(crate) fn log_route_call(
 
 /// With certificate pending store
 pub(crate) fn with_certificate_pending_store(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<CertificatePendingStore>,), Error = Infallible> + Clone {
-    let certificate_pending_store = dependency_manager.certificate_pending_store.clone();
+    let certificate_pending_store = router_state.dependencies.certificate_pending_store.clone();
     warp::any().map(move || certificate_pending_store.clone())
 }
 
 /// With signer registerer middleware
 pub fn with_signer_registerer(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<dyn SignerRegisterer>,), Error = Infallible> + Clone {
-    let signer_register = dependency_manager.signer_registerer.clone();
+    let signer_register = router_state.dependencies.signer_registerer.clone();
     warp::any().map(move || signer_register.clone())
 }
 
 /// With signer getter middleware
 pub fn with_signer_getter(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<dyn SignerGetter>,), Error = Infallible> + Clone {
-    let signer_getter = dependency_manager.signer_getter.clone();
+    let signer_getter = router_state.dependencies.signer_getter.clone();
     warp::any().map(move || signer_getter.clone())
 }
 
 /// With config middleware
 pub fn with_config(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Configuration,), Error = Infallible> + Clone {
-    let config = dependency_manager.config.clone();
+    let config = router_state.dependencies.config.clone();
     warp::any().map(move || config.clone())
 }
 
 /// With allowed signed entity discriminants middleware
 pub fn with_allowed_signed_entity_type_discriminants(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (BTreeSet<SignedEntityTypeDiscriminants>,), Error = Infallible> + Clone {
-    let allowed_discriminants = dependency_manager.allowed_discriminants.clone();
+    let allowed_discriminants = router_state.dependencies.allowed_discriminants.clone();
     warp::any().map(move || allowed_discriminants.clone())
 }
 
 /// With Event transmitter middleware
 pub fn with_event_transmitter(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<TransmitterService<EventMessage>>,), Error = Infallible> + Clone {
-    let event_transmitter = dependency_manager.event_transmitter.clone();
+    let event_transmitter = router_state.dependencies.event_transmitter.clone();
     warp::any().map(move || event_transmitter.clone())
 }
 
 /// With certifier service middleware
 pub fn with_certifier_service(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<dyn CertifierService>,), Error = Infallible> + Clone {
-    let certifier_service = dependency_manager.certifier_service.clone();
+    let certifier_service = router_state.dependencies.certifier_service.clone();
     warp::any().map(move || certifier_service.clone())
 }
 
 /// With epoch service middleware
 pub fn with_epoch_service(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (EpochServiceWrapper,), Error = Infallible> + Clone {
-    let epoch_service = dependency_manager.epoch_service.clone();
+    let epoch_service = router_state.dependencies.epoch_service.clone();
     warp::any().map(move || epoch_service.clone())
 }
 
 /// With signed entity service
 pub fn with_signed_entity_service(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<dyn SignedEntityService>,), Error = Infallible> + Clone {
-    let signed_entity_service = dependency_manager.signed_entity_service.clone();
+    let signed_entity_service = router_state.dependencies.signed_entity_service.clone();
     warp::any().map(move || signed_entity_service.clone())
 }
 
 /// With verification key store
 pub fn with_verification_key_store(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<dyn VerificationKeyStorer>,), Error = Infallible> + Clone {
-    let verification_key_store = dependency_manager.verification_key_store.clone();
+    let verification_key_store = router_state.dependencies.verification_key_store.clone();
     warp::any().map(move || verification_key_store.clone())
 }
 
 /// With API version provider
 pub fn with_api_version_provider(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<APIVersionProvider>,), Error = Infallible> + Clone {
-    let api_version_provider = dependency_manager.api_version_provider.clone();
+    let api_version_provider = router_state.dependencies.api_version_provider.clone();
     warp::any().map(move || api_version_provider.clone())
 }
 
 /// With Message service
 pub fn with_http_message_service(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<dyn MessageService>,), Error = Infallible> + Clone {
-    let message_service = dependency_manager.message_service.clone();
+    let message_service = router_state.dependencies.message_service.clone();
     warp::any().map(move || message_service.clone())
 }
 
 /// With Prover service
 pub fn with_prover_service(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<dyn ProverService>,), Error = Infallible> + Clone {
-    let prover_service = dependency_manager.prover_service.clone();
+    let prover_service = router_state.dependencies.prover_service.clone();
     warp::any().map(move || prover_service.clone())
 }
 
 /// With Single Signature Authenticator
 pub fn with_single_signature_authenticator(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<SingleSignatureAuthenticator>,), Error = Infallible> + Clone {
-    let single_signer_authenticator = dependency_manager.single_signer_authenticator.clone();
+    let single_signer_authenticator = router_state
+        .dependencies
+        .single_signer_authenticator
+        .clone();
     warp::any().map(move || single_signer_authenticator.clone())
 }
 
 /// With Metrics service
 pub fn with_metrics_service(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (Arc<MetricsService>,), Error = Infallible> + Clone {
-    let metrics_service = dependency_manager.metrics_service.clone();
+    let metrics_service = router_state.dependencies.metrics_service.clone();
     warp::any().map(move || metrics_service.clone())
 }
 
@@ -170,9 +174,10 @@ pub mod validators {
 
     /// With Prover Transactions Hash Validator
     pub fn with_prover_transactions_hash_validator(
-        dependency_manager: &DependencyContainer,
+        router_state: &RouterState,
     ) -> impl Filter<Extract = (ProverTransactionsHashValidator,), Error = Infallible> + Clone {
-        let max_hashes = dependency_manager
+        let max_hashes = router_state
+            .dependencies
             .config
             .cardano_transactions_prover_max_hashes_allowed_by_request;
 

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -154,10 +154,7 @@ mod tests {
         test_utils::{apispec::APISpec, assert_equivalent, fake_data},
     };
 
-    use crate::{
-        dependency_injection::DependenciesBuilder, http_server::SERVER_BASE_PATH,
-        services::MockProverService, Configuration,
-    };
+    use crate::{http_server::SERVER_BASE_PATH, services::MockProverService};
     use crate::{initialize_dependencies, services::MockSignedEntityService};
 
     use super::*;
@@ -250,9 +247,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_ok() {
-        let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
-        let mut dependency_manager = builder.build_dependency_container().await.unwrap();
+        let mut dependency_manager = initialize_dependencies().await;
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
             .expect_get_last_cardano_transaction_snapshot()
@@ -294,9 +289,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_not_found() {
-        let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
-        let dependency_manager = builder.build_dependency_container().await.unwrap();
+        let dependency_manager = initialize_dependencies().await;
 
         let method = Method::GET.as_str();
         let path = "/proof/cardano-transaction";
@@ -327,9 +320,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_ko() {
-        let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
-        let mut dependency_manager = builder.build_dependency_container().await.unwrap();
+        let mut dependency_manager = initialize_dependencies().await;
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
             .expect_get_last_cardano_transaction_snapshot()
@@ -365,9 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_return_bad_request_with_invalid_hashes() {
-        let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
-        let dependency_manager = builder.build_dependency_container().await.unwrap();
+        let dependency_manager = initialize_dependencies().await;
 
         let method = Method::GET.as_str();
         let path = "/proof/cardano-transaction";
@@ -397,9 +386,7 @@ mod tests {
     #[tokio::test]
     async fn proof_cardano_transaction_route_deduplicate_hashes() {
         let tx = fake_data::transaction_hashes()[0].to_string();
-        let config = Configuration::new_sample();
-        let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
-        let mut dependency_manager = builder.build_dependency_container().await.unwrap();
+        let mut dependency_manager = initialize_dependencies().await;
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
             .expect_get_last_cardano_transaction_snapshot()

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -6,9 +6,12 @@ use crate::http_server::SERVER_BASE_PATH;
 use crate::DependencyContainer;
 
 use mithril_common::api_version::APIVersionProvider;
-use mithril_common::MITHRIL_API_VERSION_HEADER;
+use mithril_common::entities::{CardanoTransactionsSigningConfig, SignedEntityTypeDiscriminants};
+use mithril_common::{CardanoNetwork, MITHRIL_API_VERSION_HEADER};
 
 use slog::{warn, Logger};
+use std::collections::BTreeSet;
+use std::path::PathBuf;
 use std::sync::Arc;
 use warp::http::Method;
 use warp::http::StatusCode;
@@ -28,12 +31,29 @@ pub struct VersionParseError;
 impl Reject for VersionParseError {}
 
 /// HTTP Server configuration
-pub struct RouterConfig {}
+pub struct RouterConfig {
+    pub network: CardanoNetwork,
+    pub server_url: String,
+    pub allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
+    pub cardano_transactions_prover_max_hashes_allowed_by_request: usize,
+    pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
+    pub snapshot_directory: PathBuf,
+}
 
 #[cfg(test)]
 impl RouterConfig {
     pub fn dummy() -> Self {
-        Self {}
+        Self {
+            network: CardanoNetwork::DevNet(87),
+            server_url: "http://0.0.0.0:8000/".to_string(),
+            allowed_discriminants: BTreeSet::from([
+                SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+                SignedEntityTypeDiscriminants::CardanoStakeDistribution,
+            ]),
+            cardano_transactions_prover_max_hashes_allowed_by_request: 1_000,
+            cardano_transactions_signing_config: CardanoTransactionsSigningConfig::dummy(),
+            snapshot_directory: PathBuf::from("/dummy/snapshot/directory"),
+        }
     }
 }
 

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -27,10 +27,46 @@ pub struct VersionParseError;
 
 impl Reject for VersionParseError {}
 
+/// HTTP Server configuration
+pub struct RouterConfig {}
+
+#[cfg(test)]
+impl RouterConfig {
+    pub fn dummy() -> Self {
+        Self {}
+    }
+}
+
+/// Shared state for the router
+pub struct RouterState {
+    pub dependencies: Arc<DependencyContainer>,
+    pub configuration: RouterConfig,
+}
+
+impl RouterState {
+    /// `RouterState` factory
+    pub fn new(dependencies: Arc<DependencyContainer>, configuration: RouterConfig) -> Self {
+        Self {
+            dependencies,
+            configuration,
+        }
+    }
+}
+
+#[cfg(test)]
+impl RouterState {
+    pub fn new_with_dummy_config(dependencies: Arc<DependencyContainer>) -> Self {
+        Self {
+            dependencies,
+            configuration: RouterConfig::dummy(),
+        }
+    }
+}
+
 /// Routes
 pub fn routes(
-    dependency_manager: Arc<DependencyContainer>,
-) -> impl Filter<Extract = (impl Reply,), Error = warp::Rejection> + Clone {
+    state: Arc<RouterState>,
+) -> impl Filter<Extract = (impl Reply,), Error = Rejection> + Clone {
     let cors = warp::cors()
         .allow_any_origin()
         .allow_headers(vec!["content-type", MITHRIL_API_VERSION_HEADER])
@@ -38,32 +74,26 @@ pub fn routes(
 
     warp::any()
         .and(header_must_be(
-            dependency_manager.api_version_provider.clone(),
-            http_server_child_logger(&dependency_manager.root_logger),
+            state.dependencies.api_version_provider.clone(),
+            http_server_child_logger(&state.dependencies.root_logger),
         ))
         .and(warp::path(SERVER_BASE_PATH))
         .and(
-            certificate_routes::routes(&dependency_manager)
-                .or(artifact_routes::snapshot::routes(&dependency_manager))
-                .or(artifact_routes::mithril_stake_distribution::routes(
-                    &dependency_manager,
-                ))
-                .or(artifact_routes::cardano_stake_distribution::routes(
-                    &dependency_manager,
-                ))
-                .or(artifact_routes::cardano_transaction::routes(
-                    &dependency_manager,
-                ))
-                .or(proof_routes::routes(&dependency_manager))
-                .or(signer_routes::routes(&dependency_manager))
-                .or(signatures_routes::routes(&dependency_manager))
-                .or(epoch_routes::routes(&dependency_manager))
-                .or(statistics_routes::routes(&dependency_manager))
-                .or(root_routes::routes(&dependency_manager))
+            certificate_routes::routes(&state)
+                .or(artifact_routes::snapshot::routes(&state))
+                .or(artifact_routes::mithril_stake_distribution::routes(&state))
+                .or(artifact_routes::cardano_stake_distribution::routes(&state))
+                .or(artifact_routes::cardano_transaction::routes(&state))
+                .or(proof_routes::routes(&state))
+                .or(signer_routes::routes(&state))
+                .or(signatures_routes::routes(&state))
+                .or(epoch_routes::routes(&state))
+                .or(statistics_routes::routes(&state))
+                .or(root_routes::routes(&state))
                 .with(cors),
         )
         .recover(handle_custom)
-        .and(middlewares::with_api_version_provider(&dependency_manager))
+        .and(middlewares::with_api_version_provider(&state))
         .map(|reply, api_version_provider: Arc<APIVersionProvider>| {
             warp::reply::with_header(
                 reply,
@@ -74,7 +104,7 @@ pub fn routes(
                     .to_string(),
             )
         })
-        .with(middlewares::log_route_call(&dependency_manager))
+        .with(middlewares::log_route_call(&state))
 }
 
 /// API Version verification
@@ -93,11 +123,11 @@ fn header_must_be(
                     None => Ok(()),
                     Some(version) => match semver::Version::parse(&version) {
                         Ok(version)
-                            if (api_version_provider
+                            if api_version_provider
                                 .compute_current_version_requirement()
                                 .unwrap()
-                                .matches(&version))
-                            .to_owned() =>
+                                .matches(&version)
+                                .to_owned() =>
                         {
                             Ok(())
                         }

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -1,26 +1,26 @@
 use crate::http_server::routes::middlewares;
-use crate::DependencyContainer;
+use crate::http_server::routes::router::RouterState;
 use warp::Filter;
 
 pub fn routes(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    register_signatures(dependency_manager)
+    register_signatures(router_state)
 }
 
 /// POST /register-signatures
 fn register_signatures(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("register-signatures")
         .and(warp::post())
         .and(warp::body::json())
-        .and(middlewares::with_logger(dependency_manager))
-        .and(middlewares::with_certifier_service(dependency_manager))
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_certifier_service(router_state))
         .and(middlewares::with_single_signature_authenticator(
-            dependency_manager,
+            router_state,
         ))
-        .and(middlewares::with_metrics_service(dependency_manager))
+        .and(middlewares::with_metrics_service(router_state))
         .and_then(handlers::register_signatures)
 }
 
@@ -131,7 +131,7 @@ mod tests {
     use super::*;
 
     fn setup_router(
-        dependency_manager: Arc<DependencyContainer>,
+        state: RouterState,
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
@@ -140,7 +140,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&dependency_manager).with(cors))
+            .and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -158,7 +158,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&RegisterSignatureMessage::dummy())
-            .reply(&setup_router(dependency_manager.clone()))
+            .reply(&setup_router(RouterState::new_with_dummy_config(
+                dependency_manager.clone(),
+            )))
             .await;
 
         assert_eq!(
@@ -195,7 +197,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
     }
 
@@ -222,7 +226,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -255,7 +261,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -288,7 +296,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -322,7 +332,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -357,7 +369,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -392,7 +406,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(
@@ -425,7 +441,9 @@ mod tests {
             .method(method)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
             .json(&message)
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         APISpec::verify_conformity(

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -1,23 +1,23 @@
 use warp::Filter;
 
 use crate::http_server::routes::middlewares;
-use crate::DependencyContainer;
+use crate::http_server::routes::router::RouterState;
 
 pub fn routes(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    post_statistics(dependency_manager)
+    post_statistics(router_state)
 }
 
 /// POST /statistics/snapshot
 fn post_statistics(
-    dependency_manager: &DependencyContainer,
+    router_state: &RouterState,
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("statistics" / "snapshot")
         .and(warp::post())
         .and(warp::body::json())
-        .and(middlewares::with_event_transmitter(dependency_manager))
-        .and(middlewares::with_metrics_service(dependency_manager))
+        .and(middlewares::with_event_transmitter(router_state))
+        .and(middlewares::with_metrics_service(router_state))
         .and_then(handlers::post_snapshot_statistics)
 }
 
@@ -73,7 +73,7 @@ mod tests {
     };
 
     fn setup_router(
-        dependency_manager: Arc<DependencyContainer>,
+        state: RouterState,
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         let cors = warp::cors()
             .allow_any_origin()
@@ -82,7 +82,7 @@ mod tests {
 
         warp::any()
             .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&dependency_manager).with(cors))
+            .and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -100,7 +100,9 @@ mod tests {
             .method(method)
             .json(&snapshot_download_message)
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(Arc::new(dependency_manager)))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
             .await;
 
         let result = APISpec::verify_conformity(
@@ -131,7 +133,9 @@ mod tests {
             .method(method)
             .json(&SnapshotDownloadMessage::dummy())
             .path(&format!("/{SERVER_BASE_PATH}{path}"))
-            .reply(&setup_router(dependency_manager.clone()))
+            .reply(&setup_router(RouterState::new_with_dummy_config(
+                dependency_manager.clone(),
+            )))
             .await;
 
         assert_eq!(


### PR DESCRIPTION
## Content

This PR changes the way the `Configuration` structure is used by the aggregator: except for one case (for tests), it's now only used in the dependency builder.

The `Configuration` struct contains un-validated, raw, values that must be transformed using an error prone operation. We should strictly limit its usages to the dependency builder to limit such errors to the application startup.

The main user of the `Configuration` beside the dependency container is the HTTP Server. In order to provide for its need validated configuration key the following refactor was done:

1. A new structure is introduced to hold validated configuration keys: `RouterConfig`
2. Another new structure, `RouterState`, is added to hold the dependency container (to access services) and the `RouterConfig`
3. **All** routes takes a `RouterState` as parameter instead of directly the `DependencyContainer`
4. For routes that needs a config value a middleware is added to extract the value needed: `middlewares::extract_config`

Beside the http server only few direct usages of the `Configuration` struct existed and this PR reduced them to only one case. This remaining case is not trivial to address, as such I think it needs further thinking.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #1957
