### PR TITLE
ci: Bump build runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -99,14 +99,8 @@ runs:
         cat >> ./release-notes-addon.txt << EOF
 
         ## Linux Requirements
-        The Linux binaries target \`glibc\`: to run them or install the \`.deb\` packages you must have \`glibc\` version \`2.31+\` installed.
-        Compatible systems include, but are not limited to, \`Ubuntu 20.04+\` or \`Debian 11+\` (Bullseye)).
-
-        > [!WARNING]
-        > From March 2025 onwards, released Linux binaries will have their minimum required  \`glibc\` version raised to \`2.35\`.
-        > Compatible systems include, but are not limited to, \`Ubuntu 22.04+\` or \`Debian 12+\` (Bookworm)).
-        >
-        > If you are using a system with an older version of \`glibc\`, you will need to compile the binaries from source.
+        The Linux binaries target \`glibc\`: to run them or install the \`.deb\` packages you must have \`glibc\` version \`2.35+\` installed.
+        Compatible systems include, but are not limited to, \`Ubuntu 22.04+\` or \`Debian 12+\` (Bookworm)).
         EOF
 
     - name: Fetch the latest version of the unstable tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build-ubuntu-X64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     outputs:
       eras: ${{ steps.eras-test-lab.outputs.eras }}
     steps:
@@ -26,7 +26,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: 20.04-${{ secrets.CACHE_VERSION }}
+          cache-version: 22.04-${{ secrets.CACHE_VERSION }}
           cargo-tools: cargo-deb
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX] - UNRELEASED
 
+- **BREAKING** changes in Mithril client library, CLI, and WASM:
+
+  - Upgraded the minimum required `glibc` version from `2.31` to `2.35` for the pre-built Linux binaries.
+
 - Crates versions:
 
 | Crate | Version |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,15 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Crates versions:
 
-| Crate | Version |
-| ----- | ------- |
-| N/A   | `-`     |
+| Crate               | Version   |
+| ------------------- | --------- |
+| mithril-aggregator  | `0.7.1`   |
+| mithril-client      | `0.11.1`  |
+| mithril-client-cli  | `0.11.0`  |
+| mithril-client-wasm | `0.8.1`   |
+| mithril-common      | `0.5.0`   |
+| mithril-signer      | `0.2.228` |
+| mithril-stm         | `0.3.37`  |
 
 ## Mithril Distribution [2450.0] - 2024-12-17
 

--- a/docs/website/blog/2025-02-04-glibc-minimum-requirement-change.md
+++ b/docs/website/blog/2025-02-04-glibc-minimum-requirement-change.md
@@ -9,9 +9,17 @@ tags: [ci, glibc, breaking-change]
 
 :::info
 
+Distribution [`2506.0`](https://github.com/input-output-hk/mithril/releases/tag/2506.0) has been released.
+Consequently, the minimum required `glibc` version has been bumped to `2.35`.
+
+:::
+
+:::info
+
 - This change **only affects users who rely on the precompiled Linux binaries** provided by the Mithril team.
 - If you compile the binaries from source or use a different operating system, you are **not affected**.
-  :::
+
+:::
 
 ## Background
 

--- a/docs/website/root/compiled-binaries.mdx
+++ b/docs/website/root/compiled-binaries.mdx
@@ -25,16 +25,7 @@ You can also install the **{props.node}** binary for other distributions:
 
 :::info
 
-The Linux binaries target `glibc`, and have a minimum requirement of `glibc 2.31` (compatible with `Ubuntu 20.04`
-or `Debian Bullseye`).
-
-:::
-
-:::warning
-
-From March 2025 onwards, released Linux binaries will have their minimum required `glibc` version raised to `2.35`
-(compatible with `Ubuntu 22.04` or `Debian 12 - Bookworm`).
-
-If you are using a system with an older version of `glibc`, you will need to compile the binaries from source.
+The Linux binaries target `glibc`, and have a minimum requirement of `glibc 2.35` (compatible with `Ubuntu 22.04`
+or `Debian 12 - Bookworm`).
 
 :::


### PR DESCRIPTION
## Content

This PR:
- bump the OS of the build runner in our CI from `ubuntu 20.04` to `ubuntu 22.04`
- update the `glibc` depreciation dev blog post to notify that the upgrade was enforced
- update the website minimum `glibc` requirement (only `next` version as the newly released `2506.0` distribution still support `glibc` `2.31`)
- update the github release notes minimum `glibc` requirement

## Pre-submit checklist

- Branch
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant)

## Issue(s)

Relates to #2216
