### PR TITLE
Docs: rotate documentation for `2450` distribution

### DIFF
--- a/docs/website/root/manual/operate/run-signer-node.md
+++ b/docs/website/root/manual/operate/run-signer-node.md
@@ -118,7 +118,7 @@ Note that this guide works on a Linux machine only.
 
 - Install a recent version of `jq` (version 1.6+) by running `apt install jq`
 
-- Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 6.9+).
+- Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 6.12+).
 
 ## Set up the Mithril signer node
 
@@ -559,17 +559,17 @@ sudo systemctl restart mithril-signer
 
 :::
 
-On the [Squid page listing released versions](https://www.squid-cache.org/Versions/), identify the latest stable released version (currently `6.9`) and download it:
+On the [Squid page listing released versions](https://www.squid-cache.org/Versions/), identify the latest stable released version (currently `6.12`) and download it:
 
 ```bash
-wget https://www.squid-cache.org/Versions/v6/squid-6.9.tar.gz
+wget https://www.squid-cache.org/Versions/v6/squid-6.12.tar.gz
 ```
 
 Uncompress the downloaded archive and change the directory:
 
 ```bash
-tar xzf squid-6.9.tar.gz
-cd squid-6.9
+tar xzf squid-6.12.tar.gz
+cd squid-6.12
 ```
 
 Then, configure the compilation:
@@ -607,7 +607,7 @@ Optionally, verify that the version is correct:
 You should see a result like this:
 
 ```bash
-Squid Cache: Version 6.9
+Squid Cache: Version 6.12
 Service Name: squid
 configure options:  '--prefix=/opt/squid' '--localstatedir=/opt/squid/var' '--libexecdir=/opt/squid/lib/squid' '--datadir=/opt/squid/share/squid' '--sysconfdir=/etc/squid' '--with-default-user=squid' '--with-logdir=/opt/squid/var/log/squid' '--with-pidfile=/opt/squid/var/run/squid.pid'
 ```

--- a/docs/website/versioned_docs/version-maintained/manual/develop/run-mithril-devnet.md
+++ b/docs/website/versioned_docs/version-maintained/manual/develop/run-mithril-devnet.md
@@ -107,7 +107,7 @@ You should see the following information displayed:
 >> Artifacts Directory[env::ARTIFACTS_DIR]: artifacts
 >> Cardano Full nodes [env::NUM_FULL_NODES]: 1
 >> Cardano SPO nodes [env::NUM_POOL_NODES]: 2
->> Cardano Node Version [env::CARDANO_NODE_VERSION]: 10.1.2
+>> Cardano Node Version [env::CARDANO_NODE_VERSION]: 10.1.3
 >> Cardano Network Magic [env::NETWORK_MAGIC]: 42
 >> Cardano Hard Fork Babbage At Epoch [env::HARD_FORK_BABBAGE_AT_EPOCH]: 0
 >> Cardano Hard Fork Conway At Epoch [env::HARD_FORK_CONWAY_AT_EPOCH]: 0
@@ -126,7 +126,7 @@ generated genesis with: 3 genesis keys, 2 non-delegating UTxO keys, 2 stake pool
 >> Start Cardano network
 cardano-cli 10.1.1.0 - linux-x86_64 - ghc-8.10
 git rev 01bda2e2cb0a70cd95067d696dbb44665f1d680a
-cardano-node 10.1.2 - linux-x86_64 - ghc-8.10
+cardano-node 10.1.3 - linux-x86_64 - ghc-8.10
 git rev 01bda2e2cb0a70cd95067d696dbb44665f1d680a
 >> Starting Cardano node 'node-full1'
 >> Starting Cardano node 'node-pool1'
@@ -191,7 +191,7 @@ Signer 2  pool1y3pxhtqytcwy3mmnawqf2ej0x9sz5frkkwkz6scfqmzyyw8u38v  Certified Po
 >> Bootstrap the Genesis certificate
 {"msg":"Started","v":0,"name":"mithril-aggregator","level":20,"time":"2024-11-14T10:29:07.953666896Z","hostname":"c993b6b764f2","pid":1,"node_version":"0.5.110+e2fa1e0","run_mode":"dev"}
 {Genesis bootstrap for test only!
-"msg":"BOOTSTRAP GENESIS command","v":0,"name":"mithril-aggregator","level":20,"time":"2024-11-14T10:29:07.95394937Z","hostname":"c993b6b764f2","pid":1,"config":"Configuration { environment: Production, cardano_cli_path: \"/app/bin/cardano-cli\", cardano_node_socket_path: \"/data/ipc/node.sock\", cardano_node_version: \"10.1.2\", network_magic: Some(42), network: \"devnet\", chain_observer_type: Pallas, protocol_parameters: ProtocolParameters { k: 5, m: 100, phi_f: 0.65 }, snapshot_uploader_type: Local, snapshot_bucket_name: None, snapshot_use_cdn_domain: false, server_ip: \"0.0.0.0\", server_port: 8080, run_interval: 1000, db_directory: \"/data/db\", snapshot_directory: \".\", data_stores_directory: \"/data/mithril/aggregator/stores\", genesis_verification_key: \"5b33322c3235332c3138362c3230312c3137372c31312c3131372c3133352c3138372c3136372c3138312c3138382c32322c35392c3230362c3130352c3233312c3135302c3231352c33302c37382c3231322c37362c31362c3235322c3138302c37322c3133342c3133372c3234372c3136312c36385d\", reset_digests_cache: false, disable_digests_cache: false, store_retention_limit: None, era_reader_adapter_type: Bootstrap, era_reader_adapter_params: None, signed_entity_types: None, snapshot_compression_algorithm: Zstandard, zstandard_parameters: None, cexplorer_pools_url: None, signer_importer_run_interval: 720, allow_unparsable_block: false, cardano_transactions_prover_cache_pool_size: 10, cardano_transactions_database_connection_pool_size: 10, cardano_transactions_signing_config: CardanoTransactionsSigningConfig { security_parameter: BlockNumber(3000), step: BlockNumber(120) }, cardano_transactions_prover_max_hashes_allowed_by_request: 100, cardano_transactions_block_streamer_max_roll_forwards_per_poll: 10000, enable_metrics_server: false, metrics_server_ip: \"0.0.0.0\", metrics_server_port: 9090, persist_usage_report_interval_in_seconds: 10 }"}
+"msg":"BOOTSTRAP GENESIS command","v":0,"name":"mithril-aggregator","level":20,"time":"2024-11-14T10:29:07.95394937Z","hostname":"c993b6b764f2","pid":1,"config":"Configuration { environment: Production, cardano_cli_path: \"/app/bin/cardano-cli\", cardano_node_socket_path: \"/data/ipc/node.sock\", cardano_node_version: \"10.1.3\", network_magic: Some(42), network: \"devnet\", chain_observer_type: Pallas, protocol_parameters: ProtocolParameters { k: 5, m: 100, phi_f: 0.65 }, snapshot_uploader_type: Local, snapshot_bucket_name: None, snapshot_use_cdn_domain: false, server_ip: \"0.0.0.0\", server_port: 8080, run_interval: 1000, db_directory: \"/data/db\", snapshot_directory: \".\", data_stores_directory: \"/data/mithril/aggregator/stores\", genesis_verification_key: \"5b33322c3235332c3138362c3230312c3137372c31312c3131372c3133352c3138372c3136372c3138312c3138382c32322c35392c3230362c3130352c3233312c3135302c3231352c33302c37382c3231322c37362c31362c3235322c3138302c37322c3133342c3133372c3234372c3136312c36385d\", reset_digests_cache: false, disable_digests_cache: false, store_retention_limit: None, era_reader_adapter_type: Bootstrap, era_reader_adapter_params: None, signed_entity_types: None, snapshot_compression_algorithm: Zstandard, zstandard_parameters: None, cexplorer_pools_url: None, signer_importer_run_interval: 720, allow_unparsable_block: false, cardano_transactions_prover_cache_pool_size: 10, cardano_transactions_database_connection_pool_size: 10, cardano_transactions_signing_config: CardanoTransactionsSigningConfig { security_parameter: BlockNumber(3000), step: BlockNumber(120) }, cardano_transactions_prover_max_hashes_allowed_by_request: 100, cardano_transactions_block_streamer_max_roll_forwards_per_poll: 10000, enable_metrics_server: false, metrics_server_ip: \"0.0.0.0\", metrics_server_port: 9090, persist_usage_report_interval_in_seconds: 10 }"}
 {"msg":"Opening SQLite connection","v":0,"name":"mithril-aggregator","level":20,"time":"2024-11-14T10:29:07.954098066Z","hostname":"c993b6b764f2","pid":1,"src":"ConnectionBuilder","path":"/data/mithril/aggregator/stores/aggregator.sqlite3"}
 {"msg":"Enabling SQLite Write Ahead Log journal mode","v":0,"name":"mithril-aggregator","level":20,"time":"2024-11-14T10:29:07.954185725Z","hostname":"c993b6b764f2","pid":1,"src":"ConnectionBuilder"}
 {"msg":"Enabling SQLite foreign key support","v":0,"name":"mithril-aggregator","level":20,"time":"2024-11-14T10:29:07.954483371Z","hostname":"c993b6b764f2","pid":1,"src":"ConnectionBuilder"}
@@ -334,7 +334,7 @@ The networks will be queried every second and will display:
       "http://0.0.0.0:8080/aggregator/artifact/snapshot/4c7b06dd2bef1416391b92a46dae7d2f606ced2954b628f844b021ba5b52b15f/download"
     ],
     "compression_algorithm": "zstandard",
-    "cardano_node_version": "10.1.2"
+    "cardano_node_version": "10.1.3"
   },
   {
     "digest": "b98b25f505401e967df1012a4c13385290db15d157d0292e9f8290bd9933a66e",
@@ -351,7 +351,7 @@ The networks will be queried every second and will display:
       "http://0.0.0.0:8080/aggregator/artifact/snapshot/b98b25f505401e967df1012a4c13385290db15d157d0292e9f8290bd9933a66e/download"
     ],
     "compression_algorithm": "zstandard",
-    "cardano_node_version": "10.1.2"
+    "cardano_node_version": "10.1.3"
   }
 ]
 
@@ -566,7 +566,7 @@ You will see more information about the snapshot:
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Size                  | 2323485648                                                                                                                                                                     |
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Cardano node version  | 10.1.2                                                                                                                                                                          |
+| Cardano node version  | 10.1.3                                                                                                                                                                          |
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Location              | https://storage.googleapis.com/cdn.aggregator.testing-preview.api.mithril.network/preview-e539-i10787.db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667.tar.zst |
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -594,9 +594,9 @@ You will see that the certificate chain is validated to ensure the issued certif
 5/5 - Verifying the cardano db signature…
 Cardano db 'db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667' has been unpacked and successfully checked against Mithril multi-signature contained in the certificate.
 
-    Files in the directory '/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db' can be used to run a Cardano node with version >= 10.1.2.
+    Files in the directory '/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db' can be used to run a Cardano node with version >= 10.1.3.
 
     If you are using Cardano Docker image, you can restore a Cardano Node with:
 
-    docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db",target=/data/db/ -e NETWORK=preview ghcr.io/intersectmbo/cardano-node:10.1.2
+    docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db",target=/data/db/ -e NETWORK=preview ghcr.io/intersectmbo/cardano-node:10.1.3
 ```

--- a/docs/website/versioned_docs/version-maintained/manual/getting-started/bootstrap-cardano-node.md
+++ b/docs/website/versioned_docs/version-maintained/manual/getting-started/bootstrap-cardano-node.md
@@ -429,7 +429,7 @@ You will see more information about the snapshot:
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Size                  | 2323485648                                                                                                                                                                     |
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Cardano node version  | 10.1.2                                                                                                                                                                          |
+| Cardano node version  | 10.1.3                                                                                                                                                                          |
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Location              | https://storage.googleapis.com/cdn.aggregator.testing-preview.api.mithril.network/preview-e539-i10787.db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667.tar.zst |
 +-----------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -457,11 +457,11 @@ You will see that the selected snapshot archive has been downloaded locally unpa
 5/5 - Verifying the cardano db signature…
 Cardano db 'db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667' has been unpacked and successfully checked against Mithril multi-signature contained in the certificate.
 
-    Files in the directory '/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db' can be used to run a Cardano node with version >= 10.1.2.
+    Files in the directory '/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db' can be used to run a Cardano node with version >= 10.1.3.
 
     If you are using a Cardano Docker image, you can restore a Cardano node with:
 
-    docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db",target=/data/db/ -e NETWORK=preview ghcr.io/intersectmbo/cardano-node:10.1.2
+    docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="/home/mithril/data/testnet/db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667/db",target=/data/db/ -e NETWORK=preview ghcr.io/intersectmbo/cardano-node:10.1.3
 ```
 
 ### Step 5: Launch a Cardano node from the restored Cardano DB snapshot
@@ -469,7 +469,7 @@ Cardano db 'db5f50a060d4b813125c4263b700ecc96e5d8c8710f0430e5c80d2f0fa79b667' ha
 Launch an empty Cardano node and make it live in minutes!
 
 ```bash
-docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="$(pwd)/data/testnet/$SNAPSHOT_DIGEST/db",target=/data/db/ -e NETWORK=$CARDANO_NETWORK ghcr.io/intersectmbo/cardano-node:10.1.2
+docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="$(pwd)/data/testnet/$SNAPSHOT_DIGEST/db",target=/data/db/ -e NETWORK=$CARDANO_NETWORK ghcr.io/intersectmbo/cardano-node:10.1.3
 ```
 
 You will see the Cardano node start by validating the files ingested from the snapshot archive. Then, it will synchronize with the other network nodes and start adding blocks:

--- a/docs/website/versioned_docs/version-maintained/manual/operate/run-signer-node.md
+++ b/docs/website/versioned_docs/version-maintained/manual/operate/run-signer-node.md
@@ -118,7 +118,7 @@ Note that this guide works on a Linux machine only.
 
 - Install a recent version of `jq` (version 1.6+) by running `apt install jq`
 
-- Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 6.9+).
+- Only for the **production** deployment, install a recent version of [`squid-cache`](http://www.squid-cache.org/) (version 6.12+).
 
 ## Set up the Mithril signer node
 
@@ -559,17 +559,17 @@ sudo systemctl restart mithril-signer
 
 :::
 
-On the [Squid page listing released versions](https://www.squid-cache.org/Versions/), identify the latest stable released version (currently `6.9`) and download it:
+On the [Squid page listing released versions](https://www.squid-cache.org/Versions/), identify the latest stable released version (currently `6.12`) and download it:
 
 ```bash
-wget https://www.squid-cache.org/Versions/v6/squid-6.9.tar.gz
+wget https://www.squid-cache.org/Versions/v6/squid-6.12.tar.gz
 ```
 
 Uncompress the downloaded archive and change the directory:
 
 ```bash
-tar xzf squid-6.9.tar.gz
-cd squid-6.9
+tar xzf squid-6.12.tar.gz
+cd squid-6.12
 ```
 
 Then, configure the compilation:
@@ -607,7 +607,7 @@ Optionally, verify that the version is correct:
 You should see a result like this:
 
 ```bash
-Squid Cache: Version 6.9
+Squid Cache: Version 6.12
 Service Name: squid
 configure options:  '--prefix=/opt/squid' '--localstatedir=/opt/squid/var' '--libexecdir=/opt/squid/lib/squid' '--datadir=/opt/squid/share/squid' '--sysconfdir=/etc/squid' '--with-default-user=squid' '--with-logdir=/opt/squid/var/log/squid' '--with-pidfile=/opt/squid/var/run/squid.pid'
 ```


### PR DESCRIPTION
## Content
This PR includes the rotation of the documentation with the release of the new `2450` distribution

### Documentation Updates:

* [`docs/website/root/manual/operate/run-signer-node.md`](diffhunk://#diff-ca80e5696ac46644482a8826a992f485257d43a5477a1ff0cba2537f3966d9feL121-R121): Updated the required version of `squid-cache` from 6.9 to 6.12 for production deployment. [[1]](diffhunk://#diff-ca80e5696ac46644482a8826a992f485257d43a5477a1ff0cba2537f3966d9feL121-R121) [[2]](diffhunk://#diff-ca80e5696ac46644482a8826a992f485257d43a5477a1ff0cba2537f3966d9feL562-R572) [[3]](diffhunk://#diff-ca80e5696ac46644482a8826a992f485257d43a5477a1ff0cba2537f3966d9feL610-R610)
* [`docs/website/versioned_docs/version-maintained/manual/develop/run-mithril-devnet.md`](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L110-R110): Updated the Cardano node version from 10.1.2 to 10.1.3 in multiple sections to reflect the new version used in the devnet. [[1]](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L110-R110) [[2]](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L129-R129) [[3]](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L194-R194) [[4]](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L337-R337) [[5]](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L354-R354) [[6]](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L569-R569) [[7]](diffhunk://#diff-9b1c827511f2848dc14970675395f36ec2d053ab96645ebd90089ce2a5e7ea07L597-R601)
* [`docs/website/versioned_docs/version-maintained/manual/getting-started/bootstrap-cardano-node.md`](diffhunk://#diff-f58f75e8fde13828674e16fbd44508c88ea82c958c8f1363cc788be422b9470dL432-R432): Updated the Cardano node version from 10.1.2 to 10.1.3 in the bootstrap instructions. [[1]](diffhunk://#diff-f58f75e8fde13828674e16fbd44508c88ea82c958c8f1363cc788be422b9470dL432-R432) [[2]](diffhunk://#diff-f58f75e8fde13828674e16fbd44508c88ea82c958c8f1363cc788be422b9470dL460-R472)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

## Issue(s)
Relates to #2124 
