### PR TITLE
Also bump versions of js packages in upgrade version script

### DIFF
--- a/docs/devbook/README.md
+++ b/docs/devbook/README.md
@@ -4,7 +4,7 @@ This page gathers the available guides and tools for Mithril nodes developers.
 
 # Guides
 
-| Operation                               | Location                                                                               | Description                                                                        |
-| --------------------------------------- | -------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| **Upgrade crates and openapi versions** | [upgrade-crates-and-openapi-versions](./upgrade-crates-and-openapi-versions/README.md) | Script to easily upgrade crates and openapi versions before merging a pull request |
-| **Upgrade the repository dependencies** | [upgrade-repository-dependencies](./upgrade-repository-dependencies/README.md)         | Upgrade the project's dependencies in the repository                               |
+| Operation                               | Location                                                                       | Description                                                                                   |
+| --------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| **Bump versions**                       | [bump-versions](bump-versions/README.md)                                       | Script to easily bump crates, js packages, and openapi versions before merging a pull request |
+| **Upgrade the repository dependencies** | [upgrade-repository-dependencies](./upgrade-repository-dependencies/README.md) | Upgrade the project's dependencies in the repository                                          |

--- a/docs/devbook/bump-versions/README.md
+++ b/docs/devbook/bump-versions/README.md
@@ -1,10 +1,10 @@
-# Upgrade the crates and openapi versions before merging a pull request
+# Bump the crates, js packages, and openapi versions before merging a pull request
 
 ## Introduction
 
-This devbook provides a script that allows to automatically upgrade the crates and Open API versions in the project.
+This devbook provides a script that allows to automatically bump the crates, js packages, and Open API versions in the project.
 
-Only the crates and Open API specifications with changes on the branch compared to `origin/main` are upgraded.
+Only the crates, js packages, and Open API specifications with changes on the branch compared to `origin/main` are bumped.
 
 ## Prerequisites
 
@@ -24,7 +24,7 @@ cargo install cargo-get
 Just run the script without argument, by default no changes are made to the project.
 
 ```shell
-. ./docs/devbook/upgrade-crates-and-openapi-versions/upgrade_crates_and_openapi_versions.sh
+. ./docs/devbook/bump-versions/bump_versions.sh
 ```
 
 ### Run
@@ -34,18 +34,18 @@ Just run the script without argument, by default no changes are made to the proj
 >
 > This means that running the script more than once will bump the versions again.
 
-Run the script with the `--run` argument to bump the crates and openapi versions.
+Run the script with the `--run` argument to bump the crates, js packages, and openapi versions.
 
 The script will output a preformatted commit message that can be used to create a commit when it completes.
 
 ```shell
-. ./docs/devbook/upgrade-crates-and-openapi-versions/upgrade_crates_and_openapi_versions.sh --run
+. ./docs/devbook/bump-versions/bump_versions.sh --run
 ```
 
 If you want the script to do the commit for you, add the `--commit` argument.
 
 ```shell
-. ./docs/devbook/upgrade-crates-and-openapi-versions/upgrade_crates_and_openapi_versions.sh --run --commit
+. ./docs/devbook/bump-versions/bump_versions.sh --run --commit
 ```
 
 > [!NOTE]

--- a/docs/devbook/bump-versions/bump_versions.sh
+++ b/docs/devbook/bump-versions/bump_versions.sh
@@ -149,7 +149,7 @@ fi
 
 if [ true = $DRY_RUN ]
 then
-    echo -e "${ORANGE}warning${RESET}: script is run in dry mode. To execute the changes, run ${GREEN}./update_crate_versions.sh --run${RESET}"
+    echo -e "${ORANGE}warning${RESET}: script is run in dry mode. To apply the changes, run ${GREEN}$0 --run${RESET}"
 else
   UPDATED_CRATES="$(find . -name Cargo.toml -exec git diff "$COMMIT_REF" {} + | grep -E "^[\+\-]version = \"[0-9\.]+\"|name = " | tr '\n' ' ' | sed -r "s/ name = \"([a-z\-]+)\" -version = \"([0-9\.]+)\" \+version = \"([0-9\.]+)\" ?/* \1 from \`\2\` to \`\3\`\n/g")"
   if [[ -n $UPDATED_CRATES ]]

--- a/docs/devbook/bump-versions/bump_versions.sh
+++ b/docs/devbook/bump-versions/bump_versions.sh
@@ -3,8 +3,7 @@ set +a -u -o pipefail
 
 if [[ "${TRACE-0}" == "1" ]]; then set -o xtrace; fi
 
-# Check crates modify against `origin/main` and update their version.
-# The openapi.yam is also verified and updated if necessary.
+# Check crates, js packages, and openapi changes against `origin/main` and update their version.
 # At the end of the script, the commit message to used is displayed.
 
 # Usage:


### PR DESCRIPTION
## Content

This PR add to the upgrade version scrip in the devbook the capacity to bump js packages versions and rename it from `upgrade-crates-and-openapi-versions` to simply `bump-versions`.

It works the following way:

1. Detect all `package.json` files in the project, excluding those auto-generated or from imported packages
1. If there was a change compared to the `main` branch in a `package.json` directory
   - _In dry run_ only print the updated version
   - _else_ use `npm version patch` to bump the patch version (with `--no-git-tag-version` to handle the commit our-self)
1. Append the modified versions to the commit message

> [!NOTE]
> `docs/website/` is excluded as we don't want to bump its version if its articles or blog posts changed.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
