### PR TITLE
fix(aggregator): properly handle `404` errors in http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.112"
+version = "0.5.113"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.112"
+version = "0.5.113"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR fix the handling of `404` errors in the aggregator http server.

In case of a `404` the custom rejection middleware  immediatly emit a rejection _(this custom rejection was added to set the appropriate status code for API Version Mistmatch errors)_.
This means that no other middleware would be applied nor our custom headers.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

This problem cascade to the browser javascript `fetch` api, the missing headers make the api immediately throw an error thus making impossible [to handle the `404` in a idiomatic way](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_response_status).

In this example the status code can't be checked in the `then` block since a exception is raised _(note: the exception doesn't contains the status code)_.
```javascript
fetch(aggregatorEndpoint)
  .then((response) => {
    if (response.status === 404) {
      // do something with it
    } else {
      return response.status === 200 ? response.json() : {};
    }
  })
  .catch((error) => {
    console.error("Fetch status error:", error);
  });
``` 

This problems made more cumbersome the fallback to `Epoch Setting` mechanism used in PR #2128, we had to handle it in the `catch` block without the ability to check that it was indeed a `404` or not.
