### PR TITLE
Chore: clean TODOs in repository

### DIFF
--- a/internal/mithril-doc/src/lib.rs
+++ b/internal/mithril-doc/src/lib.rs
@@ -104,6 +104,14 @@ impl StructDoc {
         };
         result
     }
+
+    /// Get a field by its name.
+    pub fn get_field(&self, name: &str) -> &FieldDoc {
+        let mut fields = self.data.iter().filter(|f| f.parameter == name);
+
+        assert_eq!(1, fields.clone().count());
+        fields.next().unwrap()
+    }
 }
 
 /// Extractor for struct without Default trait.

--- a/internal/mithril-doc/src/test_doc_macro.rs
+++ b/internal/mithril-doc/src/test_doc_macro.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::{Documenter, DocumenterDefault, FieldDoc, StructDoc};
+    use crate::{Documenter, DocumenterDefault, StructDoc};
     use config::{Map, Source, Value, ValueKind};
 
     #[allow(dead_code)]
@@ -41,18 +41,10 @@ mod tests {
         }
     }
 
-    // TODO May be part of StructDoc.
-    pub fn get_field<'a>(struct_doc: &'a StructDoc, name: &str) -> &'a FieldDoc {
-        let mut fields = struct_doc.data.iter().filter(|f| f.parameter == name);
-
-        assert_eq!(1, fields.clone().count());
-        fields.next().unwrap()
-    }
-
     #[test]
     fn test_extract_struct_of_default_configuration() {
         let doc = MyDefaultConfiguration::extract();
-        let field = get_field(&doc, "environment");
+        let field = doc.get_field("environment");
 
         assert_eq!("environment", field.parameter);
         assert_eq!("ENVIRONMENT", field.environment_variable.as_ref().unwrap());
@@ -63,7 +55,7 @@ mod tests {
     #[test]
     fn test_extract_struct_of_configuration() {
         let doc = MyConfiguration::extract();
-        let field = get_field(&doc, "environment");
+        let field = doc.get_field("environment");
 
         assert_eq!("environment", field.parameter);
         assert_eq!("ENVIRONMENT", field.environment_variable.as_ref().unwrap());
@@ -75,12 +67,12 @@ mod tests {
     fn test_extract_example_of_configuration() {
         {
             let doc_with_example = MyConfiguration::extract();
-            let field = get_field(&doc_with_example, "environment");
+            let field = doc_with_example.get_field("environment");
             assert_eq!(Some("dev".to_string()), field.example);
         }
         {
             let doc_without_example = MyDefaultConfiguration::extract();
-            let field = get_field(&doc_without_example, "environment");
+            let field = doc_without_example.get_field("environment");
             assert_eq!(None, field.example);
         }
     }

--- a/mithril-aggregator/src/file_uploaders/local_snapshot_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_snapshot_uploader.rs
@@ -10,7 +10,6 @@ use mithril_common::StdResult;
 use crate::file_uploaders::{url_sanitizer::sanitize_url_path, FileUploader, FileUri};
 use crate::tools;
 
-// TODO: This specific local uploader will be removed.
 // It's only used by the legacy snapshot that uploads the entire Cardano database.
 /// LocalSnapshotUploader is a file uploader working using local files
 pub struct LocalSnapshotUploader {

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -1,7 +1,5 @@
 use crate::http_server::routes::middlewares;
 use crate::http_server::routes::router::RouterState;
-use crate::http_server::SERVER_BASE_PATH;
-use warp::hyper::Uri;
 use warp::Filter;
 
 pub fn routes(
@@ -11,8 +9,6 @@ pub fn routes(
         .or(artifact_cardano_full_immutable_snapshot_by_id(router_state))
         .or(serve_snapshots_dir(router_state))
         .or(snapshot_download(router_state))
-        .or(artifact_cardano_full_immutable_snapshots_legacy())
-        .or(artifact_cardano_full_immutable_snapshot_by_id_legacy())
 }
 
 /// GET /artifact/snapshots
@@ -65,34 +61,6 @@ fn serve_snapshots_dir(
             config.allow_http_serve_directory
         }))
         .and_then(handlers::ensure_downloaded_file_is_a_snapshot)
-}
-
-/// GET /snapshots
-// TODO: This legacy route should be removed when this code is released with a new distribution
-fn artifact_cardano_full_immutable_snapshots_legacy(
-) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    warp::path!("snapshots").map(|| {
-        warp::redirect(
-            format!("/{SERVER_BASE_PATH}/artifact/snapshots")
-                .as_str()
-                .parse::<Uri>()
-                .unwrap(),
-        )
-    })
-}
-
-/// GET /snapshot/digest
-// TODO: This legacy route should be removed when this code is released with a new distribution
-fn artifact_cardano_full_immutable_snapshot_by_id_legacy(
-) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
-    warp::path!("snapshot" / String).map(|digest| {
-        warp::redirect(
-            format!("/{SERVER_BASE_PATH}/artifact/snapshot/{digest}")
-                .as_str()
-                .parse::<Uri>()
-                .unwrap(),
-        )
-    })
 }
 
 mod handlers {

--- a/mithril-common/src/crypto_helper/cardano/key_certification.rs
+++ b/mithril-common/src/crypto_helper/cardano/key_certification.rs
@@ -43,7 +43,8 @@ pub type KESPeriod = u32;
 #[derive(Error, Debug)]
 pub enum ProtocolRegistrationErrorWrapper {
     /// Error raised when a party id is needed but not provided
-    // TODO: Should be removed once the signer certification is fully deployed
+    ///
+    /// Used only for testing when SPO pool id is not certified
     #[error("missing party id")]
     PartyIdMissing,
 
@@ -246,9 +247,9 @@ impl KeyRegWrapper {
     /// Mithril key (with its corresponding Proof of Possession).
     pub fn register(
         &mut self,
-        party_id: Option<ProtocolPartyId>, // TODO: Parameter should be removed once the signer certification is fully deployed
-        opcert: Option<ProtocolOpCert>, // TODO: Option should be removed once the signer certification is fully deployed
-        kes_sig: Option<ProtocolSignerVerificationKeySignature>, // TODO: Option should be removed once the signer certification is fully deployed
+        party_id: Option<ProtocolPartyId>, // Used for only for testing when SPO pool id is not certified
+        opcert: Option<ProtocolOpCert>, // Used for only for testing when SPO pool id is not certified
+        kes_sig: Option<ProtocolSignerVerificationKeySignature>, // Used for only for testing when SPO pool id is not certified
         kes_period: Option<KESPeriod>,
         pk: ProtocolSignerVerificationKey,
     ) -> Result<ProtocolPartyId, ProtocolRegistrationErrorWrapper> {

--- a/mithril-common/src/entities/signer.rs
+++ b/mithril-common/src/entities/signer.rs
@@ -14,19 +14,22 @@ use sha2::{Digest, Sha256};
 #[derive(Clone, Eq, Serialize, Deserialize)]
 pub struct Signer {
     /// The unique identifier of the signer
-    // TODO: Should be removed once the signer certification is fully deployed
+    ///
+    /// Used only for testing when SPO pool id is not certified
     pub party_id: PartyId,
 
     /// The public key used to authenticate signer signature
     pub verification_key: ProtocolSignerVerificationKey,
 
     /// The encoded signer 'Mithril verification key' signature (signed by the Cardano node KES secret key)
-    // TODO: Option should be removed once the signer certification is fully deployed
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_key_signature: Option<ProtocolSignerVerificationKeySignature>,
 
     /// The encoded operational certificate of stake pool operator attached to the signer node
-    // TODO: Option should be removed once the signer certification is fully deployed
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operational_certificate: Option<ProtocolOpCert>,
 
@@ -136,19 +139,22 @@ impl From<SignerWithStake> for Signer {
 #[derive(Clone, Eq, Serialize, Deserialize)]
 pub struct SignerWithStake {
     /// The unique identifier of the signer
-    // TODO: Should be removed once the signer certification is fully deployed
+    ///
+    /// Used only for testing when SPO pool id is not certified
     pub party_id: PartyId,
 
     /// The public key used to authenticate signer signature
     pub verification_key: ProtocolSignerVerificationKey,
 
     /// The encoded signer 'Mithril verification key' signature (signed by the Cardano node KES secret key)
-    // TODO: Option should be removed once the signer certification is fully deployed
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_key_signature: Option<ProtocolSignerVerificationKeySignature>,
 
     /// The encoded operational certificate of stake pool operator attached to the signer node
-    // TODO: Option should be removed once the signer certification is fully deployed
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operational_certificate: Option<ProtocolOpCert>,
 

--- a/mithril-common/src/entities/single_signatures.rs
+++ b/mithril-common/src/entities/single_signatures.rs
@@ -65,8 +65,6 @@ impl SingleSignatures {
 cfg_test_tools! {
 impl SingleSignatures {
     /// Create a fake [SingleSignatures] with valid cryptographic data for testing purposes.
-    // TODO: this method is slow due to the fixture creation, we should either make
-    // the fixture faster or find a faster alternative.
     pub fn fake<TPartyId: Into<String>, TMessage: Into<String>>(party_id: TPartyId, message: TMessage) -> Self {
         use crate::entities::{ProtocolParameters};
         use crate::test_utils::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};

--- a/mithril-common/src/messages/message_parts/signer.rs
+++ b/mithril-common/src/messages/message_parts/signer.rs
@@ -16,7 +16,8 @@ use std::fmt::{Debug, Formatter};
 #[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SignerWithStakeMessagePart {
     /// The unique identifier of the signer
-    // TODO: Should be removed once the signer certification is fully deployed
+    ///
+    /// Used only for testing when SPO pool id is not certified
     pub party_id: PartyId,
 
     /// The public key used to authenticate signer signature
@@ -24,15 +25,15 @@ pub struct SignerWithStakeMessagePart {
 
     /// The encoded signer 'Mithril verification key' signature (signed by the
     /// Cardano node KES secret key).
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_key_signature: Option<HexEncodedVerificationKeySignature>,
 
     /// The encoded operational certificate of stake pool operator attached to
     /// the signer node.
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operational_certificate: Option<HexEncodedOpCert>,
 
@@ -161,7 +162,8 @@ impl Debug for SignerMessagePart {
 #[derive(Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct SignerMessagePart {
     /// The unique identifier of the signer
-    // TODO: Should be removed once the signer certification is fully deployed
+    ///
+    /// Used only for testing when SPO pool id is not certified
     pub party_id: PartyId,
 
     /// The public key used to authenticate signer signature
@@ -169,15 +171,15 @@ pub struct SignerMessagePart {
 
     /// The encoded signer 'Mithril verification key' signature (signed by the
     /// Cardano node KES secret key).
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_key_signature: Option<HexEncodedVerificationKeySignature>,
 
     /// The encoded operational certificate of stake pool operator attached to
     /// the signer node.
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operational_certificate: Option<HexEncodedOpCert>,
 

--- a/mithril-common/src/messages/register_signer.rs
+++ b/mithril-common/src/messages/register_signer.rs
@@ -13,7 +13,8 @@ pub struct RegisterSignerMessage {
     pub epoch: Epoch,
 
     /// The unique identifier of the signer
-    // TODO: Should be removed once the signer certification is fully deployed
+    ///
+    /// Used only for testing when SPO pool id is not certified
     pub party_id: PartyId,
 
     /// The public key used to authenticate signer signature
@@ -21,15 +22,15 @@ pub struct RegisterSignerMessage {
 
     /// The encoded signer 'Mithril verification key' signature (signed by the
     /// Cardano node KES secret key).
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verification_key_signature: Option<HexEncodedVerificationKeySignature>,
 
     /// The encoded operational certificate of stake pool operator attached to
     /// the signer node.
-    // TODO: Option should be removed once the signer certification is fully
-    //       deployed.
+    ///
+    /// None is used only for testing when SPO pool id is not certified
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operational_certificate: Option<HexEncodedOpCert>,
 

--- a/mithril-relay/src/relay/passive.rs
+++ b/mithril-relay/src/relay/passive.rs
@@ -7,8 +7,7 @@ use slog::{debug, info, Logger};
 /// A passive relay
 pub struct PassiveRelay {
     /// Relay peer
-    // TODO: should be private
-    pub peer: Peer,
+    peer: Peer,
     logger: Logger,
 }
 
@@ -24,13 +23,9 @@ impl PassiveRelay {
         })
     }
 
-    /// Convert event to broadcast message
-    /// TODO: should be removed
-    pub fn convert_peer_event_to_message(
-        &mut self,
-        event: PeerEvent,
-    ) -> StdResult<Option<BroadcastMessage>> {
-        self.peer.convert_peer_event_to_message(event)
+    /// Get the peer of the passive relay
+    pub fn peer_mut(&mut self) -> &mut Peer {
+        &mut self.peer
     }
 
     /// Tick the passive relay

--- a/mithril-relay/tests/register_signer_signature.rs
+++ b/mithril-relay/tests/register_signer_signature.rs
@@ -54,7 +54,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
         .await
         .expect("P2P client start failed");
     p2p_client1
-        .peer
+        .peer_mut()
         .dial(relay_peer_address.clone())
         .expect("P2P client dial to the relay should not fail");
 
@@ -62,7 +62,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
         .await
         .expect("P2P client start failed");
     p2p_client2
-        .peer
+        .peer_mut()
         .dial(relay_peer_address.clone())
         .expect("P2P client dial to the relay should not fail");
 
@@ -138,7 +138,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     loop {
         tokio::select! {
             event =  p2p_client1.tick_peer() => {
-                if let Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) = p2p_client1.convert_peer_event_to_message(event.unwrap().unwrap())
+                if let Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) = p2p_client1.peer_mut().convert_peer_event_to_message(event.unwrap().unwrap())
                 {
                     info!("Test: client1 consumed signer registration"; "message" => #?signer_message_received);
                     assert_eq!(signer_message_sent, signer_message_received);
@@ -146,7 +146,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
                 }
             }
             event =  p2p_client2.tick_peer() => {
-                if let Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) = p2p_client2.convert_peer_event_to_message(event.unwrap().unwrap())
+                if let Ok(Some(BroadcastMessage::RegisterSigner(signer_message_received))) = p2p_client2.peer_mut().convert_peer_event_to_message(event.unwrap().unwrap())
                 {
                     info!("Test: client2 consumed signer registration"; "message" => #?signer_message_received);
                     assert_eq!(signer_message_sent, signer_message_received);
@@ -183,7 +183,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     loop {
         tokio::select! {
             event =  p2p_client1.tick_peer() => {
-                if let Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) = p2p_client1.convert_peer_event_to_message(event.unwrap().unwrap())
+                if let Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) = p2p_client1.peer_mut().convert_peer_event_to_message(event.unwrap().unwrap())
                 {
                     info!("Test: client1 consumed signature"; "message" => #?signature_message_received);
                     assert_eq!(signature_message_sent, signature_message_received);
@@ -191,7 +191,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
                 }
             }
             event =  p2p_client2.tick_peer() => {
-                if let Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) = p2p_client2.convert_peer_event_to_message(event.unwrap().unwrap())
+                if let Ok(Some(BroadcastMessage::RegisterSignature(signature_message_received))) = p2p_client2.peer_mut().convert_peer_event_to_message(event.unwrap().unwrap())
                 {
                     info!("Test: client2 consumed signature"; "message" => #?signature_message_received);
                     assert_eq!(signature_message_sent, signature_message_received);

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -52,7 +52,8 @@ pub struct Configuration {
     pub relay_endpoint: Option<String>,
 
     /// Party Id
-    // TODO: Field should be removed once the signer certification is fully deployed
+    ///
+    /// Used only for testing when SPO pool id is not certified
     #[example = "`pool1pxaqe80sqpde7902er5kf6v0c7y0sv6d5g676766v2h829fvs3x`"]
     pub party_id: Option<PartyId>,
 

--- a/mithril-test-lab/mithril-devnet/configuration/byron/configuration.yaml
+++ b/mithril-test-lab/mithril-devnet/configuration/byron/configuration.yaml
@@ -3,7 +3,6 @@
 ############### Cardano Byron Node Configuration #########
 ##########################################################
 
-
 ##### Locations #####
 
 GenesisFile: genesis.json
@@ -16,7 +15,7 @@ MaxConcurrencyBulkSync: 1
 # The maximum number of used peers when fetching newly forged blocks.
 MaxConcurrencyDeadline: 2
 
-#TODO: These parameters cannot yet be used in the config file, only on the CLI:
+# These parameters cannot yet be used in the config file, only on the CLI:
 #DatabasePath: db/
 #Topology: configuration/mainnet-topology.json
 #Port 7776
@@ -30,7 +29,6 @@ Protocol: RealPBFT
 
 # The mainnet does not include the network magic into addresses. Testnets do.
 RequiresNetworkMagic: RequiresNoMagic
-
 
 ##### Update system parameters #####
 
@@ -130,9 +128,8 @@ defaultScribes:
 # in the setupScribes above for specific scribes.
 rotation:
   rpLogLimitBytes: 5000000
-  rpKeepFilesNum:  3
-  rpMaxAgeHours:   24
-
+  rpKeepFilesNum: 3
+  rpMaxAgeHours: 24
 
 ##### Coarse grained logging control #####
 
@@ -198,7 +195,7 @@ TraceIpSubscription: True
 TraceLocalRootPeers: True
 
 # Trace public root peers
-TracePublicRootPeers: True 
+TracePublicRootPeers: True
 
 # Trace peer selection
 TracePeerSelection: True
@@ -249,7 +246,6 @@ TraceTxOutbound: False
 # Trace TxSubmission protocol messages.
 TraceTxSubmissionProtocol: False
 
-
 ##### Fine grained logging control #####
 
 # It is also possible to have more fine grained control over filtering of
@@ -258,7 +254,6 @@ TraceTxSubmissionProtocol: False
 # much more precise control.
 
 options:
-
   # This routes metrics matching specific names to particular backends.
   # This overrides the 'defaultBackends' listed above. And note that it is
   # an override and not an extension so anything matched here will not

--- a/mithril-test-lab/mithril-devnet/mkfiles/mkfiles-docker.sh
+++ b/mithril-test-lab/mithril-devnet/mkfiles/mkfiles-docker.sh
@@ -229,7 +229,6 @@ EOF
 EOF
 else
     # 50% of signers without key certification (legacy)
-    # TODO: Should be removed once the signer certification is fully deployed
     cat >> ${NODE}/info.json <<EOF
 {
 "name": "Signer ${NODE_ID}",

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -207,10 +207,6 @@ impl<'a> Spec<'a> {
 
             assertions::assert_node_producing_cardano_database_digests_map(&aggregator_endpoint)
                 .await?;
-
-            // TODO: uncomment when the client can verify Cardano database snapshots
-            //let mut client = self.infrastructure.build_client()?;
-            //assertions::assert_client_can_verify_cardano_database_snapshot(&mut client, &digest).await?;
         }
 
         // Verify that Cardano transactions artifacts are produced and signed correctly

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -259,7 +259,6 @@ impl MithrilInfrastructure {
         for (index, pool_node) in pool_nodes.iter().enumerate() {
             // 50% of signers with key certification if allow unverified signer registration
             // Or 100% of signers otherwise
-            // TODO: Should be removed once the signer certification is fully deployed
             let enable_certification =
                 index % 2 == 0 || cfg!(not(feature = "allow_skip_signer_certification"));
             let aggregator_endpoint = if config.use_p2p_network_mode {


### PR DESCRIPTION
## Content

This PR includes a **cleanup of some TODOs comments in the repository** that could either be removed or fixed.

### TODO (before cleanup)

```
└─ mithril
   ├─ internal
   │  ├─ mithril-doc
   │  │  ├─ lib.rs
   │  │  │  └─ line 3: TODO : Some Configuration could not be generated properly because there is a lack of information. (TO EXPLAIN)
   │  │  └─ test_doc_macro.rs
   │  │     └─ line 44: TODO May be part of StructDoc. (FIXED)
   │  └─ mithril-persistence
   │     ├─ repository
   │     │  └─ cardano_transaction_repository.rs
   │     │     └─ line 158: TODO : remove this collect to return the iterator directly (CREATE ISSUE)
   │     └─ hydrator.rs
   │        └─ line 23: TODO : Maybe there is a better way of doing this. (FIXED)
   ├─ mithril-aggregator
   │  ├─ src
   │  │  ├─ dependency_injection
   │  │  │  ├─ builder.rs
   │  │  │  │  └─ line 1313: TODO : Make this part of a warmup phase of the aggregator?  (CREATE ISSUE)
   │  │  │  └─ containers.rs
   │  │  │     └─ line 53: TODO : remove this field and only use the `Configuration` in the dependencies builder (CREATE ISSUE)
   │  │  ├─ file_uploaders
   │  │  │  └─ local_snapshot_uploader.rs
   │  │  │     └─ line 13: TODO : This specific local uploader will be removed. (FIXED)
   │  │  ├─ http_server
   │  │  │  ├─ cardano_database.rs
   │  │  │  │  ├─ line 54: TODO : the directory opened here should be narrowed to the final directory where the artifacts are stored (CREATE ISSUE)
   │  │  │  │  ├─ line 118: TODO : this function should probable be unit tested once the file naming convention is defined (CREATE ISSUE)
   │  │  │  │  └─ line 136: TODO : enhance this check with a regular expression once the file naming convention is defined (CREATE ISSUE)
   │  │  │  └─ snapshot.rs
   │  │  │     ├─ line 71: TODO : This legacy route should be removed when this code is released with a new distribution (FIXED)
   │  │  │     └─ line 85: TODO : This legacy route should be removed when this code is released with a new distribution (FIXED)
   │  │  └─ configuration.rs
   │  │     └─ line 337: TODO : This function should be completed when the configuration of the uploaders for the Cardano database is done. (CREATE ISSUE)
   │  └─ tests
   │     └─ aggregator_observer.rs
   │        └─ line 141: TODO : This case will be implemented once the signable and artifact builders are available. (TO REFERENCE IN ISSUE #2151)
   ├─ mithril-client-cli
   │  └─ mod.rs
   │     └─ line 39: TODO : This should not be done this way. (CREATE ISSUE)
   ├─ mithril-common
   │  ├─ chain_observer
   │  │  ├─ cli_observer.rs
   │  │  │  └─ line 531: TODO : This function implements a fallback mechanism to compute the stake distribution: new/optimized computation when available, legacy computation otherwise (CREATE ISSUE)
   │  │  └─ model.rs
   │  │     └─ line 147: TODO : Remove this chunking of the bytes fields once the cardano-cli 1.36.0+ is released (CREATE ISSUE)
   │  ├─ crypto_helper
   │  │  └─ key_certification.rs
   │  │     ├─ line 46: TODO : Should be removed once the signer certification is fully deployed (FIXED)
   │  │     ├─ line 249: TODO : Parameter should be removed once the signer certification is fully deployed (FIXED)
   │  │     ├─ line 250: TODO : Option should be removed once the signer certification is fully deployed (FIXED)
   │  │     └─ line 251: TODO : Option should be removed once the signer certification is fully deployed (FIXED)
   │  ├─ entities
   │  │  ├─ signed_entity_config.rs
   │  │  │  └─ line 162: TODO : See if we can remove this adjustment by including a "partial" block range in (CREATE ISSUE)
   │  │  ├─ signer.rs
   │  │  │  ├─ line 17: TODO : Should be removed once the signer certification is fully deployed (FIXED)
   │  │  │  ├─ line 24: TODO : Option should be removed once the signer certification is fully deployed (FIXED)
   │  │  │  ├─ line 29: TODO : Option should be removed once the signer certification is fully deployed (FIXED)
   │  │  │  ├─ line 34: TODO : This kes period should not be used as is and should probably be within an allowed range of kes period for the epoch (TO EXPLAIN)
   │  │  │  ├─ line 139: TODO : Should be removed once the signer certification is fully deployed (FIXED)
   │  │  │  ├─ line 146: TODO : Option should be removed once the signer certification is fully deployed (FIXED)
   │  │  │  ├─ line 151: TODO : Option should be removed once the signer certification is fully deployed (FIXED)
   │  │  │  └─ line 156: TODO : This kes period should not be used as is and should probably be within an allowed range of kes period for the epoch (TO EXPLAIN)
   │  │  └─ single_signatures.rs
   │  │     └─ line 68: TODO : this method is slow due to the fixture creation, we should either make (FIXED)
   │  ├─ messages
   │  │  ├─ message_parts
   │  │  │  ├─ signed_entity_type_message.rs
   │  │  │  │  ├─ line 13: TODO : Remove this enum when all nodes are updated, and use the [CardanoDbBeacon] directly as before. (CREATE ISSUE)
   │  │  │  │  └─ line 33: TODO : Remove this enum when all nodes are updated, and use the [SignedEntityType] directly as before. (CREATE ISSUE)
   │  │  │  └─ signer.rs
   │  │  │     ├─ line 19: TODO : Should be removed once the signer certification is fully deployed (FIXED)
   │  │  │     ├─ line 27: TODO : Option should be removed once the signer certification is fully (FIXED)
   │  │  │     ├─ line 34: TODO : Option should be removed once the signer certification is fully (FIXED)
   │  │  │     ├─ line 40: TODO : This KES period should not be used as is and should probably be
   │  │  │     ├─ line 164: TODO : Should be removed once the signer certification is fully deployed (FIXED)
   │  │  │     ├─ line 172: TODO : Option should be removed once the signer certification is fully (FIXED)
   │  │  │     ├─ line 179: TODO : Option should be removed once the signer certification is fully (FIXED)
   │  │  │     └─ line 185: TODO : This KES period should not be used as is and should probably be (TO EXPLAIN)
   │  │  └─ register_signer.rs
   │  │     ├─ line 16: TODO : Should be removed once the signer certification is fully deployed (FIXED)
   │  │     ├─ line 24: TODO : Option should be removed once the signer certification is fully (FIXED)
   │  │     ├─ line 31: TODO : Option should be removed once the signer certification is fully (FIXED)
   │  │     └─ line 37: TODO : This KES period should not be used as is and should probably be (TO EXPLAIN)
   │  └─ test_utils
   │     └─ apispec.rs
   │        └─ line 315: TODO : For now, it verifies only one parameter, (CREATE ISSUE)
   ├─ mithril-relay
   │  ├─ src
   │  │  ├─ aggregator.rs
   │  │  │  ├─ line 40: TODO : retrieve current version (CREATE ISSUE)
   │  │  │  └─ line 68: TODO : retrieve current version (CREATE ISSUE)
   │  │  └─ passive.rs
   │  │     ├─ line 10: TODO : should be private (FIXED)
   │  │     └─ line 28: TODO : should be removed (FIXED)
   │  └─ tests
   │     └─ register_signer_signature.rs
   │        └─ line 16: TODO : this test is not optimal and should be refactored for better performances, (CREATE ISSUE)
   ├─ mithril-signer
   │  └─ configuration.rs
   │     └─ line 55: TODO : Field should be removed once the signer certification is fully deployed (FIXED)
   └─ mithril-test-lab
      ├─ mithril-devnet
      │  ├─ configuration
      │  │  └─ configuration.yaml
      │  │     └─ line 19: TODO : These parameters cannot yet be used in the config file, only on the CLI: (FIXED)
      │  └─ mkfiles
      │     └─ mkfiles-docker.sh
      │        └─ line 232: TODO : Should be removed once the signer certification is fully deployed (FIXED)
      └─ mithril-end-to-end
         ├─ mithril
         │  └─ infrastructure.rs
         │     └─ line 262: TODO : Should be removed once the signer certification is fully deployed (FIXED)
         └─ end_to_end_spec.rs
            └─ line 211: TODO : uncomment when the client can verify Cardano database snapshots (FIXED)
```

### TODO (after cleanup)

```
└─ mithril
   ├─ internal
   │  ├─ mithril-doc
   │  │  └─ lib.rs
   │  │     └─ line 3: TODO : Some Configuration could not be generated properly because there is a lack of information. (TO EXPLAIN)
   │  └─ mithril-persistence
   │     └─ cardano_transaction_repository.rs
   │        └─ line 158: TODO : remove this collect to return the iterator directly (CREATE ISSUE)
   ├─ mithril-aggregator
   │  ├─ src
   │  │  ├─ dependency_injection
   │  │  │  ├─ builder.rs
   │  │  │  │  └─ line 1313: TODO : Make this part of a warmup phase of the aggregator?  (CREATE ISSUE)
   │  │  │  └─ containers.rs
   │  │  │     └─ line 53: TODO : remove this field and only use the `Configuration` in the dependencies builder (CREATE ISSUE)
   │  │  ├─ http_server
   │  │  │  └─ cardano_database.rs
   │  │  │     ├─ line 54: TODO : the directory opened here should be narrowed to the final directory where the artifacts are stored (CREATE ISSUE)
   │  │  │     ├─ line 118: TODO : this function should probable be unit tested once the file naming convention is defined (CREATE ISSUE)
   │  │  │     └─ line 136: TODO : enhance this check with a regular expression once the file naming convention is defined (CREATE ISSUE)
   │  │  └─ configuration.rs
   │  │     └─ line 337: TODO : This function should be completed when the configuration of the uploaders for the Cardano database is done. (CREATE ISSUE)
   │  └─ tests
   │     └─ aggregator_observer.rs
   │        └─ line 141: TODO : This case will be implemented once the signable and artifact builders are available. (TO REFERENCE IN ISSUE #2151)
   ├─ mithril-client-cli
   │  └─ mod.rs
   │     └─ line 39: TODO : This should not be done this way. (CREATE ISSUE)
   ├─ mithril-common
   │  ├─ chain_observer
   │  │  ├─ cli_observer.rs
   │  │  │  └─ line 531: TODO : This function implements a fallback mechanism to compute the stake distribution: new/optimized computation when available, legacy computation otherwise (CREATE ISSUE)
   │  │  └─ model.rs
   │  │     └─ line 147: TODO : Remove this chunking of the bytes fields once the cardano-cli 1.36.0+ is released (CREATE ISSUE)
   │  ├─ entities
   │  │  ├─ signed_entity_config.rs
   │  │  │  └─ line 162: TODO : See if we can remove this adjustment by including a "partial" block range in (CREATE ISSUE)
   │  │  └─ signer.rs
   │  │     └─ line 37: TODO : This kes period should not be used as is and should probably be within an allowed range of kes period for the epoch (TO EXPLAIN)
   │  │     └─ line 156: TODO : This kes period should not be used as is and should probably be within an allowed range of kes period for the epoch (TO EXPLAIN)
   │  ├─ messages
   │  │  ├─ message_parts
   │  │  │  ├─ signed_entity_type_message.rs
   │  │  │  │  ├─ line 13: TODO : Remove this enum when all nodes are updated, and use the [CardanoDbBeacon] directly as before. (CREATE ISSUE)
   │  │  │  │  └─ line 33: TODO : Remove this enum when all nodes are updated, and use the [SignedEntityType] directly as before. (CREATE ISSUE)
   │  │  │  └─ signer.rs
   │  │  │     ├─ line 41: TODO : This KES period should not be used as is and should probably be (TO EXPLAIN)
   │  │  │     └─ line 187: TODO : This KES period should not be used as is and should probably be (TO EXPLAIN)
   │  │  └─ register_signer.rs
   │  │     └─ line 38: TODO : This KES period should not be used as is and should probably be (TO EXPLAIN)
   │  └─ test_utils
   │     └─ apispec.rs
   │        └─ line 315: TODO : For now, it verifies only one parameter, (CREATE ISSUE)
   ├─ mithril-relay
   │  ├─ src
   │  │  └─ aggregator.rs
   │  │     ├─ line 40: TODO : retrieve current version (CREATE ISSUE)
   │  │     └─ line 68: TODO : retrieve current version (CREATE ISSUE)
   │  └─ tests
   │     └─ register_signer_signature.rs
   │        └─ line 16: TODO : this test is not optimal and should be refactored for better performances, (CREATE ISSUE)

```

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

