### PR TITLE
Docs: enhance runbook for aggregator metrics and signer registrations

### DIFF
--- a/docs/runbook/aggregator-metrics/README.md
+++ b/docs/runbook/aggregator-metrics/README.md
@@ -1,24 +1,62 @@
 # Aggregator metrics
 
-A view `metrics_per_day` is available to calculate the value of a metric over a day.
+A view `metrics_per_day` is available to compute the aggregated values of metrics by day.
 
-The following request displays the sum of counter for each metric on the specify day.
-Format of `DAY` variable should be `YYYY-MM-DD` (ie: `2024-10-28`).
+The following request displays the aggregated value of each metric by day:
 
 ```sh
-$> sqlite3 -table -batch \
-       $DATA_STORES_DIRECTORY/monitoring.sqlite3 \
-       `select date, counter_name, value from metrics_per_day where date='$DAY';`
+sqlite3 -table -batch \
+       <DATA_STORES_DIRECTORY>/monitoring.sqlite3 \
+       `select date, counter_name, value from metrics_per_day order by date desc, counter_name asc;`
 ```
 
 The result looks like:
 
 ```
-+------------+-------------------------------------------------------------+--------+
-|    date    |                        counter_name                         | value  |
-+------------+-------------------------------------------------------------+--------+
-| 2024-10-29 | mithril_aggregator_certificate_total_produced_since_startup | 135532 |
-| 2024-10-29 | mithril_aggregator_runtime_cycle_success_since_startup      | 563246 |
-| 2024-10-29 | mithril_aggregator_runtime_cycle_total_since_startup        | 237513 |
-+------------+-------------------------------------------------------------+--------+
++------------+------------------------------------------------------------------------------------------+-------+
+|    date    |                                       counter_name                                       | value |
++------------+------------------------------------------------------------------------------------------+-------+
+| 2024-11-07 | mithril_aggregator_artifact_cardano_db_total_produced_since_startup                      | 14    |
+| 2024-11-07 | mithril_aggregator_artifact_cardano_stake_distribution_total_produced_since_startup      | 1     |
+| 2024-11-07 | mithril_aggregator_artifact_cardano_transaction_total_produced_since_startup             | 143   |
+| 2024-11-07 | mithril_aggregator_artifact_detail_cardano_db_total_served_since_startup                 | 5     |
+| 2024-11-07 | mithril_aggregator_artifact_mithril_stake_distribution_total_produced_since_startup      | 1     |
+| 2024-11-07 | mithril_aggregator_certificate_detail_total_served_since_startup                         | 3076  |
+| 2024-11-07 | mithril_aggregator_certificate_total_produced_since_startup                              | 159   |
+| 2024-11-07 | mithril_aggregator_runtime_cycle_success_since_startup                                   | 899   |
+| 2024-11-07 | mithril_aggregator_runtime_cycle_total_since_startup                                     | 900   |
+| 2024-11-07 | mithril_aggregator_signature_registration_total_received_since_startup                   | 1054  |
+| 2024-11-07 | mithril_aggregator_signer_registration_total_received_since_startup                      | 19    |
+| 2024-11-06 | mithril_aggregator_artifact_cardano_db_total_produced_since_startup                      | 21    |
+| 2024-11-06 | mithril_aggregator_artifact_cardano_stake_distribution_total_produced_since_startup      | 1     |
+| 2024-11-06 | mithril_aggregator_artifact_cardano_transaction_total_produced_since_startup             | 213   |
+| 2024-11-06 | mithril_aggregator_artifact_detail_cardano_db_total_served_since_startup                 | 8     |
+| 2024-11-06 | mithril_aggregator_artifact_mithril_stake_distribution_total_produced_since_startup      | 1     |
+| 2024-11-06 | mithril_aggregator_cardano_db_total_restoration_since_startup                            | 3     |
+| 2024-11-06 | mithril_aggregator_certificate_detail_total_served_since_startup                         | 4326  |
+| 2024-11-06 | mithril_aggregator_certificate_total_produced_since_startup                              | 236   |
+| 2024-11-06 | mithril_aggregator_runtime_cycle_success_since_startup                                   | 1426  |
+| 2024-11-06 | mithril_aggregator_runtime_cycle_total_since_startup                                     | 1426  |
+| 2024-11-06 | mithril_aggregator_signature_registration_total_received_since_startup                   | 2204  |
+| 2024-11-06 | mithril_aggregator_signer_registration_total_received_since_startup                      | 26    |
+| 2024-11-05 | mithril_aggregator_artifact_cardano_db_total_produced_since_startup                      | 7     |
+| 2024-11-05 | mithril_aggregator_artifact_cardano_transaction_total_produced_since_startup             | 85    |
+| 2024-11-05 | mithril_aggregator_artifact_detail_cardano_db_total_served_since_startup                 | 11    |
+| 2024-11-05 | mithril_aggregator_artifact_detail_cardano_stake_distribution_total_served_since_startup | 14    |
+| 2024-11-05 | mithril_aggregator_artifact_detail_cardano_transaction_total_served_since_startup        | 7     |
+| 2024-11-05 | mithril_aggregator_artifact_detail_mithril_stake_distribution_total_served_since_startup | 7     |
+| 2024-11-05 | mithril_aggregator_cardano_db_total_restoration_since_startup                            | 7     |
+| 2024-11-05 | mithril_aggregator_certificate_detail_total_served_since_startup                         | 20306 |
+| 2024-11-05 | mithril_aggregator_certificate_total_produced_since_startup                              | 92    |
+| 2024-11-05 | mithril_aggregator_proof_cardano_transaction_total_proofs_served_since_startup           | 3008  |
+| 2024-11-05 | mithril_aggregator_proof_cardano_transaction_total_transactions_served_since_startup     | 75508 |
+| 2024-11-05 | mithril_aggregator_runtime_cycle_success_since_startup                                   | 513   |
+| 2024-11-05 | mithril_aggregator_runtime_cycle_total_since_startup                                     | 513   |
+| 2024-11-05 | mithril_aggregator_signature_registration_total_received_since_startup                   | 1145  |
+| 2024-11-05 | mithril_aggregator_signer_registration_total_received_since_startup                      | 3     |
++------------+------------------------------------------------------------------------------------------+-------+
 ```
+
+The variable `<DATA_STORES_DIRECTORY>` should point to the directory where the
+databases files are stored (see files in `mithril-aggregator/config` using the
+key `data_stores_directory` to know where they are).

--- a/docs/runbook/registrations-monitoring/README.md
+++ b/docs/runbook/registrations-monitoring/README.md
@@ -1,17 +1,53 @@
-# Monitoring
+# Signer registration monitoring
 
-## Stakes vs Signer Version distribution
+A view `signer_registration_summary` is available to compute the aggregated signer versions and total stake by epoch.
 
-In order to set the epoch of Era changes, it is required to know the
-distribution of the stakes that run a compatible Signer node. There is a SQL
-view for that.
+The following request displays the aggregated value of each metric by day:
 
 ```sh
-$> sqlite3 -table -batch \
-       $DATA_STORES_DIRECTORY/monitoring.sqlite3 \
+sqlite3 -table -batch \
+       <DATA_STORES_DIRECTORY>/monitoring.sqlite3 \
         `select epoch, version, total_epoch_stakes, stakes_version, stakes_ratio, pool_count from signer_registration_summary;`
 ```
 
-The variable `$DATA_STORES_DIRECTORY` should point to the directory where the
+The result looks like:
+
+```
++-------+---------+--------------------+-----------------+--------------+------------+
+| epoch | version | total_epoch_stakes | stakes_version  | stakes_ratio | pool_count |
++-------+---------+--------------------+-----------------+--------------+------------+
+| 744   | 0.2.209 | 52450437146164     | 3812327831838   | 07 %         | 4          |
+| 744   | 0.2.200 | 52450437146164     | 33366778009855  | 64 %         | 9          |
+| 744   | 0.2.182 | 52450437146164     | 12863967782631  | 25 %         | 3          |
+| 744   | 0.2.161 | 52450437146164     | 2407363521840   | 05 %         | 1          |
+| 743   | 0.2.209 | 310197073989660    | 253809728067133 | 82 %         | 4          |
+| 743   | 0.2.200 | 310197073989660    | 33353353956901  | 11 %         | 9          |
+| 743   | 0.2.182 | 310197073989660    | 20627638503738  | 07 %         | 4          |
+| 743   | 0.2.161 | 310197073989660    | 2406353461888   | 01 %         | 1          |
+| 742   | 0.2.209 | 331826003409496    | 9497628870      | 00 %         | 1          |
+| 742   | 0.2.200 | 331826003409496    | 302738838096957 | 91 %         | 14         |
+| 742   | 0.2.182 | 331826003409496    | 24923416990212  | 08 %         | 5          |
+| 742   | 0.2.170 | 331826003409496    | 1758973108212   | 01 %         | 1          |
+| 742   | 0.2.161 | 331826003409496    | 2395277585245   | 01 %         | 1          |
+| 741   | 0.2.200 | 75965070455291     | 46911249090979  | 62 %         | 14         |
+| 741   | 0.2.182 | 75965070455291     | 24911579945327  | 33 %         | 5          |
+| 741   | 0.2.170 | 75965070455291     | 1757752764012   | 02 %         | 1          |
+| 741   | 0.2.161 | 75965070455291     | 2384488654973   | 03 %         | 1          |
+| 740   | 0.2.200 | 75886327123374     | 33269952693607  | 44 %         | 13         |
+| 740   | 0.2.182 | 75886327123374     | 38486213918661  | 51 %         | 6          |
+| 740   | 0.2.170 | 75886327123374     | 1746964369361   | 02 %         | 1          |
+| 740   | 0.2.161 | 75886327123374     | 2383196141745   | 03 %         | 1          |
+| 739   | 0.2.200 | 74576243846549     | 31617851706983  | 42 %         | 12         |
+| 739   | 0.2.182 | 74576243846549     | 38840828593610  | 52 %         | 6          |
+| 739   | 0.2.170 | 74576243846549     | 1745795980355   | 02 %         | 1          |
+| 739   | 0.2.161 | 74576243846549     | 2371767565601   | 03 %         | 1          |
+| 738   | 0.2.200 | 75808343712929     | 25746507335947  | 34 %         | 11         |
+| 738   | 0.2.182 | 75808343712929     | 40119362549555  | 53 %         | 7          |
+| 738   | 0.2.170 | 75808343712929     | 7581914972989   | 10 %         | 2          |
+| 738   | 0.2.161 | 75808343712929     | 2360558854438   | 03 %         | 1          |
++-------+---------+--------------------+-----------------+--------------+------------+
+```
+
+The variable `<DATA_STORES_DIRECTORY>` should point to the directory where the
 databases files are stored (see files in `mithril-aggregator/config` using the
 key `data_stores_directory` to know where they are).


### PR DESCRIPTION
## Content

This pull request includes updates to the **runbooks for monitoring metrics and signer registration monitoring**. The changes improve clarity and provide more detailed examples.

### Documentation updates:

* [`docs/runbook/aggregator-metrics/README.md`](diffhunk://#diff-9b1572e3be3ac3e5c9c7511ba42360a363c726d1c9c125c7c52e4b83f39d2b3cL3-R62): Updated the description of the `metrics_per_day` view and provided a clearer example of how to display aggregated metric values by day.
* [`docs/runbook/registrations-monitoring/README.md`](diffhunk://#diff-8bc2a01ef864f753a84f5e249ff54fd3b03875bd09040a66de3bcf1ea90a9addL1-R51): Renamed the section to "Signer registration monitoring" and updated the description of the `signer_registration_summary` view with a clearer example of how to display aggregated signer versions and total stake by epoch.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

## Issue(s)
Relates to #2076 
