### PR TITLE
Feat: record informations in epoch service for status route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.106"
+version = "0.5.107"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.83"
+version = "0.4.84"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.106"
+version = "0.5.107"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -63,14 +63,11 @@ use crate::{
     },
     entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
-    http_server::routes::{
-        router,
-        router::{RouterConfig, RouterState},
-    },
+    http_server::routes::router::{self, RouterConfig, RouterState},
     services::{
         AggregatorSignableSeedBuilder, AggregatorUpkeepService, BufferedCertifierService,
-        CardanoTransactionsImporter, CertifierService, MessageService, MithrilCertifierService,
-        MithrilEpochService, MithrilMessageService, MithrilProverService,
+        CardanoTransactionsImporter, CertifierService, EpochServiceDependencies, MessageService,
+        MithrilCertifierService, MithrilEpochService, MithrilMessageService, MithrilProverService,
         MithrilSignedEntityService, MithrilStakeDistributionService, ProverService,
         SignedEntityService, StakeDistributionService, UpkeepService, UsageReporter,
     },
@@ -1266,9 +1263,11 @@ impl DependenciesBuilder {
 
         let epoch_service = Arc::new(RwLock::new(MithrilEpochService::new(
             epoch_settings,
-            epoch_settings_storer,
-            verification_key_store,
-            chain_observer,
+            EpochServiceDependencies::new(
+                epoch_settings_storer,
+                verification_key_store,
+                chain_observer,
+            ),
             network,
             allowed_discriminants,
             self.root_logger(),

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1259,6 +1259,7 @@ impl DependenciesBuilder {
     async fn build_epoch_service(&mut self) -> Result<EpochServiceWrapper> {
         let verification_key_store = self.get_verification_key_store().await?;
         let epoch_settings_storer = self.get_epoch_settings_storer().await?;
+        let chain_observer = self.get_chain_observer().await?;
         let epoch_settings = self.get_epoch_settings_configuration()?;
         let network = self.configuration.get_network()?;
         let allowed_discriminants = self.get_allowed_signed_entity_types_discriminants()?;
@@ -1267,6 +1268,7 @@ impl DependenciesBuilder {
             epoch_settings,
             epoch_settings_storer,
             verification_key_store,
+            chain_observer,
             network,
             allowed_discriminants,
             self.root_logger(),

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1258,6 +1258,7 @@ impl DependenciesBuilder {
         let epoch_settings_storer = self.get_epoch_settings_storer().await?;
         let chain_observer = self.get_chain_observer().await?;
         let era_checker = self.get_era_checker().await?;
+        let stake_distribution_service = self.get_stake_distribution_service().await?;
         let epoch_settings = self.get_epoch_settings_configuration()?;
         let network = self.configuration.get_network()?;
         let allowed_discriminants = self.get_allowed_signed_entity_types_discriminants()?;
@@ -1269,6 +1270,7 @@ impl DependenciesBuilder {
                 verification_key_store,
                 chain_observer,
                 era_checker,
+                stake_distribution_service,
             ),
             network,
             allowed_discriminants,

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1257,6 +1257,7 @@ impl DependenciesBuilder {
         let verification_key_store = self.get_verification_key_store().await?;
         let epoch_settings_storer = self.get_epoch_settings_storer().await?;
         let chain_observer = self.get_chain_observer().await?;
+        let era_checker = self.get_era_checker().await?;
         let epoch_settings = self.get_epoch_settings_configuration()?;
         let network = self.configuration.get_network()?;
         let allowed_discriminants = self.get_allowed_signed_entity_types_discriminants()?;
@@ -1267,6 +1268,7 @@ impl DependenciesBuilder {
                 epoch_settings_storer,
                 verification_key_store,
                 chain_observer,
+                era_checker,
             ),
             network,
             allowed_discriminants,

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -252,10 +252,10 @@ impl AggregatorRuntime {
                 .update_era_checker(new_time_point.epoch)
                 .await
                 .map_err(|e| RuntimeError::critical("transiting IDLE → READY", Some(e)))?;
-            self.runner.inform_new_epoch(new_time_point.epoch).await?;
             self.runner
                 .update_stake_distribution(&new_time_point)
                 .await?;
+            self.runner.inform_new_epoch(new_time_point.epoch).await?;
             self.runner.upkeep().await?;
             self.runner
                 .open_signer_registration_round(&new_time_point)

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.83"
+version = "0.4.84"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes storing all the necessary information in the `EpochService` to support the future `/status` route on the aggregator.

The following data is now saved:
- Current Cardano era
- Current Mithril era
- Total number of SPOs for the current epoch
- Total stake for the current epoch

This PR will allow the `/status` route to expose these details when implemented.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #2071 
