### PR TITLE
Build and publish an unstable explorer version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -867,14 +867,29 @@ jobs:
         working-directory: mithril-explorer
         run: make test
 
-      - name: Build Explorer
+      - name: Build Explorer (stable)
         working-directory: mithril-explorer
         run: make build
 
-      - name: Publish Explorer build
+      - name: Publish Explorer build (stable)
         uses: actions/upload-artifact@v4
         with:
           name: explorer-build
+          if-no-files-found: error
+          path: |
+            mithril-explorer/out/*
+
+      - name: Build Explorer (unstable)
+        working-directory: mithril-explorer
+        env:
+          BASE_PATH: "/explorer/unstable"
+          UNSTABLE: "1"
+        run: make build
+
+      - name: Publish Explorer build (unstable)
+        uses: actions/upload-artifact@v4
+        with:
+          name: explorer-build-unstable
           if-no-files-found: error
           path: |
             mithril-explorer/out/*
@@ -923,11 +938,17 @@ jobs:
           name: docusaurus-build
           path: ./github-pages/doc
 
-      - name: Download Explorer build
+      - name: Download Explorer build (stable)
         uses: actions/download-artifact@v4
         with:
           name: explorer-build
           path: ./github-pages/explorer
+
+      - name: Download Explorer build (unstable)
+        uses: actions/download-artifact@v4
+        with:
+          name: explorer-build-unstable
+          path: ./github-pages/explorer/unstable
 
       - name: Download OpenAPI UI build
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX] - UNRELEASED
 
+- Build and publish both a `stable` version (for release networks) and an `unstable` version (for testing networks) of the explorer.
+
 - Crates versions:
 
 | Crate | Version |

--- a/mithril-explorer/README.md
+++ b/mithril-explorer/README.md
@@ -26,6 +26,20 @@ make dev
 
 Open [http://localhost:3000](http://localhost:3000/explorer) with your browser to see the result.
 
+### Enabling unstable features
+
+Some features are still in development and are not enabled by default. To enable them, set the `UNSTABLE` environment variable to `1` when running the development server:
+
+```bash
+UNSTABLE=1 make dev
+```
+
+Or when building the production version:
+
+```bash
+UNSTABLE=1 make build
+```
+
 ## Adding or updating an icon of the 'Mithril' font
 
 In the `./icons` folder add or modify a svg.

--- a/mithril-explorer/next.config.js
+++ b/mithril-explorer/next.config.js
@@ -3,7 +3,7 @@ const webpack = require("webpack");
 /** @type {import("next").NextConfig} */
 const nextConfig = {
   output: "export",
-  basePath: "/explorer",
+  basePath: process.env.BASE_PATH ?? "/explorer",
   reactStrictMode: true,
   images: {
     unoptimized: true,

--- a/mithril-explorer/next.config.js
+++ b/mithril-explorer/next.config.js
@@ -1,4 +1,6 @@
-/** @type {import('next').NextConfig} */
+const webpack = require("webpack");
+
+/** @type {import("next").NextConfig} */
 const nextConfig = {
   output: "export",
   basePath: "/explorer",
@@ -8,6 +10,11 @@ const nextConfig = {
   },
   webpack: (config) => {
     config.experiments = { layers: true, asyncWebAssembly: true };
+    config.plugins.push(
+      new webpack.DefinePlugin({
+        "process.env.UNSTABLE": process.env.UNSTABLE === "1",
+      }),
+    );
     return config;
   },
 };

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.22",
+      "version": "0.7.23",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/dist/web",
         "@popperjs/core": "^2.11.8",

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/app/layout.js
+++ b/mithril-explorer/src/app/layout.js
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import React, { Suspense } from "react";
+import { Badge } from "react-bootstrap";
 import { Providers } from "@/store/provider";
 
 // These styles apply to every route in the application
@@ -31,6 +32,14 @@ export default function RootLayout({ children }) {
                     <Image src="/explorer/logo.png" alt="Mithril Logo" width={55} height={55} />{" "}
                     Mithril Explorer
                   </Link>
+                  {process.env.UNSTABLE && (
+                    <>
+                      {" "}
+                      <Badge bg="danger" className="fs-6 align-text-top">
+                        Unstable
+                      </Badge>
+                    </>
+                  )}
                 </h1>
                 {children}
               </main>


### PR DESCRIPTION
## Content

This PR add a 'Unstable' feature flag to the explorer, toggled by setting a `UNSTABLE` environment variable to `1` **at compile time**.
This, alongside another change that allow to parametrize the explorer base path (to have correct intra links), allow us to have two published version of the explorer:

- `https://mithril.network/explorer/`: that will use the packaged version of the explorer from the last stable release, built with `unstable` feature disabled ( :hammer_and_pick: coming soon, see comments).
- `https://mithril.network/explorer/unstable`: that will use the latest code from the `main` branch, build with `unstable` features enabled.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments
This does not finish #2172 as we need to wait for a new release to have a packaged "stable" explorer build that can be retrieved each time we publish to github pages.
In the meantime we will keep using the `main` branch code for the published "stable" version but with the unstable features disabled.

## Issue(s)

Relates to #2172
