### PR TITLE
refactor(mithril-client): Optimize cardano db artifacts download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.11.13"
+version = "0.11.14"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.10"
+version = "0.5.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.11.13"
+version = "0.11.14"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -108,6 +108,17 @@ macro_rules! cfg_unstable {
     }
 }
 
+#[allow(unused_macros)]
+macro_rules! cfg_fs_unstable {
+    ($($item:item)*) => {
+        $(
+            #[cfg(all(feature = "unstable", feature = "fs"))]
+            #[cfg_attr(docsrs, doc(cfg(all(feature = "unstable", feature = "fs"))))]
+            $item
+        )*
+    }
+}
+
 pub mod aggregator_client;
 cfg_unstable! {
     pub mod cardano_database_client;

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -4,9 +4,9 @@
 cfg_fs! {
     mod stream_reader;
     mod fs;
-    mod vec_extensions;
+    mod vec_deque_extensions;
 
     pub use stream_reader::*;
     pub use fs::*;
-    pub use vec_extensions::VecExtensions;
+    pub use vec_deque_extensions::VecDequeExtensions;
 }

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -3,10 +3,14 @@
 
 cfg_fs! {
     mod stream_reader;
+
+    pub use stream_reader::*;
+}
+
+cfg_fs_unstable! {
     mod fs;
     mod vec_deque_extensions;
 
-    pub use stream_reader::*;
     pub use fs::*;
     pub use vec_deque_extensions::VecDequeExtensions;
 }

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -4,7 +4,9 @@
 cfg_fs! {
     mod stream_reader;
     mod fs;
+    mod vec_extensions;
 
     pub use stream_reader::*;
     pub use fs::*;
+    pub use vec_extensions::VecExtensions;
 }

--- a/mithril-client/src/utils/vec_deque_extensions.rs
+++ b/mithril-client/src/utils/vec_deque_extensions.rs
@@ -1,12 +1,14 @@
-pub trait VecExtensions<T> {
+use std::collections::VecDeque;
+
+pub trait VecDequeExtensions<T> {
     /// Removes the first `n` elements from the vector and returns them as a new vector.
     ///
     /// If `n` is greater than the length of the vector, the whole vector is drained.
-    fn pop_up_to_n(&mut self, n: usize) -> Vec<T>;
+    fn pop_up_to_n(&mut self, n: usize) -> VecDeque<T>;
 }
 
-impl<T> VecExtensions<T> for Vec<T> {
-    fn pop_up_to_n(&mut self, n: usize) -> Vec<T> {
+impl<T> VecDequeExtensions<T> for VecDeque<T> {
+    fn pop_up_to_n(&mut self, n: usize) -> VecDeque<T> {
         let num_elements_to_pop = if n <= self.len() { n } else { self.len() };
         self.drain(..num_elements_to_pop).collect()
     }
@@ -18,7 +20,7 @@ mod tests {
 
     #[test]
     fn pop_zero_element_return_empty_vec() {
-        let mut vec = vec![1, 2, 3];
+        let mut vec = VecDeque::from([1, 2, 3]);
         let popped = vec.pop_up_to_n(0);
 
         assert_eq!(popped, Vec::<i32>::new());
@@ -27,7 +29,7 @@ mod tests {
 
     #[test]
     fn pop_one_element_return_vec_with_the_first_element() {
-        let mut vec = vec![1, 2, 3];
+        let mut vec = VecDeque::from([1, 2, 3]);
         let popped = vec.pop_up_to_n(1);
 
         assert_eq!(popped, vec![1]);
@@ -36,7 +38,7 @@ mod tests {
 
     #[test]
     fn pop_all_elements_leave_source_vec_empty() {
-        let mut vec = vec![1, 2, 3];
+        let mut vec = VecDeque::from([1, 2, 3]);
         let popped = vec.pop_up_to_n(vec.len());
 
         assert_eq!(popped, vec![1, 2, 3]);
@@ -45,7 +47,7 @@ mod tests {
 
     #[test]
     fn pop_more_than_source_vec_size_is_equivalent_to_popping_all_elements() {
-        let mut vec = vec![1, 2, 3];
+        let mut vec = VecDeque::from([1, 2, 3]);
         let popped = vec.pop_up_to_n(vec.len() + 1);
 
         assert_eq!(popped, vec![1, 2, 3]);

--- a/mithril-client/src/utils/vec_extensions.rs
+++ b/mithril-client/src/utils/vec_extensions.rs
@@ -1,0 +1,54 @@
+pub trait VecExtensions<T> {
+    /// Removes the first `n` elements from the vector and returns them as a new vector.
+    ///
+    /// If `n` is greater than the length of the vector, the whole vector is drained.
+    fn pop_up_to_n(&mut self, n: usize) -> Vec<T>;
+}
+
+impl<T> VecExtensions<T> for Vec<T> {
+    fn pop_up_to_n(&mut self, n: usize) -> Vec<T> {
+        let num_elements_to_pop = if n <= self.len() { n } else { self.len() };
+        self.drain(..num_elements_to_pop).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pop_zero_element_return_empty_vec() {
+        let mut vec = vec![1, 2, 3];
+        let popped = vec.pop_up_to_n(0);
+
+        assert_eq!(popped, Vec::<i32>::new());
+        assert_eq!(vec, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn pop_one_element_return_vec_with_the_first_element() {
+        let mut vec = vec![1, 2, 3];
+        let popped = vec.pop_up_to_n(1);
+
+        assert_eq!(popped, vec![1]);
+        assert_eq!(vec, vec![2, 3]);
+    }
+
+    #[test]
+    fn pop_all_elements_leave_source_vec_empty() {
+        let mut vec = vec![1, 2, 3];
+        let popped = vec.pop_up_to_n(vec.len());
+
+        assert_eq!(popped, vec![1, 2, 3]);
+        assert_eq!(vec, Vec::<i32>::new());
+    }
+
+    #[test]
+    fn pop_more_than_source_vec_size_is_equivalent_to_popping_all_elements() {
+        let mut vec = vec![1, 2, 3];
+        let popped = vec.pop_up_to_n(vec.len() + 1);
+
+        assert_eq!(popped, vec![1, 2, 3]);
+        assert_eq!(vec, Vec::<i32>::new());
+    }
+}

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.10"
+version = "0.5.11"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR refactor the way cardano database v2 files are downloaded in the `mithril-client`:

- Unified download system for immutables in ancillary:
  - allowing them to be in the same join set
  - download tasks are now precomputed
- Fail early: as soon as the last location fails when downloading a files (instead of failing at the very end of the process)
- Continuously download `max_parallel_downloads` files:  No more threshold effect because of chunking

### Performance improvement over a download of ~10 000 immutables without ancillary

> [!NOTE]
> Those commands are run on a 1 Gbit/s download speed internet connection

Before, 10k immutables download took ~33 seconds:
```shell
$./mithril-client --unstable --run-mode dev cardano-db-v2 download latest --start 7345
1/6 - Checking local disk info…
2/6 - Fetching the certificate and verifying the certificate chain…
  Certificate chain validated
3/6 - Downloading and unpacking the cardano db snapshot
   [00:00:33] [############################################################################################] Files: 10,006/10,006 (0.0s)
4/6 - Computing and verifying the Merkle proof…
5/6 - Computing the cardano db snapshot message
6/6 - Verifying the cardano db signature…
Cardano database snapshot '5845e9e1232f91c804e483eda1e7af6b9816174d0410923da6f032c1c1c91f5f' archives have been successfully unpacked.
``` 

After, 10k immutables download took ~19 seconds:
```shell
$./mithril-client --unstable --run-mode dev cardano-db-v2 download latest --start 7345
1/6 - Checking local disk info…
2/6 - Fetching the certificate and verifying the certificate chain… 
  Certificate chain validated
3/6 - Downloading and unpacking the cardano db snapshot
   [00:00:19] [############################################################################################] Files: 10,006/10,006 (0.0s)
4/6 - Computing and verifying the Merkle proof…
5/6 - Computing the cardano db snapshot message
6/6 - Verifying the cardano db signature…
Cardano database snapshot '5845e9e1232f91c804e483eda1e7af6b9816174d0410923da6f032c1c1c91f5f' archives have been successfully unpacked.
``` 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Comments

This PR also fix the clippy warnings that were raised when checking with only the `fs` feature enabled.

## Issue(s)

Closes #2327
