### PR TITLE
Fix wasm build in rust 1.85

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,7 +3777,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.4"
+version = "0.5.5"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/signable_builder/interface.rs
+++ b/mithril-common/src/signable_builder/interface.rs
@@ -17,7 +17,7 @@ use mockall::automock;
 pub trait Beacon: Send + Sync {}
 
 /// Artifact is a trait for types that represent signed artifacts
-#[typetag::serde(tag = "type")]
+#[cfg_attr(not(target_family = "wasm"), typetag::serde(tag = "type"))]
 pub trait Artifact: Debug + Send + Sync {
     /// Get artifact identifier
     fn get_id(&self) -> String;
@@ -54,35 +54,35 @@ impl Beacon for CardanoDbBeacon {}
 
 impl Beacon for Epoch {}
 
-#[typetag::serde]
+#[cfg_attr(not(target_family = "wasm"), typetag::serde)]
 impl Artifact for CardanoDatabaseSnapshot {
     fn get_id(&self) -> String {
         self.hash.clone()
     }
 }
 
-#[typetag::serde]
+#[cfg_attr(not(target_family = "wasm"), typetag::serde)]
 impl Artifact for CardanoStakeDistribution {
     fn get_id(&self) -> String {
         self.hash.clone()
     }
 }
 
-#[typetag::serde]
+#[cfg_attr(not(target_family = "wasm"), typetag::serde)]
 impl Artifact for CardanoTransactionsSnapshot {
     fn get_id(&self) -> String {
         self.hash.clone()
     }
 }
 
-#[typetag::serde]
+#[cfg_attr(not(target_family = "wasm"), typetag::serde)]
 impl Artifact for MithrilStakeDistribution {
     fn get_id(&self) -> String {
         self.hash.clone()
     }
 }
 
-#[typetag::serde]
+#[cfg_attr(not(target_family = "wasm"), typetag::serde)]
 impl Artifact for Snapshot {
     fn get_id(&self) -> String {
         self.digest.clone()


### PR DESCRIPTION
## Content

This PR fix build of the wasm library that's failing since release of `rust 1.85`.

```shell
$ npm run build:node                                                                                                                   
                                                                                                                                        
> @mithril-dev/mithril-client-wasm@0.8.4 build:node                                                                                     
> wasm-pack build --target nodejs --out-dir dist/node $WASM_PACK_ARGS                                                                   
                                                                                                                                        
[INFO]: 🎯  Checking for the Wasm target...                                                                                             
[INFO]: 🌀  Compiling to Wasm...                                                                                                        
   Compiling mithril-common v0.5.4 (/home/dev/mithril/mithril-common)                                                             
   Compiling mithril-client v0.11.3 (/home/dev/mithril/mithril-client)                                                            
   Compiling mithril-client-wasm v0.8.4 (/home/dev/mithril/mithril-client-wasm)                                                   
    Finished `release` profile [optimized] target(s) in 13.49s                                                                          
thread 'main' panicked at crates/wasm-interpreter/src/lib.rs:245:21:                                                                    
mithril_common::signable_builder::interface::_::__ctor::h4977fb9f7c35308c: Read a negative address value from the stack. Did we run out 
of memory?                                                                                                                              
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace                                                           
Error: Running the wasm-bindgen CLI                                                                                                     
Caused by: Running the wasm-bindgen CLI
Caused by: failed to execute `wasm-bindgen`: exited with exit status: 101 
``` 

This is due to an incompatibility between the [type-tag crate](https://crates.io/crates/typetag) and wasm.
Removing `typetag` from the wasm build solve the issue at the price of not being able to use typetag bound generics fields with serde in wasm.
This is acceptable because the only use case for type tag right now in our code base is in the `mithril-aggregator`, that's not compiled to wasm, to serialize/deserialize in json the `artifact` field of the `signed_entity` table.

There's a remaining question: This incompatibility is not new and is not related to `rust 1.85` so why wasm builds start to fails only now ?

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Closes #2325
