### PR TITLE
Fix: `CardanoDatabase` artifact identifier collisions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.7"
+version = "0.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3738,7 +3738,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.99"
+version = "0.4.100"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3809,7 +3809,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.58"
+version = "0.4.59"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.7"
+version = "0.6.8"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -177,6 +177,7 @@ impl TryFrom<SignedEntityRecord> for CardanoDatabaseSnapshotMessage {
     fn try_from(value: SignedEntityRecord) -> Result<Self, Self::Error> {
         let artifact = serde_json::from_str::<CardanoDatabaseSnapshot>(&value.artifact)?;
         let cardano_database_snapshot_message = CardanoDatabaseSnapshotMessage {
+            hash: artifact.hash,
             merkle_root: artifact.merkle_root,
             beacon: artifact.beacon,
             certificate_hash: value.certificate_id,
@@ -197,6 +198,7 @@ impl TryFrom<SignedEntityRecord> for CardanoDatabaseSnapshotListItemMessage {
     fn try_from(value: SignedEntityRecord) -> Result<Self, Self::Error> {
         let artifact = serde_json::from_str::<CardanoDatabaseSnapshot>(&value.artifact)?;
         let cardano_database_snapshot_list_item_message = CardanoDatabaseSnapshotListItemMessage {
+            hash: artifact.hash,
             merkle_root: artifact.merkle_root,
             beacon: artifact.beacon,
             certificate_hash: value.certificate_id,

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_database.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_database.rs
@@ -235,7 +235,7 @@ mod tests {
     async fn test_cardano_database_detail_increments_artifact_detail_total_served_since_startup_metric(
     ) {
         let method = Method::GET.as_str();
-        let path = "/artifact/cardano-database/{merkle_root}";
+        let path = "/artifact/cardano-database/{hash}";
         let dependency_manager = Arc::new(initialize_dependencies().await);
         let initial_counter_value = dependency_manager
             .metrics_service
@@ -270,7 +270,7 @@ mod tests {
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
-        let path = "/artifact/cardano-database/{merkle_root}";
+        let path = "/artifact/cardano-database/{hash}";
 
         let response = request()
             .method(method)
@@ -304,7 +304,7 @@ mod tests {
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
-        let path = "/artifact/cardano-database/{merkle_root}";
+        let path = "/artifact/cardano-database/{hash}";
 
         let response = request()
             .method(method)
@@ -337,7 +337,7 @@ mod tests {
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
-        let path = "/artifact/cardano-database/{merkle_root}";
+        let path = "/artifact/cardano-database/{hash}";
 
         let response = request()
             .method(method)

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.99"
+version = "0.4.100"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/messages/cardano_database.rs
+++ b/mithril-common/src/messages/cardano_database.rs
@@ -30,6 +30,9 @@ impl From<ArtifactsLocations> for ArtifactsLocationsMessagePart {
 /// Cardano database snapshot.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CardanoDatabaseSnapshotMessage {
+    /// Hash of the Cardano database snapshot.
+    pub hash: String,
+
     /// Merkle root of the Cardano database snapshot.
     pub merkle_root: String,
 
@@ -59,6 +62,7 @@ impl CardanoDatabaseSnapshotMessage {
     /// Return a dummy test entity (test-only).
     pub fn dummy() -> Self {
         Self {
+            hash: "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb".to_string(),
             merkle_root: "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6"
                 .to_string(),
             beacon: CardanoDbBeacon {
@@ -99,6 +103,7 @@ mod tests {
 
     const ACTUAL_JSON: &str = r#"
     {
+        "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
         "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
         "beacon": {
             "epoch": 123,
@@ -137,6 +142,7 @@ mod tests {
 
     fn golden_actual_message() -> CardanoDatabaseSnapshotMessage {
         CardanoDatabaseSnapshotMessage {
+            hash: "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb".to_string(),
             merkle_root: "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6"
                 .to_string(),
             beacon: CardanoDbBeacon {

--- a/mithril-common/src/messages/cardano_database_list.rs
+++ b/mithril-common/src/messages/cardano_database_list.rs
@@ -9,6 +9,9 @@ pub type CardanoDatabaseSnapshotListMessage = Vec<CardanoDatabaseSnapshotListIte
 /// Message structure of a Cardano database snapshot list item
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CardanoDatabaseSnapshotListItemMessage {
+    /// Hash of the Cardano database snapshot.
+    pub hash: String,
+
     /// Merkle root of the Cardano database snapshot
     pub merkle_root: String,
 
@@ -35,6 +38,7 @@ impl CardanoDatabaseSnapshotListItemMessage {
     /// Return a dummy test entity (test-only).
     pub fn dummy() -> Self {
         Self {
+            hash: "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb".to_string(),
             merkle_root: "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6"
                 .to_string(),
             beacon: CardanoDbBeacon {
@@ -60,6 +64,7 @@ mod tests {
     const ACTUAL_JSON: &str = r#"
     [
         {
+            "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
             "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
             "beacon": {
                 "epoch": 123,
@@ -75,6 +80,7 @@ mod tests {
 
     fn golden_actual_message() -> CardanoDatabaseSnapshotListMessage {
         vec![CardanoDatabaseSnapshotListItemMessage {
+            hash: "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb".to_string(),
             merkle_root: "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6"
                 .to_string(),
             beacon: CardanoDbBeacon {

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.58"
+version = "0.4.59"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -188,12 +188,12 @@ impl<'a> Spec<'a> {
 
         // Verify that Cardano database snapshot artifacts are produced and signed correctly
         if self.is_signing_cardano_database {
-            let merkle_root =
+            let hash =
                 assertions::assert_node_producing_cardano_database_snapshot(&aggregator_endpoint)
                     .await?;
             let certificate_hash = assertions::assert_signer_is_signing_cardano_database_snapshot(
                 &aggregator_endpoint,
-                &merkle_root,
+                &hash,
                 expected_epoch_min,
             )
             .await?;

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.39
+  version: 0.1.40
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -297,15 +297,15 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
 
-  /artifact/cardano-database/{merkle_root}:
+  /artifact/cardano-database/{hash}:
     get:
       summary: Get Cardano database snapshot information
       description: |
         Returns the information of a Cardano database snapshot and where to retrieve its binary contents
       parameters:
-        - name: merkle_root
+        - name: hash
           in: path
-          description: Merkle root of the Cardano database snapshot
+          description: Hash of the Cardano database snapshot
           required: true
           schema:
             type: string
@@ -1900,6 +1900,7 @@ components:
       examples:
         [
           {
+            "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
             "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
             "beacon":
               {
@@ -1920,12 +1921,17 @@ components:
       type: object
       additionalProperties: false
       required:
+        - hash
         - merkle_root
         - beacon
         - certificate_hash
         - total_db_size_uncompressed
         - created_at
       properties:
+        hash:
+          description: Hash of the Cardano database snapshot
+          type: string
+          format: bytes
         merkle_root:
           description: Merkle root of the Cardano database snapshot
           type: string
@@ -1952,6 +1958,7 @@ components:
           type: string
       examples:
         {
+          "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
           "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
           "beacon":
             {
@@ -1971,6 +1978,7 @@ components:
       type: object
       additionalProperties: false
       required:
+        - hash
         - merkle_root
         - beacon
         - certificate_hash
@@ -1978,6 +1986,10 @@ components:
         - created_at
         - locations
       properties:
+        hash:
+          description: Hash of the Cardano database snapshot
+          type: string
+          format: bytes
         merkle_root:
           description: Merkle root of the Cardano database snapshot
           type: string
@@ -2006,6 +2018,7 @@ components:
           type: string
       examples:
         {
+          "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
           "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
           "beacon":
             {


### PR DESCRIPTION
## Content

This PR includes a **fix to avoid collisions of the `CardanoDatabase` artifacts** when a snapshot is taken for the same immutable file number at two different epochs.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #2197
