### PR TITLE
Fix BLST bindings: Error handling for infinite values of sigs and vks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.38"
+version = "0.3.39"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.38"
+version = "0.3.39"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/error.rs
+++ b/mithril-stm/src/error.rs
@@ -36,7 +36,7 @@ pub enum MultiSignatureError {
 
     /// Verification key is the infinity
     #[error("Verification key is the infinity")]
-    VerificationKeyInfinity(VerificationKey),
+    VerificationKeyInfinity(Box<VerificationKey>),
 }
 
 /// Errors which can be output by Mithril single signature verification.
@@ -145,6 +145,10 @@ pub enum RegisterError {
     /// This key has already been registered by a participant
     #[error("This key has already been registered.")]
     KeyRegistered(Box<VerificationKey>),
+
+    /// Verification key is the infinity
+    #[error("Verification key is the infinity")]
+    VerificationKeyInfinity(Box<VerificationKey>),
 
     /// The supplied key is not valid
     #[error("The verification of correctness of the supplied key is invalid.")]
@@ -263,6 +267,7 @@ impl From<MultiSignatureError> for RegisterError {
         match e {
             MultiSignatureError::SerializationError => Self::SerializationError,
             MultiSignatureError::KeyInvalid(e) => Self::KeyInvalid(e),
+            MultiSignatureError::VerificationKeyInfinity(e) => Self::VerificationKeyInfinity(e),
             _ => unreachable!(),
         }
     }
@@ -273,7 +278,7 @@ impl From<MultiSignatureError> for RegisterError {
 pub(crate) fn blst_err_to_mithril(
     e: BLST_ERROR,
     sig: Option<Signature>,
-    key: Option<VerificationKey>
+    key: Option<VerificationKey>,
 ) -> Result<(), MultiSignatureError> {
     match e {
         BLST_ERROR::BLST_SUCCESS => Ok(()),
@@ -282,7 +287,7 @@ pub(crate) fn blst_err_to_mithril(
                 return Err(MultiSignatureError::SignatureInfinity(s));
             }
             if let Some(vk) = key {
-                return Err(MultiSignatureError::VerificationKeyInfinity(vk));
+                return Err(MultiSignatureError::VerificationKeyInfinity(Box::new(vk)));
             }
             Err(MultiSignatureError::SerializationError)
         }

--- a/mithril-stm/src/key_reg.rs
+++ b/mithril-stm/src/key_reg.rs
@@ -42,12 +42,9 @@ impl KeyReg {
     /// The function fails when the proof of possession is invalid or when the key is already registered.
     pub fn register(&mut self, stake: Stake, pk: VerificationKeyPoP) -> Result<(), RegisterError> {
         if let Entry::Vacant(e) = self.keys.entry(pk.vk) {
-            if pk.check().is_ok() {
-                e.insert(stake);
-                return Ok(());
-            } else {
-                return Err(RegisterError::KeyInvalid(Box::new(pk)));
-            }
+            pk.check()?;
+            e.insert(stake);
+            return Ok(());
         }
         Err(RegisterError::KeyRegistered(Box::new(pk.vk)))
     }

--- a/mithril-stm/src/multi_sig.rs
+++ b/mithril-stm/src/multi_sig.rs
@@ -655,8 +655,7 @@ mod tests {
             let vk = VerificationKey::from(&sk);
             let sig = sk.sign(&msg);
 
-            let result = sig.verify(&msg, &vk);
-            assert!(result.is_ok(), "verify {result:?}");
+            sig.verify(&msg, &vk).unwrap();
         }
 
         #[test]


### PR DESCRIPTION
## Content
If there is any identity element in the following vectors:
```
let transmuted_vks: Vec<blst_p2> = vks.iter().map(vk_from_p2_affine).collect();
let transmuted_sigs: Vec<blst_p1> = signatures.iter().map(sig_to_p1).collect();
```
The content of the following vectors in `mithril-stm/src/multi_sig.rs`:
```
let grouped_vks = p2_affines::from(transmuted_vks.as_slice());
let grouped_sigs = p1_affines::from(transmuted_sigs.as_slice());
```
Becomes vectors full of identity elements.

This PR includes the changes to avoid having an identity element in signature and verification lists.

In `mithril-stm/src/multi_sig.rs`:
- `Signature::verify` function is updated: If signature is an infinity value, it returns an error.
- `VerificationKeyPoP::check` function is updated: If the verification key is an infinity value, it returns an error.
- `test_infinity_sig` test is added.
- `test_infinity_vk` test is added.
- `test_keyreg_with_infinity_vk` test is added.

In `mithril-stm/src/error.rs`:
- `MultiSignatureError` is updated to cover 
    - `SignatureInfinity`
    - `VerificationKeyInfinity`
- `impl From<MultiSignatureError> for StmSignatureError` is updated.
- `impl<D: Digest + FixedOutput> From<MultiSignatureError> for StmAggregateSignatureError<D>` is updated.
- `impl From<MultiSignatureError> for CoreVerifierError` is updated.
- `pub(crate) fn blst_err_to_mithril` is updated.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)


## Issue(s)
Closes #2321 
