### PR TITLE
Docs: dev blog post for one line installer

### DIFF
--- a/docs/website/blog/2024-11-25-one-line-binaries-installer.md
+++ b/docs/website/blog/2024-11-25-one-line-binaries-installer.md
@@ -1,0 +1,64 @@
+---
+title: One line installer for Mithril binaries
+authors:
+  - name: Mithril Team
+tags:
+  [
+    binaries,
+    pre-built,
+    install,
+    update,
+    nodes,
+    command-line,
+    binaries,
+    installer,
+  ]
+---
+
+### One line installer for Mithril binaries
+
+In order to facilitate the installation and update of Mithril binaries, we have created a one line installer that downloads and installs the Mithril binaries for you.
+This installer is available for Linux and MacOS, and for the Mithril signer, Mithril aggregator, and Mithril CLI.
+
+The one line command is also displayed in the several `Download the pre-built binary` sections across the documentation.
+
+Here are few examples of the one line installer:
+
+- Download the **latest Mithril signer** in the current directory:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d latest -p $(pwd)
+```
+
+- Download the **latest Mithril client CLI** in the current directory:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-client -d latest -p $(pwd)
+```
+
+- Download the **unstable Mithril aggregator** in the current directory:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-aggregator -d unstable -p $(pwd)
+```
+
+- Download the **Mithril client of distribution `2445.0`** in the current directory:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-client -d 2445.0 -p $(pwd)
+```
+
+- Installer usage:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -h
+
+Install or upgrade a Mithril node
+Usage: sh [-n node] [-v version] [-d distribution] [-p path]
+  -c node          : Mithril node to install or upgrade (mithril-signer, mithril-aggregator, mithril-client)
+  -d distribution  : Distribution to upgrade to (latest, unstable or distribution version e.g '2445.0')
+  -p path          : Path to install the component
+
+```
+
+For any inquiries or assistance, don't hesitate to reach out to the team on the [Discord channel](https://discord.gg/5kaErDKDRq).

--- a/docs/website/root/compiled-binaries.mdx
+++ b/docs/website/root/compiled-binaries.mdx
@@ -9,7 +9,9 @@ import CodeBlock from "@theme/CodeBlock";
 You can install a the **latest** released binary of the **{props.node}** by running this one line command (_replace **YOUR_PATH** with your installation path_):
 
 <CodeBlock language="bash">
-  {`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c {props.node} -d latest -p **YOUR_PATH**`}
+  curl --proto '=https' --tlsv1.2 -sSf
+  https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh
+  | sh -s -- -c {props.node} -d latest -p **YOUR_PATH**
 </CodeBlock>
 
 :::tip

--- a/docs/website/versioned_docs/version-maintained/compiled-binaries.mdx
+++ b/docs/website/versioned_docs/version-maintained/compiled-binaries.mdx
@@ -9,7 +9,9 @@ import CodeBlock from "@theme/CodeBlock";
 You can install a the **latest** released binary of the **{props.node}** by running this one line command (_replace **YOUR_PATH** with your installation path_):
 
 <CodeBlock language="bash">
-  {`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c {props.node} -d latest -p **YOUR_PATH**`}
+  curl --proto '=https' --tlsv1.2 -sSf
+  https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh
+  | sh -s -- -c {props.node} -d latest -p **YOUR_PATH**
 </CodeBlock>
 
 :::tip


### PR DESCRIPTION
## Content
This PR includes:

* [`docs/website/blog/2024-11-25-one-line-binaries-installer.md`](diffhunk://#diff-bf61a68c6a366f97d3cd6c504015e5a9a30621b8f9df7fa9510c1108e8f4559bR1-R64): Added a new blog post detailing the one-line installer for Mithril binaries, including examples and usage instructions.
* [`docs/website/root/compiled-binaries.mdx`](diffhunk://#diff-e68bd7c47d62dcacb564ed9e4e403ec27f49e3a3c6ea21117a928be3e2895325L12-R14): Updated the code block to use the new one-line installer command for installing the latest Mithril binaries.
* [`docs/website/versioned_docs/version-maintained/compiled-binaries.mdx`](diffhunk://#diff-e68bd7c47d62dcacb564ed9e4e403ec27f49e3a3c6ea21117a928be3e2895325L12-R14): Updated the code block to use the new one-line installer command for installing the latest Mithril binaries.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Add dev blog post (if relevant)

## Issue(s)
Relates to #2034 
