### PR TITLE
Feat: ancillary archive creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 - **UNSTABLE** Cardano database incremental certification:
 
   - Implement the artifact routes of the aggregator for the signed entity type `CardanoDatabase`.
+  - Implement the artifact ancillary builder in the aggregator.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.8"
+version = "0.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.100"
+version = "0.4.101"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.59"
+version = "0.4.60"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.8"
+version = "0.6.9"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -61,10 +61,7 @@ impl ArtifactBuilder<CardanoDbBeacon, CardanoDatabaseSnapshot> for CardanoDataba
             })?;
         let total_db_size_uncompressed = compute_uncompressed_database_size(&self.db_directory)?;
 
-        let ancillary_locations = self
-            .ancillary_builder
-            .upload(beacon.immutable_file_number)
-            .await?;
+        let ancillary_locations = self.ancillary_builder.upload(&beacon).await?;
 
         let locations = ArtifactsLocations {
             ancillary: ancillary_locations,
@@ -118,6 +115,7 @@ mod tests {
         digesters::DummyCardanoDbBuilder,
         entities::{AncillaryLocation, ProtocolMessage, ProtocolMessagePartKey},
         test_utils::{fake_data, TempDir},
+        CardanoNetwork,
     };
 
     use crate::{
@@ -183,6 +181,7 @@ mod tests {
             Arc::new(AncillaryArtifactBuilder::new(
                 vec![Arc::new(ancillary_uploader)],
                 Arc::new(DumbSnapshotter::new()),
+                CardanoNetwork::DevNet(123),
                 CompressionAlgorithm::Gzip,
                 TestLogger::stdout(),
             )),

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -178,13 +178,16 @@ mod tests {
             test_dir,
             &Version::parse("1.0.0").unwrap(),
             CompressionAlgorithm::Zstandard,
-            Arc::new(AncillaryArtifactBuilder::new(
-                vec![Arc::new(ancillary_uploader)],
-                Arc::new(DumbSnapshotter::new()),
-                CardanoNetwork::DevNet(123),
-                CompressionAlgorithm::Gzip,
-                TestLogger::stdout(),
-            )),
+            Arc::new(
+                AncillaryArtifactBuilder::new(
+                    vec![Arc::new(ancillary_uploader)],
+                    Arc::new(DumbSnapshotter::new()),
+                    CardanoNetwork::DevNet(123),
+                    CompressionAlgorithm::Gzip,
+                    TestLogger::stdout(),
+                )
+                .unwrap(),
+            ),
         );
 
         let beacon = fake_data::beacon();

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -116,6 +116,8 @@ mod tests {
         test_utils::{fake_data, TempDir},
     };
 
+    use crate::{test_tools::TestLogger, DumbSnapshotter};
+
     use super::*;
 
     fn get_test_directory(dir_name: &str) -> PathBuf {
@@ -166,7 +168,12 @@ mod tests {
             test_dir,
             &Version::parse("1.0.0").unwrap(),
             CompressionAlgorithm::Zstandard,
-            Arc::new(AncillaryArtifactBuilder::new(vec![])),
+            Arc::new(AncillaryArtifactBuilder::new(
+                vec![],
+                Arc::new(DumbSnapshotter::new()),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )),
         );
 
         let beacon = fake_data::beacon();

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -111,7 +111,7 @@ mod tests {
     use std::path::PathBuf;
 
     use mithril_common::{
-        digesters::DummyImmutablesDbBuilder,
+        digesters::DummyCardanoDbBuilder,
         entities::{ProtocolMessage, ProtocolMessagePartKey},
         test_utils::{fake_data, TempDir},
     };
@@ -129,7 +129,7 @@ mod tests {
         let immutable_trio_file_size = 777;
         let ledger_file_size = 6666;
         let volatile_file_size = 99;
-        DummyImmutablesDbBuilder::new(test_dir.as_os_str().to_str().unwrap())
+        DummyCardanoDbBuilder::new(test_dir.as_os_str().to_str().unwrap())
             .with_immutables(&[1, 2])
             .set_immutable_trio_file_size(immutable_trio_file_size)
             .with_ledger_files(&["blocks-0.dat", "blocks-1.dat", "blocks-2.dat"])
@@ -152,7 +152,7 @@ mod tests {
         let immutable_trio_file_size = 777;
         let ledger_file_size = 6666;
         let volatile_file_size = 99;
-        DummyImmutablesDbBuilder::new(test_dir.as_os_str().to_str().unwrap())
+        DummyCardanoDbBuilder::new(test_dir.as_os_str().to_str().unwrap())
             .with_immutables(&[1])
             .set_immutable_trio_file_size(immutable_trio_file_size)
             .with_ledger_files(&["blocks-0.dat"])

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -14,7 +14,9 @@ use mithril_common::{
     CardanoNetwork, StdResult,
 };
 
-use crate::{snapshotter::OngoingSnapshot, FileUploader, LocalSnapshotUploader, Snapshotter};
+use crate::{
+    file_uploaders::LocalUploader, snapshotter::OngoingSnapshot, FileUploader, Snapshotter,
+};
 
 /// The [AncillaryFileUploader] trait allows identifying uploaders that return locations for ancillary archive files.
 #[cfg_attr(test, mockall::automock)]
@@ -25,7 +27,7 @@ pub trait AncillaryFileUploader: Send + Sync {
 }
 
 #[async_trait]
-impl AncillaryFileUploader for LocalSnapshotUploader {
+impl AncillaryFileUploader for LocalUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
         let uri = FileUploader::upload(self, filepath).await?.into();
 

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -1,10 +1,21 @@
 #![allow(dead_code)]
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::Context;
 use async_trait::async_trait;
-use std::{path::Path, sync::Arc};
+use slog::{debug, Logger};
 
-use mithril_common::{entities::AncillaryLocation, StdResult};
+use mithril_common::{
+    digesters::{IMMUTABLE_DIR, LEDGER_DIR, VOLATILE_DIR},
+    entities::{AncillaryLocation, CompressionAlgorithm, ImmutableFileNumber},
+    logging::LoggerExtensions,
+    StdResult,
+};
 
-use crate::{FileUploader, LocalUploader};
+use crate::{FileUploader, LocalUploader, Snapshotter};
 
 /// The [AncillaryFileUploader] trait allows identifying uploaders that return locations for ancillary archive files.
 #[cfg_attr(test, mockall::automock)]
@@ -27,13 +38,81 @@ impl AncillaryFileUploader for LocalUploader {
 /// The archive is uploaded with the provided uploaders.
 pub struct AncillaryArtifactBuilder {
     uploaders: Vec<Arc<dyn AncillaryFileUploader>>,
+    snapshotter: Arc<dyn Snapshotter>,
+    compression_algorithm: CompressionAlgorithm,
+    logger: Logger,
 }
 
 impl AncillaryArtifactBuilder {
-    pub fn new(uploaders: Vec<Arc<dyn AncillaryFileUploader>>) -> Self {
-        Self { uploaders }
+    /// Creates a new [AncillaryArtifactBuilder].
+    pub fn new(
+        uploaders: Vec<Arc<dyn AncillaryFileUploader>>,
+        snapshotter: Arc<dyn Snapshotter>,
+        compression_algorithm: CompressionAlgorithm,
+        logger: Logger,
+    ) -> Self {
+        Self {
+            uploaders,
+            logger: logger.new_with_component_name::<Self>(),
+            compression_algorithm,
+            snapshotter,
+        }
     }
 
+    /// Returns the list of files and directories to include in the snapshot.
+    /// The immutable file number is incremented by 1 to include the not yet finalized immutable file.
+    fn get_files_and_directories_to_snapshot(immutable_file_number: u64) -> Vec<PathBuf> {
+        let next_immutable_file_number = immutable_file_number + 1;
+        let chunk_filename = format!("{:05}.chunk", next_immutable_file_number);
+        let primary_filename = format!("{:05}.primary", next_immutable_file_number);
+        let secondary_filename = format!("{:05}.secondary", next_immutable_file_number);
+
+        vec![
+            PathBuf::from(VOLATILE_DIR),
+            PathBuf::from(LEDGER_DIR),
+            PathBuf::from(IMMUTABLE_DIR).join(chunk_filename),
+            PathBuf::from(IMMUTABLE_DIR).join(primary_filename),
+            PathBuf::from(IMMUTABLE_DIR).join(secondary_filename),
+        ]
+    }
+
+    /// Creates an archive for the Cardano database ancillary files for the given immutable file number.
+    fn create_ancillary_archive(
+        &self,
+        immutable_file_number: ImmutableFileNumber,
+    ) -> StdResult<PathBuf> {
+        debug!(
+            self.logger,
+            "Creating ancillary archive for immutable file number: {}", immutable_file_number
+        );
+
+        let paths_to_include = Self::get_files_and_directories_to_snapshot(immutable_file_number);
+
+        let archive_name = format!(
+            "ancillary.{}",
+            self.compression_algorithm.tar_file_extension()
+        );
+
+        let snapshot = self
+            .snapshotter
+            .snapshot_subset(&archive_name, paths_to_include)
+            .with_context(|| {
+                format!(
+                    "Failed to create snapshot for immutable file number: {}",
+                    immutable_file_number
+                )
+            })?;
+
+        debug!(
+            self.logger,
+            "Ancillary archive created at path: {:?}",
+            snapshot.get_file_path()
+        );
+
+        Ok(snapshot.get_file_path().to_path_buf())
+    }
+
+    /// Uploads the ancillary archive and returns the locations of the uploaded files.
     pub async fn upload_archive(&self, db_directory: &Path) -> StdResult<Vec<AncillaryLocation>> {
         let mut locations = Vec::new();
         for uploader in &self.uploaders {
@@ -48,13 +127,31 @@ impl AncillaryArtifactBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::fs::File;
+
+    use flate2::read::GzDecoder;
     use mockall::predicate::eq;
+    use tar::Archive;
+
+    use mithril_common::digesters::{
+        DummyCardanoDbBuilder, IMMUTABLE_DIR, LEDGER_DIR, VOLATILE_DIR,
+    };
+
+    use crate::{
+        test_tools::TestLogger, CompressedArchiveSnapshotter, DumbSnapshotter,
+        SnapshotterCompressionAlgorithm,
+    };
 
     use super::*;
 
     #[tokio::test]
     async fn upload_archive_should_return_empty_locations_with_no_uploader() {
-        let builder = AncillaryArtifactBuilder::new(vec![]);
+        let builder = AncillaryArtifactBuilder::new(
+            vec![],
+            Arc::new(DumbSnapshotter::new()),
+            CompressionAlgorithm::Gzip,
+            TestLogger::stdout(),
+        );
 
         let locations = builder.upload_archive(Path::new("whatever")).await.unwrap();
 
@@ -88,7 +185,12 @@ mod tests {
         let uploaders: Vec<Arc<dyn AncillaryFileUploader>> =
             vec![Arc::new(first_uploader), Arc::new(second_uploader)];
 
-        let builder = AncillaryArtifactBuilder::new(uploaders);
+        let builder = AncillaryArtifactBuilder::new(
+            uploaders,
+            Arc::new(DumbSnapshotter::new()),
+            CompressionAlgorithm::Gzip,
+            TestLogger::stdout(),
+        );
 
         let locations = builder
             .upload_archive(Path::new("archive_path"))
@@ -106,5 +208,69 @@ mod tests {
                 }
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn create_archive_should_embed_ledger_volatile_directories_and_last_immutables() {
+        let test_dir = "cardano_database/create_archive";
+        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+            .with_immutables(&[1, 2, 3])
+            .with_ledger_files(&["blocks-0.dat", "blocks-1.dat", "blocks-2.dat"])
+            .with_volatile_files(&["437", "537", "637", "737"])
+            .build();
+        std::fs::create_dir(cardano_db.get_dir().join("whatever")).unwrap();
+
+        let db_directory = cardano_db.get_dir().to_path_buf();
+        let snapshotter = {
+            CompressedArchiveSnapshotter::new(
+                db_directory.clone(),
+                db_directory.parent().unwrap().join("snapshot_dest"),
+                SnapshotterCompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap()
+        };
+
+        let builder = AncillaryArtifactBuilder::new(
+            vec![],
+            Arc::new(snapshotter),
+            CompressionAlgorithm::Gzip,
+            TestLogger::stdout(),
+        );
+
+        let archive_file_path = builder.create_ancillary_archive(1).unwrap();
+
+        let mut archive = {
+            let file_tar_gz = File::open(archive_file_path).unwrap();
+            let file_tar_gz_decoder = GzDecoder::new(file_tar_gz);
+            Archive::new(file_tar_gz_decoder)
+        };
+
+        let dst = cardano_db.get_dir().join("unpack_dir");
+        archive.unpack(dst.clone()).unwrap();
+
+        let expected_immutable_path = dst.join(IMMUTABLE_DIR);
+        assert!(expected_immutable_path.join("00002.chunk").exists());
+        assert!(expected_immutable_path.join("00002.primary").exists());
+        assert!(expected_immutable_path.join("00002.secondary").exists());
+        let immutables_nb = std::fs::read_dir(expected_immutable_path).unwrap().count();
+        assert_eq!(3, immutables_nb);
+
+        let expected_ledger_path = dst.join(LEDGER_DIR);
+        assert!(expected_ledger_path.join("blocks-0.dat").exists());
+        assert!(expected_ledger_path.join("blocks-1.dat").exists());
+        assert!(expected_ledger_path.join("blocks-2.dat").exists());
+        let ledger_nb = std::fs::read_dir(expected_ledger_path).unwrap().count();
+        assert_eq!(3, ledger_nb);
+
+        let expected_volatile_path = dst.join(VOLATILE_DIR);
+        assert!(expected_volatile_path.join("437").exists());
+        assert!(expected_volatile_path.join("537").exists());
+        assert!(expected_volatile_path.join("637").exists());
+        assert!(expected_volatile_path.join("737").exists());
+        let volatile_nb = std::fs::read_dir(expected_volatile_path).unwrap().count();
+        assert_eq!(4, volatile_nb);
+
+        assert!(!dst.join("whatever").exists());
     }
 }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -194,8 +194,8 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn create_ancillary_builder_should_error_when_no_uploader() {
+    #[test]
+    fn create_ancillary_builder_should_error_when_no_uploader() {
         let result = AncillaryArtifactBuilder::new(
             vec![],
             Arc::new(DumbSnapshotter::new()),

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -14,7 +14,7 @@ use mithril_common::{
     CardanoNetwork, StdResult,
 };
 
-use crate::{snapshotter::OngoingSnapshot, FileUploader, LocalUploader, Snapshotter};
+use crate::{snapshotter::OngoingSnapshot, FileUploader, LocalSnapshotUploader, Snapshotter};
 
 /// The [AncillaryFileUploader] trait allows identifying uploaders that return locations for ancillary archive files.
 #[cfg_attr(test, mockall::automock)]
@@ -25,7 +25,7 @@ pub trait AncillaryFileUploader: Send + Sync {
 }
 
 #[async_trait]
-impl AncillaryFileUploader for LocalUploader {
+impl AncillaryFileUploader for LocalSnapshotUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
         let uri = FileUploader::upload(self, filepath).await?.into();
 

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -74,7 +74,8 @@ impl AncillaryArtifactBuilder {
     }
 
     /// Returns the list of files and directories to include in the snapshot.
-    /// The immutable file number is incremented by 1 to include the not yet finalized immutable file.
+    /// The immutable file included in the ancillary archive corresponds to the last one (and not finalized yet)
+    /// when the immutable file number given to the function corresponds to the penultimate.
     fn get_files_and_directories_to_snapshot(immutable_file_number: u64) -> Vec<PathBuf> {
         let next_immutable_file_number = immutable_file_number + 1;
         let chunk_filename = format!("{:05}.chunk", next_immutable_file_number);
@@ -114,7 +115,7 @@ impl AncillaryArtifactBuilder {
             .snapshot_subset(&archive_name, paths_to_include)
             .with_context(|| {
                 format!(
-                    "Failed to create snapshot for immutable file number: {}",
+                    "Failed to create ancillary archive for immutable file number: {}",
                     beacon.immutable_file_number
                 )
             })?;
@@ -263,7 +264,7 @@ mod tests {
         );
 
         let snapshot = builder
-            .create_ancillary_archive(&CardanoDbBeacon::new(99, 1))
+            .create_ancillary_archive(&CardanoDbBeacon::new(99, 2))
             .unwrap();
 
         let mut archive = {
@@ -276,9 +277,9 @@ mod tests {
         archive.unpack(dst.clone()).unwrap();
 
         let expected_immutable_path = dst.join(IMMUTABLE_DIR);
-        assert!(expected_immutable_path.join("00002.chunk").exists());
-        assert!(expected_immutable_path.join("00002.primary").exists());
-        assert!(expected_immutable_path.join("00002.secondary").exists());
+        assert!(expected_immutable_path.join("00003.chunk").exists());
+        assert!(expected_immutable_path.join("00003.primary").exists());
+        assert!(expected_immutable_path.join("00003.secondary").exists());
         let immutables_nb = std::fs::read_dir(expected_immutable_path).unwrap().count();
         assert_eq!(3, immutables_nb);
 

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -119,9 +119,13 @@ impl AncillaryArtifactBuilder {
             self.compression_algorithm.tar_file_extension()
         );
 
+        let ancillary_archive_path = Path::new("cardano-database")
+            .join("ancillary")
+            .join(&archive_name);
+
         let snapshot = self
             .snapshotter
-            .snapshot_subset(&archive_name, paths_to_include)
+            .snapshot_subset(&ancillary_archive_path, paths_to_include)
             .with_context(|| {
                 format!(
                     "Failed to create ancillary archive for immutable file number: {}",

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -2,6 +2,7 @@ use anyhow::Context;
 use async_trait::async_trait;
 use semver::Version;
 use slog::{debug, warn, Logger};
+use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -74,7 +75,7 @@ impl CardanoImmutableFilesFullArtifactBuilder {
         // spawn a separate thread to prevent blocking
         let ongoing_snapshot =
             tokio::task::spawn_blocking(move || -> StdResult<OngoingSnapshot> {
-                snapshotter.snapshot_all(&snapshot_name)
+                snapshotter.snapshot_all(Path::new(&snapshot_name))
             })
             .await??;
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -65,7 +65,7 @@ use crate::{
     },
     entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
-    file_uploaders::{FileUploader, GcpUploader},
+    file_uploaders::{FileUploader, GcpUploader, LocalUploader},
     http_server::{
         routes::router::{self, RouterConfig, RouterState},
         SERVER_BASE_PATH,
@@ -1226,8 +1226,7 @@ impl DependenciesBuilder {
                 message: format!("Could not parse server url:'{url}'."),
                 error: Some(e.into()),
             })?;
-        let local_uploader =
-            LocalSnapshotUploader::new(server_url_prefix, &snapshot_dir, logger.clone())?;
+        let local_uploader = LocalUploader::new(server_url_prefix, &snapshot_dir, logger.clone())?;
         let ancillary_builder = Arc::new(AncillaryArtifactBuilder::new(
             vec![Arc::new(local_uploader)],
             snapshotter,

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -81,7 +81,7 @@ use crate::{
     tools::{CExplorerSignerRetriever, GenesisToolsDependency, SignersImporter},
     AggregatorConfig, AggregatorRunner, AggregatorRuntime, CompressedArchiveSnapshotter,
     Configuration, DependencyContainer, DumbSnapshotter, DumbUploader, EpochSettingsStorer,
-    LocalUploader, MetricsService, MithrilSignerRegisterer, MultiSigner, MultiSignerImpl,
+    LocalSnapshotUploader, MetricsService, MithrilSignerRegisterer, MultiSigner, MultiSignerImpl,
     SingleSignatureAuthenticator, SnapshotUploaderType, Snapshotter,
     SnapshotterCompressionAlgorithm, VerificationKeyStorer,
 };
@@ -471,7 +471,7 @@ impl DependenciesBuilder {
                         logger.clone(),
                     )))
                 }
-                SnapshotUploaderType::Local => Ok(Arc::new(LocalUploader::new(
+                SnapshotUploaderType::Local => Ok(Arc::new(LocalSnapshotUploader::new(
                     format!(
                         "{}{}",
                         self.configuration.get_server_url(),
@@ -1206,7 +1206,7 @@ impl DependenciesBuilder {
                 error: Some(e.into()),
             }
         })?;
-        let local_uploader = LocalUploader::new(
+        let local_uploader = LocalSnapshotUploader::new(
             format!(
                 "{}{}",
                 self.configuration.get_server_url(),

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1225,7 +1225,7 @@ impl DependenciesBuilder {
             self.configuration.get_network()?,
             self.configuration.snapshot_compression_algorithm,
             logger.clone(),
-        ));
+        )?);
 
         Ok(CardanoDatabaseArtifactBuilder::new(
             self.configuration.db_directory.clone(),

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -65,7 +65,10 @@ use crate::{
     entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
     file_uploaders::{FileUploader, GcpUploader},
-    http_server::routes::router::{self, RouterConfig, RouterState},
+    http_server::{
+        routes::router::{self, RouterConfig, RouterState},
+        SERVER_BASE_PATH,
+    },
     services::{
         AggregatorSignableSeedBuilder, AggregatorUpkeepService, BufferedCertifierService,
         CardanoTransactionsImporter, CertifierService, EpochServiceDependencies, MessageService,
@@ -469,7 +472,11 @@ impl DependenciesBuilder {
                     )))
                 }
                 SnapshotUploaderType::Local => Ok(Arc::new(LocalUploader::new(
-                    self.configuration.get_server_url(),
+                    format!(
+                        "{}{}",
+                        self.configuration.get_server_url(),
+                        SERVER_BASE_PATH
+                    ),
                     &self.configuration.get_snapshot_dir()?,
                     logger,
                 ))),
@@ -1200,7 +1207,11 @@ impl DependenciesBuilder {
             }
         })?;
         let local_uploader = LocalUploader::new(
-            self.configuration.get_server_url(),
+            format!(
+                "{}{}",
+                self.configuration.get_server_url(),
+                SERVER_BASE_PATH
+            ),
             &snapshot_dir,
             logger.clone(),
         );

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1207,6 +1207,7 @@ impl DependenciesBuilder {
         let ancillary_builder = Arc::new(AncillaryArtifactBuilder::new(
             vec![Arc::new(local_uploader)],
             snapshotter,
+            self.configuration.get_network()?,
             self.configuration.snapshot_compression_algorithm,
             logger.clone(),
         ));

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -307,6 +307,19 @@ impl DependenciesBuilder {
         }
     }
 
+    fn get_server_url_prefix(&self) -> Result<Url> {
+        let url = format!(
+            "{}{}",
+            self.configuration.get_server_url(),
+            SERVER_BASE_PATH
+        );
+
+        Url::parse(&url).map_err(|e| DependenciesBuilderError::Initialization {
+            message: format!("Could not parse server url:'{url}'."),
+            error: Some(e.into()),
+        })
+    }
+
     /// Get the allowed signed entity types discriminants
     fn get_allowed_signed_entity_types_discriminants(
         &self,
@@ -472,24 +485,11 @@ impl DependenciesBuilder {
                         logger.clone(),
                     )))
                 }
-                SnapshotUploaderType::Local => {
-                    let url = format!(
-                        "{}{}",
-                        self.configuration.get_server_url(),
-                        SERVER_BASE_PATH
-                    );
-                    let server_url_prefix =
-                        Url::parse(&url).map_err(|e| DependenciesBuilderError::Initialization {
-                            message: format!("Could not parse server url:'{url}'."),
-                            error: Some(e.into()),
-                        })?;
-
-                    Ok(Arc::new(LocalSnapshotUploader::new(
-                        server_url_prefix,
-                        &self.configuration.get_snapshot_dir()?,
-                        logger,
-                    )?))
-                }
+                SnapshotUploaderType::Local => Ok(Arc::new(LocalSnapshotUploader::new(
+                    self.get_server_url_prefix()?,
+                    &self.configuration.get_snapshot_dir()?,
+                    logger,
+                )?)),
             }
         } else {
             Ok(Arc::new(DumbUploader::new()))
@@ -1216,17 +1216,9 @@ impl DependenciesBuilder {
                 error: Some(e.into()),
             }
         })?;
-        let url = format!(
-            "{}{}",
-            self.configuration.get_server_url(),
-            SERVER_BASE_PATH
-        );
-        let server_url_prefix =
-            Url::parse(&url).map_err(|e| DependenciesBuilderError::Initialization {
-                message: format!("Could not parse server url:'{url}'."),
-                error: Some(e.into()),
-            })?;
-        let local_uploader = LocalUploader::new(server_url_prefix, &snapshot_dir, logger.clone())?;
+
+        let local_uploader =
+            LocalUploader::new(self.get_server_url_prefix()?, &snapshot_dir, logger.clone())?;
         let ancillary_builder = Arc::new(AncillaryArtifactBuilder::new(
             vec![Arc::new(local_uploader)],
             snapshotter,

--- a/mithril-aggregator/src/file_uploaders/local_snapshot_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_snapshot_uploader.rs
@@ -9,8 +9,10 @@ use mithril_common::StdResult;
 use crate::file_uploaders::{FileUploader, FileUri};
 use crate::tools;
 
-/// LocalUploader is a file uploader working using local files
-pub struct LocalUploader {
+// TODO: This specific local uploader will be removed.
+// It's only used by the legacy snapshot that uploads the entire Cardano database.
+/// LocalSnapshotUploader is a file uploader working using local files
+pub struct LocalSnapshotUploader {
     /// File server URL prefix
     server_url_prefix: String,
 
@@ -20,11 +22,11 @@ pub struct LocalUploader {
     logger: Logger,
 }
 
-impl LocalUploader {
-    /// LocalUploader factory
+impl LocalSnapshotUploader {
+    /// LocalSnapshotUploader factory
     pub(crate) fn new(server_url_prefix: String, target_location: &Path, logger: Logger) -> Self {
         let logger = logger.new_with_component_name::<Self>();
-        debug!(logger, "New LocalUploader created"; "server_url_prefix" => &server_url_prefix);
+        debug!(logger, "New LocalSnapshotUploader created"; "server_url_prefix" => &server_url_prefix);
         Self {
             server_url_prefix,
             target_location: target_location.to_path_buf(),
@@ -34,7 +36,7 @@ impl LocalUploader {
 }
 
 #[async_trait]
-impl FileUploader for LocalUploader {
+impl FileUploader for LocalSnapshotUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<FileUri> {
         let archive_name = filepath.file_name().unwrap().to_str().unwrap();
         let target_path = &self.target_location.join(archive_name);
@@ -66,7 +68,7 @@ mod tests {
     use crate::file_uploaders::{FileUploader, FileUri};
     use crate::test_tools::TestLogger;
 
-    use super::LocalUploader;
+    use super::LocalSnapshotUploader;
 
     fn create_fake_archive(dir: &Path, digest: &str) -> PathBuf {
         let file_path = dir.join(format!("test.{digest}.tar.gz"));
@@ -92,7 +94,8 @@ mod tests {
         );
 
         let url_prefix = "http://test.com:8080/base-root".to_string();
-        let uploader = LocalUploader::new(url_prefix, target_dir.path(), TestLogger::stdout());
+        let uploader =
+            LocalSnapshotUploader::new(url_prefix, target_dir.path(), TestLogger::stdout());
         let location = uploader
             .upload(&archive)
             .await
@@ -107,7 +110,7 @@ mod tests {
         let target_dir = tempdir().unwrap();
         let digest = "41e27b9ed5a32531b95b2b7ff3c0757591a06a337efaf19a524a998e348028e7";
         let archive = create_fake_archive(source_dir.path(), digest);
-        let uploader = LocalUploader::new(
+        let uploader = LocalSnapshotUploader::new(
             "http://test.com:8080/base-root/".to_string(),
             target_dir.path(),
             TestLogger::stdout(),
@@ -126,7 +129,7 @@ mod tests {
         let digest = "41e27b9ed5a32531b95b2b7ff3c0757591a06a337efaf19a524a998e348028e7";
         create_fake_archive(source_dir.path(), digest);
         let target_dir = tempdir().unwrap();
-        let uploader = LocalUploader::new(
+        let uploader = LocalSnapshotUploader::new(
             "http://test.com:8080/base-root/".to_string(),
             target_dir.path(),
             TestLogger::stdout(),

--- a/mithril-aggregator/src/file_uploaders/local_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_uploader.rs
@@ -1,0 +1,157 @@
+use anyhow::Context;
+use async_trait::async_trait;
+use reqwest::Url;
+use slog::{debug, Logger};
+use std::path::{Path, PathBuf};
+
+use mithril_common::logging::LoggerExtensions;
+use mithril_common::StdResult;
+
+use crate::file_uploaders::{url_sanitizer::sanitize_url_path, FileUploader, FileUri};
+
+/// LocalUploader is a file uploader working using local files
+pub struct LocalUploader {
+    /// File server URL prefix
+    server_url_prefix: Url,
+
+    /// Target folder where to store files archive
+    target_location: PathBuf,
+
+    logger: Logger,
+}
+
+impl LocalUploader {
+    /// LocalUploader factory
+    pub(crate) fn new(
+        server_url_prefix: Url,
+        target_location: &Path,
+        logger: Logger,
+    ) -> StdResult<Self> {
+        let logger = logger.new_with_component_name::<Self>();
+        debug!(logger, "New LocalUploader created"; "server_url_prefix" => &server_url_prefix.as_str());
+        let server_url_prefix = sanitize_url_path(&server_url_prefix)?;
+
+        Ok(Self {
+            server_url_prefix,
+            target_location: target_location.to_path_buf(),
+            logger,
+        })
+    }
+}
+
+#[async_trait]
+impl FileUploader for LocalUploader {
+    async fn upload(&self, filepath: &Path) -> StdResult<FileUri> {
+        let archive_name = filepath.file_name().unwrap().to_str().unwrap();
+        let target_path = &self.target_location.join(archive_name);
+        tokio::fs::copy(filepath, target_path)
+            .await
+            .with_context(|| "File copy failure")?;
+
+        let location = &self
+            .server_url_prefix
+            .join("artifact/snapshot/")?
+            .join(archive_name)?;
+        let location = location.as_str().to_string();
+
+        debug!(self.logger, "File 'uploaded' to local storage"; "location" => &location);
+        Ok(FileUri(location))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::Write;
+    use std::path::{Path, PathBuf};
+
+    use mithril_common::test_utils::TempDir;
+
+    use crate::test_tools::TestLogger;
+
+    use super::*;
+
+    fn create_fake_archive(dir: &Path, name: &str) -> PathBuf {
+        let file_path = dir.join(format!("{name}.tar.gz"));
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(
+            file,
+            "I swear, this is an archive, not a temporary test file."
+        )
+        .unwrap();
+
+        file_path
+    }
+
+    #[tokio::test]
+    async fn should_extract_archive_name_to_deduce_location() {
+        let source_dir = TempDir::create(
+            "local_uploader",
+            "should_extract_archive_name_to_deduce_location_source",
+        );
+        let target_dir = TempDir::create(
+            "local_uploader",
+            "should_extract_archive_name_to_deduce_location_target",
+        );
+        let archive_name = "an_archive";
+        let archive = create_fake_archive(&source_dir, archive_name);
+        let expected_location = format!(
+            "http://test.com:8080/base-root/artifact/snapshot/{}",
+            &archive.file_name().unwrap().to_str().unwrap()
+        );
+
+        let url_prefix = Url::parse("http://test.com:8080/base-root").unwrap();
+        let uploader = LocalUploader::new(url_prefix, &target_dir, TestLogger::stdout()).unwrap();
+        let location = uploader
+            .upload(&archive)
+            .await
+            .expect("local upload should not fail");
+
+        assert_eq!(FileUri(expected_location), location);
+    }
+
+    #[tokio::test]
+    async fn should_copy_file_to_target_location() {
+        let source_dir = TempDir::create(
+            "local_uploader",
+            "should_copy_file_to_target_location_source",
+        );
+        let target_dir = TempDir::create(
+            "local_uploader",
+            "should_copy_file_to_target_location_target",
+        );
+        println!("target_dir: {:?}", target_dir);
+        let archive = create_fake_archive(&source_dir, "an_archive");
+        let uploader = LocalUploader::new(
+            Url::parse("http://test.com:8080/base-root/").unwrap(),
+            &target_dir,
+            TestLogger::stdout(),
+        )
+        .unwrap();
+        uploader.upload(&archive).await.unwrap();
+
+        assert!(target_dir.join(archive.file_name().unwrap()).exists());
+    }
+
+    #[tokio::test]
+    async fn should_error_if_path_is_a_directory() {
+        let source_dir = TempDir::create(
+            "local_uploader",
+            "should_error_if_path_is_a_directory_source",
+        );
+        let target_dir = TempDir::create(
+            "local_uploader",
+            "should_error_if_path_is_a_directory_target",
+        );
+        let uploader = LocalUploader::new(
+            Url::parse("http://test.com:8080/base-root/").unwrap(),
+            &target_dir,
+            TestLogger::stdout(),
+        )
+        .unwrap();
+        uploader
+            .upload(&source_dir)
+            .await
+            .expect_err("Uploading a directory should fail");
+    }
+}

--- a/mithril-aggregator/src/file_uploaders/mod.rs
+++ b/mithril-aggregator/src/file_uploaders/mod.rs
@@ -2,6 +2,7 @@ mod dumb_uploader;
 mod gcp_uploader;
 mod interface;
 mod local_snapshot_uploader;
+pub mod url_sanitizer;
 
 pub use dumb_uploader::*;
 pub use gcp_uploader::GcpUploader;

--- a/mithril-aggregator/src/file_uploaders/mod.rs
+++ b/mithril-aggregator/src/file_uploaders/mod.rs
@@ -2,6 +2,7 @@ mod dumb_uploader;
 mod gcp_uploader;
 mod interface;
 mod local_snapshot_uploader;
+mod local_uploader;
 pub mod url_sanitizer;
 
 pub use dumb_uploader::*;
@@ -9,6 +10,7 @@ pub use gcp_uploader::GcpUploader;
 pub use interface::FileUploader;
 pub use interface::FileUri;
 pub use local_snapshot_uploader::LocalSnapshotUploader;
+pub use local_uploader::LocalUploader;
 
 #[cfg(test)]
 pub use interface::MockFileUploader;

--- a/mithril-aggregator/src/file_uploaders/mod.rs
+++ b/mithril-aggregator/src/file_uploaders/mod.rs
@@ -1,13 +1,13 @@
 mod dumb_uploader;
 mod gcp_uploader;
 mod interface;
-mod local_uploader;
+mod local_snapshot_uploader;
 
 pub use dumb_uploader::*;
 pub use gcp_uploader::GcpUploader;
 pub use interface::FileUploader;
 pub use interface::FileUri;
-pub use local_uploader::LocalUploader;
+pub use local_snapshot_uploader::LocalSnapshotUploader;
 
 #[cfg(test)]
 pub use interface::MockFileUploader;

--- a/mithril-aggregator/src/file_uploaders/url_sanitizer.rs
+++ b/mithril-aggregator/src/file_uploaders/url_sanitizer.rs
@@ -1,0 +1,64 @@
+use anyhow::{anyhow, Context};
+use reqwest::Url;
+
+use mithril_common::StdResult;
+
+/// Sanitize URL path by removing empty segments and adding trailing slash
+pub fn sanitize_url_path(url: &Url) -> StdResult<Url> {
+    let segments_non_empty = url
+        .path_segments()
+        .map(|s| s.into_iter().filter(|s| !s.is_empty()).collect::<Vec<_>>())
+        .unwrap_or_default();
+    let mut url = url.clone();
+    {
+        let mut url_path_segments = url
+            .path_segments_mut()
+            .map_err(|e| anyhow!("error parsing URL: {e:?}"))
+            .with_context(|| "while sanitizing URL path: {url}")?;
+        let url_path_segments_cleared = url_path_segments.clear();
+        for segment in segments_non_empty {
+            url_path_segments_cleared.push(segment);
+        }
+        url_path_segments_cleared.push("");
+    }
+
+    Ok(url)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sanitize_url_path() {
+        let url = Url::parse("http://example.com/a//b/c.ext?test=123").unwrap();
+        assert_eq!(
+            "http://example.com/a/b/c.ext/?test=123",
+            sanitize_url_path(&url).unwrap().as_str()
+        );
+
+        let url = Url::parse("http://example.com/a//b/c.ext").unwrap();
+        assert_eq!(
+            "http://example.com/a/b/c.ext/",
+            sanitize_url_path(&url).unwrap().as_str()
+        );
+
+        let url = Url::parse("http://example.com/a//b/c").unwrap();
+        assert_eq!(
+            "http://example.com/a/b/c/",
+            sanitize_url_path(&url).unwrap().as_str()
+        );
+
+        let url = Url::parse("http://example.com/").unwrap();
+        assert_eq!(
+            "http://example.com/",
+            sanitize_url_path(&url).unwrap().as_str()
+        );
+
+        let url = Url::parse("http://example.com").unwrap();
+        assert_eq!(
+            "http://example.com/",
+            sanitize_url_path(&url).unwrap().as_str()
+        );
+    }
+}

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::configuration::{
 pub use crate::multi_signer::{MultiSigner, MultiSignerImpl};
 pub use commands::{CommandType, MainOpts};
 pub use dependency_injection::DependencyContainer;
-pub use file_uploaders::{DumbUploader, FileUploader, LocalUploader};
+pub use file_uploaders::{DumbUploader, FileUploader, LocalSnapshotUploader};
 pub use message_adapters::{FromRegisterSignerAdapter, ToCertificatePendingMessageAdapter};
 pub use metrics::*;
 pub use runtime::{

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -18,15 +18,11 @@ use crate::ZstandardCompressionParameters;
 
 /// Define the ability to create snapshots.
 pub trait Snapshotter: Sync + Send {
-    /// Create a new snapshot with the given archive name.
-    fn snapshot_all(&self, archive_name: &str) -> StdResult<OngoingSnapshot>;
+    /// Create a new snapshot with the given filepath.
+    fn snapshot_all(&self, filepath: &Path) -> StdResult<OngoingSnapshot>;
 
-    /// Create a new snapshot with the given archive name from a subset of directories and files.
-    fn snapshot_subset(
-        &self,
-        archive_name: &str,
-        files: Vec<PathBuf>,
-    ) -> StdResult<OngoingSnapshot>;
+    /// Create a new snapshot with the given filepath from a subset of directories and files.
+    fn snapshot_subset(&self, filepath: &Path, files: Vec<PathBuf>) -> StdResult<OngoingSnapshot>;
 }
 
 /// Compression algorithm and parameters of the [CompressedArchiveSnapshotter].
@@ -161,17 +157,17 @@ pub enum SnapshotError {
 }
 
 impl Snapshotter for CompressedArchiveSnapshotter {
-    fn snapshot_all(&self, archive_name: &str) -> StdResult<OngoingSnapshot> {
+    fn snapshot_all(&self, filepath: &Path) -> StdResult<OngoingSnapshot> {
         let appender = AppenderDirAll {
             db_directory: self.db_directory.clone(),
         };
 
-        self.snapshot(archive_name, appender)
+        self.snapshot(filepath, appender)
     }
 
     fn snapshot_subset(
         &self,
-        archive_name: &str,
+        filepath: &Path,
         entries: Vec<PathBuf>,
     ) -> StdResult<OngoingSnapshot> {
         if entries.is_empty() {
@@ -183,7 +179,7 @@ impl Snapshotter for CompressedArchiveSnapshotter {
             entries,
         };
 
-        self.snapshot(archive_name, appender)
+        self.snapshot(filepath, appender)
     }
 }
 
@@ -222,12 +218,16 @@ impl CompressedArchiveSnapshotter {
         })
     }
 
-    fn snapshot<T: TarAppender>(
-        &self,
-        archive_name: &str,
-        appender: T,
-    ) -> StdResult<OngoingSnapshot> {
-        let archive_path = self.ongoing_snapshot_directory.join(archive_name);
+    fn snapshot<T: TarAppender>(&self, filepath: &Path, appender: T) -> StdResult<OngoingSnapshot> {
+        let archive_path = self.ongoing_snapshot_directory.join(filepath);
+        if let Some(archive_dir) = archive_path.parent() {
+            fs::create_dir_all(archive_dir).with_context(|| {
+                format!(
+                    "Can not create archive directory: '{}'",
+                    archive_dir.display()
+                )
+            })?;
+        }
         let filesize = self.create_and_verify_archive(&archive_path, appender).inspect_err(|_err| {
             if archive_path.exists() {
                 if let Err(remove_error) = fs::remove_file(&archive_path) {
@@ -261,7 +261,11 @@ impl CompressedArchiveSnapshotter {
             archive_path.display()
         );
 
-        let tar_file = File::create(archive_path).map_err(SnapshotError::CreateArchiveError)?;
+        let tar_file = File::create(archive_path)
+            .map_err(SnapshotError::CreateArchiveError)
+            .with_context(|| {
+                format!("Error while creating the archive with path: {archive_path:?}")
+            })?;
 
         match self.compression_algorithm {
             SnapshotterCompressionAlgorithm::Gzip => {
@@ -466,13 +470,13 @@ impl Default for DumbSnapshotter {
 }
 
 impl Snapshotter for DumbSnapshotter {
-    fn snapshot_all(&self, archive_name: &str) -> StdResult<OngoingSnapshot> {
+    fn snapshot_all(&self, archive_name: &Path) -> StdResult<OngoingSnapshot> {
         let mut value = self
             .last_snapshot
             .write()
             .map_err(|e| SnapshotError::UploadFileError(e.to_string()))?;
         let snapshot = OngoingSnapshot {
-            filepath: Path::new(archive_name).to_path_buf(),
+            filepath: archive_name.to_path_buf(),
             filesize: 0,
         };
         *value = Some(snapshot.clone());
@@ -482,7 +486,7 @@ impl Snapshotter for DumbSnapshotter {
 
     fn snapshot_subset(
         &self,
-        archive_name: &str,
+        archive_name: &Path,
         _files: Vec<PathBuf>,
     ) -> StdResult<OngoingSnapshot> {
         self.snapshot_all(archive_name)
@@ -535,13 +539,15 @@ mod tests {
     #[test]
     fn test_dumb_snapshotter_snasphot_return_archive_name_with_size_0() {
         let snapshotter = DumbSnapshotter::new();
-        let snapshot = snapshotter.snapshot_all("archive.tar.gz").unwrap();
+        let snapshot = snapshotter
+            .snapshot_all(Path::new("archive.tar.gz"))
+            .unwrap();
 
         assert_eq!(PathBuf::from("archive.tar.gz"), *snapshot.get_file_path());
         assert_eq!(0, *snapshot.get_file_size());
 
         let snapshot = snapshotter
-            .snapshot_subset("archive.tar.gz", vec![PathBuf::from("whatever")])
+            .snapshot_subset(Path::new("archive.tar.gz"), vec![PathBuf::from("whatever")])
             .unwrap();
         assert_eq!(PathBuf::from("archive.tar.gz"), *snapshot.get_file_path());
         assert_eq!(0, *snapshot.get_file_size());
@@ -556,7 +562,7 @@ mod tests {
             .is_none());
 
         let snapshot = snapshotter
-            .snapshot_all("whatever")
+            .snapshot_all(Path::new("whatever"))
             .expect("Dumb snapshotter::snapshot should not fail.");
         assert_eq!(
             Some(snapshot),
@@ -566,7 +572,7 @@ mod tests {
         );
 
         let snapshot = snapshotter
-            .snapshot_subset("another_whatever", vec![PathBuf::from("subdir")])
+            .snapshot_subset(Path::new("another_whatever"), vec![PathBuf::from("subdir")])
             .expect("Dumb snapshotter::snapshot should not fail.");
         assert_eq!(
             Some(snapshot),
@@ -641,7 +647,7 @@ mod tests {
         File::create(pending_snapshot_directory.join("other-process.file")).unwrap();
 
         let _ = snapshotter
-            .snapshot_all("whatever.tar.gz")
+            .snapshot_all(Path::new("whatever.tar.gz"))
             .expect_err("Snapshotter::snapshot should fail if the db is empty.");
         let remaining_files: Vec<String> = fs::read_dir(&pending_snapshot_directory)
             .unwrap()
@@ -687,7 +693,7 @@ mod tests {
             .expect("verify_archive should not fail");
 
         snapshotter
-            .snapshot_all(pending_snapshot_archive_file)
+            .snapshot_all(Path::new(pending_snapshot_archive_file))
             .expect("Snapshotter::snapshot should not fail.");
     }
 
@@ -728,7 +734,7 @@ mod tests {
             .expect("verify_archive should not fail");
 
         snapshotter
-            .snapshot_all(pending_snapshot_archive_file)
+            .snapshot_all(Path::new(pending_snapshot_archive_file))
             .expect("Snapshotter::snapshot should not fail.");
     }
 
@@ -753,7 +759,7 @@ mod tests {
 
         let snapshot = snapshotter
             .snapshot_subset(
-                &random_archive_name(),
+                Path::new(&random_archive_name()),
                 vec![
                     directory_to_archive_path.clone(),
                     file_to_archive_path.clone(),
@@ -784,7 +790,10 @@ mod tests {
         .unwrap();
 
         snapshotter
-            .snapshot_subset(&random_archive_name(), vec![PathBuf::from("not_exist")])
+            .snapshot_subset(
+                Path::new(&random_archive_name()),
+                vec![PathBuf::from("not_exist")],
+            )
             .expect_err("snapshot_subset should return error when file or directory not exist");
     }
 
@@ -803,7 +812,7 @@ mod tests {
         .unwrap();
 
         snapshotter
-            .snapshot_subset(&random_archive_name(), vec![])
+            .snapshot_subset(Path::new(&random_archive_name()), vec![])
             .expect_err("snapshot_subset should return error when entries is empty");
     }
 
@@ -826,7 +835,7 @@ mod tests {
 
         let snapshot = snapshotter
             .snapshot_subset(
-                &random_archive_name(),
+                Path::new(&random_archive_name()),
                 vec![
                     directory_to_archive_path.clone(),
                     directory_to_archive_path.clone(),

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -495,7 +495,7 @@ mod tests {
 
     use uuid::Uuid;
 
-    use mithril_common::{digesters::DummyImmutablesDbBuilder, test_utils::TempDir};
+    use mithril_common::{digesters::DummyCardanoDbBuilder, test_utils::TempDir};
 
     use crate::test_tools::TestLogger;
 
@@ -658,7 +658,7 @@ mod tests {
         let pending_snapshot_archive_file = "archive.tar.gz";
         let db_directory = test_dir.join("db");
 
-        DummyImmutablesDbBuilder::new(db_directory.as_os_str().to_str().unwrap())
+        DummyCardanoDbBuilder::new(db_directory.as_os_str().to_str().unwrap())
             .with_immutables(&[1, 2, 3])
             .append_immutable_trio()
             .build();
@@ -699,7 +699,7 @@ mod tests {
         let pending_snapshot_archive_file = "archive.tar.zst";
         let db_directory = test_dir.join("db");
 
-        DummyImmutablesDbBuilder::new(db_directory.as_os_str().to_str().unwrap())
+        DummyCardanoDbBuilder::new(db_directory.as_os_str().to_str().unwrap())
             .with_immutables(&[1, 2, 3])
             .append_immutable_trio()
             .build();

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.10.6"
+version = "0.10.7"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/tests/snapshot_list_get_show_download_verify.rs
+++ b/mithril-client/tests/snapshot_list_get_show_download_verify.rs
@@ -4,7 +4,7 @@ use crate::extensions::fake::{FakeAggregator, FakeCertificateVerifier};
 use mithril_client::aggregator_client::AggregatorRequest;
 use mithril_client::feedback::SlogFeedbackReceiver;
 use mithril_client::{ClientBuilder, MessageBuilder};
-use mithril_common::digesters::DummyImmutablesDbBuilder;
+use mithril_common::digesters::DummyCardanoDbBuilder;
 use std::sync::Arc;
 
 #[tokio::test]
@@ -14,13 +14,13 @@ async fn snapshot_list_get_show_download_verify() {
         mithril_common::test_utils::fake_keys::genesis_verification_key()[0];
     let digest = "snapshot_digest";
     let certificate_hash = "certificate_hash";
-    let immutable_db = DummyImmutablesDbBuilder::new("snapshot_list_get_show_download_verify_db")
+    let cardano_db = DummyCardanoDbBuilder::new("snapshot_list_get_show_download_verify_db")
         .with_immutables(&[1, 2, 3])
         .append_immutable_trio()
         .build();
     let fake_aggregator = FakeAggregator::new();
     let test_http_server = fake_aggregator
-        .spawn_with_snapshot(digest, certificate_hash, &immutable_db, &work_dir)
+        .spawn_with_snapshot(digest, certificate_hash, &cardano_db, &work_dir)
         .await;
     let client = ClientBuilder::aggregator(&test_http_server.url(), genesis_verification_key)
         .with_certificate_verifier(FakeCertificateVerifier::build_that_validate_any_certificate())

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.100"
+version = "0.4.101"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/digesters/dummy_cardano_db.rs
+++ b/mithril-common/src/digesters/dummy_cardano_db.rs
@@ -6,31 +6,21 @@ use std::{
     path::{Path, PathBuf},
 };
 
-const IMMUTABLE_DIR: &str = "immutable";
-const LEDGER_DIR: &str = "ledger";
-const VOLATILE_DIR: &str = "volatile";
-
-/// A [DummyImmutableDb] builder.
-pub struct DummyImmutablesDbBuilder {
-    dir: PathBuf,
-    immutables_to_write: Vec<ImmutableFileNumber>,
-    non_immutables_to_write: Vec<String>,
-    append_uncompleted_trio: bool,
-    immutable_file_size: Option<u64>,
-    ledger_files_to_write: Vec<String>,
-    ledger_file_size: Option<u64>,
-    volatile_files_to_write: Vec<String>,
-    volatile_file_size: Option<u64>,
-}
+/// Directory name for the immutable files.
+pub const IMMUTABLE_DIR: &str = "immutable";
+/// Directory name for the ledger files.
+pub const LEDGER_DIR: &str = "ledger";
+/// Directory name for the volatile files.
+pub const VOLATILE_DIR: &str = "volatile";
 
 /// A dummy cardano immutable db.
-pub struct DummyImmutableDb {
+struct DummyImmutableDb {
     /// The dummy cardano db directory path.
-    pub dir: PathBuf,
+    dir: PathBuf,
     /// The [immutables files][ImmutableFile] in the dummy cardano db.
-    pub immutables_files: Vec<ImmutableFile>,
+    immutables_files: Vec<ImmutableFile>,
     /// Files that doesn't follow the immutable file name scheme in the dummy cardano db.
-    pub non_immutables_files: Vec<PathBuf>,
+    non_immutables_files: Vec<PathBuf>,
 }
 
 impl DummyImmutableDb {
@@ -50,12 +40,66 @@ impl DummyImmutableDb {
     }
 }
 
-impl DummyImmutablesDbBuilder {
-    /// [DummyImmutablesDbBuilder] factory, will create a folder with the given `dirname` in the
+/// A dummy cardano db.
+pub struct DummyCardanoDb {
+    /// The dummy cardano db directory path.
+    dir: PathBuf,
+
+    /// Dummy immutable db
+    immutable_db: DummyImmutableDb,
+}
+
+impl DummyCardanoDb {
+    /// Return the cardano db directory path.
+    pub fn get_dir(&self) -> &PathBuf {
+        &self.dir
+    }
+
+    /// Return the immutable db directory path.
+    pub fn get_immutable_dir(&self) -> &PathBuf {
+        &self.immutable_db.dir
+    }
+
+    /// Return the file number of the last immutable
+    pub fn get_immutable_files(&self) -> &Vec<ImmutableFile> {
+        &self.immutable_db.immutables_files
+    }
+
+    /// Add an immutable chunk file and its primary & secondary to the dummy DB.
+    pub fn add_immutable_file(&mut self) -> ImmutableFileNumber {
+        self.immutable_db.add_immutable_file()
+    }
+
+    /// Return the file number of the last immutable
+    pub fn last_immutable_number(&self) -> Option<ImmutableFileNumber> {
+        self.immutable_db.last_immutable_number()
+    }
+
+    /// Return the non immutables files in the immutables directory
+    pub fn get_non_immutables_files(&self) -> &Vec<PathBuf> {
+        &self.immutable_db.non_immutables_files
+    }
+}
+
+/// A [DummyCardanoDbBuilder] builder.
+pub struct DummyCardanoDbBuilder {
+    sub_dir: String,
+    immutables_to_write: Vec<ImmutableFileNumber>,
+    non_immutables_to_write: Vec<String>,
+    append_uncompleted_trio: bool,
+    immutable_file_size: Option<u64>,
+    ledger_files_to_write: Vec<String>,
+    ledger_file_size: Option<u64>,
+    volatile_files_to_write: Vec<String>,
+    volatile_file_size: Option<u64>,
+}
+
+impl DummyCardanoDbBuilder {
+    /// [DummyCardanoDbBuilder] factory, will create a folder with the given `dirname` in the
     /// system temp directory, if it exists already it will be cleaned.
     pub fn new(dir_name: &str) -> Self {
         Self {
-            dir: get_test_dir(dir_name),
+            sub_dir: dir_name.to_string(),
             immutables_to_write: vec![],
             non_immutables_to_write: vec![],
             append_uncompleted_trio: false,
@@ -125,8 +169,10 @@ impl DummyImmutablesDbBuilder {
         self
     }
 
-    /// Build a [DummyImmutableDb].
-    pub fn build(&self) -> DummyImmutableDb {
+    /// Build a [DummyCardanoDb].
+    pub fn build(&self) -> DummyCardanoDb {
+        let dir = get_test_dir(&self.sub_dir);
+
         let mut non_immutables_files = vec![];
         let mut immutable_numbers = self.immutables_to_write.clone();
         immutable_numbers.sort();
@@ -134,7 +180,7 @@ impl DummyImmutablesDbBuilder {
         if self.append_uncompleted_trio {
             write_immutable_trio(
                 self.immutable_file_size,
-                &self.dir.join(IMMUTABLE_DIR),
+                &dir.join(IMMUTABLE_DIR),
                 match immutable_numbers.last() {
                     None => 0,
                     Some(last) => last + 1,
@@ -145,37 +191,31 @@ impl DummyImmutablesDbBuilder {
         for non_immutable in &self.non_immutables_to_write {
             non_immutables_files.push(write_dummy_file(
                 self.immutable_file_size,
-                &self.dir.join(IMMUTABLE_DIR),
+                &dir.join(IMMUTABLE_DIR),
                 non_immutable,
             ));
         }
 
         for filename in &self.ledger_files_to_write {
-            write_dummy_file(self.ledger_file_size, &self.dir.join(LEDGER_DIR), filename);
+            write_dummy_file(self.ledger_file_size, &dir.join(LEDGER_DIR), filename);
         }
 
         for filename in &self.volatile_files_to_write {
-            write_dummy_file(
-                self.volatile_file_size,
-                &self.dir.join(VOLATILE_DIR),
-                filename,
-            );
+            write_dummy_file(self.volatile_file_size, &dir.join(VOLATILE_DIR), filename);
         }
 
-        DummyImmutableDb {
-            dir: self.dir.join(IMMUTABLE_DIR),
+        let immutable_db = DummyImmutableDb {
+            dir: dir.join(IMMUTABLE_DIR),
             immutables_files: immutable_numbers
                 .into_iter()
                 .flat_map(|ifn| {
-                    write_immutable_trio(
-                        self.immutable_file_size,
-                        &self.dir.join(IMMUTABLE_DIR),
-                        ifn,
-                    )
+                    write_immutable_trio(self.immutable_file_size, &dir.join(IMMUTABLE_DIR), ifn)
                 })
                 .collect::<Vec<_>>(),
             non_immutables_files,
-        }
+        };
+
+        DummyCardanoDb { dir, immutable_db }
     }
 }
 

--- a/mithril-common/src/digesters/dummy_cardano_db.rs
+++ b/mithril-common/src/digesters/dummy_cardano_db.rs
@@ -1,17 +1,13 @@
 use crate::test_utils::TempDir;
-use crate::{digesters::ImmutableFile, entities::ImmutableFileNumber};
+use crate::{
+    digesters::{ImmutableFile, IMMUTABLE_DIR, LEDGER_DIR, VOLATILE_DIR},
+    entities::ImmutableFileNumber,
+};
 use std::{
     fs::File,
     io::prelude::Write,
     path::{Path, PathBuf},
 };
-
-/// Directory name for the immutable files.
-pub const IMMUTABLE_DIR: &str = "immutable";
-/// Directory name for the ledger files.
-pub const LEDGER_DIR: &str = "ledger";
-/// Directory name for the volatile files.
-pub const VOLATILE_DIR: &str = "volatile";
 
 /// A dummy cardano immutable db.
 struct DummyImmutableDb {

--- a/mithril-common/src/digesters/mod.rs
+++ b/mithril-common/src/digesters/mod.rs
@@ -17,8 +17,15 @@ pub use immutable_file_observer::{
 
 pub use dumb_immutable_digester::DumbImmutableDigester;
 
+/// Directory name for the immutable files.
+pub const IMMUTABLE_DIR: &str = "immutable";
+/// Directory name for the ledger files.
+pub const LEDGER_DIR: &str = "ledger";
+/// Directory name for the volatile files.
+pub const VOLATILE_DIR: &str = "volatile";
+
 cfg_test_tools! {
     mod dummy_cardano_db;
 
-    pub use dummy_cardano_db::{DummyCardanoDb, DummyCardanoDbBuilder, IMMUTABLE_DIR, LEDGER_DIR, VOLATILE_DIR};
+    pub use dummy_cardano_db::{DummyCardanoDb, DummyCardanoDbBuilder};
 }

--- a/mithril-common/src/digesters/mod.rs
+++ b/mithril-common/src/digesters/mod.rs
@@ -18,7 +18,7 @@ pub use immutable_file_observer::{
 pub use dumb_immutable_digester::DumbImmutableDigester;
 
 cfg_test_tools! {
-    mod dummy_immutable_db_builder;
+    mod dummy_cardano_db;
 
-    pub use dummy_immutable_db_builder::{DummyImmutableDb, DummyImmutablesDbBuilder};
+    pub use dummy_cardano_db::{DummyCardanoDb, DummyCardanoDbBuilder, IMMUTABLE_DIR, LEDGER_DIR, VOLATILE_DIR};
 }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.59"
+version = "0.4.60"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content

This PR updates the `AncillaryArtifactBuilder` to include the creation of an archive from the ancillary files of the Cardano database. The archive contains:
- The `/ledger` directory and its content.
- The `/volatile` directory and its content.
- The `/immutable` directory, including the latest trio of immutable files (`.chunk`, `.primary`, `.secondary`).

Additionally, the returned locations for downloading the archive are now referenced in the artifact.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #2151 
