### PR TITLE
Fix for Failing STM Proptests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.31"
+version = "0.3.32"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.31"
+version = "0.3.32"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/stm.rs
+++ b/mithril-stm/src/stm.rs
@@ -1278,7 +1278,7 @@ mod tests {
         /// Test that batch verification of certificates works
         fn batch_verify(nparties in 2_usize..30,
                               m in 10_u64..20,
-                              k in 1_u64..5,
+                              k in 1_u64..4,
                               seed in any::<[u8;32]>(),
                               batch_size in 2..10,
         ) {
@@ -1290,7 +1290,7 @@ mod tests {
             for _ in 0..batch_size {
                 let mut msg = [0u8; 32];
                 rng.fill_bytes(&mut msg);
-                let params = StmParameters { m, k, phi_f: 0.8 };
+                let params = StmParameters { m, k, phi_f: 0.95 };
                 let ps = setup_equal_parties(params, nparties);
                 let clerk = StmClerk::from_signer(&ps[0]);
 


### PR DESCRIPTION
## Content
For two different random configurations of the STM property test `batch_verify`, in one iteration of each batch, not enough unique signatures were collected to meet the quorum. This caused the batch verification functionality test to fail intermittently, leading to flaky CI behavior.

This PR updates the STM parameters for this test to ensure the quorum is always met, enabling consistent testing of batch verification functionality.

## Pre-submit checklist

- Branch
  - [X] Tests are provided (if possible)
  - [X] Commit sequence broadly makes sense
  - [X] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [X] Self-reviewed the diff
  - [X] Useful pull request description
  - [X] Reviewer requested

## Issue(s)
Closes #2109 
