### PR TITLE
feat: Implement an Unknown variant in the artifact locations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3732,7 +3732,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.11.1"
+version = "0.11.2"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.11.3"
+version = "0.11.4"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Makefile
+++ b/mithril-client/Makefile
@@ -6,6 +6,7 @@
 args = `arg="$(filter-out $@,$(MAKECMDGOALS))" && echo $${arg:-${1}}`
 
 CARGO = cargo
+FEATURES := fs unstable
 
 all: test build
 
@@ -25,3 +26,19 @@ clean:
 
 doc:
 	${CARGO} doc --no-deps --open --features full
+
+# Compute the powerset of all the given features and save it to a file
+.feature-sets:
+	powerset() { [ $$# -eq 0 ] && echo || (shift; powerset "$$@") | while read r ; do echo "$$1 $$r"; echo "$$r"; done };\
+	powerset $$(echo "$(FEATURES)") > .features-sets
+
+check-all-features-set: .feature-sets
+	# Read the file to run cargo clippy on all those features sets
+	cat .features-sets | while read features_set; do \
+		echo "Clippy client with feature '$$features_set''"; \
+		${CARGO} clippy -p mithril-client --features "$$features_set"; \
+	done
+	echo "Clippy client without features"; \
+	${CARGO} clippy -p mithril-client
+
+	rm .features-sets

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.5"
+version = "0.5.6"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -80,7 +80,7 @@ pub enum DigestLocation {
         /// URI of the aggregator digests route location.
         uri: String,
     },
-    /// Other location not known.
+    /// Catchall for unknown location variants.
     #[serde(other)]
     Unknown,
 }
@@ -94,7 +94,7 @@ pub enum ImmutablesLocation {
         /// URI of the cloud storage location.
         uri: MultiFilesUri,
     },
-    /// Other location not known.
+    /// Catchall for unknown location variants.
     #[serde(other)]
     Unknown,
 }
@@ -108,7 +108,7 @@ pub enum AncillaryLocation {
         /// URI of the cloud storage location.
         uri: String,
     },
-    /// Other location not known.
+    /// Catchall for unknown location variants.
     #[serde(other)]
     Unknown,
 }

--- a/mithril-common/src/entities/cardano_database.rs
+++ b/mithril-common/src/entities/cardano_database.rs
@@ -80,6 +80,9 @@ pub enum DigestLocation {
         /// URI of the aggregator digests route location.
         uri: String,
     },
+    /// Other location not known.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Locations of the immutable files.
@@ -91,6 +94,9 @@ pub enum ImmutablesLocation {
         /// URI of the cloud storage location.
         uri: MultiFilesUri,
     },
+    /// Other location not known.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Locations of the ancillary files.
@@ -102,6 +108,9 @@ pub enum AncillaryLocation {
         /// URI of the cloud storage location.
         uri: String,
     },
+    /// Other location not known.
+    #[serde(other)]
+    Unknown,
 }
 
 /// Locations of the Cardano database related files.

--- a/mithril-common/src/messages/cardano_database.rs
+++ b/mithril-common/src/messages/cardano_database.rs
@@ -197,4 +197,54 @@ mod tests {
 
         assert_eq!(golden_current_message(), message);
     }
+
+    #[test]
+    fn test_a_future_json_deserialized_with_unknown_location_types() {
+        let json = r#"
+        {
+            "hash": "d4071d518a3ace0f6c04a9c0745b9e9560e3e2af1b373bafc4e0398423e9abfb",
+            "merkle_root": "c8224920b9f5ad7377594eb8a15f34f08eb3103cc5241d57cafc5638403ec7c6",
+            "beacon": {
+                "epoch": 123,
+                "immutable_file_number": 2345
+            },
+            "certificate_hash": "f6c01b373bafc4e039844071d5da3ace4a9c0745b9e9560e3e2af01823e9abfb",
+            "total_db_size_uncompressed": 800796318,
+            "locations": {
+                "digests": [
+                    {
+                        "type": "whatever",
+                        "new_field": "digest-1"
+                    }
+                ],
+                "immutables": [
+                    {
+                        "type": "whatever",
+                        "new_field": [123, 125]
+                    }
+                ],
+                "ancillary": [
+                    {
+                        "type": "whatever",
+                        "new_field": "ancillary-3"
+                    }
+                ]
+            },
+            "compression_algorithm": "gzip",
+            "cardano_node_version": "0.0.1",
+            "created_at": "2023-01-19T13:43:05.618857482Z"
+        }"#;
+        let message: CardanoDatabaseSnapshotMessage = serde_json::from_str(json).expect(
+            "This JSON is expected to be successfully parsed into a CardanoDatabaseSnapshotMessage instance.",
+        );
+
+        assert_eq!(message.locations.digests.len(), 1);
+        assert_eq!(DigestLocation::Unknown, message.locations.digests[0]);
+
+        assert_eq!(message.locations.immutables.len(), 1);
+        assert_eq!(ImmutablesLocation::Unknown, message.locations.immutables[0]);
+
+        assert_eq!(message.locations.ancillary.len(), 1);
+        assert_eq!(AncillaryLocation::Unknown, message.locations.ancillary[0]);
+    }
 }


### PR DESCRIPTION
## Content

To avoid creating a breaking change in the client whenever a new location is introduced (e.g. decentralized storage).
we add a fallback variant in the artifact location types for the Incremental Cardano DB.

This PR implements an Unknown variant with the #[serde(other)] macro (as explained [here](https://serde.rs/variant-attrs.html#other)) in the artifact locations messages:
- Immutable locations
- Ancillary locations
- Digest locations

The `mithril-client-cli is adapted to not show unknown location.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

Relates to #2293
