### PR TITLE
aggregator: fix flakiness of tests that uses the snapshotter and simplify http server tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.17"
+version = "0.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3739,7 +3739,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.106"
+version = "0.4.107"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.17"
+version = "0.6.18"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_database.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_database.rs
@@ -170,9 +170,7 @@ mod handlers {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        http_server::SERVER_BASE_PATH, initialize_dependencies, services::MockMessageService,
-    };
+    use crate::{initialize_dependencies, services::MockMessageService};
     use mithril_common::messages::{
         CardanoDatabaseDigestListItemMessage, CardanoDatabaseSnapshotListItemMessage,
         CardanoDatabaseSnapshotMessage,
@@ -194,9 +192,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -214,7 +210,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -247,7 +243,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -278,7 +274,7 @@ mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
             )))
@@ -308,7 +304,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -342,7 +338,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -375,7 +371,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -408,7 +404,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -441,7 +437,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -159,9 +159,7 @@ pub mod tests {
         test_utils::apispec::APISpec,
     };
 
-    use crate::{
-        http_server::SERVER_BASE_PATH, initialize_dependencies, services::MockMessageService,
-    };
+    use crate::{initialize_dependencies, services::MockMessageService};
 
     use super::*;
 
@@ -173,9 +171,7 @@ pub mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -194,7 +190,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -227,7 +223,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -259,7 +255,7 @@ pub mod tests {
 
             request()
                 .method(method)
-                .path(&format!("/{SERVER_BASE_PATH}{path}"))
+                .path(path)
                 .reply(&setup_router(RouterState::new_with_dummy_config(
                     dependency_manager.clone(),
                 )))
@@ -279,7 +275,7 @@ pub mod tests {
 
             request()
                 .method(method)
-                .path(&format!("/{SERVER_BASE_PATH}{base_path}/123"))
+                .path(&format!("{base_path}/123"))
                 .reply(&setup_router(RouterState::new_with_dummy_config(
                     dependency_manager.clone(),
                 )))
@@ -311,7 +307,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -344,7 +340,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -377,7 +373,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -411,7 +407,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/123"))
+            .path(&format!("{base_path}/123"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -440,7 +436,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/invalid-epoch"))
+            .path(&format!("{base_path}/invalid-epoch"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -473,7 +469,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/123"))
+            .path(&format!("{base_path}/123"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -506,7 +502,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/123"))
+            .path(&format!("{base_path}/123"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -104,9 +104,7 @@ pub mod tests {
     use mithril_common::test_utils::apispec::APISpec;
     use mithril_persistence::sqlite::HydrationError;
 
-    use crate::{
-        http_server::SERVER_BASE_PATH, initialize_dependencies, services::MockMessageService,
-    };
+    use crate::{initialize_dependencies, services::MockMessageService};
 
     use super::*;
 
@@ -118,9 +116,7 @@ pub mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -138,7 +134,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -171,7 +167,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -202,7 +198,7 @@ pub mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
             )))
@@ -232,7 +228,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -265,7 +261,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -298,7 +294,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -104,9 +104,7 @@ pub mod tests {
     use mithril_common::test_utils::apispec::APISpec;
     use mithril_persistence::sqlite::HydrationError;
 
-    use crate::{
-        http_server::SERVER_BASE_PATH, initialize_dependencies, services::MockMessageService,
-    };
+    use crate::{initialize_dependencies, services::MockMessageService};
 
     use super::*;
 
@@ -118,9 +116,7 @@ pub mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -138,7 +134,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -171,7 +167,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -202,7 +198,7 @@ pub mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
             )))
@@ -232,7 +228,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -265,7 +261,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -298,7 +294,7 @@ pub mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -212,7 +212,6 @@ mod tests {
     use crate::http_server::routes::artifact_routes::test_utils::*;
     use crate::http_server::routes::router::RouterConfig;
     use crate::{
-        http_server::SERVER_BASE_PATH,
         initialize_dependencies,
         services::{MockMessageService, MockSignedEntityService},
     };
@@ -237,9 +236,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -257,7 +254,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -290,7 +287,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -320,7 +317,7 @@ mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
             )))
@@ -350,7 +347,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -383,7 +380,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -416,7 +413,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -457,7 +454,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new(
                 Arc::new(dependency_manager),
                 RouterConfig {
@@ -493,7 +490,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -526,7 +523,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -128,9 +128,7 @@ mod handlers {
 mod tests {
     use super::*;
     use crate::store::MockCertificatePendingStorer;
-    use crate::{
-        http_server::SERVER_BASE_PATH, initialize_dependencies, services::MockMessageService,
-    };
+    use crate::{initialize_dependencies, services::MockMessageService};
     use anyhow::anyhow;
     use mithril_common::{
         entities::CertificatePending,
@@ -151,9 +149,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -177,7 +173,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -203,7 +199,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -236,7 +232,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -268,7 +264,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -300,7 +296,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -331,7 +327,7 @@ mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
             )))
@@ -360,7 +356,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -387,7 +383,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -419,10 +415,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!(
-                "/{SERVER_BASE_PATH}{}",
-                path.replace("{certificate_hash}", "whatever")
-            ))
+            .path(&path.replace("{certificate_hash}", "whatever"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -123,8 +123,8 @@ mod tests {
         test_utils::{apispec::APISpec, fake_data, MithrilFixtureBuilder},
     };
 
+    use crate::entities::AggregatorEpochSettings;
     use crate::services::FakeEpochService;
-    use crate::{entities::AggregatorEpochSettings, http_server::SERVER_BASE_PATH};
     use crate::{initialize_dependencies, services::FakeEpochServiceBuilder};
 
     use super::*;
@@ -137,9 +137,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -280,7 +278,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -306,7 +304,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -154,7 +154,7 @@ mod tests {
         test_utils::{apispec::APISpec, assert_equivalent, fake_data},
     };
 
-    use crate::{http_server::SERVER_BASE_PATH, services::MockProverService};
+    use crate::services::MockProverService;
     use crate::{initialize_dependencies, services::MockSignedEntityService};
 
     use super::*;
@@ -167,9 +167,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -219,7 +217,7 @@ mod tests {
         request()
             .method(method)
             .path(&format!(
-                "/{SERVER_BASE_PATH}{path}?transaction_hashes={},{},{}",
+                "{path}?transaction_hashes={},{},{}",
                 fake_data::transaction_hashes()[0],
                 fake_data::transaction_hashes()[1],
                 fake_data::transaction_hashes()[2]
@@ -266,7 +264,7 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!(
-                "/{SERVER_BASE_PATH}{path}?transaction_hashes={},{}",
+                "{path}?transaction_hashes={},{}",
                 fake_data::transaction_hashes()[0],
                 fake_data::transaction_hashes()[1]
             ))
@@ -297,7 +295,7 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!(
-                "/{SERVER_BASE_PATH}{path}?transaction_hashes={},{}",
+                "{path}?transaction_hashes={},{}",
                 fake_data::transaction_hashes()[0],
                 fake_data::transaction_hashes()[1]
             ))
@@ -333,7 +331,7 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!(
-                "/{SERVER_BASE_PATH}{path}?transaction_hashes={},{}",
+                "{path}?transaction_hashes={},{}",
                 fake_data::transaction_hashes()[0],
                 fake_data::transaction_hashes()[1]
             ))
@@ -364,7 +362,7 @@ mod tests {
         let response = request()
             .method(method)
             .path(&format!(
-                "/{SERVER_BASE_PATH}{path}?transaction_hashes=invalid%3A%2F%2Fid,,tx-456"
+                "{path}?transaction_hashes=invalid%3A%2F%2Fid,,tx-456"
             ))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -406,9 +404,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!(
-                "/{SERVER_BASE_PATH}{path}?transaction_hashes={tx},{tx}",
-            ))
+            .path(&format!("{path}?transaction_hashes={tx},{tx}",))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -91,7 +91,6 @@ mod handlers {
 #[cfg(test)]
 mod tests {
     use crate::http_server::routes::router::RouterConfig;
-    use crate::http_server::SERVER_BASE_PATH;
     use crate::initialize_dependencies;
     use mithril_common::entities::{
         BlockNumber, CardanoTransactionsSigningConfig, SignedEntityTypeDiscriminants,
@@ -118,9 +117,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -146,7 +143,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new(
                 Arc::new(dependency_manager),
                 config,
@@ -207,7 +204,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new(
                 Arc::new(dependency_manager),
                 config,

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -130,7 +130,6 @@ mod tests {
     };
 
     use crate::{
-        http_server::SERVER_BASE_PATH,
         initialize_dependencies,
         services::{CertifierServiceError, MockCertifierService, SignatureRegistrationStatus},
         SingleSignatureAuthenticator,
@@ -146,9 +145,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -164,7 +161,7 @@ mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&RegisterSignatureMessage::dummy())
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
@@ -203,7 +200,7 @@ mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -232,7 +229,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -267,7 +264,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -302,7 +299,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -338,7 +335,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -375,7 +372,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -412,7 +409,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -457,7 +454,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -501,7 +498,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&message)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -275,7 +275,6 @@ mod tests {
 
     use crate::{
         database::{record::SignerRecord, repository::MockSignerGetter},
-        http_server::SERVER_BASE_PATH,
         initialize_dependencies,
         services::FakeEpochService,
         signer_registerer::MockSignerRegisterer,
@@ -294,9 +293,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -316,7 +313,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&signer)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -348,7 +345,7 @@ mod tests {
 
         request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&RegisterSignerMessage::dummy())
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
@@ -385,7 +382,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&signer)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -424,7 +421,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&signer)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -462,7 +459,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&signer)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -496,7 +493,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .json(&signer)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
@@ -533,7 +530,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/{}", asked_epoch))
+            .path(&format!("{base_path}/{}", asked_epoch))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -560,7 +557,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/1"))
+            .path(&format!("{base_path}/1"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -593,7 +590,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/3"))
+            .path(&format!("{base_path}/3"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -625,7 +622,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{base_path}/1"))
+            .path(&format!("{base_path}/1"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -675,7 +672,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -708,7 +705,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -76,8 +76,7 @@ mod tests {
     };
 
     use crate::{
-        dependency_injection::DependenciesBuilder, http_server::SERVER_BASE_PATH,
-        initialize_dependencies, Configuration,
+        dependency_injection::DependenciesBuilder, initialize_dependencies, Configuration,
     };
 
     fn setup_router(
@@ -88,9 +87,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -107,7 +104,7 @@ mod tests {
         let response = request()
             .method(method)
             .json(&snapshot_download_message)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -140,7 +137,7 @@ mod tests {
         request()
             .method(method)
             .json(&SnapshotDownloadMessage::dummy())
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
             )))

--- a/mithril-aggregator/src/http_server/routes/status.rs
+++ b/mithril-aggregator/src/http_server/routes/status.rs
@@ -120,7 +120,6 @@ mod tests {
 
     use crate::{
         entities::AggregatorEpochSettings,
-        http_server::SERVER_BASE_PATH,
         initialize_dependencies,
         services::{FakeEpochService, FakeEpochServiceBuilder},
     };
@@ -135,9 +134,7 @@ mod tests {
             .allow_headers(vec!["content-type"])
             .allow_methods(vec![Method::GET, Method::POST, Method::OPTIONS]);
 
-        warp::any()
-            .and(warp::path(SERVER_BASE_PATH))
-            .and(routes(&state).with(cors))
+        warp::any().and(routes(&state).with(cors))
     }
 
     #[tokio::test]
@@ -148,7 +145,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))
@@ -178,7 +175,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("/{SERVER_BASE_PATH}{path}"))
+            .path(path)
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/snapshotter.rs
+++ b/mithril-aggregator/src/snapshotter.rs
@@ -239,9 +239,8 @@ impl CompressedArchiveSnapshotter {
 
     #[cfg(test)]
     /// Allow to use a custom temporary directory to avoid conflicts during the snapshot verification.
-    pub fn set_sub_temp_dir<P: AsRef<Path>>(&mut self, sub_dir: P) {
-        self.temp_dir =
-            mithril_common::test_utils::TempDir::create("snapshotter", "temp_dir").join(sub_dir);
+    pub fn set_sub_temp_dir<T: Into<String>>(&mut self, sub_dir: T) {
+        self.temp_dir = mithril_common::test_utils::TempDir::create("snapshotter-temp", sub_dir);
     }
 
     fn snapshot<T: TarAppender>(&self, filepath: &Path, appender: T) -> StdResult<OngoingSnapshot> {
@@ -964,7 +963,7 @@ mod tests {
     }
 
     #[test]
-    fn can_set_temp_dir_with_path_or_str() {
+    fn can_set_temp_dir_with_str_or_string() {
         let mut snapshotter = CompressedArchiveSnapshotter::new(
             PathBuf::from("db"),
             PathBuf::from("pending_snapshot"),
@@ -973,8 +972,7 @@ mod tests {
         )
         .unwrap();
 
-        snapshotter.set_sub_temp_dir(Path::new("sub_dir"));
-        snapshotter.set_sub_temp_dir(PathBuf::from("sub_dir"));
         snapshotter.set_sub_temp_dir("sub_dir");
+        snapshotter.set_sub_temp_dir("sub_dir".to_string());
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.106"
+version = "0.4.107"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/test_utils/temp_dir.rs
+++ b/mithril-common/src/test_utils/temp_dir.rs
@@ -16,7 +16,7 @@ const DEFAULT_SHORT_PATH_MAX_LEN: usize = 90;
 
 impl TempDir {
     /// `TempDir` builder factory
-    pub fn new<T: Into<String>>(module: T, name: T) -> Self {
+    pub fn new<M: Into<String>, N: Into<String>>(module: M, name: N) -> Self {
         Self {
             module_name: module.into(),
             name: name.into(),
@@ -85,7 +85,7 @@ impl TempDir {
     /// # use crate::mithril_common::test_utils::TempDir;
     /// TempDir::new("module", "name").build();
     /// ```
-    pub fn create<T: Into<String>>(module: T, name: T) -> PathBuf {
+    pub fn create<M: Into<String>, N: Into<String>>(module: M, name: N) -> PathBuf {
         Self::new(module, name).build()
     }
 
@@ -97,7 +97,7 @@ impl TempDir {
     /// # use crate::mithril_common::test_utils::TempDir;
     /// TempDir::new("module", "name").generate_shorter_path().build();
     /// ```
-    pub fn create_with_short_path<T: Into<String>>(module: T, name: T) -> PathBuf {
+    pub fn create_with_short_path<M: Into<String>, N: Into<String>>(module: M, name: N) -> PathBuf {
         Self::new(module, name).generate_shorter_path().build()
     }
 


### PR DESCRIPTION
## Content

This PR includes:

- A fix to the flakiness in tests that uses `snapshotter` archive verification introduced in ca3f524e0f3177cbaebe3db8b5f75c297d4d3bb3.
- A simplification of http server tests by removing all usage of the `SERVER_BASE_PATH` as the tests don't need it.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
