### PR TITLE
Cardano network on aggregator status and explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.116"
+version = "0.5.117"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.90"
+version = "0.4.91"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.38"
+version = "0.2.39"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.38"
+version = "0.2.39"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/sqlite/connection_builder.rs
+++ b/internal/mithril-persistence/src/sqlite/connection_builder.rs
@@ -81,7 +81,7 @@ impl ConnectionBuilder {
     pub fn build(self) -> StdResult<ConnectionThreadSafe> {
         let logger = self.base_logger.new_with_component_name::<Self>();
 
-        debug!(logger, "Opening SQLite connection"; "path" => self.connection_path.display());
+        debug!(logger, "Opening SQLite connection"; "path" => self.connection_path.display(), "options" => ?self.options);
         let connection =
             Connection::open_thread_safe(&self.connection_path).with_context(|| {
                 format!(
@@ -94,14 +94,12 @@ impl ConnectionBuilder {
             .options
             .contains(&ConnectionOptions::EnableWriteAheadLog)
         {
-            debug!(logger, "Enabling SQLite Write Ahead Log journal mode");
             connection
                 .execute("pragma journal_mode = wal; pragma synchronous = normal;")
                 .with_context(|| "SQLite initialization: could not enable WAL.")?;
         }
 
         if self.options.contains(&ConnectionOptions::EnableForeignKeys) {
-            debug!(logger, "Enabling SQLite foreign key support");
             connection
                 .execute("pragma foreign_keys=true")
                 .with_context(|| "SQLite initialization: could not enable FOREIGN KEY support.")?;
@@ -113,7 +111,6 @@ impl ConnectionBuilder {
             .options
             .contains(&ConnectionOptions::ForceDisableForeignKeys)
         {
-            debug!(logger, "Force disabling SQLite foreign key support");
             connection
                 .execute("pragma foreign_keys=false")
                 .with_context(|| "SQLite initialization: could not disable FOREIGN KEY support.")?;

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.116"
+version = "0.5.117"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.90"
+version = "0.4.91"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -74,51 +74,6 @@ mod tests {
         "total_cardano_stake": 888888888
         }"#;
 
-    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-    pub struct AggregatorStatusMessageUntilV0_1_37 {
-        pub epoch: Epoch,
-        pub cardano_era: CardanoEra,
-        pub mithril_era: SupportedEra,
-        pub cardano_node_version: String,
-        pub aggregator_node_version: String,
-        #[serde(rename = "protocol")]
-        pub protocol_parameters: ProtocolParameters,
-        #[serde(rename = "next_protocol")]
-        pub next_protocol_parameters: ProtocolParameters,
-        pub total_signers: usize,
-        pub total_next_signers: usize,
-        pub total_stakes_signers: Stake,
-        pub total_next_stakes_signers: Stake,
-        pub total_cardano_spo: TotalSPOs,
-        pub total_cardano_stake: Stake,
-    }
-
-    fn golden_message_until_open_api_0_1_37() -> AggregatorStatusMessageUntilV0_1_37 {
-        AggregatorStatusMessageUntilV0_1_37 {
-            epoch: Epoch(48),
-            cardano_era: "conway".to_string(),
-            mithril_era: SupportedEra::Pythagoras,
-            cardano_node_version: "1.2.3".to_string(),
-            aggregator_node_version: "4.5.6".to_string(),
-            protocol_parameters: ProtocolParameters {
-                k: 5,
-                m: 100,
-                phi_f: 0.65,
-            },
-            next_protocol_parameters: ProtocolParameters {
-                k: 50,
-                m: 1000,
-                phi_f: 0.65,
-            },
-            total_signers: 1234,
-            total_next_signers: 56789,
-            total_stakes_signers: 123456789,
-            total_next_stakes_signers: 987654321,
-            total_cardano_spo: 7777,
-            total_cardano_stake: 888888888,
-        }
-    }
-
     fn golden_actual_message() -> AggregatorStatusMessage {
         AggregatorStatusMessage {
             epoch: Epoch(48),
@@ -144,14 +99,6 @@ mod tests {
             total_cardano_spo: 7777,
             total_cardano_stake: 888888888,
         }
-    }
-
-    #[test]
-    fn test_actual_json_deserialized_into_message_supported_until_open_api_0_1_37() {
-        let json = ACTUAL_JSON;
-        let message: AggregatorStatusMessageUntilV0_1_37 = serde_json::from_str(json).unwrap();
-
-        assert_eq!(golden_message_until_open_api_0_1_37(), message);
     }
 
     // Test the compatibility with current structure.

--- a/mithril-common/src/messages/aggregator_status.rs
+++ b/mithril-common/src/messages/aggregator_status.rs
@@ -14,6 +14,9 @@ pub struct AggregatorStatusMessage {
     /// Current Cardano era
     pub cardano_era: CardanoEra,
 
+    /// Cardano network
+    pub cardano_network: String,
+
     /// Current Mithril era
     pub mithril_era: SupportedEra,
 
@@ -57,6 +60,7 @@ mod tests {
     const ACTUAL_JSON: &str = r#"{
         "epoch": 48,
         "cardano_era": "conway",
+        "cardano_network": "mainnet",
         "mithril_era": "pythagoras",
         "cardano_node_version": "1.2.3",
         "aggregator_node_version": "4.5.6",
@@ -70,8 +74,27 @@ mod tests {
         "total_cardano_stake": 888888888
         }"#;
 
-    fn golden_actual_message() -> AggregatorStatusMessage {
-        AggregatorStatusMessage {
+    #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+    pub struct AggregatorStatusMessageUntilV0_1_37 {
+        pub epoch: Epoch,
+        pub cardano_era: CardanoEra,
+        pub mithril_era: SupportedEra,
+        pub cardano_node_version: String,
+        pub aggregator_node_version: String,
+        #[serde(rename = "protocol")]
+        pub protocol_parameters: ProtocolParameters,
+        #[serde(rename = "next_protocol")]
+        pub next_protocol_parameters: ProtocolParameters,
+        pub total_signers: usize,
+        pub total_next_signers: usize,
+        pub total_stakes_signers: Stake,
+        pub total_next_stakes_signers: Stake,
+        pub total_cardano_spo: TotalSPOs,
+        pub total_cardano_stake: Stake,
+    }
+
+    fn golden_message_until_open_api_0_1_37() -> AggregatorStatusMessageUntilV0_1_37 {
+        AggregatorStatusMessageUntilV0_1_37 {
             epoch: Epoch(48),
             cardano_era: "conway".to_string(),
             mithril_era: SupportedEra::Pythagoras,
@@ -94,6 +117,41 @@ mod tests {
             total_cardano_spo: 7777,
             total_cardano_stake: 888888888,
         }
+    }
+
+    fn golden_actual_message() -> AggregatorStatusMessage {
+        AggregatorStatusMessage {
+            epoch: Epoch(48),
+            cardano_era: "conway".to_string(),
+            cardano_network: "mainnet".to_string(),
+            mithril_era: SupportedEra::Pythagoras,
+            cardano_node_version: "1.2.3".to_string(),
+            aggregator_node_version: "4.5.6".to_string(),
+            protocol_parameters: ProtocolParameters {
+                k: 5,
+                m: 100,
+                phi_f: 0.65,
+            },
+            next_protocol_parameters: ProtocolParameters {
+                k: 50,
+                m: 1000,
+                phi_f: 0.65,
+            },
+            total_signers: 1234,
+            total_next_signers: 56789,
+            total_stakes_signers: 123456789,
+            total_next_stakes_signers: 987654321,
+            total_cardano_spo: 7777,
+            total_cardano_stake: 888888888,
+        }
+    }
+
+    #[test]
+    fn test_actual_json_deserialized_into_message_supported_until_open_api_0_1_37() {
+        let json = ACTUAL_JSON;
+        let message: AggregatorStatusMessageUntilV0_1_37 = serde_json::from_str(json).unwrap();
+
+        assert_eq!(golden_message_until_open_api_0_1_37(), message);
     }
 
     // Test the compatibility with current structure.

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.19",
+      "version": "0.7.20",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/dist/web",
         "@popperjs/core": "^2.11.8",

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/components/ControlPanel/AggregatorStatus/index.js
+++ b/mithril-explorer/src/components/ControlPanel/AggregatorStatus/index.js
@@ -31,10 +31,10 @@ function InfoGroupCard({ children, title, ...props }) {
   );
 }
 
-function InfoRow({ label, children, ...props }) {
+function InfoRow({ label, children, className, ...props }) {
   return (
     <>
-      <div className="d-flex justify-content-between" {...props}>
+      <div className={`d-flex justify-content-between ${className}`} {...props}>
         <div className="me-2 flex-fill">
           <em>{label}:</em>
         </div>
@@ -120,10 +120,6 @@ export default function AggregatorStatus({ showContent = true }) {
     return ((value / total) * 100).toFixed(0);
   }
 
-  function capitalizeFirstLetter(string) {
-    return string.charAt(0).toUpperCase() + string.slice(1);
-  }
-
   return fallbackToEpochSetting ? (
     <Stack direction="horizontal">
       <Collapse in={showContent}>
@@ -138,11 +134,12 @@ export default function AggregatorStatus({ showContent = true }) {
         <div id="contentRow">
           <Row className="d-flex flex-wrap justify-content-md-center">
             <InfoGroupCard title={`Epoch ${aggregatorStatus.epoch}`}>
+              <InfoRow label="Cardano Network" className="text-capitalize">
+                {aggregatorStatus.cardano_network}
+              </InfoRow>
               <InfoRow label="Cardano Era">{aggregatorStatus.cardano_era}</InfoRow>
-              <InfoRow label="Mithril Era">
-                {aggregatorStatus.mithril_era
-                  ? capitalizeFirstLetter(aggregatorStatus.mithril_era)
-                  : ""}
+              <InfoRow label="Mithril Era" className="text-capitalize">
+                {aggregatorStatus.mithril_era}
               </InfoRow>
             </InfoGroupCard>
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -667,6 +667,7 @@ components:
       required:
         - epoch
         - cardano_era
+        - cardano_network
         - mithril_era
         - cardano_node_version
         - aggregator_node_version
@@ -683,6 +684,9 @@ components:
           $ref: "#/components/schemas/Epoch"
         cardano_era:
           description: Cardano era
+          type: string
+        cardano_network:
+          description: Cardano network of the aggregator
           type: string
         mithril_era:
           description: Mithril era
@@ -725,6 +729,7 @@ components:
         {
           "epoch": 329,
           "cardano_era": "Conway",
+          "cardano_network": "mainnet",
           "mithril_era": "pythagoras",
           "cardano_node_version": "1.2.3",
           "aggregator_node_version": "4.5.6",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.37
+  version: 0.1.38
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content

This PR add a `cardano_network` key in the data returned by the aggregator `/status` route and update the explorer to display it in its `AggregatorStatus` component.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

Not directly related to this PR, the first commit simplify the logs of the connection builder in persistence to limit the numbers of logs to one instead of up to four when opening a connection without applying migrations.

## Issue(s)

Closes #2144
