### PR TITLE
refactor(aggregator): better url sanitization process by using a value object

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.18"
+version = "0.6.19"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.18"
+version = "0.6.19"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -133,12 +133,12 @@ mod tests {
         test_utils::{fake_data, TempDir},
         CardanoNetwork,
     };
-    use reqwest::Url;
 
     use crate::{
         artifact_builder::{MockAncillaryFileUploader, MockImmutableFilesUploader},
         immutable_file_digest_mapper::MockImmutableFileDigestMapper,
         test_tools::TestLogger,
+        tools::url_sanitizer::SanitizedUrlWithTrailingSlash,
         DumbSnapshotter,
     };
 
@@ -238,7 +238,7 @@ mod tests {
                 .returning(|| Ok(BTreeMap::new()));
 
             DigestArtifactBuilder::new(
-                Url::parse("http://aggregator_uri").unwrap(),
+                SanitizedUrlWithTrailingSlash::parse("http://aggregator_uri").unwrap(),
                 vec![],
                 test_dir.join("digests"),
                 Arc::new(immutable_file_digest_mapper),

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
@@ -10,11 +10,11 @@ use mithril_common::{
     entities::DigestLocation, logging::LoggerExtensions,
     messages::CardanoDatabaseDigestListItemMessage, StdResult,
 };
-use reqwest::Url;
 use slog::{error, Logger};
 
 use crate::{
     file_uploaders::{GcpUploader, LocalUploader},
+    tools::url_sanitizer::SanitizedUrlWithTrailingSlash,
     DumbUploader, FileUploader, ImmutableFileDigestMapper,
 };
 
@@ -55,7 +55,8 @@ impl DigestFileUploader for GcpUploader {
 
 pub struct DigestArtifactBuilder {
     /// Aggregator URL prefix
-    aggregator_url_prefix: Url,
+    aggregator_url_prefix: SanitizedUrlWithTrailingSlash,
+
     /// Uploaders
     uploaders: Vec<Arc<dyn DigestFileUploader>>,
 
@@ -69,7 +70,7 @@ pub struct DigestArtifactBuilder {
 impl DigestArtifactBuilder {
     /// Creates a new [DigestArtifactBuilder].
     pub fn new(
-        aggregator_url_prefix: Url,
+        aggregator_url_prefix: SanitizedUrlWithTrailingSlash,
         uploaders: Vec<Arc<dyn DigestFileUploader>>,
         digests_dir: PathBuf,
         immutable_file_digest_mapper: Arc<dyn ImmutableFileDigestMapper>,
@@ -211,7 +212,7 @@ mod tests {
             .returning(|| Ok(BTreeMap::new()));
 
         let builder = DigestArtifactBuilder::new(
-            Url::parse("https://aggregator/").unwrap(),
+            SanitizedUrlWithTrailingSlash::parse("https://aggregator/").unwrap(),
             vec![],
             temp_dir,
             Arc::new(immutable_file_digest_mapper),
@@ -240,7 +241,7 @@ mod tests {
 
         {
             let builder = DigestArtifactBuilder::new(
-                Url::parse("https://aggregator/").unwrap(),
+                SanitizedUrlWithTrailingSlash::parse("https://aggregator/").unwrap(),
                 vec![Arc::new(uploader)],
                 PathBuf::from("/tmp/whatever"),
                 Arc::new(MockImmutableFileDigestMapper::new()),
@@ -260,7 +261,7 @@ mod tests {
         let uploader = fake_uploader_returning_error();
 
         let builder = DigestArtifactBuilder::new(
-            Url::parse("https://aggregator/").unwrap(),
+            SanitizedUrlWithTrailingSlash::parse("https://aggregator/").unwrap(),
             vec![Arc::new(uploader)],
             PathBuf::from("/tmp/whatever"),
             Arc::new(MockImmutableFileDigestMapper::new()),
@@ -289,7 +290,7 @@ mod tests {
         ];
 
         let builder = DigestArtifactBuilder::new(
-            Url::parse("https://aggregator/").unwrap(),
+            SanitizedUrlWithTrailingSlash::parse("https://aggregator/").unwrap(),
             uploaders,
             PathBuf::from("/tmp/whatever"),
             Arc::new(MockImmutableFileDigestMapper::new()),
@@ -324,7 +325,7 @@ mod tests {
             vec![Arc::new(first_uploader), Arc::new(second_uploader)];
 
         let builder = DigestArtifactBuilder::new(
-            Url::parse("https://aggregator/").unwrap(),
+            SanitizedUrlWithTrailingSlash::parse("https://aggregator/").unwrap(),
             uploaders,
             PathBuf::from("/tmp/whatever"),
             Arc::new(MockImmutableFileDigestMapper::new()),
@@ -370,7 +371,7 @@ mod tests {
             });
 
         let builder = DigestArtifactBuilder::new(
-            Url::parse("https://aggregator/").unwrap(),
+            SanitizedUrlWithTrailingSlash::parse("https://aggregator/").unwrap(),
             vec![],
             temp_dir,
             Arc::new(immutable_file_digest_mapper),
@@ -421,7 +422,7 @@ mod tests {
             });
 
         let builder = DigestArtifactBuilder::new(
-            Url::parse("https://aggregator/").unwrap(),
+            SanitizedUrlWithTrailingSlash::parse("https://aggregator/").unwrap(),
             vec![Arc::new(digest_file_uploader)],
             digests_dir,
             Arc::new(immutable_file_digest_mapper),

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -734,8 +734,8 @@ mod tests {
         use std::fs::File;
         use std::io::Write;
 
+        use crate::tools::url_sanitizer::SanitizedUrlWithTrailingSlash;
         use mithril_common::test_utils::TempDir;
-        use reqwest::Url;
 
         use super::*;
 
@@ -765,7 +765,8 @@ mod tests {
             let archive_1 = create_fake_archive(&source_dir, "00001.tar.gz");
             let archive_2 = create_fake_archive(&source_dir, "00002.tar.gz");
 
-            let url_prefix = Url::parse("http://test.com:8080/base-root").unwrap();
+            let url_prefix =
+                SanitizedUrlWithTrailingSlash::parse("http://test.com:8080/base-root").unwrap();
             let uploader =
                 LocalUploader::new(url_prefix, &target_dir, TestLogger::stdout()).unwrap();
             let location = ImmutableFilesUploader::batch_upload(
@@ -799,7 +800,8 @@ mod tests {
 
             let archive = create_fake_archive(&source_dir, "not-templatable.tar.gz");
 
-            let url_prefix = Url::parse("http://test.com:8080/base-root").unwrap();
+            let url_prefix =
+                SanitizedUrlWithTrailingSlash::parse("http://test.com:8080/base-root").unwrap();
             let uploader =
                 LocalUploader::new(url_prefix, &target_dir, TestLogger::stdout()).unwrap();
 

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -4,7 +4,6 @@ use mithril_common::chain_observer::ChainObserverType;
 use mithril_common::crypto_helper::ProtocolGenesisSigner;
 use mithril_common::era::adapters::EraReaderAdapterType;
 use mithril_doc::{Documenter, DocumenterDefault, StructDoc};
-use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeSet, HashMap};
 use std::path::PathBuf;
@@ -18,7 +17,7 @@ use mithril_common::entities::{
 use mithril_common::{CardanoNetwork, StdResult};
 
 use crate::http_server::SERVER_BASE_PATH;
-use crate::tools::url_sanitizer;
+use crate::tools::url_sanitizer::SanitizedUrlWithTrailingSlash;
 
 /// Different kinds of execution environments
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -282,20 +281,19 @@ impl Configuration {
     }
 
     /// Build the local server URL from configuration.
-    pub fn get_local_server_url(&self) -> StdResult<Url> {
-        let url = Url::parse(&format!(
+    pub fn get_local_server_url(&self) -> StdResult<SanitizedUrlWithTrailingSlash> {
+        SanitizedUrlWithTrailingSlash::parse(&format!(
             "http://{}:{}/{SERVER_BASE_PATH}/",
             self.server_ip, self.server_port
-        ))?;
-        Ok(url)
+        ))
     }
 
     /// Get the server URL from the configuration.
     ///
     /// Will return the public server URL if it is set, otherwise the local server URL.
-    pub fn get_server_url(&self) -> StdResult<Url> {
+    pub fn get_server_url(&self) -> StdResult<SanitizedUrlWithTrailingSlash> {
         match &self.public_server_url {
-            Some(url) => Ok(url_sanitizer::sanitize_url_path(&Url::parse(url)?)?),
+            Some(url) => SanitizedUrlWithTrailingSlash::parse(url),
             None => self.get_local_server_url(),
         }
     }

--- a/mithril-aggregator/src/dependency_injection/builder.rs
+++ b/mithril-aggregator/src/dependency_injection/builder.rs
@@ -1265,10 +1265,7 @@ impl DependenciesBuilder {
                 SnapshotUploaderType::Local => {
                     let server_url_prefix = self.configuration.get_server_url()?;
                     let ancillary_url_prefix = server_url_prefix
-                        .join(&format!("{CARDANO_DATABASE_DOWNLOAD_PATH}/ancillary/"))
-                        .with_context(|| {
-                            format!("Could not join `{CARDANO_DATABASE_DOWNLOAD_PATH}/ancillary/` to URL `{server_url_prefix}`")
-                        })?;
+                        .sanitize_join(&format!("{CARDANO_DATABASE_DOWNLOAD_PATH}/ancillary/"))?;
                     let target_dir = self
                         .configuration
                         .get_snapshot_dir()?
@@ -1313,8 +1310,7 @@ impl DependenciesBuilder {
                 SnapshotUploaderType::Local => {
                     let server_url_prefix = self.configuration.get_server_url()?;
                     let immutable_url_prefix = server_url_prefix
-                        .join(&format!("{CARDANO_DATABASE_DOWNLOAD_PATH}/immutable/"))
-                        .with_context(|| format!("Could not join `{CARDANO_DATABASE_DOWNLOAD_PATH}/immutable/` to URL `{server_url_prefix}`"))?;
+                        .sanitize_join(&format!("{CARDANO_DATABASE_DOWNLOAD_PATH}/immutable/"))?;
                     let target_dir = self
                         .configuration
                         .get_snapshot_dir()?
@@ -1350,8 +1346,7 @@ impl DependenciesBuilder {
                 SnapshotUploaderType::Local => {
                     let server_url_prefix = self.configuration.get_server_url()?;
                     let digests_url_prefix = server_url_prefix
-                        .join(&format!("{CARDANO_DATABASE_DOWNLOAD_PATH}/digests/"))
-                        .with_context(|| format!("Could not join `{CARDANO_DATABASE_DOWNLOAD_PATH}/digests/` to URL `{server_url_prefix}`"))?;
+                        .sanitize_join(&format!("{CARDANO_DATABASE_DOWNLOAD_PATH}/digests/"))?;
                     let target_dir = self
                         .configuration
                         .get_snapshot_dir()?
@@ -1759,7 +1754,7 @@ impl DependenciesBuilder {
             dependency_container.clone(),
             RouterConfig {
                 network: self.configuration.get_network()?,
-                server_url: self.configuration.get_server_url()?.to_string(),
+                server_url: self.configuration.get_server_url()?,
                 allowed_discriminants: self.get_allowed_signed_entity_types_discriminants()?,
                 cardano_transactions_prover_max_hashes_allowed_by_request: self
                     .configuration

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -3,6 +3,7 @@ use crate::http_server::routes::{
     signatures_routes, signer_routes, statistics_routes, status,
 };
 use crate::http_server::SERVER_BASE_PATH;
+use crate::tools::url_sanitizer::SanitizedUrlWithTrailingSlash;
 use crate::DependencyContainer;
 
 use mithril_common::api_version::APIVersionProvider;
@@ -33,7 +34,7 @@ impl Reject for VersionParseError {}
 /// HTTP Server configuration
 pub struct RouterConfig {
     pub network: CardanoNetwork,
-    pub server_url: String,
+    pub server_url: SanitizedUrlWithTrailingSlash,
     pub allowed_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
     pub cardano_transactions_prover_max_hashes_allowed_by_request: usize,
     pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
@@ -48,7 +49,7 @@ impl RouterConfig {
     pub fn dummy() -> Self {
         Self {
             network: CardanoNetwork::DevNet(87),
-            server_url: "http://0.0.0.0:8000/".to_string(),
+            server_url: SanitizedUrlWithTrailingSlash::parse("http://0.0.0.0:8000/").unwrap(),
             allowed_discriminants: BTreeSet::from([
                 SignedEntityTypeDiscriminants::MithrilStakeDistribution,
                 SignedEntityTypeDiscriminants::CardanoStakeDistribution,

--- a/mithril-aggregator/src/tools/url_sanitizer.rs
+++ b/mithril-aggregator/src/tools/url_sanitizer.rs
@@ -1,10 +1,70 @@
 use anyhow::{anyhow, Context};
 use reqwest::Url;
+use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 
 use mithril_common::StdResult;
 
+/// A sanitized URL, guaranteed to have a trailing slash and no empty segments
+///
+/// This type is meant to be used as a base path to produce resources path, for example:
+/// `https://example.xy/download/` can be joined with `artifact/file.zip` to produce a download link
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Ord, Hash)]
+pub struct SanitizedUrlWithTrailingSlash {
+    internal_url: Url,
+}
+
+impl SanitizedUrlWithTrailingSlash {
+    /// Join this URL with the given path, the resulting URL is guaranteed to have a trailing slash
+    ///
+    /// See [Url::join] for more details
+    pub fn sanitize_join(&self, input: &str) -> StdResult<SanitizedUrlWithTrailingSlash> {
+        let url = self.internal_url.join(input).with_context(|| {
+            format!(
+                "Could not join `{}` to URL `{input}`",
+                self.internal_url.as_str()
+            )
+        })?;
+        sanitize_url_path(&url)
+    }
+
+    /// Parse an absolute URL from a string.
+    ///
+    /// See [Url::parse] for more details
+    pub fn parse(input: &str) -> StdResult<SanitizedUrlWithTrailingSlash> {
+        let url = Url::parse(input).with_context(|| format!("Could not parse URL `{input}`"))?;
+        sanitize_url_path(&url)
+    }
+}
+
+impl PartialEq<Url> for SanitizedUrlWithTrailingSlash {
+    fn eq(&self, other: &Url) -> bool {
+        self.internal_url.eq(other)
+    }
+}
+
+impl Deref for SanitizedUrlWithTrailingSlash {
+    type Target = Url;
+
+    fn deref(&self) -> &Self::Target {
+        &self.internal_url
+    }
+}
+
+impl From<SanitizedUrlWithTrailingSlash> for Url {
+    fn from(value: SanitizedUrlWithTrailingSlash) -> Self {
+        value.internal_url
+    }
+}
+
+impl Display for SanitizedUrlWithTrailingSlash {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.internal_url.fmt(f)
+    }
+}
+
 /// Sanitize URL path by removing empty segments and adding trailing slash
-pub fn sanitize_url_path(url: &Url) -> StdResult<Url> {
+pub fn sanitize_url_path(url: &Url) -> StdResult<SanitizedUrlWithTrailingSlash> {
     let segments_non_empty = url
         .path_segments()
         .map(|s| s.into_iter().filter(|s| !s.is_empty()).collect::<Vec<_>>())
@@ -22,7 +82,7 @@ pub fn sanitize_url_path(url: &Url) -> StdResult<Url> {
         url_path_segments_cleared.push("");
     }
 
-    Ok(url)
+    Ok(SanitizedUrlWithTrailingSlash { internal_url: url })
 }
 
 #[cfg(test)]
@@ -59,6 +119,25 @@ mod tests {
         assert_eq!(
             "http://example.com/",
             sanitize_url_path(&url).unwrap().as_str()
+        );
+    }
+
+    #[test]
+    fn test_sanitize_url_join() {
+        let sanitized_url = sanitize_url_path(&Url::parse("http://example.com/").unwrap()).unwrap();
+        assert_eq!(
+            "http://example.com/a/b/c_ext/",
+            sanitized_url.sanitize_join("a//b/c_ext").unwrap().as_str()
+        );
+    }
+
+    #[test]
+    fn test_sanitize_url_parse() {
+        let sanitized_url =
+            SanitizedUrlWithTrailingSlash::parse("http://example.com/a//b/c.ext?test=123").unwrap();
+        assert_eq!(
+            "http://example.com/a/b/c.ext/?test=123",
+            sanitized_url.as_str()
         );
     }
 }


### PR DESCRIPTION
## Content

This PR introduce a `SanitizedUrlWithTrailingSlash` struct to avoid redundant call to the url sanitizer as it guarantee that the url that it hold is already sanitized.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
