### PR TITLE
Fix: use `unstable` Docker image ID in `test-client` workflow instead…

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -46,7 +46,7 @@ on:
         type: string
       docker_image_id:
         type: string
-        default: latest
+        default: unstable
       network:
         type: string
         default: preview


### PR DESCRIPTION
## Content

This PR includes a fix for the `test-client` github workflow when triggered by the nightly dispatcher, by changing the default `docker_image_id` from `latest` to `unstable`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
