### PR TITLE
chore(ci): reactivate publish test for `mithril-client`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,8 +486,7 @@ jobs:
       max-parallel: 1
       matrix:
         package:
-          [mithril-stm, mithril-build-script, mithril-common]
-          #[mithril-stm, mithril-build-script, mithril-common, mithril-client] Will be reactivated after release of the `2506` distribution.
+          [mithril-stm, mithril-build-script, mithril-common, mithril-client]
 
     runs-on: ubuntu-24.04
     needs:

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -255,8 +255,7 @@ jobs:
       max-parallel: 1
       matrix:
         package:
-          [mithril-stm, mithril-build-script, mithril-common]
-          #[mithril-stm, mithril-build-script, mithril-common, mithril-client] Will be reactivated after release of the `2506` distribution.
+          [mithril-stm, mithril-build-script, mithril-common, mithril-client]
 
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
## Content

This PR reactivate publish test for `mithril-client`.

It was deactivated in aa55b34f57a71be972d73b7dee682ce39e96a206 because of an issue starting rust `1.84` that make `cargo publish --dry-run --no-verify` fails when a breaking version of a workspace dependency is yet to be published to crates.io.
With the release of the `2506.0` distribution, the breaking version `0.5.0` of `mithril-common` that triggered the problem with `mithril-client` is now [published to crates.io](https://crates.io/crates/mithril-common/0.5.0), solving the issue.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #2285
