### PR TITLE
Fix: GPG verification command of released artifact

### DIFF
--- a/.github/workflows/scripts/verify-distribution.sh
+++ b/.github/workflows/scripts/verify-distribution.sh
@@ -64,7 +64,7 @@ gpg:               imported: 1
 \`\`\`
 * **Step 7**: Then verify the GPG signature of the checksum file:
 \`\`\`
-gpg --verify ./public-key.gpg ./CHECKSUM.asc
+gpg --verify ./CHECKSUM.asc
 \`\`\`
 You must see something like:
 \`\`\`


### PR DESCRIPTION
## Content

This PR includes **a fix to the GPG verification command** in the GitHub releases.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

