### PR TITLE
Chore: update dependencies for distribution `2450`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.123"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-stake-distribution"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -965,7 +965,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-transaction"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "client-mithril-stake-distribution"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -991,7 +991,7 @@ dependencies = [
 
 [[package]]
 name = "client-snapshot"
-version = "0.1.20"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.5.122"
+version = "0.5.123"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3634,7 +3634,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-fake"
-version = "0.3.15"
+version = "0.3.16"
 dependencies = [
  "anyhow",
  "axum",
@@ -3657,7 +3657,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-build-script"
-version = "0.2.13"
+version = "0.2.14"
 dependencies = [
  "semver",
  "serde_json",
@@ -3666,7 +3666,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3727,7 +3727,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "futures",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.95"
+version = "0.4.96"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,7 +3796,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-doc"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "clap",
  "config",
@@ -3806,7 +3806,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-doc-derive"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "quote",
  "syn 2.0.90",
@@ -3814,7 +3814,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.53"
+version = "0.4.54"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-metric"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -3857,7 +3857,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.40"
+version = "0.2.41"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3877,7 +3877,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.29"
+version = "0.1.30"
 dependencies = [
  "anyhow",
  "clap",
@@ -3901,7 +3901,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.220"
+version = "0.2.221"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3941,7 +3941,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.33"
+version = "0.3.34"
 dependencies = [
  "bincode",
  "blake2 0.10.6",
@@ -3964,7 +3964,7 @@ dependencies = [
 
 [[package]]
 name = "mithrildemo"
-version = "0.1.45"
+version = "0.1.46"
 dependencies = [
  "base64 0.22.1",
  "blake2 0.10.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -780,9 +780,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
+checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
 dependencies = [
  "jobserver",
  "libc",
@@ -827,9 +827,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1660,9 +1660,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fiat-crypto"
@@ -2811,9 +2811,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a865e038f7f6ed956f788f0d7d60c541fff74c7bd74272c5d4cf15c63743e705"
+checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2946,9 +2946,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libm"
@@ -3622,7 +3622,7 @@ dependencies = [
  "sqlite",
  "tar",
  "tempfile",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
@@ -3689,7 +3689,7 @@ dependencies = [
  "slog-term",
  "strum",
  "tar",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
  "uuid",
  "warp",
@@ -3721,7 +3721,7 @@ dependencies = [
  "slog-async",
  "slog-bunyan",
  "slog-term",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -3786,7 +3786,7 @@ dependencies = [
  "slog-async",
  "slog-term",
  "strum",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
  "typetag",
  "walkdir",
@@ -3833,7 +3833,7 @@ dependencies = [
  "slog-async",
  "slog-scope",
  "slog-term",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
  "tokio-util",
 ]
@@ -3871,7 +3871,7 @@ dependencies = [
  "sha2",
  "slog",
  "sqlite",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
 ]
 
@@ -3894,7 +3894,7 @@ dependencies = [
  "slog-bunyan",
  "slog-scope",
  "slog-term",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
  "warp",
 ]
@@ -3934,7 +3934,7 @@ dependencies = [
  "slog-scope",
  "slog-term",
  "sqlite",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tikv-jemallocator",
  "tokio",
 ]
@@ -3959,7 +3959,7 @@ dependencies = [
  "rayon",
  "rug",
  "serde",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
 ]
 
 [[package]]
@@ -4056,9 +4056,9 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc41f430805af9d1cf4adae4ed2149c759b877b01d909a1f40256188d09345d2"
+checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
 dependencies = [
  "core2",
  "unsigned-varint 0.8.0",
@@ -4158,9 +4158,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+checksum = "16c903aa70590cb93691bf97a767c8d1d6122d2cc9070433deb3bbf36ce8bd23"
 dependencies = [
  "bytes",
  "futures",
@@ -4624,20 +4624,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
+checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
 dependencies = [
  "memchr",
- "thiserror 1.0.69",
+ "thiserror 2.0.6",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d214365f632b123a47fd913301e14c946c61d1c183ee245fa76eb752e59a02dd"
+checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4645,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb55586734301717aea2ac313f50b2eb8f60d2fc3dc01d190eefa2e625f60c4e"
+checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
 dependencies = [
  "pest",
  "pest_meta",
@@ -4658,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.14"
+version = "2.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b75da2a70cf4d9cb76833c990ac9cd3923c9a8905a8929789ce347c84564d03d"
+checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
 dependencies = [
  "once_cell",
  "pest",
@@ -4997,7 +4997,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tokio",
  "tracing",
 ]
@@ -5016,7 +5016,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.4",
+ "thiserror 2.0.6",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5024,9 +5024,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
+checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5422,15 +5422,15 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6301,11 +6301,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f49a1853cf82743e3b7950f77e0f4d622ca36cf4317cba00c767838bac8d490"
+checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
 dependencies = [
- "thiserror-impl 2.0.4",
+ "thiserror-impl 2.0.6",
 ]
 
 [[package]]
@@ -6321,9 +6321,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.4"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8381894bb3efe0c4acac3ded651301ceee58a15d47c2e34885ed1908ad667061"
+checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7001,9 +7001,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d15e63b4482863c109d70a7b8706c1e364eb6ea449b201a76c5b89cedcec2d5c"
+checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -7012,13 +7012,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d36ef12e3aaca16ddd3f67922bc63e48e953f126de60bd33ccc0101ef9998cd"
+checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -7027,9 +7026,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.47"
+version = "0.4.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dfaf8f50e5f293737ee323940c7d8b08a66a95a419223d9f41610ca08b0833d"
+checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7040,9 +7039,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "705440e08b42d3e4b36de7d66c944be628d579796b8090bfa3471478a2260051"
+checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7050,9 +7049,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c9ae5a76e46f4deecd0f0255cc223cfa18dc9b261213b8aa0c7b36f61b3f1d"
+checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7063,19 +7062,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.97"
+version = "0.2.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ee99da9c5ba11bd675621338ef6fa52296b76b83305e9b6e5c77d4c286d6d49"
+checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d919bb60ebcecb9160afee6c71b43a58a4f0517a2de0054cd050d02cec08201"
+checksum = "c61d44563646eb934577f2772656c7ad5e9c90fac78aa8013d776fcdaf24625d"
 dependencies = [
  "js-sys",
  "minicov",
- "once_cell",
  "scoped-tls",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -7084,9 +7082,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222ebde6ea87fbfa6bdd2e9f1fd8a91d60aee5db68792632176c4e16a74fc7d8"
+checksum = "54171416ce73aa0b9c377b51cc3cb542becee1cd678204812e8392e5b0e4a031"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7108,9 +7106,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.74"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98bc3c33f0fe7e59ad7cd041b89034fa82a7c2d4365ca538dda6cdaf513863c"
+checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7169,7 +7167,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithrildemo"
-version = "0.1.45"
+version = "0.1.46"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -6315,8 +6315,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -8136,9 +8137,9 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.1.tgz",
-      "integrity": "sha512-YSFlK1Ee0/GC8QaO91tHcDxJiE/X4FbpAyQWkxAvG6AXCuR65YzK8ua6D9hvi/TzUfZMpc+BwuM1IPw8fmQBiQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8159,7 +8160,7 @@
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "0.1.12",
         "proxy-addr": "~2.0.7",
         "qs": "6.13.0",
         "range-parser": "~1.2.1",
@@ -8174,6 +8175,10 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/express/node_modules/content-disposition": {
@@ -8198,9 +8203,9 @@
       "license": "MIT"
     },
     "node_modules/express/node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w=="
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
     },
     "node_modules/express/node_modules/range-parser": {
       "version": "1.2.1",
@@ -13364,14 +13369,15 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.7",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },

--- a/docs/website/package-lock.json
+++ b/docs/website/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-doc",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-doc",
-      "version": "0.1.48",
+      "version": "0.1.49",
       "dependencies": {
         "@docusaurus/core": "^3.6.3",
         "@docusaurus/plugin-client-redirects": "^3.6.3",

--- a/docs/website/package.json
+++ b/docs/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-doc",
-  "version": "0.1.48",
+  "version": "0.1.49",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/examples/client-cardano-stake-distribution/Cargo.toml
+++ b/examples/client-cardano-stake-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-stake-distribution"
 description = "Mithril client cardano stake distribution example"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-transaction/Cargo.toml
+++ b/examples/client-cardano-transaction/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-transaction"
 description = "Mithril client cardano-transaction example"
-version = "0.1.16"
+version = "0.1.17"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-mithril-stake-distribution/Cargo.toml
+++ b/examples/client-mithril-stake-distribution/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-mithril-stake-distribution"
 description = "Mithril client stake distribution example"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-snapshot/Cargo.toml
+++ b/examples/client-snapshot/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-snapshot"
 description = "Mithril client snapshot example"
-version = "0.1.20"
+version = "0.1.21"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0"
     },
     "node_modules/@mithril-dev/mithril-client-wasm": {

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-wasm-nodejs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-wasm-nodejs",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../../mithril-client-wasm"
       },

--- a/examples/client-wasm-nodejs/package.json
+++ b/examples/client-wasm-nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-wasm-nodejs",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-wasm-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-wasm-web",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../../mithril-client-wasm"
       },

--- a/examples/client-wasm-web/package.json
+++ b/examples/client-wasm-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-wasm-web",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1733418579,
-        "narHash": "sha256-0fJaoI4B9Nn67E1P44usZhZHkSSyWdAI23HU+X+HJCQ=",
+        "lastModified": 1733688869,
+        "narHash": "sha256-KrhxxFj1CjESDrL5+u/zsVH0K+Ik9tvoac/oFPoxSB8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "62e50137688d953557f156f01e2ad2a25b22d66c",
+        "rev": "604637106e420ad99907cae401e13ab6b452e7d9",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1733229606,
-        "narHash": "sha256-FLYY5M0rpa5C2QAE3CKLYAM6TwbKicdRK6qNrSHlNrE=",
+        "lastModified": 1733686850,
+        "narHash": "sha256-NQEO/nZWWGTGlkBWtCs/1iF1yl2lmQ1oY/8YZrumn3I=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "566e53c2ad750c84f6d31f9ccb9d00f823165550",
+        "rev": "dd51f52372a20a93c219e8216fe528a648ffcbf4",
         "type": "github"
       },
       "original": {
@@ -76,11 +76,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1733440889,
-        "narHash": "sha256-qKL3vjO+IXFQ0nTinFDqNq/sbbnnS5bMI1y0xX215fU=",
+        "lastModified": 1733761991,
+        "narHash": "sha256-s4DalCDepD22jtKL5Nw6f4LP5UwoMcPzPZgHWjAfqbQ=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "50862ba6a8a0255b87377b9d2d4565e96f29b410",
+        "rev": "0ce9d149d99bc383d1f2d85f31f6ebd146e46085",
         "type": "github"
       },
       "original": {

--- a/internal/mithril-build-script/Cargo.toml
+++ b/internal/mithril-build-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-build-script"
-version = "0.2.13"
+version = "0.2.14"
 description = "A toolbox for Mithril crates build scripts"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-doc-derive/Cargo.toml
+++ b/internal/mithril-doc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-doc-derive"
-version = "0.1.12"
+version = "0.1.13"
 description = "An internal macro to support documentation generation."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-doc/Cargo.toml
+++ b/internal/mithril-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-doc"
-version = "0.1.13"
+version = "0.1.14"
 description = "An internal crate to generate documentation."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-metric/Cargo.toml
+++ b/internal/mithril-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-metric"
-version = "0.1.4"
+version = "0.1.5"
 description = "Common tools to expose metrics."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [dependencies]
 anyhow = "1.0.94"
 async-trait = "0.1.83"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 hex = "0.4.3"
 mithril-common = { path = "../../mithril-common", features = ["fs"] }
 semver = "1.0.23"
@@ -23,7 +23,7 @@ serde_json = "1.0.133"
 sha2 = "0.10.8"
 slog = "2.7.0"
 sqlite = { version = "0.36.1", features = ["bundled"] }
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["sync"] }
 
 [dev-dependencies]

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.40"
+version = "0.2.41"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.122"
+version = "0.5.123"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.5.123"
+version = "0.6.0"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -20,7 +20,7 @@ harness = false
 [dependencies]
 anyhow = "1.0.94"
 async-trait = "0.1.83"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "env", "cargo"] }
 cloud-storage = "0.11.1"
 config = "0.14.1"
@@ -49,7 +49,7 @@ slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
 sqlite = { version = "0.36.1", features = ["bundled"] }
 tar = "0.4.43"
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["codec"] }
 typetag = "0.2.18"

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -24,7 +24,7 @@ assets = [["../target/release/mithril-client", "usr/bin/", "755"]]
 [dependencies]
 anyhow = "1.0.94"
 async-trait = "0.1.83"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 cli-table = "0.4.9"
 config = "0.14.1"
@@ -45,7 +45,7 @@ slog = { version = "2.7.0", features = [
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
 slog-term = "2.9.1"
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["full"] }
 
 [dev-dependencies]

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.7.1"
+version = "0.7.2"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -18,12 +18,12 @@ futures = "0.3.31"
 mithril-client = { path = "../mithril-client", features = ["unstable"] }
 serde = { version = "1.0.215", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
-wasm-bindgen = "0.2.97"
-wasm-bindgen-futures = "0.4.47"
-web-sys = { version = "0.3.74", features = ["BroadcastChannel"] }
+wasm-bindgen = "0.2.99"
+wasm-bindgen-futures = "0.4.49"
+web-sys = { version = "0.3.76", features = ["BroadcastChannel"] }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.47"
+wasm-bindgen-test = "0.3.49"
 
 [build-dependencies]
 mithril-build-script = { path = "../internal/mithril-build-script" }

--- a/mithril-client-wasm/ci-test/package-lock.json
+++ b/mithril-client-wasm/ci-test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-wasm-ci-test",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-wasm-ci-test",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../"
       },
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/ci-test/package.json
+++ b/mithril-client-wasm/ci-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-wasm-ci-test",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client-wasm/package.json
+++ b/mithril-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithril-dev/mithril-client-wasm",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Mithril client WASM",
   "license": "Apache-2.0",
   "collaborators": [

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.10.3"
+version = "0.10.4"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -27,7 +27,7 @@ required-features = ["unstable"]
 anyhow = "1.0.94"
 async-recursion = "1.1.1"
 async-trait = "0.1.83"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 flate2 = { version = "1.0.35", optional = true }
 flume = { version = "0.11.1", optional = true }
 futures = "0.3.31"
@@ -44,7 +44,7 @@ serde_json = "1.0.133"
 slog = "2.7.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tar = { version = "0.4.43", optional = true }
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["sync"] }
 uuid = { version = "1.11.0", features = ["v4"] }
 zstd = { version = "0.13.2", optional = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.95"
+version = "0.4.96"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -34,7 +34,7 @@ anyhow = "1.0.94"
 async-trait = "0.1.83"
 bech32 = "0.11.0"
 blake2 = "0.10.6"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 ciborium = "0.2.2"
 ckb-merkle-mountain-range = "0.6.0"
 digest = "0.10.7"
@@ -68,14 +68,14 @@ serde_yaml = "0.9.34"
 sha2 = "0.10.8"
 slog = "2.7.0"
 strum = { version = "0.26.3", features = ["derive"] }
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["io-util", "rt", "sync"] }
 typetag = "0.2.18"
 walkdir = "2.5.0"
 warp = { version = "0.3.7", optional = true }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
-wasm-bindgen = "0.2.97"
+wasm-bindgen = "0.2.99"
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.21",
+      "version": "0.7.22",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/dist/web",
         "@popperjs/core": "^2.11.8",

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm/dist/web": {
       "name": "mithril-client-wasm",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Apache-2.0"
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -43,7 +43,7 @@ slog = { version = "2.7.0", features = [
 ] }
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["full"] }
 warp = "0.3.7"
 

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.29"
+version = "0.1.30"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.220"
+version = "0.2.221"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -17,7 +17,7 @@ harness = false
 anyhow = "1.0.94"
 async-trait = "0.1.83"
 axum = "0.7.9"
-chrono = { version = "0.4.38", features = ["serde"] }
+chrono = { version = "0.4.39", features = ["serde"] }
 clap = { version = "4.5.23", features = ["derive", "env"] }
 config = "0.14.1"
 hex = "0.4.3"
@@ -41,7 +41,7 @@ slog = { version = "2.7.0", features = [
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
 sqlite = { version = "0.36.1", features = ["bundled"] }
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["full"] }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -21,7 +21,7 @@ digest = { version = "0.10.7", features = ["alloc"] }
 rand_core = "0.6.4"
 rayon = "1.10.0"
 serde = { version = "1.0.215", features = ["rc", "derive"] }
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 
 [target.'cfg(not(any(target_family = "wasm", windows)))'.dependencies]
 # only unix supports the rug backend

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.33"
+version = "0.3.34"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
+++ b/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator-fake"
-version = "0.3.15"
+version = "0.3.16"
 description = "Mithril Fake Aggregator for client testing"
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.53"
+version = "0.4.54"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -35,7 +35,7 @@ slog = { version = "2.7.0", features = [
 slog-async = "2.8.0"
 slog-scope = "4.4.0"
 slog-term = "2.9.1"
-thiserror = "2.0.4"
+thiserror = "2.0.6"
 tokio = { version = "1.42.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["codec"] }
 


### PR DESCRIPTION
## Content

This PR **upgrades the repository dependencies to their latest version in preparation of the distribution `2450`** by running the [upgrade script from the runbook](https://github.com/input-output-hk/mithril/tree/main/docs/runbook/upgrade-repository-dependencies).

### Dependency Updates in Rust `Cargo.toml` Files:
* [`internal/mithril-persistence/Cargo.toml`](diffhunk://#diff-2fa39103c6fedf406a2505c7be4c8434aed103a763af3ab9351e30b959e86e70L3-R3): Updated `chrono` from `0.4.38` to `0.4.39` and `thiserror` from `2.0.4` to `2.0.6`. [[1]](diffhunk://#diff-2fa39103c6fedf406a2505c7be4c8434aed103a763af3ab9351e30b959e86e70L3-R3) [[2]](diffhunk://#diff-2fa39103c6fedf406a2505c7be4c8434aed103a763af3ab9351e30b959e86e70L17-R17) [[3]](diffhunk://#diff-2fa39103c6fedf406a2505c7be4c8434aed103a763af3ab9351e30b959e86e70L26-R26)
* [`mithril-aggregator/Cargo.toml`](diffhunk://#diff-5ae504281312c194e5e8cf6aa890f49508756041db9dbce0fd89fbf04438f90dL3-R3): Updated `chrono` from `0.4.38` to `0.4.39` and `thiserror` from `2.0.4` to `2.0.6`. [[1]](diffhunk://#diff-5ae504281312c194e5e8cf6aa890f49508756041db9dbce0fd89fbf04438f90dL3-R3) [[2]](diffhunk://#diff-5ae504281312c194e5e8cf6aa890f49508756041db9dbce0fd89fbf04438f90dL23-R23) [[3]](diffhunk://#diff-5ae504281312c194e5e8cf6aa890f49508756041db9dbce0fd89fbf04438f90dL52-R52)

### Dependency Updates in `package-lock.json` Files:
* [`docs/website/package-lock.json`](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757L3-R9): Updated `mithril-doc` version from `0.1.48` to `0.1.49` and several dependencies including `cross-spawn`, `express`, and `path-to-regexp`. [[1]](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757L3-R9) [[2]](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757L6318-R6320) [[3]](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757L8139-R8142) [[4]](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757L8162-R8163) [[5]](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757R8178-R8181) [[6]](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757L8201-R8208) [[7]](diffhunk://#diff-bfcef465a61b86f103827c63c53110dd93bba30ee2202395d08ae0a16470c757L13367-L13374)
* [`examples/client-wasm-nodejs/package-lock.json`](diffhunk://#diff-1f5bea477f75203fff5cf06c4cdcb4cd1065bd8be43b251c2bfe0bf1db5958acL3-R9): Updated package version from `0.3.2` to `0.3.3` and dependency `@mithril-dev/mithril-client-wasm` from `0.7.0` to `0.7.1`. [[1]](diffhunk://#diff-1f5bea477f75203fff5cf06c4cdcb4cd1065bd8be43b251c2bfe0bf1db5958acL3-R9) [[2]](diffhunk://#diff-1f5bea477f75203fff5cf06c4cdcb4cd1065bd8be43b251c2bfe0bf1db5958acL19-R19)
* [`mithril-client-wasm/ci-test/package-lock.json`](diffhunk://#diff-b036b7be73634cd1f4cdbe5e3775bb09a1b5014a733ab5542825682afa6c9e91L3-R9): Updated package version from `0.3.1` to `0.3.2` and dependency `@mithril-dev/mithril-client-wasm` from `0.7.1` to `0.7.2`. [[1]](diffhunk://#diff-b036b7be73634cd1f4cdbe5e3775bb09a1b5014a733ab5542825682afa6c9e91L3-R9) [[2]](diffhunk://#diff-b036b7be73634cd1f4cdbe5e3775bb09a1b5014a733ab5542825682afa6c9e91L24-R24)

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2124 
