### PR TITLE
Fix: adjust era offset in `PallasChainObserver` for correct display name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.87"
+version = "0.4.88"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.87"
+version = "0.4.88"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes a fix for the retrieval of the Cardano era in the `PallasChainObserver` to ensure the correct era display name is returned. The offset is adjusted to align with the era mapping differences in the Cardano node implementation.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2111 
