### PR TITLE
Restore `release` option for build in Makefile for `aggregator` …

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3578,7 +3578,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3689,7 +3689,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.10.10"
+version = "0.10.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.27"
+version = "0.6.28"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Makefile
+++ b/mithril-aggregator/Makefile
@@ -5,7 +5,7 @@ CARGO = cargo
 all: test build
 
 build:
-	${CARGO} build
+	${CARGO} build --release
 	cp ../target/release/mithril-aggregator .
 
 run: build

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.10.10"
+version = "0.10.11"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/Makefile
+++ b/mithril-client-cli/Makefile
@@ -10,7 +10,7 @@ CARGO = cargo
 all: test build
 
 build:
-	${CARGO} build
+	${CARGO} build --release
 	cp ../target/release/mithril-client .
 
 run: build


### PR DESCRIPTION
## Content

This PR restore the `--release` option in `build` target of `Makefile` in
- mithril-aggregator
- mithril-client-cli

It was deleted by mistake in #2260 

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #2260
