### PR TITLE
refactor(ci): use cache-version instead of 'v0-' in rust cache key prefix

### DIFF
--- a/.github/workflows/actions/toolchain-and-cache/action.yml
+++ b/.github/workflows/actions/toolchain-and-cache/action.yml
@@ -26,7 +26,7 @@ runs:
       with:
         # only save the cache on the main branch to limit github actions total cache size
         save-if: ${{ github.ref == 'refs/heads/main' }}
-        key: ${{ runner.os }}-cache-v${{ inputs.cache-version }}
+        prefix-key: v${{ inputs.cache-version }}-rust-${{ runner.os }}
 
     - name: Install cargo tools installer
       uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: 22.04-${{ secrets.CACHE_VERSION }}
+          cache-version: 22.04-${{ vars.CACHE_VERSION }}
           cargo-tools: cargo-deb
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -97,7 +97,7 @@ jobs:
       - name: Install stable toolchain and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}
+          cache-version: ${{ vars.CACHE_VERSION }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build Mithril workspace & publish artifacts
@@ -121,7 +121,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}-wasm
+          cache-version: ${{ vars.CACHE_VERSION }}-wasm
           cargo-tools: wasm-pack
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -193,7 +193,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}
+          cache-version: ${{ vars.CACHE_VERSION }}
           cargo-tools: cargo-nextest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -231,7 +231,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}
+          cache-version: ${{ vars.CACHE_VERSION }}
           cargo-tools: cargo-machete cargo-sort clippy-sarif sarif-fmt
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -532,7 +532,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}-wasm
+          cache-version: ${{ vars.CACHE_VERSION }}-wasm
           cargo-tools: wasm-pack
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -739,7 +739,7 @@ jobs:
       - name: Install stable toolchain and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}
+          cache-version: ${{ vars.CACHE_VERSION }}
           cargo-tools: clippy-sarif sarif-fmt
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/manual-publish-npm.yml
+++ b/.github/workflows/manual-publish-npm.yml
@@ -56,7 +56,7 @@ jobs:
         if: inputs.package == matrix.package || inputs.package == 'all'
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}-wasm
+          cache-version: ${{ vars.CACHE_VERSION }}-wasm
           cargo-tools: wasm-pack
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -285,7 +285,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}-wasm
+          cache-version: ${{ vars.CACHE_VERSION }}-wasm
           cargo-tools: wasm-pack
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
         with:
-          cache-version: ${{ secrets.CACHE_VERSION }}-wasm
+          cache-version: ${{ vars.CACHE_VERSION }}-wasm
           cargo-tools: wasm-pack
           github-token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Content

This PR simplify the prefix for rust cache in CI.

Previously we had a version two times:  <pre>**v0**-rust-Linux-cache-**v5d9f9d8e-fb2b-4423-9700-8ae3bc62978e**-cargo-doc-Linux-e99b5096-e698f932 </pre>
Now, alongside a change of the repository `cache-version` to a simple `2`: <pre>**v2**-rust-Linux-cache-cargo-doc-Linux-e99b5096-e698f932 </pre>

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

