### PR TITLE
Docs: protocol security page on documentation website

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -4,6 +4,9 @@
 const lightCodeTheme = require("prism-react-renderer").themes.github;
 const darkCodeTheme = require("prism-react-renderer").themes.dracula;
 
+import remarkMath from "remark-math";
+import rehypeKatex from "rehype-katex";
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: "Mithril. A complete guide.",
@@ -48,6 +51,8 @@ const config = {
               label: "Current",
             },
           },
+          remarkPlugins: [remarkMath],
+          rehypePlugins: [rehypeKatex],
         },
         blog: {
           path: "blog/",
@@ -272,6 +277,14 @@ const config = {
     mermaid: true,
   },
   themes: ["@docusaurus/theme-mermaid"],
+  stylesheets: [
+    {
+      href: "https://cdn.jsdelivr.net/npm/katex@0.13.24/dist/katex.min.css",
+      type: "text/css",
+      integrity: "sha384-odtC+0UGzzFL/6PNoE8rX/SPcQDXBJ+uRepguP4QkPCm2LBxH3FA3y+fKSiJ+AmM",
+      crossorigin: "anonymous",
+    },
+  ],
 };
 
 module.exports = config;

--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-doc",
-  "version": "0.1.44",
+  "version": "0.1.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-doc",
-      "version": "0.1.44",
+      "version": "0.1.45",
       "dependencies": {
         "@docusaurus/core": "^3.6.0",
         "@docusaurus/plugin-client-redirects": "^3.6.0",
@@ -16,7 +16,9 @@
         "clsx": "^2.1.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "redocusaurus": "^2.1.2"
+        "redocusaurus": "^2.1.2",
+        "rehype-katex": "^7.0.1",
+        "remark-math": "^6.0.0"
       },
       "devDependencies": {
         "prettier": "3.3.2"
@@ -3562,6 +3564,11 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "license": "MIT"
+    },
+    "node_modules/@types/katex": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.7.tgz",
+      "integrity": "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="
     },
     "node_modules/@types/mdast": {
       "version": "4.0.3",
@@ -7881,6 +7888,68 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-from-dom": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-from-dom/-/hast-util-from-dom-5.0.1.tgz",
+      "integrity": "sha512-N+LqofjR2zuzTjCPzyDUdSshy4Ma6li7p/c3pA78uTwzFgENbgbUrm2ugwsOdcjI1muO+o6Dgzp9p8WHtn/39Q==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hastscript": "^9.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-dom/node_modules/hastscript": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-9.0.0.tgz",
+      "integrity": "sha512-jzaLBGavEDKHrc5EfFImKN7nZKKBdSLIdGvCwDZ9TfzbF2ffXiov8CKE445L2Z1Ek2t/m4SKQ2j6Ipv7NyUolw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^6.0.0",
+        "space-separated-tokens": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html/-/hast-util-from-html-2.0.3.tgz",
+      "integrity": "sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "devlop": "^1.1.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "parse5": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-from-html-isomorphic": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-from-html-isomorphic/-/hast-util-from-html-isomorphic-2.0.0.tgz",
+      "integrity": "sha512-zJfpXq44yff2hmE0XmwEOzdWin5xwH+QIhMLOScpX91e/NSGPsAzNCvLQDIEPyO2TXi+lBmU6hjLIhV8MwP2kw==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-from-dom": "^5.0.0",
+        "hast-util-from-html": "^2.0.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.1",
       "license": "MIT",
@@ -7893,6 +7962,18 @@
         "vfile": "^6.0.0",
         "vfile-location": "^5.0.0",
         "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-is-element": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
+      "integrity": "sha512-Val9mnv2IWpLbNPqc/pUem+a7Ipj2aHacCwgNfTiK0vJKl0LF+4Ba4+v1oPHFpf3bLYmreq0/l3Gud9S5OH42g==",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -8006,6 +8087,21 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-text": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unist-util-find-after": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -9560,6 +9656,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-math": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-math/-/mdast-util-math-3.0.0.tgz",
+      "integrity": "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.1.0",
+        "unist-util-remove-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-mdx": {
       "version": "3.0.0",
       "license": "MIT",
@@ -10701,6 +10815,77 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/micromark-extension-math": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+      "integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+      "dependencies": {
+        "@types/katex": "^0.16.0",
+        "devlop": "^1.0.0",
+        "katex": "^0.16.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-math/node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ]
     },
     "node_modules/micromark-extension-mdx-expression": {
       "version": "3.0.0",
@@ -14075,6 +14260,24 @@
         "regjsparser": "bin/parser"
       }
     },
+    "node_modules/rehype-katex": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-katex/-/rehype-katex-7.0.1.tgz",
+      "integrity": "sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/katex": "^0.16.0",
+        "hast-util-from-html-isomorphic": "^2.0.0",
+        "hast-util-to-text": "^4.0.0",
+        "katex": "^0.16.0",
+        "unist-util-visit-parents": "^6.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
       "license": "MIT",
@@ -14146,6 +14349,21 @@
         "micromark-extension-gfm": "^3.0.0",
         "remark-parse": "^11.0.0",
         "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-math": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/remark-math/-/remark-math-6.0.0.tgz",
+      "integrity": "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA==",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-math": "^3.0.0",
+        "micromark-extension-math": "^3.0.0",
         "unified": "^11.0.0"
       },
       "funding": {
@@ -15854,6 +16072,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/unist-util-find-after": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/unist-util-is": {

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -17,14 +17,16 @@
   },
   "dependencies": {
     "@docusaurus/core": "^3.6.0",
-    "@docusaurus/plugin-sitemap": "^3.6.0",
     "@docusaurus/plugin-client-redirects": "^3.6.0",
+    "@docusaurus/plugin-sitemap": "^3.6.0",
     "@docusaurus/preset-classic": "^3.6.0",
     "@docusaurus/theme-mermaid": "^3.6.0",
     "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "redocusaurus": "^2.1.2"
+    "redocusaurus": "^2.1.2",
+    "rehype-katex": "^7.0.1",
+    "remark-math": "^6.0.0"
   },
   "browserslist": {
     "production": [

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-doc",
-  "version": "0.1.45",
+  "version": "0.1.46",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/docs/website/root/mithril/mithril-protocol/security.md
+++ b/docs/website/root/mithril/mithril-protocol/security.md
@@ -43,6 +43,12 @@ The STM protocol enables participants to sign a message collectively, validating
     - _Aggregation_: these signatures are aggregated into a single multi-signature; a minimum of $k$ signatures are aggregated into a single multi-signature
     - _Verification_: the multi-signature, along with the Merkle proofs, is verified using the $\mathcal{AVK}$.
 
+:::info
+
+Protocol phases are described in more detail [here](./protocol.md#protocol-phases).
+
+:::
+
 ## Adversarial model
 
 The adversarial model specifies the capabilities and goals of potential attackers.

--- a/docs/website/root/mithril/mithril-protocol/security.md
+++ b/docs/website/root/mithril/mithril-protocol/security.md
@@ -1,0 +1,227 @@
+---
+sidebar_position: 3
+sidebar_label: Security
+---
+
+# Mithril protocol security
+
+:::info
+
+Mithril is based on the research paper [Mithril: Stake-based Threshold Multisignatures](https://iohk.io/en/research/library/papers/mithril-stake-based-threshold-multisignatures/).
+
+:::
+
+Mithril is a stake-based threshold multisignature (STM) protocol designed to aggregate individual signatures into a compact certificate. This process is conditional upon the total stake supporting a given message surpassing a predefined threshold. The protocol achieves scalability in signing, communication, and verification by pseudorandomly selecting a subset of participants eligible to sign each message.
+
+This document provides an in-depth security analysis of Mithril, focusing on potential threats and the protocol's defenses against various attack vectors. We begin with a concise overview of the STM protocol and the adversarial model, followed by a detailed discussion of its security mechanisms against common cryptographic attacks. Finally, we emphasize the importance of parameter selection, supported by examples illustrating the trade-offs between security and efficiency.
+
+## Mithril protocol in a nutshell
+
+The STM protocol allows multiple participants to collectively sign a message, where the total stake of the participants determines the validity of the signature.
+It leverages threshold multisignatures, which enable the aggregation of multiple individual signatures into a single, compact signature.
+This is particularly useful in PoS systems where the security of the blockchain depends on the distribution and control of stake among participants.
+
+- _Threshold Multisignature_: A scheme where individual signatures from multiple participants can be aggregated into a single signature if the total stake of the participants exceeds a certain threshold.
+- _Stake-based Eligibility_: The protocol ensures that only participants with a certain stake are eligible to sign messages, and this eligibility is determined pseudorandomly.
+- _Aggregation and Verification_: Individual signatures are aggregated into a single multisignature, which can be verified efficiently.
+
+### Protocol phases
+
+- **Initialization Phase**
+
+  - _Setup_: The protocol sets up necessary cryptographic parameters and prepares the system for operation.
+    - _Key Generation_: Participants generate a public-private key pair $(sk_i, pk_i)$.
+    - _Proof of Possession_: Each participant creates a proof $(\mathcal{PoP_i})$ that they possess the private key corresponding to their public key.
+    - _Registration_: Participants register their public keys $(pk_i)$ and $(\mathcal{PoP_i})$, which are then stored in a Merkle tree structure for efficient verification.
+    - _Aggregate Verification Key_: The root of the Merkle tree, which serves as the aggregate verification key $(\mathcal{AVK})$.
+
+- **Operation Phase**
+  - _Eligibility Determination_:
+    - _Lottery Mechanism_: For each message, the protocol initiates a series of lotteries to determine eligible participants. Each participant's chance of winning is proportional to their stake.
+    - _Security Parameter_ $(m)$: The number of parallel lotteries, ensuring enough participants are eligible.
+    - _Quorum Parameter_ $(k)$: The minimum number of eligible signatures required to form a valid multisignature.
+  - _Signing Process_:
+    - _Individual Signature Generation_: Eligible participants generate individual signatures for the message.
+    - _Aggregation_: These signatures are aggregated into a single multisignature. A minimum of $k$ signatures are aggregated into a single multisignature.
+    - _Verification_: The multisignature, along with the Merkle proofs, is verified using the $\mathcal{AVK}$.
+
+## Adversarial model
+
+The adversarial model specifies the capabilities and goals of potential attackers.
+For Mithril, we consider the following:
+
+- **Security Assumptions**: The assumptions under which the security of Mithril is analyzed:
+  - _Majority Honest Stake_: It is assumed that the majority of the stake is controlled by honest participants who follow the protocol.
+  - _Unique Signature Scheme_: The signature scheme used is secure and ensures that only one valid signature can be produced per message for each verification key.
+  - _Random Oracle Model_: The analysis assumes the availability of secure hash functions modeled as random oracles for certain security proofs.
+- **Security Goals**:
+  - _Integrity_: Ensure that only valid and legitimate participants can generate certificates, and that these certificates accurately reflect the consensus of the stakeholders.
+  - _Resistance to attacks_: Ensure that the influence in the protocol is proportional to the stake held, making it difficult for an adversary to gain control through multiple fake identities.
+  - _Forgery Resistance_: Prevent the adversary from creating valid forged signatures or concatenated proofs, particularly those that could lead to double-spending or chain reorganization.
+  - _Long-Range attack Resistance_: Ensure that old stakes cannot be used to create an alternate certificate chain that could overwrite the current chain.
+- **Adversary Capabilities**:
+  - _Computational Power_: The adversary may have significant computational resources but is assumed to be polynomially bounded (standard assumption in cryptographic protocols).
+  - _Stake Control_: The adversary may control a portion of the total stake in the system, potentially through collusion with other stakeholders or by compromising private keys.
+  - _Identity Control_: The adversary may attempt to create multiple identities to gain influence in the protocol, though the protocol assumes this is economically challenging due to the stake-proportional selection mechanism.
+  - _Forgery Attempts_: The adversary may try to forge concatenated proofs or signatures, manipulate eligibility checks, or create alternate certificate chains using old stakes.
+- **Adversary Goals**:
+  - _Forge a Certificate_: The adversary may attempt to generate a forged certificate by manipulating the signing process or controlling sufficient stake. Forged certificate would allow the adversary to falsely certifiy the information, compromising the protocol integrity.
+  - _Prevent Certificate Production_: The adversary might attempt to prevent the legitimate production of a certificate by disrupting the participation of eligible signers or introducing conflicts that prevent successful aggregation. This could halt the certificate generation process.
+  - _Manipulate Stake Distribution or Lottery Mechanism_: The adversary may try to exploit lottery mechanism by grinding attacks or manipulate the stake distribution to increase their chance of being selected. It could influence the certificate generation process.
+
+## Signature and Proof Integrity attacks
+
+In this section, we group _Concatenation Forgery_ and _Collusion_ attacks under signature and proof integrity attacks and discuss Mithril security regarding these attacks. Please see Appendix for further details.
+
+Concatenation Forgery attacks involve an adversary attempting to forge a valid concatenated proof by manipulating or assembling parts of valid signatures from different contexts. Collusion attacks occur when multiple participants conspire to manipulate the system, potentially leading to consensus disruption or double-spending. Although these attacks differ in approach, they both target the protocol's signature and proof mechanisms.
+
+### Mithril security mechanisms
+
+1. **Contradiction soundness**:
+   - Mithril employs a concatenation-based proof system where proofs are verified by checking the relation $R(x,w) = 1$.
+   - The key feature, contradiction soundness, ensures that any attempt to manipulate concatenated proofs results in contradictions.
+   - These contradictions are detectable by the verifier, thereby preventing the success of forgery attempts.
+   - Colluding participants cannot generate contradictory proofs without being detected, as the contradiction soundness feature makes it impossible to combine valid signatures from different contexts without producing inconsistencies.
+2. **Unique signature scheme**:
+   - The unique signature scheme in Mithril guarantees that a verification key can produce only one valid signature $(\sigma)$ for any given message.
+   - This prevents adversaries from assembling multiple valid signatures into a forged concatenated proof.
+   - Colluders are also restricted by this unique signature property, as they cannot produce multiple valid signatures for the same message under the same key. This ensures that even coordinated attempts to manipulate the signing process are thwarted.
+3. **Verification key and stake binding**:
+   - Mithril binds each verification key to a specific stake.
+   - Only signatures associated with valid and registered stakes are considered during verification.
+   - This binding prevents adversaries from using unregistered or invalid keys to forge concatenated proofs.
+   - The same binding mechanism hinders collusion by ensuring that any signatures produced by colluders must come from keys and stakes that are verifiably legitimate. This reduces the risk of colluders influencing the protocol with forged or manipulated signatures.
+4. **Threshold mechanism**:
+   - Mithril requires a threshold number of signatures to create a valid multisignature.
+   - This threshold mechanism ensures that colluders must control a significant portion of the network's stake to generate a valid signature.
+   - This makes large-scale collusion difficult and economically unfeasible.
+   - The threshold mechanism also indirectly supports resistance to concatenation forgery by ensuring that only a valid, sufficiently large group of participants can produce the required signatures for a valid proof.
+5. **Lottery mechanism and stake proportionality**:
+   - The protocol uses a pseudorandom lottery mechanism to select signers based on their stake.
+   - This selection process is unpredictable and stake-proportional, making it challenging for colluding participants to ensure they are selected together.
+   - The proportionality of stake influence ensures fairness and security by requiring colluders to hold a large stake to affect outcomes significantly.
+   - While primarily aimed at preventing collusion, the lottery mechanism also reinforces security against forgery by ensuring that only legitimately selected participants contribute to the proof process.
+6. **Identity verification and protocol transparency**:
+   - Mithril's identity verification process, using the $\mathcal{AVK}$ and $\mathcal{PoP}$, ensures that only legitimate participants with valid stakes and keys can participate.
+   - The protocol's transparency allows for auditing and detection of irregularities, further deterring both forgery and collusion.
+   - By verifying identities and maintaining transparency, the protocol minimizes the risk of both collusion and concatenation forgery.
+   - Any suspicious activity or irregular combination of signatures can be identified and addressed promptly.
+
+Mithril’s security mechanisms are designed to resist both Concatenation Forgery and Collusion attacks by leveraging contradiction soundness, a unique signature scheme, and strict identity verification processes. These defenses work together to ensure that any attempt to manipulate the protocol’s signatures or proofs, whether through forgery or collusion, will be detected and invalidated. By addressing these threats in a unified manner, Mithril maintains the integrity of its signature and proof processes, ensuring the overall security and robustness of the protocol.
+
+## Identity and Selection Manipulation attacks
+
+This section groups _Grinding_ and _Sybil_ attacks under identity and selection manipulation attacks. Mithril security mechanisms are discussed in terms of these kind of attacks. Please see Appendix for further details.
+
+Grinding attacks involve an adversary repeatedly manipulating cryptographic processes, such as key generation or stake distribution, to increase their chances of being selected as a validator. Sybil attacks, on the other hand, involve creating multiple fake identities to gain disproportionate influence within the network. Both attacks target the protocol's fairness and integrity, either by gaming the selection process or overwhelming the network with fake participants.
+
+### Mithril security mechanisms
+
+1. **Robust randomness**:
+   - Mithril utilizes cryptographic random number generators (RNGs) to ensure that the selection process for validators is both fair and unpredictable.
+   - The pseudorandom selection of participants is based on their stake, but the outcome is independent of the specifics of stake distribution.
+   - This randomness prevents an adversary from manipulating the process through key or stake grinding, as the probability of selection remains resistant to such exploitation.
+   - While primarily aimed at grinding, robust randomness also helps mitigate Sybil attacks by ensuring that even if multiple identities are created, the selection process remains fair and cannot be easily manipulated by simply increasing the number of identities.
+2. **Identity verification**:
+   - During each epoch's registration process, participants must provide $\mathcal{PoP}$ to demonstrate control over the private key corresponding to their verification key.
+   - This requirement ensures that each identity in the protocol is backed by a legitimate cryptographic key, making it difficult for an adversary to create numerous fake identities without the corresponding cryptographic proof.
+   - $\mathcal{PoP}$ also plays a role in preventing grinding attacks, as it ties each registered identity to a verifiable cryptographic proof, preventing the adversary from easily generating or manipulating keys to increase their chances of selection.
+3. **Stake-proportional eligibility**:
+   - In Mithril, the probability of being selected to sign is proportional to the participant's stake.
+   - This discourages the creation of multiple identities with small stakes, as their collective influence remains limited.
+   - The protocol favors concentrated stakes, making it economically impractical to launch a Sybil attack by distributing stake across many identities.
+   - The stake-proportional eligibility mechanism also counters grinding attacks, as generating multiple low-stake keys does not significantly increase the adversary's selection chances, ensuring that the selection process remains fair and stake-dependent.
+4. **Merkle tree and aggregate verification key**:
+   - All registered public keys and their associated $\mathcal{PoP}$s are organized into a Merkle tree, with the root known as the $\mathcal{AVK}$.
+   - This structure ensures efficient and secure verification of each participant's identity.
+   - By verifying each identity against the $\mathcal{AVK}$, the protocol prevents the inclusion of fake or manipulated identities in the signing process.
+   - The Merkle tree structure ties participants' identities to their stakes, ensuring that the eligibility determination is based on verified and legitimate identities.
+   - This mitigates both grinding and Sybil attacks by securing the verification process against manipulation.
+5. **Registration and epoch-based validation**:
+   - Participants must register their stakes and keys at the beginning of each epoch.
+   - This registration process, which includes verifying the participant's stake and associated $\mathcal{PoP}$, ensures that only active and valid participants can take part in the protocol.
+   - This mechanism prevents stale or fake identities from persisting across epochs without revalidation.
+
+Mithril's security mechanisms are carefully designed to resist both Grinding and Sybil attacks by employing robust randomness, thorough identity verification, and stake-proportional selection processes. These defenses work in tandem to ensure that the protocol remains secure against attempts to manipulate identity and selection mechanisms, whether through generating multiple keys or creating fake identities. By addressing these threats together, Mithril maintains the integrity and fairness of its consensus process, ensuring that only legitimate participants have influence over the network.
+
+## Long Range attacks
+
+This section covers the security mechanisms of Mithril against long range attacks. Please see Appendix for further information.
+
+Mithril is designed to safeguard the network against _Long Range attacks_, where an adversary attempts to exploit old, valid keys or stakes to create an alternate certificate chain from a distant point in the past. These attacks can compromise the integrity of the system by producing outdated or invalid certificates that undermine the current state. Mithril employs several mechanisms to counter this threat, ensuring the security and stability of the protocol.
+
+#### Mithril security mechanisms
+
+1. **Epoch-based checkpoints**:
+   - Mithril divides the certificate chain into epochs, each serving as a natural checkpoint.
+   - At the end of every epoch, participants generate signatures that are aggregated into a certificate, which acts as a finalized record of the epoch's events.
+   - These epoch-based certificates ensure that the certificate chain's history is fixed and verifiable at regular intervals.
+   - This checkpoint system makes it highly difficult for an adversary to create a valid alternate certificate chain that diverges from the legitimate chain before the last checkpoint.
+   - Any attempt to do so would require reconstructing an entire epoch's worth of valid signatures, which is practically infeasible.
+2. **Finality of certificates**:
+   - Once a certificate is generated and accepted for an epoch, it represents a finalized and irreversible state of the protocol.
+   - This strong notion of finality means that after a certificate is in place, it cannot be replaced or reorganized.
+   - This finality mechanism ensures that even if an adversary attempts to create an alternate chain, it will be rejected if it conflicts with finalized certificates.
+   - The protocol's design guarantees that once a state is finalized, it becomes a permanent part of the chain, protecting against reorganization attacks.
+3. **Stale stake invalidation**:
+   - Mithril requires participants to register their stakes and associated verification keys at the beginning of each epoch by providing $\mathcal{PoP}$.
+   - This process ensures that only current, active participants are included in the epoch.
+   - Stale stakes (old, inactive keys) are effectively invalidated because they are not re-registered.
+   - If a participant fails to register for a new epoch, their previous $vk$ and stake are excluded from the new $\mathcal{AVK}$.
+   - This prevents the use of old keys in generating certificates for the current epoch, ensuring that only legitimate and active stakes contribute to the protocol's security.
+4. **Robust randomness in eligibility**:
+   - The selection of participants for signing certificates is determined by a pseudorandom process influenced by current stakes.
+   - This randomness ensures that the selection process is fair, secure, and unpredictable.
+   - Even if an adversary possesses old keys, they cannot predict or influence the selection process for the current epoch.
+   - This randomness makes it extremely difficult to manipulate the certificate creation process using outdated or compromised keys, further protecting the protocol against long range attacks.
+
+Mithril employs a comprehensive set of mechanisms to protect against long range attacks, ensuring that the protocol remains secure even when faced with adversaries attempting to exploit old keys or stakes. By integrating epoch-based checkpoints, certificate finality, stale stake invalidation, and robust randomness, Mithril ensures that the certificate chain remains intact and resistant to reorganization or manipulation, thereby maintaining the integrity and stability of the network.
+
+## Appendices
+
+### Concatenation Forgery attacks
+
+Concatenation Forgery attack refers to a type of cryptographic attack where an adversary attempts to forge a valid combined (or concatenated) proof or signature by manipulating or assembling parts of valid signatures or proofs from different sources. This type of attack is particularly relevant in protocols that involve aggregating or concatenating multiple cryptographic components to form a single, composite proof or signature.
+Consider a protocol where multiple participants sign different parts of a message, and these signatures are concatenated to form a final, unified signature. In a concatenation forgery attack, an adversary might try to:
+
+- Collect valid signatures from different messages or contexts.
+- Reorder or selectively combine these signatures.
+- Present the manipulated result as a valid signature for a different message.
+
+### Collusion attacks
+
+Collusion attacks occur when multiple participants in a network conspire to manipulate the system for their collective benefit, undermining the consensus mechanism and potentially leading to issues like double-spending or undue network control.
+
+Collusion involves two or more parties working together to achieve a shared malicious goal. Manipulating the protocol's outcomes, such as block production or transaction validation. The attack aims to compromise the fairness and security of the network's consensus mechanism. Successful collusion can result in economic losses and weaken the network's security.
+
+- _Double-Spending_: Colluders create a blockchain fork to spend the same assets multiple times.
+- _Validator Collusion_: Validators work together to control block validation, influencing consensus decisions.
+- _Majority Stake Collusion_: Controlling a majority of the network’s stake to perform a "$51\%$ attack."
+
+### Grinding attacks
+
+Grinding attacks in cryptography, particularly in PoS blockchains, involve an adversary repeatedly attempting to manipulate the cryptographic process (such as key generation or stake distribution) to increase their chances of being selected as a validator. By generating multiple keys or adjusting their stake, the attacker tries to gain an unfair advantage in the consensus mechanism.
+
+- _Key Grinding_: The adversary generates numerous cryptographic keys, selecting those that are most favorable in the context of eligibility or winning a lottery-based selection process .
+- _Stake Grinding_: The adversary repeatedly modifies their stake (e.g., by splitting it among multiple identities) to increase the probability of being chosen as a validator.
+
+### Sybil attacks
+
+A Sybil attack occurs when an attacker creates multiple fake identities within a decentralized network to gain undue influence or control. This undermines the integrity and fairness of the network by centralizing power in the hands of the attacker.
+
+- The attacker generates many identities to appear as multiple independent participants.
+- These identities allow the attacker to disproportionately affect decisions, such as in blockchain consensus or online voting.
+- The attack weakens the decentralized nature of the network.
+- Ensuring strong, verifiable identities reduces the risk of fake accounts.
+
+### Long Range attacks
+
+This section covers the security mechanisms of Mithril against long range attacks. Please see Appendix for further information.
+
+A long range attack in Proof-of-Stake (PoS) blockchains involves an adversary using old, valid keys or stakes to create an alternate blockchain starting from a distant point in the past. The attacker builds this alternative chain until it surpasses the length of the legitimate chain, potentially leading to a chain fork or takeover.
+
+- Old Keys/Stakes exploit previously valid, but now inactive, keys or stakes.
+- The attacker creates a competing chain that eventually overtakes the current chain.
+- Can result in double-spending or chain reorganization, undermining the network's integrity.
+
+Long range attacks exploit the time-insensitivity of PoS systems, but these mitigation strategies help protect the network's security and stability.

--- a/docs/website/root/mithril/mithril-protocol/security.md
+++ b/docs/website/root/mithril/mithril-protocol/security.md
@@ -33,7 +33,7 @@ The STM protocol enables participants to sign a message collectively, validating
     - _Registration_: participants register their public keys $(pk_i)$ and $(\mathcal{PoP_i})$, which are then stored in a Merkle tree structure for efficient verification
     - _Aggregate verification key_: the root of the Merkle tree, which serves as the aggregate verification key $(\mathcal{AVK})$.
 
-- **Operations phase**
+- **Operation phase**
   - _Eligibility determination_:
     - _Lottery mechanism_: the protocol initiates a series of lotteries for each message to determine eligible participants. Each participant's chance of winning is proportional to their stake
     - _Security parameter_ $(m)$: the number of parallel lotteries, which ensures that enough participants are eligible
@@ -200,7 +200,7 @@ Collusion involves two or more parties working together to achieve a shared mali
 
 - _Double-spending_: colluders create a blockchain fork to spend the same assets multiple times
 - _Validator collusion_: validators work together to control block validation, influencing consensus decisions
-- _Majority stake collusion_: controlling a majority of the network’s stake to perform a '$51% attack.'
+- _Majority stake collusion_: controlling a majority of the network’s stake to perform a '$51\%$ attack.'
 
 ### Grinding attacks
 

--- a/docs/website/root/mithril/mithril-protocol/security.md
+++ b/docs/website/root/mithril/mithril-protocol/security.md
@@ -3,225 +3,221 @@ sidebar_position: 3
 sidebar_label: Security
 ---
 
-# Mithril protocol security
+# Protocol security
 
 :::info
 
-Mithril is based on the research paper [Mithril: Stake-based Threshold Multisignatures](https://iohk.io/en/research/library/papers/mithril-stake-based-threshold-multisignatures/).
+Mithril is based on the [Mithril: Stake-based Threshold Multi-signatures](https://iohk.io/en/research/library/papers/mithril-stake-based-threshold-multisignatures/) research paper.
 
 :::
 
-Mithril is a stake-based threshold multisignature (STM) protocol designed to aggregate individual signatures into a compact certificate. This process is conditional upon the total stake supporting a given message surpassing a predefined threshold. The protocol achieves scalability in signing, communication, and verification by pseudorandomly selecting a subset of participants eligible to sign each message.
+Mithril is a stake-based threshold multi-signature (STM) protocol that aggregates individual signatures into a compact certificate. This process occurs when the total stake supporting a message exceeds a predefined threshold. The protocol enhances scalability in signing, communication, and verification by pseudorandomly selecting a subset of eligible participants to sign each message.
 
-This document provides an in-depth security analysis of Mithril, focusing on potential threats and the protocol's defenses against various attack vectors. We begin with a concise overview of the STM protocol and the adversarial model, followed by a detailed discussion of its security mechanisms against common cryptographic attacks. Finally, we emphasize the importance of parameter selection, supported by examples illustrating the trade-offs between security and efficiency.
+This document presents a comprehensive security analysis of Mithril, examining potential threats and the protocol’s defenses against various attack vectors. It starts with an overview of the STM protocol and the adversarial model, followed by an in-depth discussion of security measures against common cryptographic attacks. The document concludes with an analysis of parameter selection, highlighting trade-offs between security and efficiency through practical examples.
 
-## Mithril protocol in a nutshell
+## Mithril protocol explained
 
-The STM protocol allows multiple participants to collectively sign a message, where the total stake of the participants determines the validity of the signature.
-It leverages threshold multisignatures, which enable the aggregation of multiple individual signatures into a single, compact signature.
-This is particularly useful in PoS systems where the security of the blockchain depends on the distribution and control of stake among participants.
+The STM protocol enables participants to sign a message collectively, validating the signature based on their combined stake. It leverages threshold multi-signatures to aggregate multiple individual signatures into a single, compact signature. This approach is especially beneficial in proof-of-stake (PoS) systems, where blockchain security relies on the distribution and control of stake among participants.
 
-- _Threshold Multisignature_: A scheme where individual signatures from multiple participants can be aggregated into a single signature if the total stake of the participants exceeds a certain threshold.
-- _Stake-based Eligibility_: The protocol ensures that only participants with a certain stake are eligible to sign messages, and this eligibility is determined pseudorandomly.
-- _Aggregation and Verification_: Individual signatures are aggregated into a single multisignature, which can be verified efficiently.
+- _Threshold multi-signature_: a cryptographic scheme that aggregates individual signatures into one compact signature if the total stake of the signers exceeds a predefined threshold
+- _Stake-based eligibility_: the protocol ensures that only participants with sufficient stake are pseudorandomly selected as eligible to sign messages
+- _Aggregation and verification_: aggregates individual signatures into a multi-signature, enabling efficient verification.
 
 ### Protocol phases
 
-- **Initialization Phase**
+- **Initialization phase**
 
-  - _Setup_: The protocol sets up necessary cryptographic parameters and prepares the system for operation.
-    - _Key Generation_: Participants generate a public-private key pair $(sk_i, pk_i)$.
-    - _Proof of Possession_: Each participant creates a proof $(\mathcal{PoP_i})$ that they possess the private key corresponding to their public key.
-    - _Registration_: Participants register their public keys $(pk_i)$ and $(\mathcal{PoP_i})$, which are then stored in a Merkle tree structure for efficient verification.
-    - _Aggregate Verification Key_: The root of the Merkle tree, which serves as the aggregate verification key $(\mathcal{AVK})$.
+  - _Setup_: the protocol sets up the necessary cryptographic parameters and prepares the system for operation
+    - _Key generation_: participants generate a public-private key pair $(sk_i, pk_i)$
+    - _Proof of possession_: each participant creates a proof $(\mathcal{PoP_i})$ that they possess the private key corresponding to their public key
+    - _Registration_: participants register their public keys $(pk_i)$ and $(\mathcal{PoP_i})$, which are then stored in a Merkle tree structure for efficient verification
+    - _Aggregate verification key_: the root of the Merkle tree, which serves as the aggregate verification key $(\mathcal{AVK})$.
 
-- **Operation Phase**
-  - _Eligibility Determination_:
-    - _Lottery Mechanism_: For each message, the protocol initiates a series of lotteries to determine eligible participants. Each participant's chance of winning is proportional to their stake.
-    - _Security Parameter_ $(m)$: The number of parallel lotteries, ensuring enough participants are eligible.
-    - _Quorum Parameter_ $(k)$: The minimum number of eligible signatures required to form a valid multisignature.
-  - _Signing Process_:
-    - _Individual Signature Generation_: Eligible participants generate individual signatures for the message.
-    - _Aggregation_: These signatures are aggregated into a single multisignature. A minimum of $k$ signatures are aggregated into a single multisignature.
-    - _Verification_: The multisignature, along with the Merkle proofs, is verified using the $\mathcal{AVK}$.
+- **Operations phase**
+  - _Eligibility determination_:
+    - _Lottery mechanism_: the protocol initiates a series of lotteries for each message to determine eligible participants. Each participant's chance of winning is proportional to their stake
+    - _Security parameter_ $(m)$: the number of parallel lotteries, which ensures that enough participants are eligible
+    - _Quorum parameter_ $(k)$: the minimum number of eligible signatures required to form a valid multi-signature
+  - _Signing process_:
+    - _Individual signature generation_: eligible participants generate individual signatures for the message
+    - _Aggregation_: these signatures are aggregated into a single multi-signature; a minimum of $k$ signatures are aggregated into a single multi-signature
+    - _Verification_: the multi-signature, along with the Merkle proofs, is verified using the $\mathcal{AVK}$.
 
 ## Adversarial model
 
 The adversarial model specifies the capabilities and goals of potential attackers.
-For Mithril, we consider the following:
+For Mithril, the following is considered:
 
-- **Security Assumptions**: The assumptions under which the security of Mithril is analyzed:
-  - _Majority Honest Stake_: It is assumed that the majority of the stake is controlled by honest participants who follow the protocol.
-  - _Unique Signature Scheme_: The signature scheme used is secure and ensures that only one valid signature can be produced per message for each verification key.
-  - _Random Oracle Model_: The analysis assumes the availability of secure hash functions modeled as random oracles for certain security proofs.
-- **Security Goals**:
-  - _Integrity_: Ensure that only valid and legitimate participants can generate certificates, and that these certificates accurately reflect the consensus of the stakeholders.
-  - _Resistance to attacks_: Ensure that the influence in the protocol is proportional to the stake held, making it difficult for an adversary to gain control through multiple fake identities.
-  - _Forgery Resistance_: Prevent the adversary from creating valid forged signatures or concatenated proofs, particularly those that could lead to double-spending or chain reorganization.
-  - _Long-Range attack Resistance_: Ensure that old stakes cannot be used to create an alternate certificate chain that could overwrite the current chain.
-- **Adversary Capabilities**:
-  - _Computational Power_: The adversary may have significant computational resources but is assumed to be polynomially bounded (standard assumption in cryptographic protocols).
-  - _Stake Control_: The adversary may control a portion of the total stake in the system, potentially through collusion with other stakeholders or by compromising private keys.
-  - _Identity Control_: The adversary may attempt to create multiple identities to gain influence in the protocol, though the protocol assumes this is economically challenging due to the stake-proportional selection mechanism.
-  - _Forgery Attempts_: The adversary may try to forge concatenated proofs or signatures, manipulate eligibility checks, or create alternate certificate chains using old stakes.
-- **Adversary Goals**:
-  - _Forge a Certificate_: The adversary may attempt to generate a forged certificate by manipulating the signing process or controlling sufficient stake. Forged certificate would allow the adversary to falsely certifiy the information, compromising the protocol integrity.
-  - _Prevent Certificate Production_: The adversary might attempt to prevent the legitimate production of a certificate by disrupting the participation of eligible signers or introducing conflicts that prevent successful aggregation. This could halt the certificate generation process.
-  - _Manipulate Stake Distribution or Lottery Mechanism_: The adversary may try to exploit lottery mechanism by grinding attacks or manipulate the stake distribution to increase their chance of being selected. It could influence the certificate generation process.
+- **Security assumptions**: the assumptions under which the security of Mithril is analyzed:
+  - _Majority honest stake_: it is assumed that a majority of the stake is controlled by honest participants adhering to its rules
+  - _Unique signature scheme_: the signature scheme ensures security by allowing only one valid signature per message for each verification key
+  - _Random oracle model_: the analysis relies on secure hash functions, modeled as random oracles, to support specific security proofs
+- **Security goals**:
+  - _Integrity_: to ensure that only valid and legitimate participants can generate certificates and that these certificates accurately reflect the consensus of the stakeholders
+  - _Resistance to attacks_: to ensure that protocol influence aligns with stake held, preventing adversaries from gaining control via multiple fake identities
+  - _Forgery resistance_: to prevent the adversary from creating valid forged signatures or concatenated proofs, particularly those that could lead to double-spending or chain reorganization
+  - _Long-range attack resistance_: to ensure that the old stake cannot be used to create an alternate certificate chain that could overwrite the current chain
+- **Adversary capabilities**:
+  - _Computational power_: the adversary may have significant computational resources but is assumed to be polynomially bounded (standard assumption in cryptographic protocols)
+  - _Stake control_: the adversary may control a portion of the total stake in the system, potentially through collusion with other stakeholders or by compromising private keys
+  - _Identity control_: the adversary may attempt to create multiple identities to gain influence in the protocol; however, the protocol assumes this is economically challenging due to the stake-proportional selection mechanism
+  - _Forgery attempts_: the adversary may try to forge concatenated proofs or signatures, manipulate eligibility checks, or create alternate certificate chains using the old stake
+- **Adversary goals**:
+  - _Forge a certificate_: the adversary may attempt to generate a forged certificate by manipulating the signing process or controlling sufficient stake. A forged certificate would allow the adversary to falsely certify the information, compromising the protocol's integrity
+  - _Prevent certificate production_: the adversary might attempt to prevent a certificate's legitimate production by disrupting eligible signers' participation or introducing conflicts that prevent successful aggregation. This could halt the certificate generation process
+  - _Manipulate stake distribution or lottery mechanism_: the adversary may try to exploit the lottery mechanism by grinding attacks or manipulating the stake distribution to increase their chance of being selected. This could influence the certificate generation process.
 
-## Signature and Proof Integrity attacks
+## Signature and proof integrity attacks
 
-In this section, we group _Concatenation Forgery_ and _Collusion_ attacks under signature and proof integrity attacks and discuss Mithril security regarding these attacks. Please see Appendix for further details.
+This section groups _concatenation forgery_ and _collusion_ attacks under signature and proof integrity attacks and discusses Mithril security regarding these attacks. Please see the Appendix for further details.
 
-Concatenation Forgery attacks involve an adversary attempting to forge a valid concatenated proof by manipulating or assembling parts of valid signatures from different contexts. Collusion attacks occur when multiple participants conspire to manipulate the system, potentially leading to consensus disruption or double-spending. Although these attacks differ in approach, they both target the protocol's signature and proof mechanisms.
+Concatenation forgery attacks involve an adversary attempting to forge a valid concatenated proof by manipulating or assembling parts of valid signatures from different contexts. Collusion attacks occur when multiple participants conspire to manipulate the system, potentially leading to consensus disruption or double-spending. Although these attacks differ in approach, they both target the protocol's signature and proof mechanisms.
 
 ### Mithril security mechanisms
 
 1. **Contradiction soundness**:
-   - Mithril employs a concatenation-based proof system where proofs are verified by checking the relation $R(x,w) = 1$.
-   - The key feature, contradiction soundness, ensures that any attempt to manipulate concatenated proofs results in contradictions.
-   - These contradictions are detectable by the verifier, thereby preventing the success of forgery attempts.
-   - Colluding participants cannot generate contradictory proofs without being detected, as the contradiction soundness feature makes it impossible to combine valid signatures from different contexts without producing inconsistencies.
+   Mithril employs a concatenation-based proof system in which proofs are verified by checking the relation $R(x,w) = 1$
+   - The key feature, contradiction soundness, ensures that any attempt to manipulate concatenated proofs results in contradictions
+   - These contradictions are detectable by the verifier, thereby preventing the success of forgery attempts
+   - Colluding participants cannot generate contradictory proofs without being detected, as the contradiction soundness feature makes it impossible to combine valid signatures from different contexts without producing inconsistencies
 2. **Unique signature scheme**:
-   - The unique signature scheme in Mithril guarantees that a verification key can produce only one valid signature $(\sigma)$ for any given message.
-   - This prevents adversaries from assembling multiple valid signatures into a forged concatenated proof.
-   - Colluders are also restricted by this unique signature property, as they cannot produce multiple valid signatures for the same message under the same key. This ensures that even coordinated attempts to manipulate the signing process are thwarted.
+   - The unique signature scheme in Mithril guarantees that a verification key can produce only one valid signature $(\sigma)$ for any given message
+   - This prevents adversaries from assembling multiple valid signatures into a forged concatenated proof
+   - This unique signature property also restricts colluders, as they cannot produce multiple valid signatures for the same message using the same key. This ensures that even coordinated attempts to manipulate the signing process are thwarted
 3. **Verification key and stake binding**:
-   - Mithril binds each verification key to a specific stake.
-   - Only signatures associated with valid and registered stakes are considered during verification.
-   - This binding prevents adversaries from using unregistered or invalid keys to forge concatenated proofs.
-   - The same binding mechanism hinders collusion by ensuring that any signatures produced by colluders must come from keys and stakes that are verifiably legitimate. This reduces the risk of colluders influencing the protocol with forged or manipulated signatures.
+   - Mithril binds each verification key to a specific stake
+   - Only signatures associated with the valid and registered stake are considered during verification
+   - This binding prevents adversaries from using unregistered or invalid keys to forge concatenated proofs
+   - The same binding mechanism hinders collusion by ensuring that any signatures produced by colluders come from verifiably legitimate keys and stakes. This reduces the risk of colluders influencing the protocol with forged or manipulated signatures
 4. **Threshold mechanism**:
-   - Mithril requires a threshold number of signatures to create a valid multisignature.
-   - This threshold mechanism ensures that colluders must control a significant portion of the network's stake to generate a valid signature.
-   - This makes large-scale collusion difficult and economically unfeasible.
-   - The threshold mechanism also indirectly supports resistance to concatenation forgery by ensuring that only a valid, sufficiently large group of participants can produce the required signatures for a valid proof.
+   - Mithril requires a threshold number of signatures to create a valid multi-signature
+   - This threshold mechanism ensures that colluders must control a significant portion of the network's stake to generate a valid signature
+   - This makes large-scale collusion difficult and economically unfeasible
+   - The threshold mechanism also indirectly supports resistance to concatenation forgery by ensuring that only a valid, sufficiently large group of participants can produce the required signatures for a valid proof
 5. **Lottery mechanism and stake proportionality**:
-   - The protocol uses a pseudorandom lottery mechanism to select signers based on their stake.
-   - This selection process is unpredictable and stake-proportional, making it challenging for colluding participants to ensure they are selected together.
-   - The proportionality of stake influence ensures fairness and security by requiring colluders to hold a large stake to affect outcomes significantly.
-   - While primarily aimed at preventing collusion, the lottery mechanism also reinforces security against forgery by ensuring that only legitimately selected participants contribute to the proof process.
+   - The protocol uses a pseudorandom lottery mechanism to select signers based on their stake
+   - This selection process is unpredictable and stake-proportional, making it challenging for colluding participants to ensure they are selected together
+   - The proportionality of stake influence ensures fairness and security by requiring colluders to hold a large stake to affect outcomes significantly
+   - While primarily aimed at preventing collusion, the lottery mechanism also reinforces security against forgery by ensuring that only legitimately selected participants contribute to the proof process
 6. **Identity verification and protocol transparency**:
-   - Mithril's identity verification process, using the $\mathcal{AVK}$ and $\mathcal{PoP}$, ensures that only legitimate participants with valid stakes and keys can participate.
-   - The protocol's transparency allows for auditing and detection of irregularities, further deterring both forgery and collusion.
-   - By verifying identities and maintaining transparency, the protocol minimizes the risk of both collusion and concatenation forgery.
+   - Mithril's identity verification process, using the $\mathcal{AVK}$ and $\mathcal{PoP}$, ensures that only legitimate participants with valid stake and keys can participate
+   - The protocol's transparency allows for auditing and detecting irregularities, further deterring both forgery and collusion
+   - By verifying identities and maintaining transparency, the protocol minimizes collusion and concatenation forgery risks
    - Any suspicious activity or irregular combination of signatures can be identified and addressed promptly.
 
-Mithril’s security mechanisms are designed to resist both Concatenation Forgery and Collusion attacks by leveraging contradiction soundness, a unique signature scheme, and strict identity verification processes. These defenses work together to ensure that any attempt to manipulate the protocol’s signatures or proofs, whether through forgery or collusion, will be detected and invalidated. By addressing these threats in a unified manner, Mithril maintains the integrity of its signature and proof processes, ensuring the overall security and robustness of the protocol.
+Mithril’s security mechanisms are designed to resist both concatenation forgery and collusion attacks by leveraging contradiction soundness, a unique signature scheme, and strict identity verification processes. These defenses work together to ensure that any attempt to manipulate the protocol’s signatures or proofs, whether through forgery or collusion, will be detected and invalidated. By addressing these threats in a unified manner, Mithril maintains the integrity of its signature and proof processes, ensuring the overall security and robustness of the protocol.
 
-## Identity and Selection Manipulation attacks
+## Identity and selection manipulation attacks
 
-This section groups _Grinding_ and _Sybil_ attacks under identity and selection manipulation attacks. Mithril security mechanisms are discussed in terms of these kind of attacks. Please see Appendix for further details.
+This section groups _grinding_ and _Sybil_ attacks under identity and selection manipulation attacks. Mithril’s security mechanisms are discussed in relation to these types of attacks. For further details, refer to the Appendix.
 
-Grinding attacks involve an adversary repeatedly manipulating cryptographic processes, such as key generation or stake distribution, to increase their chances of being selected as a validator. Sybil attacks, on the other hand, involve creating multiple fake identities to gain disproportionate influence within the network. Both attacks target the protocol's fairness and integrity, either by gaming the selection process or overwhelming the network with fake participants.
+Grinding attacks involve an adversary manipulating cryptographic processes, such as key generation or stake distribution, to increase their chances of being selected as a validator. Sybil attacks, in contrast, involve creating multiple fake identities to gain disproportionate influence within the network. Both attacks undermine the protocol’s fairness and integrity, either by exploiting the selection process or overwhelming the network with fake participants.
 
 ### Mithril security mechanisms
 
 1. **Robust randomness**:
-   - Mithril utilizes cryptographic random number generators (RNGs) to ensure that the selection process for validators is both fair and unpredictable.
-   - The pseudorandom selection of participants is based on their stake, but the outcome is independent of the specifics of stake distribution.
-   - This randomness prevents an adversary from manipulating the process through key or stake grinding, as the probability of selection remains resistant to such exploitation.
-   - While primarily aimed at grinding, robust randomness also helps mitigate Sybil attacks by ensuring that even if multiple identities are created, the selection process remains fair and cannot be easily manipulated by simply increasing the number of identities.
+   - Mithril utilizes cryptographic random number generators (RNGs) to ensure that the selection process for validators is both fair and unpredictable
+   - The pseudorandom selection of participants is based on their stake, but the outcome is independent of the specifics of stake distribution
+   - This randomness prevents an adversary from manipulating the process through key or stake grinding, as the probability of selection remains resistant to such exploitation
+   - While primarily aimed at grinding, robust randomness also helps mitigate Sybil attacks by ensuring that even if multiple identities are created, the selection process remains fair and cannot be easily manipulated by simply increasing the number of identities
 2. **Identity verification**:
-   - During each epoch's registration process, participants must provide $\mathcal{PoP}$ to demonstrate control over the private key corresponding to their verification key.
-   - This requirement ensures that each identity in the protocol is backed by a legitimate cryptographic key, making it difficult for an adversary to create numerous fake identities without the corresponding cryptographic proof.
-   - $\mathcal{PoP}$ also plays a role in preventing grinding attacks, as it ties each registered identity to a verifiable cryptographic proof, preventing the adversary from easily generating or manipulating keys to increase their chances of selection.
+   - During each epoch's registration process, participants must provide $\mathcal{PoP}$ to demonstrate control over the private key corresponding to their verification key
+   - This requirement ensures that each identity in the protocol is backed by a legitimate cryptographic key, making it difficult for an adversary to create numerous fake identities without the corresponding cryptographic proof
+   - $\mathcal{PoP}$ also plays a role in preventing grinding attacks, as it ties each registered identity to a verifiable cryptographic proof, preventing the adversary from easily generating or manipulating keys to increase their chances of selection
 3. **Stake-proportional eligibility**:
-   - In Mithril, the probability of being selected to sign is proportional to the participant's stake.
-   - This discourages the creation of multiple identities with small stakes, as their collective influence remains limited.
-   - The protocol favors concentrated stakes, making it economically impractical to launch a Sybil attack by distributing stake across many identities.
-   - The stake-proportional eligibility mechanism also counters grinding attacks, as generating multiple low-stake keys does not significantly increase the adversary's selection chances, ensuring that the selection process remains fair and stake-dependent.
+   - In Mithril, the probability of being selected to sign is proportional to the participant's stake
+   - This discourages the creation of multiple identities with small stake, as their collective influence remains limited
+   - The protocol favors concentrated stake, making it economically impractical to launch a Sybil attack by spreading stake across many identities
+   - The stake-proportional eligibility mechanism also counters grinding attacks, as generating multiple low-stake keys does not significantly increase the adversary's selection chances, ensuring that the selection process remains fair and stake-dependent
 4. **Merkle tree and aggregate verification key**:
-   - All registered public keys and their associated $\mathcal{PoP}$s are organized into a Merkle tree, with the root known as the $\mathcal{AVK}$.
-   - This structure ensures efficient and secure verification of each participant's identity.
-   - By verifying each identity against the $\mathcal{AVK}$, the protocol prevents the inclusion of fake or manipulated identities in the signing process.
-   - The Merkle tree structure ties participants' identities to their stakes, ensuring that the eligibility determination is based on verified and legitimate identities.
-   - This mitigates both grinding and Sybil attacks by securing the verification process against manipulation.
+   - All registered public keys and their associated $\mathcal{PoP}$s are organized into a Merkle tree, with the root known as the $\mathcal{AVK}$
+   - This structure ensures efficient and secure verification of each participant's identity
+   - By verifying each identity against the $\mathcal{AVK}$, the protocol prevents the inclusion of fake or manipulated identities in the signing process
+   - The Merkle tree structure ties participants' identities to their stake, ensuring eligibility determination is based on verified and legitimate identities
+   - This mitigates both grinding and Sybil attacks by securing the verification process against manipulation
 5. **Registration and epoch-based validation**:
-   - Participants must register their stakes and keys at the beginning of each epoch.
-   - This registration process, which includes verifying the participant's stake and associated $\mathcal{PoP}$, ensures that only active and valid participants can take part in the protocol.
+   - Participants must register their stake and keys at the beginning of each epoch
+   - This registration process, which includes verifying the participant's stake and associated $\mathcal{PoP}$, ensures that only active and valid participants can participate in the protocol
    - This mechanism prevents stale or fake identities from persisting across epochs without revalidation.
 
-Mithril's security mechanisms are carefully designed to resist both Grinding and Sybil attacks by employing robust randomness, thorough identity verification, and stake-proportional selection processes. These defenses work in tandem to ensure that the protocol remains secure against attempts to manipulate identity and selection mechanisms, whether through generating multiple keys or creating fake identities. By addressing these threats together, Mithril maintains the integrity and fairness of its consensus process, ensuring that only legitimate participants have influence over the network.
+Mithril's security mechanisms are carefully designed to resist both grinding and Sybil attacks by employing robust randomness, thorough identity verification, and stake-proportional selection processes. These defenses work in tandem to ensure that the protocol remains secure against attempts to manipulate identity and selection mechanisms, whether through generating multiple keys or creating fake identities. By addressing these threats together, Mithril maintains the integrity and fairness of its consensus process, ensuring that only legitimate participants have influence over the network.
 
-## Long Range attacks
+## Long range attacks
 
-This section covers the security mechanisms of Mithril against long range attacks. Please see Appendix for further information.
+This section covers Mithril's security mechanisms against long range attacks. Please see the Appendix for further information.
 
-Mithril is designed to safeguard the network against _Long Range attacks_, where an adversary attempts to exploit old, valid keys or stakes to create an alternate certificate chain from a distant point in the past. These attacks can compromise the integrity of the system by producing outdated or invalid certificates that undermine the current state. Mithril employs several mechanisms to counter this threat, ensuring the security and stability of the protocol.
+Mithril is designed to safeguard the network against _long range attacks_, where an adversary attempts to exploit old, valid keys or stake to create an alternate certificate chain from a distant point in the past. These attacks can compromise the system's integrity by producing outdated or invalid certificates, undermining the current state. Mithril employs several mechanisms to counter this threat, ensuring the security and stability of the protocol.
 
 #### Mithril security mechanisms
 
 1. **Epoch-based checkpoints**:
-   - Mithril divides the certificate chain into epochs, each serving as a natural checkpoint.
-   - At the end of every epoch, participants generate signatures that are aggregated into a certificate, which acts as a finalized record of the epoch's events.
-   - These epoch-based certificates ensure that the certificate chain's history is fixed and verifiable at regular intervals.
-   - This checkpoint system makes it highly difficult for an adversary to create a valid alternate certificate chain that diverges from the legitimate chain before the last checkpoint.
-   - Any attempt to do so would require reconstructing an entire epoch's worth of valid signatures, which is practically infeasible.
+   - Mithril divides the certificate chain into epochs, each serving as a natural checkpoint
+   - At the end of every epoch, participants generate signatures that are aggregated into a certificate, which acts as a finalized record of the epoch's events
+   - These epoch-based certificates ensure that the certificate chain's history is fixed and verifiable at regular intervals
+   - This checkpoint system makes it highly difficult for an adversary to create a valid alternate certificate chain that diverges from the legitimate chain before the last checkpoint
+   - Any attempt to do so would require reconstructing an entire epoch's worth of valid signatures, which is practically infeasible
 2. **Finality of certificates**:
-   - Once a certificate is generated and accepted for an epoch, it represents a finalized and irreversible state of the protocol.
-   - This strong notion of finality means that after a certificate is in place, it cannot be replaced or reorganized.
-   - This finality mechanism ensures that even if an adversary attempts to create an alternate chain, it will be rejected if it conflicts with finalized certificates.
-   - The protocol's design guarantees that once a state is finalized, it becomes a permanent part of the chain, protecting against reorganization attacks.
+   - Once a certificate is generated and accepted for an epoch, it represents a finalized and irreversible protocol state
+   - This strong notion of finality means that after a certificate is in place, it cannot be replaced or reorganized
+   - This finality mechanism ensures that even if an adversary attempts to create an alternate chain, it will be rejected if it conflicts with finalized certificates
+   - The protocol's design guarantees that once a state is finalized, it becomes a permanent part of the chain, protecting against reorganization attacks
 3. **Stale stake invalidation**:
-   - Mithril requires participants to register their stakes and associated verification keys at the beginning of each epoch by providing $\mathcal{PoP}$.
-   - This process ensures that only current, active participants are included in the epoch.
-   - Stale stakes (old, inactive keys) are effectively invalidated because they are not re-registered.
-   - If a participant fails to register for a new epoch, their previous $vk$ and stake are excluded from the new $\mathcal{AVK}$.
-   - This prevents the use of old keys in generating certificates for the current epoch, ensuring that only legitimate and active stakes contribute to the protocol's security.
+   - Mithril requires participants to register their stake and associated verification keys at the beginning of each epoch by providing $\mathcal{PoP}$
+   - This process ensures that only current, active participants are included in the epoch
+   - Stale stake (old, inactive keys) are effectively invalidated because they are not re-registered
+   - If a participant fails to register for a new epoch, their previous $vk$ and stake are excluded from the new $\mathcal{AVK}$
+   - This prevents using old keys to generate certificates for the current epoch, ensuring that only legitimate and active stake contributes to the protocol's security
 4. **Robust randomness in eligibility**:
-   - The selection of participants for signing certificates is determined by a pseudorandom process influenced by current stakes.
-   - This randomness ensures that the selection process is fair, secure, and unpredictable.
-   - Even if an adversary possesses old keys, they cannot predict or influence the selection process for the current epoch.
+   - The selection of participants for signing certificates is determined by a pseudorandom process influenced by the current stake
+   - This randomness ensures that the selection process is fair, secure, and unpredictable
+   - Even if an adversary possesses old keys, they cannot predict or influence the selection process for the current epoch
    - This randomness makes it extremely difficult to manipulate the certificate creation process using outdated or compromised keys, further protecting the protocol against long range attacks.
 
-Mithril employs a comprehensive set of mechanisms to protect against long range attacks, ensuring that the protocol remains secure even when faced with adversaries attempting to exploit old keys or stakes. By integrating epoch-based checkpoints, certificate finality, stale stake invalidation, and robust randomness, Mithril ensures that the certificate chain remains intact and resistant to reorganization or manipulation, thereby maintaining the integrity and stability of the network.
+Mithril employs a comprehensive set of mechanisms to protect against long range attacks, ensuring that the protocol remains secure even when faced with adversaries attempting to exploit old keys or stake. By integrating epoch-based checkpoints, certificate finality, stale stake invalidation, and robust randomness, Mithril ensures that the certificate chain remains intact and resistant to reorganization or manipulation, thereby maintaining the integrity and stability of the network.
 
 ## Appendices
 
-### Concatenation Forgery attacks
+### Concatenation forgery attacks
 
-Concatenation Forgery attack refers to a type of cryptographic attack where an adversary attempts to forge a valid combined (or concatenated) proof or signature by manipulating or assembling parts of valid signatures or proofs from different sources. This type of attack is particularly relevant in protocols that involve aggregating or concatenating multiple cryptographic components to form a single, composite proof or signature.
+A concatenation forgery attack is a type of cryptographic attack in which an adversary attempts to forge a valid combined (or concatenated) proof or signature by manipulating or assembling parts of valid signatures or proofs from different sources. This type of attack is particularly relevant in protocols that involve aggregating or concatenating multiple cryptographic components to form a single composite proof or signature.
 Consider a protocol where multiple participants sign different parts of a message, and these signatures are concatenated to form a final, unified signature. In a concatenation forgery attack, an adversary might try to:
 
-- Collect valid signatures from different messages or contexts.
-- Reorder or selectively combine these signatures.
+- Collect valid signatures from different messages or contexts
+- Reorder or selectively combine these signatures
 - Present the manipulated result as a valid signature for a different message.
 
 ### Collusion attacks
 
 Collusion attacks occur when multiple participants in a network conspire to manipulate the system for their collective benefit, undermining the consensus mechanism and potentially leading to issues like double-spending or undue network control.
 
-Collusion involves two or more parties working together to achieve a shared malicious goal. Manipulating the protocol's outcomes, such as block production or transaction validation. The attack aims to compromise the fairness and security of the network's consensus mechanism. Successful collusion can result in economic losses and weaken the network's security.
+Collusion involves two or more parties working together to achieve a shared malicious goal by manipulating the protocol's outcomes, such as block production or transaction validation. The attack aims to compromise the fairness and security of the network's consensus mechanism. Successful collusion can result in economic losses and weaken the network's security.
 
-- _Double-Spending_: Colluders create a blockchain fork to spend the same assets multiple times.
-- _Validator Collusion_: Validators work together to control block validation, influencing consensus decisions.
-- _Majority Stake Collusion_: Controlling a majority of the network’s stake to perform a "$51\%$ attack."
+- _Double-spending_: colluders create a blockchain fork to spend the same assets multiple times
+- _Validator collusion_: validators work together to control block validation, influencing consensus decisions
+- _Majority stake collusion_: controlling a majority of the network’s stake to perform a '$51% attack.'
 
 ### Grinding attacks
 
-Grinding attacks in cryptography, particularly in PoS blockchains, involve an adversary repeatedly attempting to manipulate the cryptographic process (such as key generation or stake distribution) to increase their chances of being selected as a validator. By generating multiple keys or adjusting their stake, the attacker tries to gain an unfair advantage in the consensus mechanism.
+Grinding attacks in cryptography, particularly in PoS blockchains, involve an adversary manipulating the cryptographic process – such as key generation or stake distribution – to increase their chances of being selected as a validator. By generating multiple keys or adjusting their stake, the attacker seeks to gain an unfair advantage in the consensus mechanism.
 
-- _Key Grinding_: The adversary generates numerous cryptographic keys, selecting those that are most favorable in the context of eligibility or winning a lottery-based selection process .
-- _Stake Grinding_: The adversary repeatedly modifies their stake (e.g., by splitting it among multiple identities) to increase the probability of being chosen as a validator.
+- _Key grinding_: the adversary generates numerous cryptographic keys, selecting the most favorable ones in the context of eligibility or winning a lottery-based selection process
+- _Stake grinding_: the adversary repeatedly modifies their stake (eg, by splitting it among multiple identities) to increase the probability of being chosen as a validator.
 
 ### Sybil attacks
 
-A Sybil attack occurs when an attacker creates multiple fake identities within a decentralized network to gain undue influence or control. This undermines the integrity and fairness of the network by centralizing power in the hands of the attacker.
+A Sybil attack occurs when an attacker creates multiple fake identities within a decentralized network to gain undue influence or control. This undermines the network's integrity and fairness by centralizing power in the attacker's hands.
 
-- The attacker generates many identities to appear as multiple independent participants.
-- These identities allow the attacker to disproportionately affect decisions, such as in blockchain consensus or online voting.
-- The attack weakens the decentralized nature of the network.
+- The attacker generates many identities to appear as multiple independent participants
+- These identities allow the attacker to disproportionately affect decisions, such as in blockchain consensus or online voting
+- The attack weakens the decentralized nature of the network
 - Ensuring strong, verifiable identities reduces the risk of fake accounts.
 
-### Long Range attacks
+### Long range attacks
 
-This section covers the security mechanisms of Mithril against long range attacks. Please see Appendix for further information.
+A long range attack in PoS blockchains involves an adversary using old, valid keys or stake to create an alternate blockchain starting from a distant point in the past. The attacker builds this alternative chain until it surpasses the length of the legitimate chain, potentially leading to a chain fork or takeover.
 
-A long range attack in Proof-of-Stake (PoS) blockchains involves an adversary using old, valid keys or stakes to create an alternate blockchain starting from a distant point in the past. The attacker builds this alternative chain until it surpasses the length of the legitimate chain, potentially leading to a chain fork or takeover.
-
-- Old Keys/Stakes exploit previously valid, but now inactive, keys or stakes.
-- The attacker creates a competing chain that eventually overtakes the current chain.
-- Can result in double-spending or chain reorganization, undermining the network's integrity.
+- Old keys/stake exploit previously valid, but now inactive, keys or stake
+- The attacker creates a competing chain that eventually overtakes the current chain
+- This can result in double spending or chain reorganization, undermining the network's integrity.
 
 Long range attacks exploit the time-insensitivity of PoS systems, but these mitigation strategies help protect the network's security and stability.

--- a/docs/website/versioned_docs/version-maintained/mithril/mithril-protocol/security.md
+++ b/docs/website/versioned_docs/version-maintained/mithril/mithril-protocol/security.md
@@ -1,0 +1,229 @@
+---
+sidebar_position: 3
+sidebar_label: Security
+---
+
+# Protocol security
+
+:::info
+
+Mithril is based on the [Mithril: Stake-based Threshold Multi-signatures](https://iohk.io/en/research/library/papers/mithril-stake-based-threshold-multisignatures/) research paper.
+
+:::
+
+Mithril is a stake-based threshold multi-signature (STM) protocol that aggregates individual signatures into a compact certificate. This process occurs when the total stake supporting a message exceeds a predefined threshold. The protocol enhances scalability in signing, communication, and verification by pseudorandomly selecting a subset of eligible participants to sign each message.
+
+This document presents a comprehensive security analysis of Mithril, examining potential threats and the protocol’s defenses against various attack vectors. It starts with an overview of the STM protocol and the adversarial model, followed by an in-depth discussion of security measures against common cryptographic attacks. The document concludes with an analysis of parameter selection, highlighting trade-offs between security and efficiency through practical examples.
+
+## Mithril protocol explained
+
+The STM protocol enables participants to sign a message collectively, validating the signature based on their combined stake. It leverages threshold multi-signatures to aggregate multiple individual signatures into a single, compact signature. This approach is especially beneficial in proof-of-stake (PoS) systems, where blockchain security relies on the distribution and control of stake among participants.
+
+- _Threshold multi-signature_: a cryptographic scheme that aggregates individual signatures into one compact signature if the total stake of the signers exceeds a predefined threshold
+- _Stake-based eligibility_: the protocol ensures that only participants with sufficient stake are pseudorandomly selected as eligible to sign messages
+- _Aggregation and verification_: aggregates individual signatures into a multi-signature, enabling efficient verification.
+
+### Protocol phases
+
+- **Initialization phase**
+
+  - _Setup_: the protocol sets up the necessary cryptographic parameters and prepares the system for operation
+    - _Key generation_: participants generate a public-private key pair $(sk_i, pk_i)$
+    - _Proof of possession_: each participant creates a proof $(\mathcal{PoP_i})$ that they possess the private key corresponding to their public key
+    - _Registration_: participants register their public keys $(pk_i)$ and $(\mathcal{PoP_i})$, which are then stored in a Merkle tree structure for efficient verification
+    - _Aggregate verification key_: the root of the Merkle tree, which serves as the aggregate verification key $(\mathcal{AVK})$.
+
+- **Operation phase**
+  - _Eligibility determination_:
+    - _Lottery mechanism_: the protocol initiates a series of lotteries for each message to determine eligible participants. Each participant's chance of winning is proportional to their stake
+    - _Security parameter_ $(m)$: the number of parallel lotteries, which ensures that enough participants are eligible
+    - _Quorum parameter_ $(k)$: the minimum number of eligible signatures required to form a valid multi-signature
+  - _Signing process_:
+    - _Individual signature generation_: eligible participants generate individual signatures for the message
+    - _Aggregation_: these signatures are aggregated into a single multi-signature; a minimum of $k$ signatures are aggregated into a single multi-signature
+    - _Verification_: the multi-signature, along with the Merkle proofs, is verified using the $\mathcal{AVK}$.
+
+:::info
+
+Protocol phases are described in more detail [here](./protocol.md#protocol-phases).
+
+:::
+
+## Adversarial model
+
+The adversarial model specifies the capabilities and goals of potential attackers.
+For Mithril, the following is considered:
+
+- **Security assumptions**: the assumptions under which the security of Mithril is analyzed:
+  - _Majority honest stake_: it is assumed that a majority of the stake is controlled by honest participants adhering to its rules
+  - _Unique signature scheme_: the signature scheme ensures security by allowing only one valid signature per message for each verification key
+  - _Random oracle model_: the analysis relies on secure hash functions, modeled as random oracles, to support specific security proofs
+- **Security goals**:
+  - _Integrity_: to ensure that only valid and legitimate participants can generate certificates and that these certificates accurately reflect the consensus of the stakeholders
+  - _Resistance to attacks_: to ensure that protocol influence aligns with stake held, preventing adversaries from gaining control via multiple fake identities
+  - _Forgery resistance_: to prevent the adversary from creating valid forged signatures or concatenated proofs, particularly those that could lead to double-spending or chain reorganization
+  - _Long-range attack resistance_: to ensure that the old stake cannot be used to create an alternate certificate chain that could overwrite the current chain
+- **Adversary capabilities**:
+  - _Computational power_: the adversary may have significant computational resources but is assumed to be polynomially bounded (standard assumption in cryptographic protocols)
+  - _Stake control_: the adversary may control a portion of the total stake in the system, potentially through collusion with other stakeholders or by compromising private keys
+  - _Identity control_: the adversary may attempt to create multiple identities to gain influence in the protocol; however, the protocol assumes this is economically challenging due to the stake-proportional selection mechanism
+  - _Forgery attempts_: the adversary may try to forge concatenated proofs or signatures, manipulate eligibility checks, or create alternate certificate chains using the old stake
+- **Adversary goals**:
+  - _Forge a certificate_: the adversary may attempt to generate a forged certificate by manipulating the signing process or controlling sufficient stake. A forged certificate would allow the adversary to falsely certify the information, compromising the protocol's integrity
+  - _Prevent certificate production_: the adversary might attempt to prevent a certificate's legitimate production by disrupting eligible signers' participation or introducing conflicts that prevent successful aggregation. This could halt the certificate generation process
+  - _Manipulate stake distribution or lottery mechanism_: the adversary may try to exploit the lottery mechanism by grinding attacks or manipulating the stake distribution to increase their chance of being selected. This could influence the certificate generation process.
+
+## Signature and proof integrity attacks
+
+This section groups _concatenation forgery_ and _collusion_ attacks under signature and proof integrity attacks and discusses Mithril security regarding these attacks. Please see the Appendix for further details.
+
+Concatenation forgery attacks involve an adversary attempting to forge a valid concatenated proof by manipulating or assembling parts of valid signatures from different contexts. Collusion attacks occur when multiple participants conspire to manipulate the system, potentially leading to consensus disruption or double-spending. Although these attacks differ in approach, they both target the protocol's signature and proof mechanisms.
+
+### Mithril security mechanisms
+
+1. **Contradiction soundness**:
+   Mithril employs a concatenation-based proof system in which proofs are verified by checking the relation $R(x,w) = 1$
+   - The key feature, contradiction soundness, ensures that any attempt to manipulate concatenated proofs results in contradictions
+   - These contradictions are detectable by the verifier, thereby preventing the success of forgery attempts
+   - Colluding participants cannot generate contradictory proofs without being detected, as the contradiction soundness feature makes it impossible to combine valid signatures from different contexts without producing inconsistencies
+2. **Unique signature scheme**:
+   - The unique signature scheme in Mithril guarantees that a verification key can produce only one valid signature $(\sigma)$ for any given message
+   - This prevents adversaries from assembling multiple valid signatures into a forged concatenated proof
+   - This unique signature property also restricts colluders, as they cannot produce multiple valid signatures for the same message using the same key. This ensures that even coordinated attempts to manipulate the signing process are thwarted
+3. **Verification key and stake binding**:
+   - Mithril binds each verification key to a specific stake
+   - Only signatures associated with the valid and registered stake are considered during verification
+   - This binding prevents adversaries from using unregistered or invalid keys to forge concatenated proofs
+   - The same binding mechanism hinders collusion by ensuring that any signatures produced by colluders come from verifiably legitimate keys and stakes. This reduces the risk of colluders influencing the protocol with forged or manipulated signatures
+4. **Threshold mechanism**:
+   - Mithril requires a threshold number of signatures to create a valid multi-signature
+   - This threshold mechanism ensures that colluders must control a significant portion of the network's stake to generate a valid signature
+   - This makes large-scale collusion difficult and economically unfeasible
+   - The threshold mechanism also indirectly supports resistance to concatenation forgery by ensuring that only a valid, sufficiently large group of participants can produce the required signatures for a valid proof
+5. **Lottery mechanism and stake proportionality**:
+   - The protocol uses a pseudorandom lottery mechanism to select signers based on their stake
+   - This selection process is unpredictable and stake-proportional, making it challenging for colluding participants to ensure they are selected together
+   - The proportionality of stake influence ensures fairness and security by requiring colluders to hold a large stake to affect outcomes significantly
+   - While primarily aimed at preventing collusion, the lottery mechanism also reinforces security against forgery by ensuring that only legitimately selected participants contribute to the proof process
+6. **Identity verification and protocol transparency**:
+   - Mithril's identity verification process, using the $\mathcal{AVK}$ and $\mathcal{PoP}$, ensures that only legitimate participants with valid stake and keys can participate
+   - The protocol's transparency allows for auditing and detecting irregularities, further deterring both forgery and collusion
+   - By verifying identities and maintaining transparency, the protocol minimizes collusion and concatenation forgery risks
+   - Any suspicious activity or irregular combination of signatures can be identified and addressed promptly.
+
+Mithril’s security mechanisms are designed to resist both concatenation forgery and collusion attacks by leveraging contradiction soundness, a unique signature scheme, and strict identity verification processes. These defenses work together to ensure that any attempt to manipulate the protocol’s signatures or proofs, whether through forgery or collusion, will be detected and invalidated. By addressing these threats in a unified manner, Mithril maintains the integrity of its signature and proof processes, ensuring the overall security and robustness of the protocol.
+
+## Identity and selection manipulation attacks
+
+This section groups _grinding_ and _Sybil_ attacks under identity and selection manipulation attacks. Mithril’s security mechanisms are discussed in relation to these types of attacks. For further details, refer to the Appendix.
+
+Grinding attacks involve an adversary manipulating cryptographic processes, such as key generation or stake distribution, to increase their chances of being selected as a validator. Sybil attacks, in contrast, involve creating multiple fake identities to gain disproportionate influence within the network. Both attacks undermine the protocol’s fairness and integrity, either by exploiting the selection process or overwhelming the network with fake participants.
+
+### Mithril security mechanisms
+
+1. **Robust randomness**:
+   - Mithril utilizes cryptographic random number generators (RNGs) to ensure that the selection process for validators is both fair and unpredictable
+   - The pseudorandom selection of participants is based on their stake, but the outcome is independent of the specifics of stake distribution
+   - This randomness prevents an adversary from manipulating the process through key or stake grinding, as the probability of selection remains resistant to such exploitation
+   - While primarily aimed at grinding, robust randomness also helps mitigate Sybil attacks by ensuring that even if multiple identities are created, the selection process remains fair and cannot be easily manipulated by simply increasing the number of identities
+2. **Identity verification**:
+   - During each epoch's registration process, participants must provide $\mathcal{PoP}$ to demonstrate control over the private key corresponding to their verification key
+   - This requirement ensures that each identity in the protocol is backed by a legitimate cryptographic key, making it difficult for an adversary to create numerous fake identities without the corresponding cryptographic proof
+   - $\mathcal{PoP}$ also plays a role in preventing grinding attacks, as it ties each registered identity to a verifiable cryptographic proof, preventing the adversary from easily generating or manipulating keys to increase their chances of selection
+3. **Stake-proportional eligibility**:
+   - In Mithril, the probability of being selected to sign is proportional to the participant's stake
+   - This discourages the creation of multiple identities with small stake, as their collective influence remains limited
+   - The protocol favors concentrated stake, making it economically impractical to launch a Sybil attack by spreading stake across many identities
+   - The stake-proportional eligibility mechanism also counters grinding attacks, as generating multiple low-stake keys does not significantly increase the adversary's selection chances, ensuring that the selection process remains fair and stake-dependent
+4. **Merkle tree and aggregate verification key**:
+   - All registered public keys and their associated $\mathcal{PoP}$s are organized into a Merkle tree, with the root known as the $\mathcal{AVK}$
+   - This structure ensures efficient and secure verification of each participant's identity
+   - By verifying each identity against the $\mathcal{AVK}$, the protocol prevents the inclusion of fake or manipulated identities in the signing process
+   - The Merkle tree structure ties participants' identities to their stake, ensuring eligibility determination is based on verified and legitimate identities
+   - This mitigates both grinding and Sybil attacks by securing the verification process against manipulation
+5. **Registration and epoch-based validation**:
+   - Participants must register their stake and keys at the beginning of each epoch
+   - This registration process, which includes verifying the participant's stake and associated $\mathcal{PoP}$, ensures that only active and valid participants can participate in the protocol
+   - This mechanism prevents stale or fake identities from persisting across epochs without revalidation.
+
+Mithril's security mechanisms are carefully designed to resist both grinding and Sybil attacks by employing robust randomness, thorough identity verification, and stake-proportional selection processes. These defenses work in tandem to ensure that the protocol remains secure against attempts to manipulate identity and selection mechanisms, whether through generating multiple keys or creating fake identities. By addressing these threats together, Mithril maintains the integrity and fairness of its consensus process, ensuring that only legitimate participants have influence over the network.
+
+## Long range attacks
+
+This section covers Mithril's security mechanisms against long range attacks. Please see the Appendix for further information.
+
+Mithril is designed to safeguard the network against _long range attacks_, where an adversary attempts to exploit old, valid keys or stake to create an alternate certificate chain from a distant point in the past. These attacks can compromise the system's integrity by producing outdated or invalid certificates, undermining the current state. Mithril employs several mechanisms to counter this threat, ensuring the security and stability of the protocol.
+
+#### Mithril security mechanisms
+
+1. **Epoch-based checkpoints**:
+   - Mithril divides the certificate chain into epochs, each serving as a natural checkpoint
+   - At the end of every epoch, participants generate signatures that are aggregated into a certificate, which acts as a finalized record of the epoch's events
+   - These epoch-based certificates ensure that the certificate chain's history is fixed and verifiable at regular intervals
+   - This checkpoint system makes it highly difficult for an adversary to create a valid alternate certificate chain that diverges from the legitimate chain before the last checkpoint
+   - Any attempt to do so would require reconstructing an entire epoch's worth of valid signatures, which is practically infeasible
+2. **Finality of certificates**:
+   - Once a certificate is generated and accepted for an epoch, it represents a finalized and irreversible protocol state
+   - This strong notion of finality means that after a certificate is in place, it cannot be replaced or reorganized
+   - This finality mechanism ensures that even if an adversary attempts to create an alternate chain, it will be rejected if it conflicts with finalized certificates
+   - The protocol's design guarantees that once a state is finalized, it becomes a permanent part of the chain, protecting against reorganization attacks
+3. **Stale stake invalidation**:
+   - Mithril requires participants to register their stake and associated verification keys at the beginning of each epoch by providing $\mathcal{PoP}$
+   - This process ensures that only current, active participants are included in the epoch
+   - Stale stake (old, inactive keys) are effectively invalidated because they are not re-registered
+   - If a participant fails to register for a new epoch, their previous $vk$ and stake are excluded from the new $\mathcal{AVK}$
+   - This prevents using old keys to generate certificates for the current epoch, ensuring that only legitimate and active stake contributes to the protocol's security
+4. **Robust randomness in eligibility**:
+   - The selection of participants for signing certificates is determined by a pseudorandom process influenced by the current stake
+   - This randomness ensures that the selection process is fair, secure, and unpredictable
+   - Even if an adversary possesses old keys, they cannot predict or influence the selection process for the current epoch
+   - This randomness makes it extremely difficult to manipulate the certificate creation process using outdated or compromised keys, further protecting the protocol against long range attacks.
+
+Mithril employs a comprehensive set of mechanisms to protect against long range attacks, ensuring that the protocol remains secure even when faced with adversaries attempting to exploit old keys or stake. By integrating epoch-based checkpoints, certificate finality, stale stake invalidation, and robust randomness, Mithril ensures that the certificate chain remains intact and resistant to reorganization or manipulation, thereby maintaining the integrity and stability of the network.
+
+## Appendices
+
+### Concatenation forgery attacks
+
+A concatenation forgery attack is a type of cryptographic attack in which an adversary attempts to forge a valid combined (or concatenated) proof or signature by manipulating or assembling parts of valid signatures or proofs from different sources. This type of attack is particularly relevant in protocols that involve aggregating or concatenating multiple cryptographic components to form a single composite proof or signature.
+Consider a protocol where multiple participants sign different parts of a message, and these signatures are concatenated to form a final, unified signature. In a concatenation forgery attack, an adversary might try to:
+
+- Collect valid signatures from different messages or contexts
+- Reorder or selectively combine these signatures
+- Present the manipulated result as a valid signature for a different message.
+
+### Collusion attacks
+
+Collusion attacks occur when multiple participants in a network conspire to manipulate the system for their collective benefit, undermining the consensus mechanism and potentially leading to issues like double-spending or undue network control.
+
+Collusion involves two or more parties working together to achieve a shared malicious goal by manipulating the protocol's outcomes, such as block production or transaction validation. The attack aims to compromise the fairness and security of the network's consensus mechanism. Successful collusion can result in economic losses and weaken the network's security.
+
+- _Double-spending_: colluders create a blockchain fork to spend the same assets multiple times
+- _Validator collusion_: validators work together to control block validation, influencing consensus decisions
+- _Majority stake collusion_: controlling a majority of the network’s stake to perform a '$51\%$ attack.'
+
+### Grinding attacks
+
+Grinding attacks in cryptography, particularly in PoS blockchains, involve an adversary manipulating the cryptographic process – such as key generation or stake distribution – to increase their chances of being selected as a validator. By generating multiple keys or adjusting their stake, the attacker seeks to gain an unfair advantage in the consensus mechanism.
+
+- _Key grinding_: the adversary generates numerous cryptographic keys, selecting the most favorable ones in the context of eligibility or winning a lottery-based selection process
+- _Stake grinding_: the adversary repeatedly modifies their stake (eg, by splitting it among multiple identities) to increase the probability of being chosen as a validator.
+
+### Sybil attacks
+
+A Sybil attack occurs when an attacker creates multiple fake identities within a decentralized network to gain undue influence or control. This undermines the network's integrity and fairness by centralizing power in the attacker's hands.
+
+- The attacker generates many identities to appear as multiple independent participants
+- These identities allow the attacker to disproportionately affect decisions, such as in blockchain consensus or online voting
+- The attack weakens the decentralized nature of the network
+- Ensuring strong, verifiable identities reduces the risk of fake accounts.
+
+### Long range attacks
+
+A long range attack in PoS blockchains involves an adversary using old, valid keys or stake to create an alternate blockchain starting from a distant point in the past. The attacker builds this alternative chain until it surpasses the length of the legitimate chain, potentially leading to a chain fork or takeover.
+
+- Old keys/stake exploit previously valid, but now inactive, keys or stake
+- The attacker creates a competing chain that eventually overtakes the current chain
+- This can result in double spending or chain reorganization, undermining the network's integrity.
+
+Long range attacks exploit the time-insensitivity of PoS systems, but these mitigation strategies help protect the network's security and stability.


### PR DESCRIPTION
## Content

This PR includes a page for **Mithril protocol security** in the documentation website (which nows supports mathematical notations by integrating `remark-math` and `rehype-katex`).

> [!NOTE]
> Here is a screenshot of the rendered page:
> ![Screenshot from 2024-11-20 15-10-43](https://github.com/user-attachments/assets/07cc2eaf-784f-48ef-8637-80624f4c979e)

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)
