### PR TITLE
Do not add unfollow files when commit with upgrade_crates_and_openapi_versions.sh

### DIFF
--- a/docs/devbook/upgrade-crates-and-openapi-versions/upgrade_crates_and_openapi_versions.sh
+++ b/docs/devbook/upgrade-crates-and-openapi-versions/upgrade_crates_and_openapi_versions.sh
@@ -106,7 +106,7 @@ else
 
   if [ true = $COMMIT ]
   then
-    git add $OPEN_API_FILE Cargo.lock ./*/Cargo.toml ./internal/*/Cargo.toml ./mithril-test-lab/*/Cargo.toml
+    git add --update $OPEN_API_FILE Cargo.lock ./*/Cargo.toml ./internal/*/Cargo.toml ./mithril-test-lab/*/Cargo.toml
     git commit -m "$COMMIT_MESSAGE"
   fi
 fi


### PR DESCRIPTION
## Content

Add `--update` git option to not commit unfollow files.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
