### PR TITLE
Add warning for linux requirements upgrade

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -101,6 +101,13 @@ runs:
         ## Linux Requirements
         The Linux binaries target \`glibc\`: to run them or install the \`.deb\` packages you must have \`glibc\` version \`2.31+\` installed.
         Compatible systems include, but are not limited to, \`Ubuntu 20.04+\` or \`Debian 11+\` (Bullseye)).
+
+        > [!WARNING]
+        > After the release of distribution `2506`, the minimum required  \`glibc\` version for Linux binaries
+        > will be raised to \`2.35\`.
+        > Compatible systems include, but are not limited to, \`Ubuntu 22.04+\` or \`Debian 12+\` (Bookworm)).
+        >
+        > If you using a system with an older version of \`glibc\`, you will need to compile the binaries from source.
         EOF
 
     - name: Fetch the latest version of the unstable tag

--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -103,11 +103,10 @@ runs:
         Compatible systems include, but are not limited to, \`Ubuntu 20.04+\` or \`Debian 11+\` (Bullseye)).
 
         > [!WARNING]
-        > After the release of distribution `2506`, the minimum required  \`glibc\` version for Linux binaries
-        > will be raised to \`2.35\`.
+        > From March 2025 onwards, released Linux binaries will have their minimum required  \`glibc\` version raised to \`2.35\`.
         > Compatible systems include, but are not limited to, \`Ubuntu 22.04+\` or \`Debian 12+\` (Bookworm)).
         >
-        > If you using a system with an older version of \`glibc\`, you will need to compile the binaries from source.
+        > If you are using a system with an older version of \`glibc\`, you will need to compile the binaries from source.
         EOF
 
     - name: Fetch the latest version of the unstable tag

--- a/docs/website/blog/2025-02-04-glibc-minimum-requirement-change.md
+++ b/docs/website/blog/2025-02-04-glibc-minimum-requirement-change.md
@@ -1,11 +1,11 @@
 ---
-title: Minimum Required glibc Version Bump
+title: Minimum required glibc version bump
 authors:
   - name: Mithril Team
-tags: [mithril client, cli, breaking-change]
+tags: [ci, glibc, breaking-change]
 ---
 
-# Upcoming Change: Minimum Required glibc Version Bump
+# Upcoming Change: Minimum required glibc version bump
 
 :::info
 This only affects users who rely on the **precompiled Linux binaries** provided by the Mithril team.
@@ -29,27 +29,27 @@ the last two LTS versions.
 
 As a result, we need to update our CI environment to use a more recent version of Ubuntu.
 
-## Upcoming Change
+## Upcoming change
 
 Distribution `2506` will be the last distribution with a minimum required glibc version of `2.31`.
 
 After the release of distribution `2506`, our CI builders will be updated to use `Ubuntu 22.04`. Raising the minimum
 required glibc version for our Linux binaries to `2.35`.
 
-## Impact on Users
+## Impact for users
 
 The new glibc version `2.35` is compatible with systems such as `Ubuntu 22.04` and `Debian 12 (Bookworm)`.
 
 If you are using a system with an older version of glibc, you can either:
 
-- Upgrade your system to a newer version that supports glibc `2.35` to continue using our compiled binaries.
+- Upgrade your system to a newer version that supports glibc `2.35` to keep using our compiled binaries.
 - Compile the binaries from source to avoid upgrading your system.
 
 ## Summary
 
 - **Current minimum glibc version**: `2.31`
   - Examples of compatible systems: `Ubuntu 20.04`, `Debian 11 (Bullseye)`
-- **New minimum glibc version**: `2.35` (effective **after** distribution `2506` release)
+- **New minimum glibc version**: `2.35` (effective for distributions released from **March 2025** )
   - Examples of compatible systems: `Ubuntu 22.04`, `Debian 12 (Bookworm)`
 
 For any inquiries or assistance, don't hesitate to contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).

--- a/docs/website/blog/2025-02-04-glibc-minimum-requirement-change.md
+++ b/docs/website/blog/2025-02-04-glibc-minimum-requirement-change.md
@@ -1,0 +1,55 @@
+---
+title: Minimum Required glibc Version Bump
+authors:
+  - name: Mithril Team
+tags: [mithril client, cli, breaking-change]
+---
+
+# Upcoming Change: Minimum Required glibc Version Bump
+
+:::info
+This only affects users who rely on the **precompiled Linux binaries** provided by the Mithril team.
+
+If you compile the binaries from source or use a different operating system, you are not affected by this change.
+:::
+
+Following [the deprecation of `Ubuntu 20.04` in GitHub Actions](https://github.com/actions/runner-images/issues/11101),
+we are updating the minimum required glibc version for our Linux binaries from `2.31` to `2.35`.
+
+## Current Situation
+
+Our Continuous Integration (CI) uses GitHub Actions to build and test the Mithril binaries for different platforms.
+
+Currently, our CI builders target `Ubuntu 20.04` to build Linux binaries, leading to a minimum required glibc version of
+`2.31`.
+This version is compatible with systems such as `Ubuntu 20.04` and `Debian 11 (Bullseye)`.
+
+However, with the release of `Ubuntu 24.04`, GitHub Actions is dropping support for `Ubuntu 20.04` as they only support
+the last two LTS versions.
+
+As a result, we need to update our CI environment to use a more recent version of Ubuntu.
+
+## Upcoming Change
+
+Distribution `2506` will be the last distribution with a minimum required glibc version of `2.31`.
+
+After the release of distribution `2506`, our CI builders will be updated to use `Ubuntu 22.04`. Raising the minimum
+required glibc version for our Linux binaries to `2.35`.
+
+## Impact on Users
+
+The new glibc version `2.35` is compatible with systems such as `Ubuntu 22.04` and `Debian 12 (Bookworm)`.
+
+If you are using a system with an older version of glibc, you can either:
+
+- Upgrade your system to a newer version that supports glibc `2.35` to continue using our compiled binaries.
+- Compile the binaries from source to avoid upgrading your system.
+
+## Summary
+
+- **Current minimum glibc version**: `2.31`
+  - Examples of compatible systems: `Ubuntu 20.04`, `Debian 11 (Bullseye)`
+- **New minimum glibc version**: `2.35` (effective **after** distribution `2506` release)
+  - Examples of compatible systems: `Ubuntu 22.04`, `Debian 12 (Bookworm)`
+
+For any inquiries or assistance, don't hesitate to contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).

--- a/docs/website/root/compiled-binaries.mdx
+++ b/docs/website/root/compiled-binaries.mdx
@@ -32,9 +32,9 @@ or `Debian Bullseye`).
 
 :::warning
 
-After the release of distribution `2506` mid-February, the minimum required `glibc` version for Linux binaries
-will be raised to `2.35` (compatible with `Ubuntu 22.04` or `Debian 12 - Bookworm`).
+From March 2025 onwards, released Linux binaries will have their minimum required `glibc` version raised to `2.35`
+(compatible with `Ubuntu 22.04` or `Debian 12 - Bookworm`).
 
-If you using a system with an older version of `glibc`, you will need to compile the binaries from source.
+If you are using a system with an older version of `glibc`, you will need to compile the binaries from source.
 
 :::

--- a/docs/website/root/compiled-binaries.mdx
+++ b/docs/website/root/compiled-binaries.mdx
@@ -29,3 +29,12 @@ The Linux binaries target `glibc`, and have a minimum requirement of `glibc 2.31
 or `Debian Bullseye`).
 
 :::
+
+:::warning
+
+After the release of distribution `2506` mid-February, the minimum required `glibc` version for Linux binaries
+will be raised to `2.35` (compatible with `Ubuntu 22.04` or `Debian 12 - Bookworm`).
+
+If you using a system with an older version of `glibc`, you will need to compile the binaries from source.
+
+:::

--- a/docs/website/versioned_docs/version-maintained/compiled-binaries.mdx
+++ b/docs/website/versioned_docs/version-maintained/compiled-binaries.mdx
@@ -32,9 +32,9 @@ or `Debian Bullseye`).
 
 :::warning
 
-After the release of distribution `2506` mid-February, the minimum required `glibc` version for Linux binaries
-will be raised to `2.35` (compatible with `Ubuntu 22.04` or `Debian 12 - Bookworm`).
+From March 2025 onwards, released Linux binaries will have their minimum required `glibc` version raised to `2.35`
+(compatible with `Ubuntu 22.04` or `Debian 12 - Bookworm`).
 
-If you using a system with an older version of `glibc`, you will need to compile the binaries from source.
+If you are using a system with an older version of `glibc`, you will need to compile the binaries from source.
 
 :::

--- a/docs/website/versioned_docs/version-maintained/compiled-binaries.mdx
+++ b/docs/website/versioned_docs/version-maintained/compiled-binaries.mdx
@@ -29,3 +29,12 @@ The Linux binaries target `glibc`, and have a minimum requirement of `glibc 2.31
 or `Debian Bullseye`).
 
 :::
+
+:::warning
+
+After the release of distribution `2506` mid-February, the minimum required `glibc` version for Linux binaries
+will be raised to `2.35` (compatible with `Ubuntu 22.04` or `Debian 12 - Bookworm`).
+
+If you using a system with an older version of `glibc`, you will need to compile the binaries from source.
+
+:::

--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -5,23 +5,35 @@ set -e
 # Function to display usage
 usage() {
   echo "Install or upgrade a Mithril node"
-  echo "Usage: $0 [-n node] [-v version] [-d distribution] [-p path]"
+  echo "Usage: $0 [-c node] [-v version] [-d distribution] [-p path]"
   echo "  -c node          : Mithril node to install or upgrade (mithril-signer, mithril-aggregator, mithril-client)"
   echo "  -d distribution  : Distribution to upgrade to (latest, unstable or distribution version e.g '2445.0')"
   echo "  -p path          : Path to install the component"
   exit 1
 }
 
-# Default values
-DISTRIBUTION="latest"
-GITHUB_ORGANIZATION="input-output-hk"
-GITHUB_REPOSITORY="mithril"
-
 # Function to display an error message and exit
 error_exit() {
   echo "$1" 1>&2
   exit 1
 }
+
+# Function to check that required tools are installed
+check_requirements() {
+    which curl >/dev/null ||
+        error_exit "It seems 'curl' is not installed or not in the path.";
+    which jq >/dev/null ||
+        error_exit "It seems 'jq' is not installed or not in the path.";
+}
+
+# --- MAIN execution ---
+
+# Default values
+DISTRIBUTION="latest"
+GITHUB_ORGANIZATION="input-output-hk"
+GITHUB_REPOSITORY="mithril"
+
+check_requirements
 
 # Parse command line arguments
 while getopts "c:v:d:p:" opt; do

--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -26,6 +26,16 @@ check_requirements() {
         error_exit "It seems 'jq' is not installed or not in the path.";
 }
 
+check_glibc_min_version() {
+  glibc_version=$(ldd --version | awk 'NR==1{print $NF}')
+
+  if [ "$(echo "$glibc_version" | grep -cE "2\.3[1-4]")" -gt 0 ]; then
+    echo "Warning: Mithril support for your GLIBC version $glibc_version is deprecated. The minimum required version will be bumped to 2.35 after the 2506 distribution."
+  elif [ "$(echo "$glibc_version" | grep -cE -e "2\.[0-2][0-9]" -e "2\.30")" -gt 0 ]; then
+    error_exit "Error: Your GLIBC version is $glibc_version, but the minimum required version is 2.31."
+  fi
+}
+
 # --- MAIN execution ---
 
 # Default values
@@ -59,6 +69,7 @@ OS_CODE=$(echo "$OS" | awk '{print tolower($0)}')
 
 case "$OS" in
   Linux)
+    check_glibc_min_version
     ;;
   Darwin)
     OS_CODE="macos"

--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -30,7 +30,7 @@ check_glibc_min_version() {
   glibc_version=$(ldd --version | awk 'NR==1{print $NF}')
 
   if [ "$(echo "$glibc_version" | grep -cE "2\.3[1-4]")" -gt 0 ]; then
-    echo "Warning: Mithril support for your GLIBC version $glibc_version is deprecated. The minimum required version will be bumped to 2.35 after the 2506 distribution."
+    echo "Warning: Mithril support for your GLIBC version $glibc_version is deprecated. The minimum required version will be bumped to 2.35 for distributions released from March 2025 onwards."
   elif [ "$(echo "$glibc_version" | grep -cE -e "2\.[0-2][0-9]" -e "2\.30")" -gt 0 ]; then
     error_exit "Error: Your GLIBC version is $glibc_version, but the minimum required version is 2.31."
   fi


### PR DESCRIPTION
## Content

This PR add warnings for the upcoming glibc minimum version upgrade (from `2.31` to `2.35`).

- Docusaurus: Add a warning in the linux requirements block
- Docusaurus: Add a blog post about the upcoming change
- CI: Add a warning in the linux requirements block in our release note
- install script: Add an automatic check of the `glibc` version when used on linux. If below the actual supported version of `2.31` the script will now fails with a message, if the version is supported but deprecated (between `2.31` and `2.34` included) a deprecation warning is shown.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [x] Add dev blog post (if relevant)

## Issue(s)

Relates to #2216