### PR TITLE
Cleanup unused dependencies and auto CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,7 +237,7 @@ jobs:
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
           cache-version: ${{ secrets.CACHE_VERSION }}
-          cargo-tools: cargo-sort clippy-sarif sarif-fmt
+          cargo-tools: cargo-machete cargo-sort clippy-sarif sarif-fmt
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install prettier
@@ -272,6 +272,11 @@ jobs:
         if: success() || failure()
         shell: bash
         run: cargo sort -w -c
+
+      - name: Cargo machete (check unused dependencies)
+        if: success() || failure()
+        shell: bash
+        run: cargo machete
 
       - name: Dependency & Vulnerabilities Review
         if: github.event_name == 'pull_request'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3626,7 +3626,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3667,7 +3667,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-fake"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3774,7 +3774,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.69"
+version = "0.4.70"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3865,7 +3865,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-metric"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3882,7 +3882,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.44"
+version = "0.2.45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3899,7 +3899,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "anyhow",
  "clap",
@@ -3923,7 +3923,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.228"
+version = "0.2.229"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3957,7 +3957,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.37"
+version = "0.3.38"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,16 +641,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
-name = "binary-layout"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5845e3504cf59b9588fff324710f27ee519515b8a8a9f1207042da9a9e64f819"
-dependencies = [
- "doc-comment",
- "paste",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1544,12 +1534,6 @@ checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
 ]
-
-[[package]]
-name = "doc-comment"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dotenv"
@@ -3653,22 +3637,17 @@ dependencies = [
  "criterion",
  "flate2",
  "hex",
- "httpmock",
  "mithril-common",
  "mithril-doc",
  "mithril-metric",
  "mithril-persistence",
  "mockall",
- "paste",
- "prometheus",
  "rayon",
  "regex",
  "reqwest 0.12.12",
  "semver",
  "serde",
  "serde_json",
- "serde_yaml",
- "sha2",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -3681,7 +3660,6 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
- "typetag",
  "uuid",
  "warp",
  "zstd",
@@ -3694,7 +3672,6 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
- "clap_derive",
  "futures",
  "mithril-build-script",
  "mithril-common",
@@ -3732,7 +3709,6 @@ dependencies = [
  "futures",
  "getrandom 0.2.15",
  "httpmock",
- "indicatif",
  "mithril-common",
  "mockall",
  "reqwest 0.12.12",
@@ -3785,7 +3761,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "futures",
  "mithril-build-script",
  "mithril-client",
  "serde",
@@ -3823,7 +3798,6 @@ dependencies = [
  "pallas-addresses",
  "pallas-codec",
  "pallas-crypto",
- "pallas-hardano",
  "pallas-network",
  "pallas-primitives",
  "pallas-traverse",
@@ -3874,24 +3848,19 @@ version = "0.4.69"
 dependencies = [
  "anyhow",
  "async-recursion",
- "async-trait",
  "clap",
- "glob",
- "hex",
  "indicatif",
  "mithril-common",
  "mithril-doc",
  "reqwest 0.12.12",
  "serde",
  "serde_json",
- "serde_yaml",
  "slog",
  "slog-async",
  "slog-scope",
  "slog-term",
  "thiserror 2.0.11",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]
@@ -3918,13 +3887,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "hex",
  "mithril-common",
- "mockall",
  "semver",
  "serde",
  "serde_json",
- "sha2",
  "slog",
  "sqlite",
  "thiserror 2.0.11",
@@ -3945,7 +3911,6 @@ dependencies = [
  "reqwest 0.12.12",
  "serde",
  "serde_json",
- "serde_yaml",
  "slog",
  "slog-async",
  "slog-bunyan",
@@ -3962,7 +3927,6 @@ version = "0.2.228"
 dependencies = [
  "anyhow",
  "async-trait",
- "axum",
  "chrono",
  "clap",
  "config",
@@ -3975,10 +3939,7 @@ dependencies = [
  "mithril-metric",
  "mithril-persistence",
  "mockall",
- "paste",
- "prometheus",
  "prometheus-parse",
- "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "reqwest 0.12.12",
  "serde",
@@ -4003,7 +3964,6 @@ dependencies = [
  "blst",
  "criterion",
  "digest 0.10.7",
- "hex",
  "num-bigint 0.4.6",
  "num-rational",
  "num-traits",
@@ -4021,11 +3981,9 @@ dependencies = [
 name = "mithrildemo"
 version = "0.1.48"
 dependencies = [
- "base64 0.22.1",
  "blake2 0.10.6",
  "clap",
  "hex",
- "log",
  "mithril-common",
  "mithril-doc",
  "mithril-stm",
@@ -4540,20 +4498,6 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "zeroize",
-]
-
-[[package]]
-name = "pallas-hardano"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "641f1ce6df44330bbf8a707aeffd04b97d7f52cc50284ffe8e73fabf1c91582a"
-dependencies = [
- "binary-layout",
- "pallas-network",
- "pallas-traverse",
- "tap",
- "thiserror 1.0.69",
- "tracing",
 ]
 
 [[package]]
@@ -6319,12 +6263,6 @@ name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
-
-[[package]]
-name = "tap"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -9,11 +9,9 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [dependencies]
-base64 = "0.22.1"
 blake2 = "0.10.6"
 clap = { version = "4.5.28", features = ["derive"] }
 hex = "0.4.3"
-log = "0.4.25"
 mithril-common = { path = "../../mithril-common", features = ["fs"] }
 mithril-doc = { path = "../../internal/mithril-doc" }
 rand_chacha = "0.3.1"

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Apache-2.0"
     },
     "node_modules/@mithril-dev/mithril-client-wasm": {

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/internal/mithril-metric/Cargo.toml
+++ b/internal/mithril-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-metric"
-version = "0.1.7"
+version = "0.1.8"
 description = "Common tools to expose metrics."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-metric/src/helper.rs
+++ b/internal/mithril-metric/src/helper.rs
@@ -1,5 +1,12 @@
 //! Helper to create a metric service.
 
+/// Required re-exports to avoid requiring childs crates to depend on them when using the `build_metrics_service` macro.
+#[doc(hidden)]
+pub mod re_export {
+    pub use paste;
+    pub use prometheus;
+}
+
 /// Create a MetricService.
 ///
 /// To build the service you need to provide the structure name and a list of metrics.
@@ -36,6 +43,9 @@
 #[macro_export]
 macro_rules! build_metrics_service {
     ($service:ident, $($metric_attribute:ident:$metric_type:ident($name:literal, $help:literal)),*) => {
+        use $crate::helper::re_export::paste;
+        use $crate::helper::re_export::prometheus;
+
         paste::item! {
             /// Metrics service which is responsible for recording and exposing metrics.
             pub struct $service {

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -15,12 +15,10 @@ crate-type = ["lib", "cdylib", "staticlib"]
 anyhow = "1.0.95"
 async-trait = "0.1.86"
 chrono = { version = "0.4.39", features = ["serde"] }
-hex = "0.4.3"
 mithril-common = { path = "../../mithril-common", features = ["fs"] }
 semver = "1.0.25"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
-sha2 = "0.10.8"
 slog = "2.7.0"
 sqlite = { version = "0.36.1", features = ["bundled"] }
 thiserror = "2.0.11"
@@ -28,5 +26,4 @@ tokio = { version = "1.43.0", features = ["sync"] }
 
 [dev-dependencies]
 mithril-common = { path = "../../mithril-common", features = ["test_tools"] }
-mockall = "0.13.1"
 tokio = { version = "1.43.0", features = ["macros", "time"] }

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.44"
+version = "0.2.45"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -30,8 +30,6 @@ mithril-common = { path = "../mithril-common", features = ["full"] }
 mithril-doc = { path = "../internal/mithril-doc" }
 mithril-metric = { path = "../internal/mithril-metric" }
 mithril-persistence = { path = "../internal/mithril-persistence" }
-paste = "1.0.15"
-prometheus = "0.13.4"
 rayon = "1.10.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.12", features = [
@@ -40,12 +38,10 @@ reqwest = { version = "0.12.12", features = [
     "zstd",
     "deflate",
     "brotli"
-    ] }
+] }
 semver = "1.0.25"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
-serde_yaml = "0.9.34"
-sha2 = "0.10.8"
 slog = { version = "2.7.0", features = [
     "max_level_trace",
     "release_max_level_debug",
@@ -57,7 +53,6 @@ tar = "0.4.43"
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["codec"] }
-typetag = "0.2.19"
 uuid = { version = "1.13.1", features = [
     "v4",
     "fast-rng",
@@ -71,7 +66,6 @@ tikv-jemallocator = { version = "0.6.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", features = ["html_reports", "async_tokio"] }
-httpmock = "0.7.0"
 mithril-common = { path = "../mithril-common", features = [
     "allow_skip_signer_certification",
     "test_tools",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.4"
+version = "0.7.5"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -16,7 +16,6 @@ crate-type = ["cdylib"]
 anyhow = "1.0.95"
 async-trait = "0.1.86"
 chrono = { version = "0.4.39", features = ["serde"] }
-futures = "0.3.31"
 mithril-client = { path = "../mithril-client", default-features = false, features = ["unstable"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -39,3 +39,7 @@ test-node = []
 all-features = true
 # enable unstable features in the documentation
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo-machete]
+# wasm-bindgen-futures is required to build the project, but it's not used in the code
+ignored = ["wasm-bindgen-futures"]

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.8.3"
+version = "0.8.4"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/ci-test/package-lock.json
+++ b/mithril-client-wasm/ci-test/package-lock.json
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/package.json
+++ b/mithril-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithril-dev/mithril-client-wasm",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Mithril client WASM",
   "license": "Apache-2.0",
   "collaborators": [

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -68,7 +68,6 @@ uuid = { version = "1.13.1", features = ["v4", "js"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"
-indicatif = { version = "0.17.11", features = ["tokio"] }
 mithril-common = { path = "../mithril-common", version = "=0.5", default-features = false, features = [
     "test_tools",
 ] }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.11.1"
+version = "0.11.2"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -51,7 +51,6 @@ mithril-stm = { path = "../mithril-stm", version = "0.3", default-features = fal
 nom = "7.1.3"
 pallas-addresses = { version = "0.32.0", optional = true }
 pallas-codec = { version = "0.32.0", optional = true }
-pallas-hardano = { version = "0.32.0", optional = true }
 pallas-network = { version = "0.32.0", optional = true }
 pallas-primitives = { version = "0.32.0", optional = true }
 pallas-traverse = { version = "0.32.0", optional = true }
@@ -99,7 +98,6 @@ fs = [
     "tokio/process",
     "dep:pallas-addresses",
     "dep:pallas-codec",
-    "dep:pallas-hardano",
     "dep:pallas-network",
     "dep:pallas-primitives",
     "dep:pallas-traverse",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.0"
+version = "0.5.1"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -121,3 +121,7 @@ test_http_server = ["dep:warp"]
 all-features = true
 # enable unstable features in the documentation
 rustdoc-args = ["--cfg", "docsrs"]
+
+[package.metadata.cargo-machete]
+# `serde_bytes` is used for OpCert serialization
+ignored = ["serde_bytes"]

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -36,7 +36,7 @@
     },
     "../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.8.3",
+      "version": "0.8.4",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.34"
+version = "0.1.35"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -39,10 +39,9 @@ reqwest = { version = "0.12.12", features = [
     "zstd",
     "deflate",
     "brotli"
-    ] }
+] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
-serde_yaml = "0.9.34"
 slog = { version = "2.7.0", features = [
     "max_level_trace",
     "release_max_level_trace",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -16,7 +16,6 @@ harness = false
 [dependencies]
 anyhow = "1.0.95"
 async-trait = "0.1.86"
-axum = "0.8.1"
 chrono = { version = "0.4.39", features = ["serde"] }
 clap = { version = "4.5.28", features = ["derive", "env"] }
 config = "0.15.7"
@@ -25,9 +24,6 @@ mithril-common = { path = "../mithril-common", features = ["full"] }
 mithril-doc = { path = "../internal/mithril-doc" }
 mithril-metric = { path = "../internal/mithril-metric" }
 mithril-persistence = { path = "../internal/mithril-persistence" }
-paste = "1.0.15"
-prometheus = "0.13.4"
-rand_chacha = "0.3.1"
 rand_core = "0.6.4"
 reqwest = { version = "0.12.12", features = [
     "json",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.228"
+version = "0.2.229"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.37"
+version = "0.3.38"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -39,7 +39,6 @@ num-traits = { version = "0.2.19" }
 [dev-dependencies]
 bincode = "1.3.3"
 criterion = { version = "0.5.1", features = ["html_reports"] }
-hex = "0.4.3"
 num-bigint = "0.4.6"
 num-rational = "0.4.2"
 proptest = "1.6.0"

--- a/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
+++ b/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
@@ -13,7 +13,6 @@ repository = { workspace = true }
 anyhow = "1.0.95"
 axum = { version = "0.8.1", features = ["tokio", "http1"] }
 clap = { version = "4.5.28", features = ["derive"] }
-clap_derive = "4.5.28"
 futures = "0.3.31"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
+++ b/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator-fake"
-version = "0.4.0"
+version = "0.4.1"
 description = "Mithril Fake Aggregator for client testing"
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.69"
+version = "0.4.70"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -17,17 +17,13 @@ bench = false
 [dependencies]
 anyhow = "1.0.95"
 async-recursion = "1.1.1"
-async-trait = "0.1.86"
 clap = { version = "4.5.28", features = ["derive"] }
-glob = "0.3.2"
-hex = "0.4.3"
 indicatif = { version = "0.17.11", features = ["tokio"] }
 mithril-common = { path = "../../mithril-common", features = ["full"] }
 mithril-doc = { path = "../../internal/mithril-doc" }
 reqwest = { version = "0.12.12", features = ["json"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"
-serde_yaml = "0.9.34"
 slog = { version = "2.7.0", features = [
     "max_level_trace",
     "release_max_level_trace",
@@ -37,7 +33,6 @@ slog-scope = "4.4.0"
 slog-term = "2.9.1"
 thiserror = "2.0.11"
 tokio = { version = "1.43.0", features = ["full"] }
-tokio-util = { version = "0.7.13", features = ["codec"] }
 
 [features]
 default = []


### PR DESCRIPTION
## Content

This PR removes unused dependencies in our `Cargo.toml`(s) and add a CI check to avoid adding them in the future.

[`cargo machete`](https://github.com/bnjbvr/cargo-machete) was used to track those unused dependencies (without and with `--with-metadata`) and is added to the CI for the check since it returns an error when it found at least one.

## Pre-submit checklist

- Branch
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
