### PR TITLE
Feat: implement the Ancillary sub builder for Incremental Cardano DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3743,7 +3743,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.96"
+version = "0.4.97"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.3"
+version = "0.6.4"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -15,7 +15,7 @@ use mithril_common::{
 use crate::artifact_builder::ArtifactBuilder;
 
 pub struct CardanoDatabaseArtifactBuilder {
-    db_directory: PathBuf, // TODO: temporary, will be accessed through another dependency instead of direct path.
+    db_directory: PathBuf,
     cardano_node_version: Version,
     compression_algorithm: CompressionAlgorithm,
 }
@@ -55,11 +55,14 @@ impl ArtifactBuilder<CardanoDbBeacon, CardanoDatabaseSnapshot> for CardanoDataba
             })?;
         let total_db_size_uncompressed = compute_uncompressed_database_size(&self.db_directory)?;
 
+        // TODO: implement the sub-builder logic to get the locations.
+        let locations = ArtifactsLocations::default();
+
         let cardano_database = CardanoDatabaseSnapshot::new(
             merkle_root.to_string(),
             beacon,
             total_db_size_uncompressed,
-            ArtifactsLocations::default(), // TODO: temporary default locations, will be injected in next PR.
+            locations,
             self.compression_algorithm,
             &self.cardano_node_version,
         );

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -120,7 +120,7 @@ mod tests {
         test_utils::{fake_data, TempDir},
     };
 
-    use crate::artifact_builder::cardano_database_artifacts::MockAncillaryFileUploaderAggregator;
+    use crate::artifact_builder::cardano_database_artifacts::MockAncillaryFileUploader;
 
     use super::*;
 
@@ -168,7 +168,7 @@ mod tests {
             .build();
         let expected_total_size = immutable_trio_file_size + ledger_file_size + volatile_file_size;
 
-        let mut uploader = MockAncillaryFileUploaderAggregator::new();
+        let mut uploader = MockAncillaryFileUploader::new();
         uploader.expect_upload().return_once(|_| {
             Ok(AncillaryLocation::CloudStorage {
                 uri: "ancillary_location_uri".to_string(),

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -65,7 +65,7 @@ impl ArtifactBuilder<CardanoDbBeacon, CardanoDatabaseSnapshot> for CardanoDataba
             .ancillary_builder
             .upload_archive(&self.db_directory)
             .await
-            .with_context(|| "Can not compute CardanoDatabase artifact")?;
+            .with_context(|| "Can not compute CardanoDatabase ancillary artifact")?;
         let locations = ArtifactsLocations {
             ancillary: ancillary_locations,
             digest: vec![],

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -1,0 +1,109 @@
+use async_trait::async_trait;
+use std::{path::Path, sync::Arc};
+
+use mithril_common::{entities::AncillaryLocation, StdResult};
+
+use crate::{FileUploader, LocalUploader};
+
+pub struct AncillaryArtifactBuilder {
+    uploaders: Vec<Arc<dyn AncillaryFileUploaderAggregator>>,
+}
+
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait AncillaryFileUploaderAggregator {
+    async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation>;
+}
+
+#[async_trait]
+impl AncillaryFileUploaderAggregator for LocalUploader {
+    async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
+        let uri = FileUploader::upload(self, filepath).await?.into();
+
+        Ok(AncillaryLocation::CloudStorage { uri })
+    }
+}
+
+impl AncillaryArtifactBuilder {
+    pub fn new(uploaders: Vec<Arc<dyn AncillaryFileUploaderAggregator>>) -> Self {
+        Self { uploaders }
+    }
+
+    pub async fn upload_archive(&self, db_directory: &Path) -> StdResult<Vec<AncillaryLocation>> {
+        let mut locations = Vec::new();
+        for uploader in &self.uploaders {
+            // TODO: Temporary preparation work, `db_directory` is used as the ancillary archive path for now.
+            let location = uploader.upload(db_directory).await?;
+            locations.push(location);
+        }
+
+        Ok(locations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mockall::predicate::eq;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn upload_archive_should_return_empty_locations_with_no_uploader() {
+        let builder = AncillaryArtifactBuilder::new(vec![]);
+
+        let locations = builder.upload_archive(Path::new("whatever")).await.unwrap();
+
+        assert!(locations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn upload_archive_should_return_all_uploaders_cloud_storage_locations() {
+        let mut first_uploader = MockAncillaryFileUploaderAggregator::new();
+        first_uploader
+            .expect_upload()
+            .with(eq(Path::new("archive_path")))
+            .times(1)
+            .return_once(|_| {
+                Ok(AncillaryLocation::CloudStorage {
+                    uri: "an_uri".to_string(),
+                })
+            });
+
+        let mut second_uploader = MockAncillaryFileUploaderAggregator::new();
+        second_uploader
+            .expect_upload()
+            .with(eq(Path::new("archive_path")))
+            .times(1)
+            .return_once(|_| {
+                Ok(AncillaryLocation::CloudStorage {
+                    uri: "another_uri".to_string(),
+                })
+            });
+
+        let uploaders: Vec<Arc<dyn AncillaryFileUploaderAggregator>> =
+            vec![Arc::new(first_uploader), Arc::new(second_uploader)];
+
+        let builder = AncillaryArtifactBuilder::new(uploaders);
+
+        let locations = builder
+            .upload_archive(Path::new("archive_path"))
+            .await
+            .unwrap();
+
+        assert!(locations.len() == 2);
+
+        assert_eq!(
+            locations[0],
+            AncillaryLocation::CloudStorage {
+                uri: "an_uri".to_string()
+            }
+        );
+
+        assert_eq!(
+            locations[1],
+            AncillaryLocation::CloudStorage {
+                uri: "another_uri".to_string()
+            }
+        );
+    }
+}

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use async_trait::async_trait;
 use std::{path::Path, sync::Arc};
 

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -5,9 +5,11 @@ use mithril_common::{entities::AncillaryLocation, StdResult};
 
 use crate::{FileUploader, LocalUploader};
 
+/// The [AncillaryFileUploader] trait allows identifying uploaders that return locations for ancillary archive files.
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait AncillaryFileUploader: Send + Sync {
+    /// Uploads the archive at the given filepath and returns the location of the uploaded file.
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation>;
 }
 
@@ -20,6 +22,8 @@ impl AncillaryFileUploader for LocalUploader {
     }
 }
 
+/// The [AncillaryArtifactBuilder] creates an ancillary archive from the cardano database directory (including ledger and volatile directories).
+/// The archive is uploaded with the provided uploaders.
 pub struct AncillaryArtifactBuilder {
     uploaders: Vec<Arc<dyn AncillaryFileUploader>>,
 }
@@ -90,20 +94,16 @@ mod tests {
             .await
             .unwrap();
 
-        assert!(locations.len() == 2);
-
         assert_eq!(
-            locations[0],
-            AncillaryLocation::CloudStorage {
-                uri: "an_uri".to_string()
-            }
-        );
-
-        assert_eq!(
-            locations[1],
-            AncillaryLocation::CloudStorage {
-                uri: "another_uri".to_string()
-            }
+            locations,
+            vec![
+                AncillaryLocation::CloudStorage {
+                    uri: "an_uri".to_string()
+                },
+                AncillaryLocation::CloudStorage {
+                    uri: "another_uri".to_string()
+                }
+            ]
         );
     }
 }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -5,13 +5,9 @@ use mithril_common::{entities::AncillaryLocation, StdResult};
 
 use crate::{FileUploader, LocalUploader};
 
-pub struct AncillaryArtifactBuilder {
-    uploaders: Vec<Arc<dyn AncillaryFileUploaderAggregator>>,
-}
-
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
-pub trait AncillaryFileUploaderAggregator {
+pub trait AncillaryFileUploaderAggregator: Send + Sync {
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation>;
 }
 
@@ -22,6 +18,10 @@ impl AncillaryFileUploaderAggregator for LocalUploader {
 
         Ok(AncillaryLocation::CloudStorage { uri })
     }
+}
+
+pub struct AncillaryArtifactBuilder {
+    uploaders: Vec<Arc<dyn AncillaryFileUploaderAggregator>>,
 }
 
 impl AncillaryArtifactBuilder {

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
@@ -1,3 +1,3 @@
 mod ancillary;
 
-pub use ancillary::AncillaryArtifactBuilder;
+pub use ancillary::*;

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
@@ -1,3 +1,4 @@
+//! The module is responsible for creating and uploading the archives of the Cardano database artifacts.
 mod ancillary;
 
 pub use ancillary::*;

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
@@ -1,0 +1,3 @@
+mod ancillary;
+
+pub use ancillary::AncillaryArtifactBuilder;

--- a/mithril-aggregator/src/artifact_builder/mod.rs
+++ b/mithril-aggregator/src/artifact_builder/mod.rs
@@ -1,5 +1,6 @@
 //! The module used for building artifact
 mod cardano_database;
+mod cardano_database_artifacts;
 mod cardano_immutable_files_full;
 mod cardano_stake_distribution;
 mod cardano_transactions;
@@ -7,6 +8,7 @@ mod interface;
 mod mithril_stake_distribution;
 
 pub use cardano_database::*;
+pub use cardano_database_artifacts::*;
 pub use cardano_immutable_files_full::*;
 pub use cardano_stake_distribution::*;
 pub use cardano_transactions::*;

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -284,7 +284,7 @@ impl Configuration {
             .map_err(|e| anyhow!(ConfigError::Message(e.to_string())))
     }
 
-    /// Return the file of the SQLite stores. If the directory does not exist, it is created.
+    /// Return the directory of the SQLite stores. If the directory does not exist, it is created.
     pub fn get_sqlite_dir(&self) -> PathBuf {
         let store_dir = &self.data_stores_directory;
 
@@ -293,6 +293,15 @@ impl Configuration {
         }
 
         self.data_stores_directory.clone()
+    }
+
+    /// Return the snapshots directory.
+    pub fn get_snapshot_dir(&self) -> StdResult<PathBuf> {
+        if !&self.snapshot_directory.exists() {
+            std::fs::create_dir_all(&self.snapshot_directory)?;
+        }
+
+        Ok(self.snapshot_directory.clone())
     }
 
     /// Same as the [store retention limit][Configuration::store_retention_limit] but will never

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1189,7 +1189,11 @@ impl DependenciesBuilder {
     ) -> CardanoDatabaseArtifactBuilder {
         let local_uploader = LocalUploader::new(
             self.configuration.get_server_url(),
-            &self.configuration.snapshot_directory.join("ancillary"),
+            &self
+                .configuration
+                .snapshot_directory
+                .join("cardano-database")
+                .join("ancillary"),
             logger.clone(),
         );
         let ancillary_builder = Arc::new(AncillaryArtifactBuilder::new(vec![Arc::new(

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -64,7 +64,7 @@ use crate::{
     },
     entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
-    file_uploaders::GcpUploader,
+    file_uploaders::{FileUploader, GcpUploader},
     http_server::routes::router::{self, RouterConfig, RouterState},
     services::{
         AggregatorSignableSeedBuilder, AggregatorUpkeepService, BufferedCertifierService,
@@ -78,8 +78,8 @@ use crate::{
     tools::{CExplorerSignerRetriever, GenesisToolsDependency, SignersImporter},
     AggregatorConfig, AggregatorRunner, AggregatorRuntime, CompressedArchiveSnapshotter,
     Configuration, DependencyContainer, DumbSnapshotter, DumbUploader, EpochSettingsStorer,
-    FileUploader, LocalUploader, MetricsService, MithrilSignerRegisterer, MultiSigner,
-    MultiSignerImpl, SingleSignatureAuthenticator, SnapshotUploaderType, Snapshotter,
+    LocalUploader, MetricsService, MithrilSignerRegisterer, MultiSigner, MultiSignerImpl,
+    SingleSignatureAuthenticator, SnapshotUploaderType, Snapshotter,
     SnapshotterCompressionAlgorithm, VerificationKeyStorer,
 };
 

--- a/mithril-aggregator/src/file_uploaders/local_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_uploader.rs
@@ -124,4 +124,21 @@ mod tests {
             .join(archive.file_name().unwrap())
             .exists());
     }
+
+    #[tokio::test]
+    async fn should_error_if_path_is_a_directory() {
+        let source_dir = tempdir().unwrap();
+        let digest = "41e27b9ed5a32531b95b2b7ff3c0757591a06a337efaf19a524a998e348028e7";
+        create_fake_archive(source_dir.path(), digest);
+        let target_dir = tempdir().unwrap();
+        let uploader = LocalUploader::new(
+            "http://test.com:8080/".to_string(),
+            target_dir.path(),
+            TestLogger::stdout(),
+        );
+        uploader
+            .upload(source_dir.path())
+            .await
+            .expect_err("Uploading a directory should fail");
+    }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.96"
+version = "0.4.97"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -56,12 +56,12 @@ impl CardanoDatabaseSnapshot {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum DigestLocation {
-    /// Aggregator endpoint location.
+    /// Aggregator digest route location.
     Aggregator {
-        /// URI of the aggregator endpoint location.
+        /// URI of the aggregator digests route location.
         uri: String,
     },
-    /// Cloud storage location (e.g. GCP, AWS, etc.).
+    /// Cloud storage location.
     CloudStorage {
         /// URI of the cloud storage location.
         uri: String,
@@ -72,7 +72,7 @@ pub enum DigestLocation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ImmutablesLocation {
-    /// Cloud storage location (e.g. GCP, AWS, etc.).
+    /// Cloud storage location.
     CloudStorage {
         /// URI of the cloud storage location.
         uri: String,
@@ -83,7 +83,7 @@ pub enum ImmutablesLocation {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumDiscriminants)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum AncillaryLocation {
-    /// Cloud storage location (e.g. GCP, AWS, etc.).
+    /// Cloud storage location.
     CloudStorage {
         /// URI of the cloud storage location.
         uri: String,

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -1,5 +1,6 @@
 use semver::Version;
 use serde::{Deserialize, Serialize};
+use strum::EnumDiscriminants;
 
 use crate::{
     entities::{CardanoDbBeacon, CompressionAlgorithm},
@@ -51,34 +52,55 @@ impl CardanoDatabaseSnapshot {
     }
 }
 
+/// Locations of the the immutable file digests.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
-enum DigestLocation {
-    Aggregator { uri: String },
-    CloudStorage { uri: String },
+pub enum DigestLocation {
+    /// Aggregator endpoint location.
+    Aggregator {
+        /// URI of the aggregator endpoint location.
+        uri: String,
+    },
+    /// Cloud storage location (e.g. GCP, AWS, etc.).
+    CloudStorage {
+        /// URI of the cloud storage location.
+        uri: String,
+    },
 }
 
+/// Locations of the ancillary files.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
-enum ImmutablesLocation {
-    CloudStorage { uri: String },
+pub enum ImmutablesLocation {
+    /// Cloud storage location (e.g. GCP, AWS, etc.).
+    CloudStorage {
+        /// URI of the cloud storage location.
+        uri: String,
+    },
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+/// Locations of the ancillary files.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumDiscriminants)]
 #[serde(rename_all = "snake_case", tag = "type")]
-enum AncillaryLocation {
-    CloudStorage { uri: String },
+pub enum AncillaryLocation {
+    /// Cloud storage location (e.g. GCP, AWS, etc.).
+    CloudStorage {
+        /// URI of the cloud storage location.
+        uri: String,
+    },
 }
 
 /// Locations of the Cardano database related files.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ArtifactsLocations {
-    /// Locations of the the immutable file digests.
-    digest: Vec<DigestLocation>,
+    /// Locations of the immutable file digests.
+    pub digest: Vec<DigestLocation>,
+
     /// Locations of the immutable files.
-    immutables: Vec<ImmutablesLocation>,
+    pub immutables: Vec<ImmutablesLocation>,
+
     /// Locations of the ancillary files.
-    ancillary: Vec<AncillaryLocation>,
+    pub ancillary: Vec<AncillaryLocation>,
 }
 
 #[typetag::serde]

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -33,7 +33,9 @@ mod type_alias;
 pub use block_number::BlockNumber;
 pub use block_range::{BlockRange, BlockRangeLength, BlockRangesSequence};
 pub use cardano_chain_point::{BlockHash, ChainPoint};
-pub use cardano_database::{ArtifactsLocations, CardanoDatabaseSnapshot};
+pub use cardano_database::{
+    AncillaryLocation, AncillaryLocationDiscriminants, ArtifactsLocations, CardanoDatabaseSnapshot,
+};
 pub use cardano_db_beacon::CardanoDbBeacon;
 pub use cardano_network::CardanoNetwork;
 pub use cardano_stake_distribution::CardanoStakeDistribution;


### PR DESCRIPTION
## Content

This PR includes the first implementation of the ancillary builder for the Incremental Cardano Database.

It handles the upload of ancillary artifacts using a Local Uploader and adds the returned locations to the `CardanoDatabaseSnapshot`. The creation and verification of the ancillary archive will be handled in a separate PR.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #2151 
