### PR TITLE
fix(ci): fix generation of swagger-ui page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -874,6 +874,7 @@ jobs:
         with:
           output: out/
           spec-file: ./openapi.yaml
+          version: ^5.0.0
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish OpenAPI UI build


### PR DESCRIPTION
## Content

This PR fixes our swagger ui page, https://mithril.network/openapi-ui/,  that has been broken since merging #2062:

![image](https://github.com/user-attachments/assets/dc4160bc-93f4-495b-8308-936aa112ade6)

The faulty PR modified the version of our openapi file to `3.1.1`, but the action that we use (`Legion2/swagger-ui-action@v1`) is configured by default to use swagger ui version 3 or up, said swagger ui is only compatible with openapi `3.1` [since version 5](https://github.com/swagger-api/swagger-ui/tree/master?tab=readme-ov-file#compatibility).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
