### PR TITLE
explorer: use main `mithril-client-wasm` package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3780,7 +3780,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/devbook/upgrade-repository-dependencies/upgrade_dependencies.sh
+++ b/docs/devbook/upgrade-repository-dependencies/upgrade_dependencies.sh
@@ -22,9 +22,6 @@ git commit -am "chore: upgrade Rust dependencies"
 cargo set-version --bump patch
 git commit -am "chore: bump crates versions"
 
-# Build mithril-client wasm (to have latest version used in the explorer)
-make -C mithril-client-wasm build
-
 # Upgrade the documentation website dependencies
 make -C docs/website upgrade
 git commit -am "chore: upgrade doc dependencies

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "Apache-2.0"
     },
     "node_modules/@mithril-dev/mithril-client-wasm": {

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.8.2"
+version = "0.8.3"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/ci-test/package-lock.json
+++ b/mithril-client-wasm/ci-test/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/package.json
+++ b/mithril-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithril-dev/mithril-client-wasm",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Mithril client WASM",
   "license": "Apache-2.0",
   "collaborators": [

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -404,18 +404,6 @@ impl MithrilClient {
 
         Ok(serde_wasm_bindgen::to_value(&result)?)
     }
-
-    /// `unstable` Reset the certificate verifier cache if enabled
-    #[wasm_bindgen]
-    pub async fn reset_certificate_verifier_cache(&self) -> Result<(), JsValue> {
-        self.guard_unstable()?;
-
-        if let Some(cache) = self.certificate_verifier_cache.as_ref() {
-            cache.reset().await.map_err(|err| format!("{err:?}"))?;
-        }
-
-        Ok(())
-    }
 }
 
 // Unstable functions are only available when the unstable flag is set
@@ -464,6 +452,26 @@ impl MithrilClient {
             .map_err(|err| format!("{err:?}"))?;
 
         Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// `unstable` Reset the certificate verifier cache if enabled
+    #[wasm_bindgen]
+    pub async fn reset_certificate_verifier_cache(&self) -> Result<(), JsValue> {
+        self.guard_unstable()?;
+
+        if let Some(cache) = self.certificate_verifier_cache.as_ref() {
+            cache.reset().await.map_err(|err| format!("{err:?}"))?;
+        }
+
+        Ok(())
+    }
+
+    /// `unstable` Check if the certificate verifier cache is enabled
+    #[wasm_bindgen]
+    pub async fn is_certificate_verifier_cache_enabled(&self) -> Result<bool, JsValue> {
+        self.guard_unstable()?;
+
+        Ok(self.certificate_verifier_cache.is_some())
     }
 }
 

--- a/mithril-explorer/Makefile
+++ b/mithril-explorer/Makefile
@@ -25,7 +25,7 @@ serve: build
 	@echo "\033[1mServing production build at: http://localhost:3001/explorer \033[0m"
 	python3 -m http.server --bind 127.0.0.1 3001
 
-dev: build
+dev:
 	@echo "=========================================================================="
 	@echo "\033[1mServing dev build at: http://localhost:3000/explorer \033[0m"
 	npm run dev

--- a/mithril-explorer/next.config.js
+++ b/mithril-explorer/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
     unoptimized: true,
   },
   webpack: (config) => {
-    config.experiments = { layers: true, asyncWebAssembly: true };
+    config.experiments = { ...config.experiments, layers: true, asyncWebAssembly: true };
     config.plugins.push(
       new webpack.DefinePlugin({
         "process.env.UNSTABLE": process.env.UNSTABLE === "1",

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -14,7 +14,7 @@
         "bootstrap": "^5.3.3",
         "bootstrap-icons": "^1.11.3",
         "chart.js": "^4.4.7",
-        "next": "^15.1.6",
+        "next": "^15.1.7",
         "react": "^19.0.0",
         "react-bootstrap": "^2.10.9",
         "react-chartjs-2": "^5.3.0",
@@ -24,13 +24,13 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
-        "eslint": "^9.19.0",
-        "eslint-config-next": "^15.1.6",
+        "eslint": "^9.20.1",
+        "eslint-config-next": "^15.1.7",
         "fantasticon": "^3.0.0",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "next-router-mock": "^0.9.13",
-        "prettier": "^3.4.2",
+        "prettier": "^3.5.1",
         "prettier-eslint": "^16.3.0"
       }
     },
@@ -591,7 +591,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.19.0",
+      "version": "9.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.20.0.tgz",
+      "integrity": "sha512-iZA07H9io9Wn836aVTytRaNqh00Sad+EamwOVJT12GTLw1VGMFV/4JaME+JjLtr9fiGaoWgYnS54wrfWsSs4oQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1271,11 +1273,15 @@
       "link": true
     },
     "node_modules/@next/env": {
-      "version": "15.1.6",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.1.7.tgz",
+      "integrity": "sha512-d9jnRrkuOH7Mhi+LHav2XW91HOgTAWHxjMPkXMGBc9B2b7614P7kjt8tAplRvJpbSt4nbO1lugcT/kAaWzjlLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.1.6",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.1.7.tgz",
+      "integrity": "sha512-kRP7RjSxfTO13NE317ek3mSGzoZlI33nc/i5hs1KaWpK+egs85xg0DJ4p32QEiHnR0mVjuUfhRIun7awqfL7pQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1283,12 +1289,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.6.tgz",
-      "integrity": "sha512-u7lg4Mpl9qWpKgy6NzEkz/w0/keEHtOybmIl0ykgItBxEM5mYotS5PmqTpo+Rhg8FiOiWgwr8USxmKQkqLBCrw==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.1.7.tgz",
+      "integrity": "sha512-hPFwzPJDpA8FGj7IKV3Yf1web3oz2YsR8du4amKw8d+jAOHfYHYFpMkoF6vgSY4W6vB29RtZEklK9ayinGiCmQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1298,12 +1305,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.6.tgz",
-      "integrity": "sha512-x1jGpbHbZoZ69nRuogGL2MYPLqohlhnT9OCU6E6QFewwup+z+M6r8oU47BTeJcWsF2sdBahp5cKiAcDbwwK/lg==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.1.7.tgz",
+      "integrity": "sha512-2qoas+fO3OQKkU0PBUfwTiw/EYpN+kdAx62cePRyY1LqKtP09Vp5UcUntfZYajop5fDFTjSxCHfZVRxzi+9FYQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1313,12 +1321,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.6.tgz",
-      "integrity": "sha512-jar9sFw0XewXsBzPf9runGzoivajeWJUc/JkfbLTC4it9EhU8v7tCRLH7l5Y1ReTMN6zKJO0kKAGqDk8YSO2bg==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.1.7.tgz",
+      "integrity": "sha512-sKLLwDX709mPdzxMnRIXLIT9zaX2w0GUlkLYQnKGoXeWUhcvpCrK+yevcwCJPdTdxZEUA0mOXGLdPsGkudGdnA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1328,12 +1337,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.6.tgz",
-      "integrity": "sha512-+n3u//bfsrIaZch4cgOJ3tXCTbSxz0s6brJtU3SzLOvkJlPQMJ+eHVRi6qM2kKKKLuMY+tcau8XD9CJ1OjeSQQ==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.1.7.tgz",
+      "integrity": "sha512-zblK1OQbQWdC8fxdX4fpsHDw+VSpBPGEUX4PhSE9hkaWPrWoeIJn+baX53vbsbDRaDKd7bBNcXRovY1hEhFd7w==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1343,7 +1353,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "15.1.6",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.1.7.tgz",
+      "integrity": "sha512-GOzXutxuLvLHFDAPsMP2zDBMl1vfUHHpdNpFGhxu90jEzH6nNIgmtw/s1MDwpTOiM+MT5V8+I1hmVFeAUhkbgQ==",
       "cpu": [
         "x64"
       ],
@@ -1357,7 +1369,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "15.1.6",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.1.7.tgz",
+      "integrity": "sha512-WrZ7jBhR7ATW1z5iEQ0ZJfE2twCNSXbpCSaAunF3BKcVeHFADSI/AW1y5Xt3DzTqPF1FzQlwQTewqetAABhZRQ==",
       "cpu": [
         "x64"
       ],
@@ -1371,12 +1385,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.6.tgz",
-      "integrity": "sha512-s8w6EeqNmi6gdvM19tqKKWbCyOBvXFbndkGHl+c9YrzsLARRdCHsD9S1fMj8gsXm9v8vhC8s3N8rjuC/XrtkEg==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.1.7.tgz",
+      "integrity": "sha512-LDnj1f3OVbou1BqvvXVqouJZKcwq++mV2F+oFHptToZtScIEnhNRJAhJzqAtTE2dB31qDYL45xJwrc+bLeKM2Q==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1386,12 +1401,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.6.tgz",
-      "integrity": "sha512-6xomMuu54FAFxttYr5PJbEfu96godcxBTRk1OhAvJq0/EnmFU/Ybiax30Snis4vdWZ9LGpf7Roy5fSs7v/5ROQ==",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.1.7.tgz",
+      "integrity": "sha512-dC01f1quuf97viOfW05/K8XYv2iuBgAxJZl7mbCKEjMgdQl5JjAKJ0D2qMKZCgPWDeFbFT0Q0nYWwytEW0DWTQ==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1475,6 +1491,8 @@
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -1496,6 +1514,8 @@
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.1.tgz",
+      "integrity": "sha512-UHhy3p0oUpdhnSxyDjaRDYaw8Xra75UiLbCiRozVPHjfDwNYkh0TsVm/1OmTW8Md+iDAJmYPWUKMvsMc2GtpNg==",
       "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
@@ -1625,6 +1645,8 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
+      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1661,6 +1683,8 @@
     },
     "node_modules/@testing-library/react": {
       "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2564,6 +2588,8 @@
     },
     "node_modules/bootstrap": {
       "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "funding": [
         {
           "type": "github",
@@ -2581,6 +2607,8 @@
     },
     "node_modules/bootstrap-icons": {
       "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
       "funding": [
         {
           "type": "github",
@@ -2877,6 +2905,8 @@
     },
     "node_modules/chart.js": {
       "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
+      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
       "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
@@ -3758,16 +3788,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.19.0",
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.20.1.tgz",
+      "integrity": "sha512-m1mM33o6dBUjxl2qb6wv6nGNwCAsns1eKtaQ4l/NPHeTvhiUPbtdfMyktxN4B3fgHIgsYh1VT3V9txblpQHq+g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.19.0",
-        "@eslint/core": "^0.10.0",
+        "@eslint/core": "^0.11.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.19.0",
+        "@eslint/js": "9.20.0",
         "@eslint/plugin-kit": "^0.2.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -3816,11 +3848,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.1.6",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.1.7.tgz",
+      "integrity": "sha512-zXoMnYUIy3XHaAoOhrcYkT9UQWvXqWju2K7NNsmb5wd/7XESDwof61eUdW4QhERr3eJ9Ko/vnXqIrj8kk/drYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.1.6",
+        "@next/eslint-plugin-next": "15.1.7",
         "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
@@ -4119,6 +4153,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/core": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.11.0.tgz",
+      "integrity": "sha512-DWUB2pksgNEb6Bz2fggIy1wh6fGgZP4Xyy/Mt0QZPiloKKXerbqq9D3SBQTlCRYOrcRPu4vuz+CGjwdfqxnoWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/esniff": {
       "version": "2.0.1",
       "dev": true,
@@ -4272,6 +4319,8 @@
     },
     "node_modules/fantasticon": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fantasticon/-/fantasticon-3.0.0.tgz",
+      "integrity": "sha512-PylulixZA8I0SeiUKtuyOhwrz/ojZTSA1KXddipvEyQXCVrpPMTnSXzaE9nXXK7nCjJWFkqoBAQ1aBdaxMltrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5588,6 +5637,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5907,6 +5958,8 @@
     },
     "node_modules/jest-environment-jsdom": {
       "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7167,10 +7220,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "15.1.6",
+      "version": "15.1.7",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.1.7.tgz",
+      "integrity": "sha512-GNeINPGS9c6OZKCvKypbL8GTsT5GhWPp4DM0fzkXJuXMilOO2EeFxuAY6JZbtk6XIl6Ws10ag3xRINDjSO5+wg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "15.1.6",
+        "@next/env": "15.1.7",
         "@swc/counter": "0.1.3",
         "@swc/helpers": "0.5.15",
         "busboy": "1.6.0",
@@ -7185,14 +7240,14 @@
         "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "15.1.6",
-        "@next/swc-darwin-x64": "15.1.6",
-        "@next/swc-linux-arm64-gnu": "15.1.6",
-        "@next/swc-linux-arm64-musl": "15.1.6",
-        "@next/swc-linux-x64-gnu": "15.1.6",
-        "@next/swc-linux-x64-musl": "15.1.6",
-        "@next/swc-win32-arm64-msvc": "15.1.6",
-        "@next/swc-win32-x64-msvc": "15.1.6",
+        "@next/swc-darwin-arm64": "15.1.7",
+        "@next/swc-darwin-x64": "15.1.7",
+        "@next/swc-linux-arm64-gnu": "15.1.7",
+        "@next/swc-linux-arm64-musl": "15.1.7",
+        "@next/swc-linux-x64-gnu": "15.1.7",
+        "@next/swc-linux-x64-musl": "15.1.7",
+        "@next/swc-win32-arm64-msvc": "15.1.7",
+        "@next/swc-win32-x64-msvc": "15.1.7",
         "sharp": "^0.33.5"
       },
       "peerDependencies": {
@@ -7220,6 +7275,8 @@
     },
     "node_modules/next-router-mock": {
       "version": "0.9.13",
+      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.13.tgz",
+      "integrity": "sha512-906n2RRaE6Y28PfYJbaz5XZeJ6Tw8Xz1S6E31GGwZ0sXB6/XjldD1/2azn1ZmBmRk5PQRkzjg+n+RHZe5xQzWA==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -7777,7 +7834,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.1.tgz",
+      "integrity": "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -7792,6 +7851,8 @@
     },
     "node_modules/prettier-eslint": {
       "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.3.0.tgz",
+      "integrity": "sha512-Lh102TIFCr11PJKUMQ2kwNmxGhTsv/KzUg9QYF2Gkw259g/kPgndZDWavk7/ycbRvj2oz4BPZ1gCU8bhfZH/Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8324,6 +8385,8 @@
     },
     "node_modules/react": {
       "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
+      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8331,6 +8394,8 @@
     },
     "node_modules/react-bootstrap": {
       "version": "2.10.9",
+      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.9.tgz",
+      "integrity": "sha512-TJUCuHcxdgYpOqeWmRApM/Dy0+hVsxNRFvq2aRFQuxhNi/+ivOxC5OdWIeHS3agxvzJ4Ev4nDw2ZdBl9ymd/JQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
@@ -8360,6 +8425,8 @@
     },
     "node_modules/react-chartjs-2": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
       "license": "MIT",
       "peerDependencies": {
         "chart.js": "^4.1.1",
@@ -8368,6 +8435,8 @@
     },
     "node_modules/react-dom": {
       "version": "19.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
+      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.25.0"
@@ -8388,6 +8457,8 @@
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.7.29",
+      "version": "0.7.30",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm",
         "@popperjs/core": "^2.11.8",
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -8,7 +8,7 @@
       "name": "mithril-explorer",
       "version": "0.7.29",
       "dependencies": {
-        "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/dist/web",
+        "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm",
         "@popperjs/core": "^2.11.8",
         "@reduxjs/toolkit": "^2.5.1",
         "bootstrap": "^5.3.3",
@@ -34,8 +34,8 @@
         "prettier-eslint": "^16.3.0"
       }
     },
-    "../mithril-client-wasm/dist/web": {
-      "name": "mithril-client-wasm",
+    "../mithril-client-wasm": {
+      "name": "@mithril-dev/mithril-client-wasm",
       "version": "0.8.2",
       "license": "Apache-2.0"
     },
@@ -1267,7 +1267,7 @@
       "license": "MIT"
     },
     "node_modules/@mithril-dev/mithril-client-wasm": {
-      "resolved": "../mithril-client-wasm/dist/web",
+      "resolved": "../mithril-client-wasm",
       "link": true
     },
     "node_modules/@next/env": {
@@ -1475,8 +1475,7 @@
     },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -1497,8 +1496,7 @@
     },
     "node_modules/@reduxjs/toolkit": {
       "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.5.1.tgz",
-      "integrity": "sha512-UHhy3p0oUpdhnSxyDjaRDYaw8Xra75UiLbCiRozVPHjfDwNYkh0TsVm/1OmTW8Md+iDAJmYPWUKMvsMc2GtpNg==",
+      "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
         "redux": "^5.0.1",
@@ -1627,9 +1625,8 @@
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.6.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.6.3.tgz",
-      "integrity": "sha512-IteBhl4XqYNkM54f4ejhLRJiZNqcSCoXUOG2CPK7qbD322KjQozM4kHQOfkG2oln9b9HTYqs+Sae8vBATubxxA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -1664,9 +1661,8 @@
     },
     "node_modules/@testing-library/react": {
       "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.2.0.tgz",
-      "integrity": "sha512-2cSskAvA1QNtKc8Y9VJQRv0tm3hLVgxRGDB+KYhIaPQJ1I+RHbhIXcM+zClKXzMes/wshsMVzf4B9vS4IZpqDQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -2568,8 +2564,6 @@
     },
     "node_modules/bootstrap": {
       "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
       "funding": [
         {
           "type": "github",
@@ -2580,14 +2574,13 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
     },
     "node_modules/bootstrap-icons": {
       "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
-      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
       "funding": [
         {
           "type": "github",
@@ -2597,7 +2590,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/bootstrap"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2883,8 +2877,7 @@
     },
     "node_modules/chart.js": {
       "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.7.tgz",
-      "integrity": "sha512-pwkcKfdzTMAU/+jNosKhNL2bHtJc/sSmYgVbuGTEDhzkrhmyihmP7vUc/5ZK9WopidMDHNe3Wm7jOd/WhuHWuw==",
+      "license": "MIT",
       "dependencies": {
         "@kurkle/color": "^0.3.0"
       },
@@ -3766,9 +3759,8 @@
     },
     "node_modules/eslint": {
       "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.19.0.tgz",
-      "integrity": "sha512-ug92j0LepKlbbEv6hD911THhoRHmbdXt2gX+VDABAW/Ir7D3nqKdv5Pf5vtlyY6HQMTEP2skXY43ueqTCWssEA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3825,9 +3817,8 @@
     },
     "node_modules/eslint-config-next": {
       "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.1.6.tgz",
-      "integrity": "sha512-Wd1uy6y7nBbXUSg9QAuQ+xYEKli5CgUhLjz1QHW11jLDis5vK5XB3PemL6jEmy7HrdhaRFDz+GTZ/3FoH+EUjg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@next/eslint-plugin-next": "15.1.6",
         "@rushstack/eslint-patch": "^1.10.3",
@@ -4281,9 +4272,8 @@
     },
     "node_modules/fantasticon": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/fantasticon/-/fantasticon-3.0.0.tgz",
-      "integrity": "sha512-PylulixZA8I0SeiUKtuyOhwrz/ojZTSA1KXddipvEyQXCVrpPMTnSXzaE9nXXK7nCjJWFkqoBAQ1aBdaxMltrg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "case": "^1.6.3",
         "cli-color": "^2.0.4",
@@ -5598,9 +5588,8 @@
     },
     "node_modules/jest": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
-      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5918,9 +5907,8 @@
     },
     "node_modules/jest-environment-jsdom": {
       "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
-      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@jest/environment": "^29.7.0",
         "@jest/fake-timers": "^29.7.0",
@@ -7180,8 +7168,7 @@
     },
     "node_modules/next": {
       "version": "15.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-15.1.6.tgz",
-      "integrity": "sha512-Hch4wzbaX0vKQtalpXvUiw5sYivBy4cm5rzUKrBnUB/y436LGrvOUqYvlSeNVCWFO/770gDlltR9gqZH62ct4Q==",
+      "license": "MIT",
       "dependencies": {
         "@next/env": "15.1.6",
         "@swc/counter": "0.1.3",
@@ -7233,9 +7220,8 @@
     },
     "node_modules/next-router-mock": {
       "version": "0.9.13",
-      "resolved": "https://registry.npmjs.org/next-router-mock/-/next-router-mock-0.9.13.tgz",
-      "integrity": "sha512-906n2RRaE6Y28PfYJbaz5XZeJ6Tw8Xz1S6E31GGwZ0sXB6/XjldD1/2azn1ZmBmRk5PQRkzjg+n+RHZe5xQzWA==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "next": ">=10.0.0",
         "react": ">=17.0.0"
@@ -7792,9 +7778,8 @@
     },
     "node_modules/prettier": {
       "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -7807,9 +7792,8 @@
     },
     "node_modules/prettier-eslint": {
       "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/prettier-eslint/-/prettier-eslint-16.3.0.tgz",
-      "integrity": "sha512-Lh102TIFCr11PJKUMQ2kwNmxGhTsv/KzUg9QYF2Gkw259g/kPgndZDWavk7/ycbRvj2oz4BPZ1gCU8bhfZH/Xg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/parser": "^6.7.5",
         "common-tags": "^1.4.0",
@@ -8340,16 +8324,14 @@
     },
     "node_modules/react": {
       "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
-      "integrity": "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-bootstrap": {
       "version": "2.10.9",
-      "resolved": "https://registry.npmjs.org/react-bootstrap/-/react-bootstrap-2.10.9.tgz",
-      "integrity": "sha512-TJUCuHcxdgYpOqeWmRApM/Dy0+hVsxNRFvq2aRFQuxhNi/+ivOxC5OdWIeHS3agxvzJ4Ev4nDw2ZdBl9ymd/JQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.24.7",
         "@restart/hooks": "^0.4.9",
@@ -8378,8 +8360,7 @@
     },
     "node_modules/react-chartjs-2": {
       "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
-      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
       "peerDependencies": {
         "chart.js": "^4.1.1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -8387,8 +8368,7 @@
     },
     "node_modules/react-dom": {
       "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.0.0.tgz",
-      "integrity": "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ==",
+      "license": "MIT",
       "dependencies": {
         "scheduler": "^0.25.0"
       },
@@ -8408,8 +8388,7 @@
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
-      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -13,7 +13,7 @@
     "test:ci": "jest --ci"
   },
   "dependencies": {
-    "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm/dist/web",
+    "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm",
     "@popperjs/core": "^2.11.8",
     "@reduxjs/toolkit": "^2.5.1",
     "bootstrap": "^5.3.3",

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -19,7 +19,7 @@
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
     "chart.js": "^4.4.7",
-    "next": "^15.1.6",
+    "next": "^15.1.7",
     "react": "^19.0.0",
     "react-bootstrap": "^2.10.9",
     "react-chartjs-2": "^5.3.0",
@@ -29,13 +29,13 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",
-    "eslint": "^9.19.0",
-    "eslint-config-next": "^15.1.6",
+    "eslint": "^9.20.1",
+    "eslint-config-next": "^15.1.7",
     "fantasticon": "^3.0.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "next-router-mock": "^0.9.13",
-    "prettier": "^3.4.2",
+    "prettier": "^3.5.1",
     "prettier-eslint": "^16.3.0"
   }
 }

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.7.29",
+  "version": "0.7.30",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/mithril-explorer/src/app/page.js
+++ b/mithril-explorer/src/app/page.js
@@ -14,7 +14,6 @@ import {
   Title,
   Tooltip,
 } from "chart.js";
-import initMithrilClient from "@mithril-dev/mithril-client-wasm";
 import ControlPanel from "#/ControlPanel";
 import CardanoDbSnapshotsList from "#/Artifacts/CardanoDbSnapshotsList";
 import CardanoDbV2SnapshotsList from "#/Artifacts/CardanoDbV2SnapshotsList";
@@ -69,6 +68,11 @@ export default function Explorer() {
 
   // Global mithril client wasm init
   useEffect(() => {
+    const initMithrilClient = async () => {
+      const wasmClient = await import("@mithril-dev/mithril-client-wasm");
+      await wasmClient.default();
+    };
+
     initMithrilClient().catch((err) => console.error("Mithril-client-wasm init error:", err));
   }, []);
 

--- a/mithril-explorer/src/components/CertifyCardanoTransactionsModal/index.js
+++ b/mithril-explorer/src/components/CertifyCardanoTransactionsModal/index.js
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Alert, Col, Modal, Row, Tab } from "react-bootstrap";
 import { useSelector } from "react-redux";
-import { fetchGenesisVerificationKey, newMithrilWasmClient } from "@/utils";
 import CertificateModal from "#/CertificateModal";
 import CertificateVerifier, {
   certificateValidationSteps,
@@ -47,6 +46,11 @@ export default function CertifyCardanoTransactionsModal({
     setCurrentError(undefined);
 
     if (transactionHashes?.length > 0) {
+      const {
+        fetchGenesisVerificationKey,
+        newMithrilWasmClient,
+      } = require("@/wasm-client-helpers");
+
       fetchGenesisVerificationKey(currentAggregator)
         .then((genesisKey) => newMithrilWasmClient(currentAggregator, genesisKey))
         .then((client) => setClient(client))

--- a/mithril-explorer/src/components/VerifyCertificate/CertificateVerifier.js
+++ b/mithril-explorer/src/components/VerifyCertificate/CertificateVerifier.js
@@ -56,7 +56,6 @@ export default function CertificateVerifier({
   certificate,
   hideSpinner = false,
   showCertificateLinks = false,
-  isCacheEnabled = false,
   onStepChange = (step) => {},
   onChainValidationError = (error) => {},
   onCertificateClick = (hash) => {},
@@ -221,14 +220,15 @@ export default function CertificateVerifier({
                 .map((evt) => (
                   <div key={evt.id}>{evt.message}</div>
                 ))}
-              {isCacheEnabled && currentStep === certificateValidationSteps.done && (
-                <>
-                  Cache enabled:{" "}
-                  <a href="#" onClick={onCacheResetClick}>
-                    reset cache
-                  </a>
-                </>
-              )}
+              {client.is_certificate_verifier_cache_enabled() &&
+                currentStep === certificateValidationSteps.done && (
+                  <>
+                    Cache enabled:{" "}
+                    <a href="#" onClick={onCacheResetClick}>
+                      reset cache
+                    </a>
+                  </>
+                )}
               {validationError !== undefined && (
                 <Alert variant="danger" className="mt-2">
                   <Alert.Heading>

--- a/mithril-explorer/src/components/VerifyCertificate/VerifyCertificateModal.js
+++ b/mithril-explorer/src/components/VerifyCertificate/VerifyCertificateModal.js
@@ -1,7 +1,6 @@
 import { Modal } from "react-bootstrap";
 import { useEffect, useState } from "react";
 import CertificateVerifier, { certificateValidationSteps } from "./CertificateVerifier";
-import { fetchGenesisVerificationKey, newMithrilWasmClient } from "@/utils";
 import { useSelector } from "react-redux";
 
 export default function VerifyCertificateModal({ show, onClose, certificateHash }) {
@@ -29,6 +28,8 @@ export default function VerifyCertificateModal({ show, onClose, certificateHash 
   }, [loading]);
 
   async function init(aggregator, certificateHash) {
+    const { fetchGenesisVerificationKey, newMithrilWasmClient } = require("@/wasm-client-helpers");
+
     const genesisVerificationKey = await fetchGenesisVerificationKey(aggregator);
     const client = await newMithrilWasmClient(aggregator, genesisVerificationKey);
     const certificate = await client.get_mithril_certificate(certificateHash);

--- a/mithril-explorer/src/components/VerifyCertificate/VerifyCertificateModal.js
+++ b/mithril-explorer/src/components/VerifyCertificate/VerifyCertificateModal.js
@@ -9,15 +9,25 @@ export default function VerifyCertificateModal({ show, onClose, certificateHash 
   const [showLoadingWarning, setShowLoadingWarning] = useState(false);
   const [client, setClient] = useState(undefined);
   const [certificate, setCertificate] = useState(undefined);
-  const [isCacheEnabled, setIsCacheEnabled] = useState(false);
 
   useEffect(() => {
     if (show) {
+      const {
+        fetchGenesisVerificationKey,
+        newMithrilWasmClient,
+      } = require("@/wasm-client-helpers");
+
       // Reset existing warning when shown
       setShowLoadingWarning(false);
-      init(currentAggregator, certificateHash).catch((err) =>
-        console.error("VerifyCertificateModal init error:", err),
-      );
+
+      fetchGenesisVerificationKey(currentAggregator)
+        .then((genesisKey) => newMithrilWasmClient(currentAggregator, genesisKey))
+        .then((client) => {
+          setClient(client);
+          return client.get_mithril_certificate(certificateHash);
+        })
+        .then((certificate) => setCertificate(certificate))
+        .catch((err) => console.error("VerifyCertificateModal init error:", err));
     }
   }, [show, currentAggregator, certificateHash]);
 
@@ -26,18 +36,6 @@ export default function VerifyCertificateModal({ show, onClose, certificateHash 
       setShowLoadingWarning(false);
     }
   }, [loading]);
-
-  async function init(aggregator, certificateHash) {
-    const { fetchGenesisVerificationKey, newMithrilWasmClient } = require("@/wasm-client-helpers");
-
-    const genesisVerificationKey = await fetchGenesisVerificationKey(aggregator);
-    const client = await newMithrilWasmClient(aggregator, genesisVerificationKey);
-    const certificate = await client.get_mithril_certificate(certificateHash);
-
-    setClient(client);
-    setCertificate(certificate);
-    setIsCacheEnabled(isCacheEnabled);
-  }
 
   function handleModalClose() {
     // Only allow closing if not loading
@@ -71,7 +69,6 @@ export default function VerifyCertificateModal({ show, onClose, certificateHash 
               <CertificateVerifier
                 client={client}
                 certificate={certificate}
-                isCacheEnabled={isCacheEnabled}
                 onStepChange={(step) =>
                   setLoading(step === certificateValidationSteps.validationInProgress)
                 }

--- a/mithril-explorer/src/utils.js
+++ b/mithril-explorer/src/utils.js
@@ -1,5 +1,3 @@
-import { MithrilClient } from "@mithril-dev/mithril-client-wasm";
-
 function checkUrl(url) {
   try {
     // Use the url constructor to check if the value is an url
@@ -105,15 +103,6 @@ function computeAggregatorNetworkFromUrl(aggregatorUrl) {
   return network && network[1] ? network[1] : null;
 }
 
-async function fetchGenesisVerificationKey(aggregator) {
-  const network = computeAggregatorNetworkFromUrl(aggregator);
-  return fetch(
-    `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${network}/genesis.vkey`,
-  )
-    .then((res) => res.text())
-    .catch((err) => console.error("Error fetching genesis verification key:", err));
-}
-
 /**
  * Compute the in and out registrations for given epochs.
  *
@@ -180,20 +169,6 @@ function compareRegistrations(left, right) {
   };
 }
 
-async function newMithrilWasmClient(aggregator, genesisVerificationKey) {
-  const isCacheEnabled = process.env.UNSTABLE === true;
-  const client_options = process.env.UNSTABLE
-    ? {
-        // The following option activates the unstable features of the client.
-        // Unstable features will trigger an error if this option is not set.
-        unstable: true,
-        enable_certificate_chain_verification_cache: isCacheEnabled,
-      }
-    : {};
-
-  return new MithrilClient(aggregator, genesisVerificationKey, client_options);
-}
-
 function getImmutableUrlFromTemplate(urlTemplate, immutableFileNumber) {
   return urlTemplate.replace(
     "{immutable_file_number}",
@@ -236,11 +211,9 @@ module.exports = {
   poolTickerCExplorerUrl,
   formatProcessDuration,
   computeAggregatorNetworkFromUrl,
-  fetchGenesisVerificationKey,
   computeInOutRegistrations,
   dedupInOutRegistrations,
   compareRegistrations,
-  newMithrilWasmClient,
   getImmutableUrlFromTemplate,
   parseSignedEntity,
 };

--- a/mithril-explorer/src/wasm-client-helpers.js
+++ b/mithril-explorer/src/wasm-client-helpers.js
@@ -1,0 +1,45 @@
+"use client";
+/*
+ * Helpers for the wasm client.
+ *
+ * *IMPORTANT*: Those functions should never be imported directly using `import` since this
+ * may cause the wasm client to be included in SSR builds, which will fail with the following error:
+ * ```
+ * Error: ENOENT: no such file or directory, open '/mithril/mithril-explorer/.next/server/app/mithril_client_wasm_bg.wasm'
+ * ```
+ * Instead, use `require` to import these functions:
+ * ```js
+ * const { newMithrilWasmClient, fetchGenesisVerificationKey } = require("@/wasm-client-helpers");
+ * ```
+ */
+
+import { MithrilClient } from "@mithril-dev/mithril-client-wasm";
+import { computeAggregatorNetworkFromUrl } from "@/utils";
+
+async function newMithrilWasmClient(aggregator, genesisVerificationKey) {
+  const isCacheEnabled = process.env.UNSTABLE === true;
+  const client_options = process.env.UNSTABLE
+    ? {
+        // The following option activates the unstable features of the client.
+        // Unstable features will trigger an error if this option is not set.
+        unstable: true,
+        enable_certificate_chain_verification_cache: isCacheEnabled,
+      }
+    : {};
+
+  return new MithrilClient(aggregator, genesisVerificationKey, client_options);
+}
+
+async function fetchGenesisVerificationKey(aggregator) {
+  const network = computeAggregatorNetworkFromUrl(aggregator);
+  return fetch(
+    `https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/${network}/genesis.vkey`,
+  )
+    .then((res) => res.text())
+    .catch((err) => console.error("Error fetching genesis verification key:", err));
+}
+
+module.exports = {
+  newMithrilWasmClient,
+  fetchGenesisVerificationKey,
+};


### PR DESCRIPTION
## Content

This PR changes `mithril-explorer` dependency to `mithril-client-wasm` to use its main package directly instead of targeting a build artefact (`/dist/web`).

This is allowed by a small refactor of how the client wasm library is used in the explored so it's never included in Server Side Rendered builds since this cause the following error:
```
Error: ENOENT: no such file or directory, open '/mithril/mithril-explorer/.next/server/app/mithril_client_wasm_bg.wasm'
```

This error was avoided previously by using the `dist/web` version of the wasm client as it's "flagged" for client side only.

> [!NOTE]
> This change makes the explore compatible with the `bump-version` runbook script :partying_face: 

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
