### PR TITLE
ci: publish packaged explorer in latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -938,11 +938,15 @@ jobs:
           name: docusaurus-build
           path: ./github-pages/doc
 
-      - name: Download Explorer build (stable)
-        uses: actions/download-artifact@v4
-        with:
-          name: explorer-build
-          path: ./github-pages/explorer
+      - name: Download and unpack Explorer build (stable)
+        shell: bash
+        run: |
+          # Note: If the tag is omitted, 'gh release' commands uses the latest released version
+          LAST_DISTRIBUTION=$(gh release view -R ${{ github.repository }} --json "tagName" --jq ".tagName")
+          gh release download -R ${{ github.repository }} --pattern "mithril-explorer-${LAST_DISTRIBUTION}*"
+
+          mkdir -p ./github-pages/explorer/
+          tar xvf mithril-explorer-${LAST_DISTRIBUTION}.tar.gz --directory=./github-pages/explorer/
 
       - name: Download Explorer build (unstable)
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Content

This PR swap the packaged explorer that's published in our github pages.
Now the package deployed is fetched from our latest released instead of using the one built in the `build-test-explorer` job (that we still need since it's used in (pre-)releases).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Closes #2172
