### PR TITLE
Feat: Create immutable builder for incremental Cardano DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ As a minor extension, we have adopted a slightly different versioning convention
   - Implement the artifact routes of the aggregator for the signed entity type `CardanoDatabase`.
   - Implement the immutable file digests route in the aggregator.
   - Implement the artifact ancillary builder in the aggregator.
+  - Implement the artifact immutable builder in the aggregator.
+  - Implement the artifact digest builder in the aggregator.
 
 - Crates versions:
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.12"
+version = "0.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.104"
+version = "0.4.105"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3600,6 +3600,7 @@ dependencies = [
  "paste",
  "prometheus",
  "rayon",
+ "regex",
  "reqwest 0.12.12",
  "semver",
  "serde",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -35,6 +35,7 @@ openssl-probe = { version = "0.1.5", optional = true }
 paste = "1.0.15"
 prometheus = "0.13.4"
 rayon = "1.10.0"
+regex = "1.11.1"
 reqwest = { version = "0.12.12", features = ["json"] }
 semver = "1.0.24"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.12"
+version = "0.6.13"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -240,6 +240,7 @@ mod tests {
             DigestArtifactBuilder::new(
                 Url::parse("http://aggregator_uri").unwrap(),
                 vec![],
+                test_dir.join("digests"),
                 Arc::new(immutable_file_digest_mapper),
                 TestLogger::stdout(),
             )

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -133,6 +133,7 @@ mod tests {
         test_utils::{fake_data, TempDir},
         CardanoNetwork,
     };
+    use reqwest::Url;
 
     use crate::{
         artifact_builder::{
@@ -230,17 +231,12 @@ mod tests {
             .unwrap()
         };
 
-        let digest_artifact_builder = {
-            let mut digest_uploader = MockDigestFileUploader::new();
-            digest_uploader.expect_upload().return_once(|| {
-                Ok(DigestLocation::Aggregator {
-                    uri: "aggregator_uri".to_string(),
-                })
-            });
-
-            DigestArtifactBuilder::new(vec![Arc::new(digest_uploader)], TestLogger::stdout())
-                .unwrap()
-        };
+        let digest_artifact_builder = DigestArtifactBuilder::new(
+            Url::parse("http://aggregator_uri").unwrap(),
+            vec![],
+            TestLogger::stdout(),
+        )
+        .unwrap();
 
         let cardano_database_artifact_builder = CardanoDatabaseArtifactBuilder::new(
             test_dir,
@@ -277,7 +273,7 @@ mod tests {
         }];
 
         let expected_digest_locations = vec![DigestLocation::Aggregator {
-            uri: "aggregator_uri".to_string(),
+            uri: "http://aggregator_uri/artifact/cardano-database/digests".to_string(),
         }];
 
         let artifact_expected = CardanoDatabaseSnapshot::new(

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
@@ -64,6 +64,7 @@ impl DigestArtifactBuilder {
                 digest_path.display()
             )
         })?;
+
         locations
     }
 
@@ -92,7 +93,7 @@ impl DigestArtifactBuilder {
             })?;
         }
 
-        let digest_file = fs::File::create(digests_file_path.clone()).unwrap();
+        let digest_file = fs::File::create(digests_file_path.clone())?;
         serde_json::to_writer(digest_file, &immutable_file_digest_map)?;
 
         Ok(digests_file_path)
@@ -120,12 +121,12 @@ impl DigestArtifactBuilder {
             }
         }
 
-        locations.push(self.aggregator_location()?);
+        locations.push(self.aggregator_digests_route_location()?);
 
         Ok(locations)
     }
 
-    fn aggregator_location(&self) -> StdResult<DigestLocation> {
+    fn aggregator_digests_route_location(&self) -> StdResult<DigestLocation> {
         Ok(DigestLocation::Aggregator {
             uri: self
                 .aggregator_url_prefix
@@ -176,6 +177,10 @@ mod tests {
 
     #[tokio::test]
     async fn digest_artifact_builder_return_digests_route_on_aggregator() {
+        let temp_dir = TempDir::create(
+            "digest",
+            "digest_artifact_builder_return_digests_route_on_aggregator",
+        );
         let mut immutable_file_digest_mapper = MockImmutableFileDigestMapper::new();
         immutable_file_digest_mapper
             .expect_get_immutable_file_digest_map()
@@ -184,7 +189,7 @@ mod tests {
         let builder = DigestArtifactBuilder::new(
             Url::parse("https://aggregator/").unwrap(),
             vec![],
-            PathBuf::from("/tmp/mithril"),
+            temp_dir,
             Arc::new(immutable_file_digest_mapper),
             TestLogger::stdout(),
         )
@@ -213,7 +218,7 @@ mod tests {
             let builder = DigestArtifactBuilder::new(
                 Url::parse("https://aggregator/").unwrap(),
                 vec![Arc::new(uploader)],
-                PathBuf::from("/tmp/mithril"),
+                PathBuf::from("/tmp/whatever"),
                 Arc::new(MockImmutableFileDigestMapper::new()),
                 TestLogger::file(&log_path),
             )
@@ -235,7 +240,7 @@ mod tests {
         let builder = DigestArtifactBuilder::new(
             Url::parse("https://aggregator/").unwrap(),
             vec![Arc::new(uploader)],
-            PathBuf::from("/tmp/mithril"),
+            PathBuf::from("/tmp/whatever"),
             Arc::new(MockImmutableFileDigestMapper::new()),
             TestLogger::stdout(),
         )
@@ -264,7 +269,7 @@ mod tests {
         let builder = DigestArtifactBuilder::new(
             Url::parse("https://aggregator/").unwrap(),
             uploaders,
-            PathBuf::from("/tmp/mithril"),
+            PathBuf::from("/tmp/whatever"),
             Arc::new(MockImmutableFileDigestMapper::new()),
             TestLogger::stdout(),
         )
@@ -299,7 +304,7 @@ mod tests {
         let builder = DigestArtifactBuilder::new(
             Url::parse("https://aggregator/").unwrap(),
             uploaders,
-            PathBuf::from("/tmp/mithril"),
+            PathBuf::from("/tmp/whatever"),
             Arc::new(MockImmutableFileDigestMapper::new()),
             TestLogger::stdout(),
         )
@@ -328,6 +333,10 @@ mod tests {
 
     #[tokio::test]
     async fn create_digest_archive_should_create_json_file_with_all_digests() {
+        let temp_dir = TempDir::create(
+            "digest",
+            "create_digest_archive_should_create_json_file_with_all_digests",
+        );
         let mut immutable_file_digest_mapper = MockImmutableFileDigestMapper::new();
         immutable_file_digest_mapper
             .expect_get_immutable_file_digest_map()
@@ -341,7 +350,7 @@ mod tests {
         let builder = DigestArtifactBuilder::new(
             Url::parse("https://aggregator/").unwrap(),
             vec![],
-            PathBuf::from("/tmp/mithril"),
+            temp_dir,
             Arc::new(immutable_file_digest_mapper),
             TestLogger::stdout(),
         )

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+use mithril_common::{entities::DigestLocation, logging::LoggerExtensions, StdResult};
+use slog::{error, Logger};
+
+/// The [DigestFileUploader] trait allows identifying uploaders that return locations for digest archive files.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait DigestFileUploader: Send + Sync {
+    /// Uploads the archive at the given filepath and returns the location of the uploaded file.
+    async fn upload(&self) -> StdResult<DigestLocation>;
+}
+
+pub struct DigestArtifactBuilder {
+    uploaders: Vec<Arc<dyn DigestFileUploader>>,
+    logger: Logger,
+}
+
+impl DigestArtifactBuilder {
+    /// Creates a new [DigestArtifactBuilder].
+    pub fn new(uploaders: Vec<Arc<dyn DigestFileUploader>>, logger: Logger) -> StdResult<Self> {
+        if uploaders.is_empty() {
+            return Err(anyhow!(
+                "At least one uploader is required to create an 'DigestArtifactBuilder'"
+            ));
+        }
+
+        Ok(Self {
+            uploaders,
+            logger: logger.new_with_component_name::<Self>(),
+        })
+    }
+
+    pub async fn upload(&self) -> StdResult<Vec<DigestLocation>> {
+        self.upload_digest_archive().await
+    }
+
+    /// Uploads the digest archive and returns the locations of the uploaded files.
+    async fn upload_digest_archive(&self) -> StdResult<Vec<DigestLocation>> {
+        let mut locations = Vec::<DigestLocation>::new();
+        for uploader in &self.uploaders {
+            let result = uploader.upload().await;
+            match result {
+                Ok(location) => {
+                    locations.push(location);
+                }
+                Err(e) => {
+                    error!(
+                        self.logger,
+                        "Failed to upload digest archive";
+                        "error" => e.to_string()
+                    );
+                }
+            }
+        }
+
+        if locations.is_empty() {
+            return Err(anyhow!(
+                "Failed to upload digest archive with all uploaders"
+            ));
+        }
+
+        Ok(locations)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::test_tools::TestLogger;
+    use mithril_common::test_utils::{assert_equivalent, TempDir};
+
+    use super::*;
+
+    fn fake_uploader_returning_error() -> MockDigestFileUploader {
+        let mut uploader = MockDigestFileUploader::new();
+        uploader
+            .expect_upload()
+            .return_once(|| Err(anyhow!("Failure while uploading...")));
+
+        uploader
+    }
+
+    fn fake_uploader(location_uri: &str) -> MockDigestFileUploader {
+        let uri = location_uri.to_string();
+        let mut uploader = MockDigestFileUploader::new();
+        uploader
+            .expect_upload()
+            .times(1)
+            .return_once(|| Ok(DigestLocation::CloudStorage { uri }));
+
+        uploader
+    }
+
+    #[test]
+    fn create_digest_builder_should_error_when_no_uploader() {
+        let result = DigestArtifactBuilder::new(vec![], TestLogger::stdout());
+
+        assert!(result.is_err(), "Should return an error when no uploaders")
+    }
+
+    #[tokio::test]
+    async fn upload_digest_archive_should_log_upload_errors() {
+        let log_path = TempDir::create("digest", "upload_digest_archive_should_log_upload_errors")
+            .join("test.log");
+
+        let mut uploader = MockDigestFileUploader::new();
+        uploader
+            .expect_upload()
+            .return_once(|| Err(anyhow!("Failure while uploading...")));
+
+        {
+            let builder =
+                DigestArtifactBuilder::new(vec![Arc::new(uploader)], TestLogger::file(&log_path))
+                    .unwrap();
+
+            let _ = builder.upload_digest_archive().await;
+        }
+
+        let logs = std::fs::read_to_string(&log_path).unwrap();
+        assert!(logs.contains("Failure while uploading..."));
+    }
+
+    #[tokio::test]
+    async fn upload_digest_archive_should_error_when_no_location_is_returned() {
+        let uploader = fake_uploader_returning_error();
+
+        let builder =
+            DigestArtifactBuilder::new(vec![Arc::new(uploader)], TestLogger::stdout()).unwrap();
+
+        let result = builder.upload_digest_archive().await;
+
+        assert!(
+            result.is_err(),
+            "Should return an error when no location is returned"
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_digest_archive_should_return_location_even_with_uploaders_errors() {
+        let first_uploader = fake_uploader_returning_error();
+        let second_uploader = fake_uploader("an_uri");
+        let third_uploader = fake_uploader_returning_error();
+
+        let uploaders: Vec<Arc<dyn DigestFileUploader>> = vec![
+            Arc::new(first_uploader),
+            Arc::new(second_uploader),
+            Arc::new(third_uploader),
+        ];
+
+        let builder = DigestArtifactBuilder::new(uploaders, TestLogger::stdout()).unwrap();
+
+        let locations = builder.upload_digest_archive().await.unwrap();
+
+        assert_equivalent(
+            locations,
+            vec![DigestLocation::CloudStorage {
+                uri: "an_uri".to_string(),
+            }],
+        );
+    }
+
+    #[tokio::test]
+    async fn upload_digest_archive_should_return_all_uploaders_returned_locations() {
+        let first_uploader = fake_uploader("an_uri");
+        let second_uploader = fake_uploader("another_uri");
+
+        let uploaders: Vec<Arc<dyn DigestFileUploader>> =
+            vec![Arc::new(first_uploader), Arc::new(second_uploader)];
+
+        let builder = DigestArtifactBuilder::new(uploaders, TestLogger::stdout()).unwrap();
+
+        let locations = builder.upload_digest_archive().await.unwrap();
+
+        assert_equivalent(
+            locations,
+            vec![
+                DigestLocation::CloudStorage {
+                    uri: "an_uri".to_string(),
+                },
+                DigestLocation::CloudStorage {
+                    uri: "another_uri".to_string(),
+                },
+            ],
+        );
+    }
+}

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -1,0 +1,404 @@
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use anyhow::anyhow;
+use async_trait::async_trait;
+
+use mithril_common::{
+    digesters::IMMUTABLE_DIR,
+    entities::{CompressionAlgorithm, ImmutableFileNumber, ImmutablesLocation},
+    StdResult,
+};
+
+use crate::Snapshotter;
+
+/// The [ImmutableFilesUploader] trait allows identifying uploaders that return locations for immutable files archive.
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait ImmutableFilesUploader: Send + Sync {
+    /// Uploads the archives at the given filepaths and returns the location of the uploaded file.
+    async fn upload<'a>(&self, filepaths: Vec<&'a Path>) -> StdResult<ImmutablesLocation>;
+}
+
+pub struct ImmutableArtifactBuilder {
+    uploaders: Vec<Arc<dyn ImmutableFilesUploader>>,
+    snapshotter: Arc<dyn Snapshotter>,
+    compression_algorithm: CompressionAlgorithm,
+}
+
+impl ImmutableArtifactBuilder {
+    pub fn new(
+        uploaders: Vec<Arc<dyn ImmutableFilesUploader>>,
+        snapshotter: Arc<dyn Snapshotter>,
+        compression_algorithm: CompressionAlgorithm,
+    ) -> StdResult<Self> {
+        if uploaders.is_empty() {
+            return Err(anyhow!(
+                "At least one uploader is required to create an 'ImmutableArtifactBuilder'"
+            ));
+        }
+
+        Ok(Self {
+            uploaders,
+            snapshotter,
+            compression_algorithm,
+        })
+    }
+
+    pub fn upload(
+        &self,
+        up_to_immutable_file_number: ImmutableFileNumber,
+    ) -> StdResult<Vec<ImmutablesLocation>> {
+        let _archives_paths = self.create_immutables_archives(up_to_immutable_file_number)?;
+
+        Ok(vec![])
+    }
+
+    pub fn create_immutables_archives(
+        &self,
+        up_to_immutable_file_number: ImmutableFileNumber,
+    ) -> StdResult<Vec<PathBuf>> {
+        fn immutable_trio_names(immutable_file_number: ImmutableFileNumber) -> Vec<String> {
+            vec![
+                format!("{:05}.chunk", immutable_file_number),
+                format!("{:05}.primary", immutable_file_number),
+                format!("{:05}.secondary", immutable_file_number),
+            ]
+        }
+
+        let immutable_archive_path = Path::new("cardano-database").join("immutable");
+
+        let mut archive_paths = vec![];
+        for immutable_file_number in 1..=up_to_immutable_file_number {
+            let files_to_archive = immutable_trio_names(immutable_file_number)
+                .iter()
+                .map(|filename| PathBuf::from(IMMUTABLE_DIR).join(filename))
+                .collect();
+
+            let archive_name = format!(
+                "{:05}.{}",
+                immutable_file_number,
+                self.compression_algorithm.tar_file_extension()
+            );
+
+            if !self
+                .snapshotter
+                .is_snapshot_exist(&immutable_archive_path.join(archive_name.clone()))
+            {
+                let archive_path = self.snapshotter.snapshot_subset(
+                    &immutable_archive_path.join(archive_name),
+                    files_to_archive,
+                )?;
+                archive_paths.push(archive_path.get_file_path().to_path_buf());
+            }
+        }
+
+        Ok(archive_paths)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::{digesters::DummyCardanoDbBuilder, test_utils::assert_equivalent};
+    use mockall::predicate::eq;
+
+    use crate::{
+        file_uploaders::MockFileUploader,
+        snapshotter::{MockSnapshotter, OngoingSnapshot},
+        test_tools::TestLogger,
+        CompressedArchiveSnapshotter, DumbSnapshotter, SnapshotterCompressionAlgorithm,
+    };
+
+    use super::*;
+
+    #[test]
+    fn create_immutable_builder_should_error_when_no_uploader() {
+        let result = ImmutableArtifactBuilder::new(
+            vec![],
+            Arc::new(DumbSnapshotter::new()),
+            CompressionAlgorithm::Gzip,
+        );
+
+        assert!(result.is_err(), "Should return an error when no uploaders")
+    }
+
+    #[test]
+    fn upload_should_return_locations() {
+        let test_dir = "cardano_database/upload_should_return_locations";
+        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+            .with_immutables(&[1, 2, 3])
+            .build();
+
+        let db_directory = cardano_db.get_dir().to_path_buf();
+        let snapshot_directory = db_directory.parent().unwrap().join("snapshot_dest");
+        let mut snapshotter = MockSnapshotter::new();
+        snapshotter.expect_is_snapshot_exist().returning(|_| false);
+
+        let dest_filepath = Path::new("/tmp");
+        snapshotter
+            .expect_snapshot_subset()
+            .times(1)
+            .with(
+                eq(Path::new("cardano-database/immutable/00001.tar.gz")),
+                eq(vec![
+                    PathBuf::from(IMMUTABLE_DIR).join("00001.chunk"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00001.primary"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00001.secondary"),
+                ]),
+            )
+            .returning(|filepath, _| Ok(OngoingSnapshot::new(dest_filepath.join(filepath), 0)));
+
+        snapshotter
+            .expect_snapshot_subset()
+            .times(1)
+            .with(
+                eq(Path::new("cardano-database/immutable/00002.tar.gz")),
+                eq(vec![
+                    PathBuf::from(IMMUTABLE_DIR).join("00002.chunk"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00002.primary"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00002.secondary"),
+                ]),
+            )
+            .returning(|filepath, _| Ok(OngoingSnapshot::new(dest_filepath.join(filepath), 0)));
+        // let snapshotter = SnapshotterWrapper {
+        //     snapshotter: {
+        //         CompressedArchiveSnapshotter::new(
+        //             db_directory.clone(),
+        //             snapshot_directory.clone(),
+        //             SnapshotterCompressionAlgorithm::Gzip,
+        //             TestLogger::stdout(),
+        //         )
+        //         .unwrap()
+        //     },
+        // };
+
+        let mut uploader = MockImmutableFilesUploader::new();
+        uploader
+            .expect_upload()
+            .return_once(|_| Err(anyhow!("Failure while uploading, no location returned")));
+
+        let builder = ImmutableArtifactBuilder::new(
+            vec![Arc::new(uploader)],
+            Arc::new(snapshotter),
+            CompressionAlgorithm::Gzip,
+        )
+        .unwrap();
+
+        builder.upload(2).unwrap();
+
+        // let expected_archives_directory = snapshot_directory
+        //     .join("cardano-database")
+        //     .join("immutable");
+        // assert!(expected_archives_directory.join("00001.tar.gz").exists());
+        // assert!(expected_archives_directory.join("00002.tar.gz").exists());
+        // let archives_nb = std::fs::read_dir(expected_archives_directory)
+        //     .unwrap()
+        //     .count();
+        // assert_eq!(2, archives_nb);
+    }
+
+    #[test]
+    fn create_immutables_archives_should_snapshot_immutables_files_up_to_the_given_immutable_file_number(
+    ) {
+        let mut snapshotter = MockSnapshotter::new();
+        snapshotter.expect_is_snapshot_exist().returning(|_| false);
+
+        snapshotter
+            .expect_snapshot_subset()
+            .times(1)
+            .with(
+                eq(Path::new("cardano-database/immutable/00001.tar.gz")),
+                eq(vec![
+                    PathBuf::from(IMMUTABLE_DIR).join("00001.chunk"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00001.primary"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00001.secondary"),
+                ]),
+            )
+            .returning(|filepath, _| {
+                let path = Path::new("/tmp").join(filepath);
+                Ok(OngoingSnapshot::new(path, 0))
+            });
+
+        snapshotter
+            .expect_snapshot_subset()
+            .times(1)
+            .with(
+                eq(Path::new("cardano-database/immutable/00002.tar.gz")),
+                eq(vec![
+                    PathBuf::from(IMMUTABLE_DIR).join("00002.chunk"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00002.primary"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00002.secondary"),
+                ]),
+            )
+            .returning(|filepath, _| {
+                let path = Path::new("/tmp").join(filepath);
+                Ok(OngoingSnapshot::new(path, 0))
+            });
+
+        let builder = ImmutableArtifactBuilder::new(
+            vec![Arc::new(MockImmutableFilesUploader::new())],
+            Arc::new(snapshotter),
+            CompressionAlgorithm::Gzip,
+        )
+        .unwrap();
+
+        let archive_paths = builder.create_immutables_archives(2).unwrap();
+
+        assert_equivalent(
+            archive_paths,
+            vec![
+                PathBuf::from("/tmp/cardano-database/immutable/00001.tar.gz"),
+                PathBuf::from("/tmp/cardano-database/immutable/00002.tar.gz"),
+            ],
+        )
+    }
+
+    #[test]
+    fn create_immutables_archives_should_return_error_when_one_of_the_three_immutable_files_is_missing(
+    ) {
+        let test_dir = "cardano_database/error_when_one_of_the_three_immutable_files_is_missing";
+        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+            .with_immutables(&[1, 2])
+            .build();
+
+        let file_to_remove = cardano_db.get_immutable_dir().join("00002.chunk");
+        std::fs::remove_file(file_to_remove).unwrap();
+
+        let db_directory = cardano_db.get_dir().to_path_buf();
+        let snapshotter = {
+            CompressedArchiveSnapshotter::new(
+                db_directory.clone(),
+                db_directory.parent().unwrap().join("snapshot_dest"),
+                SnapshotterCompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap()
+        };
+
+        let builder = ImmutableArtifactBuilder::new(
+            vec![Arc::new(MockImmutableFilesUploader::new())],
+            Arc::new(snapshotter),
+            CompressionAlgorithm::Gzip,
+        )
+        .unwrap();
+
+        builder
+            .create_immutables_archives(2)
+            .expect_err("Should return an error when one of the three immutable files is missing");
+    }
+
+    #[test]
+    fn create_immutables_archives_should_return_error_when_an_immutable_file_trio_is_missing() {
+        let test_dir = "cardano_database/error_when_an_immutable_file_trio_is_missing";
+        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+            .with_immutables(&[1, 3])
+            .build();
+
+        let db_directory = cardano_db.get_dir().to_path_buf();
+        let snapshotter = {
+            CompressedArchiveSnapshotter::new(
+                db_directory.clone(),
+                db_directory.parent().unwrap().join("snapshot_dest"),
+                SnapshotterCompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap()
+        };
+
+        let builder = ImmutableArtifactBuilder::new(
+            vec![Arc::new(MockImmutableFilesUploader::new())],
+            Arc::new(snapshotter),
+            CompressionAlgorithm::Gzip,
+        )
+        .unwrap();
+
+        builder
+            .create_immutables_archives(3)
+            .expect_err("Should return an error when an immutable file trio is missing");
+    }
+
+    #[test]
+    fn create_immutables_archives_should_return_error_when_up_to_immutable_file_number_is_missing()
+    {
+        let test_dir = "cardano_database/error_when_up_to_immutable_file_number_is_missing";
+        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+            .with_immutables(&[1, 2])
+            .build();
+
+        let db_directory = cardano_db.get_dir().to_path_buf();
+        let snapshotter = {
+            CompressedArchiveSnapshotter::new(
+                db_directory.clone(),
+                db_directory.parent().unwrap().join("snapshot_dest"),
+                SnapshotterCompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap()
+        };
+
+        let builder = ImmutableArtifactBuilder::new(
+            vec![Arc::new(MockImmutableFilesUploader::new())],
+            Arc::new(snapshotter),
+            CompressionAlgorithm::Gzip,
+        )
+        .unwrap();
+
+        builder
+            .create_immutables_archives(3)
+            .expect_err("Should return an error when an immutable file trio is missing");
+    }
+
+    #[test]
+    fn create_immutables_archives_should_not_rebuild_archives_already_compressed() {
+        let mut snapshotter = MockSnapshotter::new();
+
+        snapshotter
+            .expect_is_snapshot_exist()
+            .times(1)
+            .with(eq(Path::new("cardano-database/immutable/00001.tar.gz")))
+            .returning(|_| true);
+        snapshotter
+            .expect_is_snapshot_exist()
+            .times(1)
+            .with(eq(Path::new("cardano-database/immutable/00002.tar.gz")))
+            .returning(|_| true);
+        snapshotter
+            .expect_is_snapshot_exist()
+            .times(1)
+            .with(eq(Path::new("cardano-database/immutable/00003.tar.gz")))
+            .returning(|_| false);
+        snapshotter
+            .expect_snapshot_subset()
+            .times(1)
+            .with(
+                eq(Path::new("cardano-database/immutable/00003.tar.gz")),
+                eq(vec![
+                    PathBuf::from(IMMUTABLE_DIR).join("00003.chunk"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00003.primary"),
+                    PathBuf::from(IMMUTABLE_DIR).join("00003.secondary"),
+                ]),
+            )
+            .returning(|filepath, _| {
+                let path = Path::new("/tmp").join(filepath);
+                Ok(OngoingSnapshot::new(path, 0))
+            });
+
+        let builder = ImmutableArtifactBuilder::new(
+            vec![Arc::new(MockImmutableFilesUploader::new())],
+            Arc::new(snapshotter),
+            CompressionAlgorithm::Gzip,
+        )
+        .unwrap();
+
+        let archive_paths = builder.create_immutables_archives(3).unwrap();
+
+        assert_equivalent(
+            archive_paths,
+            vec![PathBuf::from(
+                "/tmp/cardano-database/immutable/00003.tar.gz",
+            )],
+        )
+    }
+}

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -126,7 +126,7 @@ impl ImmutableArtifactBuilder {
             let immutable_archive_file_path = immutable_archive_dir_path.join(archive_name);
             if !self
                 .snapshotter
-                .is_snapshot_exist(&immutable_archive_file_path)
+                .does_snapshot_exist(&immutable_archive_file_path)
             {
                 self.snapshotter
                     .snapshot_subset(&immutable_archive_file_path, files_to_archive)?;
@@ -225,7 +225,9 @@ mod tests {
     async fn upload_call_archive_creation_and_upload_to_retrieve_locations() {
         let snapshotter = {
             let mut snapshotter = MockSnapshotter::new();
-            snapshotter.expect_is_snapshot_exist().returning(|_| false);
+            snapshotter
+                .expect_does_snapshot_exist()
+                .returning(|_| false);
             snapshotter
                 .expect_get_file_path()
                 .returning(move |f| Path::new("/destination").join(f));
@@ -287,7 +289,9 @@ mod tests {
                 .expect_get_file_path()
                 .returning(move |f| Path::new("/tmp").join(f));
 
-            snapshotter.expect_is_snapshot_exist().returning(|_| false);
+            snapshotter
+                .expect_does_snapshot_exist()
+                .returning(|_| false);
 
             snapshotter
                 .expect_snapshot_subset()
@@ -440,19 +444,19 @@ mod tests {
                 .returning(move |f| Path::new("/tmp").join(f));
 
             snapshotter
-                .expect_is_snapshot_exist()
+                .expect_does_snapshot_exist()
                 .times(1)
                 .with(eq(Path::new("cardano-database/immutable/00001.tar.gz")))
                 .returning(|_| true);
 
             snapshotter
-                .expect_is_snapshot_exist()
+                .expect_does_snapshot_exist()
                 .times(1)
                 .with(eq(Path::new("cardano-database/immutable/00002.tar.gz")))
                 .returning(|_| true);
 
             snapshotter
-                .expect_is_snapshot_exist()
+                .expect_does_snapshot_exist()
                 .times(1)
                 .with(eq(Path::new("cardano-database/immutable/00003.tar.gz")))
                 .returning(|_| false);
@@ -497,7 +501,7 @@ mod tests {
             snapshotter
                 .expect_get_file_path()
                 .returning(move |f| Path::new("/tmp").join(f));
-            snapshotter.expect_is_snapshot_exist().returning(|_| true);
+            snapshotter.expect_does_snapshot_exist().returning(|_| true);
             snapshotter.expect_snapshot_subset().never();
 
             let builder = ImmutableArtifactBuilder::new(

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -9,8 +9,10 @@ use async_trait::async_trait;
 use mithril_common::{
     digesters::IMMUTABLE_DIR,
     entities::{CompressionAlgorithm, ImmutableFileNumber, ImmutablesLocation},
+    logging::LoggerExtensions,
     StdResult,
 };
+use slog::{error, Logger};
 
 use crate::Snapshotter;
 
@@ -19,13 +21,14 @@ use crate::Snapshotter;
 #[async_trait]
 pub trait ImmutableFilesUploader: Send + Sync {
     /// Uploads the archives at the given filepaths and returns the location of the uploaded file.
-    async fn upload<'a>(&self, filepaths: Vec<&'a Path>) -> StdResult<ImmutablesLocation>;
+    async fn upload<'a>(&self, filepaths: &[&'a Path]) -> StdResult<ImmutablesLocation>;
 }
 
 pub struct ImmutableArtifactBuilder {
     uploaders: Vec<Arc<dyn ImmutableFilesUploader>>,
     snapshotter: Arc<dyn Snapshotter>,
     compression_algorithm: CompressionAlgorithm,
+    logger: Logger,
 }
 
 impl ImmutableArtifactBuilder {
@@ -33,6 +36,7 @@ impl ImmutableArtifactBuilder {
         uploaders: Vec<Arc<dyn ImmutableFilesUploader>>,
         snapshotter: Arc<dyn Snapshotter>,
         compression_algorithm: CompressionAlgorithm,
+        logger: Logger,
     ) -> StdResult<Self> {
         if uploaders.is_empty() {
             return Err(anyhow!(
@@ -44,6 +48,7 @@ impl ImmutableArtifactBuilder {
             uploaders,
             snapshotter,
             compression_algorithm,
+            logger: logger.new_with_component_name::<Self>(),
         })
     }
 
@@ -97,6 +102,36 @@ impl ImmutableArtifactBuilder {
 
         Ok(archive_paths)
     }
+
+    async fn upload_immutable_archives(
+        &self,
+        archive_paths: &[&Path],
+    ) -> StdResult<Vec<ImmutablesLocation>> {
+        let mut locations = Vec::new();
+        for uploader in &self.uploaders {
+            let result = uploader.upload(archive_paths).await;
+            match result {
+                Ok(location) => {
+                    locations.push(location);
+                }
+                Err(e) => {
+                    error!(
+                        self.logger,
+                        "Failed to upload immutable archive";
+                        "error" => e.to_string()
+                    );
+                }
+            }
+        }
+
+        if locations.is_empty() {
+            return Err(anyhow!(
+                "Failed to upload immutable archive with all uploaders"
+            ));
+        }
+
+        Ok(locations)
+    }
 }
 
 #[cfg(test)]
@@ -106,24 +141,12 @@ mod tests {
     use uuid::Uuid;
 
     use crate::{
-        file_uploaders::MockFileUploader,
         snapshotter::{MockSnapshotter, OngoingSnapshot},
         test_tools::TestLogger,
         CompressedArchiveSnapshotter, DumbSnapshotter, SnapshotterCompressionAlgorithm,
     };
 
     use super::*;
-
-    #[test]
-    fn create_immutable_builder_should_error_when_no_uploader() {
-        let result = ImmutableArtifactBuilder::new(
-            vec![],
-            Arc::new(DumbSnapshotter::new()),
-            CompressionAlgorithm::Gzip,
-        );
-
-        assert!(result.is_err(), "Should return an error when no uploaders")
-    }
 
     #[test]
     fn upload_should_return_locations() {
@@ -184,6 +207,7 @@ mod tests {
             vec![Arc::new(uploader)],
             Arc::new(snapshotter),
             CompressionAlgorithm::Gzip,
+            TestLogger::stdout(),
         )
         .unwrap();
 
@@ -200,203 +224,393 @@ mod tests {
         // assert_eq!(2, archives_nb);
     }
 
-    #[test]
-    fn create_immutables_archives_should_snapshot_immutables_files_up_to_the_given_immutable_file_number(
-    ) {
-        let mut snapshotter = MockSnapshotter::new();
-        snapshotter.expect_is_snapshot_exist().returning(|_| false);
+    mod create_archive {
 
-        snapshotter
-            .expect_snapshot_subset()
-            .times(1)
-            .with(
-                eq(Path::new("cardano-database/immutable/00001.tar.gz")),
-                eq(vec![
-                    PathBuf::from(IMMUTABLE_DIR).join("00001.chunk"),
-                    PathBuf::from(IMMUTABLE_DIR).join("00001.primary"),
-                    PathBuf::from(IMMUTABLE_DIR).join("00001.secondary"),
-                ]),
+        use super::*;
+
+        #[test]
+        fn create_immutables_archives_should_snapshot_immutables_files_up_to_the_given_immutable_file_number(
+        ) {
+            let mut snapshotter = MockSnapshotter::new();
+            snapshotter.expect_is_snapshot_exist().returning(|_| false);
+
+            snapshotter
+                .expect_snapshot_subset()
+                .times(1)
+                .with(
+                    eq(Path::new("cardano-database/immutable/00001.tar.gz")),
+                    eq(vec![
+                        PathBuf::from(IMMUTABLE_DIR).join("00001.chunk"),
+                        PathBuf::from(IMMUTABLE_DIR).join("00001.primary"),
+                        PathBuf::from(IMMUTABLE_DIR).join("00001.secondary"),
+                    ]),
+                )
+                .returning(|filepath, _| {
+                    let path = Path::new("/tmp").join(filepath);
+                    Ok(OngoingSnapshot::new(path, 0))
+                });
+
+            snapshotter
+                .expect_snapshot_subset()
+                .times(1)
+                .with(
+                    eq(Path::new("cardano-database/immutable/00002.tar.gz")),
+                    eq(vec![
+                        PathBuf::from(IMMUTABLE_DIR).join("00002.chunk"),
+                        PathBuf::from(IMMUTABLE_DIR).join("00002.primary"),
+                        PathBuf::from(IMMUTABLE_DIR).join("00002.secondary"),
+                    ]),
+                )
+                .returning(|filepath, _| {
+                    let path = Path::new("/tmp").join(filepath);
+                    Ok(OngoingSnapshot::new(path, 0))
+                });
+
+            let builder = ImmutableArtifactBuilder::new(
+                vec![Arc::new(MockImmutableFilesUploader::new())],
+                Arc::new(snapshotter),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
             )
-            .returning(|filepath, _| {
-                let path = Path::new("/tmp").join(filepath);
-                Ok(OngoingSnapshot::new(path, 0))
-            });
+            .unwrap();
 
-        snapshotter
-            .expect_snapshot_subset()
-            .times(1)
-            .with(
-                eq(Path::new("cardano-database/immutable/00002.tar.gz")),
-                eq(vec![
-                    PathBuf::from(IMMUTABLE_DIR).join("00002.chunk"),
-                    PathBuf::from(IMMUTABLE_DIR).join("00002.primary"),
-                    PathBuf::from(IMMUTABLE_DIR).join("00002.secondary"),
-                ]),
+            let archive_paths = builder.create_immutables_archives(2).unwrap();
+
+            assert_equivalent(
+                archive_paths,
+                vec![
+                    PathBuf::from("/tmp/cardano-database/immutable/00001.tar.gz"),
+                    PathBuf::from("/tmp/cardano-database/immutable/00002.tar.gz"),
+                ],
             )
-            .returning(|filepath, _| {
-                let path = Path::new("/tmp").join(filepath);
-                Ok(OngoingSnapshot::new(path, 0))
-            });
+        }
 
-        let builder = ImmutableArtifactBuilder::new(
-            vec![Arc::new(MockImmutableFilesUploader::new())],
-            Arc::new(snapshotter),
-            CompressionAlgorithm::Gzip,
-        )
-        .unwrap();
+        #[test]
+        fn create_immutables_archives_should_return_error_when_one_of_the_three_immutable_files_is_missing(
+        ) {
+            let test_dir =
+                "error_when_one_of_the_three_immutable_files_is_missing/cardano_database";
+            let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+                .with_immutables(&[1, 2])
+                .build();
 
-        let archive_paths = builder.create_immutables_archives(2).unwrap();
+            let file_to_remove = cardano_db.get_immutable_dir().join("00002.chunk");
+            std::fs::remove_file(file_to_remove).unwrap();
 
-        assert_equivalent(
-            archive_paths,
-            vec![
-                PathBuf::from("/tmp/cardano-database/immutable/00001.tar.gz"),
-                PathBuf::from("/tmp/cardano-database/immutable/00002.tar.gz"),
-            ],
-        )
-    }
-
-    #[test]
-    fn create_immutables_archives_should_return_error_when_one_of_the_three_immutable_files_is_missing(
-    ) {
-        let test_dir = "error_when_one_of_the_three_immutable_files_is_missing/cardano_database";
-        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
-            .with_immutables(&[1, 2])
-            .build();
-
-        let file_to_remove = cardano_db.get_immutable_dir().join("00002.chunk");
-        std::fs::remove_file(file_to_remove).unwrap();
-
-        let db_directory = cardano_db.get_dir().to_path_buf();
-        let mut snapshotter = CompressedArchiveSnapshotter::new(
-            db_directory.clone(),
-            db_directory.parent().unwrap().join("snapshot_dest"),
-            SnapshotterCompressionAlgorithm::Gzip,
-            TestLogger::stdout(),
-        )
-        .unwrap();
-        snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
-
-        let builder = ImmutableArtifactBuilder::new(
-            vec![Arc::new(MockImmutableFilesUploader::new())],
-            Arc::new(snapshotter),
-            CompressionAlgorithm::Gzip,
-        )
-        .unwrap();
-
-        builder
-            .create_immutables_archives(2)
-            .expect_err("Should return an error when one of the three immutable files is missing");
-    }
-
-    #[test]
-    fn create_immutables_archives_should_return_error_when_an_immutable_file_trio_is_missing() {
-        let test_dir = "error_when_an_immutable_file_trio_is_missing/cardano_database";
-        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
-            .with_immutables(&[1, 3])
-            .build();
-
-        let db_directory = cardano_db.get_dir().to_path_buf();
-        let mut snapshotter = CompressedArchiveSnapshotter::new(
-            db_directory.clone(),
-            db_directory.parent().unwrap().join("snapshot_dest"),
-            SnapshotterCompressionAlgorithm::Gzip,
-            TestLogger::stdout(),
-        )
-        .unwrap();
-        snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
-
-        let builder = ImmutableArtifactBuilder::new(
-            vec![Arc::new(MockImmutableFilesUploader::new())],
-            Arc::new(snapshotter),
-            CompressionAlgorithm::Gzip,
-        )
-        .unwrap();
-
-        builder
-            .create_immutables_archives(3)
-            .expect_err("Should return an error when an immutable file trio is missing");
-    }
-
-    #[test]
-    fn create_immutables_archives_should_return_error_when_up_to_immutable_file_number_is_missing()
-    {
-        let test_dir = "error_when_up_to_immutable_file_number_is_missing/cardano_database";
-        let cardano_db = DummyCardanoDbBuilder::new(test_dir)
-            .with_immutables(&[1, 2])
-            .build();
-
-        let db_directory = cardano_db.get_dir().to_path_buf();
-        let mut snapshotter = CompressedArchiveSnapshotter::new(
-            db_directory.clone(),
-            db_directory.parent().unwrap().join("snapshot_dest"),
-            SnapshotterCompressionAlgorithm::Gzip,
-            TestLogger::stdout(),
-        )
-        .unwrap();
-        snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
-
-        let builder = ImmutableArtifactBuilder::new(
-            vec![Arc::new(MockImmutableFilesUploader::new())],
-            Arc::new(snapshotter),
-            CompressionAlgorithm::Gzip,
-        )
-        .unwrap();
-
-        builder
-            .create_immutables_archives(3)
-            .expect_err("Should return an error when an immutable file trio is missing");
-    }
-
-    #[test]
-    fn create_immutables_archives_should_not_rebuild_archives_already_compressed() {
-        let mut snapshotter = MockSnapshotter::new();
-
-        snapshotter
-            .expect_is_snapshot_exist()
-            .times(1)
-            .with(eq(Path::new("cardano-database/immutable/00001.tar.gz")))
-            .returning(|_| true);
-        snapshotter
-            .expect_is_snapshot_exist()
-            .times(1)
-            .with(eq(Path::new("cardano-database/immutable/00002.tar.gz")))
-            .returning(|_| true);
-        snapshotter
-            .expect_is_snapshot_exist()
-            .times(1)
-            .with(eq(Path::new("cardano-database/immutable/00003.tar.gz")))
-            .returning(|_| false);
-        snapshotter
-            .expect_snapshot_subset()
-            .times(1)
-            .with(
-                eq(Path::new("cardano-database/immutable/00003.tar.gz")),
-                eq(vec![
-                    PathBuf::from(IMMUTABLE_DIR).join("00003.chunk"),
-                    PathBuf::from(IMMUTABLE_DIR).join("00003.primary"),
-                    PathBuf::from(IMMUTABLE_DIR).join("00003.secondary"),
-                ]),
+            let db_directory = cardano_db.get_dir().to_path_buf();
+            let mut snapshotter = CompressedArchiveSnapshotter::new(
+                db_directory.clone(),
+                db_directory.parent().unwrap().join("snapshot_dest"),
+                SnapshotterCompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
             )
-            .returning(|filepath, _| {
-                let path = Path::new("/tmp").join(filepath);
-                Ok(OngoingSnapshot::new(path, 0))
-            });
+            .unwrap();
+            snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
 
-        let builder = ImmutableArtifactBuilder::new(
-            vec![Arc::new(MockImmutableFilesUploader::new())],
-            Arc::new(snapshotter),
-            CompressionAlgorithm::Gzip,
-        )
-        .unwrap();
+            let builder = ImmutableArtifactBuilder::new(
+                vec![Arc::new(MockImmutableFilesUploader::new())],
+                Arc::new(snapshotter),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
 
-        let archive_paths = builder.create_immutables_archives(3).unwrap();
+            builder.create_immutables_archives(2).expect_err(
+                "Should return an error when one of the three immutable files is missing",
+            );
+        }
 
-        assert_equivalent(
-            archive_paths,
-            vec![PathBuf::from(
-                "/tmp/cardano-database/immutable/00003.tar.gz",
-            )],
-        )
+        #[test]
+        fn create_immutables_archives_should_return_error_when_an_immutable_file_trio_is_missing() {
+            let test_dir = "error_when_an_immutable_file_trio_is_missing/cardano_database";
+            let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+                .with_immutables(&[1, 3])
+                .build();
+
+            let db_directory = cardano_db.get_dir().to_path_buf();
+            let mut snapshotter = CompressedArchiveSnapshotter::new(
+                db_directory.clone(),
+                db_directory.parent().unwrap().join("snapshot_dest"),
+                SnapshotterCompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+            snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
+
+            let builder = ImmutableArtifactBuilder::new(
+                vec![Arc::new(MockImmutableFilesUploader::new())],
+                Arc::new(snapshotter),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+
+            builder
+                .create_immutables_archives(3)
+                .expect_err("Should return an error when an immutable file trio is missing");
+        }
+
+        #[test]
+        fn create_immutables_archives_should_return_error_when_up_to_immutable_file_number_is_missing(
+        ) {
+            let test_dir = "error_when_up_to_immutable_file_number_is_missing/cardano_database";
+            let cardano_db = DummyCardanoDbBuilder::new(test_dir)
+                .with_immutables(&[1, 2])
+                .build();
+
+            let db_directory = cardano_db.get_dir().to_path_buf();
+            let mut snapshotter = CompressedArchiveSnapshotter::new(
+                db_directory.clone(),
+                db_directory.parent().unwrap().join("snapshot_dest"),
+                SnapshotterCompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+            snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
+
+            let builder = ImmutableArtifactBuilder::new(
+                vec![Arc::new(MockImmutableFilesUploader::new())],
+                Arc::new(snapshotter),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+
+            builder
+                .create_immutables_archives(3)
+                .expect_err("Should return an error when an immutable file trio is missing");
+        }
+
+        #[test]
+        fn create_immutables_archives_should_not_rebuild_archives_already_compressed() {
+            let mut snapshotter = MockSnapshotter::new();
+
+            snapshotter
+                .expect_is_snapshot_exist()
+                .times(1)
+                .with(eq(Path::new("cardano-database/immutable/00001.tar.gz")))
+                .returning(|_| true);
+            snapshotter
+                .expect_is_snapshot_exist()
+                .times(1)
+                .with(eq(Path::new("cardano-database/immutable/00002.tar.gz")))
+                .returning(|_| true);
+            snapshotter
+                .expect_is_snapshot_exist()
+                .times(1)
+                .with(eq(Path::new("cardano-database/immutable/00003.tar.gz")))
+                .returning(|_| false);
+            snapshotter
+                .expect_snapshot_subset()
+                .times(1)
+                .with(
+                    eq(Path::new("cardano-database/immutable/00003.tar.gz")),
+                    eq(vec![
+                        PathBuf::from(IMMUTABLE_DIR).join("00003.chunk"),
+                        PathBuf::from(IMMUTABLE_DIR).join("00003.primary"),
+                        PathBuf::from(IMMUTABLE_DIR).join("00003.secondary"),
+                    ]),
+                )
+                .returning(|filepath, _| {
+                    let path = Path::new("/tmp").join(filepath);
+                    Ok(OngoingSnapshot::new(path, 0))
+                });
+
+            let builder = ImmutableArtifactBuilder::new(
+                vec![Arc::new(MockImmutableFilesUploader::new())],
+                Arc::new(snapshotter),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+
+            let archive_paths = builder.create_immutables_archives(3).unwrap();
+
+            assert_equivalent(
+                archive_paths,
+                vec![PathBuf::from(
+                    "/tmp/cardano-database/immutable/00003.tar.gz",
+                )],
+            )
+        }
+    }
+
+    mod upload {
+        use mithril_common::test_utils::{equivalent_to, TempDir};
+
+        use super::MockImmutableFilesUploader;
+
+        use super::*;
+
+        fn fake_uploader(
+            archive_paths: Vec<&str>,
+            location_uri: &str,
+        ) -> MockImmutableFilesUploader {
+            let uri = location_uri.to_string();
+            let archive_paths: Vec<_> = archive_paths.into_iter().map(String::from).collect();
+
+            let mut uploader = MockImmutableFilesUploader::new();
+            uploader
+                .expect_upload()
+                .withf(move |p| {
+                    let paths: Vec<_> =
+                        p.iter().map(|s| s.to_string_lossy().into_owned()).collect();
+
+                    equivalent_to(paths, archive_paths.clone())
+                })
+                .times(1)
+                .return_once(|_| Ok(ImmutablesLocation::CloudStorage { uri }));
+
+            uploader
+        }
+
+        fn fake_uploader_returning_error() -> MockImmutableFilesUploader {
+            let mut uploader = MockImmutableFilesUploader::new();
+            uploader
+                .expect_upload()
+                .return_once(|_| Err(anyhow!("Failure while uploading...")));
+
+            uploader
+        }
+
+        #[test]
+        fn create_immutable_builder_should_error_when_no_uploader() {
+            let result = ImmutableArtifactBuilder::new(
+                vec![],
+                Arc::new(DumbSnapshotter::new()),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            );
+
+            assert!(result.is_err(), "Should return an error when no uploaders")
+        }
+
+        #[tokio::test]
+        async fn upload_immutable_archives_should_log_upload_errors() {
+            let log_path = TempDir::create(
+                "immutable",
+                "upload_immutable_archives_should_log_upload_errors",
+            )
+            .join("test.log");
+
+            let mut uploader = MockImmutableFilesUploader::new();
+            uploader
+                .expect_upload()
+                .return_once(|_| Err(anyhow!("Failure while uploading...")));
+
+            {
+                let builder = ImmutableArtifactBuilder::new(
+                    vec![Arc::new(uploader)],
+                    Arc::new(MockSnapshotter::new()),
+                    CompressionAlgorithm::Gzip,
+                    TestLogger::file(&log_path),
+                )
+                .unwrap();
+
+                let _ = builder
+                    .upload_immutable_archives(&vec![
+                        Path::new("01.tar.gz"),
+                        Path::new("02.tar.gz"),
+                    ])
+                    .await;
+            }
+
+            let logs = std::fs::read_to_string(&log_path).unwrap();
+            assert!(logs.contains("Failure while uploading..."));
+        }
+
+        #[tokio::test]
+        async fn upload_immutable_archives_should_error_when_no_location_is_returned() {
+            let uploaders: Vec<Arc<dyn ImmutableFilesUploader>> =
+                vec![Arc::new(fake_uploader_returning_error())];
+
+            let builder = ImmutableArtifactBuilder::new(
+                uploaders,
+                Arc::new(MockSnapshotter::new()),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+
+            let result = builder
+                .upload_immutable_archives(&vec![Path::new("01.tar.gz"), Path::new("02.tar.gz")])
+                .await;
+
+            assert!(
+                result.is_err(),
+                "Should return an error when no location is returned"
+            );
+        }
+
+        #[tokio::test]
+        async fn upload_immutable_archives_should_return_location_even_with_uploaders_errors() {
+            let uploaders: Vec<Arc<dyn ImmutableFilesUploader>> = vec![
+                Arc::new(fake_uploader_returning_error()),
+                Arc::new(fake_uploader(
+                    vec!["01.tar.gz", "02.tar.gz"],
+                    "archive_2.tar.gz",
+                )),
+                Arc::new(fake_uploader_returning_error()),
+            ];
+
+            let builder = ImmutableArtifactBuilder::new(
+                uploaders,
+                Arc::new(MockSnapshotter::new()),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+
+            let archive_paths = builder
+                .upload_immutable_archives(&vec![Path::new("01.tar.gz"), Path::new("02.tar.gz")])
+                .await
+                .unwrap();
+
+            assert_equivalent(
+                archive_paths,
+                vec![ImmutablesLocation::CloudStorage {
+                    uri: "archive_2.tar.gz".to_string(),
+                }],
+            )
+        }
+
+        #[tokio::test]
+        async fn upload_immutable_archives_should_return_all_uploaders_returned_locations() {
+            let uploaders: Vec<Arc<dyn ImmutableFilesUploader>> = vec![
+                Arc::new(fake_uploader(
+                    vec!["01.tar.gz", "02.tar.gz"],
+                    "archive_1.tar.gz",
+                )),
+                Arc::new(fake_uploader(
+                    vec!["01.tar.gz", "02.tar.gz"],
+                    "archive_2.tar.gz",
+                )),
+            ];
+
+            let builder = ImmutableArtifactBuilder::new(
+                uploaders,
+                Arc::new(MockSnapshotter::new()),
+                CompressionAlgorithm::Gzip,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+
+            let archive_paths = builder
+                .upload_immutable_archives(&vec![Path::new("01.tar.gz"), Path::new("02.tar.gz")])
+                .await
+                .unwrap();
+
+            assert_equivalent(
+                archive_paths,
+                vec![
+                    ImmutablesLocation::CloudStorage {
+                        uri: "archive_1.tar.gz".to_string(),
+                    },
+                    ImmutablesLocation::CloudStorage {
+                        uri: "archive_2.tar.gz".to_string(),
+                    },
+                ],
+            )
+        }
     }
 }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -103,6 +103,7 @@ impl ImmutableArtifactBuilder {
 mod tests {
     use mithril_common::{digesters::DummyCardanoDbBuilder, test_utils::assert_equivalent};
     use mockall::predicate::eq;
+    use uuid::Uuid;
 
     use crate::{
         file_uploaders::MockFileUploader,
@@ -126,7 +127,7 @@ mod tests {
 
     #[test]
     fn upload_should_return_locations() {
-        let test_dir = "cardano_database/upload_should_return_locations";
+        let test_dir = "upload_should_return_locations/cardano_database";
         let cardano_db = DummyCardanoDbBuilder::new(test_dir)
             .with_immutables(&[1, 2, 3])
             .build();
@@ -258,7 +259,7 @@ mod tests {
     #[test]
     fn create_immutables_archives_should_return_error_when_one_of_the_three_immutable_files_is_missing(
     ) {
-        let test_dir = "cardano_database/error_when_one_of_the_three_immutable_files_is_missing";
+        let test_dir = "error_when_one_of_the_three_immutable_files_is_missing/cardano_database";
         let cardano_db = DummyCardanoDbBuilder::new(test_dir)
             .with_immutables(&[1, 2])
             .build();
@@ -267,15 +268,14 @@ mod tests {
         std::fs::remove_file(file_to_remove).unwrap();
 
         let db_directory = cardano_db.get_dir().to_path_buf();
-        let snapshotter = {
-            CompressedArchiveSnapshotter::new(
-                db_directory.clone(),
-                db_directory.parent().unwrap().join("snapshot_dest"),
-                SnapshotterCompressionAlgorithm::Gzip,
-                TestLogger::stdout(),
-            )
-            .unwrap()
-        };
+        let mut snapshotter = CompressedArchiveSnapshotter::new(
+            db_directory.clone(),
+            db_directory.parent().unwrap().join("snapshot_dest"),
+            SnapshotterCompressionAlgorithm::Gzip,
+            TestLogger::stdout(),
+        )
+        .unwrap();
+        snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
 
         let builder = ImmutableArtifactBuilder::new(
             vec![Arc::new(MockImmutableFilesUploader::new())],
@@ -291,21 +291,20 @@ mod tests {
 
     #[test]
     fn create_immutables_archives_should_return_error_when_an_immutable_file_trio_is_missing() {
-        let test_dir = "cardano_database/error_when_an_immutable_file_trio_is_missing";
+        let test_dir = "error_when_an_immutable_file_trio_is_missing/cardano_database";
         let cardano_db = DummyCardanoDbBuilder::new(test_dir)
             .with_immutables(&[1, 3])
             .build();
 
         let db_directory = cardano_db.get_dir().to_path_buf();
-        let snapshotter = {
-            CompressedArchiveSnapshotter::new(
-                db_directory.clone(),
-                db_directory.parent().unwrap().join("snapshot_dest"),
-                SnapshotterCompressionAlgorithm::Gzip,
-                TestLogger::stdout(),
-            )
-            .unwrap()
-        };
+        let mut snapshotter = CompressedArchiveSnapshotter::new(
+            db_directory.clone(),
+            db_directory.parent().unwrap().join("snapshot_dest"),
+            SnapshotterCompressionAlgorithm::Gzip,
+            TestLogger::stdout(),
+        )
+        .unwrap();
+        snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
 
         let builder = ImmutableArtifactBuilder::new(
             vec![Arc::new(MockImmutableFilesUploader::new())],
@@ -322,21 +321,20 @@ mod tests {
     #[test]
     fn create_immutables_archives_should_return_error_when_up_to_immutable_file_number_is_missing()
     {
-        let test_dir = "cardano_database/error_when_up_to_immutable_file_number_is_missing";
+        let test_dir = "error_when_up_to_immutable_file_number_is_missing/cardano_database";
         let cardano_db = DummyCardanoDbBuilder::new(test_dir)
             .with_immutables(&[1, 2])
             .build();
 
         let db_directory = cardano_db.get_dir().to_path_buf();
-        let snapshotter = {
-            CompressedArchiveSnapshotter::new(
-                db_directory.clone(),
-                db_directory.parent().unwrap().join("snapshot_dest"),
-                SnapshotterCompressionAlgorithm::Gzip,
-                TestLogger::stdout(),
-            )
-            .unwrap()
-        };
+        let mut snapshotter = CompressedArchiveSnapshotter::new(
+            db_directory.clone(),
+            db_directory.parent().unwrap().join("snapshot_dest"),
+            SnapshotterCompressionAlgorithm::Gzip,
+            TestLogger::stdout(),
+        )
+        .unwrap();
+        snapshotter.set_sub_temp_dir(Uuid::new_v4().to_string());
 
         let builder = ImmutableArtifactBuilder::new(
             vec![Arc::new(MockImmutableFilesUploader::new())],

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
@@ -1,4 +1,6 @@
 //! The module is responsible for creating and uploading the archives of the Cardano database artifacts.
 mod ancillary;
+mod immutable;
 
 pub use ancillary::*;
+pub use immutable::*;

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/mod.rs
@@ -1,6 +1,8 @@
 //! The module is responsible for creating and uploading the archives of the Cardano database artifacts.
 mod ancillary;
+mod digest;
 mod immutable;
 
 pub use ancillary::*;
+pub use digest::*;
 pub use immutable::*;

--- a/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_immutable_files_full.rs
@@ -1,12 +1,13 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use mithril_common::entities::FileUri;
 use semver::Version;
 use slog::{debug, warn, Logger};
 use std::path::Path;
 use std::sync::Arc;
 use thiserror::Error;
 
-use crate::{file_uploaders::FileUri, snapshotter::OngoingSnapshot, FileUploader, Snapshotter};
+use crate::{snapshotter::OngoingSnapshot, FileUploader, Snapshotter};
 
 use super::ArtifactBuilder;
 use mithril_common::logging::LoggerExtensions;

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -53,7 +53,7 @@ use mithril_persistence::{
 use super::{DependenciesBuilderError, EpochServiceWrapper, Result};
 use crate::{
     artifact_builder::{
-        AggregatorDigestFileUploader, AncillaryArtifactBuilder, CardanoDatabaseArtifactBuilder,
+        AncillaryArtifactBuilder, CardanoDatabaseArtifactBuilder,
         CardanoImmutableFilesFullArtifactBuilder, CardanoStakeDistributionArtifactBuilder,
         CardanoTransactionsArtifactBuilder, DigestArtifactBuilder, ImmutableArtifactBuilder,
         MithrilStakeDistributionArtifactBuilder,
@@ -1262,10 +1262,9 @@ impl DependenciesBuilder {
             logger.clone(),
         )?);
 
-        let local_uploader =
-            AggregatorDigestFileUploader::new(self.get_server_url_prefix()?, logger.clone())?;
         let digest_builder = Arc::new(DigestArtifactBuilder::new(
-            vec![Arc::new(local_uploader)],
+            self.get_server_url_prefix()?,
+            vec![],
             logger.clone(),
         )?);
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -53,9 +53,9 @@ use mithril_persistence::{
 use super::{DependenciesBuilderError, EpochServiceWrapper, Result};
 use crate::{
     artifact_builder::{
-        AncillaryArtifactBuilder, CardanoDatabaseArtifactBuilder,
+        AggregatorDigestFileUploader, AncillaryArtifactBuilder, CardanoDatabaseArtifactBuilder,
         CardanoImmutableFilesFullArtifactBuilder, CardanoStakeDistributionArtifactBuilder,
-        CardanoTransactionsArtifactBuilder, ImmutableArtifactBuilder,
+        CardanoTransactionsArtifactBuilder, DigestArtifactBuilder, ImmutableArtifactBuilder,
         MithrilStakeDistributionArtifactBuilder,
     },
     configuration::ExecutionEnvironment,
@@ -1262,12 +1262,20 @@ impl DependenciesBuilder {
             logger.clone(),
         )?);
 
+        let local_uploader =
+            AggregatorDigestFileUploader::new(self.get_server_url_prefix()?, logger.clone())?;
+        let digest_builder = Arc::new(DigestArtifactBuilder::new(
+            vec![Arc::new(local_uploader)],
+            logger.clone(),
+        )?);
+
         Ok(CardanoDatabaseArtifactBuilder::new(
             self.configuration.db_directory.clone(),
             &cardano_node_version,
             self.configuration.snapshot_compression_algorithm,
             ancillary_builder,
             immutable_builder,
+            digest_builder,
         ))
     }
 

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1267,9 +1267,7 @@ impl DependenciesBuilder {
         let digest_builder = Arc::new(DigestArtifactBuilder::new(
             self.get_server_url_prefix()?,
             vec![],
-            self.configuration
-                .get_snapshot_dir()?
-                .join(digests_dir.clone()),
+            self.configuration.get_snapshot_dir()?.join(digests_dir),
             immutable_file_digest_mapper,
             logger.clone(),
         )?);

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1263,9 +1263,13 @@ impl DependenciesBuilder {
             logger.clone(),
         )?);
 
+        let digests_dir = Path::new("cardano-database").join("digests");
         let digest_builder = Arc::new(DigestArtifactBuilder::new(
             self.get_server_url_prefix()?,
             vec![],
+            self.configuration
+                .get_snapshot_dir()?
+                .join(digests_dir.clone()),
             immutable_file_digest_mapper,
             logger.clone(),
         )?);

--- a/mithril-aggregator/src/file_uploaders/dumb_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/dumb_uploader.rs
@@ -1,9 +1,9 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
-use mithril_common::StdResult;
+use mithril_common::{entities::FileUri, StdResult};
 use std::{path::Path, sync::RwLock};
 
-use crate::file_uploaders::{FileUploader, FileUri};
+use crate::file_uploaders::FileUploader;
 
 /// Dummy uploader for test purposes.
 ///

--- a/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
@@ -8,9 +8,9 @@ use slog::{info, Logger};
 use std::{env, path::Path};
 use tokio_util::codec::{BytesCodec, FramedRead};
 
-use mithril_common::{logging::LoggerExtensions, StdResult};
+use mithril_common::{entities::FileUri, logging::LoggerExtensions, StdResult};
 
-use crate::{file_uploaders::FileUri, FileUploader};
+use crate::FileUploader;
 
 /// GcpUploader represents a Google Cloud Platform file uploader interactor
 pub struct GcpUploader {

--- a/mithril-aggregator/src/file_uploaders/interface.rs
+++ b/mithril-aggregator/src/file_uploaders/interface.rs
@@ -3,7 +3,7 @@ use mithril_common::StdResult;
 use std::path::Path;
 
 /// FileUri represents a file URI used to identify the file's location
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
 pub struct FileUri(pub String);
 
 impl From<FileUri> for String {

--- a/mithril-aggregator/src/file_uploaders/interface.rs
+++ b/mithril-aggregator/src/file_uploaders/interface.rs
@@ -1,16 +1,6 @@
 use async_trait::async_trait;
-use mithril_common::StdResult;
+use mithril_common::{entities::FileUri, StdResult};
 use std::path::Path;
-
-/// FileUri represents a file URI used to identify the file's location
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
-pub struct FileUri(pub String);
-
-impl From<FileUri> for String {
-    fn from(file_uri: FileUri) -> Self {
-        file_uri.0
-    }
-}
 
 /// FileUploader represents a file uploader interactor
 #[cfg_attr(test, mockall::automock)]

--- a/mithril-aggregator/src/file_uploaders/local_snapshot_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_snapshot_uploader.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use mithril_common::entities::FileUri;
 use reqwest::Url;
 use slog::{debug, Logger};
 use std::path::{Path, PathBuf};
@@ -7,7 +8,7 @@ use std::path::{Path, PathBuf};
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
 
-use crate::file_uploaders::{url_sanitizer::sanitize_url_path, FileUploader, FileUri};
+use crate::file_uploaders::{url_sanitizer::sanitize_url_path, FileUploader};
 use crate::tools;
 
 // It's only used by the legacy snapshot that uploads the entire Cardano database.
@@ -70,7 +71,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
 
-    use crate::file_uploaders::{FileUploader, FileUri};
+    use crate::file_uploaders::FileUploader;
     use crate::test_tools::TestLogger;
 
     use super::*;

--- a/mithril-aggregator/src/file_uploaders/local_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_uploader.rs
@@ -102,8 +102,7 @@ mod tests {
 
         let url_prefix = Url::parse("http://test.com:8080/base-root").unwrap();
         let uploader = LocalUploader::new(url_prefix, &target_dir, TestLogger::stdout()).unwrap();
-        let location = uploader
-            .upload(&archive)
+        let location = FileUploader::upload(&uploader, &archive)
             .await
             .expect("local upload should not fail");
 
@@ -128,7 +127,7 @@ mod tests {
             TestLogger::stdout(),
         )
         .unwrap();
-        uploader.upload(&archive).await.unwrap();
+        FileUploader::upload(&uploader, &archive).await.unwrap();
 
         assert!(target_dir.join(archive.file_name().unwrap()).exists());
     }
@@ -149,8 +148,7 @@ mod tests {
             TestLogger::stdout(),
         )
         .unwrap();
-        uploader
-            .upload(&source_dir)
+        FileUploader::upload(&uploader, &source_dir)
             .await
             .expect_err("Uploading a directory should fail");
     }

--- a/mithril-aggregator/src/file_uploaders/local_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_uploader.rs
@@ -4,10 +4,10 @@ use reqwest::Url;
 use slog::{debug, Logger};
 use std::path::{Path, PathBuf};
 
-use mithril_common::logging::LoggerExtensions;
 use mithril_common::StdResult;
+use mithril_common::{entities::FileUri, logging::LoggerExtensions};
 
-use crate::file_uploaders::{url_sanitizer::sanitize_url_path, FileUploader, FileUri};
+use crate::file_uploaders::{url_sanitizer::sanitize_url_path, FileUploader};
 
 /// LocalUploader is a file uploader working using local files
 pub struct LocalUploader {

--- a/mithril-aggregator/src/file_uploaders/mod.rs
+++ b/mithril-aggregator/src/file_uploaders/mod.rs
@@ -7,8 +7,7 @@ pub mod url_sanitizer;
 
 pub use dumb_uploader::*;
 pub use gcp_uploader::GcpUploader;
-pub use interface::FileUploader;
-pub use interface::FileUri;
+pub use interface::{FileUploader, FileUri /*FilesUploader, MultiFilesUri, TemplateUri*/};
 pub use local_snapshot_uploader::LocalSnapshotUploader;
 pub use local_uploader::LocalUploader;
 

--- a/mithril-aggregator/src/file_uploaders/mod.rs
+++ b/mithril-aggregator/src/file_uploaders/mod.rs
@@ -7,7 +7,7 @@ pub mod url_sanitizer;
 
 pub use dumb_uploader::*;
 pub use gcp_uploader::GcpUploader;
-pub use interface::{FileUploader, FileUri /*FilesUploader, MultiFilesUri, TemplateUri*/};
+pub use interface::FileUploader;
 pub use local_snapshot_uploader::LocalSnapshotUploader;
 pub use local_uploader::LocalUploader;
 

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -519,7 +519,7 @@ impl Snapshotter for DumbSnapshotter {
     }
 
     fn is_snapshot_exist(&self, _filepath: &Path) -> bool {
-        return false;
+        false
     }
 
     fn get_file_path(&self, filepath: &Path) -> PathBuf {

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -975,6 +975,5 @@ mod tests {
         snapshotter.set_sub_temp_dir(Path::new("sub_dir"));
         snapshotter.set_sub_temp_dir(PathBuf::from("sub_dir"));
         snapshotter.set_sub_temp_dir("sub_dir");
-        snapshotter.set_sub_temp_dir("sub_dir".to_string());
     }
 }

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -26,7 +26,7 @@ pub trait Snapshotter: Sync + Send {
     fn snapshot_subset(&self, filepath: &Path, files: Vec<PathBuf>) -> StdResult<OngoingSnapshot>;
 
     /// Check if the snapshot exists.
-    fn is_snapshot_exist(&self, filepath: &Path) -> bool;
+    fn does_snapshot_exist(&self, filepath: &Path) -> bool;
 
     /// Give the full target path for the filepath.
     fn get_file_path(&self, filepath: &Path) -> PathBuf;
@@ -192,7 +192,7 @@ impl Snapshotter for CompressedArchiveSnapshotter {
         self.snapshot(filepath, appender)
     }
 
-    fn is_snapshot_exist(&self, filepath: &Path) -> bool {
+    fn does_snapshot_exist(&self, filepath: &Path) -> bool {
         self.get_file_path(filepath).exists()
     }
 
@@ -518,7 +518,7 @@ impl Snapshotter for DumbSnapshotter {
         self.snapshot_all(archive_name)
     }
 
-    fn is_snapshot_exist(&self, _filepath: &Path) -> bool {
+    fn does_snapshot_exist(&self, _filepath: &Path) -> bool {
         false
     }
 
@@ -936,11 +936,11 @@ mod tests {
         .unwrap();
 
         let snapshot_path = PathBuf::from(random_archive_name());
-        assert!(!snapshotter.is_snapshot_exist(&snapshot_path));
+        assert!(!snapshotter.does_snapshot_exist(&snapshot_path));
 
         snapshotter.snapshot_all(&snapshot_path).unwrap();
 
-        assert!(snapshotter.is_snapshot_exist(&snapshot_path));
+        assert!(snapshotter.does_snapshot_exist(&snapshot_path));
     }
 
     #[test]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.104"
+version = "0.4.105"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -69,7 +69,7 @@ impl CardanoDatabaseSnapshot {
 }
 
 /// Locations of the the immutable file digests.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum DigestLocation {
     /// Aggregator digest route location.
@@ -85,7 +85,7 @@ pub enum DigestLocation {
 }
 
 /// Locations of the ancillary files.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ImmutablesLocation {
     /// Cloud storage location.
@@ -96,7 +96,9 @@ pub enum ImmutablesLocation {
 }
 
 /// Locations of the ancillary files.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, EnumDiscriminants)]
+#[derive(
+    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize, EnumDiscriminants,
+)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum AncillaryLocation {
     /// Cloud storage location.

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -99,11 +99,7 @@ impl MultiFilesUri {
             return Err(anyhow!("Multiple templates found in the file URIs"));
         }
 
-        if let Some(template) = templates.into_iter().next() {
-            Ok(Some(TemplateUri(template)))
-        } else {
-            Ok(None)
-        }
+        Ok(templates.into_iter().next().map(TemplateUri))
     }
 }
 

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -1,6 +1,3 @@
-use std::collections::HashSet;
-
-use anyhow::anyhow;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -9,8 +6,9 @@ use strum::EnumDiscriminants;
 use crate::{
     entities::{CardanoDbBeacon, CompressionAlgorithm},
     signable_builder::Artifact,
-    StdResult,
 };
+
+use super::MultiFilesUri;
 
 /// Cardano database snapshot.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -69,37 +67,6 @@ impl CardanoDatabaseSnapshot {
         hasher.update(self.merkle_root.as_bytes());
 
         hex::encode(hasher.finalize())
-    }
-}
-
-/// [TemplateUri] represents an URI pattern used to build a file's location
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
-pub struct TemplateUri(pub String);
-
-/// [MultiFilesUri] represents a unique location uri for multiple files
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
-pub enum MultiFilesUri {
-    /// URI template representing several URI
-    Template(TemplateUri),
-}
-
-impl MultiFilesUri {
-    /// Extract a template from a list of URIs
-    pub fn extract_template_from_uris(
-        file_uris: Vec<String>,
-        extractor: impl Fn(&str) -> StdResult<Option<String>>,
-    ) -> StdResult<Option<TemplateUri>> {
-        let mut templates = HashSet::new();
-        for file_uri in file_uris {
-            let template_uri = extractor(&file_uri)?;
-            template_uri.map(|template| templates.insert(template));
-        }
-
-        if templates.len() > 1 {
-            return Err(anyhow!("Multiple templates found in the file URIs"));
-        }
-
-        Ok(templates.into_iter().next().map(TemplateUri))
     }
 }
 
@@ -269,50 +236,6 @@ mod tests {
                 }
                 .compute_hash()
             );
-        }
-    }
-
-    mod extract_template_from_uris {
-        use super::*;
-
-        #[test]
-        fn returns_template() {
-            let file_uris = vec![
-                "http://whatever/00001.tar.gz".to_string(),
-                "http://whatever/00002.tar.gz".to_string(),
-            ];
-            fn extractor_returning_same_uri(_file_uri: &str) -> StdResult<Option<String>> {
-                Ok(Some(
-                    "http://whatever/{immutable_file_number}.tar.gz".to_string(),
-                ))
-            }
-
-            let template =
-                MultiFilesUri::extract_template_from_uris(file_uris, extractor_returning_same_uri)
-                    .unwrap();
-
-            assert_eq!(
-                template,
-                Some(TemplateUri(
-                    "http://whatever/{immutable_file_number}.tar.gz".to_string()
-                ))
-            );
-        }
-
-        #[test]
-        fn returns_error_with_multiple_templates() {
-            let file_uris = vec![
-                "http://whatever/00001.tar.gz".to_string(),
-                "http://00002.tar.gz/whatever".to_string(),
-            ];
-            fn extractor_returning_different_uri(file_uri: &str) -> StdResult<Option<String>> {
-                Ok(Some(file_uri.to_string()))
-            }
-
-            MultiFilesUri::extract_template_from_uris(file_uris, extractor_returning_different_uri)
-                .expect_err(
-                    "Should return an error when multiple templates are found in the file URIs",
-                );
         }
     }
 }

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -68,7 +68,7 @@ impl CardanoDatabaseSnapshot {
     }
 }
 
-/// Locations of the the immutable file digests.
+/// Locations of the immutable file digests.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum DigestLocation {
@@ -84,7 +84,7 @@ pub enum DigestLocation {
     },
 }
 
-/// Locations of the ancillary files.
+/// Locations of the immutable files.
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum ImmutablesLocation {

--- a/mithril-common/src/entities/file_uri.rs
+++ b/mithril-common/src/entities/file_uri.rs
@@ -1,0 +1,92 @@
+use std::collections::HashSet;
+
+use anyhow::anyhow;
+use serde::{Deserialize, Serialize};
+
+use crate::StdResult;
+
+/// FileUri represents a file URI used to identify the file's location
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+pub struct FileUri(pub String);
+
+impl From<FileUri> for String {
+    fn from(file_uri: FileUri) -> Self {
+        file_uri.0
+    }
+}
+
+/// [TemplateUri] represents an URI pattern used to build a file's location
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+pub struct TemplateUri(pub String);
+
+/// [MultiFilesUri] represents a unique location uri for multiple files
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
+pub enum MultiFilesUri {
+    /// URI template representing several URI
+    Template(TemplateUri),
+}
+
+impl MultiFilesUri {
+    /// Extract a template from a list of URIs
+    pub fn extract_template_from_uris(
+        file_uris: Vec<String>,
+        extractor: impl Fn(&str) -> StdResult<Option<String>>,
+    ) -> StdResult<Option<TemplateUri>> {
+        let mut templates = HashSet::new();
+        for file_uri in file_uris {
+            let template_uri = extractor(&file_uri)?;
+            template_uri.map(|template| templates.insert(template));
+        }
+
+        if templates.len() > 1 {
+            return Err(anyhow!("Multiple templates found in the file URIs"));
+        }
+
+        Ok(templates.into_iter().next().map(TemplateUri))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_template() {
+        let file_uris = vec![
+            "http://whatever/00001.tar.gz".to_string(),
+            "http://whatever/00002.tar.gz".to_string(),
+        ];
+        fn extractor_returning_same_uri(_file_uri: &str) -> StdResult<Option<String>> {
+            Ok(Some(
+                "http://whatever/{immutable_file_number}.tar.gz".to_string(),
+            ))
+        }
+
+        let template =
+            MultiFilesUri::extract_template_from_uris(file_uris, extractor_returning_same_uri)
+                .unwrap();
+
+        assert_eq!(
+            template,
+            Some(TemplateUri(
+                "http://whatever/{immutable_file_number}.tar.gz".to_string()
+            ))
+        );
+    }
+
+    #[test]
+    fn returns_error_with_multiple_templates() {
+        let file_uris = vec![
+            "http://whatever/00001.tar.gz".to_string(),
+            "http://00002.tar.gz/whatever".to_string(),
+        ];
+        fn extractor_returning_different_uri(file_uri: &str) -> StdResult<Option<String>> {
+            Ok(Some(file_uri.to_string()))
+        }
+
+        MultiFilesUri::extract_template_from_uris(file_uris, extractor_returning_different_uri)
+            .expect_err(
+                "Should return an error when multiple templates are found in the file URIs",
+            );
+    }
+}

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -35,7 +35,7 @@ pub use block_range::{BlockRange, BlockRangeLength, BlockRangesSequence};
 pub use cardano_chain_point::{BlockHash, ChainPoint};
 pub use cardano_database::{
     AncillaryLocation, AncillaryLocationDiscriminants, ArtifactsLocations, CardanoDatabaseSnapshot,
-    DigestLocation, ImmutablesLocation,
+    DigestLocation, ImmutablesLocation, MultiFilesUri, TemplateUri,
 };
 pub use cardano_db_beacon::CardanoDbBeacon;
 pub use cardano_network::CardanoNetwork;

--- a/mithril-common/src/entities/mod.rs
+++ b/mithril-common/src/entities/mod.rs
@@ -16,6 +16,7 @@ mod certificate_metadata;
 mod certificate_pending;
 mod compression_algorithm;
 mod epoch;
+mod file_uri;
 mod http_server_error;
 mod mithril_stake_distribution;
 mod protocol_message;
@@ -35,7 +36,7 @@ pub use block_range::{BlockRange, BlockRangeLength, BlockRangesSequence};
 pub use cardano_chain_point::{BlockHash, ChainPoint};
 pub use cardano_database::{
     AncillaryLocation, AncillaryLocationDiscriminants, ArtifactsLocations, CardanoDatabaseSnapshot,
-    DigestLocation, ImmutablesLocation, MultiFilesUri, TemplateUri,
+    DigestLocation, ImmutablesLocation,
 };
 pub use cardano_db_beacon::CardanoDbBeacon;
 pub use cardano_network::CardanoNetwork;
@@ -48,6 +49,7 @@ pub use certificate_metadata::{CertificateMetadata, StakeDistributionParty};
 pub use certificate_pending::CertificatePending;
 pub use compression_algorithm::*;
 pub use epoch::{Epoch, EpochError};
+pub use file_uri::{FileUri, MultiFilesUri, TemplateUri};
 pub use http_server_error::{ClientError, ServerError};
 pub use mithril_stake_distribution::MithrilStakeDistribution;
 pub use protocol_message::{ProtocolMessage, ProtocolMessagePartKey, ProtocolMessagePartValue};

--- a/mithril-common/src/messages/cardano_database.rs
+++ b/mithril-common/src/messages/cardano_database.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::entities::{
     AncillaryLocation, ArtifactsLocations, CardanoDbBeacon, CompressionAlgorithm, DigestLocation,
-    Epoch, ImmutablesLocation,
+    Epoch, ImmutablesLocation, MultiFilesUri, TemplateUri,
 };
 
 /// Locations of the Cardano database related files.
@@ -81,10 +81,14 @@ impl CardanoDatabaseSnapshotMessage {
                 }],
                 immutables: vec![
                     ImmutablesLocation::CloudStorage {
-                        uri: "https://host-1/immutables-2".to_string(),
+                        uri: MultiFilesUri::Template(TemplateUri(
+                            "https://host-1/immutables-2".to_string(),
+                        )),
                     },
                     ImmutablesLocation::CloudStorage {
-                        uri: "https://host-2/immutables-2".to_string(),
+                        uri: MultiFilesUri::Template(TemplateUri(
+                            "https://host-2/immutables-2".to_string(),
+                        )),
                     },
                 ],
                 ancillary: vec![AncillaryLocation::CloudStorage {
@@ -121,11 +125,15 @@ mod tests {
             "immutables": [
             {
                 "type": "cloud_storage",
-                "uri": "https://host-1/immutables-2"
+                "uri": {
+                    "Template": "https://host-1/immutables-{immutable_file_number}"
+                }
             },
             {
                 "type": "cloud_storage",
-                "uri": "https://host-2/immutables-2"
+                "uri": {
+                    "Template": "https://host-2/immutables-{immutable_file_number}"
+                }
             }
             ],
             "ancillary": [
@@ -161,10 +169,14 @@ mod tests {
                 }],
                 immutables: vec![
                     ImmutablesLocation::CloudStorage {
-                        uri: "https://host-1/immutables-2".to_string(),
+                        uri: MultiFilesUri::Template(TemplateUri(
+                            "https://host-1/immutables-{immutable_file_number}".to_string(),
+                        )),
                     },
                     ImmutablesLocation::CloudStorage {
-                        uri: "https://host-2/immutables-2".to_string(),
+                        uri: MultiFilesUri::Template(TemplateUri(
+                            "https://host-2/immutables-{immutable_file_number}".to_string(),
+                        )),
                     },
                 ],
                 ancillary: vec![AncillaryLocation::CloudStorage {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1935,11 +1935,9 @@ components:
     MultiFilesUri:
       description: MultiFilesUri represents information to retrieve multiple files
       oneOf:
-          - $ref: "#/components/schemas/TemplateUri"
+        - $ref: "#/components/schemas/TemplateUri"
       examples:
-        {
-          "Template": "https://aggregator/{immutable_file_number}.tar.gz"
-        }
+        { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
 
     TemplateUri:
       description: TemplateUri represents a URI template for multiple files
@@ -1952,9 +1950,7 @@ components:
           description: URI template
           type: string
       examples:
-        {
-          "Template": "https://aggregator/{immutable_file_number}.tar.gz"
-        }
+        { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
 
     CardanoDatabaseSnapshotListMessage:
       description: CardanoDatabaseSnapshotListMessage represents a list of Cardano database snapshots

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1877,22 +1877,39 @@ components:
           items:
             $ref: "#/components/schemas/CardanoDatabaseArtifactLocationMessagePart"
       examples:
-        [
-          {
-            "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
-            "beacon":
+        {
+          "digests":
+            [
               {
-                "network": "preview",
-                "epoch": 123,
-                "immutable_file_number": 2345
+                "type": "cloud_storage",
+                "uri": "https://aggregator-endpoint/artifact/cardano-database/digests"
+              }
+            ],
+          "immutables":
+            [
+              {
+                "type": "cloud_storage",
+                "uri":
+                  {
+                    "Template": "https://mithril-cdn-us.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                  }
               },
-            "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
-            "total_db_size_uncompressed": 800796318,
-            "compression_algorithm": "gzip",
-            "cardano_node_version": "0.0.1",
-            "created_at": "2023-01-19T13:43:05.618857482Z"
-          }
-        ]
+              {
+                "type": "cloud_storage",
+                "uri":
+                  {
+                    "Template": "https://mithril-cdn-eu.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                  }
+              }
+            ],
+          "ancillary":
+            [
+              {
+                "type": "cloud_storage",
+                "uri": "https://mithril-cdn-us.iohk.io/snapshot/ancillary-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.tar.zst"
+              }
+            ]
+        }
 
     CardanoDatabaseArtifactLocationMessagePart:
       description: CardanoDatabaseArtifactLocationMessagePart represents the location of a single Cardano database artifact
@@ -2094,18 +2111,24 @@ components:
                 [
                   {
                     "type": "cloud_storage",
-                    "uri": "https://mithril-cdn-us.iohk.io/snapshot/digests-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.txt"
+                    "uri": "https://aggregator-endpoint/artifact/cardano-database/digests"
                   }
                 ],
               "immutables":
                 [
                   {
                     "type": "cloud_storage",
-                    "uri": "https://mithril-cdn-us.iohk.io/snapshot/immutables-{immutable-file_number}.tar.zst"
+                    "uri":
+                      {
+                        "Template": "https://mithril-cdn-us.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                      }
                   },
                   {
                     "type": "cloud_storage",
-                    "uri": "https://mithril-cdn-eu.iohk.io/snapshot/immutables-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732-{immutable-file_number}.tar.zst"
+                    "uri":
+                      {
+                        "Template": "https://mithril-cdn-eu.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                      }
                   }
                 ],
               "ancillary":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.41
+  version: 0.1.42
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1871,7 +1871,7 @@ components:
         immutables:
           type: array
           items:
-            $ref: "#/components/schemas/CardanoDatabaseArtifactLocationMessagePart"
+            $ref: "#/components/schemas/CardanoDatabaseImmutableLocationMessagePart"
         ancillary:
           type: array
           items:
@@ -1911,6 +1911,49 @@ components:
         {
           "type": "cloud_storage",
           "uri": "https://mithril-cdn-us.iohk.io/snapshot/digests-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.txt"
+        }
+
+    CardanoDatabaseImmutableLocationMessagePart:
+      description: CardanoDatabaseImmutableLocationMessagePart represents the location of a single Cardano database immutable archive
+      type: object
+      required:
+        - type
+        - uri
+      properties:
+        type:
+          description: Type of the artifact location
+          type: string
+        uri:
+          $ref: "#/components/schemas/MultiFilesUri"
+      examples:
+        {
+          "type": "cloud_storage",
+          "uri":
+            { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
+        }
+
+    MultiFilesUri:
+      description: MultiFilesUri represents information to retrieve multiple files
+      oneOf:
+          - $ref: "#/components/schemas/TemplateUri"
+      examples:
+        {
+          "Template": "https://aggregator/{immutable_file_number}.tar.gz"
+        }
+
+    TemplateUri:
+      description: TemplateUri represents a URI template for multiple files
+      type: object
+      additionalProperties: false
+      required:
+        - Template
+      properties:
+        Template:
+          description: URI template
+          type: string
+      examples:
+        {
+          "Template": "https://aggregator/{immutable_file_number}.tar.gz"
         }
 
     CardanoDatabaseSnapshotListMessage:


### PR DESCRIPTION
## Content

The `CardanoDatabaseArtifactBuilder` can build and upload immutables files and digests file

Implement the artifact builder for the Incremental Cardano Database with the target JSON structure:

```json
{
  "merkle_root": "0506e5e1f7df9314ebdbb532768a5addc2931004c5cd8fd8cd464090f95e46e4",
  "beacon": {
    "network": "mainnet",
    "epoch": 525,
    "immutable_file_number": 6550
  },
  "certificate_hash": "04219eb7a66c37f0d917160b8bdc617dc4ff911344f2e72bdb22c1316cbe8d71",
  "total_db_size_uncompressed": 52470081414,
  "created_at": "2024-12-02T04:36:40.811764301Z",
  "locations": {
    "digests": [
      {
        "type": "aggregator",
        "uri": "https://aggregator.release-mainnet.api.mithril.network/aggregator/artifact/cardano-database/digests"
      },
      {
        "type": "cloud_storage",
        "uri": "https://storage.googleapis.com/cdn.aggregator.release-mainnet.api.mithril.network/mainnet-e525-i6550.digests.tar.zst"
      }
    ],
    "immutables": [
      {
        "type": "cloud_storage",
        "uri": {
                "Template": "https://storage.googleapis.com/cdn.aggregator.release-mainnet.api.mithril.network/mainnet-e525-i6550.{immutable_file_number}.tar.zst"
        }
      },
      {
        "type": "bit_torrent",
        "uri": {
                "Template": "https://storage.googleapis.com/cdn.aggregator.release-mainnet.api.mithril.network/mainnet-e525-i6550.{immutable_file_number}.tar.zst"
        }
      }
    ],
    "ancillary": [
      {
        "type": "cloud_storage",
        "uri": "https://storage.googleapis.com/cdn.aggregator.release-mainnet.api.mithril.network/mainnet-e525.ancillary.tar.zst"
      }
    ]
  },
  "compression_algorithm": "zstandard",
  "cardano_node_version": "10.1.2"
}
```

And the target design:

![Image](https://github.com/user-attachments/assets/d586d695-39a1-4029-b19d-f68df72d0ba6)

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2151
