### PR TITLE
ci: fix downloading of stable explorer when publishing to pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -940,6 +940,8 @@ jobs:
 
       - name: Download and unpack Explorer build (stable)
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Note: If the tag is omitted, 'gh release' commands uses the latest released version
           LAST_DISTRIBUTION=$(gh release view -R ${{ github.repository }} --json "tagName" --jq ".tagName")


### PR DESCRIPTION
## Content

This PR fix the stable explored download step in the `publish_docs` job, the github secret token was missing in order to use `gh` cli.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #2172