### PR TITLE
Feat: add `genesis generate-keypair` command in aggregator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX] - UNRELEASED
 
+- Implement a new `genesis generate-keypair` command in aggregator CLI to generate a new genesis keypair.
+
 - Crates versions:
 
 | Crate | Version |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.108"
+version = "0.5.109"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.84"
+version = "0.4.85"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/website/root/manual/develop/nodes/mithril-aggregator.md
+++ b/docs/website/root/manual/develop/nodes/mithril-aggregator.md
@@ -398,6 +398,7 @@ Here are the available subcommands:
 | **genesis sign**                      | Signs the genesis payload with the genesis secret key                                                                                     |
 | **genesis import**                    | Imports the genesis signature (the payload signed with the genesis secret key) and creates and imports a genesis certificate in the store |
 | **genesis bootstrap**                 | Bootstraps a genesis certificate (test only usage)                                                                                        |
+| **genesis generate-keypair**          | Generates a genesis keypair                                                                                                               |
 | **era list**                          | Lists the supported eras                                                                                                                  |
 | **era generate-tx-datum**             | Generates the era markers transaction datum to be stored on-chain                                                                         |
 | **tools recompute-certificates-hash** | Loads all certificates in the database, recomputing their hash, and updating all related entities                                         |
@@ -482,6 +483,12 @@ Here is a list of the available parameters:
 | `to_sign_payload_path`       | `--to-sign-payload-path`       |          -           | -                    | Path of the payload to sign.          | -             | -       |     -     |
 | `target_signed_payload_path` | `--target-signed-payload-path` |          -           | -                    | Path of the signed payload to export. | -             | -       |     -     |
 | `genesis_secret_key_path`    | `--genesis-secret-key-path`    |          -           | -                    | Path of the genesis secret key.       | -             | -       |     -     |
+
+`genesis generate-keypair` command:
+
+| Parameter     | Command line (long) | Command line (short) | Environment variable | Description                           | Default value | Example |     Mandatory      |
+| ------------- | ------------------- | :------------------: | -------------------- | ------------------------------------- | ------------- | ------- | :----------------: |
+| `target_path` | `--target-path`     |          -           | -                    | Target path for the generated keypair | -             | -       | :heavy_check_mark: |
 
 `era list` command:
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.108"
+version = "0.5.109"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/era_command.rs
+++ b/mithril-aggregator/src/commands/era_command.rs
@@ -99,7 +99,7 @@ pub struct GenerateTxDatumEraSubCommand {
     #[clap(long, env = "ERA_MARKERS_SECRET_KEY")]
     era_markers_secret_key: HexEncodedEraMarkersSecretKey,
 
-    /// Target Path
+    /// Target path
     #[clap(long)]
     target_path: PathBuf,
 }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -46,7 +46,7 @@ pub enum GenesisSubCommand {
     /// Genesis certificate bootstrap command.
     Bootstrap(BootstrapGenesisSubCommand),
 
-    /// Genesis certificate keypair generation command.
+    /// Genesis keypair generation command.
     GenerateKeypair(GenerateKeypairGenesisSubCommand),
 }
 
@@ -69,7 +69,7 @@ impl GenesisSubCommand {
 /// Genesis certificate export command
 #[derive(Parser, Debug, Clone)]
 pub struct ExportGenesisSubCommand {
-    /// Target Path
+    /// Target path
     #[clap(long)]
     target_path: PathBuf,
 }
@@ -234,10 +234,10 @@ impl BootstrapGenesisSubCommand {
     }
 }
 
-/// Genesis certificate keypair generation command.
+/// Genesis keypair generation command.
 #[derive(Parser, Debug, Clone)]
 pub struct GenerateKeypairGenesisSubCommand {
-    /// Target Path for the generated keypair
+    /// Target path for the generated keypair
     #[clap(long)]
     target_path: PathBuf,
 }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -45,6 +45,9 @@ pub enum GenesisSubCommand {
 
     /// Genesis certificate bootstrap command.
     Bootstrap(BootstrapGenesisSubCommand),
+
+    /// Genesis certificate keypair generation command.
+    GenerateKeypair(GenerateKeypairGenesisSubCommand),
 }
 
 impl GenesisSubCommand {
@@ -58,6 +61,7 @@ impl GenesisSubCommand {
             Self::Export(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Import(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Sign(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::GenerateKeypair(cmd) => cmd.execute(root_logger, config_builder).await,
         }
     }
 }
@@ -226,6 +230,33 @@ impl BootstrapGenesisSubCommand {
             .bootstrap_test_genesis_certificate(genesis_signer)
             .await
             .with_context(|| "genesis-tools: bootstrap error")?;
+        Ok(())
+    }
+}
+
+/// Genesis certificate keypair generation command.
+#[derive(Parser, Debug, Clone)]
+pub struct GenerateKeypairGenesisSubCommand {
+    /// Target Path for the generated keypair
+    #[clap(long)]
+    target_path: PathBuf,
+}
+
+impl GenerateKeypairGenesisSubCommand {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        _config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
+        debug!(root_logger, "GENERATE KEYPAIR GENESIS command");
+        println!(
+            "Generating genesis keypair to {}",
+            self.target_path.to_string_lossy()
+        );
+
+        GenesisTools::create_and_save_genesis_keypair(&self.target_path)
+            .with_context(|| "genesis-tools: keypair generation error")?;
+
         Ok(())
     }
 }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -250,7 +250,7 @@ impl GenerateKeypairGenesisSubCommand {
     ) -> StdResult<()> {
         debug!(root_logger, "GENERATE KEYPAIR GENESIS command");
         println!(
-            "Generating genesis keypair to {}",
+            "Genesis generate keypair to {}",
             self.target_path.to_string_lossy()
         );
 

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -1,5 +1,10 @@
 use anyhow::{anyhow, Context};
-use std::{fs::File, io::prelude::*, io::Write, path::Path, sync::Arc};
+use std::{
+    fs::File,
+    io::{prelude::*, Write},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use mithril_common::{
     certificate_chain::{CertificateGenesisProducer, CertificateVerifier},
@@ -201,16 +206,25 @@ impl GenesisTools {
             })?;
         Ok(())
     }
+
+    /// Export the genesis keypair to a folder and returns the paths to the files (secret key, verification_key)
+    pub fn create_and_save_genesis_keypair(keypair_path: &Path) -> StdResult<(PathBuf, PathBuf)> {
+        let genesis_signer = ProtocolGenesisSigner::create_non_deterministic_genesis_signer();
+
+        genesis_signer.export_keypair_to_files(keypair_path)
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use mithril_common::{
         certificate_chain::MithrilCertificateVerifier,
-        crypto_helper::ProtocolGenesisSigner,
+        crypto_helper::{
+            ProtocolGenesisSecretKey, ProtocolGenesisSigner, ProtocolGenesisVerificationKey,
+        },
         test_utils::{fake_data, MithrilFixtureBuilder, TempDir},
     };
-    use std::path::PathBuf;
+    use std::{fs::read_to_string, path::PathBuf};
 
     use crate::database::test_helper::main_db_connection;
     use crate::test_tools::TestLogger;
@@ -266,14 +280,13 @@ mod tests {
         let test_dir = get_temp_dir("export_payload_to_sign");
         let payload_path = test_dir.join("payload.txt");
         let signed_payload_path = test_dir.join("payload-signed.txt");
-        let genesis_secret_key_path = test_dir.join("genesis.sk");
         let genesis_signer = ProtocolGenesisSigner::create_deterministic_genesis_signer();
         let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
             build_tools(&genesis_signer);
 
-        genesis_signer
-            .export_to_file(&genesis_secret_key_path)
-            .expect("exporting the secret key should not fail");
+        let (genesis_secret_key_path, _) = genesis_signer
+            .export_keypair_to_files(&test_dir)
+            .expect("exporting the keypair should not fail");
         genesis_tools
             .export_payload_to_sign(&payload_path)
             .expect("export_payload_to_sign should not fail");
@@ -326,5 +339,28 @@ mod tests {
             .expect(
                 "verify_genesis_certificate should successfully validate the genesis certificate",
             );
+    }
+
+    #[test]
+    fn test_create_and_save_genesis_keypair() {
+        let temp_dir = get_temp_dir("test_create_and_save_genesis_keypair");
+        let (genesis_secret_key_path, genesis_verification_key_path) =
+            GenesisTools::create_and_save_genesis_keypair(&temp_dir)
+                .expect("Failed to create and save genesis keypair");
+        let genesis_secret_key = ProtocolGenesisSecretKey::from_json_hex(
+            &read_to_string(&genesis_secret_key_path)
+                .expect("Failed to read genesis secret key file"),
+        )
+        .expect("Failed to parse genesis secret key");
+        let genesis_verification_key = ProtocolGenesisVerificationKey::from_json_hex(
+            &read_to_string(&genesis_verification_key_path)
+                .expect("Failed to read genesis verification key file"),
+        )
+        .expect("Failed to parse genesis verification key");
+        let genesis_verifier =
+            ProtocolGenesisSigner::from_secret_key(genesis_secret_key).create_genesis_verifier();
+
+        let expected_genesis_verification_key = genesis_verifier.to_verification_key();
+        assert_eq!(expected_genesis_verification_key, genesis_verification_key);
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.84"
+version = "0.4.85"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/genesis.rs
+++ b/mithril-common/src/crypto_helper/genesis.rs
@@ -6,7 +6,11 @@ use rand_chacha::rand_core;
 use rand_chacha::rand_core::{CryptoRng, RngCore, SeedableRng};
 use rand_chacha::ChaCha20Rng;
 use serde::{Deserialize, Serialize};
-use std::{fs::File, io::Write, path::Path};
+use std::{
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
 use thiserror::Error;
 
 use super::{ProtocolGenesisSecretKey, ProtocolGenesisSignature, ProtocolGenesisVerificationKey};
@@ -63,13 +67,25 @@ impl ProtocolGenesisSigner {
         self.secret_key.sign(message).into()
     }
 
-    /// Export the secret key from the genesis verifier to a file. TEST ONLY
-    #[doc(hidden)]
-    pub fn export_to_file(&self, secret_key_path: &Path) -> StdResult<()> {
-        let mut genesis_secret_key_file = File::create(secret_key_path)?;
-        genesis_secret_key_file.write_all(self.secret_key.to_json_hex().unwrap().as_bytes())?;
+    /// Export the keypair from the genesis verifier to files
+    pub fn export_keypair_to_files(&self, keypair_path: &Path) -> StdResult<(PathBuf, PathBuf)> {
+        let genesis_secret_key_path = keypair_path.join("genesis.sk");
+        {
+            let genesis_secret_key_payload = self.secret_key.to_json_hex().unwrap();
+            let mut genesis_secret_key_file = File::create(&genesis_secret_key_path)?;
+            genesis_secret_key_file.write_all(genesis_secret_key_payload.as_bytes())?;
+        }
 
-        Ok(())
+        let genesis_verification_key_path = keypair_path.join("genesis.vk");
+        {
+            let genesis_verification_key: ProtocolGenesisVerificationKey =
+                self.secret_key.verifying_key().into();
+            let genesis_verification_key_payload = genesis_verification_key.to_json_hex().unwrap();
+            let mut genesis_verification_key_file = File::create(&genesis_verification_key_path)?;
+            genesis_verification_key_file.write_all(genesis_verification_key_payload.as_bytes())?;
+        }
+
+        Ok((genesis_secret_key_path, genesis_verification_key_path))
     }
 }
 


### PR DESCRIPTION
## Content

This PR includes the implementation and documentation of the new `genesis generate-keypair` command in the aggregator that is used to **create Genesis keypairs**.

### Documentation Updates:
* Added `generate-keypair` command to the list of subcommands in `mithril-aggregator.md`.
* Documented parameters for the `generate-keypair` command in `mithril-aggregator.md`.

### Command Implementation:
* Added `GenerateKeypair` variant to the `GenesisSubCommand` enum in `genesis_command.rs`.
* Implemented the `execute` method for the `GenerateKeypairGenesisSubCommand` struct in `genesis_command.rs`.

### Utility Functions:
* Added `create_and_save_genesis_keypair` function to `GenesisTools` in `genesis.rs`.
* Updated the `export_keypair_to_files` method in `ProtocolGenesisSigner` to export both secret and verification keys in `genesis.rs`.

### Test Updates:
* Added a test for the `create_and_save_genesis_keypair` function in `genesis.rs`.
* Modified existing tests to use the new keypair export function in `genesis.rs`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

## Issue(s)
Closes #2074 
