### PR TITLE
Fix: support trailing whitespace in protocol key files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.14"
+version = "0.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.105"
+version = "0.4.106"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.14"
+version = "0.6.15"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -240,7 +240,8 @@ impl CompressedArchiveSnapshotter {
     #[cfg(test)]
     /// Allow to use a custom temporary directory to avoid conflicts during the snapshot verification.
     pub fn set_sub_temp_dir<P: AsRef<Path>>(&mut self, sub_dir: P) {
-        self.temp_dir = std::env::temp_dir().join(sub_dir);
+        self.temp_dir =
+            mithril_common::test_utils::TempDir::create("snapshotter", "temp_dir").join(sub_dir);
     }
 
     fn snapshot<T: TarAppender>(&self, filepath: &Path, appender: T) -> StdResult<OngoingSnapshot> {

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.105"
+version = "0.4.106"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/codec.rs
+++ b/mithril-common/src/crypto_helper/codec.rs
@@ -44,7 +44,7 @@ pub fn key_decode_hex<T>(from: HexEncodedKeySlice) -> Result<T, CodecError>
 where
     T: DeserializeOwned,
 {
-    let from_vec = Vec::from_hex(from).map_err(|e| {
+    let from_vec = Vec::from_hex(from.trim()).map_err(|e| {
         CodecError::new(
             "Key decode hex: can not turn hexadecimal value into bytes",
             e.into(),
@@ -88,6 +88,18 @@ mod tests {
             key_encode_hex(&test_to_serialize).expect("unexpected hex encoding error");
         let test_to_serialize_restored =
             key_decode_hex(&test_to_serialize_hex).expect("unexpected hex decoding error");
+        assert_eq!(test_to_serialize, test_to_serialize_restored);
+    }
+
+    #[test]
+    fn test_key_decode_hex_with_leading_and_trailing_whitespace() {
+        let test_to_serialize = TestSerialize {
+            inner_string: "my inner string".to_string(),
+        };
+        let test_to_serialize_hex =
+            key_encode_hex(&test_to_serialize).expect("unexpected hex encoding error");
+        let test_to_serialize_restored = key_decode_hex(&format!(" \r{test_to_serialize_hex} \n"))
+            .expect("unexpected hex decoding error");
         assert_eq!(test_to_serialize, test_to_serialize_restored);
     }
 

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -2,7 +2,7 @@
 use super::{genesis::*, types::*, OpCert, SerDeShelleyFileFormat};
 use crate::{
     entities::{Certificate, ProtocolMessage, ProtocolMessagePartKey, SignerWithStake, Stake},
-    test_utils::{CertificateChainBuilder, SignerFixture},
+    test_utils::{CertificateChainBuilder, SignerFixture, TempDir},
 };
 
 use rand_chacha::ChaCha20Rng;
@@ -14,9 +14,10 @@ pub fn setup_temp_directory_for_signer(
     party_id: &ProtocolPartyId,
     auto_create: bool,
 ) -> Option<PathBuf> {
-    let temp_dir = std::env::temp_dir()
-        .join("mithril_crypto_helper_material")
+    let temp_dir = TempDir::new("tests_setup", "mithril_crypto_helper_material")
+        .build_path()
         .join(party_id);
+
     if auto_create {
         fs::create_dir_all(&temp_dir).expect("temp dir creation should not fail");
     }

--- a/mithril-common/src/crypto_helper/types/protocol_key.rs
+++ b/mithril-common/src/crypto_helper/types/protocol_key.rs
@@ -218,12 +218,9 @@ macro_rules! impl_codec_and_type_conversions_for_protocol_key {
 
 #[cfg(test)]
 mod test {
-    use std::{io::Write, path::Path};
-
     use crate::{
         crypto_helper::ProtocolKey,
         test_utils::{fake_keys, TempDir},
-        StdResult,
     };
     use mithril_stm::stm::StmVerificationKeyPoP;
     use serde::{Deserialize, Serialize};
@@ -290,32 +287,6 @@ mod test {
         expected_key
             .write_json_hex_to_file(&key_path)
             .expect("Writing to file should not fail");
-        let read_key = ProtocolKey::<StmVerificationKeyPoP>::read_json_hex_from_file(&key_path)
-            .expect("Reading from file should not fail");
-
-        assert_eq!(expected_key, read_key);
-    }
-
-    #[test]
-    fn can_read_a_verification_key_from_file_with_trailing_whitespaces() {
-        fn add_space_to_file(key_path: &Path) -> StdResult<()> {
-            let mut key_file = std::fs::OpenOptions::new().append(true).open(key_path)?;
-            key_file.write_all(b"\n")?;
-
-            Ok(())
-        }
-
-        let expected_key: ProtocolKey<StmVerificationKeyPoP> = VERIFICATION_KEY.try_into().unwrap();
-        let key_path = TempDir::create(
-            "protocol_key",
-            "can_read_a_verification_key_from_file_with_trailing_whitespaces",
-        )
-        .join("key.out");
-
-        expected_key
-            .write_json_hex_to_file(&key_path)
-            .expect("Writing to file should not fail");
-        add_space_to_file(&key_path).expect("Adding space to file should not fail");
         let read_key = ProtocolKey::<StmVerificationKeyPoP>::read_json_hex_from_file(&key_path)
             .expect("Reading from file should not fail");
 

--- a/mithril-common/src/crypto_helper/types/protocol_key.rs
+++ b/mithril-common/src/crypto_helper/types/protocol_key.rs
@@ -50,7 +50,7 @@ where
 
     /// Create an instance from a JSON hex representation
     pub fn from_json_hex(hex_string: &str) -> StdResult<Self> {
-        let key = key_decode_hex::<T>(hex_string.trim()).with_context(|| {
+        let key = key_decode_hex::<T>(hex_string).with_context(|| {
             format!(
                 "Could not deserialize a ProtocolKey from JSON hex string. Inner key type: {}",
                 type_name::<T>()

--- a/mithril-common/src/crypto_helper/types/protocol_key.rs
+++ b/mithril-common/src/crypto_helper/types/protocol_key.rs
@@ -220,7 +220,10 @@ macro_rules! impl_codec_and_type_conversions_for_protocol_key {
 mod test {
     use std::io::Write;
 
-    use crate::{crypto_helper::ProtocolKey, test_utils::fake_keys};
+    use crate::{
+        crypto_helper::ProtocolKey,
+        test_utils::{fake_keys, TempDir},
+    };
     use mithril_stm::stm::StmVerificationKeyPoP;
     use serde::{Deserialize, Serialize};
 
@@ -277,7 +280,11 @@ mod test {
     #[test]
     fn can_read_and_write_to_file_a_verification_key() {
         let expected_key: ProtocolKey<StmVerificationKeyPoP> = VERIFICATION_KEY.try_into().unwrap();
-        let key_path = std::env::temp_dir().join("can_read_and_write_to_file_a_verification_key");
+        let key_path = TempDir::create(
+            "protocol_key",
+            "can_read_and_write_to_file_a_verification_key",
+        )
+        .join("key.out");
 
         expected_key
             .write_json_hex_to_file(&key_path)
@@ -291,7 +298,11 @@ mod test {
     #[test]
     fn can_read_a_verification_key_from_file_with_trailing_whitespaces() {
         let expected_key: ProtocolKey<StmVerificationKeyPoP> = VERIFICATION_KEY.try_into().unwrap();
-        let key_path = std::env::temp_dir().join("can_read_and_write_to_file_a_verification_key");
+        let key_path = TempDir::create(
+            "protocol_key",
+            "can_read_a_verification_key_from_file_with_trailing_whitespaces",
+        )
+        .join("key.out");
 
         expected_key
             .write_json_hex_to_file(&key_path)


### PR DESCRIPTION
## Content

This PR includes a **fix to the deserialization of the protocol keys to support trailing whitespace in their files**.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

