### PR TITLE
Fix: recompute certificate chain hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.0"
+version = "0.6.1"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes a fix to the **certificate chain hash recomputation** to support large datasets.

### Version Update:
* [`mithril-aggregator/Cargo.toml`](diffhunk://#diff-5ae504281312c194e5e8cf6aa890f49508756041db9dbce0fd89fbf04438f90dL3-R3): Updated the package version from `0.6.0` to `0.6.1`.

### Optimizations for Handling Large Datasets:
* [`mithril-aggregator/src/tools/certificates_hash_migrator.rs`](diffhunk://#diff-3228ebed3a11208c88b8d7bf73520a40098014e18162acf3c8987aed190e654fR149-L162): Added chunk processing for old hashes and old certificates to improve efficiency when updating signed entities and deleting old certificates. [[1]](diffhunk://#diff-3228ebed3a11208c88b8d7bf73520a40098014e18162acf3c8987aed190e654fR149-L162) [[2]](diffhunk://#diff-3228ebed3a11208c88b8d7bf73520a40098014e18162acf3c8987aed190e654fL182-R209)

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2124