### PR TITLE
Fix: add missing `workflow_call` trigger on Test Notify on Failure workflow

### DIFF
--- a/.github/workflows/scripts/notify-nightly-failure.js
+++ b/.github/workflows/scripts/notify-nightly-failure.js
@@ -28,5 +28,8 @@ const msg = {
 
 sgMail
   .send(msg)
-  .then(() => console.log("Mail sent successfully"))
-  .catch((error) => console.error(error.toString()));
+  .then(() => {
+    console.log("Mail sent successfully");
+    console.log("Message details:", msg);
+  })
+  .catch((error) => console.error("Error sending email:", error));

--- a/.github/workflows/test-notify-on-failure.yml
+++ b/.github/workflows/test-notify-on-failure.yml
@@ -2,6 +2,7 @@ name: Test Notify on Failure
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   notify-on-failure:


### PR DESCRIPTION
## Content

This PR includes a fix for the `test-notify-on-failure` workflow to allow it to be triggered by the Nightly Dispatcher workflow.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
