### PR TITLE
Reduce e2e flakiness by changing protocol parameters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3870,7 +3870,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.68"
+version = "0.4.69"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.68"
+version = "0.4.69"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
@@ -62,7 +62,7 @@ pub async fn update_protocol_parameters(aggregator: &mut Aggregator) -> StdResul
     info!("> stopping aggregator");
     aggregator.stop().await?;
     let protocol_parameters_new = ProtocolParameters {
-        k: 150,
+        k: 145,
         m: 210,
         phi_f: 0.80,
     };

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -293,6 +293,14 @@ impl App {
         }
     }
 
+    async fn last_error_in_logs(&self) {
+        if let Some(infrastructure) = self.infrastructure.lock().await.as_ref() {
+            let _ = infrastructure.last_error_in_logs(1).await.inspect_err(|e| {
+                error!("Failed to grep error in logs: {}", e);
+            });
+        }
+    }
+
     pub async fn run(
         &mut self,
         args: Args,
@@ -360,6 +368,7 @@ impl App {
             Ok(()) => Ok(()),
             Err(error) => {
                 self.tail_logs().await;
+                self.last_error_in_logs().await;
                 Err(error)
             }
         }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -279,4 +279,8 @@ impl Aggregator {
     pub async fn tail_logs(&self, number_of_line: u64) -> StdResult<()> {
         self.command.tail_logs(None, number_of_line).await
     }
+
+    pub async fn last_error_in_logs(&self, number_of_error: u64) -> StdResult<()> {
+        self.command.last_error_in_logs(None, number_of_error).await
+    }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -373,4 +373,12 @@ impl MithrilInfrastructure {
 
         Ok(())
     }
+
+    pub async fn last_error_in_logs(&self, number_of_error: u64) -> StdResult<()> {
+        self.aggregator()
+            .last_error_in_logs(number_of_error)
+            .await?;
+
+        Ok(())
+    }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
@@ -38,14 +38,14 @@ pub async fn last_errors(file_path: &Path, number_of_error: u64) -> StdResult<St
         ])
         .stdout(Stdio::piped())
         .spawn()
-        .expect("failed to spawn grep");
+        .with_context(|| format!("Failed to spawn grep file `{}`", file_path.display()))?;
 
     let tail_stdin: Stdio = grep
         .stdout
         .take()
         .unwrap()
         .try_into()
-        .expect("failed to convert to Stdio");
+        .with_context(|| "Failed to convert to Stdio.".to_string())?;
 
     let result = Command::new("tail")
         .args(vec![

--- a/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/file_utils.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use mithril_common::StdResult;
-use std::path::Path;
+use std::{path::Path, process::Stdio};
 use tokio::process::Command;
 
 /// Tail a file into into the given stream
@@ -20,6 +20,47 @@ pub async fn tail(file_path: &Path, number_of_line: u64) -> StdResult<String> {
         .with_context(|| format!("Failed to tail file `{}`", file_path.display()))?;
 
     String::from_utf8(tail_result.stdout).with_context(|| "Failed to parse tail output to utf8")
+}
+
+/// Return the lastest errors in a file with the lines preceding them.
+///
+/// For the sake of simplicity it use internally the `tail` and `grep` commands so be sure to have them on
+/// your system.
+pub async fn last_errors(file_path: &Path, number_of_error: u64) -> StdResult<String> {
+    let number_of_line_before = 5;
+    let mut grep = Command::new("grep")
+        .args(vec![
+            "-n",
+            "\"level\":50",
+            file_path.to_str().unwrap(),
+            "-B",
+            &number_of_line_before.to_string(),
+        ])
+        .stdout(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn grep");
+
+    let tail_stdin: Stdio = grep
+        .stdout
+        .take()
+        .unwrap()
+        .try_into()
+        .expect("failed to convert to Stdio");
+
+    let result = Command::new("tail")
+        .args(vec![
+            "-n",
+            &(number_of_error * (number_of_line_before + 1)).to_string(),
+        ])
+        .stdin(tail_stdin)
+        .kill_on_drop(true)
+        .output()
+        .await
+        .with_context(|| format!("Failed to tail file `{}`", file_path.display()))?;
+
+    String::from_utf8(result.stdout)
+        .map(|s| s.replace("\\n", "\n"))
+        .with_context(|| "Failed to parse command output to utf8")
 }
 
 #[cfg(test)]
@@ -71,6 +112,63 @@ mod tests {
         Eu mi bibendum neque egestas congue quisque egestas diam."
                 .to_string(),
             tail_result
+        );
+    }
+
+    #[tokio::test]
+    pub async fn should_return_last_error() {
+        let temp_dir = get_temp_dir("should_return_last_error");
+        let file_path = temp_dir.join("file_with_error.txt");
+        write_file(
+            &file_path,
+            r#"{"msg":"A","content":"Ok"}
+{"msg":"B","level":50,"content":"First error\n\nStack backtrace:\nline 1\nline 2"}
+{"msg":"C","content":"Ok"}
+{"msg":"D","content":"Ok"}
+{"msg":"E","content":"Ok"}
+{"msg":"F","content":"Ok"}
+{"msg":"G","content":"Ok"}
+{"msg":"H","content":"Ok"}
+{"msg":"I","level":50,"content":"Second error\n\nStack backtrace:\nline 1\nline 2"}
+{"msg":"J","level":70,"content":"other error"}
+{"msg":"K","content":"Ok"}"#,
+        );
+
+        let error_result = file_utils::last_errors(&file_path, 1)
+            .await
+            .expect("failed to grep file");
+
+        write_file(
+            &temp_dir.join("expected.txt"),
+            r#"4-{"msg":"D","content":"Ok"}
+5-{"msg":"E","content":"Ok"}
+6-{"msg":"F","content":"Ok"}
+7-{"msg":"G","content":"Ok"}
+8-{"msg":"H","content":"Ok"}
+9-{"msg":"I","level":50,"content":"Second error
+
+Stack backtrace:
+line 1
+line 2"}
+"#,
+        );
+
+        write_file(&temp_dir.join("obtain.txt"), &error_result);
+
+        assert_eq!(
+            r#"4-{"msg":"D","content":"Ok"}
+5-{"msg":"E","content":"Ok"}
+6-{"msg":"F","content":"Ok"}
+7-{"msg":"G","content":"Ok"}
+8-{"msg":"H","content":"Ok"}
+9:{"msg":"I","level":50,"content":"Second error
+
+Stack backtrace:
+line 1
+line 2"}
+"#
+            .to_string(),
+            error_result
         );
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
@@ -148,6 +148,43 @@ impl MithrilCommand {
             ));
         }
 
+        self.print_header(name, &format!("LAST {} LINES", number_of_line));
+
+        println!(
+            "{}",
+            file_utils::tail(&self.log_path, number_of_line).await?
+        );
+
+        Ok(())
+    }
+
+    /// Grep error in log
+    ///
+    /// You can override the title with the name parameter.
+    pub(crate) async fn last_error_in_logs(
+        &self,
+        name: Option<&str>,
+        number_of_error: u64,
+    ) -> StdResult<()> {
+        if !self.log_path.exists() {
+            return Err(anyhow!(
+                "No log for {}, did you run the command at least once ? expected path: {}",
+                self.name,
+                self.log_path.display()
+            ));
+        }
+
+        self.print_header(name, &format!("LAST {} ERROR(S)", number_of_error));
+
+        println!(
+            "{}",
+            file_utils::last_errors(&self.log_path, number_of_error).await?
+        );
+
+        Ok(())
+    }
+
+    fn print_header(&self, name: Option<&str>, title: &str) {
         let name = match name {
             Some(n) => n,
             None => &self.name,
@@ -156,19 +193,8 @@ impl MithrilCommand {
         println!("{:-^100}", "");
         println!(
             "{:^30}",
-            format!(
-                "{} LOGS - LAST {} LINES:",
-                name.to_uppercase(),
-                number_of_line
-            )
+            format!("{} LOGS - {}:", name.to_uppercase(), title)
         );
         println!("{:-^100}", "");
-
-        println!(
-            "{}",
-            file_utils::tail(&self.log_path, number_of_line).await?
-        );
-
-        Ok(())
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
@@ -178,7 +178,9 @@ impl MithrilCommand {
 
         println!(
             "{}",
-            file_utils::last_errors(&self.log_path, number_of_error).await?
+            file_utils::last_errors(&self.log_path, number_of_error)
+                .await
+                .unwrap_or("Failed to get last error in logs".to_string())
         );
 
         Ok(())


### PR DESCRIPTION
## Content

Change protocol parameters to reduce e2e test flakiness.

We decrease the `k` parameter of the protocol to 145 to avoid an epoch gap due to a too low number of signatures (less than 150). 
This PR also print the last aggregator error in the console to help investigation when tests fail.

Example of the error shown in log when test fail
```
----------------------------------------------------------------------------------------------------
MITHRIL-AGGREGATOR LOGS - LAST 1 ERROR(S):
----------------------------------------------------------------------------------------------------
10293-{"msg":">> update_epoch_settings","v":0,"name":"mithril-aggregator","level":20,"time":"2025-02-12T11:57:08.013719446+01:00","hostname":"sfauvel-XPS-15-9560","pid":238456,"src":"MithrilEpochService"}
10294-{"msg":"Inserting epoch settings in epoch 37","v":0,"name":"mithril-aggregator","level":20,"time":"2025-02-12T11:57:08.01372586+01:00","hostname":"sfauvel-XPS-15-9560","pid":238456,"src":"MithrilEpochService","epoch_settings":"AggregatorEpochSettings { protocol_parameters: ProtocolParameters { k: 250, m: 210, phi_f: 0.8 }, cardano_transactions_signing_config: CardanoTransactionsSigningConfig { security_parameter: BlockNumber(1), step: BlockNumber(15) } }"}
10295-{"msg":">> precompute_epoch_data","v":0,"name":"mithril-aggregator","level":20,"time":"2025-02-12T11:57:08.017775711+01:00","hostname":"sfauvel-XPS-15-9560","pid":238456,"src":"AggregatorRunner"}
10296-{"msg":">> precompute_epoch_data","v":0,"name":"mithril-aggregator","level":20,"time":"2025-02-12T11:57:08.017797842+01:00","hostname":"sfauvel-XPS-15-9560","pid":238456,"src":"MithrilEpochService"}
10297-{"msg":">> is_certificate_chain_valid","v":0,"name":"mithril-aggregator","level":20,"time":"2025-02-12T11:57:08.033187445+01:00","hostname":"sfauvel-XPS-15-9560","pid":238456,"src":"AggregatorRunner"}
10298:{"msg":"An error occurred, runtime state kept. message = 'certificate chain is invalid'","v":0,"name":"mithril-aggregator","level":50,"time":"2025-02-12T11:57:08.03436876+01:00","hostname":"sfauvel-XPS-15-9560","pid":238456,"src":"AggregatorRuntime","nested_error":"There is an epoch gap between the last certificate epoch (Epoch(31)) and current epoch (Epoch(35))

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: <mithril_aggregator::services::certifier::certifier_service::MithrilCertifierService as mithril_aggregator::services::certifier::interface::CertifierService>::verify_certificate_chain::{{closure}}
   2: <mithril_aggregator::services::certifier::buffered_certifier::BufferedCertifierService as mithril_aggregator::services::certifier::interface::CertifierService>::verify_certificate_chain::{{closure}}
   3: <mithril_aggregator::runtime::runner::AggregatorRunner as mithril_aggregator::runtime::runner::AggregatorRunnerTrait>::is_certificate_chain_valid::{{closure}}
   4: mithril_aggregator::runtime::state_machine::AggregatorRuntime::cycle::{{closure}}
   5: mithril_aggregator::commands::serve_command::ServeCommand::execute::{{closure}}::{{closure}}
   6: tokio::runtime::task::core::Core<T,S>::poll
   7: tokio::runtime::task::harness::Harness<T,S>::poll
   8: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
   9: tokio::runtime::scheduler::multi_thread::worker::Context::run
  10: tokio::runtime::context::runtime::enter_runtime
  11: tokio::runtime::scheduler::multi_thread::worker::run
  12: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
  13: tokio::runtime::task::core::Core<T,S>::poll
  14: tokio::runtime::task::harness::Harness<T,S>::poll
  15: tokio::runtime::blocking::pool::Inner::run
  16: std::sys::backtrace::__rust_begin_short_backtrace
  17: core::ops::function::FnOnce::call_once{{vtable.shim}}
  18: std::sys::pal::unix::thread::Thread::new::thread_start
  19: start_thread
             at ./nptl/pthread_create.c:442:8
  20: __GI___clone3
             at ./misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:81"}

Feb 12 10:57:08.088 INFO Stopping Mithril infrastructure
Feb 12 10:57:08.088 INFO Stopping mithril-signer-1-pool1hu9q6gg7w4s2v52n7kuengae4a7p2ym9rj46juxjqpfa5dh5dm4
Feb 12 10:57:08.095 INFO Stopping mithril-signer-2-pool1gfav880r9mhu5l7t5ymxmd5d0g4vrtj6faszzmgeks847sg87ym
Feb 12 10:57:08.103 INFO Stopping aggregator
Feb 12 10:57:08.114 INFO Stopping the Devnet, script: /tmp/mithril/devnet/stop.sh
>> Stop Cardano network
>> Stop Mithril network
cardano-node: thread killed
cardano-node: thread killed
cardano-node: thread killed
 
----------------------------------------------------------------------------------------------------
Mithril End to End test outcome:
----------------------------------------------------------------------------------------------------
Error(Unretryable): Mithril End to End test failed

Caused by:
    Minimum expected mithril stake distribution epoch not reached : 31 < 32
```

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Relates to #2222
