### PR TITLE
Refactor event message creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.103"
+version = "0.5.104"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.103"
+version = "0.5.104"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/event_store/database/query.rs
+++ b/mithril-aggregator/src/event_store/database/query.rs
@@ -48,7 +48,7 @@ mod tests {
 
     #[test]
     fn provider_sql() {
-        let message = EventMessage::new("source", "action", serde_json::json!("content"));
+        let message = EventMessage::new("source", "action", &"content".to_string(), Vec::new());
 
         let (final_expression, parameters) =
             InsertEventQuery::one(message).unwrap().filters().expand();
@@ -62,15 +62,16 @@ mod tests {
 
     #[test]
     fn build_a_json_for_content_field_with_content_and_headers() {
-        let content = serde_json::json!({
-            "attr1": "content".to_string(),
-            "attr2": 123,
-        });
-
-        let mut message = EventMessage::new("source", "action", content);
-        message
-            .headers
-            .insert("key".to_string(), "value".to_string());
+        #[derive(serde::Serialize)]
+        struct Content {
+            attr1: String,
+            attr2: i32,
+        }
+        let content = Content {
+            attr1: "content".to_string(),
+            attr2: 123,
+        };
+        let message = EventMessage::new("source", "action", &content, [("key", "value")].to_vec());
 
         let (_, parameters) = InsertEventQuery::one(message).unwrap().filters().expand();
 

--- a/mithril-aggregator/src/event_store/database/repository.rs
+++ b/mithril-aggregator/src/event_store/database/repository.rs
@@ -42,7 +42,7 @@ mod tests {
         let connection = Arc::new(event_store_db_connection().unwrap());
 
         let persister = EventPersister::new(connection);
-        let message = EventMessage::new("source", "action", serde_json::json!("content"));
+        let message = EventMessage::new("source", "action", &"content".to_string(), Vec::new());
 
         let _event = persister.persist(message)?;
         Ok(())
@@ -53,7 +53,7 @@ mod tests {
         let connection = Arc::new(event_store_db_connection().unwrap());
 
         let persister = EventPersister::new(connection);
-        let message = EventMessage::new("source", "action", serde_json::json!("content"));
+        let message = EventMessage::new("source", "action", &"content".to_string(), Vec::new());
 
         let _event = persister.persist(message)?;
         Ok(())

--- a/mithril-aggregator/src/event_store/database/repository.rs
+++ b/mithril-aggregator/src/event_store/database/repository.rs
@@ -63,9 +63,7 @@ mod tests {
         use std::time::Duration;
 
         use crate::{
-            event_store::{database::test_helper::event_store_db_connection, TransmitterService},
-            services::UsageReporter,
-            test_tools::TestLogger,
+            event_store::database::test_helper::event_store_db_connection, services::UsageReporter,
         };
         use chrono::DateTime;
 
@@ -103,17 +101,12 @@ mod tests {
             let metric_date =
                 DateTime::parse_from_str(&format!("{date} +0000"), "%Y-%m-%d %H:%M:%S %z").unwrap();
 
-            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<EventMessage>();
-            let transmitter_service = Arc::new(TransmitterService::new(tx, TestLogger::stdout()));
-            let _result = UsageReporter::send_metric_event(
-                &transmitter_service,
+            let message = UsageReporter::create_metric_event(
                 metric_name.to_string(),
                 value,
                 Duration::from_secs(5),
                 metric_date.into(),
             );
-
-            let message: EventMessage = rx.try_recv().unwrap();
 
             let _event = persister.persist(message).unwrap();
         }
@@ -150,12 +143,9 @@ mod tests {
     mod signer_registration_summary {
         use std::sync::Arc;
 
-        use crate::event_store::{
-            database::test_helper::event_store_db_connection, TransmitterService,
-        };
-        use crate::test_tools::TestLogger;
-        use mithril_common::entities::Stake;
-        use mithril_common::{entities::SignerWithStake, test_utils::fake_data, StdResult};
+        use crate::event_store::database::test_helper::event_store_db_connection;
+        use mithril_common::entities::{SignerWithStake, Stake};
+        use mithril_common::{test_utils::fake_data, StdResult};
         use sqlite::ConnectionThreadSafe;
 
         use super::{EventMessage, EventPersister};
@@ -168,9 +158,6 @@ mod tests {
             stake: Stake,
             signer_node_version: &str,
         ) {
-            let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<EventMessage>();
-            let transmitter_service = Arc::new(TransmitterService::new(tx, TestLogger::stdout()));
-
             let signers = fake_data::signers_with_stakes(1);
             let signer = SignerWithStake {
                 party_id: party_id.to_string(),
@@ -178,14 +165,12 @@ mod tests {
                 ..signers[0].clone()
             };
 
-            let _ = transmitter_service.send_signer_registration_event(
+            let message = EventMessage::signer_registration(
                 "Test",
                 &signer,
                 Some(signer_node_version.to_string()),
                 epoch,
             );
-
-            let message: EventMessage = rx.try_recv().unwrap();
 
             let _event = persister.persist(message).unwrap();
         }

--- a/mithril-aggregator/src/event_store/database/repository.rs
+++ b/mithril-aggregator/src/event_store/database/repository.rs
@@ -101,7 +101,7 @@ mod tests {
             let metric_date =
                 DateTime::parse_from_str(&format!("{date} +0000"), "%Y-%m-%d %H:%M:%S %z").unwrap();
 
-            let message = UsageReporter::create_metric_event(
+            let message = UsageReporter::create_metrics_event_message(
                 metric_name.to_string(),
                 value,
                 Duration::from_secs(5),

--- a/mithril-aggregator/src/event_store/event.rs
+++ b/mithril-aggregator/src/event_store/event.rs
@@ -26,16 +26,7 @@ pub struct EventMessage {
 
 impl EventMessage {
     /// Instantiate a new EventMessage.
-    pub fn new(source: &str, action: &str, content: serde_json::Value) -> Self {
-        Self {
-            source: source.to_string(),
-            action: action.to_string(),
-            content,
-            headers: HashMap::new(),
-        }
-    }
-
-    pub fn create<T>(source: &str, action: &str, content: &T, headers: Vec<(&str, &str)>) -> Self
+    pub fn new<T>(source: &str, action: &str, content: &T, headers: Vec<(&str, &str)>) -> Self
     where
         T: Serialize,
     {
@@ -68,7 +59,7 @@ impl EventMessage {
             headers.push(("epoch", epoch_str));
         }
 
-        Self::create::<SignerWithStake>(source, "register_signer", signer_with_stake, headers)
+        Self::new::<SignerWithStake>(source, "register_signer", signer_with_stake, headers)
     }
 }
 

--- a/mithril-aggregator/src/event_store/transmitter_service.rs
+++ b/mithril-aggregator/src/event_store/transmitter_service.rs
@@ -1,4 +1,3 @@
-use serde::Serialize;
 use slog::{warn, Logger};
 use std::fmt::Debug;
 use tokio::sync::mpsc::UnboundedSender;
@@ -36,24 +35,9 @@ where
 }
 
 impl TransmitterService<EventMessage> {
-    /// Craft and send an [EventMessage] given the serializable data.
-    /// This method is done in a way to make as simple as possible to send a
-    /// message and make any error not to cause a business failure. A warning is
+    /// Send an [EventMessage].
+    /// This method make any error not to cause a business failure. A warning is
     /// issued so the resulting error may be discarded.
-    pub fn send_event_message<T>(
-        &self,
-        source: &str,
-        action: &str,
-        content: &T,
-        headers: Vec<(&str, &str)>,
-    ) -> Result<(), String>
-    where
-        T: Serialize,
-    {
-        let message = EventMessage::new(source, action, content, headers);
-        self.send(message)
-    }
-
     pub fn send(&self, message: EventMessage) -> Result<(), String> {
         self.get_transmitter().send(message.clone()).map_err(|e| {
             let error_msg =

--- a/mithril-aggregator/src/event_store/transmitter_service.rs
+++ b/mithril-aggregator/src/event_store/transmitter_service.rs
@@ -50,7 +50,7 @@ impl TransmitterService<EventMessage> {
     where
         T: Serialize,
     {
-        let message = EventMessage::create(source, action, content, headers);
+        let message = EventMessage::new(source, action, content, headers);
         self.send(message)
     }
 

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -144,7 +144,7 @@ mod handlers {
             .await
         {
             Ok(signer_with_stake) => {
-                let _ = event_transmitter.send(EventMessage::signer_registration(
+                event_transmitter.send(EventMessage::signer_registration(
                     "HTTP::signer_register",
                     &signer_with_stake,
                     signer_node_version,
@@ -156,7 +156,7 @@ mod handlers {
             Err(SignerRegistrationError::ExistingSigner(signer_with_stake)) => {
                 debug!(logger, "register_signer::already_registered");
 
-                let _ = event_transmitter.send(EventMessage::signer_registration(
+                event_transmitter.send(EventMessage::signer_registration(
                     "HTTP::signer_register",
                     &signer_with_stake,
                     signer_node_version,

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -144,24 +144,25 @@ mod handlers {
             .await
         {
             Ok(signer_with_stake) => {
-                let _ = event_transmitter.send_signer_registration_event(
+                let _ = event_transmitter.send(EventMessage::signer_registration(
                     "HTTP::signer_register",
                     &signer_with_stake,
                     signer_node_version,
                     epoch_str.as_str(),
-                );
+                ));
 
                 Ok(reply::empty(StatusCode::CREATED))
             }
             Err(SignerRegistrationError::ExistingSigner(signer_with_stake)) => {
                 debug!(logger, "register_signer::already_registered");
 
-                let _ = event_transmitter.send_signer_registration_event(
+                let _ = event_transmitter.send(EventMessage::signer_registration(
                     "HTTP::signer_register",
                     &signer_with_stake,
                     signer_node_version,
                     epoch_str.as_str(),
-                );
+                ));
+
                 Ok(reply::empty(StatusCode::CREATED))
             }
             Err(SignerRegistrationError::FailedSignerRegistration(err)) => {

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -54,11 +54,8 @@ mod handlers {
 
         match event_transmitter.try_send(message.clone()) {
             Err(e) => {
-                let error_msg = format!(
-                    "An error occurred when sending message {message:?} to monitoring: '{e}'."
-                );
-                warn!(logger, "Event message error"; "error" => &error_msg);
-                Ok(reply::internal_server_error(error_msg))
+                warn!(logger, "Event message error"; "error" => ?e);
+                Ok(reply::internal_server_error(e))
             }
             Ok(_) => Ok(reply::empty(StatusCode::CREATED)),
         }

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -42,12 +42,14 @@ mod handlers {
 
         let headers: Vec<(&str, &str)> = Vec::new();
 
-        match event_transmitter.send_event_message(
+        let message = EventMessage::new(
             "HTTP::statistics",
             "snapshot_downloaded",
             &snapshot_download_message,
             headers,
-        ) {
+        );
+
+        match event_transmitter.send(message) {
             Err(e) => Ok(reply::internal_server_error(e)),
             Ok(_) => Ok(reply::empty(StatusCode::CREATED)),
         }

--- a/mithril-aggregator/src/services/usage_reporter.rs
+++ b/mithril-aggregator/src/services/usage_reporter.rs
@@ -67,7 +67,7 @@ impl UsageReporter {
         self.last_reported_metrics = metrics;
 
         for (name, value) in delta {
-            let message = Self::create_metric_event(name, value, *duration, date);
+            let message = Self::create_metrics_event_message(name, value, *duration, date);
             let _result = self.transmitter_service.send(message);
         }
     }
@@ -87,7 +87,9 @@ impl UsageReporter {
             );
         }
     }
-    pub fn create_metric_event(
+
+    /// Create a new EventMessage for a metrics.
+    pub fn create_metrics_event_message(
         name: String,
         value: i64,
         period: Duration,

--- a/mithril-aggregator/src/services/usage_reporter.rs
+++ b/mithril-aggregator/src/services/usage_reporter.rs
@@ -93,7 +93,7 @@ impl UsageReporter {
         period: Duration,
         date: DateTime<Utc>,
     ) -> EventMessage {
-        EventMessage::create(
+        EventMessage::new(
             "Metrics",
             &name.clone(),
             &MetricEventMessage {

--- a/mithril-aggregator/src/services/usage_reporter.rs
+++ b/mithril-aggregator/src/services/usage_reporter.rs
@@ -68,7 +68,7 @@ impl UsageReporter {
 
         for (name, value) in delta {
             let message = Self::create_metrics_event_message(name, value, *duration, date);
-            let _result = self.transmitter_service.send(message);
+            self.transmitter_service.send(message);
         }
     }
 

--- a/mithril-aggregator/src/services/usage_reporter.rs
+++ b/mithril-aggregator/src/services/usage_reporter.rs
@@ -59,26 +59,6 @@ impl UsageReporter {
             .collect()
     }
 
-    pub(crate) fn send_metric_event(
-        transmitter: &TransmitterService<EventMessage>,
-        name: String,
-        value: i64,
-        period: Duration,
-        date: DateTime<Utc>,
-    ) -> Result<(), String> {
-        transmitter.send_event_message::<MetricEventMessage>(
-            "Metrics",
-            &name.clone(),
-            &MetricEventMessage {
-                name,
-                value,
-                period,
-                date,
-            },
-            vec![],
-        )
-    }
-
     fn send_metrics(&mut self, duration: &Duration) {
         let metrics = self.metrics_service.export_metrics_map();
         let delta = Self::compute_metrics_delta(&self.last_reported_metrics, &metrics);
@@ -87,8 +67,8 @@ impl UsageReporter {
         self.last_reported_metrics = metrics;
 
         for (name, value) in delta {
-            let _result =
-                Self::send_metric_event(&self.transmitter_service, name, value, *duration, date);
+            let message = Self::create_metric_event(name, value, *duration, date);
+            let _result = self.transmitter_service.send(message);
         }
     }
 
@@ -106,6 +86,24 @@ impl UsageReporter {
                 run_interval.as_secs()
             );
         }
+    }
+    pub fn create_metric_event(
+        name: String,
+        value: i64,
+        period: Duration,
+        date: DateTime<Utc>,
+    ) -> EventMessage {
+        EventMessage::create(
+            "Metrics",
+            &name.clone(),
+            &MetricEventMessage {
+                name,
+                value,
+                period,
+                date,
+            },
+            vec![],
+        )
     }
 }
 


### PR DESCRIPTION
## Content

Separates the creation of the event message from its sending.
This allows messages to be easily injected into the database while guaranteeing the same construction as in production

This PR move the `EventMessage` creation from `TransmitterService` to the `EventMessage`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #2086
