### PR TITLE
chore: upgrade dockerfiles base image version to Debian 12

### DIFF
--- a/mithril-aggregator/Dockerfile
+++ b/mithril-aggregator/Dockerfile
@@ -1,7 +1,7 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM rust:bullseye AS rustbuilder
+FROM rust:bookworm AS rustbuilder
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser
@@ -32,7 +32,7 @@ RUN /app/target/release/mithril-aggregator --version
 ###############################
 # STEP 2: build a small image
 ###############################
-FROM debian:11-slim
+FROM debian:12-slim
 
 # Args
 ARG CARDANO_NODE_VERSION=10.1.4

--- a/mithril-aggregator/Dockerfile.ci
+++ b/mithril-aggregator/Dockerfile.ci
@@ -1,7 +1,7 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-aggregator executable has been built
 # on a debian-compatible x86-64 environment
-ARG DOCKER_IMAGE_FROM=debian:11-slim
+ARG DOCKER_IMAGE_FROM=debian:12-slim
 FROM $DOCKER_IMAGE_FROM
 
 # Create appuser

--- a/mithril-client-cli/Dockerfile
+++ b/mithril-client-cli/Dockerfile
@@ -1,7 +1,7 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM rust:bullseye AS rustbuilder
+FROM rust:bookworm AS rustbuilder
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser
@@ -30,7 +30,7 @@ RUN /app/target/release/mithril-client --version
 ###############################
 # STEP 2: build a small image
 ###############################
-FROM debian:11-slim
+FROM debian:12-slim
 
 # Upgrade
 RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*

--- a/mithril-client-cli/Dockerfile.ci
+++ b/mithril-client-cli/Dockerfile.ci
@@ -1,7 +1,7 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-client executable has been built
 # on a debian-compatible x86-64 environment
-ARG DOCKER_IMAGE_FROM=debian:11-slim
+ARG DOCKER_IMAGE_FROM=debian:12-slim
 FROM $DOCKER_IMAGE_FROM
 
 # Create appuser

--- a/mithril-relay/Dockerfile
+++ b/mithril-relay/Dockerfile
@@ -1,7 +1,7 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM rust:bullseye AS rustbuilder
+FROM rust:bookworm AS rustbuilder
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser
@@ -30,7 +30,7 @@ RUN /app/target/release/mithril-relay --version
 ###############################
 # STEP 2: build a small image
 ###############################
-FROM debian:11-slim
+FROM debian:12-slim
 
 # Upgrade
 RUN apt-get update -y && apt-get install -y libssl-dev ca-certificates wget sqlite3 && rm -rf /var/lib/apt/lists/*

--- a/mithril-relay/Dockerfile.ci
+++ b/mithril-relay/Dockerfile.ci
@@ -1,7 +1,7 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-relay executable has been built
 # on a debian-compatible x86-64 environment
-ARG DOCKER_IMAGE_FROM=debian:11-slim
+ARG DOCKER_IMAGE_FROM=debian:12-slim
 FROM $DOCKER_IMAGE_FROM
 
 # Create appuser

--- a/mithril-signer/Dockerfile
+++ b/mithril-signer/Dockerfile
@@ -1,7 +1,7 @@
 ###############################
 # STEP 1: build rust executable
 ###############################
-FROM rust:bullseye AS rustbuilder
+FROM rust:bookworm AS rustbuilder
 
 # Create appuser
 RUN adduser --no-create-home --disabled-password appuser
@@ -33,7 +33,7 @@ RUN /app/target/release/mithril-signer --version
 ###############################
 # STEP 2: build a small image
 ###############################
-FROM debian:11-slim
+FROM debian:12-slim
 
 # Args
 ARG CARDANO_NODE_VERSION=10.1.4

--- a/mithril-signer/Dockerfile.ci
+++ b/mithril-signer/Dockerfile.ci
@@ -1,7 +1,7 @@
 # Creates a docker image to run an executable built outside of the image
 # This relies on the fact the mithril-signer executable has been built
 # on a debian-compatible x86-64 environment
-ARG DOCKER_IMAGE_FROM=debian:11-slim
+ARG DOCKER_IMAGE_FROM=debian:12-slim
 FROM $DOCKER_IMAGE_FROM
 
 # Create appuser

--- a/mithril-test-lab/mithril-devnet/README.md
+++ b/mithril-test-lab/mithril-devnet/README.md
@@ -55,8 +55,7 @@ MITHRIL_NODE_DOCKER_BUILD_TYPE=ci ./devnet-run.sh
 ## from locally built binaries with a custom slim image used as Docker image source
 ### This configuration depends on the version of 'glibc' on your computer
 ### 'debian:12-slim': default value, works on Ubuntu 22.04
-### 'debian:11-slim': works on Ubuntu 20.04
-MITHRIL_NODE_DOCKER_CI_IMAGE_FROM=debian:11-slim MITHRIL_NODE_DOCKER_BUILD_TYPE=ci ./devnet-run.sh
+MITHRIL_NODE_DOCKER_CI_IMAGE_FROM=debian:12-slim MITHRIL_NODE_DOCKER_BUILD_TYPE=ci ./devnet-run.sh
 
 ## from rust builder in Docker (slower build times, always works)
 MITHRIL_NODE_DOCKER_BUILD_TYPE=legacy ./devnet-run.sh


### PR DESCRIPTION
## Content

This PR upgrade dockerfiles base images from Debian 11 to Debian 12 as the former is not supported any-more with the upgrade of the minimum supported `glibc` version to `2.35`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #2216