### PR TITLE
Compress the digests file uploaded on gcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.12"
+version = "0.7.13"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -147,7 +147,9 @@ mod tests {
     use mockall::{predicate, Predicate};
 
     use crate::{
-        artifact_builder::{MockAncillaryFileUploader, MockImmutableFilesUploader},
+        artifact_builder::{
+            DigestSnapshotter, MockAncillaryFileUploader, MockImmutableFilesUploader,
+        },
         immutable_file_digest_mapper::MockImmutableFileDigestMapper,
         services::{DumbSnapshotter, FakeSnapshotter},
         test_tools::TestLogger,
@@ -270,8 +272,10 @@ mod tests {
             DigestArtifactBuilder::new(
                 SanitizedUrlWithTrailingSlash::parse("http://aggregator_uri").unwrap(),
                 vec![],
-                Arc::new(DumbSnapshotter::new()),
-                CompressionAlgorithm::Gzip,
+                DigestSnapshotter {
+                    snapshotter: Arc::new(DumbSnapshotter::new()),
+                    compression_algorithm: CompressionAlgorithm::Gzip,
+                },
                 network,
                 test_dir.join("digests"),
                 Arc::new(immutable_file_digest_mapper),

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -270,6 +270,7 @@ mod tests {
             DigestArtifactBuilder::new(
                 SanitizedUrlWithTrailingSlash::parse("http://aggregator_uri").unwrap(),
                 vec![],
+                CompressionAlgorithm::Gzip,
                 network,
                 test_dir.join("digests"),
                 Arc::new(immutable_file_digest_mapper),

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -149,7 +149,7 @@ mod tests {
     use crate::{
         artifact_builder::{MockAncillaryFileUploader, MockImmutableFilesUploader},
         immutable_file_digest_mapper::MockImmutableFileDigestMapper,
-        services::FakeSnapshotter,
+        services::{DumbSnapshotter, FakeSnapshotter},
         test_tools::TestLogger,
         tools::url_sanitizer::SanitizedUrlWithTrailingSlash,
     };
@@ -270,6 +270,7 @@ mod tests {
             DigestArtifactBuilder::new(
                 SanitizedUrlWithTrailingSlash::parse("http://aggregator_uri").unwrap(),
                 vec![],
+                Arc::new(DumbSnapshotter::new()),
                 CompressionAlgorithm::Gzip,
                 network,
                 test_dir.join("digests"),

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
@@ -228,7 +228,12 @@ impl DigestArtifactBuilder {
     async fn upload_digest_file(&self, digest_filepath: &Path) -> StdResult<Vec<DigestLocation>> {
         let mut locations = Vec::<DigestLocation>::new();
         for uploader in &self.uploaders {
-            let result = uploader.upload(digest_filepath, None).await;
+            let result = uploader
+                .upload(
+                    digest_filepath,
+                    Some(self.digest_snapshotter.compression_algorithm),
+                )
+                .await;
             match result {
                 Ok(location) => {
                     locations.push(location);
@@ -618,7 +623,7 @@ mod tests {
 
         digest_file_uploader
             .expect_upload()
-            .with(eq(archive_path.clone()), eq(None))
+            .with(eq(archive_path.clone()), eq(Some(compression_algorithm)))
             .times(1)
             .return_once(move |_, _| {
                 assert!(

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
@@ -353,6 +353,7 @@ impl DependenciesBuilder {
         let digest_builder = Arc::new(DigestArtifactBuilder::new(
             self.configuration.get_server_url()?,
             self.build_cardano_database_digests_uploaders()?,
+            CompressionAlgorithm::Gzip,
             self.configuration.get_network()?,
             snapshot_dir.join("pending_cardano_database_digests"),
             self.get_immutable_file_digest_mapper().await?,

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.11.14"
+version = "0.11.15"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

Compress the digests file in the digests artifact builder for the cloud locations of the Incremental Cardano DB.

:hand: We create the digests archive in self.configuration.get_snapshot_dir()?.join("digests". Is it OK ?

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [ ] No new TODOs introduced

Closes #2356
