### PR TITLE
Openapi examples check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.107"
+version = "0.4.108"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -76,7 +76,7 @@ const config = {
       {
         specs: [
           {
-            spec: "../openapi.yaml",
+            spec: "../../openapi.yaml",
             route: "/aggregator-api/",
           },
         ],

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.107"
+version = "0.4.108"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.43
+  version: 0.1.44
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -171,7 +171,8 @@ paths:
           schema:
             type: string
             format: bytes
-            examples: "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572"
+            examples:
+              - "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572"
       responses:
         "200":
           description: certificate found
@@ -224,7 +225,8 @@ paths:
           schema:
             type: string
             format: bytes
-            examples: "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732"
+            examples:
+              - "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732"
       responses:
         "200":
           description: snapshot found
@@ -256,7 +258,8 @@ paths:
           schema:
             type: string
             format: bytes
-            examples: "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732"
+            examples:
+              - "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732"
       responses:
         "200":
           description: snapshot found
@@ -331,7 +334,8 @@ paths:
           schema:
             type: string
             format: bytes
-            examples: "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6"
+            examples:
+              - "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6"
       responses:
         "200":
           description: Cardano database snapshot found
@@ -384,7 +388,8 @@ paths:
           schema:
             type: string
             format: bytes
-            examples: "6da2b104ed68481ef829d72d72c2f6a20142916d17985e01774b14ed49f0fea1"
+            examples:
+              - "6da2b104ed68481ef829d72d72c2f6a20142916d17985e01774b14ed49f0fea1"
       responses:
         "200":
           description: Mithril stake distribution found
@@ -437,7 +442,8 @@ paths:
           schema:
             type: string
             format: bytes
-            examples: "6da2b104ed68481ef829d72d72c2f6a20142916d17985e01774b14ed49f0fea1"
+            examples:
+              - "6da2b104ed68481ef829d72d72c2f6a20142916d17985e01774b14ed49f0fea1"
       responses:
         "200":
           description: Cardano stake distribution found
@@ -469,7 +475,8 @@ paths:
           schema:
             type: integer
             format: int64
-            examples: 419
+            examples:
+              - 419
       responses:
         "200":
           description: Cardano stake distribution found
@@ -522,7 +529,8 @@ paths:
           schema:
             type: string
             format: bytes
-            examples: "6da2b104ed68481ef829d72d72c2f6a20142916d17985e01774b14ed49f0fea1"
+            examples:
+              - "6da2b104ed68481ef829d72d72c2f6a20142916d17985e01774b14ed49f0fea1"
       responses:
         "200":
           description: Cardano transactions set snapshot found
@@ -556,7 +564,8 @@ paths:
             items:
               type: string
               format: bytes
-              examples: "6dbb104ed68481ef829a26a20142916d17985e01774d72d72c2f"
+              examples:
+                - "6dbb104ed68481ef829a26a20142916d17985e01774d72d72c2f"
           explode: false
       responses:
         "200":
@@ -592,7 +601,8 @@ paths:
                 const: "latest"
               - type: integer
                 format: int64
-                examples: 419
+                examples:
+                  - 419
       responses:
         "200":
           description: Registered Signers found
@@ -804,22 +814,22 @@ components:
           type: integer
           format: int64
       examples:
-        {
-          "epoch": 329,
-          "cardano_era": "Conway",
-          "cardano_network": "mainnet",
-          "mithril_era": "pythagoras",
-          "cardano_node_version": "1.2.3",
-          "aggregator_node_version": "4.5.6",
-          "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
-          "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
-          "total_signers": 3,
-          "total_next_signers": 72,
-          "total_stakes_signers": 123456789,
-          "total_next_stakes_signers": 987654321,
-          "total_cardano_spo": 5738,
-          "total_cardano_stake": 999999999
-        }
+        - {
+            "epoch": 329,
+            "cardano_era": "Conway",
+            "cardano_network": "mainnet",
+            "mithril_era": "pythagoras",
+            "cardano_node_version": "1.2.3",
+            "aggregator_node_version": "4.5.6",
+            "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
+            "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
+            "total_signers": 3,
+            "total_next_signers": 72,
+            "total_stakes_signers": 123456789,
+            "total_next_stakes_signers": 987654321,
+            "total_cardano_spo": 5738,
+            "total_cardano_stake": 999999999
+          }
 
     AggregatorFeaturesMessage:
       description: Represents general information about Aggregator public information and signing capabilities
@@ -888,23 +898,23 @@ components:
                   type: integer
                   format: int64
       examples:
-        {
-          "open_api_version": "0.1.17",
-          "documentation_url": "https://mithril.network",
-          "capabilities":
-            {
-              "signed_entity_types":
-                [
-                  "MithrilStakeDistribution",
-                  "CardanoImmutableFilesFull",
-                  "CardanoTransactions"
-                ],
-              "cardano_transactions_prover":
-                { "max_hashes_allowed_by_request": 100 },
-              "cardano_transactions_signing_config":
-                { "security_parameter": 100, "step": 10 }
-            }
-        }
+        - {
+            "open_api_version": "0.1.17",
+            "documentation_url": "https://mithril.network",
+            "capabilities":
+              {
+                "signed_entity_types":
+                  [
+                    "MithrilStakeDistribution",
+                    "CardanoImmutableFilesFull",
+                    "CardanoTransactions"
+                  ],
+                "cardano_transactions_prover":
+                  { "max_hashes_allowed_by_request": 100 },
+                "cardano_transactions_signing_config":
+                  { "security_parameter": 100, "step": 10 }
+              }
+          }
 
     Epoch:
       description: Cardano chain epoch number
@@ -946,50 +956,50 @@ components:
         next_cardano_transactions_signing_config:
           $ref: "#/components/schemas/CardanoTransactionsSigningConfig"
       examples:
-        {
-          "epoch": 329,
-          "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
-          "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
-          "signer_registration_protocol": { "k": 9, "m": 77, "phi_f": 0.5 },
-          "current_signers":
-            [
-              {
-                "party_id": "1234567890",
-                "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
-                "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
-                "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
-                "kes_period": 123
-              },
-              {
-                "party_id": "2345678900",
-                "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
-                "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
-                "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
-                "kes_period": 456
-              }
-            ],
-          "next_signers":
-            [
-              {
-                "party_id": "3456789000",
-                "verification_key": "7b22766b223a5b3133382c32392c3137332c3134342c36332c3233352c39372c3138302c3",
-                "verification_key_signature": "7b227369676d61223a7b227369676d61223a7b227369676d61223a7b227369676d612239",
-                "operational_certificate": "5b5b5b3232352c3230332c3235352c3130302c3136372c38302c37342c3136362c3135362c38322c39382c3232312c36332c3137372c3232332c3232332c31392c35372c39332c312c35302c3133392c3233342c3137332c32352",
-                "kes_period": 789
-              },
-              {
-                "party_id": "4567890000",
-                "verification_key": "34302c3132332c3139302c3134352c3132342c35342c3133302c37302c3136332c3139332",
-                "verification_key_signature": "302c3230312c38362c3139312c36302c3234352c3138332c3134342c3139392c3130335f",
-                "operational_certificate": "2c38382c3138372c3233332c34302c37322c31362c36365d2c312c3132332c5b31362c3136392c3134312c3138332c32322c3137342c3131312c33322c36342c35322c2c3232382c37392c3137352c32395312c3838282c323030",
-                "kes_period": 876
-              }
-            ],
-          "cardano_transactions_signing_config":
-            { "security_parameter": 100, "step": 10 },
-          "next_cardano_transactions_signing_config":
-            { "security_parameter": 50, "step": 5 }
-        }
+        - {
+            "epoch": 329,
+            "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
+            "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
+            "signer_registration_protocol": { "k": 9, "m": 77, "phi_f": 0.5 },
+            "current_signers":
+              [
+                {
+                  "party_id": "1234567890",
+                  "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
+                  "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
+                  "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
+                  "kes_period": 123
+                },
+                {
+                  "party_id": "2345678900",
+                  "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
+                  "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
+                  "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
+                  "kes_period": 456
+                }
+              ],
+            "next_signers":
+              [
+                {
+                  "party_id": "3456789000",
+                  "verification_key": "7b22766b223a5b3133382c32392c3137332c3134342c36332c3233352c39372c3138302c3",
+                  "verification_key_signature": "7b227369676d61223a7b227369676d61223a7b227369676d61223a7b227369676d612239",
+                  "operational_certificate": "5b5b5b3232352c3230332c3235352c3130302c3136372c38302c37342c3136362c3135362c38322c39382c3232312c36332c3137372c3232332c3232332c31392c35372c39332c312c35302c3133392c3233342c3137332c32352",
+                  "kes_period": 789
+                },
+                {
+                  "party_id": "4567890000",
+                  "verification_key": "34302c3132332c3139302c3134352c3132342c35342c3133302c37302c3136332c3139332",
+                  "verification_key_signature": "302c3230312c38362c3139312c36302c3234352c3138332c3134342c3139392c3130335f",
+                  "operational_certificate": "2c38382c3138372c3233332c34302c37322c31362c36365d2c312c3132332c5b31362c3136392c3134312c3138332c32322c3137342c3131312c33322c36342c35322c2c3232382c37392c3137352c32395312c3838282c323030",
+                  "kes_period": 876
+                }
+              ],
+            "cardano_transactions_signing_config":
+              { "security_parameter": 100, "step": 10 },
+            "next_cardano_transactions_signing_config":
+              { "security_parameter": 50, "step": 5 }
+          }
 
     ProtocolParameters:
       description: Protocol cryptographic parameters
@@ -1012,7 +1022,8 @@ components:
           description: f in phi(w) = 1 - (1 - f)^w, where w is the stake of a participant
           type: number
           format: double
-      examples: { "k": 857, "m": 6172, "phi_f": 0.2 }
+      examples:
+        - { "k": 857, "m": 6172, "phi_f": 0.2 }
 
     CardanoTransactionsSigningConfig:
       description: Cardano transactions signing configuration
@@ -1030,7 +1041,8 @@ components:
           description: Number of blocks between signature of Cardano transactions
           type: integer
           format: int64
-      examples: { "security_parameter": 100, "step": 10 }
+      examples:
+        - { "security_parameter": 100, "step": 10 }
 
     CardanoDbBeacon:
       description: A point in the Cardano chain at which a Mithril certificate of the Cardano Database should be produced
@@ -1050,13 +1062,15 @@ components:
           description: Number of the last immutable file that should be included the snapshot
           type: integer
           format: int64
-      examples: { "epoch": 329, "immutable_file_number": 7060000 }
+      examples:
+        - { "epoch": 329, "immutable_file_number": 7060000 }
 
     SignedEntityType:
       description: Entity type of the message that is signed
       type: object
       additionalProperties: true
-      examples: { "MithrilStakeDistribution": 246 }
+      examples:
+        - { "MithrilStakeDistribution": 246 }
 
     CertificatePendingMessage:
       description: CertificatePendingMessage represents all the information related to the certificate currently expecting to receive quorum of single signatures
@@ -1097,47 +1111,47 @@ components:
           items:
             $ref: "#/components/schemas/Signer"
       examples:
-        {
-          "epoch": 329,
-          "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
-          "entity_type": { "MithrilStakeDistribution": 246 },
-          "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
-          "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
-          "signers":
-            [
-              {
-                "party_id": "1234567890",
-                "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
-                "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
-                "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
-                "kes_period": 123
-              },
-              {
-                "party_id": "2345678900",
-                "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
-                "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
-                "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
-                "kes_period": 456
-              }
-            ],
-          "next_signers":
-            [
-              {
-                "party_id": "3456789000",
-                "verification_key": "7b22766b223a5b3133382c32392c3137332c3134342c36332c3233352c39372c3138302c3",
-                "verification_key_signature": "7b227369676d61223a7b227369676d61223a7b227369676d61223a7b227369676d612239",
-                "operational_certificate": "5b5b5b3232352c3230332c3235352c3130302c3136372c38302c37342c3136362c3135362c38322c39382c3232312c36332c3137372c3232332c3232332c31392c35372c39332c312c35302c3133392c3233342c3137332c32352",
-                "kes_period": 789
-              },
-              {
-                "party_id": "4567890000",
-                "verification_key": "34302c3132332c3139302c3134352c3132342c35342c3133302c37302c3136332c3139332",
-                "verification_key_signature": "302c3230312c38362c3139312c36302c3234352c3138332c3134342c3139392c3130335f",
-                "operational_certificate": "2c38382c3138372c3233332c34302c37322c31362c36365d2c312c3132332c5b31362c3136392c3134312c3138332c32322c3137342c3131312c33322c36342c35322c2c3232382c37392c3137352c32395312c3838282c323030",
-                "kes_period": 876
-              }
-            ]
-        }
+        - {
+            "epoch": 329,
+            "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
+            "entity_type": { "MithrilStakeDistribution": 246 },
+            "protocol": { "k": 857, "m": 6172, "phi_f": 0.2 },
+            "next_protocol": { "k": 2422, "m": 20973, "phi_f": 0.2 },
+            "signers":
+              [
+                {
+                  "party_id": "1234567890",
+                  "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
+                  "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
+                  "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
+                  "kes_period": 123
+                },
+                {
+                  "party_id": "2345678900",
+                  "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
+                  "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
+                  "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
+                  "kes_period": 456
+                }
+              ],
+            "next_signers":
+              [
+                {
+                  "party_id": "3456789000",
+                  "verification_key": "7b22766b223a5b3133382c32392c3137332c3134342c36332c3233352c39372c3138302c3",
+                  "verification_key_signature": "7b227369676d61223a7b227369676d61223a7b227369676d61223a7b227369676d612239",
+                  "operational_certificate": "5b5b5b3232352c3230332c3235352c3130302c3136372c38302c37342c3136362c3135362c38322c39382c3232312c36332c3137372c3232332c3232332c31392c35372c39332c312c35302c3133392c3233342c3137332c32352",
+                  "kes_period": 789
+                },
+                {
+                  "party_id": "4567890000",
+                  "verification_key": "34302c3132332c3139302c3134352c3132342c35342c3133302c37302c3136332c3139332",
+                  "verification_key_signature": "302c3230312c38362c3139312c36302c3234352c3138332c3134342c3139392c3130335f",
+                  "operational_certificate": "2c38382c3138372c3233332c34302c37322c31362c36365d2c312c3132332c5b31362c3136392c3134312c3138332c32322c3137342c3131312c33322c36342c35322c2c3232382c37392c3137352c32395312c3838282c323030",
+                  "kes_period": 876
+                }
+              ]
+          }
 
     Stake:
       description: Stake represents the stakes of a participant in the Cardano chain
@@ -1150,7 +1164,8 @@ components:
           description: Stake share as computed in the 'stake distribution' by the Cardano Node, multiplied by a billion (1.0e9)
           type: integer
           format: int64
-      examples: { "stake": 1234 }
+      examples:
+        - { "stake": 1234 }
 
     Signer:
       description: Signer represents a signing participant in the network
@@ -1180,13 +1195,13 @@ components:
           type: integer
           format: int64
       examples:
-        {
-          "party_id": "1234567890",
-          "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
-          "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
-          "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
-          "kes_period": 123
-        }
+        - {
+            "party_id": "1234567890",
+            "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
+            "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
+            "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
+            "kes_period": 123
+          }
 
     RegisterSignerMessage:
       description: This message represents a signing participant in the network.
@@ -1197,14 +1212,14 @@ components:
       allOf:
         - $ref: "#/components/schemas/Signer"
       examples:
-        {
-          "epoch": 329,
-          "party_id": "1234567890",
-          "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
-          "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
-          "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
-          "kes_period": 123
-        }
+        - {
+            "epoch": 329,
+            "party_id": "1234567890",
+            "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
+            "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
+            "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
+            "kes_period": 123
+          }
 
     SignerWithStake:
       description: Signer represents a signing party in the network (including its stakes)
@@ -1213,14 +1228,14 @@ components:
         - $ref: "#/components/schemas/Signer"
         - $ref: "#/components/schemas/Stake"
       examples:
-        {
-          "party_id": "1234567890",
-          "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
-          "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
-          "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
-          "kes_period": 123,
-          "stake": 1234
-        }
+        - {
+            "party_id": "1234567890",
+            "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
+            "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
+            "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
+            "kes_period": 123,
+            "stake": 1234
+          }
 
     StakeDistributionParty:
       description: |
@@ -1235,7 +1250,8 @@ components:
           description: Stake share as computed in the 'stake distribution' by the Cardano Node, multiplied by a billion (1.0e9)
           type: integer
           format: int64
-      examples: { "party_id": "1234567890", "stake": 1234 }
+      examples:
+        - { "party_id": "1234567890", "stake": 1234 }
 
     SignerRegistrationsMessage:
       description: |
@@ -1252,11 +1268,11 @@ components:
           items:
             $ref: "#/components/schemas/SignerRegistrationsListItemMessage"
       examples:
-        {
-          "registered_at": 420,
-          "signing_at": 422,
-          "registrations": [{ "party_id": "1234567890", "stake": 1234 }]
-        }
+        - {
+            "registered_at": 420,
+            "signing_at": 422,
+            "registrations": [{ "party_id": "1234567890", "stake": 1234 }]
+          }
 
     SignerRegistrationsListItemMessage:
       description: represents an item of a SignerRegistrationsMessage registration
@@ -1285,18 +1301,18 @@ components:
           items:
             $ref: "#/components/schemas/SignerTickerListItemMessage"
       examples:
-        {
-          "network": "mainnet",
-          "signers":
-            [
-              {
-                "party_id": "pool1234567890",
-                "pool_ticker": "[Pool_Name]",
-                "has_registered": true
-              },
-              { "party_id": "pool0987654321", "has_registered": false }
-            ]
-        }
+        - {
+            "network": "mainnet",
+            "signers":
+              [
+                {
+                  "party_id": "pool1234567890",
+                  "pool_ticker": "[Pool_Name]",
+                  "has_registered": true
+                },
+                { "party_id": "pool0987654321", "has_registered": false }
+              ]
+          }
 
     SignerTickerListItemMessage:
       description: represents a known signer with its pool ticker
@@ -1316,11 +1332,11 @@ components:
           description: The signer has registered at least once
           type: boolean
       examples:
-        {
-          "party_id": "pool1234567890",
-          "pool_ticker": "[Pool_Name]",
-          "has_registered": true
-        }
+        - {
+            "party_id": "pool1234567890",
+            "pool_ticker": "[Pool_Name]",
+            "has_registered": true
+          }
 
     RegisterSingleSignatureMessage:
       description: |
@@ -1358,13 +1374,13 @@ components:
           type: string
           format: bytes
       examples:
-        {
-          "entity_type": { "MithrilStakeDistribution": 246 },
-          "party_id": "1234567890",
-          "signature": "7b2c36322c3130352c3232322c31302c3131302c33312c37312c39372c22766b223a5b3136342c2c31393137352c313834",
-          "indexes": [25, 35],
-          "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc"
-        }
+        - {
+            "entity_type": { "MithrilStakeDistribution": 246 },
+            "party_id": "1234567890",
+            "signature": "7b2c36322c3130352c3232322c31302c3131302c33312c37312c39372c22766b223a5b3136342c2c31393137352c313834",
+            "indexes": [25, 35],
+            "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc"
+          }
 
     ProtocolMessageParts:
       description: ProtocolMessage represents a message that is signed (or verified) by the Mithril protocol
@@ -1385,11 +1401,11 @@ components:
           description: The latest signed block number
           type: string
       examples:
-        {
-          "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-          "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363",
-          "latest_block_number": "123456"
-        }
+        - {
+            "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363",
+            "latest_block_number": "123456"
+          }
 
     ProtocolMessage:
       description: ProtocolMessage represents a message that is signed (or verified) by the Mithril protocol
@@ -1401,13 +1417,13 @@ components:
         message_parts:
           $ref: "#/components/schemas/ProtocolMessageParts"
       examples:
-        {
-          "message_parts":
-            {
-              "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-              "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
-            }
-        }
+        - {
+            "message_parts":
+              {
+                "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
+              }
+          }
 
     CertificateListItemMessageMetadata:
       description: CertificateListItemMessageMetadata represents the metadata associated to a CertificateListItemMessage
@@ -1443,14 +1459,14 @@ components:
           type: integer
           format: int64
       examples:
-        {
-          "network": "mainnet",
-          "version": "0.1.0",
-          "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
-          "initiated_at": "2022-07-17T18:51:23.192811338Z",
-          "sealed_at": "2022-07-17T18:51:35.830832580Z",
-          "total_signers": 3
-        }
+        - {
+            "network": "mainnet",
+            "version": "0.1.0",
+            "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
+            "initiated_at": "2022-07-17T18:51:23.192811338Z",
+            "sealed_at": "2022-07-17T18:51:35.830832580Z",
+            "total_signers": 3
+          }
 
     CertificateListMessage:
       description: CertificateListMessage represents a list of Mithril certificates
@@ -1458,33 +1474,33 @@ components:
       items:
         $ref: "#/components/schemas/CertificateListItemMessage"
       examples:
-        [
-          {
-            "hash": "9dc998101590f733f7a50e7c03b5b336e69a751cc02d811395d49618db3ba3d7",
-            "previous_hash": "aa2ddfb87a17103bdf15bfb21a2941b3f3223a3c8d710910496c392b14f8c403",
-            "epoch": 329,
-            "signed_entity_type": { "MithrilStakeDistribution": 246 },
-            "metadata":
-              {
-                "network": "mainnet",
-                "version": "0.1.0",
-                "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
-                "initiated_at": "2022-07-17T18:51:23.192811338Z",
-                "sealed_at": "2022-07-17T18:51:35.830832580Z",
-                "total_signers": 3
-              },
-            "protocol_message":
-              {
-                "message_parts":
-                  {
-                    "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-                    "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
-                  }
-              },
-            "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc",
-            "aggregate_verification_key": "7b232392c3130342c34392c35312c3130332c3136352c37364223a7b22726f6f74223a5b3137392c3135312c3135382c37332c37372c2c3135392c3226d745f636f6d6d69746d656e7"
-          }
-        ]
+        - [
+            {
+              "hash": "9dc998101590f733f7a50e7c03b5b336e69a751cc02d811395d49618db3ba3d7",
+              "previous_hash": "aa2ddfb87a17103bdf15bfb21a2941b3f3223a3c8d710910496c392b14f8c403",
+              "epoch": 329,
+              "signed_entity_type": { "MithrilStakeDistribution": 246 },
+              "metadata":
+                {
+                  "network": "mainnet",
+                  "version": "0.1.0",
+                  "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
+                  "initiated_at": "2022-07-17T18:51:23.192811338Z",
+                  "sealed_at": "2022-07-17T18:51:35.830832580Z",
+                  "total_signers": 3
+                },
+              "protocol_message":
+                {
+                  "message_parts":
+                    {
+                      "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                      "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
+                    }
+                },
+              "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc",
+              "aggregate_verification_key": "7b232392c3130342c34392c35312c3130332c3136352c37364223a7b22726f6f74223a5b3137392c3135312c3135382c37332c37372c2c3135392c3226d745f636f6d6d69746d656e7"
+            }
+          ]
 
     CertificateListItemMessage:
       description: CertificateListItemMessage represents an item of a list of Mithril certificates
@@ -1525,31 +1541,31 @@ components:
           type: string
           format: bytes
       examples:
-        {
-          "hash": "9dc998101590f733f7a50e7c03b5b336e69a751cc02d811395d49618db3ba3d7",
-          "previous_hash": "aa2ddfb87a17103bdf15bfb21a2941b3f3223a3c8d710910496c392b14f8c403",
-          "epoch": 32,
-          "signed_entity_type": { "MithrilStakeDistribution": 246 },
-          "metadata":
-            {
-              "network": "mainnet",
-              "version": "0.1.0",
-              "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
-              "initiated_at": "2022-07-17T18:51:23.192811338Z",
-              "sealed_at": "2022-07-17T18:51:35.830832580Z",
-              "total_signers": 3
-            },
-          "protocol_message":
-            {
-              "message_parts":
-                {
-                  "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-                  "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
-                }
-            },
-          "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc",
-          "aggregate_verification_key": "7b232392c3130342c34392c35312c3130332c3136352c37364223a7b22726f6f74223a5b3137392c3135312c3135382c37332c37372c2c3135392c3226d745f636f6d6d69746d656e7"
-        }
+        - {
+            "hash": "9dc998101590f733f7a50e7c03b5b336e69a751cc02d811395d49618db3ba3d7",
+            "previous_hash": "aa2ddfb87a17103bdf15bfb21a2941b3f3223a3c8d710910496c392b14f8c403",
+            "epoch": 32,
+            "signed_entity_type": { "MithrilStakeDistribution": 246 },
+            "metadata":
+              {
+                "network": "mainnet",
+                "version": "0.1.0",
+                "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
+                "initiated_at": "2022-07-17T18:51:23.192811338Z",
+                "sealed_at": "2022-07-17T18:51:35.830832580Z",
+                "total_signers": 3
+              },
+            "protocol_message":
+              {
+                "message_parts":
+                  {
+                    "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                    "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
+                  }
+              },
+            "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc",
+            "aggregate_verification_key": "7b232392c3130342c34392c35312c3130332c3136352c37364223a7b22726f6f74223a5b3137392c3135312c3135382c37332c37372c2c3135392c3226d745f636f6d6d69746d656e7"
+          }
 
     CertificateMetadata:
       description: CertificateMetadata represents the metadata associated to a Certificate
@@ -1586,18 +1602,18 @@ components:
           items:
             $ref: "#/components/schemas/StakeDistributionParty"
       examples:
-        {
-          "network": "mainnet",
-          "version": "0.1.0",
-          "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
-          "initiated_at": "2022-07-17T18:51:23.192811338Z",
-          "sealed_at": "2022-07-17T18:51:35.830832580Z",
-          "signers":
-            [
-              { "party_id": "1234567890", "stake": 1234 },
-              { "party_id": "2345678900", "stake": 2345 }
-            ]
-        }
+        - {
+            "network": "mainnet",
+            "version": "0.1.0",
+            "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
+            "initiated_at": "2022-07-17T18:51:23.192811338Z",
+            "sealed_at": "2022-07-17T18:51:35.830832580Z",
+            "signers":
+              [
+                { "party_id": "1234567890", "stake": 1234 },
+                { "party_id": "2345678900", "stake": 2345 }
+              ]
+          }
 
     CertificateMessage:
       description: Certificate represents a Mithril certificate embedding a Mithril STM multi signature
@@ -1648,51 +1664,51 @@ components:
           type: string
           format: bytes
       examples:
-        {
-          "hash": "9dc998101590f733f7a50e7c03b5b336e69a751cc02d811395d49618db3ba3d7",
-          "previous_hash": "aa2ddfb87a17103bdf15bfb21a2941b3f3223a3c8d710910496c392b14f8c403",
-          "epoch": 329,
-          "signed_entity_type": { "MithrilStakeDistribution": 246 },
-          "metadata":
-            {
-              "network": "mainnet",
-              "version": "0.1.0",
-              "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
-              "initiated_at": "2022-07-17T18:51:23.192811338Z",
-              "sealed_at": "2022-07-17T18:51:35.830832580Z",
-              "signers":
-                [
+        - {
+            "hash": "1324",
+            "previous_hash": "aa2ddfb87a17103bdf15bfb21a2941b3f3223a3c8d710910496c392b14f8c403",
+            "epoch": 329,
+            "signed_entity_type": { "MithrilStakeDistribution": 246 },
+            "metadata":
+              {
+                "network": "mainnet",
+                "version": "0.1.0",
+                "parameters": { "k": 5, "m": 100, "phi_f": 0.65 },
+                "initiated_at": "2022-07-17T18:51:23.192811338Z",
+                "sealed_at": "2022-07-17T18:51:35.830832580Z",
+                "signers":
+                  [
+                    {
+                      "party_id": "1234567890",
+                      "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
+                      "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
+                      "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
+                      "kes_period": 123,
+                      "stake": 1234
+                    },
+                    {
+                      "party_id": "2345678900",
+                      "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
+                      "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
+                      "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
+                      "kes_period": 456,
+                      "stake": 2345
+                    }
+                  ]
+              },
+            "protocol_message":
+              {
+                "message_parts":
                   {
-                    "party_id": "1234567890",
-                    "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
-                    "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
-                    "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
-                    "kes_period": 123,
-                    "stake": 1234
-                  },
-                  {
-                    "party_id": "2345678900",
-                    "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
-                    "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
-                    "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
-                    "kes_period": 456,
-                    "stake": 2345
+                    "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                    "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
                   }
-                ]
-            },
-          "protocol_message":
-            {
-              "message_parts":
-                {
-                  "snapshot_digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-                  "next_aggregate_verification_key": "b132362c3232352c36392c31373133352c31323235392c3235332c3233342c34226d745f636f6d6d69746d656e74223a7b22726f6f74223a5b33382c3382c3138322c3231322c2c363"
-                }
-            },
-          "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc",
-          "aggregate_verification_key": "7b232392c3130342c34392c35312c3130332c3136352c37364223a7b22726f6f74223a5b3137392c3135312c3135382c37332c37372c2c3135392c3226d745f636f6d6d69746d656e7",
-          "multi_signature": "7bc3139392c3135392c3235342c3231392c3133362c3132392c38342c353227369676e617475726573223a5b5b7b227369676d61223a5b3135312c362c3131222c33382c3135382c3137312c3137312c3234392c32342c3232382c3133302c38352c32362c38382c3135382c32303c323337322c323339362c32342c313530342c313532302c3135323737302c323830372c323831392c323834302c323834342c323836302c323837322c323838362c323839312c323839382c3239333533332c343538352c343632342c343634322c343634372c343636362c334312c31343636382c31343637352c31343639352c31343639392c31343730312c31343730352c31343733302c31343733382c31343733392c31343734362c31343735342c31343736312c31343738362c31343739352c31343739362c31343832362c31343835392c31343836302c31343836322c31343837312c31343837322c31343837392c31343838392c31343839332c31343839372c31343839392c31343932362c31343937372c31343939312c31353032332c31353033382c31353034342c31353036332c31353039312c31353039322c31353039382c31353131392c31353132312c31353136362c31353139362c31353230322c31353231302c31353231392c31353233392c31353234362c31353235322c31353237352c31353238312c31353334372c31353335372c31353338372c31353431372c31353434352c31353434382c31353435332c31353435342c31353530382c31353534352c31353536302c31353537302c31353538392c31353631302c31353631312c31353631322c31353632382c31353633302c31353633392c31353636302c31353636312c31353637392c31353731372c31353731392c31353732362c31353733382c31353734382c31353735392c31353736312c31353739312c31353830312c31353830332c31353831342c31353831392c31353832372c31353832392c31353834392c31353835332c31353835372c31353835392c31353836372c31353839362c31353930312c31353930372c31353931302c31353931332c31353931352c31353935352c31353937362c31353938372c31363031372c31363036332c31363131382c31363132382c31363135352c31363136372c31363230312c31363230362c31363231392c31363232312c31363232392c31363233342c31363234362c31363333302c31363335302c31363336362c31353739312c31353830312c31353830332c31353831342c31353831392c31353832372c31353832392c31353834392c31353835332c31353835372c31353835392c31353836372c31353839362c31353930312c31353930372c31353931302c31353931332c31353931352c31353935352c31353937362c31353938372c31363031372c31363036332c31363131382c31363132382c31363135352c31363136372c31363230312c31363230362c31363231392c31363232312c31363232392c31363233342c31363234362c31363333302c31363335302c31363336362c31363339302c31363430342c31363435342c31363437392c31363533302c31363533382c31363534372c31363535322c31363630382c31363631312c31363631382c31363633312c31363635382c31363637312c31363639352c31363730302c31363731332c31363732372c31363733312c31363733322c31363734322c31363736302c31363737342c31363739322c31363739362c31363739382c31363830342c31363831302c31363834302c31363834382c31363835392c31363836332c31363838362c31363838382c31363930302c31363932372c31363932382c31363932392c31363933372c31363934302c31363934362c31363935302c31363936312c31363938312c31373033302c31373035332c31373036322c31373038322c31373130312c31373130332c31373130352c31373130362c31373132302c31373132312c31373133322c31373133332c31373135312c31373135392c31373138332c31373232302c31373239322c31373331312c31373331332c31373332362c31373333362c31373334352c31373334392c31373335372c31373337352c31373338332c31373338352c31373430302c31373430362c31373431342c31373432322c31373434362c31373435312c31373436362c31373530322c31373531392c31373535382c31373536352c31373537332c31373538302c31373630362c31373632332c31373636382c31373639352c31373732392c31373733312c31373733352c31373733372c31373734342c31373734352c31373734372c31373736382c31373737302c31373737332c31373737352c31373739362c31373830342c31373831302c31373831332c31373832332c31373834352c31373834362c31373838382c31373839342c31373930352c31373931302c31373935372c31373936372c31373938372c31373939342c31383030322c31383030332c31383031312c31383032302c31383032392c31383034362c31383036382c31383037322c31383131372c31383133372c31383134302c31383134332c31383136322c31383137302c31383137342c31383138342c31383138392c31383139392c31383230382c31383232302c31383235312c31383235332c31383237392c31383238312c31383239312c31383239382c31383330312c31383331362c31383332382c31383334312c31383336332c31383337342c31383338352c31383338372c31383434392c31383437362c31383438322c31383439382c31383530352c31383530362c31383531342c31383532362c31383532382c31383533382c31383535322c31383535382c31383537342c31383538342c31383539322c31383631392c32c3832392c3834382c3835312c3835342c3836352c3838332c3838342c3839332c3839372c3930392c3937312c3938362c3939352c313032312c313032362c313035312c313036322c313036382c313038322c313038332c313038352c313133312c313134392c313135392c313136342c313137322c313137332c313231372c313231382c313234372c313239332c313330382c313331352c313333302c313335302c313336342c313337392c313430302c313430362c313432372c313434392c313436342c313436362c313436372c313437362c313530312c313530342c313532302c313532352c313533322c313534322c313536372c313537362c313538322c313538332c313632362c313633322c313633332c313634312c313635322c313730302c313732392c313831322c313832302c313834322c313835392c313837312c313930352c313930372c313931322c313931332c313935362c313936302c313937342c323030302c323031302c323033322c323033372c323037372c323038372c323039382c323130372c323131382c323133322c323133382c323135312c323230332c323230392c323231312c323233372c323234382c323235332c323237372c323238302c323330382c323331342c323333322c323334332c323334382c373535362c373535382c373537372c373630392c373631382c373633392c373635342c373635352c373731392c373732322c373732332c373830342c373832372c373833362c373833372c373835302c373835332c373835362c373837382c373839362c373931392c373933312c373933332c373934332c373934362c373935342c383030302c383031302c383031342c383033302c383034332c383035352c383036342c383036382c383037362c383132322c383134332c383134382c383136362c383139302c383234372c383235312c383236302c383237352c383238312c383238352c383330362c383332352c383337332c383337372c383338372c383339372c383339382c383431362c383433312c383436362c383436372c383437372c383438332c383438392c383439322c383439382c383531372c383533302c383533352c383534302c383536392c383539392c383631322c383634322c383635322c383637302c383730312c383733342c383738382c383739312c383832372c383834352c383835312c383836312c383837362c383932392c383933372c383935322c383937362c393031362c393032302c393032372c393032392c393034382c393036302c393038392c393130332c393130362c393131312c393131322c393131382c393133342c393134392c393137372c393137382c393231312c393231322c393232392c393234332c393236312c393236322c393238362c393239372c393331382c393333392c393338312c393339352c393339362c393431372c393433302c393436332c393439322c393532342c393633332c393633352c393634322c393639322c393731382c393732342c393732362c393733352c393735362c393738302c393738322c393739332c393831332c393837312c393839382c393931382c393932332c393932362c393934312c393934392c393935322c393935382c393936312c393936342c393937352c31303030362c31303032362c31303032392c31303035382c31303037342c31303037392c31303131302c31303132332c31303133392c31303134382c31303135362c31303136392c31303230362c31303235352c31303235372c31303235382c31303237332c31303237342c31303239312c31303239332c31303239342c31303330352c31303334312c31303334332c31303338322c31303338332c31303430342c31303431312c31303431332c31303432302c31303434322c31303434342c31303435372c31303436302c31303437322c31303438372c31303532322c31303535312c31303536342c31303636352c31303638352c31303730302c31303730362c31303733322c31303734332c31303737322c31303831352c31303833332c31303834332c31303836362c31303839322c31303930382c31303938382c31313033362c31313034312c31313037312c31313038322c31313039322c31313039392c31313130392c31313131352c31313134362c31313139332c31313230302c31313232382c31313232392c31313235342c31313236372c31313238302c31313239332c31313239352c31313331312c31313331382c31313332322c31313334302c31313334342c31313335322c31313335342c31313335352c31313335362c31313338352c31313430322c31313431332c31313433342c31313434322c31313436382c31313437322c31313437372c31313439362c31313439392c31313530362c31313531302c31313532342c31313532372c31313534342c31313538312c31313539322c31313630342c31313633352c31313635382c31313733332c31313733362c31313735342c31313739342c31313831332c31313831392c31313832342c31313832372c31313836392c31313837312c31313931342c31313937302c31313937342c31323031362c31323031392c31323034302c31323034342c31323035342c31323036382c31323037302c31323037372c31323039392c31323130342c31323133302c31323133392c31323135302c31323135392c31323136302c31323137352c31323230302c31323230322c31323232382c31323233392c31323330352c31323336382c31323337352c31323337392c31323338392c31323430372c31323431302c31323433322c31323434302c31323434312c31323437352c31323530362c31323531322c31323531332c31323531372c31323532312c31323533302c31323538302c31323633362c31323636392c31323637322c31323637362c31323637372c31323638332c31323638372c31323730352c31323732342c31323734362c31323734382c31323737362c31323739392c31323838352c31323839392c31323930372c31323933302c31323933322c31323935382c31323939332c31333030332c31333033302c31333036312c31333038302c31333038332c31333130352c31333132372c31333133312c31333136392c31333138312c31333138322c31333138352c3133323231231333236352c31333238362c31333234322cc31333239342c3131333438362c1e233332362c31333333392c31333336352c31333337332c31333338352c31333339392c31333433332c31333435312c31333437382c3",
-          "genesis_signature": ""
-        }
+              },
+            "signed_message": "07ed7c9e128744c1a4797b7eb34c54823cc7a21fc95c19876122ab4bb0fe796d6bba2bc",
+            "aggregate_verification_key": "7b232392c3130342c34392c35312c3130332c3136352c37364223a7b22726f6f74223a5b3137392c3135312c3135382c37332c37372c2c3135392c3226d745f636f6d6d69746d656e7",
+            "multi_signature": "7bc3139392c3135392c3235342c3231392c3133362c3132392c38342c353227369676e617475726573223a5b5b7b227369676d61223a5b3135312c362c3131222c33382c3135382c3137312c3137312c3234392c32342c3232382c3133302c38352c32362c38382c3135382c32303c323337322c323339362c32342c313530342c313532302c3135323737302c323830372c323831392c323834302c323834342c323836302c323837322c323838362c323839312c323839382c3239333533332c343538352c343632342c343634322c343634372c343636362c334312c31343636382c31343637352c31343639352c31343639392c31343730312c31343730352c31343733302c31343733382c31343733392c31343734362c31343735342c31343736312c31343738362c31343739352c31343739362c31343832362c31343835392c31343836302c31343836322c31343837312c31343837322c31343837392c31343838392c31343839332c31343839372c31343839392c31343932362c31343937372c31343939312c31353032332c31353033382c31353034342c31353036332c31353039312c31353039322c31353039382c31353131392c31353132312c31353136362c31353139362c31353230322c31353231302c31353231392c31353233392c31353234362c31353235322c31353237352c31353238312c31353334372c31353335372c31353338372c31353431372c31353434352c31353434382c31353435332c31353435342c31353530382c31353534352c31353536302c31353537302c31353538392c31353631302c31353631312c31353631322c31353632382c31353633302c31353633392c31353636302c31353636312c31353637392c31353731372c31353731392c31353732362c31353733382c31353734382c31353735392c31353736312c31353739312c31353830312c31353830332c31353831342c31353831392c31353832372c31353832392c31353834392c31353835332c31353835372c31353835392c31353836372c31353839362c31353930312c31353930372c31353931302c31353931332c31353931352c31353935352c31353937362c31353938372c31363031372c31363036332c31363131382c31363132382c31363135352c31363136372c31363230312c31363230362c31363231392c31363232312c31363232392c31363233342c31363234362c31363333302c31363335302c31363336362c31353739312c31353830312c31353830332c31353831342c31353831392c31353832372c31353832392c31353834392c31353835332c31353835372c31353835392c31353836372c31353839362c31353930312c31353930372c31353931302c31353931332c31353931352c31353935352c31353937362c31353938372c31363031372c31363036332c31363131382c31363132382c31363135352c31363136372c31363230312c31363230362c31363231392c31363232312c31363232392c31363233342c31363234362c31363333302c31363335302c31363336362c31363339302c31363430342c31363435342c31363437392c31363533302c31363533382c31363534372c31363535322c31363630382c31363631312c31363631382c31363633312c31363635382c31363637312c31363639352c31363730302c31363731332c31363732372c31363733312c31363733322c31363734322c31363736302c31363737342c31363739322c31363739362c31363739382c31363830342c31363831302c31363834302c31363834382c31363835392c31363836332c31363838362c31363838382c31363930302c31363932372c31363932382c31363932392c31363933372c31363934302c31363934362c31363935302c31363936312c31363938312c31373033302c31373035332c31373036322c31373038322c31373130312c31373130332c31373130352c31373130362c31373132302c31373132312c31373133322c31373133332c31373135312c31373135392c31373138332c31373232302c31373239322c31373331312c31373331332c31373332362c31373333362c31373334352c31373334392c31373335372c31373337352c31373338332c31373338352c31373430302c31373430362c31373431342c31373432322c31373434362c31373435312c31373436362c31373530322c31373531392c31373535382c31373536352c31373537332c31373538302c31373630362c31373632332c31373636382c31373639352c31373732392c31373733312c31373733352c31373733372c31373734342c31373734352c31373734372c31373736382c31373737302c31373737332c31373737352c31373739362c31373830342c31373831302c31373831332c31373832332c31373834352c31373834362c31373838382c31373839342c31373930352c31373931302c31373935372c31373936372c31373938372c31373939342c31383030322c31383030332c31383031312c31383032302c31383032392c31383034362c31383036382c31383037322c31383131372c31383133372c31383134302c31383134332c31383136322c31383137302c31383137342c31383138342c31383138392c31383139392c31383230382c31383232302c31383235312c31383235332c31383237392c31383238312c31383239312c31383239382c31383330312c31383331362c31383332382c31383334312c31383336332c31383337342c31383338352c31383338372c31383434392c31383437362c31383438322c31383439382c31383530352c31383530362c31383531342c31383532362c31383532382c31383533382c31383535322c31383535382c31383537342c31383538342c31383539322c31383631392c32c3832392c3834382c3835312c3835342c3836352c3838332c3838342c3839332c3839372c3930392c3937312c3938362c3939352c313032312c313032362c313035312c313036322c313036382c313038322c313038332c313038352c313133312c313134392c313135392c313136342c313137322c313137332c313231372c313231382c313234372c313239332c313330382c313331352c313333302c313335302c313336342c313337392c313430302c313430362c313432372c313434392c313436342c313436362c313436372c313437362c313530312c313530342c313532302c313532352c313533322c313534322c313536372c313537362c313538322c313538332c313632362c313633322c313633332c313634312c313635322c313730302c313732392c313831322c313832302c313834322c313835392c313837312c313930352c313930372c313931322c313931332c313935362c313936302c313937342c323030302c323031302c323033322c323033372c323037372c323038372c323039382c323130372c323131382c323133322c323133382c323135312c323230332c323230392c323231312c323233372c323234382c323235332c323237372c323238302c323330382c323331342c323333322c323334332c323334382c373535362c373535382c373537372c373630392c373631382c373633392c373635342c373635352c373731392c373732322c373732332c373830342c373832372c373833362c373833372c373835302c373835332c373835362c373837382c373839362c373931392c373933312c373933332c373934332c373934362c373935342c383030302c383031302c383031342c383033302c383034332c383035352c383036342c383036382c383037362c383132322c383134332c383134382c383136362c383139302c383234372c383235312c383236302c383237352c383238312c383238352c383330362c383332352c383337332c383337372c383338372c383339372c383339382c383431362c383433312c383436362c383436372c383437372c383438332c383438392c383439322c383439382c383531372c383533302c383533352c383534302c383536392c383539392c383631322c383634322c383635322c383637302c383730312c383733342c383738382c383739312c383832372c383834352c383835312c383836312c383837362c383932392c383933372c383935322c383937362c393031362c393032302c393032372c393032392c393034382c393036302c393038392c393130332c393130362c393131312c393131322c393131382c393133342c393134392c393137372c393137382c393231312c393231322c393232392c393234332c393236312c393236322c393238362c393239372c393331382c393333392c393338312c393339352c393339362c393431372c393433302c393436332c393439322c393532342c393633332c393633352c393634322c393639322c393731382c393732342c393732362c393733352c393735362c393738302c393738322c393739332c393831332c393837312c393839382c393931382c393932332c393932362c393934312c393934392c393935322c393935382c393936312c393936342c393937352c31303030362c31303032362c31303032392c31303035382c31303037342c31303037392c31303131302c31303132332c31303133392c31303134382c31303135362c31303136392c31303230362c31303235352c31303235372c31303235382c31303237332c31303237342c31303239312c31303239332c31303239342c31303330352c31303334312c31303334332c31303338322c31303338332c31303430342c31303431312c31303431332c31303432302c31303434322c31303434342c31303435372c31303436302c31303437322c31303438372c31303532322c31303535312c31303536342c31303636352c31303638352c31303730302c31303730362c31303733322c31303734332c31303737322c31303831352c31303833332c31303834332c31303836362c31303839322c31303930382c31303938382c31313033362c31313034312c31313037312c31313038322c31313039322c31313039392c31313130392c31313131352c31313134362c31313139332c31313230302c31313232382c31313232392c31313235342c31313236372c31313238302c31313239332c31313239352c31313331312c31313331382c31313332322c31313334302c31313334342c31313335322c31313335342c31313335352c31313335362c31313338352c31313430322c31313431332c31313433342c31313434322c31313436382c31313437322c31313437372c31313439362c31313439392c31313530362c31313531302c31313532342c31313532372c31313534342c31313538312c31313539322c31313630342c31313633352c31313635382c31313733332c31313733362c31313735342c31313739342c31313831332c31313831392c31313832342c31313832372c31313836392c31313837312c31313931342c31313937302c31313937342c31323031362c31323031392c31323034302c31323034342c31323035342c31323036382c31323037302c31323037372c31323039392c31323130342c31323133302c31323133392c31323135302c31323135392c31323136302c31323137352c31323230302c31323230322c31323232382c31323233392c31323330352c31323336382c31323337352c31323337392c31323338392c31323430372c31323431302c31323433322c31323434302c31323434312c31323437352c31323530362c31323531322c31323531332c31323531372c31323532312c31323533302c31323538302c31323633362c31323636392c31323637322c31323637362c31323637372c31323638332c31323638372c31323730352c31323732342c31323734362c31323734382c31323737362c31323739392c31323838352c31323839392c31323930372c31323933302c31323933322c31323935382c31323939332c31333030332c31333033302c31333036312c31333038302c31333038332c31333130352c31333132372c31333133312c31333136392c31333138312c31333138322c31333138352c3133323231231333236352c31333238362c31333234322cc31333239342c3131333438362c1e233332362c31333333392c31333336352c31333337332c31333338352c31333339392c31333433332c31333435312c31333437382c3",
+            "genesis_signature": ""
+          }
 
     SnapshotListMessage:
       description: SnapshotListMessage represents a list of snapshots
@@ -1700,23 +1716,23 @@ components:
       items:
         $ref: "#/components/schemas/Snapshot"
       examples:
-        [
-          {
-            "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-            "network": "mainnet",
-            "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
-            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-            "size": 26058531636,
-            "created_at": "2022-07-21T17:32:28Z",
-            "locations":
-              [
-                "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-                "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-                "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
-                "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
-              ]
-          }
-        ]
+        - [
+            {
+              "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+              "network": "mainnet",
+              "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
+              "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+              "size": 26058531636,
+              "created_at": "2022-07-21T17:32:28Z",
+              "locations":
+                [
+                  "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                  "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                  "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
+                  "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
+                ]
+            }
+          ]
 
     Snapshot:
       description: Snapshot represents a snapshot file and its metadata
@@ -1764,51 +1780,51 @@ components:
           description: Version of the Cardano node which is used to create snapshot archives.
           type: string
       examples:
-        {
-          "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-          "network": "mainnet",
-          "beacon":
-            {
-              "network": "mainnet",
-              "epoch": 329,
-              "immutable_file_number": 7060000
-            },
-          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-          "size": 26058531636,
-          "created_at": "2022-07-21T17:32:28Z",
-          "locations":
-            [
-              "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-              "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-              "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
-              "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
-            ],
-          "compression_algorithm": "zstandard",
-          "cardano_node_version": "1.0.0"
-        }
+        - {
+            "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "network": "mainnet",
+            "beacon":
+              {
+                "network": "mainnet",
+                "epoch": 329,
+                "immutable_file_number": 7060000
+              },
+            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+            "size": 26058531636,
+            "created_at": "2022-07-21T17:32:28Z",
+            "locations":
+              [
+                "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
+                "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
+              ],
+            "compression_algorithm": "zstandard",
+            "cardano_node_version": "1.0.0"
+          }
 
     SnapshotMessage:
       description: This message represents a snapshot file and its metadata.
       allOf:
         - $ref: "#/components/schemas/Snapshot"
       examples:
-        {
-          "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-          "network": "mainnet",
-          "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
-          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-          "size": 26058531636,
-          "created_at": "2022-07-21T17:32:28Z",
-          "locations":
-            [
-              "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-              "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-              "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
-              "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
-            ],
-          "compression_algorithm": "zstandard",
-          "cardano_node_version": "1.0.0"
-        }
+        - {
+            "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "network": "mainnet",
+            "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
+            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+            "size": 26058531636,
+            "created_at": "2022-07-21T17:32:28Z",
+            "locations":
+              [
+                "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
+                "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
+              ],
+            "compression_algorithm": "zstandard",
+            "cardano_node_version": "1.0.0"
+          }
 
     SnapshotDownloadMessage:
       description: SnapshotDownloadMessage represents a downloaded snapshot event
@@ -1848,21 +1864,21 @@ components:
           description: Version of the Cardano node which is used to create snapshot archives.
           type: string
       examples:
-        {
-          "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-          "network": "mainnet",
-          "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
-          "size": 26058531636,
-          "locations":
-            [
-              "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-              "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-              "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
-              "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
-            ],
-          "compression_algorithm": "zstandard",
-          "cardano_node_version": "1.0.0"
-        }
+        - {
+            "digest": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "network": "mainnet",
+            "beacon": { "epoch": 329, "immutable_file_number": 7060000 },
+            "size": 26058531636,
+            "locations":
+              [
+                "https://mithril-cdn-us.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                "https://mithril-cdn-eu.iohk.io/snapshot/6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                "magnet:?xt=urn:sha1:YNCKHTQCWBTRNJIV4WNAE52SJUQCZO5C",
+                "ipfs:QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT"
+              ],
+            "compression_algorithm": "zstandard",
+            "cardano_node_version": "1.0.0"
+          }
 
     CardanoDatabaseArtifactsLocationsMessagePart:
       description: CardanoDatabaseArtifactsLocationsMessagePart represents the locations of the Cardano database artifacts
@@ -1881,39 +1897,39 @@ components:
           items:
             $ref: "#/components/schemas/CardanoDatabaseArtifactLocationMessagePart"
       examples:
-        {
-          "digests":
-            [
-              {
-                "type": "cloud_storage",
-                "uri": "https://aggregator-endpoint/artifact/cardano-database/digests"
-              }
-            ],
-          "immutables":
-            [
-              {
-                "type": "cloud_storage",
-                "uri":
-                  {
-                    "Template": "https://mithril-cdn-us.iohk.io/snapshot/{immutable-file_number}.tar.zst"
-                  }
-              },
-              {
-                "type": "cloud_storage",
-                "uri":
-                  {
-                    "Template": "https://mithril-cdn-eu.iohk.io/snapshot/{immutable-file_number}.tar.zst"
-                  }
-              }
-            ],
-          "ancillary":
-            [
-              {
-                "type": "cloud_storage",
-                "uri": "https://mithril-cdn-us.iohk.io/snapshot/ancillary-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.tar.zst"
-              }
-            ]
-        }
+        - {
+            "digests":
+              [
+                {
+                  "type": "cloud_storage",
+                  "uri": "https://aggregator-endpoint/artifact/cardano-database/digests"
+                }
+              ],
+            "immutables":
+              [
+                {
+                  "type": "cloud_storage",
+                  "uri":
+                    {
+                      "Template": "https://mithril-cdn-us.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                    }
+                },
+                {
+                  "type": "cloud_storage",
+                  "uri":
+                    {
+                      "Template": "https://mithril-cdn-eu.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                    }
+                }
+              ],
+            "ancillary":
+              [
+                {
+                  "type": "cloud_storage",
+                  "uri": "https://mithril-cdn-us.iohk.io/snapshot/ancillary-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.tar.zst"
+                }
+              ]
+          }
 
     CardanoDatabaseArtifactLocationMessagePart:
       description: CardanoDatabaseArtifactLocationMessagePart represents the location of a single Cardano database artifact
@@ -1929,10 +1945,10 @@ components:
           description: URI of the artifact location
           type: string
       examples:
-        {
-          "type": "cloud_storage",
-          "uri": "https://mithril-cdn-us.iohk.io/snapshot/digests-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.txt"
-        }
+        - {
+            "type": "cloud_storage",
+            "uri": "https://mithril-cdn-us.iohk.io/snapshot/digests-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.txt"
+          }
 
     CardanoDatabaseImmutableLocationMessagePart:
       description: CardanoDatabaseImmutableLocationMessagePart represents the location of a single Cardano database immutable archive
@@ -1947,18 +1963,20 @@ components:
         uri:
           $ref: "#/components/schemas/MultiFilesUri"
       examples:
-        {
-          "type": "cloud_storage",
-          "uri":
-            { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
-        }
+        - {
+            "type": "cloud_storage",
+            "uri":
+              {
+                "Template": "https://aggregator/{immutable_file_number}.tar.gz"
+              }
+          }
 
     MultiFilesUri:
       description: MultiFilesUri represents information to retrieve multiple files
       oneOf:
         - $ref: "#/components/schemas/TemplateUri"
       examples:
-        { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
+        - { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
 
     TemplateUri:
       description: TemplateUri represents a URI template for multiple files
@@ -1971,7 +1989,7 @@ components:
           description: URI template
           type: string
       examples:
-        { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
+        - { "Template": "https://aggregator/{immutable_file_number}.tar.gz" }
 
     CardanoDatabaseSnapshotListMessage:
       description: CardanoDatabaseSnapshotListMessage represents a list of Cardano database snapshots
@@ -1979,23 +1997,23 @@ components:
       items:
         $ref: "#/components/schemas/CardanoDatabaseSnapshotListItemMessage"
       examples:
-        [
-          {
-            "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
-            "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
-            "beacon":
-              {
-                "network": "preview",
-                "epoch": 123,
-                "immutable_file_number": 2345
-              },
-            "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
-            "total_db_size_uncompressed": 800796318,
-            "compression_algorithm": "gzip",
-            "cardano_node_version": "0.0.1",
-            "created_at": "2023-01-19T13:43:05.618857482Z"
-          }
-        ]
+        - [
+            {
+              "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
+              "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
+              "beacon":
+                {
+                  "network": "preview",
+                  "epoch": 123,
+                  "immutable_file_number": 2345
+                },
+              "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
+              "total_db_size_uncompressed": 800796318,
+              "compression_algorithm": "gzip",
+              "cardano_node_version": "0.0.1",
+              "created_at": "2023-01-19T13:43:05.618857482Z"
+            }
+          ]
 
     CardanoDatabaseSnapshotListItemMessage:
       description: CardanoDatabaseSnapshotListItemMessage represents a list item of Cardano database snapshots
@@ -2038,21 +2056,21 @@ components:
           description: Version of the Cardano node which is used to create snapshot archives.
           type: string
       examples:
-        {
-          "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
-          "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
-          "beacon":
-            {
-              "network": "preview",
-              "epoch": 123,
-              "immutable_file_number": 2345
-            },
-          "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
-          "total_db_size_uncompressed": 800796318,
-          "compression_algorithm": "zstandard",
-          "cardano_node_version": "0.0.1",
-          "created_at": "2023-01-19T13:43:05.618857482Z"
-        }
+        - {
+            "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
+            "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
+            "beacon":
+              {
+                "network": "preview",
+                "epoch": 123,
+                "immutable_file_number": 2345
+              },
+            "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
+            "total_db_size_uncompressed": 800796318,
+            "compression_algorithm": "zstandard",
+            "cardano_node_version": "0.0.1",
+            "created_at": "2023-01-19T13:43:05.618857482Z"
+          }
 
     CardanoDatabaseSnapshotMessage:
       description: CardanoDatabaseSnapshot represents a Cardano database snapshot and its metadata
@@ -2098,55 +2116,55 @@ components:
           description: Version of the Cardano node which is used to create snapshot archives.
           type: string
       examples:
-        {
-          "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
-          "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
-          "beacon":
-            {
-              "network": "preview",
-              "epoch": 123,
-              "immutable_file_number": 2345
-            },
-          "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
-          "total_db_size_uncompressed": 800796318,
-          "locations":
-            {
-              "digests":
-                [
-                  {
-                    "type": "cloud_storage",
-                    "uri": "https://aggregator-endpoint/artifact/cardano-database/digests"
-                  }
-                ],
-              "immutables":
-                [
-                  {
-                    "type": "cloud_storage",
-                    "uri":
-                      {
-                        "Template": "https://mithril-cdn-us.iohk.io/snapshot/{immutable-file_number}.tar.zst"
-                      }
-                  },
-                  {
-                    "type": "cloud_storage",
-                    "uri":
-                      {
-                        "Template": "https://mithril-cdn-eu.iohk.io/snapshot/{immutable-file_number}.tar.zst"
-                      }
-                  }
-                ],
-              "ancillary":
-                [
-                  {
-                    "type": "cloud_storage",
-                    "uri": "https://mithril-cdn-us.iohk.io/snapshot/ancillary-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.tar.zst"
-                  }
-                ]
-            },
-          "compression_algorithm": "zstandard",
-          "cardano_node_version": "0.0.1",
-          "created_at": "2023-01-19T13:43:05.618857482Z"
-        }
+        - {
+            "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
+            "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
+            "beacon":
+              {
+                "network": "preview",
+                "epoch": 123,
+                "immutable_file_number": 2345
+              },
+            "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
+            "total_db_size_uncompressed": 800796318,
+            "locations":
+              {
+                "digests":
+                  [
+                    {
+                      "type": "cloud_storage",
+                      "uri": "https://aggregator-endpoint/artifact/cardano-database/digests"
+                    }
+                  ],
+                "immutables":
+                  [
+                    {
+                      "type": "cloud_storage",
+                      "uri":
+                        {
+                          "Template": "https://mithril-cdn-us.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                        }
+                    },
+                    {
+                      "type": "cloud_storage",
+                      "uri":
+                        {
+                          "Template": "https://mithril-cdn-eu.iohk.io/snapshot/{immutable-file_number}.tar.zst"
+                        }
+                    }
+                  ],
+                "ancillary":
+                  [
+                    {
+                      "type": "cloud_storage",
+                      "uri": "https://mithril-cdn-us.iohk.io/snapshot/ancillary-6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732.tar.zst"
+                    }
+                  ]
+              },
+            "compression_algorithm": "zstandard",
+            "cardano_node_version": "0.0.1",
+            "created_at": "2023-01-19T13:43:05.618857482Z"
+          }
 
     CardanoDatabaseDigestListMessage:
       description: CardanoDatabaseDigestListMessage represents a list of Cardano database immutable files and their digests
@@ -2154,20 +2172,20 @@ components:
       items:
         $ref: "#/components/schemas/CardanoDatabaseDigestListItemMessage"
       examples:
-        [
-          {
-            "immutable_file_name": "06685.chunk",
-            "digest": "0af556ab2620dd9363bf76963a231abe8948a500ea6be31b131d87907ab09b1e"
-          },
-          {
-            "immutable_file_name": "06685.primary",
-            "digest": "32dfd6b722d87f253e78eb8b478fb94f1e13463826e674d6ec7b6bf0892b2e39"
-          },
-          {
-            "immutable_file_name": "06685.secondary",
-            "digest": "f37e751c1d7866f9c2bf88e870e5a9c9351f8521b41f259601fb208d5641a5ec"
-          }
-        ]
+        - [
+            {
+              "immutable_file_name": "06685.chunk",
+              "digest": "0af556ab2620dd9363bf76963a231abe8948a500ea6be31b131d87907ab09b1e"
+            },
+            {
+              "immutable_file_name": "06685.primary",
+              "digest": "32dfd6b722d87f253e78eb8b478fb94f1e13463826e674d6ec7b6bf0892b2e39"
+            },
+            {
+              "immutable_file_name": "06685.secondary",
+              "digest": "f37e751c1d7866f9c2bf88e870e5a9c9351f8521b41f259601fb208d5641a5ec"
+            }
+          ]
 
     CardanoDatabaseDigestListItemMessage:
       description: CardanoDatabaseSnapshotListItemMessage represents a list item of Cardano database immutable file and digest
@@ -2186,10 +2204,10 @@ components:
           type: string
           format: bytes
       examples:
-        {
-          "immutable_file_name": "06685.chunk",
-          "digest": "0af556ab2620dd9363bf76963a231abe8948a500ea6be31b131d87907ab09b1e"
-        }
+        - {
+            "immutable_file_name": "06685.chunk",
+            "digest": "0af556ab2620dd9363bf76963a231abe8948a500ea6be31b131d87907ab09b1e"
+          }
 
     MithrilStakeDistributionListMessage:
       description: MithrilStakeDistributionListMessage represents a list of Mithril stake distribution
@@ -2217,12 +2235,12 @@ components:
             type: string
             format: date-time,
         examples:
-          {
-            "epoch": 123,
-            "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-            "created_at": "2022-06-14T10:52:31Z"
-          }
+          - {
+              "epoch": 123,
+              "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+              "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+              "created_at": "2022-06-14T10:52:31Z"
+            }
 
     MithrilStakeDistributionMessage:
       description: This message represents a Mithril stake distribution.
@@ -2257,32 +2275,32 @@ components:
         protocol_parameters:
           $ref: "#/components/schemas/ProtocolParameters"
       examples:
-        {
-          "epoch": 123,
-          "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-          "signers":
-            [
-              {
-                "party_id": "1234567890",
-                "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
-                "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
-                "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
-                "kes_period": 123,
-                "stake": 1234
-              },
-              {
-                "party_id": "2345678900",
-                "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
-                "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
-                "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
-                "kes_period": 456,
-                "stake": 2345
-              }
-            ],
-          "created_at": "2022-06-14T10:52:31Z",
-          "protocol_parameters": { "k": 5, "m": 100, "phi_f": 0.65 }
-        }
+        - {
+            "epoch": 123,
+            "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+            "signers":
+              [
+                {
+                  "party_id": "1234567890",
+                  "verification_key": "7b12766b223a5c342b39302c32392c39392c39382c3131313138342c32252c32352c31353",
+                  "verification_key_signature": "7b5473693727369676d61223a7b227369676d6d61223a7b261223a9b227369676d61213a",
+                  "operational_certificate": "5b73136372c38302c37342c3136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537",
+                  "kes_period": 123,
+                  "stake": 1234
+                },
+                {
+                  "party_id": "2345678900",
+                  "verification_key": "7b392c39392c13131312766b223a5c39382c313342b39302c252c32352c31353328342c32",
+                  "verification_key_signature": "2c33302c3133312c3138322c34362c3133352c372c3139302c3235322c35352c32322c39",
+                  "operational_certificate": "3231342c3137372c37312c3232352c3233332c3135335d2c322c3139322c5b3133352c34312c3230332c3131332c3c33352c3234302c3230392c312c32392c3233332c33342c3138382c3134312c3130342c3234382c3231392c3",
+                  "kes_period": 456,
+                  "stake": 2345
+                }
+              ],
+            "created_at": "2022-06-14T10:52:31Z",
+            "protocol_parameters": { "k": 5, "m": 100, "phi_f": 0.65 }
+          }
 
     StakeDistribution:
       description: The list of Stake Pool Operator pool identifiers with their associated stake in the Cardano chain
@@ -2292,10 +2310,10 @@ components:
         text:
           type: integer
       examples:
-        {
-          "pool15ka28a4a3qxgcgh60wavkylku4vqjg385jezsrqxlafyrhahf02": 1192520901428,
-          "pool1aymf474uv528zafxlpfg3yr55zp267wj5mpu4qt557z5k5frn9p": 1009503382720
-        }
+        - {
+            "pool15ka28a4a3qxgcgh60wavkylku4vqjg385jezsrqxlafyrhahf02": 1192520901428,
+            "pool1aymf474uv528zafxlpfg3yr55zp267wj5mpu4qt557z5k5frn9p": 1009503382720
+          }
 
     CardanoStakeDistributionListMessage:
       description: CardanoStakeDistributionListMessage represents a list of Cardano stake distribution
@@ -2325,12 +2343,12 @@ components:
             type: string
             format: date-time,
         examples:
-          {
-            "epoch": 123,
-            "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-            "created_at": "2022-06-14T10:52:31Z"
-          }
+          - {
+              "epoch": 123,
+              "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+              "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+              "created_at": "2022-06-14T10:52:31Z"
+            }
 
     CardanoStakeDistributionMessage:
       description: This message represents a Cardano stake distribution.
@@ -2364,17 +2382,17 @@ components:
           type: string
           format: date-time,
       examples:
-        {
-          "epoch": 123,
-          "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-          "stake_distribution":
-            {
-              "pool15ka28a4a3qxgcgh60wavkylku4vqjg385jezsrqxlafyrhahf02": 1192520901428,
-              "pool1aymf474uv528zafxlpfg3yr55zp267wj5mpu4qt557z5k5frn9p": 1009503382720
-            },
-          "created_at": "2022-06-14T10:52:31Z"
-        }
+        - {
+            "epoch": 123,
+            "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+            "stake_distribution":
+              {
+                "pool15ka28a4a3qxgcgh60wavkylku4vqjg385jezsrqxlafyrhahf02": 1192520901428,
+                "pool1aymf474uv528zafxlpfg3yr55zp267wj5mpu4qt557z5k5frn9p": 1009503382720
+              },
+            "created_at": "2022-06-14T10:52:31Z"
+          }
 
     CardanoTransactionSnapshotListMessage:
       description: CardanoTransactionSnapshotListMessage represents a list of Cardano transactions set snapshots
@@ -2413,14 +2431,14 @@ components:
             type: string
             format: date-time,
         examples:
-          {
-            "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-            "merkle_root": "33bfd17bc082ab5dd1fc0788241c70aa5325241c70aa532530d190809c5391bbc307905e8372",
-            "epoch": 123,
-            "block_number": 1234,
-            "created_at": "2022-06-14T10:52:31Z"
-          }
+          - {
+              "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+              "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+              "merkle_root": "33bfd17bc082ab5dd1fc0788241c70aa5325241c70aa532530d190809c5391bbc307905e8372",
+              "epoch": 123,
+              "block_number": 1234,
+              "created_at": "2022-06-14T10:52:31Z"
+            }
 
     CardanoTransactionSnapshotMessage:
       description: This message represents a Cardano transactions set snapshot.
@@ -2457,14 +2475,14 @@ components:
           type: string
           format: date-time,
       examples:
-        {
-          "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-          "merkle_root": "33bfd17bc082ab5dd1fc0788241c70aa5325241c70aa532530d190809c5391bbc307905e8372",
-          "epoch": 123,
-          "block_number": 1234,
-          "created_at": "2022-06-14T10:52:31Z"
-        }
+        - {
+            "hash": "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+            "merkle_root": "33bfd17bc082ab5dd1fc0788241c70aa5325241c70aa532530d190809c5391bbc307905e8372",
+            "epoch": 123,
+            "block_number": 1234,
+            "created_at": "2022-06-14T10:52:31Z"
+          }
 
     CardanoTransactionProofMessage:
       description: This message represents proofs for Cardano Transactions.
@@ -2510,23 +2528,25 @@ components:
           type: integer
           format: int64
       examples:
-        {
-          "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
-          "certified_transactions":
-            [
-              {
-                "transactions_hashes":
-                  [
-                    "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
-                    "5d0d1272e6e70736a1ea2cae34015876367ee64517f6328364f6b73930966732"
-                  ],
-                "proof": "5b73136372c38302c37342c3136362c313535b5b323136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c313532352c3230332c3235352c313030262c33136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c31358322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537"
-              }
-            ],
-          "non_certified_transactions":
-            ["732d0d1272e6e70736367ee6f6328364f6b739309666a1ea2cae34015874517"],
-          "latest_block_number": 7060000
-        }
+        - {
+            "certificate_hash": "7905e83ab5d7bc082c1bbc3033bfd19c539078830d19080d1f241c70aa532572",
+            "certified_transactions":
+              [
+                {
+                  "transactions_hashes":
+                    [
+                      "6367ee65d0d1272e6e70736a1ea2cae34015874517f6328364f6b73930966732",
+                      "5d0d1272e6e70736a1ea2cae34015876367ee64517f6328364f6b73930966732"
+                    ],
+                  "proof": "5b73136372c38302c37342c3136362c313535b5b323136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c313532352c3230332c3235352c313030262c33136362c313535b5b3232352c3230332c3235352c313030262c38322c39382c32c39332c3138342c31358322c39382c32c39332c3138342c3135362c3136362c32312c3131312c3232312c36332c3137372c3232332c3232332c31392c3537"
+                }
+              ],
+            "non_certified_transactions":
+              [
+                "732d0d1272e6e70736367ee6f6328364f6b739309666a1ea2cae34015874517"
+              ],
+            "latest_block_number": 7060000
+          }
 
     Error:
       description: Internal error representation
@@ -2541,9 +2561,10 @@ components:
         message:
           description: error message
           type: string
-          examples: "An error occurred, the operation could not be completed"
+          examples:
+            - "An error occurred, the operation could not be completed"
       examples:
-        {
-          "label": "Internal error",
-          "message": "An error occurred, the operation could not be completed"
-        }
+        - {
+            "label": "Internal error",
+            "message": "An error occurred, the operation could not be completed"
+          }


### PR DESCRIPTION
## Content

To be conform to the OpenAPI specification 3.1, in a previous commit we have changed `example` property to `examples`.
Doing that, we have created 2 issues:
- Examples are no longer verified because we only looking for `example` property
- Examples are not correctly displayed because the `examples` property must contain an array of examples.

This PR fix this two issues and adjust the relative path to `openapi.yaml`to generate locally `aggregator-api` with docusaurus.
`ApiSpec` tests are modified to take into account `examples` property.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2235
