### PR TITLE
Feat: verify minimum node version with squash database migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.13"
+version = "0.7.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3900,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.47"
+version = "0.2.48"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.233"
+version = "0.2.234"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/website/adr/009-database-migration-squashing.md
+++ b/docs/website/adr/009-database-migration-squashing.md
@@ -14,17 +14,17 @@ Accepted
 
 ## Context
 
-Many database migrations have accumulated over time for the Mithril nodes. As the migrations are done sequentially, the resulting scheme of the database is hard to understand and maintain.
+Over time, many database migrations have accumulated in Mithril nodes. Since these migrations are applied sequentially, the resulting database schema has become difficult to understand and maintain.
 
 ## Decision
 
-To mitigate these concerns, we have decided to implement a migration squashing once we have stacked too many migrations for a store: all the existing migrations are consolidated and replaced by the equivalent new migration.
+To address this, the team decided to implement migration squashing once too many migrations have accumulated for a store. This process consolidates all existing migrations into a single, equivalent migration.
 
 ## Consequences
 
-- This applies to the migrations of all the stores of the Mithril nodes
+- This applies to the migrations of all Mithril node stores
 - A squashed migration will be applied when a database is initialized for the first time
-- A squashed migration must be optional and run only if not already applied previously with the equivalent migration sequence
-- Some nodes may have only partially applied the equivalent sequence of migrations and thus can not apply the squashed migration right away:
-  - They need to first run the migration with the latest distribution that does not ship the squashed migration so that their database is ready to play the squashed migration
-  - This distribution is associated to a squashed migration to provide a smooth user experience.
+- A squashed migration must be optional and should only run if it has not been previously applied with the equivalent migration sequence
+- Some nodes may have only partially applied the equivalent sequence of migrations and cannot apply the squashed migration immediately:
+  - They must first run the migration using the latest distribution that does not include the squashed migration, ensuring their database is prepared to apply it
+  - This distribution is associated with a squashed migration to provide a smooth user experience.

--- a/docs/website/adr/009-database-migration-squashing.md
+++ b/docs/website/adr/009-database-migration-squashing.md
@@ -1,0 +1,30 @@
+---
+slug: 9
+title: |
+  9. Database migration squashing
+authors:
+  - name: Mithril Team
+tags: [Accepted]
+date: 2025-03-13
+---
+
+## Status
+
+Accepted
+
+## Context
+
+Many database migrations have accumulated over time for the Mithril nodes. As the migrations are done sequentially, the resulting scheme of the database is hard to understand and maintain.
+
+## Decision
+
+To mitigate these concerns, we have decided to implement a migration squashing once we have stacked too many migrations for a store: all the existing migrations are consolidated and replaced by the equivalent new migration.
+
+## Consequences
+
+- This applies to the migrations of all the stores of the Mithril nodes
+- A squashed migration will be applied when a database is initialized for the first time
+- A squashed migration must be optional and run only if not already applied previously with the equivalent migration sequence
+- Some nodes may have only partially applied the equivalent sequence of migrations and thus can not apply the squashed migration right away:
+  - They need to first run the migration with the latest distribution that does not ship the squashed migration so that their database is ready to play the squashed migration
+  - This distribution is associated to a squashed migration to provide a smooth user experience.

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.47"
+version = "0.2.48"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/mod.rs
+++ b/internal/mithril-persistence/src/database/mod.rs
@@ -11,7 +11,7 @@ mod version_checker;
 
 pub use db_version::*;
 pub use hydrator::Hydrator;
-pub use version_checker::{DatabaseVersionChecker, NodeVersionRequirement, SqlMigration};
+pub use version_checker::{DatabaseVersionChecker, SqlMigration};
 
 /// Database version.
 pub type DbVersion = i64;

--- a/internal/mithril-persistence/src/database/mod.rs
+++ b/internal/mithril-persistence/src/database/mod.rs
@@ -11,7 +11,7 @@ mod version_checker;
 
 pub use db_version::*;
 pub use hydrator::Hydrator;
-pub use version_checker::{DatabaseVersionChecker, SqlMigration};
+pub use version_checker::{DatabaseVersionChecker, NodeVersionRequirement, SqlMigration};
 
 /// Database version.
 pub type DbVersion = i64;

--- a/internal/mithril-persistence/src/database/version_checker.rs
+++ b/internal/mithril-persistence/src/database/version_checker.rs
@@ -175,6 +175,9 @@ insert into db_version (application_type, version, updated_at) values ('{applica
 
                         First, download the required node version in your current directory by running the following command:
                         curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-{} -d {} -p $(pwd)
+
+                        Then run the database migrate command:
+                        mithril-{} database migrate --stores-directory /path/to/stores-directory
                     "#,
                     migration.version,
                     self.application_type.to_string(),
@@ -182,6 +185,7 @@ insert into db_version (application_type, version, updated_at) values ('{applica
                     min_requirement.release_version,
                     self.application_type.to_string(),
                     min_requirement.release_version,
+                    self.application_type.to_string()
                 ));
             }
         }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.13"
+version = "0.7.14"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/database_command.rs
+++ b/mithril-aggregator/src/commands/database_command.rs
@@ -1,0 +1,81 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::{Parser, Subcommand};
+use slog::{debug, Logger};
+
+use mithril_common::StdResult;
+
+use crate::{dependency_injection::DependenciesBuilder, Configuration, ExecutionEnvironment};
+
+/// Database tools
+#[derive(Parser, Debug, Clone)]
+pub struct DatabaseCommand {
+    /// commands
+    #[clap(subcommand)]
+    pub database_subcommand: DatabaseSubCommand,
+}
+
+impl DatabaseCommand {
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        self.database_subcommand.execute(root_logger).await
+    }
+}
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum DatabaseSubCommand {
+    /// Migrate databases located in the given stores directory
+    Migrate(MigrateCommand),
+}
+
+impl DatabaseSubCommand {
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        match self {
+            Self::Migrate(cmd) => cmd.execute(root_logger).await,
+        }
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct MigrateCommand {
+    /// Stores directory
+    #[clap(long, env = "STORES_DIRECTORY")]
+    stores_directory: PathBuf,
+}
+
+impl MigrateCommand {
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        let config = Configuration {
+            environment: ExecutionEnvironment::Production,
+            data_stores_directory: self.stores_directory.clone(),
+            // Temporary solution to avoid the need to provide a full configuration
+            ..Configuration::new_sample()
+        };
+        debug!(root_logger, "DATABASE MIGRATE command"; "config" => format!("{config:?}"));
+        println!(
+            "Migrating databases from stores directory: {}",
+            self.stores_directory.to_string_lossy()
+        );
+        let mut dependencies_builder =
+            DependenciesBuilder::new(root_logger.clone(), config.clone());
+
+        dependencies_builder
+            .get_sqlite_connection()
+            .await
+            .with_context(|| "Dependencies Builder can not get sqlite connection")?;
+
+        dependencies_builder
+            .get_event_store_sqlite_connection()
+            .await
+            .with_context(|| "Dependencies Builder can not get event store sqlite connection")?;
+
+        dependencies_builder
+            .get_sqlite_connection_cardano_transaction_pool()
+            .await
+            .with_context(|| {
+                "Dependencies Builder can not get cardano transaction pool sqlite connection"
+            })?;
+
+        Ok(())
+    }
+}

--- a/mithril-aggregator/src/commands/mod.rs
+++ b/mithril-aggregator/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod database_command;
 mod era_command;
 mod genesis_command;
 mod serve_command;
@@ -21,6 +22,7 @@ pub enum MainCommand {
     Era(era_command::EraCommand),
     Serve(serve_command::ServeCommand),
     Tools(tools_command::ToolsCommand),
+    Database(database_command::DatabaseCommand),
     #[clap(alias("doc"), hide(true))]
     GenerateDoc(GenerateDocCommands),
 }
@@ -44,6 +46,7 @@ impl MainCommand {
             Self::Era(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Serve(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Tools(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::Database(cmd) => cmd.execute(root_logger).await,
             Self::GenerateDoc(cmd) => {
                 let config_infos = vec![Configuration::extract(), DefaultConfiguration::extract()];
                 cmd.execute_with_configurations(&mut MainOpts::command(), &config_infos)
@@ -58,6 +61,7 @@ impl MainCommand {
             MainCommand::Genesis(_) => CommandType::CommandLine,
             MainCommand::Era(_) => CommandType::CommandLine,
             MainCommand::Tools(_) => CommandType::CommandLine,
+            MainCommand::Database(_) => CommandType::CommandLine,
             MainCommand::GenerateDoc(_) => CommandType::CommandLine,
         }
     }

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -1,8 +1,6 @@
 //! Migration module
 //!
-use semver::Version;
-
-use mithril_persistence::database::{NodeVersionRequirement, SqlMigration};
+use mithril_persistence::database::SqlMigration;
 
 /// Get all the migrations required by this version of the software.
 /// There shall be one migration per database version. There could be several
@@ -11,10 +9,7 @@ pub fn get_migrations() -> Vec<SqlMigration> {
     vec![
         SqlMigration::new_squashed(
             29,
-            NodeVersionRequirement {
-                node_version: Version::parse("0.2.228").unwrap(),
-                release_version: "2445.0".to_string(),
-            },
+            "2445.0",
             r#"
 create table if not exists signed_entity_type (
     signed_entity_type_id       integer     not null,

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -1,14 +1,20 @@
 //! Migration module
 //!
-use mithril_persistence::database::SqlMigration;
+use semver::Version;
+
+use mithril_persistence::database::{NodeVersionRequirement, SqlMigration};
 
 /// Get all the migrations required by this version of the software.
 /// There shall be one migration per database version. There could be several
 /// statements per migration.
 pub fn get_migrations() -> Vec<SqlMigration> {
     vec![
-        SqlMigration::new(
+        SqlMigration::new_squashed(
             29,
+            NodeVersionRequirement {
+                node_version: Version::parse("0.2.228").unwrap(),
+                release_version: "2445.0".to_string(),
+            },
             r#"
 create table if not exists signed_entity_type (
     signed_entity_type_id       integer     not null,

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.233"
+version = "0.2.234"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/commands/database_command.rs
+++ b/mithril-signer/src/commands/database_command.rs
@@ -1,0 +1,85 @@
+use std::path::PathBuf;
+
+use anyhow::Context;
+use clap::{Parser, Subcommand};
+use slog::{debug, Logger};
+
+use mithril_common::StdResult;
+
+use crate::{
+    dependency_injection::DependenciesBuilder, Configuration, SQLITE_FILE,
+    SQLITE_FILE_CARDANO_TRANSACTION,
+};
+
+/// Database tools
+#[derive(Parser, Debug, Clone)]
+pub struct DatabaseCommand {
+    /// commands
+    #[clap(subcommand)]
+    pub database_subcommand: DatabaseSubCommand,
+}
+
+impl DatabaseCommand {
+    /// Execute the database command
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        self.database_subcommand.execute(root_logger).await
+    }
+}
+
+/// Database subcommands
+#[derive(Debug, Clone, Subcommand)]
+pub enum DatabaseSubCommand {
+    /// Migrate databases located in the given stores directory
+    Migrate(MigrateCommand),
+}
+
+impl DatabaseSubCommand {
+    /// Execute the database subcommand
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        match self {
+            Self::Migrate(cmd) => cmd.execute(root_logger).await,
+        }
+    }
+}
+
+/// Migrate command
+#[derive(Parser, Debug, Clone)]
+pub struct MigrateCommand {
+    /// Stores directory
+    #[clap(long, env = "STORES_DIRECTORY")]
+    stores_directory: PathBuf,
+}
+
+impl MigrateCommand {
+    /// Execute the migrate command
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        let config = Configuration {
+            data_stores_directory: self.stores_directory.clone(),
+            // Temporary solution to avoid the need to provide a full configuration
+            ..Configuration::new_sample("0")
+        };
+        debug!(root_logger, "DATABASE MIGRATE command"; "config" => format!("{config:?}"));
+        println!(
+            "Migrating databases from stores directory: {}",
+            self.stores_directory.to_string_lossy()
+        );
+        let services = DependenciesBuilder::new(&config, root_logger.clone());
+
+        services
+            .build_sqlite_connection(SQLITE_FILE, crate::database::migration::get_migrations())
+            .await
+            .with_context(|| "Dependencies Builder can not get sqlite connection")?;
+
+        services
+            .build_sqlite_connection(
+                SQLITE_FILE_CARDANO_TRANSACTION,
+                mithril_persistence::database::cardano_transaction_migration::get_migrations(),
+            )
+            .await
+            .with_context(|| {
+                "Dependencies Builder can not get cardano transaction pool sqlite connection"
+            })?;
+
+        Ok(())
+    }
+}

--- a/mithril-signer/src/commands/mod.rs
+++ b/mithril-signer/src/commands/mod.rs
@@ -1,0 +1,3 @@
+mod database_command;
+
+pub use database_command::*;

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -6,6 +6,7 @@
 //! See the [Mithril documentation](https://mithril.network/doc/manual/developer-docs/nodes/mithril-signer)
 //! for more information on how it works.
 
+mod commands;
 mod configuration;
 pub mod database;
 pub mod dependency_injection;
@@ -16,6 +17,7 @@ mod runtime;
 pub mod services;
 pub mod store;
 
+pub use commands::*;
 pub use configuration::{Configuration, DefaultConfiguration};
 pub use entities::SignerEpochSettings;
 pub use message_adapters::{FromEpochSettingsAdapter, ToRegisterSignerMessageAdapter};


### PR DESCRIPTION
## Content

This PR includes the implementation of a minimum node version check for squash database migrations. In case of a version gap, an error message guides users to upgrade their node accordingly.

A new command has been added to both aggregator and signer nodes to manually trigger database migrations:

```bash
mithril-aggregator database migrate --stores-directory ./stores
```

```bash
mithril-signer database migrate --stores-directory ./stores
```

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [x] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2357 
