### PR TITLE
feat(ci): include explorer in packaged releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -546,6 +546,7 @@ jobs:
     needs:
       - build
       - build-test-wasm
+      - build-test-explorer
       - test
       - e2e
       - check
@@ -589,6 +590,12 @@ jobs:
         with:
           name: mithril-distribution-Windows-X64
           path: ./package-Windows-X64
+
+      - name: Download built artifacts (Explorer)
+        uses: actions/download-artifact@v4
+        with:
+          name: explorer-build
+          path: ./package
 
       - name: Prepare distribution package
         uses: ./.github/workflows/actions/prepare-distribution


### PR DESCRIPTION
## Content

This PR add to our nightly releases (and, since we promote them, to other releases) the packaged Explorer.

This will allow to have two explorer: one based on the latest released stable and one based on the latest nightly.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

