### PR TITLE
Fix: missing `DEBUG` logs release builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3658,7 +3658,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.10.7"
+version = "0.10.8"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.10.7"
+version = "0.10.8"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -41,7 +41,7 @@ reqwest = { version = "0.12.12", default-features = false, features = [
 semver = "1.0.24"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
-slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_warn"] }
+slog = "2.7.0"
 strum = { version = "0.26.3", features = ["derive"] }
 tar = { version = "0.4.43", optional = true }
 thiserror = "2.0.9"
@@ -73,6 +73,10 @@ mithril-common = { path = "../mithril-common", version = "=0.4", default-feature
     "test_tools",
 ] }
 mockall = "0.13.1"
+slog = { version = "2.7.0", features = [
+    "max_level_trace",
+    "release_max_level_warn",
+] }
 slog-async = "2.8.0"
 slog-term = "2.9.1"
 tokio = { version = "1.42.0", features = ["macros", "rt"] }


### PR DESCRIPTION
## Content

This PR includes a fix to the **missing `DEBUG` logs in the release binaries built in the CI**.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #2227 
