### PR TITLE
Feat: `GcpUploader` implements synchronization for Cardano database artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.13"
+version = "0.6.14"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -15,7 +15,9 @@ use mithril_common::{
 };
 
 use crate::{
-    file_uploaders::LocalUploader, snapshotter::OngoingSnapshot, FileUploader, Snapshotter,
+    file_uploaders::{GcpUploader, LocalUploader},
+    snapshotter::OngoingSnapshot,
+    DumbUploader, FileUploader, Snapshotter,
 };
 
 /// The [AncillaryFileUploader] trait allows identifying uploaders that return locations for ancillary archive files.
@@ -27,11 +29,35 @@ pub trait AncillaryFileUploader: Send + Sync {
 }
 
 #[async_trait]
+impl AncillaryFileUploader for DumbUploader {
+    async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
+        let uri = FileUploader::upload(self, filepath)
+            .await
+            .with_context(|| "Error while uploading with 'GcpUploader'")?
+            .into();
+
+        Ok(AncillaryLocation::CloudStorage { uri })
+    }
+}
+
+#[async_trait]
 impl AncillaryFileUploader for LocalUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
         let uri = FileUploader::upload(self, filepath)
             .await
             .with_context(|| "Error while uploading with 'LocalUploader'")?
+            .into();
+
+        Ok(AncillaryLocation::CloudStorage { uri })
+    }
+}
+
+#[async_trait]
+impl AncillaryFileUploader for GcpUploader {
+    async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
+        let uri = FileUploader::upload(self, filepath)
+            .await
+            .with_context(|| "Error while uploading with 'GcpUploader'")?
             .into();
 
         Ok(AncillaryLocation::CloudStorage { uri })

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/ancillary.rs
@@ -31,10 +31,7 @@ pub trait AncillaryFileUploader: Send + Sync {
 #[async_trait]
 impl AncillaryFileUploader for DumbUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
-        let uri = FileUploader::upload(self, filepath)
-            .await
-            .with_context(|| "Error while uploading with 'GcpUploader'")?
-            .into();
+        let uri = FileUploader::upload(self, filepath).await?.into();
 
         Ok(AncillaryLocation::CloudStorage { uri })
     }
@@ -43,10 +40,7 @@ impl AncillaryFileUploader for DumbUploader {
 #[async_trait]
 impl AncillaryFileUploader for LocalUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
-        let uri = FileUploader::upload(self, filepath)
-            .await
-            .with_context(|| "Error while uploading with 'LocalUploader'")?
-            .into();
+        let uri = FileUploader::upload(self, filepath).await?.into();
 
         Ok(AncillaryLocation::CloudStorage { uri })
     }
@@ -55,10 +49,7 @@ impl AncillaryFileUploader for LocalUploader {
 #[async_trait]
 impl AncillaryFileUploader for GcpUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<AncillaryLocation> {
-        let uri = FileUploader::upload(self, filepath)
-            .await
-            .with_context(|| "Error while uploading with 'GcpUploader'")?
-            .into();
+        let uri = FileUploader::upload(self, filepath).await?.into();
 
         Ok(AncillaryLocation::CloudStorage { uri })
     }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
@@ -13,7 +13,10 @@ use mithril_common::{
 use reqwest::Url;
 use slog::{error, Logger};
 
-use crate::ImmutableFileDigestMapper;
+use crate::{
+    file_uploaders::{GcpUploader, LocalUploader},
+    DumbUploader, FileUploader, ImmutableFileDigestMapper,
+};
 
 /// The [DigestFileUploader] trait allows identifying uploaders that return locations for digest files.
 #[cfg_attr(test, mockall::automock)]
@@ -21,6 +24,42 @@ use crate::ImmutableFileDigestMapper;
 pub trait DigestFileUploader: Send + Sync {
     /// Uploads the file at the given filepath and returns the location of the uploaded file.
     async fn upload(&self, filepath: &Path) -> StdResult<DigestLocation>;
+}
+
+#[async_trait]
+impl DigestFileUploader for DumbUploader {
+    async fn upload(&self, filepath: &Path) -> StdResult<DigestLocation> {
+        let uri = FileUploader::upload(self, filepath)
+            .await
+            .with_context(|| "Error while uploading with 'LocalUploader'")?
+            .into();
+
+        Ok(DigestLocation::CloudStorage { uri })
+    }
+}
+
+#[async_trait]
+impl DigestFileUploader for LocalUploader {
+    async fn upload(&self, filepath: &Path) -> StdResult<DigestLocation> {
+        let uri = FileUploader::upload(self, filepath)
+            .await
+            .with_context(|| "Error while uploading with 'LocalUploader'")?
+            .into();
+
+        Ok(DigestLocation::CloudStorage { uri })
+    }
+}
+
+#[async_trait]
+impl DigestFileUploader for GcpUploader {
+    async fn upload(&self, filepath: &Path) -> StdResult<DigestLocation> {
+        let uri = FileUploader::upload(self, filepath)
+            .await
+            .with_context(|| "Error while uploading with 'GcpUploader'")?
+            .into();
+
+        Ok(DigestLocation::CloudStorage { uri })
+    }
 }
 
 pub struct DigestArtifactBuilder {

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
@@ -29,10 +29,7 @@ pub trait DigestFileUploader: Send + Sync {
 #[async_trait]
 impl DigestFileUploader for DumbUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<DigestLocation> {
-        let uri = FileUploader::upload(self, filepath)
-            .await
-            .with_context(|| "Error while uploading with 'LocalUploader'")?
-            .into();
+        let uri = FileUploader::upload(self, filepath).await?.into();
 
         Ok(DigestLocation::CloudStorage { uri })
     }
@@ -41,10 +38,7 @@ impl DigestFileUploader for DumbUploader {
 #[async_trait]
 impl DigestFileUploader for LocalUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<DigestLocation> {
-        let uri = FileUploader::upload(self, filepath)
-            .await
-            .with_context(|| "Error while uploading with 'LocalUploader'")?
-            .into();
+        let uri = FileUploader::upload(self, filepath).await?.into();
 
         Ok(DigestLocation::CloudStorage { uri })
     }
@@ -53,10 +47,7 @@ impl DigestFileUploader for LocalUploader {
 #[async_trait]
 impl DigestFileUploader for GcpUploader {
     async fn upload(&self, filepath: &Path) -> StdResult<DigestLocation> {
-        let uri = FileUploader::upload(self, filepath)
-            .await
-            .with_context(|| "Error while uploading with 'GcpUploader'")?
-            .into();
+        let uri = FileUploader::upload(self, filepath).await?.into();
 
         Ok(DigestLocation::CloudStorage { uri })
     }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -45,14 +45,17 @@ pub trait ImmutableFilesUploader: Send + Sync {
 #[async_trait]
 impl ImmutableFilesUploader for DumbUploader {
     async fn batch_upload(&self, filepaths: &[PathBuf]) -> StdResult<ImmutablesLocation> {
-        let mut file_uris = Vec::new();
-        for filepath in filepaths {
-            file_uris.push(self.upload(filepath).await?.into());
-        }
+        let last_file_path = filepaths.last().ok_or_else(|| {
+            anyhow!("No file to upload with 'DumbUploader' as the filepaths list is empty")
+        })?;
 
-        let template_uri =
-            MultiFilesUri::extract_template_from_uris(file_uris, immmutable_file_number_extractor)?
-                .ok_or_else(|| anyhow!("No matching template found in the uploaded files"))?;
+        let template_uri = MultiFilesUri::extract_template_from_uris(
+            vec![self.upload(last_file_path).await?.into()],
+            immmutable_file_number_extractor,
+        )?
+        .ok_or_else(|| {
+            anyhow!("No matching template found in the uploaded files with 'DumbUploader'")
+        })?;
 
         Ok(ImmutablesLocation::CloudStorage {
             uri: MultiFilesUri::Template(template_uri),
@@ -70,7 +73,9 @@ impl ImmutableFilesUploader for LocalUploader {
 
         let template_uri =
             MultiFilesUri::extract_template_from_uris(file_uris, immmutable_file_number_extractor)?
-                .ok_or_else(|| anyhow!("No matching template found in the uploaded files"))?;
+                .ok_or_else(|| {
+                    anyhow!("No matching template found in the uploaded files with 'LocalUploader'")
+                })?;
 
         Ok(ImmutablesLocation::CloudStorage {
             uri: MultiFilesUri::Template(template_uri),
@@ -88,7 +93,9 @@ impl ImmutableFilesUploader for GcpUploader {
 
         let template_uri =
             MultiFilesUri::extract_template_from_uris(file_uris, immmutable_file_number_extractor)?
-                .ok_or_else(|| anyhow!("No matching template found in the uploaded files"))?;
+                .ok_or_else(|| {
+                    anyhow!("No matching template found in the uploaded files with 'GcpUploader'")
+                })?;
 
         Ok(ImmutablesLocation::CloudStorage {
             uri: MultiFilesUri::Template(template_uri),

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -67,7 +67,7 @@ use crate::{
     },
     entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
-    file_uploaders::{FileUploader, GcpUploader, LocalUploader},
+    file_uploaders::{FileUploader, GcpBackendUploader, GcpUploader, LocalUploader},
     http_server::{
         routes::router::{self, RouterConfig, RouterState},
         SERVER_BASE_PATH,
@@ -485,11 +485,13 @@ impl DependenciesBuilder {
                             )
                         })?;
 
-                    Ok(Arc::new(GcpUploader::new(
-                        bucket,
-                        self.configuration.snapshot_use_cdn_domain,
-                        logger.clone(),
-                    )))
+                    Ok(Arc::new(GcpUploader::new(Arc::new(
+                        GcpBackendUploader::try_new(
+                            bucket,
+                            self.configuration.snapshot_use_cdn_domain,
+                            logger.clone(),
+                        )?,
+                    ))))
                 }
                 SnapshotUploaderType::Local => Ok(Arc::new(LocalSnapshotUploader::new(
                     self.get_server_url_prefix()?,

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -67,7 +67,9 @@ use crate::{
     },
     entities::AggregatorEpochSettings,
     event_store::{EventMessage, EventStore, TransmitterService},
-    file_uploaders::{FileUploader, GcpBackendUploader, GcpUploader, LocalUploader},
+    file_uploaders::{
+        CloudRemotePath, FileUploader, GcpBackendUploader, GcpUploader, LocalUploader,
+    },
     http_server::{
         routes::router::{self, RouterConfig, RouterState},
         SERVER_BASE_PATH,
@@ -485,6 +487,7 @@ impl DependenciesBuilder {
                             )
                         })?;
                     let allow_overwriting = false;
+                    let remote_folder_path = CloudRemotePath::new("");
 
                     Ok(Arc::new(GcpUploader::new(
                         Arc::new(GcpBackendUploader::try_new(
@@ -492,6 +495,7 @@ impl DependenciesBuilder {
                             self.configuration.snapshot_use_cdn_domain,
                             logger.clone(),
                         )?),
+                        remote_folder_path,
                         allow_overwriting,
                     )))
                 }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -484,14 +484,16 @@ impl DependenciesBuilder {
                                 "snapshot_bucket_name".to_string(),
                             )
                         })?;
+                    let allow_overwriting = false;
 
-                    Ok(Arc::new(GcpUploader::new(Arc::new(
-                        GcpBackendUploader::try_new(
+                    Ok(Arc::new(GcpUploader::new(
+                        Arc::new(GcpBackendUploader::try_new(
                             bucket,
                             self.configuration.snapshot_use_cdn_domain,
                             logger.clone(),
-                        )?,
-                    ))))
+                        )?),
+                        allow_overwriting,
+                    )))
                 }
                 SnapshotUploaderType::Local => Ok(Arc::new(LocalSnapshotUploader::new(
                     self.get_server_url_prefix()?,

--- a/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
@@ -220,7 +220,7 @@ impl GcpUploader {
 impl FileUploader for GcpUploader {
     async fn upload(&self, file_path: &Path) -> StdResult<FileUri> {
         let remote_file_path = self.remote_folder.join(get_file_name(file_path)?);
-        if self.allow_overwrite {
+        if !self.allow_overwrite {
             if let Some(file_uri) = self
                 .cloud_backend_uploader
                 .file_exists(&remote_file_path)
@@ -257,9 +257,9 @@ mod tests {
         use super::*;
 
         #[tokio::test]
-        async fn upload_public_file_succeeds_when_file_does_not_exist_remotely_and_with_overwriting_allowed(
+        async fn upload_public_file_succeeds_when_file_does_not_exist_remotely_and_without_overwriting_allowed(
         ) {
-            let allow_overwrite = true;
+            let allow_overwrite = false;
             let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
             let remote_folder_path = CloudRemotePath::new("remote_folder");
             let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
@@ -298,9 +298,9 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn upload_public_file_succeeds_when_file_exists_remotely_and_with_overwriting_allowed(
+        async fn upload_public_file_succeeds_when_file_exists_remotely_and_without_overwriting_allowed(
         ) {
-            let allow_overwrite = true;
+            let allow_overwrite = false;
             let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
             let remote_folder_path = CloudRemotePath::new("remote_folder");
             let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
@@ -329,8 +329,8 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn upload_public_file_succeeds_without_overwriting_allowed() {
-            let allow_overwrite = false;
+        async fn upload_public_file_succeeds_with_overwriting_allowed() {
+            let allow_overwrite = true;
             let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
             let remote_folder_path = CloudRemotePath::new("remote_folder");
             let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
@@ -364,8 +364,8 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn upload_public_file_fails_when_file_exists_fails_and_with_overwriting_allowed() {
-            let allow_overwrite = true;
+        async fn upload_public_file_fails_when_file_exists_fails_and_without_overwriting_allowed() {
+            let allow_overwrite = false;
             let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
             let remote_folder_path = CloudRemotePath::new("remote_folder");
             let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
@@ -393,7 +393,7 @@ mod tests {
 
         #[tokio::test]
         async fn upload_public_file_fails_when_upload_fails() {
-            let allow_overwrite = false;
+            let allow_overwrite = true;
             let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
             let remote_folder_path = CloudRemotePath::new("remote_folder");
             let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
@@ -421,7 +421,7 @@ mod tests {
 
         #[tokio::test]
         async fn upload_public_file_fails_when_make_public_fails() {
-            let allow_overwrite = false;
+            let allow_overwrite = true;
             let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
             let remote_folder_path = CloudRemotePath::new("remote_folder");
             let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");

--- a/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
@@ -5,25 +5,73 @@ use cloud_storage::{
     Client,
 };
 use slog::{info, Logger};
-use std::{env, path::Path, sync::Arc};
+use std::{
+    env,
+    fmt::Display,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 use mithril_common::{entities::FileUri, logging::LoggerExtensions, StdResult};
 
 use crate::FileUploader;
 
+/// CloudRemotePath represents a cloud remote path
+#[derive(Debug, Clone, PartialEq)]
+pub struct CloudRemotePath(PathBuf);
+
+impl CloudRemotePath {
+    /// CloudRemotePath factory
+    pub fn new(file_path: &str) -> Self {
+        Self(PathBuf::from(file_path))
+    }
+
+    /// Join a file path to the current remote path
+    pub fn join(&self, file_path: &str) -> Self {
+        let mut path = self.0.clone();
+        path.push(file_path);
+
+        Self(path)
+    }
+}
+
+impl Display for CloudRemotePath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0.to_string_lossy())
+    }
+}
+
+impl From<&Path> for CloudRemotePath {
+    fn from(path: &Path) -> Self {
+        CloudRemotePath(path.to_path_buf())
+    }
+}
+
+fn get_file_name(file_path: &Path) -> StdResult<&str> {
+    file_path
+        .file_name()
+        .map(|s| s.to_str())
+        .ok_or(anyhow!("Could not convert file path to file name"))?
+        .ok_or(anyhow!("Could not find the final component of the path"))
+}
+
 /// CloudBackendUploader represents a cloud backend uploader
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait CloudBackendUploader: Send + Sync {
-    /// Check if a file exists in the Cloud backend
-    async fn file_exists(&self, file_path: &Path) -> StdResult<Option<FileUri>>;
+    /// Check if a file exists in the cloud backend
+    async fn file_exists(&self, remote_file_path: &CloudRemotePath) -> StdResult<Option<FileUri>>;
 
-    /// Upload a file to the Cloud backend
-    async fn upload_file(&self, file_path: &Path) -> StdResult<FileUri>;
+    /// Upload a file to the cloud backend
+    async fn upload_file(
+        &self,
+        local_file_path: &Path,
+        remote_file_path: &CloudRemotePath,
+    ) -> StdResult<FileUri>;
 
-    /// Make a file public in the Cloud backend
-    async fn make_file_public(&self, file_path: &Path) -> StdResult<()>;
+    /// Make a file public in the cloud backend
+    async fn make_file_public(&self, remote_file_path: &CloudRemotePath) -> StdResult<()>;
 }
 
 /// GcpBackendUploader represents a Google Cloud Platform file uploader
@@ -52,13 +100,14 @@ impl GcpBackendUploader {
         })
     }
 
-    fn get_location(&self, filename: &str) -> FileUri {
+    fn get_location(&self, remote_file_path: &CloudRemotePath) -> FileUri {
         let mut uri = vec![];
         if !self.use_cdn_domain {
             uri.push("storage.googleapis.com");
         }
         uri.push(&self.bucket);
-        uri.push(filename);
+        let file_path = remote_file_path.to_string();
+        uri.push(&file_path);
 
         FileUri(format!("https://{}", uri.join("/")))
     }
@@ -66,24 +115,22 @@ impl GcpBackendUploader {
 
 #[async_trait]
 impl CloudBackendUploader for GcpBackendUploader {
-    async fn file_exists(&self, file_path: &Path) -> StdResult<Option<FileUri>> {
-        let file_name =
-            get_file_name(file_path).with_context(|| "computing file name from path")?;
-        info!(self.logger, "Reading file metadata {file_name}");
+    async fn file_exists(&self, remote_file_path: &CloudRemotePath) -> StdResult<Option<FileUri>> {
+        info!(self.logger, "Reading file metadata {remote_file_path}");
         let file_uri = match self
             .client
             .object()
-            .read(&self.bucket, file_name)
+            .read(&self.bucket, &remote_file_path.to_string())
             .await
             .with_context(|| "remote reading file metadata failure")
         {
             Ok(_) => {
-                info!(self.logger, "Found file metadata {file_name}");
+                info!(self.logger, "Found file metadata {remote_file_path}");
 
-                Some(self.get_location(file_name))
+                Some(self.get_location(remote_file_path))
             }
             Err(_) => {
-                info!(self.logger, "Missing file metadata {file_name}");
+                info!(self.logger, "Missing file metadata {remote_file_path}");
 
                 None
             }
@@ -92,11 +139,16 @@ impl CloudBackendUploader for GcpBackendUploader {
         Ok(file_uri)
     }
 
-    async fn upload_file(&self, file_path: &Path) -> StdResult<FileUri> {
-        let file_name =
-            get_file_name(file_path).with_context(|| "computing file name from path")?;
-        info!(self.logger, "Uploading {file_name}");
-        let file = tokio::fs::File::open(file_path).await.unwrap();
+    async fn upload_file(
+        &self,
+        local_file_path: &Path,
+        remote_file_path: &CloudRemotePath,
+    ) -> StdResult<FileUri> {
+        info!(
+            self.logger,
+            "Uploading {local_file_path:?} to {remote_file_path}"
+        );
+        let file = tokio::fs::File::open(local_file_path).await.unwrap();
         let stream = FramedRead::new(file, BytesCodec::new());
         self.client
             .object()
@@ -104,50 +156,48 @@ impl CloudBackendUploader for GcpBackendUploader {
                 &self.bucket,
                 stream,
                 None,
-                file_name,
+                &remote_file_path.to_string(),
                 "application/octet-stream",
             )
             .await
             .with_context(|| "remote uploading failure")?;
-        info!(self.logger, "Uploaded {file_name}");
+        info!(
+            self.logger,
+            "Uploaded {local_file_path:?} to {remote_file_path}"
+        );
 
-        Ok(self.get_location(file_name))
+        Ok(self.get_location(remote_file_path))
     }
 
-    async fn make_file_public(&self, file_path: &Path) -> StdResult<()> {
-        let file_name =
-            get_file_name(file_path).with_context(|| "computing file name from path")?;
+    async fn make_file_public(&self, remote_file_path: &CloudRemotePath) -> StdResult<()> {
         let new_bucket_access_control = NewObjectAccessControl {
             entity: Entity::AllUsers,
             role: Role::Reader,
         };
         info!(
             self.logger,
-            "Updating acl for {file_name}: {new_bucket_access_control:?}"
+            "Updating acl for {remote_file_path}: {new_bucket_access_control:?}"
         );
         self.client
             .object_access_control()
-            .create(&self.bucket, file_name, &new_bucket_access_control)
+            .create(
+                &self.bucket,
+                &remote_file_path.to_string(),
+                &new_bucket_access_control,
+            )
             .await
             .with_context(|| "updating acl failure")?;
 
-        info!(self.logger, "Updated acl for {file_name}");
+        info!(self.logger, "Updated acl for {remote_file_path}");
 
         Ok(())
     }
 }
 
-fn get_file_name(file_path: &Path) -> StdResult<&str> {
-    file_path
-        .file_name()
-        .map(|s| s.to_str())
-        .ok_or(anyhow!("Could not convert file path to file name"))?
-        .ok_or(anyhow!("Could not find the final component of the path"))
-}
-
 /// GcpUploader represents a Google Cloud Platform file uploader interactor
 pub struct GcpUploader {
     cloud_backend_uploader: Arc<dyn CloudBackendUploader>,
+    remote_folder: CloudRemotePath,
     allow_overwrite: bool,
 }
 
@@ -155,10 +205,12 @@ impl GcpUploader {
     /// GcpUploader factory
     pub fn new(
         cloud_backend_uploader: Arc<dyn CloudBackendUploader>,
+        remote_folder: CloudRemotePath,
         allow_overwrite: bool,
     ) -> Self {
         Self {
             cloud_backend_uploader,
+            remote_folder,
             allow_overwrite,
         }
     }
@@ -167,10 +219,11 @@ impl GcpUploader {
 #[async_trait]
 impl FileUploader for GcpUploader {
     async fn upload(&self, file_path: &Path) -> StdResult<FileUri> {
+        let remote_file_path = self.remote_folder.join(get_file_name(file_path)?);
         if self.allow_overwrite {
             if let Some(file_uri) = self
                 .cloud_backend_uploader
-                .file_exists(file_path)
+                .file_exists(&remote_file_path)
                 .await
                 .with_context(|| "checking if file exists in cloud")?
             {
@@ -180,12 +233,11 @@ impl FileUploader for GcpUploader {
 
         let file_uri = self
             .cloud_backend_uploader
-            .upload_file(file_path)
+            .upload_file(file_path, &remote_file_path)
             .await
             .with_context(|| "uploading file to cloud")?;
-
         self.cloud_backend_uploader
-            .make_file_public(file_path)
+            .make_file_public(&remote_file_path)
             .await
             .with_context(|| "making file public in cloud")?;
 
@@ -207,34 +259,40 @@ mod tests {
         #[tokio::test]
         async fn upload_public_file_succeeds_when_file_does_not_exist_remotely_and_with_overwriting_allowed(
         ) {
-            let allow_overwriting = true;
-            let file_path = Path::new("snapshot.xxx.tar.gz");
-            let expected_file_uri = FileUri("https://cloud-host/snapshot.xxx.tar.gz".to_string());
-            let expected_file_uri_clone = expected_file_uri.clone();
+            let allow_overwrite = true;
+            let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+            let remote_folder_path = CloudRemotePath::new("remote_folder");
+            let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
+            let expected_file_uri =
+                FileUri("https://cloud-host/remote_folder/snapshot.xxx.tar.gz".to_string());
             let cloud_backend_uploader = {
                 let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
                 mock_cloud_backend_uploader
                     .expect_file_exists()
-                    .with(eq(file_path))
+                    .with(eq(remote_file_path.clone()))
                     .return_once(move |_| Ok(None))
                     .once();
+                let expected_file_uri_clone = expected_file_uri.clone();
                 mock_cloud_backend_uploader
                     .expect_upload_file()
-                    .with(eq(file_path))
-                    .return_once(move |_| Ok(expected_file_uri_clone))
+                    .with(eq(local_file_path.clone()), eq(remote_file_path.clone()))
+                    .return_once(move |_, _| Ok(expected_file_uri_clone))
                     .once();
                 mock_cloud_backend_uploader
                     .expect_make_file_public()
-                    .with(eq(file_path))
+                    .with(eq(remote_file_path.clone()))
                     .return_once(move |_| Ok(()))
                     .once();
 
                 mock_cloud_backend_uploader
             };
-            let file_uploader =
-                GcpUploader::new(Arc::new(cloud_backend_uploader), allow_overwriting);
+            let file_uploader = GcpUploader::new(
+                Arc::new(cloud_backend_uploader),
+                remote_folder_path,
+                allow_overwrite,
+            );
 
-            let file_uri = file_uploader.upload(file_path).await.unwrap();
+            let file_uri = file_uploader.upload(&local_file_path).await.unwrap();
 
             assert_eq!(expected_file_uri, file_uri);
         }
@@ -242,129 +300,157 @@ mod tests {
         #[tokio::test]
         async fn upload_public_file_succeeds_when_file_exists_remotely_and_with_overwriting_allowed(
         ) {
-            let allow_overwriting = true;
-            let file_path = Path::new("snapshot.xxx.tar.gz");
-            let expected_file_uri = FileUri("https://cloud-host/snapshot.xxx.tar.gz".to_string());
-            let expected_file_uri_clone = expected_file_uri.clone();
+            let allow_overwrite = true;
+            let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+            let remote_folder_path = CloudRemotePath::new("remote_folder");
+            let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
+            let expected_file_uri =
+                FileUri("https://cloud-host/remote_folder/snapshot.xxx.tar.gz".to_string());
             let cloud_backend_uploader = {
                 let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+                let expected_file_uri_clone = expected_file_uri.clone();
                 mock_cloud_backend_uploader
                     .expect_file_exists()
-                    .with(eq(file_path))
+                    .with(eq(remote_file_path))
                     .return_once(move |_| Ok(Some(expected_file_uri_clone)))
                     .once();
 
                 mock_cloud_backend_uploader
             };
-            let file_uploader =
-                GcpUploader::new(Arc::new(cloud_backend_uploader), allow_overwriting);
+            let file_uploader = GcpUploader::new(
+                Arc::new(cloud_backend_uploader),
+                remote_folder_path,
+                allow_overwrite,
+            );
 
-            let file_uri = file_uploader.upload(file_path).await.unwrap();
+            let file_uri = file_uploader.upload(&local_file_path).await.unwrap();
 
             assert_eq!(expected_file_uri, file_uri);
         }
 
         #[tokio::test]
         async fn upload_public_file_succeeds_without_overwriting_allowed() {
-            let allow_overwriting = false;
-            let file_path = Path::new("snapshot.xxx.tar.gz");
-            let expected_file_uri = FileUri("https://cloud-host/snapshot.xxx.tar.gz".to_string());
-            let expected_file_uri_clone = expected_file_uri.clone();
+            let allow_overwrite = false;
+            let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+            let remote_folder_path = CloudRemotePath::new("remote_folder");
+            let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
+            let expected_file_uri =
+                FileUri("https://cloud-host/remote_folder/snapshot.xxx.tar.gz".to_string());
             let cloud_backend_uploader = {
                 let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+                let expected_file_uri_clone = expected_file_uri.clone();
                 mock_cloud_backend_uploader
                     .expect_upload_file()
-                    .with(eq(file_path))
-                    .return_once(move |_| Ok(expected_file_uri_clone))
+                    .with(eq(local_file_path.clone()), eq(remote_file_path.clone()))
+                    .return_once(move |_, _| Ok(expected_file_uri_clone))
                     .once();
                 mock_cloud_backend_uploader
                     .expect_make_file_public()
-                    .with(eq(file_path))
+                    .with(eq(remote_file_path))
                     .return_once(move |_| Ok(()))
                     .once();
 
                 mock_cloud_backend_uploader
             };
-            let file_uploader =
-                GcpUploader::new(Arc::new(cloud_backend_uploader), allow_overwriting);
+            let file_uploader = GcpUploader::new(
+                Arc::new(cloud_backend_uploader),
+                remote_folder_path,
+                allow_overwrite,
+            );
 
-            let file_uri = file_uploader.upload(file_path).await.unwrap();
+            let file_uri = file_uploader.upload(&local_file_path).await.unwrap();
 
             assert_eq!(expected_file_uri, file_uri);
         }
 
         #[tokio::test]
         async fn upload_public_file_fails_when_file_exists_fails_and_with_overwriting_allowed() {
-            let allow_overwriting = true;
-            let file_path = Path::new("snapshot.xxx.tar.gz");
+            let allow_overwrite = true;
+            let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+            let remote_folder_path = CloudRemotePath::new("remote_folder");
+            let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
             let cloud_backend_uploader = {
                 let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
                 mock_cloud_backend_uploader
                     .expect_file_exists()
-                    .with(eq(file_path))
+                    .with(eq(remote_file_path))
                     .return_once(move |_| Err(anyhow!("file exists error")))
                     .once();
 
                 mock_cloud_backend_uploader
             };
-            let file_uploader =
-                GcpUploader::new(Arc::new(cloud_backend_uploader), allow_overwriting);
+            let file_uploader = GcpUploader::new(
+                Arc::new(cloud_backend_uploader),
+                remote_folder_path,
+                allow_overwrite,
+            );
 
             file_uploader
-                .upload(file_path)
+                .upload(&local_file_path)
                 .await
                 .expect_err("should have failed");
         }
 
         #[tokio::test]
         async fn upload_public_file_fails_when_upload_fails() {
-            let allow_overwriting = false;
-            let file_path = Path::new("snapshot.xxx.tar.gz");
+            let allow_overwrite = false;
+            let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+            let remote_folder_path = CloudRemotePath::new("remote_folder");
+            let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
             let cloud_backend_uploader = {
                 let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
                 mock_cloud_backend_uploader
                     .expect_upload_file()
-                    .with(eq(file_path))
-                    .return_once(move |_| Err(anyhow!("upload error")))
+                    .with(eq(local_file_path.clone()), eq(remote_file_path.clone()))
+                    .return_once(move |_, _| Err(anyhow!("upload error")))
                     .once();
 
                 mock_cloud_backend_uploader
             };
-            let file_uploader =
-                GcpUploader::new(Arc::new(cloud_backend_uploader), allow_overwriting);
+            let file_uploader = GcpUploader::new(
+                Arc::new(cloud_backend_uploader),
+                remote_folder_path,
+                allow_overwrite,
+            );
 
             file_uploader
-                .upload(file_path)
+                .upload(&local_file_path)
                 .await
                 .expect_err("should have failed");
         }
 
         #[tokio::test]
         async fn upload_public_file_fails_when_make_public_fails() {
-            let allow_overwriting = false;
-            let file_path = Path::new("snapshot.xxx.tar.gz");
-            let expected_file_uri = FileUri("https://cloud-host/snapshot.xxx.tar.gz".to_string());
-            let expected_file_uri_clone = expected_file_uri.clone();
+            let allow_overwrite = false;
+            let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+            let remote_folder_path = CloudRemotePath::new("remote_folder");
+            let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
+            let expected_file_uri =
+                FileUri("https://cloud-host/remote_folder/snapshot.xxx.tar.gz".to_string());
             let cloud_backend_uploader = {
                 let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+                let expected_file_uri_clone = expected_file_uri.clone();
                 mock_cloud_backend_uploader
                     .expect_upload_file()
-                    .with(eq(file_path))
-                    .return_once(move |_| Ok(expected_file_uri_clone))
+                    .with(eq(local_file_path.clone()), eq(remote_file_path.clone()))
+                    .return_once(move |_, _| Ok(expected_file_uri_clone))
                     .once();
                 mock_cloud_backend_uploader
                     .expect_make_file_public()
-                    .with(eq(file_path))
+                    .with(eq(remote_file_path))
                     .return_once(move |_| Err(anyhow!("make public error")))
                     .once();
 
                 mock_cloud_backend_uploader
             };
-            let file_uploader =
-                GcpUploader::new(Arc::new(cloud_backend_uploader), allow_overwriting);
+            let file_uploader = GcpUploader::new(
+                Arc::new(cloud_backend_uploader),
+                remote_folder_path,
+                allow_overwrite,
+            );
 
             file_uploader
-                .upload(file_path)
+                .upload(&local_file_path)
                 .await
                 .expect_err("should have failed");
         }
@@ -383,12 +469,13 @@ mod tests {
                 TestLogger::stdout(),
             )
             .unwrap();
-            let filename = "snapshot.xxx.tar.gz";
+            let remote_file_path =
+                CloudRemotePath::new("remote_folder").join("snapshot.xxx.tar.gz");
             let expected_location =
-                "https://storage.googleapis.com/cdn.mithril.network/snapshot.xxx.tar.gz"
+                "https://storage.googleapis.com/cdn.mithril.network/remote_folder/snapshot.xxx.tar.gz"
                     .to_string();
 
-            let location = gcp_file_uploader.get_location(filename);
+            let location = gcp_file_uploader.get_location(&remote_file_path);
 
             assert_eq!(FileUri(expected_location), location);
         }
@@ -403,10 +490,12 @@ mod tests {
                 TestLogger::stdout(),
             )
             .unwrap();
-            let filename = "snapshot.xxx.tar.gz";
-            let expected_location = "https://cdn.mithril.network/snapshot.xxx.tar.gz".to_string();
+            let remote_file_path =
+                CloudRemotePath::new("remote_folder").join("snapshot.xxx.tar.gz");
+            let expected_location =
+                "https://cdn.mithril.network/remote_folder/snapshot.xxx.tar.gz".to_string();
 
-            let location = gcp_file_uploader.get_location(filename);
+            let location = gcp_file_uploader.get_location(&remote_file_path);
 
             assert_eq!(FileUri(expected_location), location);
         }

--- a/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/gcp_uploader.rs
@@ -5,28 +5,48 @@ use cloud_storage::{
     Client,
 };
 use slog::{info, Logger};
-use std::{env, path::Path};
+use std::{env, path::Path, sync::Arc};
 use tokio_util::codec::{BytesCodec, FramedRead};
 
 use mithril_common::{entities::FileUri, logging::LoggerExtensions, StdResult};
 
 use crate::FileUploader;
 
-/// GcpUploader represents a Google Cloud Platform file uploader interactor
-pub struct GcpUploader {
+/// CloudBackendUploader represents a cloud backend uploader
+#[cfg_attr(test, mockall::automock)]
+#[async_trait]
+pub trait CloudBackendUploader: Send + Sync {
+    /// Upload a file to the Cloud backend
+    async fn upload_file(&self, file_path: &Path) -> StdResult<FileUri>;
+
+    /// Make a file public in the Cloud backend
+    async fn make_file_public(&self, file_path: &Path) -> StdResult<()>;
+}
+
+/// GcpBackendUploader represents a Google Cloud Platform file uploader
+#[derive(Debug)]
+pub struct GcpBackendUploader {
     bucket: String,
     use_cdn_domain: bool,
+    client: Client,
     logger: Logger,
 }
 
-impl GcpUploader {
-    /// GcpUploader factory
-    pub fn new(bucket: String, use_cdn_domain: bool, logger: Logger) -> Self {
-        Self {
+impl GcpBackendUploader {
+    /// GcpBackendUploader factory
+    pub fn try_new(bucket: String, use_cdn_domain: bool, logger: Logger) -> StdResult<Self> {
+        if env::var("GOOGLE_APPLICATION_CREDENTIALS_JSON").is_err() {
+            return Err(anyhow!(
+                "Missing GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable".to_string()
+            ));
+        };
+
+        Ok(Self {
             bucket,
             use_cdn_domain,
             logger: logger.new_with_component_name::<Self>(),
-        }
+            client: Client::default(),
+        })
     }
 
     fn get_location(&self, filename: &str) -> FileUri {
@@ -42,56 +62,89 @@ impl GcpUploader {
 }
 
 #[async_trait]
-impl FileUploader for GcpUploader {
-    async fn upload(&self, filepath: &Path) -> StdResult<FileUri> {
-        if env::var("GOOGLE_APPLICATION_CREDENTIALS_JSON").is_err() {
-            return Err(anyhow!(
-                "Missing GOOGLE_APPLICATION_CREDENTIALS_JSON environment variable".to_string()
-            ));
-        };
-
-        let filename = filepath.file_name().unwrap().to_str().unwrap();
-
-        info!(self.logger, "Uploading {filename}");
-        let client = Client::default();
-        let file = tokio::fs::File::open(filepath).await.unwrap();
+impl CloudBackendUploader for GcpBackendUploader {
+    async fn upload_file(&self, file_path: &Path) -> StdResult<FileUri> {
+        let file_name =
+            get_file_name(file_path).with_context(|| "computing file name from path")?;
+        info!(self.logger, "Uploading {file_name}");
+        let file = tokio::fs::File::open(file_path).await.unwrap();
         let stream = FramedRead::new(file, BytesCodec::new());
-        client
+        self.client
             .object()
             .create_streamed(
                 &self.bucket,
                 stream,
                 None,
-                filename,
+                file_name,
                 "application/octet-stream",
             )
             .await
             .with_context(|| "remote uploading failure")?;
+        info!(self.logger, "Uploaded {file_name}");
 
-        info!(self.logger, "Uploaded {filename}");
+        Ok(self.get_location(file_name))
+    }
 
-        // ensure the uploaded file as public read access
-        // when a file is uploaded to Google cloud storage its permissions are overwritten so
-        // we need to put them back
+    async fn make_file_public(&self, file_path: &Path) -> StdResult<()> {
+        let file_name =
+            get_file_name(file_path).with_context(|| "computing file name from path")?;
         let new_bucket_access_control = NewObjectAccessControl {
             entity: Entity::AllUsers,
             role: Role::Reader,
         };
-
         info!(
             self.logger,
-            "Updating acl for {filename}: {new_bucket_access_control:?}"
+            "Updating acl for {file_name}: {new_bucket_access_control:?}"
         );
-
-        client
+        self.client
             .object_access_control()
-            .create(&self.bucket, filename, &new_bucket_access_control)
+            .create(&self.bucket, file_name, &new_bucket_access_control)
             .await
             .with_context(|| "updating acl failure")?;
 
-        info!(self.logger, "Updated acl for {filename}");
+        info!(self.logger, "Updated acl for {file_name}");
 
-        Ok(self.get_location(filename))
+        Ok(())
+    }
+}
+
+fn get_file_name(file_path: &Path) -> StdResult<&str> {
+    file_path
+        .file_name()
+        .map(|s| s.to_str())
+        .ok_or(anyhow!("Could not convert file path to file name"))?
+        .ok_or(anyhow!("Could not find the final component of the path"))
+}
+
+/// GcpUploader represents a Google Cloud Platform file uploader interactor
+pub struct GcpUploader {
+    cloud_backend_uploader: Arc<dyn CloudBackendUploader>,
+}
+
+impl GcpUploader {
+    /// GcpUploader factory
+    pub fn new(cloud_backend_uploader: Arc<dyn CloudBackendUploader>) -> Self {
+        Self {
+            cloud_backend_uploader,
+        }
+    }
+}
+
+#[async_trait]
+impl FileUploader for GcpUploader {
+    async fn upload(&self, file_path: &Path) -> StdResult<FileUri> {
+        let file_uri = self
+            .cloud_backend_uploader
+            .upload_file(file_path)
+            .await
+            .with_context(|| "uploading file to cloud")?;
+
+        self.cloud_backend_uploader
+            .make_file_public(file_path)
+            .await
+            .with_context(|| "making file public in cloud")?;
+
+        Ok(file_uri)
     }
 }
 
@@ -101,38 +154,127 @@ mod tests {
 
     use super::*;
 
-    #[tokio::test]
-    async fn get_location_not_using_cdn_domain_return_google_api_uri() {
-        let use_cdn_domain = false;
+    mod cloud_backend_uploader {
+        use mockall::predicate::eq;
 
-        let file_uploader = GcpUploader::new(
-            "cardano-testnet".to_string(),
-            use_cdn_domain,
-            TestLogger::stdout(),
-        );
-        let filename = "snapshot.xxx.tar.gz";
-        let expected_location =
-            "https://storage.googleapis.com/cardano-testnet/snapshot.xxx.tar.gz".to_string();
+        use super::*;
 
-        let location = file_uploader.get_location(filename);
+        #[tokio::test]
+        async fn upload_public_file_success() {
+            let file_path = Path::new("snapshot.xxx.tar.gz");
+            let expected_file_uri = FileUri("https://cloud-host/snapshot.xxx.tar.gz".to_string());
+            let expected_file_uri_clone = expected_file_uri.clone();
+            let cloud_backend_uploader = {
+                let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+                mock_cloud_backend_uploader
+                    .expect_upload_file()
+                    .with(eq(file_path))
+                    .return_once(move |_| Ok(expected_file_uri_clone))
+                    .once();
+                mock_cloud_backend_uploader
+                    .expect_make_file_public()
+                    .with(eq(file_path))
+                    .return_once(move |_| Ok(()))
+                    .once();
 
-        assert_eq!(FileUri(expected_location), location);
+                mock_cloud_backend_uploader
+            };
+            let file_uploader = GcpUploader::new(Arc::new(cloud_backend_uploader));
+
+            let file_uri = file_uploader.upload(file_path).await.unwrap();
+
+            assert_eq!(expected_file_uri, file_uri);
+        }
+
+        #[tokio::test]
+        async fn upload_public_file_fails_when_upload_fails() {
+            let file_path = Path::new("snapshot.xxx.tar.gz");
+            let cloud_backend_uploader = {
+                let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+                mock_cloud_backend_uploader
+                    .expect_upload_file()
+                    .with(eq(file_path))
+                    .return_once(move |_| Err(anyhow!("upload error")))
+                    .once();
+
+                mock_cloud_backend_uploader
+            };
+            let file_uploader = GcpUploader::new(Arc::new(cloud_backend_uploader));
+
+            file_uploader
+                .upload(file_path)
+                .await
+                .expect_err("should have failed");
+        }
+
+        #[tokio::test]
+        async fn upload_public_file_fails_when_make_public_fails() {
+            let file_path = Path::new("snapshot.xxx.tar.gz");
+            let expected_file_uri = FileUri("https://cloud-host/snapshot.xxx.tar.gz".to_string());
+            let expected_file_uri_clone = expected_file_uri.clone();
+            let cloud_backend_uploader = {
+                let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+                mock_cloud_backend_uploader
+                    .expect_upload_file()
+                    .with(eq(file_path))
+                    .return_once(move |_| Ok(expected_file_uri_clone))
+                    .once();
+                mock_cloud_backend_uploader
+                    .expect_make_file_public()
+                    .with(eq(file_path))
+                    .return_once(move |_| Err(anyhow!("make public error")))
+                    .once();
+
+                mock_cloud_backend_uploader
+            };
+            let file_uploader = GcpUploader::new(Arc::new(cloud_backend_uploader));
+
+            file_uploader
+                .upload(file_path)
+                .await
+                .expect_err("should have failed");
+        }
     }
 
-    #[tokio::test]
-    async fn get_location_using_cdn_domain_return_cdn_in_uri() {
-        let use_cdn_domain = true;
+    mod gcp_backend_uploader {
+        use super::*;
 
-        let file_uploader = GcpUploader::new(
-            "cdn.mithril.network".to_string(),
-            use_cdn_domain,
-            TestLogger::stdout(),
-        );
-        let filename = "snapshot.xxx.tar.gz";
-        let expected_location = "https://cdn.mithril.network/snapshot.xxx.tar.gz".to_string();
+        #[tokio::test]
+        async fn get_location_not_using_cdn_domain_return_google_api_uri() {
+            env::set_var("GOOGLE_APPLICATION_CREDENTIALS_JSON", "credentials");
+            let use_cdn_domain = false;
+            let gcp_file_uploader = GcpBackendUploader::try_new(
+                "cdn.mithril.network".to_string(),
+                use_cdn_domain,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+            let filename = "snapshot.xxx.tar.gz";
+            let expected_location =
+                "https://storage.googleapis.com/cdn.mithril.network/snapshot.xxx.tar.gz"
+                    .to_string();
 
-        let location = file_uploader.get_location(filename);
+            let location = gcp_file_uploader.get_location(filename);
 
-        assert_eq!(FileUri(expected_location), location);
+            assert_eq!(FileUri(expected_location), location);
+        }
+
+        #[tokio::test]
+        async fn get_location_using_cdn_domain_return_cdn_in_uri() {
+            env::set_var("GOOGLE_APPLICATION_CREDENTIALS_JSON", "credentials");
+            let use_cdn_domain = true;
+            let gcp_file_uploader = GcpBackendUploader::try_new(
+                "cdn.mithril.network".to_string(),
+                use_cdn_domain,
+                TestLogger::stdout(),
+            )
+            .unwrap();
+            let filename = "snapshot.xxx.tar.gz";
+            let expected_location = "https://cdn.mithril.network/snapshot.xxx.tar.gz".to_string();
+
+            let location = gcp_file_uploader.get_location(filename);
+
+            assert_eq!(FileUri(expected_location), location);
+        }
     }
 }

--- a/mithril-aggregator/src/file_uploaders/mod.rs
+++ b/mithril-aggregator/src/file_uploaders/mod.rs
@@ -6,7 +6,7 @@ mod local_uploader;
 pub mod url_sanitizer;
 
 pub use dumb_uploader::*;
-pub use gcp_uploader::{GcpBackendUploader, GcpUploader};
+pub use gcp_uploader::{CloudRemotePath, GcpBackendUploader, GcpUploader};
 pub use interface::FileUploader;
 pub use local_snapshot_uploader::LocalSnapshotUploader;
 pub use local_uploader::LocalUploader;

--- a/mithril-aggregator/src/file_uploaders/mod.rs
+++ b/mithril-aggregator/src/file_uploaders/mod.rs
@@ -6,7 +6,7 @@ mod local_uploader;
 pub mod url_sanitizer;
 
 pub use dumb_uploader::*;
-pub use gcp_uploader::GcpUploader;
+pub use gcp_uploader::{GcpBackendUploader, GcpUploader};
 pub use interface::FileUploader;
 pub use local_snapshot_uploader::LocalSnapshotUploader;
 pub use local_uploader::LocalUploader;

--- a/mithril-infra/main.cloud-storage.tf
+++ b/mithril-infra/main.cloud-storage.tf
@@ -7,7 +7,8 @@ resource "google_storage_bucket" "cloud_storage" {
 
   lifecycle_rule {
     condition {
-      age = var.google_storage_bucket_max_age
+      age            = var.google_storage_bucket_max_age
+      matches_prefix = var.google_storage_bucket_prefix_with_lifecyle_rule
     }
     action {
       type = "Delete"

--- a/mithril-infra/variables.tf
+++ b/mithril-infra/variables.tf
@@ -132,6 +132,12 @@ variable "google_storage_bucket_max_age" {
   default     = 14
 }
 
+variable "google_storage_bucket_prefix_with_lifecyle_rule" {
+  type        = list(any)
+  description = "The prefix of the object in the storage bucket to apply the lifecycle rule"
+  default     = ["cardano-immutable-files-full", "cardano-database/ancillary"]
+}
+
 locals {
   google_service_credentials_json_file_decoded = jsondecode(file(var.google_service_credentials_json_file))
   google_service_account_private_key           = local.google_service_credentials_json_file_decoded.private_key


### PR DESCRIPTION
## Content

This PR includes the **update of the `GcpUploader` to support synchronization of Cardano database artifacts.**

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #2211 
