### PR TITLE
CI: enhance nightly backward compatibility testing workflow

### DIFF
--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -91,15 +91,13 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          # TODO: adjust the e2e test parameters for slower execution (slower epochs and slot lengths)
-          # cardano-slot-length 0.25
-          # cardano-epoch-length 45.0
-
           ./mithril-binaries/e2e/mithril-end-to-end -vvv \
             --bin-directory ./mithril-binaries/e2e \
             --work-directory=./artifacts \
             --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \
             --cardano-node-version ${{ matrix.cardano_node_version }} \
+            --cardano-slot-length 0.25 \
+            --cardano-epoch-length 45.0 \
           && echo "SUCCESS=true" >> $GITHUB_ENV \
           || (echo "SUCCESS=false" >> $GITHUB_ENV && exit 1)
 

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -97,3 +97,17 @@ jobs:
             --work-directory=./artifacts \
             --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \
             --cardano-node-version ${{ matrix.cardano_node_version }}
+
+      - name: Upload E2E Tests Artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-tag_${{ matrix.tag }}-node-${{ matrix.node }}-cardano-${{ matrix.cardano_node_version }}-run_id_${{ matrix.run_id }}
+          path: |
+            ./artifacts/*
+            # including node.sock makes the upload fails so exclude them:
+            !./artifacts/**/node.sock
+            # exclude cardano tools, saving ~50mb of data:
+            !./artifacts/devnet/cardano-cli
+            !./artifacts/devnet/cardano-node
+          if-no-files-found: error

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -27,6 +27,7 @@ jobs:
     steps:
       - name: Prepare env variables
         id: set-env
+        shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "total_releases=3" >> $GITHUB_OUTPUT
@@ -48,6 +49,7 @@ jobs:
       - name: Download releases artifacts binaries
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
           ./.github/workflows/scripts/download-distribution-binaries.sh ${{ needs.prepare-env-variables.outputs.total_releases }}
 
@@ -57,6 +59,7 @@ jobs:
           toolchain: stable
 
       - name: Build e2e
+        shell: bash
         run: |
           cargo build --release --bin mithril-end-to-end
           cp ./target/release/mithril-end-to-end ./mithril-binaries/unstable
@@ -69,6 +72,7 @@ jobs:
 
       - name: Prepare test lab tags
         id: tags-test-lab
+        shell: bash
         run: |
           TAGS=$(jq -c '.' ./mithril-binaries/tags.json)
           echo "Test Lab Tags: $TAGS"
@@ -96,6 +100,7 @@ jobs:
           path: ./mithril-binaries
 
       - name: Prepare binaries
+        shell: bash
         run: |
           mkdir -p mithril-binaries/e2e
           cp ./mithril-binaries/unstable/* ./mithril-binaries/e2e
@@ -109,6 +114,7 @@ jobs:
           mkdir artifacts
 
       - name: Run E2E tests
+        shell: bash
         run: |
           ./mithril-binaries/e2e/mithril-end-to-end -vvv \
             --bin-directory ./mithril-binaries/e2e \
@@ -121,11 +127,13 @@ jobs:
           || (echo "SUCCESS=false" >> $GITHUB_ENV && exit 1)
 
       - name: Define the JSON file name for the test result
+        shell: bash
         if: success() || failure()
         run: echo "RESULT_FILE_NAME=e2e-test-result-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-tag_${{ matrix.tag }}-node-${{ matrix.node }}-cardano-${{ matrix.cardano_node_version }}-run_id_${{ matrix.run_id }}" >> $GITHUB_ENV
 
       - name: Write test result JSON
         if: success() || failure()
+        shell: bash
         run: |
           AGGREGATOR_TAG="unstable"
           SIGNER_TAG="unstable"
@@ -188,10 +196,12 @@ jobs:
           merge-multiple: true
 
       - name: Concatenate JSON result files into summary.json
+        shell: bash
         run: |
           jq -s '.' ./test-results/e2e-test-result-*.json > ./test-results/summary.json
 
       - name: Add distributions backward compatibility summary
+        shell: bash
         run: |
           CHECK_MARK=":heavy_check_mark:"
           CROSS_MARK=":no_entry:"

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -16,7 +16,7 @@ on:
         description: "Cardano node version used in e2e"
         required: true
         type: string
-        default: "10.1.1"
+        default: "10.1.2"
 
 jobs:
   prepare-env-variables:
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "total_releases=3" >> $GITHUB_OUTPUT
-            echo 'cardano_node_version=["10.1.1"]' >> $GITHUB_OUTPUT
+            echo 'cardano_node_version=["10.1.2"]' >> $GITHUB_OUTPUT
           else
             echo "total_releases=${{ inputs.total-releases }}" >> $GITHUB_OUTPUT
             echo "cardano_node_version=[\"${{ inputs.cardano-node-version }}\"]" >> $GITHUB_OUTPUT
@@ -121,11 +121,11 @@ jobs:
           || (echo "SUCCESS=false" >> $GITHUB_ENV && exit 1)
 
       - name: Define the JSON file name for the test result
-        if: always()
+        if: success() || failure()
         run: echo "RESULT_FILE_NAME=e2e-test-result-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-tag_${{ matrix.tag }}-node-${{ matrix.node }}-cardano-${{ matrix.cardano_node_version }}-run_id_${{ matrix.run_id }}" >> $GITHUB_ENV
 
       - name: Write test result JSON
-        if: always()
+        if: success() || failure()
         run: |
           AGGREGATOR_TAG="unstable"
           SIGNER_TAG="unstable"
@@ -154,7 +154,7 @@ jobs:
                 > ./${{ env.RESULT_FILE_NAME }}.json
 
       - name: Upload test result JSON
-        if: always()
+        if: success() || failure()
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.RESULT_FILE_NAME }}
@@ -177,7 +177,7 @@ jobs:
   summarize-test-results:
     runs-on: ubuntu-22.04
     needs: [e2e]
-    if: always()
+    if: success() || failure()
 
     steps:
       - name: Download all test result artifacts

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -1,9 +1,10 @@
 name: Nightly backward compatibility
 
 on:
+  # Important note about scheduled workflows:
+  # Notifications for scheduled workflows are sent to the user who last modified the cron syntax in the workflow file.
   schedule:
-    - cron: "0 2 * * *"
-    - cron: "0 14 * * *"
+    - cron: "30 2 * * *"
   workflow_dispatch:
     inputs:
       total-releases:

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -64,7 +64,7 @@ jobs:
         tag: ${{ fromJSON(needs.prepare-binaries.outputs.tags) }}
         node:
           [mithril-aggregator, mithril-client, mithril-signer, mithril-relay]
-        cardano_node_version: ${{ inputs.cardano-node-version }}
+        cardano_node_version: ${{ fromJSON(inputs.cardano-node-version) }}
         run_id: ["#1"]
 
     steps:

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -92,8 +92,8 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          ./mithril-binaries/e2e/mithril-end-to-end -vvv \\
-                --bin-directory ./mithril-binaries/e2e \\
-                --work-directory=./artifacts \\
-                --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \\
-                --cardano-node-version ${{ matrix.cardano_node_version }}
+          ./mithril-binaries/e2e/mithril-end-to-end -vvv \
+            --bin-directory ./mithril-binaries/e2e \
+            --work-directory=./artifacts \
+            --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \
+            --cardano-node-version ${{ matrix.cardano_node_version }}

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -18,8 +18,26 @@ on:
         default: "10.1.1"
 
 jobs:
+  prepare-env-variables:
+    runs-on: ubuntu-22.04
+    outputs:
+      total_releases: ${{ steps.set-env.outputs.total_releases }}
+      cardano_node_version: ${{ steps.set-env.outputs.cardano_node_version }}
+    steps:
+      - name: Prepare env variables
+        id: set-env
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "total_releases=3" >> $GITHUB_OUTPUT
+            echo 'cardano_node_version=["10.1.1"]' >> $GITHUB_OUTPUT
+          else
+            echo "total_releases=${{ inputs.total-releases }}" >> $GITHUB_OUTPUT
+            echo "cardano_node_version=[\"${{ inputs.cardano-node-version }}\"]" >> $GITHUB_OUTPUT
+          fi
+
   prepare-binaries:
     runs-on: ubuntu-22.04
+    needs: [prepare-env-variables]
     outputs:
       tags: ${{ steps.tags-test-lab.outputs.tags }}
     steps:
@@ -30,7 +48,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          ./.github/workflows/scripts/download-distribution-binaries.sh ${{ inputs.total-releases }}
+          ./.github/workflows/scripts/download-distribution-binaries.sh ${{ needs.prepare-env-variables.outputs.total_releases }}
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -57,13 +75,13 @@ jobs:
 
   e2e:
     runs-on: ubuntu-22.04
-    needs: [prepare-binaries]
+    needs: [prepare-env-variables, prepare-binaries]
     strategy:
       fail-fast: false
       matrix:
         tag: ${{ fromJSON(needs.prepare-binaries.outputs.tags) }}
         node: [mithril-aggregator, mithril-client, mithril-signer]
-        cardano_node_version: ${{ fromJSON(inputs.cardano-node-version) }}
+        cardano_node_version: ${{ fromJSON(needs.prepare-env-variables.outputs.cardano_node_version) }}
         run_id: ["#1"]
 
     steps:

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -62,8 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         tag: ${{ fromJSON(needs.prepare-binaries.outputs.tags) }}
-        node:
-          [mithril-aggregator, mithril-client, mithril-signer, mithril-relay]
+        node: [mithril-aggregator, mithril-client, mithril-signer]
         cardano_node_version: ${{ fromJSON(inputs.cardano-node-version) }}
         run_id: ["#1"]
 
@@ -92,11 +91,57 @@ jobs:
 
       - name: Run E2E tests
         run: |
+          # TODO: adjust the e2e test parameters for slower execution (slower epochs and slot lengths)
+          # cardano-slot-length 0.25
+          # cardano-epoch-length 45.0
+
           ./mithril-binaries/e2e/mithril-end-to-end -vvv \
             --bin-directory ./mithril-binaries/e2e \
             --work-directory=./artifacts \
             --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \
-            --cardano-node-version ${{ matrix.cardano_node_version }}
+            --cardano-node-version ${{ matrix.cardano_node_version }} \
+          && echo "SUCCESS=true" >> $GITHUB_ENV \
+          || (echo "SUCCESS=false" >> $GITHUB_ENV && exit 1)
+
+      - name: Define the JSON file name for the test result
+        if: always()
+        run: echo "RESULT_FILE_NAME=e2e-test-result-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-tag_${{ matrix.tag }}-node-${{ matrix.node }}-cardano-${{ matrix.cardano_node_version }}-run_id_${{ matrix.run_id }}" >> $GITHUB_ENV
+
+      - name: Write test result JSON
+        if: always()
+        run: |
+          AGGREGATOR_TAG="unstable"
+          SIGNER_TAG="unstable"
+          CLIENT_TAG="unstable"
+
+          case "$NODE" in
+            mithril-aggregator)
+              AGGREGATOR_TAG="${{ matrix.tag }}"
+              ;;
+            mithril-signer)
+              SIGNER_TAG="${{ matrix.tag }}"
+              ;;
+            mithril-client)
+              CLIENT_TAG="${{ matrix.tag }}"
+              ;;
+          esac
+
+          jq -n --arg TAG "${{ matrix.tag }}" \
+                --arg NODE "${{ matrix.node }}" \
+                --arg CARDANO_NODE "${{ matrix.cardano_node_version }}" \
+                --arg AGGREGATOR "$AGGREGATOR_TAG" \
+                --arg SIGNER "$SIGNER_TAG" \
+                --arg CLIENT "$CLIENT_TAG" \
+                --argjson SUCCESS "${{ env.SUCCESS }}" \
+                '{tag: $TAG, node: $NODE, mithril_signer: $SIGNER, mithril_aggregator: $AGGREGATOR, mithril_client: $CLIENT, cardano_node_version: $CARDANO_NODE, success: $SUCCESS}' \
+                > ./${{ env.RESULT_FILE_NAME }}.json
+
+      - name: Upload test result JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.RESULT_FILE_NAME }}
+          path: ./${{ env.RESULT_FILE_NAME }}.json
 
       - name: Upload E2E Tests Artifacts
         if: ${{ failure() }}
@@ -111,3 +156,49 @@ jobs:
             !./artifacts/devnet/cardano-cli
             !./artifacts/devnet/cardano-node
           if-no-files-found: error
+
+  summarize-test-results:
+    runs-on: ubuntu-22.04
+    needs: [e2e]
+    if: always()
+
+    steps:
+      - name: Download all test result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./test-results
+          pattern: e2e-test-result*
+          merge-multiple: true
+
+      - name: Concatenate JSON result files into summary.json
+        run: |
+          jq -s '.' ./test-results/e2e-test-result-*.json > ./test-results/summary.json
+
+      - name: Add distributions backward compatibility summary
+        run: |
+          CHECK_MARK=":heavy_check_mark:"
+          CROSS_MARK=":no_entry:"
+
+          echo "## Distributions backward compatibility" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "This is the compatibility report of previous distributions nodes with the current unstable nodes." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "| Compatibility | mithril-signer | mithril-aggregator | mithril-client |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | :---: | :---: | :---: |" >> $GITHUB_STEP_SUMMARY
+
+          # Transform summary.json into Markdown table rows
+          jq -r --arg CHECK_MARK "$CHECK_MARK" --arg CROSS_MARK "$CROSS_MARK" \
+            'group_by(.tag) |
+            sort_by(.[0].tag | tonumber) | reverse |
+            .[] |
+            {
+              tag: .[0].tag, 
+              signer: (map(select(.node == "mithril-signer") | if .success then $CHECK_MARK else $CROSS_MARK end) | join("")),
+              aggregator: (map(select(.node == "mithril-aggregator") | if .success then $CHECK_MARK else $CROSS_MARK end) | join("")),
+              client: (map(select(.node == "mithril-client") | if .success then $CHECK_MARK else $CROSS_MARK end) | join(""))
+            } |
+            "| `\(.tag)` | \(.signer) | \(.aggregator) | \(.client) |"' "./test-results/summary.json" >> $GITHUB_STEP_SUMMARY
+
+          cat "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download releases artifacts binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           ./.github/workflows/scripts/download-distribution-binaries.sh ${{ inputs.total-releases }}
 

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Download releases artifacts binaries
         run: |
-          ./.github/workflows/scripts/download-distribution-binaries.sh ${{ inputs.total-releases }
+          ./.github/workflows/scripts/download-distribution-binaries.sh ${{ inputs.total-releases }}
 
       - name: Build e2e
         run: |

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Prepare test lab tags
         id: tags-test-lab
         run: |
-          TAGS=$(cat ./mithril-binaries/tags.json)
+          TAGS=$(jq -c '.' ./mithril-binaries/tags.json)
           echo "Test Lab Tags: $TAGS"
           echo "tags=$TAGS" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/nightly-backward-compatibility.yml
+++ b/.github/workflows/nightly-backward-compatibility.yml
@@ -32,6 +32,11 @@ jobs:
         run: |
           ./.github/workflows/scripts/download-distribution-binaries.sh ${{ inputs.total-releases }}
 
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
       - name: Build e2e
         run: |
           cargo build --release --bin mithril-end-to-end


### PR DESCRIPTION
## Content

This PR includes enhancements for the nightly backward compatibility testing workflow.
It schedules the workflow to run at night (2:30 UTC) and uploads artifacts upon failure.

Additionally, it introduces a comprehensive published summary for the runs:

![Screenshot 2024-11-04 at 16 36 52](https://github.com/user-attachments/assets/55b445dc-2b83-45dc-9618-343946462536)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Closes #2027 
