### PR TITLE
Feat: implement `/status` route to expose aggregator information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Implement a new `genesis generate-keypair` command in aggregator CLI to generate a new genesis keypair.
 
+- Implement the `/status` route on the aggregator's REST API to provide information about its current status.
+
 - Crates versions:
 
 | Crate | Version |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.109"
+version = "0.5.110"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.109"
+version = "0.5.110"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1522,6 +1522,7 @@ impl DependenciesBuilder {
                     .cardano_transactions_signing_config
                     .clone(),
                 snapshot_directory: self.configuration.snapshot_directory.clone(),
+                cardano_node_version: self.configuration.cardano_node_version.clone(),
             },
         );
 

--- a/mithril-aggregator/src/http_server/routes/aggregator_status.rs
+++ b/mithril-aggregator/src/http_server/routes/aggregator_status.rs
@@ -51,6 +51,8 @@ async fn get_aggregator_status_message(
         .iter()
         .map(|s| s.stake)
         .sum();
+    let total_cardano_spo = epoch_service.total_spo()?;
+    let total_cardano_stake = epoch_service.total_stake()?;
 
     let message = AggregatorStatusMessage {
         epoch,
@@ -64,6 +66,8 @@ async fn get_aggregator_status_message(
         total_next_signers,
         total_stakes_signers,
         total_next_stakes_signers,
+        total_cardano_spo,
+        total_cardano_stake,
     };
 
     Ok(message)

--- a/mithril-aggregator/src/http_server/routes/aggregator_status.rs
+++ b/mithril-aggregator/src/http_server/routes/aggregator_status.rs
@@ -1,0 +1,156 @@
+use warp::Filter;
+
+use mithril_common::{messages::AggregatorStatusMessage, StdResult};
+
+use crate::{
+    dependency_injection::EpochServiceWrapper,
+    http_server::routes::{middlewares, router::RouterState},
+};
+
+pub fn routes(
+    router_state: &RouterState,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    status(router_state)
+}
+
+/// GET /status
+fn status(
+    router_state: &RouterState,
+) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+    warp::path!("status")
+        .and(warp::get())
+        .and(middlewares::with_logger(router_state))
+        .and(middlewares::with_epoch_service(router_state))
+        .and_then(handlers::status)
+}
+
+async fn get_aggregator_status_message(
+    epoch_service: EpochServiceWrapper,
+) -> StdResult<AggregatorStatusMessage> {
+    let epoch_service = epoch_service.read().await;
+
+    let epoch = epoch_service.epoch_of_current_data()?;
+
+    let message = AggregatorStatusMessage { epoch };
+
+    Ok(message)
+}
+
+mod handlers {
+    use std::convert::Infallible;
+
+    use slog::{warn, Logger};
+    use warp::http::StatusCode;
+
+    use crate::{
+        dependency_injection::EpochServiceWrapper,
+        http_server::routes::{aggregator_status::get_aggregator_status_message, reply},
+    };
+
+    /// Status
+    pub async fn status(
+        logger: Logger,
+        epoch_service: EpochServiceWrapper,
+    ) -> Result<impl warp::Reply, Infallible> {
+        let aggregator_status_message = get_aggregator_status_message(epoch_service).await;
+
+        match aggregator_status_message {
+            Ok(message) => Ok(reply::json(&message, StatusCode::OK)),
+            Err(err) => {
+                warn!(logger,"aggregator_status::error"; "error" => ?err);
+                Ok(reply::server_error(err))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use serde_json::Value::Null;
+    use tokio::sync::RwLock;
+    use warp::{
+        http::{Method, StatusCode},
+        test::request,
+    };
+
+    use mithril_common::{
+        entities::Epoch, test_utils::apispec::APISpec, test_utils::MithrilFixtureBuilder,
+    };
+
+    use crate::{
+        http_server::SERVER_BASE_PATH, initialize_dependencies, services::FakeEpochService,
+    };
+
+    use super::*;
+
+    fn setup_router(
+        state: RouterState,
+    ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
+        let cors = warp::cors()
+            .allow_any_origin()
+            .allow_headers(vec!["content-type"])
+            .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
+
+        warp::any()
+            .and(warp::path(SERVER_BASE_PATH))
+            .and(routes(&state).with(cors))
+    }
+
+    #[tokio::test]
+    async fn status_route_ko_500() {
+        let dependency_manager = initialize_dependencies().await;
+        let method = Method::GET.as_str();
+        let path = "/status";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::INTERNAL_SERVER_ERROR,
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn status_route_ok_200() {
+        let mut dependency_manager = initialize_dependencies().await;
+        let fixture = MithrilFixtureBuilder::default().build();
+        let epoch_service = FakeEpochService::from_fixture(Epoch(5), &fixture);
+        dependency_manager.epoch_service = Arc::new(RwLock::new(epoch_service));
+
+        let method = Method::GET.as_str();
+        let path = "/status";
+
+        let response = request()
+            .method(method)
+            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
+                dependency_manager,
+            ))))
+            .await;
+
+        APISpec::verify_conformity(
+            APISpec::get_all_spec_files(),
+            method,
+            path,
+            "application/json",
+            &Null,
+            &response,
+            &StatusCode::OK,
+        )
+        .unwrap();
+    }
+}

--- a/mithril-aggregator/src/http_server/routes/aggregator_status.rs
+++ b/mithril-aggregator/src/http_server/routes/aggregator_status.rs
@@ -30,8 +30,14 @@ async fn get_aggregator_status_message(
     let epoch_service = epoch_service.read().await;
 
     let epoch = epoch_service.epoch_of_current_data()?;
+    let cardano_era = epoch_service.cardano_era()?;
+    let mithril_era = epoch_service.mithril_era()?;
 
-    let message = AggregatorStatusMessage { epoch };
+    let message = AggregatorStatusMessage {
+        epoch,
+        cardano_era,
+        mithril_era,
+    };
 
     Ok(message)
 }

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -1,3 +1,4 @@
+mod aggregator_status;
 mod artifact_routes;
 mod certificate_routes;
 mod epoch_routes;

--- a/mithril-aggregator/src/http_server/routes/mod.rs
+++ b/mithril-aggregator/src/http_server/routes/mod.rs
@@ -1,4 +1,3 @@
-mod aggregator_status;
 mod artifact_routes;
 mod certificate_routes;
 mod epoch_routes;
@@ -10,6 +9,7 @@ pub mod router;
 mod signatures_routes;
 mod signer_routes;
 mod statistics_routes;
+mod status;
 
 /// Match the given result and do an early return with an internal server error (500)
 /// if it was an Error. Else return the unwrapped value.

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -1,6 +1,6 @@
 use crate::http_server::routes::{
-    aggregator_status, artifact_routes, certificate_routes, epoch_routes, http_server_child_logger,
-    root_routes, signatures_routes, signer_routes, statistics_routes,
+    artifact_routes, certificate_routes, epoch_routes, http_server_child_logger, root_routes,
+    signatures_routes, signer_routes, statistics_routes, status,
 };
 use crate::http_server::SERVER_BASE_PATH;
 use crate::DependencyContainer;
@@ -112,7 +112,7 @@ pub fn routes(
                 .or(epoch_routes::routes(&state))
                 .or(statistics_routes::routes(&state))
                 .or(root_routes::routes(&state))
-                .or(aggregator_status::routes(&state))
+                .or(status::routes(&state))
                 .with(cors),
         )
         .recover(handle_custom)

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -1,6 +1,6 @@
 use crate::http_server::routes::{
-    artifact_routes, certificate_routes, epoch_routes, http_server_child_logger, root_routes,
-    signatures_routes, signer_routes, statistics_routes,
+    aggregator_status, artifact_routes, certificate_routes, epoch_routes, http_server_child_logger,
+    root_routes, signatures_routes, signer_routes, statistics_routes,
 };
 use crate::http_server::SERVER_BASE_PATH;
 use crate::DependencyContainer;
@@ -110,6 +110,7 @@ pub fn routes(
                 .or(epoch_routes::routes(&state))
                 .or(statistics_routes::routes(&state))
                 .or(root_routes::routes(&state))
+                .or(aggregator_status::routes(&state))
                 .with(cors),
         )
         .recover(handle_custom)

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -38,6 +38,7 @@ pub struct RouterConfig {
     pub cardano_transactions_prover_max_hashes_allowed_by_request: usize,
     pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
     pub snapshot_directory: PathBuf,
+    pub cardano_node_version: String,
 }
 
 #[cfg(test)]
@@ -53,6 +54,7 @@ impl RouterConfig {
             cardano_transactions_prover_max_hashes_allowed_by_request: 1_000,
             cardano_transactions_signing_config: CardanoTransactionsSigningConfig::dummy(),
             snapshot_directory: PathBuf::from("/dummy/snapshot/directory"),
+            cardano_node_version: "1.2.3".to_string(),
         }
     }
 }

--- a/mithril-aggregator/src/http_server/routes/status.rs
+++ b/mithril-aggregator/src/http_server/routes/status.rs
@@ -81,7 +81,7 @@ mod handlers {
 
     use crate::{
         dependency_injection::EpochServiceWrapper,
-        http_server::routes::{aggregator_status::get_aggregator_status_message, reply},
+        http_server::routes::{reply, status::get_aggregator_status_message},
     };
 
     /// Status

--- a/mithril-aggregator/src/http_server/routes/status.rs
+++ b/mithril-aggregator/src/http_server/routes/status.rs
@@ -41,16 +41,8 @@ async fn get_aggregator_status_message(
     let next_protocol_parameters = epoch_service.next_protocol_parameters()?.clone();
     let total_signers = epoch_service.current_signers()?.len();
     let total_next_signers = epoch_service.next_signers()?.len();
-    let total_stakes_signers = epoch_service
-        .current_signers_with_stake()?
-        .iter()
-        .map(|s| s.stake)
-        .sum();
-    let total_next_stakes_signers = epoch_service
-        .next_signers_with_stake()?
-        .iter()
-        .map(|s| s.stake)
-        .sum();
+    let total_stakes_signers = epoch_service.total_stakes_signers()?;
+    let total_next_stakes_signers = epoch_service.total_next_stakes_signers()?;
     let total_cardano_spo = epoch_service.total_spo()?;
     let total_cardano_stake = epoch_service.total_stake()?;
 

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -9,8 +9,8 @@ use thiserror::Error;
 
 use mithril_common::crypto_helper::ProtocolAggregateVerificationKey;
 use mithril_common::entities::{
-    CardanoTransactionsSigningConfig, Epoch, ProtocolParameters, SignedEntityConfig,
-    SignedEntityTypeDiscriminants, Signer, SignerWithStake, Stake,
+    CardanoEra, CardanoTransactionsSigningConfig, Epoch, ProtocolParameters, SignedEntityConfig,
+    SignedEntityTypeDiscriminants, Signer, SignerWithStake, Stake, TotalSPOs,
 };
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::protocol::{MultiSigner as ProtocolMultiSigner, SignerBuilder};
@@ -20,9 +20,6 @@ use crate::{
     entities::AggregatorEpochSettings, services::StakeDistributionService, EpochSettingsStorer,
     VerificationKeyStorer,
 };
-
-type TotalSPOs = u32;
-type CardanoEra = String;
 
 /// Errors dedicated to the CertifierService.
 #[derive(Debug, Error)]

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -102,6 +102,12 @@ pub trait EpochService: Sync + Send {
     /// Get signers for the next epoch
     fn next_signers(&self) -> StdResult<&Vec<Signer>>;
 
+    /// Get the total stakes of signers for the current epoch
+    fn total_stakes_signers(&self) -> StdResult<Stake>;
+
+    /// Get the total stakes of signers for the next epoch
+    fn total_next_stakes_signers(&self) -> StdResult<Stake>;
+
     /// Get the [protocol multi signer][ProtocolMultiSigner] for the current epoch
     fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner>;
 
@@ -129,6 +135,8 @@ struct EpochData {
     next_signers_with_stake: Vec<SignerWithStake>,
     current_signers: Vec<Signer>,
     next_signers: Vec<Signer>,
+    total_stakes_signers: Stake,
+    total_next_stakes_signers: Stake,
     signed_entity_config: SignedEntityConfig,
     total_spo: TotalSPOs,
     total_stake: Stake,
@@ -333,6 +341,8 @@ impl EpochService for MithrilEpochService {
             .await?;
         let current_signers = Signer::vec_from(current_signers_with_stake.clone());
         let next_signers = Signer::vec_from(next_signers_with_stake.clone());
+        let total_stakes_signers = current_signers_with_stake.iter().map(|s| s.stake).sum();
+        let total_next_stakes_signers = next_signers_with_stake.iter().map(|s| s.stake).sum();
 
         let signed_entity_config = SignedEntityConfig {
             allowed_discriminants: self.allowed_signed_entity_discriminants.clone(),
@@ -355,6 +365,8 @@ impl EpochService for MithrilEpochService {
             next_signers_with_stake,
             current_signers,
             next_signers,
+            total_stakes_signers,
+            total_next_stakes_signers,
             signed_entity_config,
             total_spo,
             total_stake,
@@ -478,6 +490,14 @@ impl EpochService for MithrilEpochService {
         Ok(&self.unwrap_data()?.next_signers)
     }
 
+    fn total_stakes_signers(&self) -> StdResult<Stake> {
+        Ok(self.unwrap_data()?.total_stakes_signers)
+    }
+
+    fn total_next_stakes_signers(&self) -> StdResult<Stake> {
+        Ok(self.unwrap_data()?.total_next_stakes_signers)
+    }
+
     fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner> {
         Ok(&self.unwrap_computed_data()?.protocol_multi_signer)
     }
@@ -547,6 +567,12 @@ impl FakeEpochServiceBuilder {
     pub fn build(self) -> FakeEpochService {
         let current_signers = Signer::vec_from(self.current_signers_with_stake.clone());
         let next_signers = Signer::vec_from(self.next_signers_with_stake.clone());
+        let total_stakes_signers = self
+            .current_signers_with_stake
+            .iter()
+            .map(|s| s.stake)
+            .sum();
+        let total_next_stakes_signers = self.next_signers_with_stake.iter().map(|s| s.stake).sum();
 
         let protocol_multi_signer = SignerBuilder::new(
             &self.current_signers_with_stake,
@@ -575,6 +601,8 @@ impl FakeEpochServiceBuilder {
                 next_signers_with_stake: self.next_signers_with_stake,
                 current_signers,
                 next_signers,
+                total_stakes_signers,
+                total_next_stakes_signers,
                 signed_entity_config: self.signed_entity_config,
                 total_spo: self.total_spo,
                 total_stake: self.total_stake,
@@ -758,6 +786,14 @@ impl EpochService for FakeEpochService {
 
     fn next_signers(&self) -> StdResult<&Vec<Signer>> {
         Ok(&self.unwrap_data()?.next_signers)
+    }
+
+    fn total_stakes_signers(&self) -> StdResult<Stake> {
+        Ok(self.unwrap_data()?.total_stakes_signers)
+    }
+
+    fn total_next_stakes_signers(&self) -> StdResult<Stake> {
+        Ok(self.unwrap_data()?.total_next_stakes_signers)
     }
 
     fn protocol_multi_signer(&self) -> StdResult<&ProtocolMultiSigner> {

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.85"
+version = "0.4.86"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/type_alias.rs
+++ b/mithril-common/src/entities/type_alias.rs
@@ -56,3 +56,9 @@ pub type HexEncodedDigest = HexEncodedKey;
 
 /// Hex encoded Era Markers Secret Key
 pub type HexEncodedEraMarkersSecretKey = HexEncodedKey;
+
+/// Number of SPOs
+pub type TotalSPOs = u32;
+
+/// Cardano Era
+pub type CardanoEra = String;

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -5,7 +5,7 @@ use crate::{
     era::SupportedEra,
 };
 
-/// Message advertised by an Aggregator to inform about its status
+/// Message advertised by an aggregator to inform about its status
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AggregatorStatusMessage {
     /// Current epoch

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -13,6 +13,12 @@ pub struct AggregatorStatusMessage {
 
     /// Current Mithril era
     pub mithril_era: SupportedEra,
+
+    /// Cardano node version
+    pub cardano_node_version: String,
+
+    /// Aggregator node version
+    pub aggregator_node_version: String,
 }
 
 #[cfg(test)]
@@ -22,7 +28,9 @@ mod tests {
     const ACTUAL_JSON: &str = r#"{
         "epoch": 48,
         "cardano_era": "conway",
-        "mithril_era": "pythagoras"
+        "mithril_era": "pythagoras",
+        "cardano_node_version": "1.2.3",
+        "aggregator_node_version": "4.5.6"
         }"#;
 
     fn golden_actual_message() -> AggregatorStatusMessage {
@@ -30,6 +38,8 @@ mod tests {
             epoch: Epoch(48),
             cardano_era: "conway".to_string(),
             mithril_era: SupportedEra::Pythagoras,
+            cardano_node_version: "1.2.3".to_string(),
+            aggregator_node_version: "4.5.6".to_string(),
         }
     }
 

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -1,12 +1,18 @@
 use serde::{Deserialize, Serialize};
 
-use crate::entities::Epoch;
+use crate::{entities::Epoch, era::SupportedEra};
 
 /// Message advertised by an Aggregator to inform about its status
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct AggregatorStatusMessage {
     /// Current epoch
     pub epoch: Epoch,
+
+    /// Current Cardano era
+    pub cardano_era: String,
+
+    /// Current Mithril era
+    pub mithril_era: SupportedEra,
 }
 
 #[cfg(test)]
@@ -14,11 +20,17 @@ mod tests {
     use super::*;
 
     const ACTUAL_JSON: &str = r#"{
-        "epoch": 48
+        "epoch": 48,
+        "cardano_era": "conway",
+        "mithril_era": "pythagoras"
         }"#;
 
     fn golden_actual_message() -> AggregatorStatusMessage {
-        AggregatorStatusMessage { epoch: Epoch(48) }
+        AggregatorStatusMessage {
+            epoch: Epoch(48),
+            cardano_era: "conway".to_string(),
+            mithril_era: SupportedEra::Pythagoras,
+        }
     }
 
     // Test the compatibility with current structure.

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    entities::{Epoch, ProtocolParameters, Stake},
+    entities::{CardanoEra, Epoch, ProtocolParameters, Stake, TotalSPOs},
     era::SupportedEra,
 };
 
@@ -12,7 +12,7 @@ pub struct AggregatorStatusMessage {
     pub epoch: Epoch,
 
     /// Current Cardano era
-    pub cardano_era: String,
+    pub cardano_era: CardanoEra,
 
     /// Current Mithril era
     pub mithril_era: SupportedEra,
@@ -42,6 +42,12 @@ pub struct AggregatorStatusMessage {
 
     /// The total stakes of the signers that will be able to sign on the next epoch
     pub total_next_stakes_signers: Stake,
+
+    /// The number of Cardano SPOs
+    pub total_cardano_spo: TotalSPOs,
+
+    /// The total stake in Cardano
+    pub total_cardano_stake: Stake,
 }
 
 #[cfg(test)]
@@ -59,7 +65,9 @@ mod tests {
         "total_signers": 1234,
         "total_next_signers": 56789,
         "total_stakes_signers": 123456789,
-        "total_next_stakes_signers": 987654321
+        "total_next_stakes_signers": 987654321,
+        "total_cardano_spo": 7777,
+        "total_cardano_stake": 888888888
         }"#;
 
     fn golden_actual_message() -> AggregatorStatusMessage {
@@ -83,6 +91,8 @@ mod tests {
             total_next_signers: 56789,
             total_stakes_signers: 123456789,
             total_next_stakes_signers: 987654321,
+            total_cardano_spo: 7777,
+            total_cardano_stake: 888888888,
         }
     }
 

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{entities::Epoch, era::SupportedEra};
+use crate::{
+    entities::{Epoch, ProtocolParameters},
+    era::SupportedEra,
+};
 
 /// Message advertised by an Aggregator to inform about its status
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -19,6 +22,14 @@ pub struct AggregatorStatusMessage {
 
     /// Aggregator node version
     pub aggregator_node_version: String,
+
+    /// Current Protocol parameters
+    #[serde(rename = "protocol")]
+    pub protocol_parameters: ProtocolParameters,
+
+    /// Next Protocol parameters
+    #[serde(rename = "next_protocol")]
+    pub next_protocol_parameters: ProtocolParameters,
 }
 
 #[cfg(test)]
@@ -30,7 +41,9 @@ mod tests {
         "cardano_era": "conway",
         "mithril_era": "pythagoras",
         "cardano_node_version": "1.2.3",
-        "aggregator_node_version": "4.5.6"
+        "aggregator_node_version": "4.5.6",
+        "protocol": { "k": 5, "m": 100, "phi_f": 0.65 },
+        "next_protocol": { "k": 50, "m": 1000, "phi_f": 0.65 }
         }"#;
 
     fn golden_actual_message() -> AggregatorStatusMessage {
@@ -40,6 +53,16 @@ mod tests {
             mithril_era: SupportedEra::Pythagoras,
             cardano_node_version: "1.2.3".to_string(),
             aggregator_node_version: "4.5.6".to_string(),
+            protocol_parameters: ProtocolParameters {
+                k: 5,
+                m: 100,
+                phi_f: 0.65,
+            },
+            next_protocol_parameters: ProtocolParameters {
+                k: 50,
+                m: 1000,
+                phi_f: 0.65,
+            },
         }
     }
 

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -1,0 +1,34 @@
+use serde::{Deserialize, Serialize};
+
+use crate::entities::Epoch;
+
+/// Message advertised by an Aggregator to inform about its status
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct AggregatorStatusMessage {
+    /// Current epoch
+    pub epoch: Epoch,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ACTUAL_JSON: &str = r#"{
+        "epoch": 48
+        }"#;
+
+    fn golden_actual_message() -> AggregatorStatusMessage {
+        AggregatorStatusMessage { epoch: Epoch(48) }
+    }
+
+    // Test the compatibility with current structure.
+    #[test]
+    fn test_actual_json_deserialized_into_actual_message() {
+        let json = ACTUAL_JSON;
+        let message: AggregatorStatusMessage = serde_json::from_str(json).expect(
+            "This JSON is expected to be successfully parsed into a AggregatorStatusMessage instance.",
+        );
+
+        assert_eq!(golden_actual_message(), message);
+    }
+}

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -30,6 +30,12 @@ pub struct AggregatorStatusMessage {
     /// Next Protocol parameters
     #[serde(rename = "next_protocol")]
     pub next_protocol_parameters: ProtocolParameters,
+
+    /// The number of signers for the current epoch
+    pub total_signers: usize,
+
+    /// The number of signers that will be able to sign on the next epoch
+    pub total_next_signers: usize,
 }
 
 #[cfg(test)]
@@ -43,7 +49,9 @@ mod tests {
         "cardano_node_version": "1.2.3",
         "aggregator_node_version": "4.5.6",
         "protocol": { "k": 5, "m": 100, "phi_f": 0.65 },
-        "next_protocol": { "k": 50, "m": 1000, "phi_f": 0.65 }
+        "next_protocol": { "k": 50, "m": 1000, "phi_f": 0.65 },
+        "total_signers": 1234,
+        "total_next_signers": 56789
         }"#;
 
     fn golden_actual_message() -> AggregatorStatusMessage {
@@ -63,6 +71,8 @@ mod tests {
                 m: 1000,
                 phi_f: 0.65,
             },
+            total_signers: 1234,
+            total_next_signers: 56789,
         }
     }
 

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    entities::{Epoch, ProtocolParameters},
+    entities::{Epoch, ProtocolParameters, Stake},
     era::SupportedEra,
 };
 
@@ -36,6 +36,12 @@ pub struct AggregatorStatusMessage {
 
     /// The number of signers that will be able to sign on the next epoch
     pub total_next_signers: usize,
+
+    /// The total stakes of the signers for the current epoch
+    pub total_stakes_signers: Stake,
+
+    /// The total stakes of the signers that will be able to sign on the next epoch
+    pub total_next_stakes_signers: Stake,
 }
 
 #[cfg(test)]
@@ -51,7 +57,9 @@ mod tests {
         "protocol": { "k": 5, "m": 100, "phi_f": 0.65 },
         "next_protocol": { "k": 50, "m": 1000, "phi_f": 0.65 },
         "total_signers": 1234,
-        "total_next_signers": 56789
+        "total_next_signers": 56789,
+        "total_stakes_signers": 123456789,
+        "total_next_stakes_signers": 987654321
         }"#;
 
     fn golden_actual_message() -> AggregatorStatusMessage {
@@ -73,6 +81,8 @@ mod tests {
             },
             total_signers: 1234,
             total_next_signers: 56789,
+            total_stakes_signers: 123456789,
+            total_next_stakes_signers: 987654321,
         }
     }
 

--- a/mithril-common/src/messages/mod.rs
+++ b/mithril-common/src/messages/mod.rs
@@ -1,6 +1,7 @@
 //! Messages module
 //! This module aims at providing shared structures for API communications.
 mod aggregator_features;
+mod aggregator_status;
 mod cardano_stake_distribution;
 mod cardano_stake_distribution_list;
 mod cardano_transaction_snapshot;
@@ -23,6 +24,7 @@ mod snapshot_list;
 pub use aggregator_features::{
     AggregatorCapabilities, AggregatorFeaturesMessage, CardanoTransactionsProverCapabilities,
 };
+pub use aggregator_status::AggregatorStatusMessage;
 pub use cardano_stake_distribution::CardanoStakeDistributionMessage;
 pub use cardano_stake_distribution_list::{
     CardanoStakeDistributionListItemMessage, CardanoStakeDistributionListMessage,

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -64,6 +64,8 @@ paths:
           * Total number of signers for next epoch
           * Total stakes of signers for current epoch
           * Total stakes of signers for next epoch
+          * Total of Cardano SPOs
+          * Total stake in Cardano
       responses:
         "200":
           description: aggregator status found
@@ -674,6 +676,8 @@ components:
         - total_next_signers
         - total_stakes_signers
         - total_next_stakes_signers
+        - total_cardano_spo
+        - total_cardano_stake
       properties:
         epoch:
           $ref: "#/components/schemas/Epoch"
@@ -709,6 +713,14 @@ components:
           description: The total stakes of signers for the next epoch
           type: integer
           format: int64
+        total_cardano_spo:
+          description: The number of Cardano SPOs
+          type: integer
+          format: int64
+        total_cardano_stake:
+          description: The total stake in Cardano
+          type: integer
+          format: int64
       examples:
         {
           "epoch": 329,
@@ -721,7 +733,9 @@ components:
           "total_signers": 3,
           "total_next_signers": 72,
           "total_stakes_signers": 123456789,
-          "total_next_stakes_signers": 987654321
+          "total_next_stakes_signers": 987654321,
+          "total_cardano_spo": 5738,
+          "total_cardano_stake": 999999999
         }
 
     AggregatorFeaturesMessage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -58,6 +58,8 @@ paths:
           * Current Mithril era
           * Cardano node version
           * Aggregator node version
+          * Protocol parameters for current epoch
+          * Protocol parameters for next epoch
       responses:
         "200":
           description: aggregator status found
@@ -662,6 +664,8 @@ components:
         - mithril_era
         - cardano_node_version
         - aggregator_node_version
+        - protocol
+        - next_protocol
       properties:
         epoch:
           $ref: "#/components/schemas/Epoch"
@@ -677,13 +681,19 @@ components:
         aggregator_node_version:
           description: Version of the Aggregator node
           type: string
+        protocol:
+          $ref: "#/components/schemas/ProtocolParameters"
+        next_protocol:
+          $ref: "#/components/schemas/ProtocolParameters"
       examples:
         {
           "epoch": 329,
           "cardano_era": "conway",
           "mithril_era": "pythagoras",
           "cardano_node_version": "1.2.3",
-          "aggregator_node_version": "4.5.6"
+          "aggregator_node_version": "4.5.6",
+          "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
+          "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 }
         }
 
     AggregatorFeaturesMessage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.36
+  version: 0.1.37
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -60,6 +60,8 @@ paths:
           * Aggregator node version
           * Protocol parameters for current epoch
           * Protocol parameters for next epoch
+          * Total number of signers for current epoch
+          * Total number of signers for next epoch
       responses:
         "200":
           description: aggregator status found
@@ -666,6 +668,8 @@ components:
         - aggregator_node_version
         - protocol
         - next_protocol
+        - total_signers
+        - total_next_signers
       properties:
         epoch:
           $ref: "#/components/schemas/Epoch"
@@ -685,6 +689,14 @@ components:
           $ref: "#/components/schemas/ProtocolParameters"
         next_protocol:
           $ref: "#/components/schemas/ProtocolParameters"
+        total_signers:
+          description: The number of signers for the current epoch
+          type: integer
+          format: int64
+        total_next_signers:
+          description: The number of signers that will be able to sign on the next epoch
+          type: integer
+          format: int64
       examples:
         {
           "epoch": 329,
@@ -693,7 +705,9 @@ components:
           "cardano_node_version": "1.2.3",
           "aggregator_node_version": "4.5.6",
           "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
-          "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 }
+          "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
+          "total_signers": 3,
+          "total_next_signers": 72
         }
 
     AggregatorFeaturesMessage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -52,7 +52,7 @@ paths:
     get:
       summary: Get information about the aggregator status
       description: |
-        Returns the informations related to the aggregator status:
+        Returns the aggregator status information:
           * Current epoch
           * Current Cardano era
           * Current Mithril era
@@ -65,7 +65,7 @@ paths:
           * Total stakes of signers for current epoch
           * Total stakes of signers for next epoch
           * Total of Cardano SPOs
-          * Total stake in Cardano
+          * Total stakes in Cardano
       responses:
         "200":
           description: aggregator status found
@@ -718,13 +718,13 @@ components:
           type: integer
           format: int64
         total_cardano_stake:
-          description: The total stake in Cardano
+          description: The total stakes in Cardano
           type: integer
           format: int64
       examples:
         {
           "epoch": 329,
-          "cardano_era": "conway",
+          "cardano_era": "Conway",
           "mithril_era": "pythagoras",
           "cardano_node_version": "1.2.3",
           "aggregator_node_version": "4.5.6",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -57,6 +57,7 @@ paths:
           * Current Cardano era
           * Current Mithril era
           * Cardano node version
+          * Aggregator node version
       responses:
         "200":
           description: aggregator status found
@@ -659,6 +660,8 @@ components:
         - epoch
         - cardano_era
         - mithril_era
+        - cardano_node_version
+        - aggregator_node_version
       properties:
         epoch:
           $ref: "#/components/schemas/Epoch"
@@ -668,8 +671,20 @@ components:
         mithril_era:
           description: Mithril era
           type: string
+        cardano_node_version:
+          description: Version of the Cardano node
+          type: string
+        aggregator_node_version:
+          description: Version of the Aggregator node
+          type: string
       examples:
-        { "epoch": 329, "cardano_era": "conway", "mithril_era": "pythagoras" }
+        {
+          "epoch": 329,
+          "cardano_era": "conway",
+          "mithril_era": "pythagoras",
+          "cardano_node_version": "1.2.3",
+          "aggregator_node_version": "4.5.6"
+        }
 
     AggregatorFeaturesMessage:
       description: Represents general information about Aggregator public information and signing capabilities

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -62,6 +62,8 @@ paths:
           * Protocol parameters for next epoch
           * Total number of signers for current epoch
           * Total number of signers for next epoch
+          * Total stakes of signers for current epoch
+          * Total stakes of signers for next epoch
       responses:
         "200":
           description: aggregator status found
@@ -670,6 +672,8 @@ components:
         - next_protocol
         - total_signers
         - total_next_signers
+        - total_stakes_signers
+        - total_next_stakes_signers
       properties:
         epoch:
           $ref: "#/components/schemas/Epoch"
@@ -697,6 +701,14 @@ components:
           description: The number of signers that will be able to sign on the next epoch
           type: integer
           format: int64
+        total_stakes_signers:
+          description: The total stakes of signers for the current epoch
+          type: integer
+          format: int64
+        total_next_stakes_signers:
+          description: The total stakes of signers for the next epoch
+          type: integer
+          format: int64
       examples:
         {
           "epoch": 329,
@@ -707,7 +719,9 @@ components:
           "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
           "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
           "total_signers": 3,
-          "total_next_signers": 72
+          "total_next_signers": 72,
+          "total_stakes_signers": 123456789,
+          "total_next_stakes_signers": 987654321
         }
 
     AggregatorFeaturesMessage:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -657,10 +657,19 @@ components:
       additionalProperties: false
       required:
         - epoch
+        - cardano_era
+        - mithril_era
       properties:
         epoch:
           $ref: "#/components/schemas/Epoch"
-      examples: { "epoch": 329 }
+        cardano_era:
+          description: Cardano era
+          type: string
+        mithril_era:
+          description: Mithril era
+          type: string
+      examples:
+        { "epoch": 329, "cardano_era": "conway", "mithril_era": "pythagoras" }
 
     AggregatorFeaturesMessage:
       description: Represents general information about Aggregator public information and signing capabilities

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -48,6 +48,31 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
+  /status:
+    get:
+      summary: Get information about the aggregator status
+      description: |
+        Returns the informations related to the aggregator status:
+          * Current epoch
+          * Current Cardano era
+          * Current Mithril era
+          * Cardano node version
+      responses:
+        "200":
+          description: aggregator status found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AggregatorStatusMessage"
+        "412":
+          description: API version mismatch
+        default:
+          description: root error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+
   /epoch-settings:
     get:
       summary: Get current epoch settings
@@ -626,6 +651,17 @@ paths:
 
 components:
   schemas:
+    AggregatorStatusMessage:
+      description: Represents the information related to the aggregator status
+      type: object
+      additionalProperties: false
+      required:
+        - epoch
+      properties:
+        epoch:
+          $ref: "#/components/schemas/Epoch"
+      examples: { "epoch": 329 }
+
     AggregatorFeaturesMessage:
       description: Represents general information about Aggregator public information and signing capabilities
       type: object


### PR DESCRIPTION
## Content

This PR includes the creation of a `/status` route on the aggregator REST API that exposes essential information about the aggregator's status.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2071 