### PR TITLE
Add an `era` subcommand to create keypair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.26"
+version = "0.6.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3735,7 +3735,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.112"
+version = "0.4.113"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/website/root/manual/develop/nodes/mithril-aggregator.md
+++ b/docs/website/root/manual/develop/nodes/mithril-aggregator.md
@@ -259,6 +259,7 @@ Usage: mithril-aggregator era <COMMAND>
 Commands:
   list               Era list command
   generate-tx-datum  Era tx datum generate command
+  generate-keypair   Era keypair generation command
   help               Print this message or the help of the given subcommand(s)
 
 Options:
@@ -401,6 +402,7 @@ Here are the available subcommands:
 | **genesis generate-keypair**          | Generates a genesis keypair                                                                                                               |
 | **era list**                          | Lists the supported eras                                                                                                                  |
 | **era generate-tx-datum**             | Generates the era markers transaction datum to be stored on-chain                                                                         |
+| **era generate-keypair**              | Generates an era keypair                                                                                                                  |
 | **tools recompute-certificates-hash** | Loads all certificates in the database, recomputing their hash, and updating all related entities                                         |
 
 ## Configuration parameters
@@ -505,5 +507,11 @@ Here is a list of the available parameters:
 | `next_era_epoch`         | `--next-era-epoch`         |          -           | `NEXT_ERA_EPOCH`         | Epoch at which the next era starts. If not specified and an upcoming era is available, it will announce the next era. If specified, it must be strictly greater than `current-epoch-era` | -             | -       |         -          |
 | `era_markers_secret_key` | `--era-markers-secret-key` |          -           | `ERA_MARKERS_SECRET_KEY` | Era markers secret key that is used to verify the authenticity of the era markers on the chain.                                                                                          | -             | -       | :heavy_check_mark: |
 | `target_path`            | `--target-path`            |          -           | -                        | Path of the file to export the payload to.                                                                                                                                               | -             | -       |         -          |
+
+`era generate-keypair` command:
+
+| Parameter     | Command line (long) | Command line (short) | Environment variable | Description                           | Default value | Example |     Mandatory      |
+| ------------- | ------------------- | :------------------: | -------------------- | ------------------------------------- | ------------- | ------- | :----------------: |
+| `target_path` | `--target-path`     |          -           | -                    | Target path for the generated keypair | -             | -       | :heavy_check_mark: |
 
 The `tools recompute-certificates-hash` command has no dedicated parameters.

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.26"
+version = "0.6.27"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/era_command.rs
+++ b/mithril-aggregator/src/commands/era_command.rs
@@ -40,6 +40,9 @@ pub enum EraSubCommand {
 
     /// Era tx datum generate command.
     GenerateTxDatum(GenerateTxDatumEraSubCommand),
+
+    /// Era keypair generation command.
+    GenerateKeypair(GenerateKeypairEraSubCommand),
 }
 
 impl EraSubCommand {
@@ -51,6 +54,7 @@ impl EraSubCommand {
         match self {
             Self::List(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::GenerateTxDatum(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::GenerateKeypair(cmd) => cmd.execute(root_logger, config_builder).await,
         }
     }
 }
@@ -125,6 +129,33 @@ impl GenerateTxDatumEraSubCommand {
 
         let mut target_file = File::create(&self.target_path)?;
         target_file.write_all(tx_datum.as_bytes())?;
+
+        Ok(())
+    }
+}
+
+/// Era keypair generation command.
+#[derive(Parser, Debug, Clone)]
+pub struct GenerateKeypairEraSubCommand {
+    /// Target path for the generated keypair
+    #[clap(long)]
+    target_path: PathBuf,
+}
+
+impl GenerateKeypairEraSubCommand {
+    pub async fn execute(
+        &self,
+        root_logger: Logger,
+        _config_builder: ConfigBuilder<DefaultState>,
+    ) -> StdResult<()> {
+        debug!(root_logger, "GENERATE KEYPAIR ERA command");
+        println!(
+            "Era generate keypair to {}",
+            self.target_path.to_string_lossy()
+        );
+
+        EraTools::create_and_save_era_keypair(&self.target_path)
+            .with_context(|| "era-tools: keypair generation error")?;
 
         Ok(())
     }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.112"
+version = "0.4.113"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/era.rs
+++ b/mithril-common/src/crypto_helper/era.rs
@@ -54,6 +54,16 @@ impl EraMarkersSigner {
         Self::create_test_signer(rng)
     }
 
+    /// Get the [EraMarkersVerifierSecretKey]
+    pub fn secret_key(&self) -> EraMarkersVerifierSecretKey {
+        self.secret_key.clone()
+    }
+
+    /// Get the [EraMarkersVerifierVerificationKey]
+    pub fn verification_key(&self) -> EraMarkersVerifierVerificationKey {
+        self.secret_key.verifying_key().into()
+    }
+
     /// [EraMarkersSigner] from [EraMarkersVerifierSecretKey]
     pub fn from_secret_key(secret_key: EraMarkersVerifierSecretKey) -> Self {
         Self { secret_key }

--- a/mithril-common/src/crypto_helper/era.rs
+++ b/mithril-common/src/crypto_helper/era.rs
@@ -47,7 +47,6 @@ impl EraMarkersSigner {
         Self::create_test_signer(rng)
     }
 
-    #[cfg(test)]
     /// [EraMarkersSigner] non deterministic
     pub fn create_non_deterministic_signer() -> Self {
         let rng = rand_core::OsRng;


### PR DESCRIPTION
## Content

Creation of a command on the aggregator to create test era keys for setting up a test

This PR includes:
- a new sub-command `generate-keypair` for the era command to export non deterministic `era.sk` and `era.vk` files.
- a parameter `target-path` to define the export directory
- the update of the aggregator documentation

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2271
