### PR TITLE
Chore: update aggregator in examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-stake-distribution"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-transaction"
-version = "0.1.14"
+version = "0.1.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "client-mithril-stake-distribution"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "client-snapshot"
-version = "0.1.18"
+version = "0.1.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/client-cardano-stake-distribution/Cargo.toml
+++ b/examples/client-cardano-stake-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-stake-distribution"
 description = "Mithril client cardano stake distribution example"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-stake-distribution/README.md
+++ b/examples/client-cardano-stake-distribution/README.md
@@ -4,7 +4,7 @@
 
 This example shows how to implement a Mithril client and use the features related to the `Cardano stake distribution` type.
 
-In this example, the client interacts by default with a real aggregator on the network `testing-preview` to:
+In this example, the client interacts by default with a real aggregator on the network `release-preprod` to:
 
 - list the available Cardano stake distributions
 - get a single Cardano stake distribution
@@ -17,6 +17,9 @@ The crates [`slog`](https://docs.rs/slog/latest/slog/) and [`slog_term`](https:/
 ## Build and run the example
 
 ```bash
+# Switch to the latest release tag
+git checkout tags/$(curl -sSL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')
+
 # Build from the crate directory
 cargo build
 

--- a/examples/client-cardano-stake-distribution/README.md
+++ b/examples/client-cardano-stake-distribution/README.md
@@ -26,8 +26,8 @@ cargo run
 # Run with your custom network configuration
 AGGREGATOR_ENDPOINT=YOUR_AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY=YOUR_GENESIS_VERIFICATION_KEY cargo run
 
-# Example with 'pre-release-preview' network
-AGGREGATOR_ENDPOINT=https://aggregator.pre-release-preview.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey) cargo run
+# Example with 'release-preprod' network
+AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey) cargo run
 ```
 
 ## Links

--- a/examples/client-cardano-stake-distribution/src/main.rs
+++ b/examples/client-cardano-stake-distribution/src/main.rs
@@ -1,6 +1,6 @@
 //! This example shows how to implement a Mithril client and use its features.
 //!
-//! In this example, the client interacts by default with a real aggregator (`testing-preview`) to get the data.
+//! In this example, the client interacts by default with a real aggregator (`release-preprod`) to get the data.
 
 use anyhow::anyhow;
 use clap::Parser;
@@ -24,7 +24,7 @@ pub struct Args {
     #[clap(
         long,
         env = "AGGREGATOR_ENDPOINT",
-        default_value = "https://aggregator.testing-preview.api.mithril.network/aggregator"
+        default_value = "https://aggregator.release-preprod.api.mithril.network/aggregator"
     )]
     aggregator_endpoint: String,
 }

--- a/examples/client-cardano-transaction/Cargo.toml
+++ b/examples/client-cardano-transaction/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-transaction"
 description = "Mithril client cardano-transaction example"
-version = "0.1.14"
+version = "0.1.15"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-transaction/README.md
+++ b/examples/client-cardano-transaction/README.md
@@ -19,6 +19,9 @@ In this example, the client interacts with an aggregator and performs the follow
 ## Build and run the example
 
 ```bash
+# Switch to the latest release tag
+git checkout tags/$(curl -sSL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')
+
 # Build from the crate directory
 cargo build
 

--- a/examples/client-cardano-transaction/README.md
+++ b/examples/client-cardano-transaction/README.md
@@ -25,8 +25,8 @@ cargo build
 # Run from the crate directory
 AGGREGATOR_ENDPOINT=YOUR_AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY=YOUR_GENESIS_VERIFICATION_KEY cargo run CARDANO_TX_HASH1,CARDANO_TX_HASH2,CARDANO_TX_HASH3
 
-# Example with from 'testing-sanchonet' network
-AGGREGATOR_ENDPOINT=https://aggregator.testing-sanchonet.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-sanchonet/genesis.vkey) cargo run db0dfab664045b117375a743a925385a7a3fa6a104f8bd95fa0f748088bcaff0,b457a094439cc5e371474f5758b4ecded3e1b035fe0717e39d78080e6fe169b2
+# Example with from 'release-preprod' network
+AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey) cargo run 0ea207ab71493f012faab0d1f8151eaf931901141c1482ce6e9a501498076484,326b5b67d926937bf19c6113d0957a39f2eae9df94875ce8a96eff5c8521303b
 ```
 
 ## Links

--- a/examples/client-cardano-transaction/src/main.rs
+++ b/examples/client-cardano-transaction/src/main.rs
@@ -25,7 +25,7 @@ pub struct Args {
     #[clap(
         long,
         env = "AGGREGATOR_ENDPOINT",
-        default_value = "https://aggregator.testing-sanchonet.api.mithril.network/aggregator"
+        default_value = "https://aggregator.release-preprod.api.mithril.network/aggregator"
     )]
     aggregator_endpoint: String,
 

--- a/examples/client-mithril-stake-distribution/Cargo.toml
+++ b/examples/client-mithril-stake-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-mithril-stake-distribution"
 description = "Mithril client stake distribution example"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-mithril-stake-distribution/README.md
+++ b/examples/client-mithril-stake-distribution/README.md
@@ -4,7 +4,7 @@
 
 This example shows how to implement a Mithril client and use the features related to the `Mithril stake distribution` type.
 
-In this example, the client interacts by default with a real aggregator on the network `testing-preview` to:
+In this example, the client interacts by default with a real aggregator on the network `release-preprod` to:
 
 - list the available Mithril stake distributions
 - get a single Mithril stake distribution
@@ -17,6 +17,9 @@ The crates [`slog`](https://docs.rs/slog/latest/slog/) and [`slog_term`](https:/
 ## Build and run the example
 
 ```bash
+# Switch to the latest release tag
+git checkout tags/$(curl -sSL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')
+
 # Build from the crate directory
 cargo build
 

--- a/examples/client-mithril-stake-distribution/README.md
+++ b/examples/client-mithril-stake-distribution/README.md
@@ -26,8 +26,8 @@ cargo run
 # Run with your custom network configuration
 AGGREGATOR_ENDPOINT=YOUR_AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY=YOUR_GENESIS_VERIFICATION_KEY cargo run
 
-# Example with 'pre-release-preview' network
-AGGREGATOR_ENDPOINT=https://aggregator.pre-release-preview.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey) cargo run
+# Example with 'release-preprod' network
+AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey) cargo run
 ```
 
 ## Links

--- a/examples/client-mithril-stake-distribution/src/main.rs
+++ b/examples/client-mithril-stake-distribution/src/main.rs
@@ -1,6 +1,6 @@
 //! This example shows how to implement a Mithril client and use its features.
 //!
-//! In this example, the client interacts by default with a real aggregator (`testing-preview`) to get the data.
+//! In this example, the client interacts by default with a real aggregator (`release-preprod`) to get the data.
 
 use anyhow::anyhow;
 use clap::Parser;
@@ -24,7 +24,7 @@ pub struct Args {
     #[clap(
         long,
         env = "AGGREGATOR_ENDPOINT",
-        default_value = "https://aggregator.testing-preview.api.mithril.network/aggregator"
+        default_value = "https://aggregator.release-preprod.api.mithril.network/aggregator"
     )]
     aggregator_endpoint: String,
 }

--- a/examples/client-snapshot/Cargo.toml
+++ b/examples/client-snapshot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-snapshot"
 description = "Mithril client snapshot example"
-version = "0.1.18"
+version = "0.1.19"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-snapshot/README.md
+++ b/examples/client-snapshot/README.md
@@ -4,7 +4,7 @@
 
 This example shows how to implement a Mithril client and use its features related to the `Snapshot` type.
 
-In this example, the client interacts by default with a real aggregator on the network `testing-preview` to:
+In this example, the client interacts by default with a real aggregator on the network `release-preprod` to:
 
 - list the available snapshots
 - get a single snapshot
@@ -19,6 +19,9 @@ The crate [indicatif](https://docs.rs/indicatif/latest/indicatif/) is used to ni
 ## Build and run the example
 
 ```bash
+# Switch to the latest release tag
+git checkout tags/$(curl -sSL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')
+
 # Build from the crate directory
 cargo build
 

--- a/examples/client-snapshot/README.md
+++ b/examples/client-snapshot/README.md
@@ -28,8 +28,8 @@ cargo run
 # Run with your custom network configuration
 AGGREGATOR_ENDPOINT=YOUR_AGGREGATOR_ENDPOINT GENESIS_VERIFICATION_KEY=YOUR_GENESIS_VERIFICATION_KEY cargo run
 
-# Example with 'pre-release-preview' network
-AGGREGATOR_ENDPOINT=https://aggregator.pre-release-preview.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/pre-release-preview/genesis.vkey) cargo run
+# Example with 'release-preprod' network
+AGGREGATOR_ENDPOINT=https://aggregator.release-preprod.api.mithril.network/aggregator GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/release-preprod/genesis.vkey) cargo run
 ```
 
 ## Links

--- a/examples/client-snapshot/src/main.rs
+++ b/examples/client-snapshot/src/main.rs
@@ -1,6 +1,6 @@
 //! This example shows how to implement a Mithril client and use its features.
 //!
-//! In this example, the client interacts by default with a real aggregator (`testing-preview`) to get the data.
+//! In this example, the client interacts by default with a real aggregator (`release-preprod`) to get the data.
 //!
 //! A [FeedbackReceiver] using [indicatif] is used to nicely report the progress to the console.
 
@@ -33,7 +33,7 @@ pub struct Args {
     #[clap(
         long,
         env = "AGGREGATOR_ENDPOINT",
-        default_value = "https://aggregator.testing-preview.api.mithril.network/aggregator"
+        default_value = "https://aggregator.release-preprod.api.mithril.network/aggregator"
     )]
     aggregator_endpoint: String,
 }

--- a/examples/client-wasm-nodejs/README.md
+++ b/examples/client-wasm-nodejs/README.md
@@ -20,7 +20,13 @@ In this example, the client interacts by default with a real aggregator on the n
 
 ## Build and run the example
 
-First you need to compile the Mithril client Wasm library:
+First you need to switch to the latest release tag:
+
+```bash
+git checkout tags/$(curl -sSL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')
+```
+
+Compile the Mithril client Wasm library:
 
 ```bash
 make -C ../../mithril-client-wasm build

--- a/examples/client-wasm-nodejs/README.md
+++ b/examples/client-wasm-nodejs/README.md
@@ -4,7 +4,7 @@
 
 This example shows how to implement a Mithril client and use its features in a Node.js environment.
 
-In this example, the client interacts by default with a real aggregator on the network `testing-sanchonet` to:
+In this example, the client interacts by default with a real aggregator on the network `release-preprod` to:
 
 - Mithril Stake Distribution:
   - list the available Mithril Stake Distributions

--- a/examples/client-wasm-nodejs/index.js
+++ b/examples/client-wasm-nodejs/index.js
@@ -1,6 +1,6 @@
 import { MithrilClient } from "@mithril-dev/mithril-client-wasm";
 
-let aggregator_endpoint = "https://aggregator.testing-sanchonet.api.mithril.network/aggregator";
+let aggregator_endpoint = "https://aggregator.release-preprod.api.mithril.network/aggregator";
 let genesis_verification_key =
   "5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3232392c322c3234392c3230352c3230352c33392c3233352c34345d";
 let certificate_chain_validated_occurs = false;
@@ -109,8 +109,8 @@ async function main() {
 
   console.log(7, "Getting transaction proof...");
   const proof = await client.get_cardano_transaction_proofs([
-    "eac09f970f47ef3ab378db9232914e146773853397e79b904f1a45123a23c21f",
-    "81fe7a5dab42867ef309b6d7210158bf99331884ac3c3b6c7188a8c9c18d5974",
+    "0ea207ab71493f012faab0d1f8151eaf931901141c1482ce6e9a501498076484",
+    "326b5b67d926937bf19c6113d0957a39f2eae9df94875ce8a96eff5c8521303b",
     "320c13f4a3e51f6f4f66fcd9007e02bf658aa4ee9a88a509028d867d3b8a8e9a",
   ]);
   console.log("Certificate hash of the returned proof", proof.certificate_hash);

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-wasm-nodejs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-wasm-nodejs",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../../mithril-client-wasm"
       },

--- a/examples/client-wasm-nodejs/package.json
+++ b/examples/client-wasm-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-wasm-nodejs",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/client-wasm-web/README.md
+++ b/examples/client-wasm-web/README.md
@@ -20,7 +20,13 @@ In this example, the client interacts by default with a real aggregator on the n
 
 ## Build and run the example
 
-First you need to compile the Mithril client Wasm library:
+First you need to switch to the latest release tag:
+
+```bash
+git checkout tags/$(curl -sSL https://api.github.com/repos/input-output-hk/mithril/releases/latest | jq -r '.tag_name')
+```
+
+Compile the Mithril client Wasm library:
 
 ```bash
 make -C ../../mithril-client-wasm build

--- a/examples/client-wasm-web/README.md
+++ b/examples/client-wasm-web/README.md
@@ -4,7 +4,7 @@
 
 This example shows how to implement a Mithril client and use its features in a Web browser environment.
 
-In this example, the client interacts by default with a real aggregator on the network `testing-sanchonet` to:
+In this example, the client interacts by default with a real aggregator on the network `release-preprod` to:
 
 - Mithril Stake Distribution:
   - list the available Mithril Stake Distributions

--- a/examples/client-wasm-web/index.js
+++ b/examples/client-wasm-web/index.js
@@ -1,7 +1,7 @@
 import initMithrilClient, { MithrilClient } from "@mithril-dev/mithril-client-wasm";
 
-// This example uses sanchonet network aggregator as it handles Cardano transactions entity type
-let aggregator_endpoint = "https://aggregator.testing-sanchonet.api.mithril.network/aggregator";
+// This example uses 'release-preprod' network aggregator as it handles Cardano transactions entity type
+let aggregator_endpoint = "https://aggregator.release-preprod.api.mithril.network/aggregator";
 let genesis_verification_key =
   "5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3232392c322c3234392c3230352c3230352c33392c3233352c34345d";
 let certificate_chain_validated_occurs = false;
@@ -133,8 +133,8 @@ console.log("valid_stake_distribution_message:", valid_stake_distribution_messag
 
 displayStepInDOM(7, "Getting transaction proof...");
 const proof = await client.get_cardano_transaction_proofs([
-  "eac09f970f47ef3ab378db9232914e146773853397e79b904f1a45123a23c21f",
-  "81fe7a5dab42867ef309b6d7210158bf99331884ac3c3b6c7188a8c9c18d5974",
+  "0ea207ab71493f012faab0d1f8151eaf931901141c1482ce6e9a501498076484",
+  "326b5b67d926937bf19c6113d0957a39f2eae9df94875ce8a96eff5c8521303b",
   "320c13f4a3e51f6f4f66fcd9007e02bf658aa4ee9a88a509028d867d3b8a8e9a",
 ]);
 displayMessageInDOM("Certificate hash of the returned proof", proof.certificate_hash);

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-wasm-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-wasm-web",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../../mithril-client-wasm"
       },

--- a/examples/client-wasm-web/package.json
+++ b/examples/client-wasm-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-wasm-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",


### PR DESCRIPTION
## Content

This PR updates the aggregator used in the examples, both Rust and JS, located in the [`/examples`](https://github.com/input-output-hk/mithril/tree/main/examples) directory of the repository. Specifically:
- `testing-sanchonet` to `release-preprod`
- `testing-preview` to `release-preprod`

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)