### PR TITLE
Feat: support retries in e2e tests in CI

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -119,18 +119,29 @@ jobs:
           mkdir artifacts
 
       - name: Run E2E tests
-        shell: bash
-        run: |
-          ./mithril-binaries/e2e/mithril-end-to-end -vvv \
-            --bin-directory ./mithril-binaries/e2e \
-            --work-directory=./artifacts \
-            --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \
-            --cardano-node-version ${{ matrix.cardano_node_version }} \
-            --cardano-slot-length 0.25 \
-            --cardano-epoch-length 45.0 \
-            --signed-entity-types ${{ needs.prepare-env-variables.outputs.signed-entity-types }} \
-          && echo "SUCCESS=true" >> $GITHUB_ENV \
-          || (echo "SUCCESS=false" >> $GITHUB_ENV && exit 1)
+        uses: nick-fields/retry@v3
+        with:
+          shell: bash
+          max_attempts: 3
+          retry_on_exit_code: 2
+          timeout_minutes: 10
+          warning_on_retry: true
+          command: |
+            ./mithril-binaries/e2e/mithril-end-to-end -vvv \
+              --bin-directory ./mithril-binaries/e2e \
+              --work-directory=./artifacts \
+              --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \
+              --cardano-node-version ${{ matrix.cardano_node_version }} \
+              --cardano-slot-length 0.25 \
+              --cardano-epoch-length 45.0 \
+              --signed-entity-types ${{ needs.prepare-env-variables.outputs.signed-entity-types }}
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "SUCCESS=true" >> $GITHUB_ENV
+            else
+              echo "SUCCESS=false" >> $GITHUB_ENV
+            fi
+            exit $EXIT_CODE
 
       - name: Define the JSON file name for the test result
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,25 +347,34 @@ jobs:
           mkdir artifacts
 
       - name: Test
-        run: |
-          cat > ./mithril-end-to-end.sh << EOF
-          #!/bin/bash
-          set -x
-          ./mithril-end-to-end -vvv \\
-                  --bin-directory ./bin \\
-                  --work-directory=./artifacts \\
-                  --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \\
-                  --mithril-era=${{ matrix.era }} \\
-                  --cardano-node-version ${{ matrix.cardano_node_version }} \\
-                  --cardano-hard-fork-latest-era-at-epoch ${{ matrix.hard_fork_latest_era_at_epoch }} ${{ matrix.extra_args }} \\
-          EOF
-          # If there is a next era, we need to specify it with '--mithril-next-era'
-          if [[ "${{ matrix.next_era }}" != "" ]]; then
-            echo "  --mithril-next-era=${{ matrix.next_era }}" >> ./mithril-end-to-end.sh
-          fi
-          chmod u+x ./mithril-end-to-end.sh
-          ./mithril-end-to-end.sh
-          rm ./mithril-end-to-end.sh
+        uses: nick-fields/retry@v3
+        with:
+          shell: bash
+          max_attempts: 3
+          retry_on_exit_code: 2
+          timeout_minutes: 10
+          warning_on_retry: true
+          command: |
+            cat > ./mithril-end-to-end.sh << EOF
+            #!/bin/bash
+            set -x
+            ./mithril-end-to-end -vvv \\
+                    --bin-directory ./bin \\
+                    --work-directory=./artifacts \\
+                    --devnet-scripts-directory=./mithril-test-lab/mithril-devnet \\
+                    --mithril-era=${{ matrix.era }} \\
+                    --cardano-node-version ${{ matrix.cardano_node_version }} \\
+                    --cardano-hard-fork-latest-era-at-epoch ${{ matrix.hard_fork_latest_era_at_epoch }} ${{ matrix.extra_args }} \\
+            EOF
+            # If there is a next era, we need to specify it with '--mithril-next-era'
+            if [[ "${{ matrix.next_era }}" != "" ]]; then
+              echo "  --mithril-next-era=${{ matrix.next_era }}" >> ./mithril-end-to-end.sh
+            fi
+            chmod u+x ./mithril-end-to-end.sh
+            ./mithril-end-to-end.sh
+            EXIT_CODE=$?
+            rm ./mithril-end-to-end.sh
+            exit $EXIT_CODE
 
       - name: Upload E2E Tests Artifacts
         if: ${{ failure() }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.49"
+version = "0.4.50"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.49"
+version = "0.4.50"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/mod.rs
@@ -1,3 +1,3 @@
 mod runner;
 
-pub use runner::{Devnet, DevnetBootstrapArgs, DevnetTopology, PoolNode};
+pub use runner::{Devnet, DevnetBootstrapArgs, DevnetTopology, PoolNode, UnrecoverableDevnetError};

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/mod.rs
@@ -1,3 +1,3 @@
 mod runner;
 
-pub use runner::{Devnet, DevnetBootstrapArgs, DevnetTopology, PoolNode, UnrecoverableDevnetError};
+pub use runner::{Devnet, DevnetBootstrapArgs, DevnetTopology, PoolNode, RetryableDevnetError};

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -6,7 +6,12 @@ use std::fs::{self, read_to_string, File};
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+use thiserror::Error;
 use tokio::process::Command;
+
+#[derive(Error, Debug, PartialEq, Eq)]
+#[error("Unrecoverable devnet error: `{0}`")]
+pub struct UnrecoverableDevnetError(pub String);
 
 #[derive(Debug, Clone, Default)]
 pub struct Devnet {
@@ -211,7 +216,9 @@ impl Devnet {
             .with_context(|| "Error while starting the devnet")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!("Run devnet exited with status code: {code}")),
+            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
+                "Run devnet exited with status code: {code}"
+            )))),
             None => Err(anyhow!("Run devnet terminated by signal")),
         }
     }
@@ -258,7 +265,9 @@ impl Devnet {
             .with_context(|| "Error while delegating stakes to the pools")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!("Delegating stakes exited with status code: {code}")),
+            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
+                "Delegating stakes exited with status code: {code}"
+            )))),
             None => Err(anyhow!("Delegating stakes terminated by signal")),
         }
     }
@@ -282,9 +291,9 @@ impl Devnet {
             .with_context(|| "Error while writing era marker on chain")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!(
+            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
                 "Write era marker on chain exited with status code: {code}"
-            )),
+            )))),
             None => Err(anyhow!("Write era marker on chain terminated by signal")),
         }
     }
@@ -308,9 +317,9 @@ impl Devnet {
             .with_context(|| "Error while to transferring funds on chain")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!(
+            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
                 "Transfer funds on chain exited with status code: {code}"
-            )),
+            )))),
             None => Err(anyhow!("Transfer funds on chain terminated by signal")),
         }
     }

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -10,8 +10,8 @@ use thiserror::Error;
 use tokio::process::Command;
 
 #[derive(Error, Debug, PartialEq, Eq)]
-#[error("Unrecoverable devnet error: `{0}`")]
-pub struct UnrecoverableDevnetError(pub String);
+#[error("Retryable devnet error: `{0}`")]
+pub struct RetryableDevnetError(pub String);
 
 #[derive(Debug, Clone, Default)]
 pub struct Devnet {
@@ -216,7 +216,7 @@ impl Devnet {
             .with_context(|| "Error while starting the devnet")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
+            Some(code) => Err(anyhow!(RetryableDevnetError(format!(
                 "Run devnet exited with status code: {code}"
             )))),
             None => Err(anyhow!("Run devnet terminated by signal")),
@@ -265,7 +265,7 @@ impl Devnet {
             .with_context(|| "Error while delegating stakes to the pools")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
+            Some(code) => Err(anyhow!(RetryableDevnetError(format!(
                 "Delegating stakes exited with status code: {code}"
             )))),
             None => Err(anyhow!("Delegating stakes terminated by signal")),
@@ -291,7 +291,7 @@ impl Devnet {
             .with_context(|| "Error while writing era marker on chain")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
+            Some(code) => Err(anyhow!(RetryableDevnetError(format!(
                 "Write era marker on chain exited with status code: {code}"
             )))),
             None => Err(anyhow!("Write era marker on chain terminated by signal")),
@@ -317,7 +317,7 @@ impl Devnet {
             .with_context(|| "Error while to transferring funds on chain")?;
         match status.code() {
             Some(0) => Ok(()),
-            Some(code) => Err(anyhow!(UnrecoverableDevnetError(format!(
+            Some(code) => Err(anyhow!(RetryableDevnetError(format!(
                 "Transfer funds on chain exited with status code: {code}"
             )))),
             None => Err(anyhow!("Transfer funds on chain terminated by signal")),

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -18,8 +18,8 @@ use tokio::{
 use mithril_common::StdResult;
 use mithril_doc::GenerateDocCommands;
 use mithril_end_to_end::{
-    Devnet, DevnetBootstrapArgs, MithrilInfrastructure, MithrilInfrastructureConfig, RunOnly, Spec,
-    UnrecoverableDevnetError,
+    Devnet, DevnetBootstrapArgs, MithrilInfrastructure, MithrilInfrastructureConfig,
+    RetryableDevnetError, RunOnly, Spec,
 };
 
 /// Tests args
@@ -257,7 +257,7 @@ impl From<StdResult<()>> for AppResult {
         match result {
             Ok(()) => AppResult::Success(),
             Err(error) => {
-                if error.is::<UnrecoverableDevnetError>() {
+                if error.is::<RetryableDevnetError>() {
                     AppResult::RetryableError(error)
                 } else {
                     AppResult::UnretryableError(error)
@@ -466,9 +466,7 @@ mod tests {
         assert!(matches!(AppResult::from(Ok(())), AppResult::Success()));
 
         assert!(matches!(
-            AppResult::from(Err(anyhow!(UnrecoverableDevnetError(
-                "an error".to_string()
-            )))),
+            AppResult::from(Err(anyhow!(RetryableDevnetError("an error".to_string())))),
             AppResult::RetryableError(_)
         ));
 

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -243,11 +243,10 @@ impl Termination for AppResult {
     fn report(self) -> ExitCode {
         let exit_code = self.exit_code();
         println!(" ");
-        println!("----------------------------------------------------------------------------------------------------");
+        println!("{:-^100}", "");
         println!("Mithril End to End test outcome:");
-        println!("----------------------------------------------------------------------------------------------------");
+        println!("{:-^100}", "");
         println!("{self}");
-        println!("{exit_code:?}");
 
         exit_code
     }


### PR DESCRIPTION
## Content
This PR includes **support for retrying e2e test runs** in case of transient error on the Cardano network of the underlying devnet (which happen because of the custom configuration used for it). This will overall remove the main source of flakiness in the CI runs.

### Error handling improvements:

* [`mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs`](diffhunk://#diff-4c3f983f30bbeca5e07e02770b654dceb5d153aed2e01a03cfdec4b119fd4331R9-R15): Introduced `UnrecoverableDevnetError` and updated error handling in `impl Devnet` to use this new error type. 

### Main execution flow restructuring:

* [`mithril-test-lab/mithril-end-to-end/src/main.rs`](diffhunk://#diff-a49c167415a5a251d16e124965eb257f95ebd243022897a79f5e0e8b00e4a2f0R22): Refactored the main function to use a new `AppResult` enum for handling different exit codes and added implementation for `Termination` to map results to exit codes. 

### Enhancements to GitHub workflows:

* [`.github/workflows/backward-compatibility.yml`](diffhunk://#diff-51141989cff80aaee01e58e0c9fe349b19cd3d511f0c7711a957afb8d287aaebR122-R141): Added retry logic to the E2E tests using `nick-fields/retry@v3`.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL350-R356): Added retry logic to the Test job using `nick-fields/retry@v3`.

### Examples
Here is an example of retry in the CI:
- https://github.com/input-output-hk/mithril/actions/runs/12067533496/job/33650957051#step:6:473
- https://github.com/input-output-hk/mithril/actions/runs/12067533496/job/33650957051#step:6:989

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #2123 
