### PR TITLE
Docs: bump minor versions of crates for `2506.0` distribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,7 +486,8 @@ jobs:
       max-parallel: 1
       matrix:
         package:
-          [mithril-stm, mithril-build-script, mithril-common, mithril-client]
+          [mithril-stm, mithril-build-script, mithril-common]
+          #[mithril-stm, mithril-build-script, mithril-common, mithril-client] Will be reactivated after release of the `2506` distribution.
 
     runs-on: ubuntu-24.04
     needs:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -255,7 +255,8 @@ jobs:
       max-parallel: 1
       matrix:
         package:
-          [mithril-stm, mithril-build-script, mithril-common, mithril-client]
+          [mithril-stm, mithril-build-script, mithril-common]
+          #[mithril-stm, mithril-build-script, mithril-common, mithril-client] Will be reactivated after release of the `2506` distribution.
 
     runs-on: ubuntu-24.04
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3590,7 +3590,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.6.30"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3637,7 +3637,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-fake"
-version = "0.3.22"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3669,7 +3669,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.10.11"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.10.12"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3728,7 +3728,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3747,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.4.114"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.7",
+      "version": "0.8.0",
       "license": "Apache-2.0"
     },
     "node_modules/@mithril-dev/mithril-client-wasm": {

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.7",
+      "version": "0.8.0",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.6.30"
+version = "0.7.0"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.10.12"
+version = "0.11.0"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.7.8"
+version = "0.8.0"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/ci-test/package-lock.json
+++ b/mithril-client-wasm/ci-test/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/package.json
+++ b/mithril-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithril-dev/mithril-client-wasm",
-  "version": "0.7.8",
+  "version": "0.8.0",
   "description": "Mithril client WASM",
   "license": "Apache-2.0",
   "collaborators": [

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.10.11"
+version = "0.11.0"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -50,13 +50,13 @@ uuid = { version = "1.13.1", features = ["v4"] }
 zstd = { version = "0.13.2", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-mithril-common = { path = "../mithril-common", version = "=0.4", default-features = false, features = [
+mithril-common = { path = "../mithril-common", version = "=0.5", default-features = false, features = [
     "fs",
 ] }
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 getrandom = { version = "0.2.15", features = ["js"] }
-mithril-common = { path = "../mithril-common", version = "=0.4", default-features = false }
+mithril-common = { path = "../mithril-common", version = "=0.5", default-features = false }
 reqwest = { version = "0.12.12", default-features = false, features = [
     "charset",
     "http2",
@@ -69,7 +69,7 @@ uuid = { version = "1.13.1", features = ["v4", "js"] }
 [dev-dependencies]
 httpmock = "0.7.0"
 indicatif = { version = "0.17.11", features = ["tokio"] }
-mithril-common = { path = "../mithril-common", version = "=0.4", default-features = false, features = [
+mithril-common = { path = "../mithril-common", version = "=0.5", default-features = false, features = [
     "test_tools",
 ] }
 mockall = "0.13.1"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.4.114"
+version = "0.5.0"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm/dist/web": {
       "name": "mithril-client-wasm",
-      "version": "0.7.8",
+      "version": "0.8.0",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {

--- a/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
+++ b/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator-fake"
-version = "0.3.22"
+version = "0.4.0"
 description = "Mithril Fake Aggregator for client testing"
 authors = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes the **bump of minor versions of crates for `2506.0` distribution release**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2207  
