### PR TITLE
chore: add build target nodejs

### DIFF
--- a/mithril-client-wasm/Makefile
+++ b/mithril-client-wasm/Makefile
@@ -12,6 +12,9 @@ all: test build
 build:
 	wasm-pack build --target web --release --out-name index
 
+build-nodejs: 
+	wasm-pack build --target nodejs --release --out-name index
+
 test:
 	pkill -f "mithril-aggregator-fake" || true
 	${CARGO} run -p mithril-aggregator-fake -- -p 8000 &

--- a/mithril-client-wasm/Makefile
+++ b/mithril-client-wasm/Makefile
@@ -13,6 +13,7 @@ build:
 	wasm-pack build --target web --release --out-name index
 
 build-nodejs: 
+	echo "This is an experimental feature which may change in the future."
 	wasm-pack build --target nodejs --release --out-name index
 
 test:


### PR DESCRIPTION
Dear Mithril-team,

we need a commonjs package to run the mithril-client-wasm module within our ibc gateway setup. 

Would it be possible to bundle the module for the nodejs target as well and publishing it within your pipeline to the npm package regsitry? I added the needed line to your Makefile. 

Thanks for your support and keep up the great work ! 💪 
Fabian