### PR TITLE
CI: move `notify-on-failure` to a dedicated workflow

### DIFF
--- a/.github/workflows/nightly-dispatcher.yml
+++ b/.github/workflows/nightly-dispatcher.yml
@@ -21,22 +21,6 @@ jobs:
     uses: ./.github/workflows/test-client.yml
 
   notify-on-failure:
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/test-notify-on-failure.yml
     needs: [docker-builds, aggregator-stress-test, test-client]
     if: failure()
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Make script executable
-        shell: bash
-        run: |
-          chmod +x ./.github/workflows/scripts/notify-nightly-failure.js
-
-      - name: Send failure notification by email
-        uses: peter-evans/sendgrid-action@v1
-        env:
-          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
-          SCRIPT_FILEPATH: ./.github/workflows/scripts/notify-nightly-failure.js
-          SENDGRID_MAIL_FROM: ${{ secrets.CI_NOTIFICATION_EMAIL_FROM }}
-          SENDGRID_MAIL_TO: ${{ secrets.CI_NOTIFICATION_EMAIL_TO }}

--- a/.github/workflows/test-notify-on-failure.yml
+++ b/.github/workflows/test-notify-on-failure.yml
@@ -1,0 +1,24 @@
+name: Test Notify on Failure
+
+on:
+  workflow_dispatch:
+
+jobs:
+  notify-on-failure:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make script executable
+        shell: bash
+        run: |
+          chmod +x ./.github/workflows/scripts/notify-nightly-failure.js
+
+      - name: Send failure notification by email
+        uses: peter-evans/sendgrid-action@v1
+        env:
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          SCRIPT_FILEPATH: ./.github/workflows/scripts/notify-nightly-failure.js
+          SENDGRID_MAIL_FROM: ${{ secrets.CI_NOTIFICATION_EMAIL_FROM }}
+          SENDGRID_MAIL_TO: ${{ secrets.CI_NOTIFICATION_EMAIL_TO }}


### PR DESCRIPTION
## Content

This PR introduces a new manual workflow to test email alert delivery when an error occurs in the nightly dispatcher.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2251 