### PR TITLE
Fix explorer packaging in releases

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -56,6 +56,15 @@ runs:
         --version "${{ inputs.version-name }}" \
         --target "windows-x64"
 
+    - name: Package Explorer
+      shell: bash
+      run: |
+        python3 ./.github/workflows/scripts/package-distribution.py \
+        --input package-explorer/ \
+        --dest package/ \
+        --name "mithril-explorer" \
+        --version "${{ inputs.version-name }}"
+
     - name: Prepare crates versions table
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -595,7 +595,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: explorer-build
-          path: ./package
+          path: ./package-explorer
 
       - name: Prepare distribution package
         uses: ./.github/workflows/actions/prepare-distribution

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -63,6 +63,15 @@ jobs:
           workflow: ci.yml
           workflow_conclusion: success
 
+      - name: Download built artifacts (Explorer)
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          name: explorer-build
+          path: ./package-explorer
+          commit: ${{ github.sha }}
+          workflow: ci.yml
+          workflow_conclusion: success
+
       - name: Append VERSION file
         run: |
           echo ${{ github.ref_name }} >> ./package/VERSION

--- a/.github/workflows/scripts/package-distribution.py
+++ b/.github/workflows/scripts/package-distribution.py
@@ -48,8 +48,9 @@ def check_archive(archive_path, original_input_dir):
 
 
 def main(args):
-    archive_path = build_archive(
-        args.input, args.dest, archive_basename=f"mithril-{args.version}-{args.target}")
+    archive_basename = f"{args.name}-{args.version}" if args.target is None else f"{args.name}-{args.version}-{args.target}"
+
+    archive_path = build_archive(args.input, args.dest, archive_basename)
     check_archive(archive_path, args.input)
 
 
@@ -58,6 +59,8 @@ if __name__ == '__main__':
         prog="Mithril distribution packager",
         description="Package the files in the given '--input' dir in a .tar.gz (linux, macOs) or .zip (windows)."
     )
+    parser.add_argument("--name", help="name of the distribution to package, prefix of the archive name",
+                        default="mithril")
     parser.add_argument("--input", type=dir_path,
                         help="input folder which content will be archived", required=True)
     parser.add_argument("--dest", type=dir_path, help="destination folder for the archive, default to current folder",
@@ -65,6 +68,6 @@ if __name__ == '__main__':
     parser.add_argument(
         "--version", help="version of the distribution to package", required=True)
     parser.add_argument(
-        "--target", help="target os & architecture of the package", required=True)
+        "--target", help="target os & architecture of the package", required=False)
 
     main(parser.parse_args())


### PR DESCRIPTION
## Content

This PR fix the explorer packaging when doing releases.

### package-distribution script enhancement

- allow to change the prepended name of the archive built (default to `mithril` to keep current behaviour)
- allow to omit the `--target` so this script can be used to packages project aht have a "target os" and or "target arch" (such as web projects)

### Unstable release changes

- Fix explorer packaging: as #2167 all the explorer files were included uncompressed at the root of the release files instead of being packaged in a single archive.

### Pre-release changes

- Include the explorer package in pre-release

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

