### PR TITLE
Chore: upgrade `release-preprod` VM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
             terraform_backend_bucket: hydra-terraform-admin
             google_region: europe-west1
             google_zone: europe-west1-b
-            google_machine_type: e2-highmem-2
+            google_machine_type: e2-highmem-4
             google_compute_instance_boot_disk_size: 200
             google_compute_instance_boot_disk_type: pd-standard
             google_compute_instance_data_disk_size: 250


### PR DESCRIPTION
## Content

This PR includes the **upgrade of the `release-preprod` VM from `e2-highmem-2` to `e2-highmem-4`**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2207 
