### PR TITLE
Docs: add dev blog post for distribution `2450`

### DIFF
--- a/docs/website/blog/2024-12-17-distribution-2450.md
+++ b/docs/website/blog/2024-12-17-distribution-2450.md
@@ -1,0 +1,31 @@
+---
+title: Distribution `2450` is now available
+authors:
+  - name: Mithril Team
+tags: [release, distribution, 2450]
+---
+
+### Distribution `2450` is now available
+
+We have released the [`2450.0`](https://github.com/input-output-hk/mithril/releases/tag/2450.0) distribution, which includes the following:
+
+- :fire: **BREAKING** changes in Mithril client library, CLI, and WASM:
+  - Remove deprecated `network` field from the internal `CardanoDbBeacon`.
+  - The Mithril certificates of type `CardanoImmutableFilesFull` can't be verified anymore with the previous clients.
+  - Clients from distribution `2445` and earlier must be updated.
+- Stable support for **Cardano node** `10.1.3` in the signer and the aggregator.
+- Stable support for one line shell installation script of the Mithril nodes pre-built binaries.
+- Bug fixes and performance improvements.
+
+This new distribution has been deployed to the **Mithril aggregator** of the `release-mainnet` and `release-preprod` networks.
+
+If you are running a **Mithril signer** on:
+
+- the **pre-release-preview** network: there is nothing to do at the moment.
+- the **release-preprod** network: you can upgrade the binary of your signer node to the version `0.2.221`, no configuration update is needed.
+- the **release-mainnet** network: you can upgrade the binary of your signer node to the version `0.2.221`, no configuration update is needed.
+
+You can **easily update your Mithril signer with this one line command** (it will be downloaded in the current directory, a custom folder can be specified with `-p` option):
+`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2450.0 -p $(pwd)`
+
+For any inquiries or assistance, feel free to contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).


### PR DESCRIPTION
## Content

This PR includes a **dev blog post announcing the release of the [`2450`](https://github.com/input-output-hk/mithril/releases/tag/2450.0) distribution**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Add dev blog post (if relevant)

## Issue(s)
Relates to #2124 
