### PR TITLE
Chore: add Mithril client CLI version in debug logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.10.9"
+version = "0.10.10"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.10.9"
+version = "0.10.10"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -85,6 +85,11 @@ pub struct Args {
 
 impl Args {
     pub async fn execute(&self, root_logger: Logger) -> MithrilResult<()> {
+        debug!(
+            root_logger,
+            "Mithril client CLI version: {}",
+            env!("CARGO_PKG_VERSION")
+        );
         debug!(root_logger, "Run Mode: {}", self.run_mode);
         let filename = format!("{}/{}.json", self.config_directory.display(), self.run_mode);
         debug!(root_logger, "Reading configuration file '{filename}'.");


### PR DESCRIPTION
## Content

This PR adds a new debug log that specifies the version of the Mithril client CLI whenever a command is executed.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested