### PR TITLE
Fix: `CardanoDatabase` artifacts verification in e2e test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,7 +3817,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.56"
+version = "0.4.57"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/docs/website/blog/2024-12-17-era-switch-pythagoras.md
+++ b/docs/website/blog/2024-12-17-era-switch-pythagoras.md
@@ -7,7 +7,7 @@ tags: [era, switch, thales, pythagoras]
 
 ### Era switch to Pythagoras
 
-We have introduced the **Pythagoras era** in the Mithril networks. The era switch to `Pythagoras` is a significant milestone that brings new features and improvements to the Mithril protocol.
+We have introduced the **Pythagoras era** in the Mithril networks. The era switch to `Pythagoras` is a significant milestone that brings new features and security improvements to the Mithril protocol.
 
 :::danger
 

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.56"
+version = "0.4.57"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -9,6 +9,7 @@ pub struct Spec<'a> {
     pub infrastructure: &'a mut MithrilInfrastructure,
     is_signing_cardano_transactions: bool,
     is_signing_cardano_stake_distribution: bool,
+    is_signing_cardano_database: bool,
     next_era: Option<String>,
     regenesis_on_era_switch: bool,
 }
@@ -29,6 +30,11 @@ impl<'a> Spec<'a> {
             ),
             is_signing_cardano_stake_distribution: signed_entity_types.contains(
                 &SignedEntityTypeDiscriminants::CardanoStakeDistribution
+                    .as_ref()
+                    .to_string(),
+            ),
+            is_signing_cardano_database: signed_entity_types.contains(
+                &SignedEntityTypeDiscriminants::CardanoDatabase
                     .as_ref()
                     .to_string(),
             ),
@@ -181,7 +187,7 @@ impl<'a> Spec<'a> {
         }
 
         // Verify that Cardano database snapshot artifacts are produced and signed correctly
-        {
+        if self.is_signing_cardano_database {
             let merkle_root =
                 assertions::assert_node_producing_cardano_database_snapshot(&aggregator_endpoint)
                     .await?;


### PR DESCRIPTION
## Content

This PR includes a fix to **verify the `CardanoDatabase` artifacts in the e2e test only if the signed entity type is activated**.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #2193
