### PR TITLE
Fix: `notify-on-failure` job succeeds despite email sending failure

### DIFF
--- a/.github/workflows/nightly-dispatcher.yml
+++ b/.github/workflows/nightly-dispatcher.yml
@@ -24,3 +24,4 @@ jobs:
     uses: ./.github/workflows/test-notify-on-failure.yml
     needs: [docker-builds, aggregator-stress-test, test-client]
     if: failure()
+    secrets: inherit

--- a/.github/workflows/scripts/notify-nightly-failure.js
+++ b/.github/workflows/scripts/notify-nightly-failure.js
@@ -32,4 +32,7 @@ sgMail
     console.log("Mail sent successfully");
     console.log("Message details:", msg);
   })
-  .catch((error) => console.error("Error sending email:", error));
+  .catch((error) => {
+    console.error("Error sending email:", error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Content

This PR includes a fix for the notification script, ensuring that the job fails when email sending fails.

Before fix: https://github.com/input-output-hk/mithril/actions/runs/13677606215
After fix: https://github.com/input-output-hk/mithril/actions/runs/13677635751

Additionally, [secrets: inherit](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit) has been added to the reusable `test-notify-on-failure` workflow call, ensuring that all required secrets are passed to the notification job in scheduled workflows.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
