### PR TITLE
Docs: add dev blog post for distribution `2506`

### DIFF
--- a/docs/website/blog/2025-02-14-distribution-2506.md
+++ b/docs/website/blog/2025-02-14-distribution-2506.md
@@ -1,0 +1,39 @@
+---
+title: Distribution `2506` is now available
+authors:
+  - name: Mithril Team
+tags: [release, distribution, 2506, security-advisory]
+---
+
+### Distribution `2506` is now available
+
+:::warning
+
+- This distribution embeds a fix for the **Mithril certificate chain could be manipulated by an adversarial signer** security advisory [GHSA-724h-fpm5-4qvr](https://github.com/input-output-hk/mithril/security/advisories/GHSA-724h-fpm5-4qvr)
+- All users running a **client library, client CLI or client WASM** are **strongly encouraged** to update them to the latest version.
+
+:::
+
+We have released the [`2506.0`](https://github.com/input-output-hk/mithril/releases/tag/2506.0) distribution, which includes the following:
+
+- Support certification of the protocol parameters and epoch in the certificate chain in the clients
+- Stable support for **Cardano node v.10.1.4** in the signer and aggregator
+- Remove support for `Thales` era in the signer and the aggregator
+- Stable support for aggregator HTTP responses compression in the signer, aggregator and clients
+- Build and publish both a `stable` version (for release networks) and an `unstable` version (for testing networks) of the explorer.
+
+This new distribution has been deployed to the **Mithril aggregator** of the `release-mainnet` and `release-preprod` networks.
+
+If you are running a **Mithril signer**:
+
+- **pre-release-preview** network: no action is required at this time
+- **release-preprod** network: upgrade your signer node binary to version `0.2.228` - no configuration updates are required
+- **release-mainnet** network: upgrade your signer node binary to version `0.2.228` - no configuration updates are required.
+
+You can easily update your Mithril signer with this one-line command (it downloads to the current directory by default; you can specify a custom folder by using the `-p` option):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2506.0 -p $(pwd)
+```
+
+For any inquiries or assistance, feel free to contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).

--- a/docs/website/blog/2025-02-14-distribution-2506.md
+++ b/docs/website/blog/2025-02-14-distribution-2506.md
@@ -10,27 +10,27 @@ tags: [release, distribution, 2506, security-advisory]
 :::warning
 
 - This distribution embeds a fix for the **Mithril certificate chain could be manipulated by an adversarial signer** security advisory [GHSA-724h-fpm5-4qvr](https://github.com/input-output-hk/mithril/security/advisories/GHSA-724h-fpm5-4qvr)
-- All users running a **client library, client CLI or client WASM** are **strongly encouraged** to update them to the latest version.
+- All users running a **client library, client CLI, or client WASM** are **strongly encouraged** to update to the latest versions.
 
 :::
 
 We have released the [`2506.0`](https://github.com/input-output-hk/mithril/releases/tag/2506.0) distribution, which includes the following:
 
-- Support certification of the protocol parameters and epoch in the certificate chain in the clients
+- Support for certifying protocol parameters and epochs in the certificate chain in clients
 - Stable support for **Cardano node v.10.1.4** in the signer and aggregator
-- Remove support for `Thales` era in the signer and the aggregator
-- Stable support for aggregator HTTP responses compression in the signer, aggregator and clients
-- Build and publish both a `stable` version (for release networks) and an `unstable` version (for testing networks) of the explorer.
+- Removal of support for the `Thales` era in the signer and aggregator
+- Stable support for aggregator HTTP response compression in the signer, aggregator, and clients
+- Building and publication of both a [`stable`](https://mithril.network/explorer) version (for release networks) and an [`unstable`](https://mithril.network/explorer/unstable) version (for testing networks) of the explorer.
 
 This new distribution has been deployed to the **Mithril aggregator** of the `release-mainnet` and `release-preprod` networks.
 
 If you are running a **Mithril signer**:
 
 - **pre-release-preview** network: no action is required at this time
-- **release-preprod** network: upgrade your signer node binary to version `0.2.228` - no configuration updates are required
-- **release-mainnet** network: upgrade your signer node binary to version `0.2.228` - no configuration updates are required.
+- **release-preprod** network: upgrade your signer node binary to version `0.2.228` – no configuration updates are required
+- **release-mainnet** network: upgrade your signer node binary to version `0.2.228` – no configuration updates are required.
 
-You can easily update your Mithril signer with this one-line command (it downloads to the current directory by default; you can specify a custom folder by using the `-p` option):
+You can easily update the Mithril signer with this one-line command. It downloads to the current directory by default, but a custom folder can be specified using the -p option:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2506.0 -p $(pwd)


### PR DESCRIPTION
## Content

This PR includes a **dev blog post announcing the release of the [`2506`](https://github.com/input-output-hk/mithril/releases/tag/2506.0) distribution**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Add dev blog post (if relevant)

## Issue(s)
Relates to #2207  
