### PR TITLE
Fix: execute Wasm tests on node in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Test 'mithril-client-wasm' - NodeJS
         shell: bash
         run: |
-          wasm-pack test --node mithril-client-wasm --release
+          wasm-pack test --node mithril-client-wasm --release --features test-node
 
       - name: Publish Mithril Distribution (WASM)
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,11 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3719,7 +3719,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.3",
+      "version": "0.7.5",
       "license": "Apache-2.0"
     },
     "node_modules/@mithril-dev/mithril-client-wasm": {

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.3",
+      "version": "0.7.5",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -34,6 +34,7 @@ mithril-build-script = { path = "../internal/mithril-build-script" }
 [features]
 # Include nothing by default
 default = []
+test-node = []
 
 [package.metadata.docs.rs]
 all-features = true

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.7.4"
+version = "0.7.5"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/Makefile
+++ b/mithril-client-wasm/Makefile
@@ -15,12 +15,15 @@ build:
 test:
 	pkill -f "mithril-aggregator-fake" || true
 	${CARGO} run -p mithril-aggregator-fake -- -p 8000 &
-	if wasm-pack test --headless --firefox --chrome --node --release; then \
+	if ! wasm-pack test --headless --firefox --chrome --release; then \
 		pkill -f "mithril-aggregator-fake" || true; \
-	else \
+        exit 1; \
+    fi
+	if ! wasm-pack test --node --release --features test-node; then \
 		pkill -f "mithril-aggregator-fake" || true; \
 		exit 1; \
 	fi
+	pkill -f "mithril-aggregator-fake" || true
 
 check:
 	${CARGO} check --release --all-features --all-targets

--- a/mithril-client-wasm/ci-test/package-lock.json
+++ b/mithril-client-wasm/ci-test/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/package.json
+++ b/mithril-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithril-dev/mithril-client-wasm",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Mithril client WASM",
   "license": "Apache-2.0",
   "collaborators": [

--- a/mithril-client-wasm/src/certificate_verification_cache.rs
+++ b/mithril-client-wasm/src/certificate_verification_cache.rs
@@ -151,7 +151,7 @@ impl CertificateVerifierCache for LocalStorageCertificateVerifierCache {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "test-node")))]
 pub(crate) mod test_tools {
     use std::collections::HashMap;
 
@@ -249,7 +249,7 @@ pub(crate) mod test_tools {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(feature = "test-node")))]
 mod tests {
     use std::collections::HashMap;
     use wasm_bindgen_test::*;

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -477,6 +477,7 @@ mod tests {
         get_mithril_client(options)
     }
 
+    #[cfg(not(feature = "test-node"))]
     wasm_bindgen_test_configure!(run_in_browser);
 
     #[wasm_bindgen_test]

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -42,9 +42,9 @@ impl JSBroadcastChannelFeedbackReceiver {
 impl FeedbackReceiver for JSBroadcastChannelFeedbackReceiver {
     async fn handle_event(&self, event: MithrilEvent) {
         let event = MithrilEventWasm::from(event);
-        let _ = web_sys::BroadcastChannel::new(&self.channel)
-            .unwrap()
-            .post_message(&serde_wasm_bindgen::to_value(&event).unwrap());
+        let bc = web_sys::BroadcastChannel::new(&self.channel).unwrap();
+        let _ = bc.post_message(&serde_wasm_bindgen::to_value(&event).unwrap());
+        bc.close();
     }
 }
 

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm/dist/web": {
       "name": "mithril-client-wasm",
-      "version": "0.7.4",
+      "version": "0.7.5",
       "license": "Apache-2.0"
     },
     "node_modules/@aashutoshrathi/word-wrap": {


### PR DESCRIPTION
## Content

This PR includes several updates to enable running Wasm tests in Node environments:
- Adds a `test-node` feature to the `mithril-client-wasm` crate to skip code that isn't compatible with Node.
- Upgrades the default Node version from `18` to `22` in the `build-test-wasm` step of the CI, ensuring `wasm-pack test` runs smoothly with node.
- Closes the `BroadcastChannel` after usage in `handle_event`, preventing Wasm tests from hanging indefinitely with node.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2138 
