### PR TITLE
Feat: improve disk space calculation for Incremental DB Restoration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.11.6"
+version = "0.11.7"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db_v2/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db_v2/download.rs
@@ -241,7 +241,7 @@ impl CardanoDbV2DownloadCommand {
                 total_immutables_restored_size + cardano_db.digests.size_uncompressed
             };
 
-            total_size + ((total_size as f64 * DISK_SPACE_SAFETY_MARGIN_RATIO) as u64)
+            (total_size as f64 * (1.0 + DISK_SPACE_SAFETY_MARGIN_RATIO)) as u64
         }
     }
 
@@ -656,8 +656,8 @@ mod tests {
             cardano_db_snapshot.immutables.average_size_uncompressed;
 
         let expected_size = digest_size + 10 * average_size_uncompressed_immutable;
-        let expected_size = expected_size + (expected_size * 10 / 100); // 10% safety margin
-        assert_eq!(required_size, expected_size);
+        let expected_size_with_margin = (expected_size as f64 * 1.10) as u64; // 10% safety margin
+        assert!((required_size as f64 - expected_size_with_margin as f64).abs() < 1.0);
     }
 
     #[test]
@@ -697,7 +697,7 @@ mod tests {
         let ancillary_size = cardano_db_snapshot.ancillary.size_uncompressed;
 
         let expected_size = digest_size + 10 * average_size_uncompressed_immutable + ancillary_size;
-        let expected_size = expected_size + (expected_size * 10 / 100); // 10% safety margin
-        assert_eq!(required_size, expected_size);
+        let expected_size_with_margin = (expected_size as f64 * 1.10) as u64; // 10% safety margin
+        assert!((required_size as f64 - expected_size_with_margin as f64).abs() < 1.0);
     }
 }

--- a/mithril-client-cli/src/commands/cardano_db_v2/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db_v2/download.rs
@@ -32,6 +32,7 @@ struct RestorationOptions {
     db_dir: PathBuf,
     immutable_file_range: ImmutableFileRange,
     download_unpack_options: DownloadUnpackOptions,
+    disk_space_safety_margin_ratio: f64,
 }
 
 /// Clap command to download a Cardano db and verify its associated certificate.
@@ -109,6 +110,7 @@ impl CardanoDbV2DownloadCommand {
                 include_ancillary: self.include_ancillary,
                 ..DownloadUnpackOptions::default()
             },
+            disk_space_safety_margin_ratio: DISK_SPACE_SAFETY_MARGIN_RATIO,
         };
         let logger = context.logger();
 
@@ -241,7 +243,7 @@ impl CardanoDbV2DownloadCommand {
                 total_immutables_restored_size + cardano_db.digests.size_uncompressed
             };
 
-            (total_size as f64 * (1.0 + DISK_SPACE_SAFETY_MARGIN_RATIO)) as u64
+            (total_size as f64 * (1.0 + restoration_options.disk_space_safety_margin_ratio)) as u64
         }
     }
 
@@ -610,6 +612,7 @@ mod tests {
             immutable_file_range: ImmutableFileRange::Full,
             db_dir: PathBuf::from("db_dir"),
             download_unpack_options: DownloadUnpackOptions::default(),
+            disk_space_safety_margin_ratio: 0.0,
         };
 
         let required_size = CardanoDbV2DownloadCommand::compute_required_disk_space_for_snapshot(
@@ -644,6 +647,7 @@ mod tests {
                 include_ancillary: false,
                 ..DownloadUnpackOptions::default()
             },
+            disk_space_safety_margin_ratio: 0.1,
         };
 
         let required_size = CardanoDbV2DownloadCommand::compute_required_disk_space_for_snapshot(
@@ -684,6 +688,7 @@ mod tests {
                 include_ancillary: true,
                 ..DownloadUnpackOptions::default()
             },
+            disk_space_safety_margin_ratio: 0.1,
         };
 
         let required_size = CardanoDbV2DownloadCommand::compute_required_disk_space_for_snapshot(


### PR DESCRIPTION
## Content

This PR includes enhancements to the disk space computation for incremental Cardano DB snapshot restoration in the client CLI.
It leverages updated artifact metadata to compute the required disk space for both full and partial restorations, adding ancillary files sizes when necessary.
Additionally, for partial restorations, a 10% safety margin is applied to ensure that sufficient disk space is available before download, as the computation uses the average size of an immutable file.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)

## Issue(s)

Closes #2292 
