### PR TITLE
Fix mithril-aggregator genesis bootstrap flakiness in e2e tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,7 +3642,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.2"
+version = "0.7.3"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/epoch.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/epoch.rs
@@ -10,7 +10,7 @@ impl DependenciesBuilder {
         let epoch_settings_storer = self.get_epoch_settings_store().await?;
         let chain_observer = self.get_chain_observer().await?;
         let era_checker = self.get_era_checker().await?;
-        let stake_distribution_service = self.get_stake_distribution_service().await?;
+        let stake_store = self.get_stake_store().await?;
         let epoch_settings = self.configuration.get_epoch_settings_configuration();
         let allowed_discriminants = self
             .configuration
@@ -23,7 +23,7 @@ impl DependenciesBuilder {
                 verification_key_store,
                 chain_observer,
                 era_checker,
-                stake_distribution_service,
+                stake_store,
             ),
             allowed_discriminants,
             self.root_logger(),

--- a/mithril-aggregator/src/dependency_injection/builder/support/stores.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/stores.rs
@@ -120,6 +120,12 @@ impl DependenciesBuilder {
                 message: "cannot build aggregator runner: no epoch returned.".to_string(),
                 error: None,
             })?;
+        let retrieval_epoch = current_epoch
+            .offset_to_signer_retrieval_epoch()
+            .map_err(|e| DependenciesBuilderError::Initialization {
+                message: format!("cannot create aggregator runner: failed to offset current epoch '{current_epoch}' to signer retrieval epoch."),
+                error: Some(e.into()),
+            })?;
 
         {
             // Temporary fix, should be removed
@@ -136,11 +142,11 @@ impl DependenciesBuilder {
         let epoch_settings_configuration = self.configuration.get_epoch_settings_configuration();
         debug!(
             logger,
-            "Handle discrepancies at startup of epoch settings store, will record epoch settings from the configuration for epoch {current_epoch}";
+            "Handle discrepancies at startup of epoch settings store, will record epoch settings from the configuration for epoch {retrieval_epoch}";
             "epoch_settings_configuration" => ?epoch_settings_configuration,
         );
         epoch_settings_store
-            .handle_discrepancies_at_startup(current_epoch, &epoch_settings_configuration)
+            .handle_discrepancies_at_startup(retrieval_epoch, &epoch_settings_configuration)
             .await
             .map_err(|e| DependenciesBuilderError::Initialization {
                 message: "can not create aggregator runner".to_string(),

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -348,7 +348,9 @@ impl EpochService for MithrilEpochService {
                 .clone(),
         };
 
-        let (total_spo, total_stake) = self.get_total_spo_and_total_stake(epoch).await?;
+        let (total_spo, total_stake) = self
+            .get_total_spo_and_total_stake(signer_retrieval_epoch)
+            .await?;
 
         self.epoch_data = Some(EpochData {
             cardano_era,

--- a/mithril-aggregator/src/services/epoch_service.rs
+++ b/mithril-aggregator/src/services/epoch_service.rs
@@ -15,11 +15,9 @@ use mithril_common::entities::{
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::protocol::{MultiSigner as ProtocolMultiSigner, SignerBuilder};
 use mithril_common::StdResult;
+use mithril_persistence::store::StakeStorer;
 
-use crate::{
-    entities::AggregatorEpochSettings, services::StakeDistributionService, EpochSettingsStorer,
-    VerificationKeyStorer,
-};
+use crate::{entities::AggregatorEpochSettings, EpochSettingsStorer, VerificationKeyStorer};
 
 /// Errors dedicated to the CertifierService.
 #[derive(Debug, Error)]
@@ -118,10 +116,14 @@ pub trait EpochService: Sync + Send {
     fn signed_entity_config(&self) -> StdResult<&SignedEntityConfig>;
 
     /// Get the total number of SPOs for the current epoch in the Cardano stake distribution.
-    fn total_spo(&self) -> StdResult<TotalSPOs>;
+    ///
+    /// Optional as the stake distribution is not available at Aggregator first startup.
+    fn total_spo(&self) -> StdResult<Option<TotalSPOs>>;
 
     /// Get the total stake for the current epoch in the Cardano stake distribution.
-    fn total_stake(&self) -> StdResult<Stake>;
+    ///
+    /// Optional as the stake distribution is not available at Aggregator first startup.
+    fn total_stake(&self) -> StdResult<Option<Stake>>;
 }
 
 struct EpochData {
@@ -138,8 +140,8 @@ struct EpochData {
     total_stakes_signers: Stake,
     total_next_stakes_signers: Stake,
     signed_entity_config: SignedEntityConfig,
-    total_spo: TotalSPOs,
-    total_stake: Stake,
+    total_spo: Option<TotalSPOs>,
+    total_stake: Option<Stake>,
 }
 
 struct ComputedEpochData {
@@ -155,7 +157,7 @@ pub struct EpochServiceDependencies {
     verification_key_store: Arc<dyn VerificationKeyStorer>,
     chain_observer: Arc<dyn ChainObserver>,
     era_checker: Arc<EraChecker>,
-    stake_distribution_service: Arc<dyn StakeDistributionService>,
+    stake_store: Arc<dyn StakeStorer>,
 }
 
 impl EpochServiceDependencies {
@@ -165,14 +167,14 @@ impl EpochServiceDependencies {
         verification_key_store: Arc<dyn VerificationKeyStorer>,
         chain_observer: Arc<dyn ChainObserver>,
         era_checker: Arc<EraChecker>,
-        stake_distribution_service: Arc<dyn StakeDistributionService>,
+        stake_store: Arc<dyn StakeStorer>,
     ) -> Self {
         Self {
             epoch_settings_storer,
             verification_key_store,
             chain_observer,
             era_checker,
-            stake_distribution_service,
+            stake_store,
         }
     }
 }
@@ -187,7 +189,7 @@ pub struct MithrilEpochService {
     verification_key_store: Arc<dyn VerificationKeyStorer>,
     chain_observer: Arc<dyn ChainObserver>,
     era_checker: Arc<EraChecker>,
-    stake_distribution_service: Arc<dyn StakeDistributionService>,
+    stake_store: Arc<dyn StakeStorer>,
     allowed_signed_entity_discriminants: BTreeSet<SignedEntityTypeDiscriminants>,
     logger: Logger,
 }
@@ -208,7 +210,7 @@ impl MithrilEpochService {
             verification_key_store: dependencies.verification_key_store,
             chain_observer: dependencies.chain_observer,
             era_checker: dependencies.era_checker,
-            stake_distribution_service: dependencies.stake_distribution_service,
+            stake_store: dependencies.stake_store,
             allowed_signed_entity_discriminants: allowed_discriminants,
             logger: logger.new_with_component_name::<Self>(),
         }
@@ -224,19 +226,16 @@ impl MithrilEpochService {
         Ok(cardano_era)
     }
 
-    async fn get_total_spo_and_total_stake(&self, epoch: Epoch) -> StdResult<(TotalSPOs, Stake)> {
-        let stake_distribution = self
-            .stake_distribution_service
-            .get_stake_distribution(epoch)
-            .await
-            .with_context(|| {
-                format!("Epoch service failed to obtain the stake distribution for epoch: {epoch}")
-            })?;
-
-        Ok((
-            stake_distribution.len() as TotalSPOs,
-            stake_distribution.values().sum(),
-        ))
+    async fn get_total_spo_and_total_stake(
+        &self,
+        epoch: Epoch,
+    ) -> StdResult<(Option<TotalSPOs>, Option<Stake>)> {
+        match self.stake_store.get_stakes(epoch).await.with_context(|| {
+            format!("Epoch service failed to obtain the stake distribution for epoch: {epoch}")
+        })? {
+            None => Ok((None, None)),
+            Some(sd) => Ok((Some(sd.len() as TotalSPOs), Some(sd.values().sum()))),
+        }
     }
 
     async fn get_signers_with_stake_at_epoch(
@@ -508,11 +507,11 @@ impl EpochService for MithrilEpochService {
         Ok(&self.unwrap_data()?.signed_entity_config)
     }
 
-    fn total_spo(&self) -> StdResult<TotalSPOs> {
+    fn total_spo(&self) -> StdResult<Option<TotalSPOs>> {
         Ok(self.unwrap_data()?.total_spo)
     }
 
-    fn total_stake(&self) -> StdResult<Stake> {
+    fn total_stake(&self) -> StdResult<Option<Stake>> {
         Ok(self.unwrap_data()?.total_stake)
     }
 }
@@ -537,8 +536,8 @@ pub(crate) struct FakeEpochServiceBuilder {
     pub current_signers_with_stake: Vec<SignerWithStake>,
     pub next_signers_with_stake: Vec<SignerWithStake>,
     pub signed_entity_config: SignedEntityConfig,
-    pub total_spo: TotalSPOs,
-    pub total_stake: Stake,
+    pub total_spo: Option<TotalSPOs>,
+    pub total_stake: Option<Stake>,
 }
 
 #[cfg(test)]
@@ -557,8 +556,8 @@ impl FakeEpochServiceBuilder {
             current_signers_with_stake: signers.clone(),
             next_signers_with_stake: signers,
             signed_entity_config: SignedEntityConfig::dummy(),
-            total_spo: 0,
-            total_stake: 0,
+            total_spo: None,
+            total_stake: None,
         }
     }
 
@@ -807,11 +806,11 @@ impl EpochService for FakeEpochService {
         Ok(&self.unwrap_data()?.signed_entity_config)
     }
 
-    fn total_spo(&self) -> StdResult<u32> {
+    fn total_spo(&self) -> StdResult<Option<u32>> {
         Ok(self.unwrap_data()?.total_spo)
     }
 
-    fn total_stake(&self) -> StdResult<u64> {
+    fn total_stake(&self) -> StdResult<Option<u64>> {
         Ok(self.unwrap_data()?.total_stake)
     }
 }
@@ -828,9 +827,9 @@ mod tests {
     };
     use mockall::predicate::eq;
 
-    use crate::services::MockStakeDistributionService;
     use crate::store::{FakeEpochSettingsStorer, MockVerificationKeyStorer};
     use crate::test_tools::TestLogger;
+    use crate::tools::mocks::MockStakeStore;
 
     use super::*;
 
@@ -861,8 +860,8 @@ mod tests {
         current_signers: BTreeSet<Signer>,
         next_signers: BTreeSet<Signer>,
         signed_entity_config: SignedEntityConfig,
-        total_spo: TotalSPOs,
-        total_stake: Stake,
+        total_spo: Option<TotalSPOs>,
+        total_stake: Option<Stake>,
     }
 
     #[derive(Debug, Clone, PartialEq)]
@@ -1000,22 +999,23 @@ mod tests {
             chain_observer.set_current_era(self.cardano_era).await;
             let era_checker = EraChecker::new(self.mithril_era, Epoch::default());
 
-            let stake_distribution_service = {
+            let stake_store = {
                 assert!(
-                self.total_stake % self.total_spo as u64 == 0,
-                "'total_stake' must be a multiple of 'total_spo' to create a uniform stake distribution"
-            );
+                    self.total_stake % self.total_spo as u64 == 0,
+                    "'total_stake' must be a multiple of 'total_spo' to create a uniform stake distribution"
+                );
                 let stake_per_spo = self.total_stake / self.total_spo as u64;
 
                 let stake_distribution =
                     build_uniform_stake_distribution(self.total_spo, stake_per_spo);
 
-                let mut stake_distribution_service = MockStakeDistributionService::new();
-                stake_distribution_service
-                    .expect_get_stake_distribution()
-                    .returning(move |_| Ok(stake_distribution.clone()));
+                let mut stake_store = MockStakeStore::new();
+                stake_store
+                    .expect_get_stakes()
+                    .with(eq(signer_retrieval_epoch))
+                    .returning(move |_| Ok(Some(stake_distribution.clone())));
 
-                stake_distribution_service
+                stake_store
             };
 
             MithrilEpochService::new(
@@ -1028,7 +1028,7 @@ mod tests {
                     Arc::new(verification_key_store),
                     Arc::new(chain_observer),
                     Arc::new(era_checker),
-                    Arc::new(stake_distribution_service),
+                    Arc::new(stake_store),
                 ),
                 self.allowed_discriminants,
                 TestLogger::stdout(),
@@ -1097,8 +1097,8 @@ mod tests {
                 current_signers: current_epoch_fixture.signers().into_iter().collect(),
                 next_signers: next_epoch_fixture.signers().into_iter().collect(),
                 signed_entity_config: SignedEntityConfig::dummy(),
-                total_spo: 10,
-                total_stake: 20_000_000,
+                total_spo: Some(10),
+                total_stake: Some(20_000_000),
             }
         );
     }

--- a/mithril-aggregator/src/tools/mocks.rs
+++ b/mithril-aggregator/src/tools/mocks.rs
@@ -1,7 +1,11 @@
 use async_trait::async_trait;
+
 use mithril_common::chain_observer::{ChainAddress, ChainObserver, ChainObserverError, TxDatum};
 use mithril_common::crypto_helper::{KESPeriod, OpCert};
 use mithril_common::entities::{ChainPoint, Epoch, StakeDistribution};
+use mithril_persistence::store::StakeStorer;
+
+use mithril_common::StdResult;
 use mockall::mock;
 
 mock! {
@@ -28,5 +32,16 @@ mock! {
             &self,
             opcert: &OpCert,
         ) -> Result<Option<KESPeriod>, ChainObserverError>;
+    }
+}
+
+mock! {
+    pub StakeStore {}
+
+    #[async_trait]
+    impl StakeStorer for StakeStore {
+        async fn save_stakes(&self, epoch: Epoch, stakes: StakeDistribution) -> StdResult<Option<StakeDistribution>>;
+
+        async fn get_stakes(&self, epoch: Epoch) -> StdResult<Option<StakeDistribution>>;
     }
 }

--- a/mithril-explorer/__tests__/percent.test.js
+++ b/mithril-explorer/__tests__/percent.test.js
@@ -1,0 +1,29 @@
+import { percent } from "@/utils";
+
+describe("Percent computation", () => {
+  it("Default number of digit is 0", () => {
+    expect(percent(1, 7)).toEqual("14");
+  });
+
+  it("Round numbers up", () => {
+    expect(percent(2, 3)).toEqual("67");
+  });
+
+  it.each([
+    [1, 3, 0, "33"],
+    [1, 3, 1, "33.3"],
+    [1, 3, 2, "33.33"],
+    [1, 3, 5, "33.33333"],
+  ])("Computing percent", (number, total, number_of_digits, expected) => {
+    expect(percent(number, total, number_of_digits)).toEqual(expected);
+  });
+
+  it.each([
+    [14324, 0],
+    [21, 1],
+    [423, 5],
+  ])("When total is 0 always return 0", (number, number_of_digits) => {
+    const total = 0;
+    expect(percent(number, total, number_of_digits)).toEqual("0");
+  });
+});

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.28",
+      "version": "0.7.29",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/dist/web",
         "@popperjs/core": "^2.11.8",

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.28",
+  "version": "0.7.29",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/components/ControlPanel/AggregatorStatus/index.js
+++ b/mithril-explorer/src/components/ControlPanel/AggregatorStatus/index.js
@@ -8,7 +8,7 @@ import ProtocolParameters from "#/ProtocolParameters";
 import QuestionTooltip from "#/QuestionTooltip";
 import Stake from "#/Stake";
 import { selectedAggregator } from "@/store/settingsSlice";
-import { checkUrl, formatStake } from "@/utils";
+import { checkUrl, formatStake, percent } from "@/utils";
 
 function InfoGroupCard({ children, title, ...props }) {
   return (
@@ -100,11 +100,6 @@ export default function AggregatorStatus({ showContent = true }) {
       setRegistrationPageUrl(`/registrations?${params.toString()}`);
     }
   }, [currentAggregator, aggregatorStatus]);
-
-  // Calculate percentage without decimal
-  function percent(value, total) {
-    return ((value / total) * 100).toFixed(0);
-  }
 
   return fallbackToEpochSetting ? (
     <Stack direction="horizontal">

--- a/mithril-explorer/src/utils.js
+++ b/mithril-explorer/src/utils.js
@@ -9,6 +9,11 @@ function checkUrl(url) {
   }
 }
 
+// Calculate percentage
+function percent(value, total, number_of_digits = 0) {
+  return total === 0 ? "0" : ((value / total) * 100).toFixed(number_of_digits);
+}
+
 const toAda = (lovelace) => lovelace / 1000000;
 
 const formatCurrency = (number, maximumFractionDigits = 2) =>
@@ -221,6 +226,7 @@ function parseSignedEntity(signedEntityType) {
 
 module.exports = {
   checkUrl,
+  percent,
   formatStake,
   toAda,
   formatCurrency,


### PR DESCRIPTION
## Content

This PR fix a flakiness in mithril-end-to-end tests that manifest with a failure when bootstrapping the genesis certificate.

### Analysis

#### Summary

In a successful run:

1.  the stake distribution that we try to fetch (for the actual epoch, without offset) isn't immediately available since when we register them we do so with an offset of +1.
2. we don't see stake distribution unavailability errors because ... the epoch settings also isn't available because  the ones we are fetching in `EpochService::inform_epoch` are with offset -1, 0, +1 and the one we register in `handle_discrepancies_at_startup` are with offset 0, 1, 2.
3. the errors solve themself after epoch change, then the stake distribution registered in the previous epoch is now available and the epoch settings registered by `handle_discrepancies_at_startup` too.
4. The state machine will still have it cycles fails but after the call to `update_epoch_settings`, allowing the genesis bootstrap to run since it was what was missing.

In failing run:
1. There's an epoch change between `handle_discrepancies_at_startup` and the first state machine cycle
2. This time there's the three epoch settings available because of the epoch change
3. But there's still no stake distribution available for the actual epoch so `EpochService::inform_epoch` will fail, making it missing calls to `update_epoch_settings`.
4. After an epoch change the epoch settings for epoch +1, needed by `EpochService::inform_epoch`, is not available since `update_epoch_settings` was not called, making each subsequent cycles fails.

#### Details
<details><summary>Details</summary>
<p>

> :notebook: **Note** 
> Logs extracted from the following failed run: https://github.com/input-output-hk/mithril/actions/runs/12178789405/job/33970064206#step:6:533 

1. The genesis bootstrap fails with the following error:

```
Error: genesis-tools: initialization error

Caused by:
    Missing protocol parameters for epoch 10
``` 

2. The protocol parameters are part of the epoch settings that are inserted:
-  at startup when building the epoch settings store by running `handle_discrepancies_at_startup`: this fills epochs settings for the actual epoch plus the two following.
- by the state machine `update_epoch_settings` when transitioning from `idle` to `ready` state after calling to `EpochService::inform_epoch`

3. We can see epoch settings inserted by `handle_discrepancies_at_startup` in the database at epoch 5, 6 and 7 plus 10, 11, and 12 (when the bootstrap command was run). This means that `handle_discrepancies_at_startup` was run at epoch 5 and 10.

4. In the logs we can see that between the run of `handle_discrepancies_at_startup` at epoch 5 and the first state machine cycle, the epoch changed.

5. When reading the aggregator logs we see that the state machine got **every cycle for the epoch 6** an error from `EpochService::inform_epoch`:
```
Epoch service failed to obtain the stake distribution for epoch: 6

Caused by:
    The stake distribution for epoch Epoch(6) is not available.
``` 

6. This error is raised at the end of `EpochService::inform_epoch` when it tries to obtains the total cardano spo and stakes which is based on stakes distribution stored previously.
In turn the state machine never get to `update_epoch_settings` since this call is done after `inform_epoch`.

7. As a consequence of being unable to run `update_epoch_settings` the error raised at each cycle change after epoch change (to epoch 7). It fails earlier in the function when trying to obtains the epoch settings for signer registration epoch (+1):
```
Epoch service could not obtain signer registration epoch settings for epoch 8

Stack backtrace:
    0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
    1: mithril_aggregator::services::epoch_service::MithrilEpochService::get_epoch_settings::{{closure}}
``` 
Afterward the state machine cycle will always fails for this same reason and won't be able to be ready for genesis bootstrap.
</p>
</details> 

### Issues

#### Unavailability of the stake distribution
 
> [!IMPORTANT]
> There's a missing offset of -1 (signer retrieval epoch) when fetching the stake distribution for total spo and stake in epoch service.
> This is because the stake distribution that should be used is the one associated with the **current** signers (those who can sign), which use that offset.

This is normal, when we first start an aggregator the stake distribution that we register won't be usable before two epochs.
This means that we can't reliably provide total spo/stake in the epoch service, those have to be `Option` to take in account this gap when there's no stake distribution usable.

Making this change solve the problems since the `inform_epoch` won't fail anymore, but the aggregator status route have to be adapted.

####  Unavailability of the epoch settings

This is a minor issue as this don't stop the aggregator from bootstrapping a genesis certificate as long as we wait for one epoch after start.
But this makes the signers calls to `/epoch-settings` fails, delaying when they can register and filling their logs with errors.

By also filling epoch settings with the retrieval offset in `handle_discrepancies_at_startup` we can avoid this problem. Also we should fills epoch settings for 4 epochs to avoid the edge case when there's a epoch change between `handle_discrepancies_at_startup` and the first state machine cycle.

### Changes

For `mithril-aggregator`:

- `EpochService`: 
  - fix incorrect epoch for fetching the stake distribution used to compute total cardano stake and spo
  - total cardano stake and spo are now `Option` since they are not available before two epochs when starting an aggregator for the first time
- `/status` route: use 0 for  total cardano stake and spo when the values returned by the Epoch Service are none
- `handle_discrepancies_at_startup`:
  - called with an offset of `-1` so data are available for `EpochService::inform_epoch`
  - register epoch settings for `4` epochs instead of `3` so `EpochService::inform_epoch` won't fails if there's an epoch change between calls to `handle_discrepancies_at_startup` in the aggregator builder and the first state machine cycle.

For `mithril-explorer`:
- Properly handle a total of 0 when computing percentages.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #2222 
