### PR TITLE
feat: extend `Snapshotter` to archive only specific files and directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.5"
+version = "0.6.6"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -74,7 +74,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         // spawn a separate thread to prevent blocking
         let ongoing_snapshot =
             tokio::task::spawn_blocking(move || -> StdResult<OngoingSnapshot> {
-                snapshotter.snapshot(&snapshot_name)
+                snapshotter.snapshot_all(&snapshot_name)
             })
             .await??;
 


### PR DESCRIPTION
## Content

This PR includes an update to the `Snapshotter` that allows it to create archives from specific directories and files.
It’s a preparatory step for the creation of archives from ancillary files.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #2151 
