### PR TITLE
Reduce flakiness in the ci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3792,7 +3792,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.14"
+version = "0.7.15"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/database_command.rs
+++ b/mithril-aggregator/src/commands/database_command.rs
@@ -49,7 +49,7 @@ impl MigrateCommand {
             environment: ExecutionEnvironment::Production,
             data_stores_directory: self.stores_directory.clone(),
             // Temporary solution to avoid the need to provide a full configuration
-            ..Configuration::new_sample()
+            ..Configuration::new_sample(std::env::temp_dir())
         };
         debug!(root_logger, "DATABASE MIGRATE command"; "config" => format!("{config:?}"));
         println!(

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
@@ -184,7 +184,7 @@ impl DependenciesBuilder {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::entities::SignedEntityTypeDiscriminants;
+    use mithril_common::{entities::SignedEntityTypeDiscriminants, temp_dir};
 
     use crate::Configuration;
 
@@ -211,7 +211,7 @@ mod tests {
     ) {
         let configuration = Configuration {
             signed_entity_types: Some(signed_entity_types),
-            ..Configuration::new_sample()
+            ..Configuration::new_sample(temp_dir!())
         };
         let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
 

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
@@ -409,7 +409,7 @@ impl DependenciesBuilder {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::test_utils::TempDir;
+    use mithril_common::temp_dir_create;
     use mithril_persistence::sqlite::ConnectionBuilder;
 
     use crate::dependency_injection::builder::CARDANO_DB_ARTIFACTS_DIR;
@@ -419,10 +419,7 @@ mod tests {
 
     #[tokio::test]
     async fn if_not_local_uploader_create_cardano_database_immutable_dirs() {
-        let snapshot_directory = TempDir::create(
-            "builder",
-            "if_not_local_uploader_create_cardano_database_immutable_dirs",
-        );
+        let snapshot_directory = temp_dir_create!();
         let cdb_dir = snapshot_directory.join(CARDANO_DB_ARTIFACTS_DIR);
         let ancillary_dir = cdb_dir.join("ancillary");
         let immutable_dir = cdb_dir.join("immutable");
@@ -430,10 +427,9 @@ mod tests {
 
         let mut dep_builder = {
             let config = Configuration {
-                snapshot_directory,
                 // Test environment yield dumb uploaders
                 environment: ExecutionEnvironment::Test,
-                ..Configuration::new_sample()
+                ..Configuration::new_sample(snapshot_directory)
             };
 
             DependenciesBuilder::new_with_stdout_logger(config)
@@ -455,10 +451,7 @@ mod tests {
 
     #[tokio::test]
     async fn if_local_uploader_creates_all_cardano_database_subdirs() {
-        let snapshot_directory = TempDir::create(
-            "builder",
-            "if_local_uploader_creates_all_cardano_database_subdirs",
-        );
+        let snapshot_directory = temp_dir_create!();
         let cdb_dir = snapshot_directory.join(CARDANO_DB_ARTIFACTS_DIR);
         let ancillary_dir = cdb_dir.join("ancillary");
         let immutable_dir = cdb_dir.join("immutable");
@@ -466,11 +459,10 @@ mod tests {
 
         let mut dep_builder = {
             let config = Configuration {
-                snapshot_directory,
                 // Must use production environment to make `snapshot_uploader_type` effective
                 environment: ExecutionEnvironment::Production,
                 snapshot_uploader_type: SnapshotUploaderType::Local,
-                ..Configuration::new_sample()
+                ..Configuration::new_sample(snapshot_directory)
             };
 
             DependenciesBuilder::new_with_stdout_logger(config)

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -311,12 +311,12 @@ impl DependencyContainer {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    use std::path::{Path, PathBuf};
-
-    use mithril_common::current_function;
+    use mithril_common::test_utils::build_function_path;
 
     use crate::{dependency_injection::DependenciesBuilder, Configuration, DependencyContainer};
 
+    /// Initialize dependency container with a unique temporary snapshot directory build fril test path.
+    /// This macro should used directly in a function test to be able to retrieve the function name.
     #[macro_export]
     macro_rules! initialize_dependencies {
         () => {{
@@ -329,36 +329,12 @@ pub(crate) mod tests {
         name: N,
     ) -> DependencyContainer {
         let config = Configuration {
-            snapshot_directory: std::env::temp_dir().join(build_path(module, name)),
+            snapshot_directory: std::env::temp_dir().join(build_function_path(module, name)),
             ..Configuration::new_sample()
         };
 
         let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
 
         builder.build_dependency_container().await.unwrap()
-    }
-
-    fn build_path<M: Into<String>, N: Into<String>>(module: M, function: N) -> PathBuf {
-        PathBuf::from(module.into().replace("::", "/")).join(function.into())
-    }
-
-    #[test]
-    fn test_build_path() {
-        assert_eq!(
-            Path::new("module")
-                .join("sub_module")
-                .join("file")
-                .join("function"),
-            build_path("module::sub_module::file", "function")
-        );
-
-        assert_eq!(
-            Path::new("mithril_aggregator")
-                .join("dependency_injection")
-                .join("containers")
-                .join("tests")
-                .join("test_build_path"),
-            build_path(module_path!(), current_function!())
-        );
     }
 }

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -311,27 +311,21 @@ impl DependencyContainer {
 #[cfg(test)]
 pub(crate) mod tests {
 
-    use mithril_common::test_utils::build_function_path;
+    use std::path::PathBuf;
 
     use crate::{dependency_injection::DependenciesBuilder, Configuration, DependencyContainer};
 
-    /// Initialize dependency container with a unique temporary snapshot directory build fril test path.
+    /// Initialize dependency container with a unique temporary snapshot directory build from test path.
     /// This macro should used directly in a function test to be able to retrieve the function name.
     #[macro_export]
     macro_rules! initialize_dependencies {
         () => {{
-            initialize_dependencies(module_path!(), mithril_common::current_function!())
+            initialize_dependencies(mithril_common::temp_dir!())
         }};
     }
 
-    pub async fn initialize_dependencies<M: Into<String>, N: Into<String>>(
-        module: M,
-        name: N,
-    ) -> DependencyContainer {
-        let config = Configuration {
-            snapshot_directory: std::env::temp_dir().join(build_function_path(module, name)),
-            ..Configuration::new_sample()
-        };
+    pub async fn initialize_dependencies(tmp_path: PathBuf) -> DependencyContainer {
+        let config = Configuration::new_sample(tmp_path);
 
         let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
 

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_database.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_database.rs
@@ -202,7 +202,9 @@ mod tests {
             .expect_get_cardano_database_list_message()
             .return_once(|_| Ok(vec![CardanoDatabaseSnapshotListItemMessage::dummy()]))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+
+        let mut dependency_manager = initialize_dependencies!().await;
+
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -235,7 +237,7 @@ mod tests {
             .expect_get_cardano_database_list_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -266,7 +268,7 @@ mod tests {
     ) {
         let method = Method::GET.as_str();
         let path = "/artifact/cardano-database/{hash}";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_artifact_detail_cardano_database_total_served_since_startup()
@@ -296,7 +298,7 @@ mod tests {
             .expect_get_cardano_database_message()
             .return_once(|_| Ok(Some(CardanoDatabaseSnapshotMessage::dummy())))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -330,7 +332,7 @@ mod tests {
             .expect_get_cardano_database_message()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -363,7 +365,7 @@ mod tests {
             .expect_get_cardano_database_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -396,7 +398,7 @@ mod tests {
             .expect_get_cardano_database_digest_list_message()
             .return_once(|| Ok(vec![CardanoDatabaseDigestListItemMessage::dummy()]))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -429,7 +431,7 @@ mod tests {
             .expect_get_cardano_database_digest_list_message()
             .return_once(|| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_stake_distribution.rs
@@ -182,7 +182,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_list_message()
             .return_once(|_| Ok(message))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -215,7 +215,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_list_message()
             .return_once(|_| Err(anyhow!("an error occured")))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -245,7 +245,7 @@ pub mod tests {
     async fn test_cardano_stake_distribution_increments_artifact_detail_total_served_since_startup_metric(
     ) {
         let method = Method::GET.as_str();
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_artifact_detail_cardano_stake_distribution_total_served_since_startup()
@@ -299,7 +299,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_message()
             .return_once(|_| Ok(Some(message)))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -332,7 +332,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_message()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -365,7 +365,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_message()
             .return_once(|_| Err(anyhow!("an error occured")))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -399,7 +399,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_message_by_epoch()
             .return_once(|_| Ok(Some(message)))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -428,7 +428,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_cardano_stake_distribution_by_epoch_returns_400_bad_request_when_invalid_epoch() {
         let mock_http_message_service = MockMessageService::new();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -461,7 +461,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_message_by_epoch()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -494,7 +494,7 @@ pub mod tests {
             .expect_get_cardano_stake_distribution_message_by_epoch()
             .return_once(|_| Err(anyhow!("an error occured")))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/cardano_transaction.rs
@@ -126,7 +126,7 @@ pub mod tests {
             .expect_get_cardano_transaction_list_message()
             .return_once(|_| Ok(vec![CardanoTransactionSnapshotListItemMessage::dummy()]))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -159,7 +159,7 @@ pub mod tests {
             .expect_get_cardano_transaction_list_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -190,7 +190,7 @@ pub mod tests {
     {
         let method = Method::GET.as_str();
         let path = "/artifact/cardano-transaction/{hash}";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_artifact_detail_cardano_transaction_total_served_since_startup()
@@ -220,7 +220,7 @@ pub mod tests {
             .expect_get_cardano_transaction_message()
             .return_once(|_| Ok(Some(CardanoTransactionSnapshotMessage::dummy())))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -253,7 +253,7 @@ pub mod tests {
             .expect_get_cardano_transaction_message()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -286,7 +286,7 @@ pub mod tests {
             .expect_get_cardano_transaction_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/mithril_stake_distribution.rs
@@ -126,7 +126,7 @@ pub mod tests {
             .expect_get_mithril_stake_distribution_list_message()
             .return_once(|_| Ok(vec![MithrilStakeDistributionListItemMessage::dummy()]))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -159,7 +159,7 @@ pub mod tests {
             .expect_get_mithril_stake_distribution_list_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -190,7 +190,7 @@ pub mod tests {
     ) {
         let method = Method::GET.as_str();
         let path = "/artifact/mithril-stake-distribution/{hash}";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_artifact_detail_mithril_stake_distribution_total_served_since_startup()
@@ -220,7 +220,7 @@ pub mod tests {
             .expect_get_mithril_stake_distribution_message()
             .return_once(|_| Ok(Some(MithrilStakeDistributionMessage::dummy())))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -253,7 +253,7 @@ pub mod tests {
             .expect_get_mithril_stake_distribution_message()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -286,7 +286,7 @@ pub mod tests {
             .expect_get_mithril_stake_distribution_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();

--- a/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
+++ b/mithril-aggregator/src/http_server/routes/artifact_routes/snapshot.rs
@@ -248,7 +248,7 @@ mod tests {
             .expect_get_snapshot_list_message()
             .return_once(|_| Ok(vec![SnapshotListItemMessage::dummy()]))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -281,7 +281,7 @@ mod tests {
             .expect_get_snapshot_list_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -311,7 +311,7 @@ mod tests {
     async fn test_snapshot_digest_increments_artifact_detail_total_served_since_startup_metric() {
         let method = Method::GET.as_str();
         let path = "/artifact/snapshot/{digest}";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_artifact_detail_cardano_immutable_files_full_total_served_since_startup()
@@ -341,7 +341,7 @@ mod tests {
             .expect_get_snapshot_message()
             .return_once(|_| Ok(Some(SnapshotMessage::dummy())))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -374,7 +374,7 @@ mod tests {
             .expect_get_snapshot_message()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -407,7 +407,7 @@ mod tests {
             .expect_get_snapshot_message()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.message_service = Arc::new(mock_http_message_service);
 
         let method = Method::GET.as_str();
@@ -448,7 +448,7 @@ mod tests {
             .expect_get_signed_snapshot_by_id()
             .return_once(|_| Ok(Some(signed_entity)))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signed_entity_service = Arc::new(mock_signed_entity_service);
 
         let method = Method::GET.as_str();
@@ -484,7 +484,7 @@ mod tests {
             .expect_get_signed_snapshot_by_id()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signed_entity_service = Arc::new(mock_signed_entity_service);
 
         let method = Method::GET.as_str();
@@ -517,7 +517,7 @@ mod tests {
             .expect_get_signed_snapshot_by_id()
             .return_once(|_| Err(HydrationError::InvalidData("invalid data".to_string()).into()))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signed_entity_service = Arc::new(mock_signed_entity_service);
 
         let method = Method::GET.as_str();

--- a/mithril-aggregator/src/http_server/routes/certificate_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/certificate_routes.rs
@@ -113,7 +113,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_certificate_certificates_get_ok() {
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
         dependency_manager
             .certificate_repository
             .create_certificate(fake_data::genesis_certificate("{certificate_hash}"))
@@ -145,7 +145,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_certificate_when_error_retrieving_certificates_returns_ko_500() {
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let mut message_service = MockMessageService::new();
         message_service
             .expect_get_certificate_list_message()
@@ -180,7 +180,7 @@ mod tests {
     ) {
         let method = Method::GET.as_str();
         let path = "/certificate/{certificate_hash}";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_certificate_detail_total_served_since_startup()
@@ -205,7 +205,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_certificate_certificate_hash_get_ok() {
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
         dependency_manager
             .certificate_repository
             .create_certificate(fake_data::genesis_certificate("{certificate_hash}"))
@@ -237,7 +237,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_certificate_certificate_hash_get_ok_404() {
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
 
         let method = Method::GET.as_str();
         let path = "/certificate/{certificate_hash}";
@@ -264,7 +264,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_certificate_when_error_on_retrieving_certificate_hash_returns_ko_500() {
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let mut message_service = MockMessageService::new();
         message_service
             .expect_get_certificate_message()

--- a/mithril-aggregator/src/http_server/routes/epoch_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/epoch_routes.rs
@@ -86,7 +86,7 @@ mod tests {
     async fn test_epoch_settings_get_ok() {
         let method = Method::GET.as_str();
         let path = "/epoch-settings";
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let mut mock_http_message_service = MockMessageService::new();
         mock_http_message_service
             .expect_get_epoch_settings_message()
@@ -118,7 +118,7 @@ mod tests {
     async fn test_epoch_settings_get_ko_500() {
         let method = Method::GET.as_str();
         let path = "/epoch-settings";
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let mut mock_http_message_service = MockMessageService::new();
         mock_http_message_service
             .expect_get_epoch_settings_message()

--- a/mithril-aggregator/src/http_server/routes/proof_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/proof_routes.rs
@@ -202,7 +202,7 @@ mod tests {
     async fn test_proof_cardano_transaction_increments_proofs_metrics() {
         let method = Method::GET.as_str();
         let path = "/proof/cardano-transaction";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_proofs_counter_value = dependency_manager
             .metrics_service
             .get_proof_cardano_transaction_total_proofs_served_since_startup()
@@ -243,7 +243,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_ok() {
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
             .expect_get_last_cardano_transaction_snapshot()
@@ -285,7 +285,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_not_found() {
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
 
         let method = Method::GET.as_str();
         let path = "/proof/cardano-transaction";
@@ -316,7 +316,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_ko() {
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
             .expect_get_last_cardano_transaction_snapshot()
@@ -352,7 +352,7 @@ mod tests {
 
     #[tokio::test]
     async fn proof_cardano_transaction_return_bad_request_with_invalid_hashes() {
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
 
         let method = Method::GET.as_str();
         let path = "/proof/cardano-transaction";
@@ -382,7 +382,7 @@ mod tests {
     #[tokio::test]
     async fn proof_cardano_transaction_route_deduplicate_hashes() {
         let tx = fake_data::transaction_hashes()[0].to_string();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let mut mock_signed_entity_service = MockSignedEntityService::new();
         mock_signed_entity_service
             .expect_get_last_cardano_transaction_snapshot()

--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -120,7 +120,7 @@ mod tests {
             ]),
             ..RouterConfig::dummy()
         };
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
 
         let expected_open_api_version = dependency_manager
             .api_version_provider
@@ -182,7 +182,7 @@ mod tests {
             cardano_transactions_prover_max_hashes_allowed_by_request: 99,
             ..RouterConfig::dummy()
         };
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
 
         let response = request()
             .method(method)

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -190,9 +190,8 @@ mod tests {
         era::{EraChecker, SupportedEra},
     };
 
-    use crate::dependency_injection::DependenciesBuilder;
+    use crate::initialize_dependencies;
     use crate::test_tools::TestLogger;
-    use crate::Configuration;
 
     use super::*;
 
@@ -259,12 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_404_response_should_include_status_code_and_headers() {
-        let container = Arc::new(
-            DependenciesBuilder::new_with_stdout_logger(Configuration::new_sample())
-                .build_dependency_container()
-                .await
-                .unwrap(),
-        );
+        let container = Arc::new(initialize_dependencies!().await);
         let state = RouterState::new_with_dummy_config(container);
         let routes = routes(Arc::new(state));
 

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -151,7 +151,7 @@ mod tests {
     ) {
         let method = Method::POST.as_str();
         let path = "/register-signatures";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_signature_registration_total_received_since_startup()
@@ -183,7 +183,7 @@ mod tests {
             .withf(|_, signature| signature.is_authenticated())
             .once()
             .return_once(move |_, _| Ok(SignatureRegistrationStatus::Registered));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());
@@ -212,7 +212,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .never();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_reject_everything());
@@ -252,7 +252,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .return_once(move |_, _| Ok(SignatureRegistrationStatus::Registered));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());
@@ -289,7 +289,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .return_once(move |_, _| Ok(SignatureRegistrationStatus::Buffered));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());
@@ -326,7 +326,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .return_once(move |_, _| Ok(SignatureRegistrationStatus::Registered));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());
@@ -368,7 +368,7 @@ mod tests {
             .return_once(move |_, _| {
                 Err(CertifierServiceError::NotFound(signed_entity_type).into())
             });
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());
@@ -407,7 +407,7 @@ mod tests {
             .return_once(move |_, _| {
                 Err(CertifierServiceError::AlreadyCertified(signed_entity_type).into())
             });
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());
@@ -454,7 +454,7 @@ mod tests {
             .return_once(move |_, _| {
                 Err(CertifierServiceError::Expired(SignedEntityType::dummy()).into())
             });
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());
@@ -498,7 +498,7 @@ mod tests {
         mock_certifier_service
             .expect_register_single_signature()
             .return_once(move |_, _| Err(anyhow!("an error occurred")));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.certifier_service = Arc::new(mock_certifier_service);
         dependency_manager.single_signer_authenticator =
             Arc::new(SingleSignatureAuthenticator::new_that_authenticate_everything());

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -302,7 +302,7 @@ mod tests {
         mock_signer_registerer
             .expect_register_signer()
             .return_once(|_, _| Ok(signer_with_stake));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signer_registerer = Arc::new(mock_signer_registerer);
 
         let signer: RegisterSignerMessage = RegisterSignerMessage::dummy();
@@ -336,7 +336,7 @@ mod tests {
     ) {
         let method = Method::POST.as_str();
         let path = "/register-signer";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_signer_registration_total_received_since_startup()
@@ -371,7 +371,7 @@ mod tests {
                     signer_with_stake,
                 )))
             });
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signer_registerer = Arc::new(mock_signer_registerer);
 
         let signer: RegisterSignerMessage = RegisterSignerMessage::dummy();
@@ -410,7 +410,7 @@ mod tests {
                     ProtocolRegistrationError::OpCertInvalid
                 )))
             });
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signer_registerer = Arc::new(mock_signer_registerer);
 
         let signer: RegisterSignerMessage = RegisterSignerMessage::dummy();
@@ -449,7 +449,7 @@ mod tests {
                     "an error occurred".to_string(),
                 ))
             });
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signer_registerer = Arc::new(mock_signer_registerer);
 
         let signer: RegisterSignerMessage = RegisterSignerMessage::dummy();
@@ -483,7 +483,7 @@ mod tests {
         mock_signer_registerer
             .expect_register_signer()
             .return_once(|_, _| Err(SignerRegistrationError::RegistrationRoundNotYetOpened));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signer_registerer = Arc::new(mock_signer_registerer);
 
         let signer: RegisterSignerMessage = RegisterSignerMessage::dummy();
@@ -521,7 +521,7 @@ mod tests {
             .with(eq(expected_retrieval_epoch))
             .return_once(|_| Ok(Some(fake_data::signers_with_stakes(3))))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.verification_key_store = Arc::new(mock_verification_key_store);
 
         let method = Method::GET.as_str();
@@ -548,7 +548,7 @@ mod tests {
             .expect_get_signers()
             .return_once(|_| Ok(Some(fake_data::signers_with_stakes(3))))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.verification_key_store = Arc::new(mock_verification_key_store);
 
         let base_path = "/signers/registered";
@@ -581,7 +581,7 @@ mod tests {
             .expect_get_signers()
             .return_once(|_| Ok(None))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.verification_key_store = Arc::new(mock_verification_key_store);
 
         let method = Method::GET.as_str();
@@ -613,7 +613,7 @@ mod tests {
         mock_verification_key_store
             .expect_get_signers()
             .return_once(|_| Err(anyhow!("invalid query")));
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.verification_key_store = Arc::new(mock_verification_key_store);
 
         let method = Method::GET.as_str();
@@ -663,7 +663,7 @@ mod tests {
                 ])
             })
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signer_getter = Arc::new(mock_signer_getter);
 
         let method = Method::GET.as_str();
@@ -696,7 +696,7 @@ mod tests {
             .expect_get_all()
             .return_once(|| Err(anyhow!("an error")))
             .once();
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         dependency_manager.signer_getter = Arc::new(mock_signer_getter);
 
         let method = Method::GET.as_str();

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -192,14 +192,14 @@ mod handlers {
 mod tests {
     use super::*;
 
-    use mithril_common::current_function;
     use mithril_common::messages::{
         CardanoDatabaseImmutableFilesRestoredMessage, SnapshotDownloadMessage,
     };
+    use mithril_common::temp_dir;
     use mithril_common::test_utils::apispec::APISpec;
-    use mithril_common::test_utils::build_function_path;
     use tokio::sync::mpsc::UnboundedReceiver;
 
+    use std::path::PathBuf;
     use std::sync::Arc;
     use warp::{
         http::{Method, StatusCode},
@@ -227,7 +227,7 @@ mod tests {
 
     #[tokio::test]
     async fn post_statistics_ok() {
-        let (dependency_manager, mut rx) = setup_dependencies(current_function!()).await;
+        let (dependency_manager, mut rx) = setup_dependencies(temp_dir!()).await;
         let snapshot_download_message = SnapshotDownloadMessage::dummy();
 
         let method = Method::POST.as_str();
@@ -396,13 +396,9 @@ mod tests {
     }
 
     async fn setup_dependencies(
-        test_name: &str,
+        snapshot_directory: PathBuf,
     ) -> (Arc<DependencyContainer>, UnboundedReceiver<EventMessage>) {
-        let config = Configuration {
-            snapshot_directory: std::env::temp_dir()
-                .join(build_function_path(module_path!(), test_name)),
-            ..Configuration::new_sample()
-        };
+        let config = Configuration::new_sample(snapshot_directory);
         let mut builder = DependenciesBuilder::new_with_stdout_logger(config);
         let rx = builder.get_event_transmitter_receiver().await.unwrap();
         let dependency_manager = Arc::new(builder.build_dependency_container().await.unwrap());
@@ -417,7 +413,7 @@ mod tests {
 
         #[tokio::test]
         async fn conform_to_open_api_when_created() {
-            let (dependency_manager, _rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, _rx) = setup_dependencies(temp_dir!()).await;
 
             let response = request()
                 .method(HTTP_METHOD.as_str())
@@ -443,7 +439,7 @@ mod tests {
 
         #[tokio::test]
         async fn should_conform_to_openapi_when_server_error() {
-            let (dependency_manager, mut rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, mut rx) = setup_dependencies(temp_dir!()).await;
             rx.close();
 
             let response = request()
@@ -469,7 +465,7 @@ mod tests {
 
         #[tokio::test]
         async fn should_send_event() {
-            let (dependency_manager, mut rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, mut rx) = setup_dependencies(temp_dir!()).await;
 
             request()
                 .method(HTTP_METHOD.as_str())
@@ -488,7 +484,7 @@ mod tests {
 
         #[tokio::test]
         async fn increments_metric() {
-            let (dependency_manager, _rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, _rx) = setup_dependencies(temp_dir!()).await;
             let metric_counter = dependency_manager
                 .metrics_service
                 .get_cardano_database_complete_restoration_since_startup();
@@ -516,7 +512,7 @@ mod tests {
 
         #[tokio::test]
         async fn conform_to_open_api_when_created() {
-            let (dependency_manager, _rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, _rx) = setup_dependencies(temp_dir!()).await;
             let response = request()
                 .method(HTTP_METHOD.as_str())
                 .json(&Value::Null)
@@ -541,7 +537,7 @@ mod tests {
 
         #[tokio::test]
         async fn should_conform_to_openapi_when_server_error() {
-            let (dependency_manager, mut rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, mut rx) = setup_dependencies(temp_dir!()).await;
             rx.close();
 
             let response = request()
@@ -567,7 +563,7 @@ mod tests {
 
         #[tokio::test]
         async fn should_send_event() {
-            let (dependency_manager, mut rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, mut rx) = setup_dependencies(temp_dir!()).await;
 
             request()
                 .method(HTTP_METHOD.as_str())
@@ -586,7 +582,7 @@ mod tests {
 
         #[tokio::test]
         async fn increments_metric() {
-            let (dependency_manager, _rx) = setup_dependencies(current_function!()).await;
+            let (dependency_manager, _rx) = setup_dependencies(temp_dir!()).await;
             let metric_counter = dependency_manager
                 .metrics_service
                 .get_cardano_database_partial_restoration_since_startup();

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -261,7 +261,7 @@ mod tests {
     async fn test_post_statistics_increments_cardano_db_total_restoration_since_startup_metric() {
         let method = Method::POST.as_str();
         let path = "/statistics/snapshot";
-        let dependency_manager = Arc::new(initialize_dependencies().await);
+        let dependency_manager = Arc::new(initialize_dependencies!().await);
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_cardano_immutable_files_full_total_restoration_since_startup()
@@ -295,7 +295,7 @@ mod tests {
         async fn conform_to_open_api_when_created() {
             let message = CardanoDatabaseImmutableFilesRestoredMessage::dummy();
 
-            let dependency_manager = Arc::new(initialize_dependencies().await);
+            let dependency_manager = Arc::new(initialize_dependencies!().await);
             let response = request()
                 .method(HTTP_METHOD.as_str())
                 .json(&message)
@@ -320,7 +320,7 @@ mod tests {
 
         #[tokio::test]
         async fn increments_metric() {
-            let dependency_manager = Arc::new(initialize_dependencies().await);
+            let dependency_manager = Arc::new(initialize_dependencies!().await);
             let metric_counter = dependency_manager
                 .metrics_service
                 .get_cardano_database_immutable_files_restored_since_startup();
@@ -351,7 +351,7 @@ mod tests {
 
         #[tokio::test]
         async fn conform_to_open_api_when_created() {
-            let dependency_manager = Arc::new(initialize_dependencies().await);
+            let dependency_manager = Arc::new(initialize_dependencies!().await);
             let response = request()
                 .method(HTTP_METHOD.as_str())
                 .json(&Value::Null)
@@ -376,7 +376,7 @@ mod tests {
 
         #[tokio::test]
         async fn increments_metric() {
-            let dependency_manager = Arc::new(initialize_dependencies().await);
+            let dependency_manager = Arc::new(initialize_dependencies!().await);
             let metric_counter = dependency_manager
                 .metrics_service
                 .get_cardano_database_ancillary_files_restored_since_startup();

--- a/mithril-aggregator/src/http_server/routes/status.rs
+++ b/mithril-aggregator/src/http_server/routes/status.rs
@@ -139,7 +139,7 @@ mod tests {
 
     #[tokio::test]
     async fn status_route_ko_500() {
-        let dependency_manager = initialize_dependencies().await;
+        let dependency_manager = initialize_dependencies!().await;
         let method = Method::GET.as_str();
         let path = "/status";
 
@@ -165,7 +165,7 @@ mod tests {
 
     #[tokio::test]
     async fn status_route_ok_200() {
-        let mut dependency_manager = initialize_dependencies().await;
+        let mut dependency_manager = initialize_dependencies!().await;
         let fixture = MithrilFixtureBuilder::default().build();
         let epoch_service = FakeEpochService::from_fixture(Epoch(5), &fixture);
         dependency_manager.epoch_service = Arc::new(RwLock::new(epoch_service));

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -531,9 +531,11 @@ pub mod tests {
     };
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
+    use mithril_common::current_function;
     use mithril_common::entities::{
         ChainPoint, Epoch, SignedEntityConfig, SignedEntityTypeDiscriminants,
     };
+    use mithril_common::test_utils::build_function_path;
     use mithril_common::{
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
@@ -875,7 +877,11 @@ pub mod tests {
             .returning(|_| Ok(()))
             .times(1);
 
-        let config = Configuration::new_sample();
+        let config = Configuration {
+            snapshot_directory: std::env::temp_dir()
+                .join(build_function_path(module_path!(), current_function!())),
+            ..Configuration::new_sample()
+        };
         let mut deps = DependenciesBuilder::new_with_stdout_logger(config.clone())
             .build_dependency_container()
             .await

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -585,7 +585,7 @@ pub mod tests {
     }
 
     async fn build_runner(mock_certifier_service: MockCertifierService) -> AggregatorRunner {
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         deps.certifier_service = Arc::new(mock_certifier_service);
 
         let mut mock_signable_builder_service = MockSignableBuilderServiceImpl::new();
@@ -654,7 +654,7 @@ pub mod tests {
     #[tokio::test]
     async fn test_get_time_point_from_chain() {
         let expected = TimePoint::new(2, 17, ChainPoint::dummy());
-        let mut dependencies = initialize_dependencies().await;
+        let mut dependencies = initialize_dependencies!().await;
         let immutable_file_observer = Arc::new(DumbImmutableFileObserver::default());
         immutable_file_observer
             .shall_return(Some(expected.immutable_file_number))
@@ -673,7 +673,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_update_stake_distribution() {
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         let chain_observer = Arc::new(FakeObserver::default());
         deps.chain_observer = chain_observer.clone();
         deps.stake_distribution_service = Arc::new(MithrilStakeDistributionService::new(
@@ -711,7 +711,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_open_signer_registration_round() {
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         let signer_registration_round_opener = Arc::new(MithrilSignerRegistrationMaster::new(
             deps.verification_key_store.clone(),
             deps.signer_recorder.clone(),
@@ -751,7 +751,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_close_signer_registration_round() {
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         let signer_registration_round_opener = Arc::new(MithrilSignerRegistrationMaster::new(
             deps.verification_key_store.clone(),
             deps.signer_recorder.clone(),
@@ -797,7 +797,7 @@ pub mod tests {
             .expect_mark_open_message_if_expired()
             .return_once(|_| Ok(Some(open_message_clone)));
 
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         deps.certifier_service = Arc::new(mock_certifier_service);
 
         let runner = build_runner_with_fixture_data(deps).await;
@@ -811,7 +811,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_update_era_checker() {
-        let deps = initialize_dependencies().await;
+        let deps = initialize_dependencies!().await;
         let ticker_service = deps.ticker_service.clone();
         let era_checker = deps.era_checker.clone();
         let mut time_point = ticker_service.get_current_time_point().await.unwrap();
@@ -831,7 +831,7 @@ pub mod tests {
             .expect_inform_epoch()
             .returning(|_| Ok(()))
             .times(1);
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         let current_epoch = deps
             .chain_observer
             .get_current_epoch()
@@ -859,7 +859,7 @@ pub mod tests {
             .returning(|_| Ok(()))
             .times(1);
 
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         deps.upkeep_service = Arc::new(upkeep_service);
 
         let runner = AggregatorRunner::new(Arc::new(deps));
@@ -911,7 +911,7 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_precompute_epoch_data() {
-        let mut deps = initialize_dependencies().await;
+        let mut deps = initialize_dependencies!().await;
         let current_epoch = deps
             .chain_observer
             .get_current_epoch()
@@ -1132,7 +1132,7 @@ pub mod tests {
     #[tokio::test]
     async fn list_available_signed_entity_types_list_all_configured_entities_if_none_are_locked() {
         let runner = {
-            let mut dependencies = initialize_dependencies().await;
+            let mut dependencies = initialize_dependencies!().await;
             let epoch_service = FakeEpochServiceBuilder {
                 signed_entity_config: SignedEntityConfig {
                     allowed_discriminants: SignedEntityTypeDiscriminants::all(),
@@ -1167,7 +1167,7 @@ pub mod tests {
     async fn list_available_signed_entity_types_exclude_locked_entities() {
         let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
         let runner = {
-            let mut dependencies = initialize_dependencies().await;
+            let mut dependencies = initialize_dependencies!().await;
             dependencies.signed_entity_type_lock = signed_entity_type_lock.clone();
             let epoch_service = FakeEpochServiceBuilder {
                 signed_entity_config: SignedEntityConfig {
@@ -1241,7 +1241,7 @@ pub mod tests {
         };
 
         let runner = {
-            let mut deps = initialize_dependencies().await;
+            let mut deps = initialize_dependencies!().await;
             let mut mock_certifier_service = MockCertifierService::new();
 
             let open_message_current = open_message_to_verify.clone();

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -531,11 +531,10 @@ pub mod tests {
     };
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
-    use mithril_common::current_function;
     use mithril_common::entities::{
         ChainPoint, Epoch, SignedEntityConfig, SignedEntityTypeDiscriminants,
     };
-    use mithril_common::test_utils::build_function_path;
+    use mithril_common::temp_dir;
     use mithril_common::{
         chain_observer::FakeObserver,
         digesters::DumbImmutableFileObserver,
@@ -877,11 +876,7 @@ pub mod tests {
             .returning(|_| Ok(()))
             .times(1);
 
-        let config = Configuration {
-            snapshot_directory: std::env::temp_dir()
-                .join(build_function_path(module_path!(), current_function!())),
-            ..Configuration::new_sample()
-        };
+        let config = Configuration::new_sample(temp_dir!());
         let mut deps = DependenciesBuilder::new_with_stdout_logger(config.clone())
             .build_dependency_container()
             .await

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -385,15 +385,17 @@ impl CertifierService for MithrilCertifierService {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use crate::{
         dependency_injection::DependenciesBuilder, multi_signer::MockMultiSigner,
         services::FakeEpochService, test_tools::TestLogger, Configuration,
     };
     use chrono::{DateTime, Days};
     use mithril_common::{
-        current_function,
         entities::{CardanoDbBeacon, ProtocolMessagePartKey},
-        test_utils::{build_function_path, fake_data, MithrilFixture, MithrilFixtureBuilder},
+        temp_dir,
+        test_utils::{fake_data, MithrilFixture, MithrilFixtureBuilder},
     };
     use tokio::sync::RwLock;
 
@@ -430,17 +432,13 @@ mod tests {
 
     /// Note: If current_epoch is provided the [EpochService] will be automatically initialized
     async fn setup_certifier_service_with_network(
-        test_name: &str,
+        snapshot_directory: PathBuf,
         network: CardanoNetwork,
         fixture: &MithrilFixture,
         epochs_with_signers: &[Epoch],
         current_epoch: Option<Epoch>,
     ) -> MithrilCertifierService {
-        let configuration = Configuration {
-            snapshot_directory: std::env::temp_dir()
-                .join(build_function_path(module_path!(), test_name)),
-            ..Configuration::new_sample()
-        };
+        let configuration = Configuration::new_sample(snapshot_directory);
         let mut dependency_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         if let Some(epoch) = current_epoch {
             dependency_builder.epoch_service = Some(Arc::new(RwLock::new(
@@ -460,13 +458,13 @@ mod tests {
     }
 
     async fn setup_certifier_service(
-        test_name: &str,
+        snapshot_directory: PathBuf,
         fixture: &MithrilFixture,
         epochs_with_signers: &[Epoch],
         current_epoch: Option<Epoch>,
     ) -> MithrilCertifierService {
         setup_certifier_service_with_network(
-            test_name,
+            snapshot_directory,
             fake_data::network(),
             fixture,
             epochs_with_signers,
@@ -484,8 +482,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         certifier_service
             .create_open_message(&signed_entity_type, &protocol_message)
             .await
@@ -506,8 +503,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -540,8 +536,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -569,8 +564,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -598,7 +592,7 @@ mod tests {
         let epochs_with_signers = (1..=3).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
         let certifier_service = setup_certifier_service(
-            current_function!(),
+            temp_dir!(),
             &fixture,
             &epochs_with_signers,
             Some(beacon.epoch),
@@ -636,7 +630,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
         let certifier_service = setup_certifier_service(
-            current_function!(),
+            temp_dir!(),
             &fixture,
             &epochs_with_signers,
             Some(beacon.epoch),
@@ -681,8 +675,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -715,8 +708,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -751,7 +743,7 @@ mod tests {
         let epochs_with_signers = (1..=3).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
         let certifier_service = setup_certifier_service_with_network(
-            current_function!(),
+            temp_dir!(),
             network,
             &fixture,
             &epochs_with_signers,
@@ -825,8 +817,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         certifier_service
             .create_certificate(&signed_entity_type)
             .await
@@ -842,8 +833,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         certifier_service
             .open_message_repository
             .create_open_message(epoch, &signed_entity_type, &protocol_message)
@@ -867,8 +857,7 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let mut certifier_service =
-            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
-                .await;
+            setup_certifier_service(temp_dir!(), &fixture, &epochs_with_signers, None).await;
         certifier_service.multi_signer = Arc::new(mock_multi_signer);
         certifier_service
             .create_open_message(&signed_entity_type, &protocol_message)
@@ -885,7 +874,7 @@ mod tests {
     async fn test_epoch_gap_certificate_chain() {
         let builder = MithrilFixtureBuilder::default();
         let certifier_service =
-            setup_certifier_service(current_function!(), &builder.build(), &[], None).await;
+            setup_certifier_service(temp_dir!(), &builder.build(), &[], None).await;
         let certificate = fake_data::genesis_certificate("whatever");
         let epoch = certificate.epoch + 2;
         certifier_service
@@ -911,7 +900,7 @@ mod tests {
     async fn test_epoch_gap_certificate_chain_ok() {
         let builder = MithrilFixtureBuilder::default();
         let certifier_service =
-            setup_certifier_service(current_function!(), &builder.build(), &[], None).await;
+            setup_certifier_service(temp_dir!(), &builder.build(), &[], None).await;
         let certificate = fake_data::genesis_certificate("whatever");
         let epoch = certificate.epoch + 1;
         certifier_service

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -391,8 +391,9 @@ mod tests {
     };
     use chrono::{DateTime, Days};
     use mithril_common::{
+        current_function,
         entities::{CardanoDbBeacon, ProtocolMessagePartKey},
-        test_utils::{fake_data, MithrilFixture, MithrilFixtureBuilder},
+        test_utils::{build_function_path, fake_data, MithrilFixture, MithrilFixtureBuilder},
     };
     use tokio::sync::RwLock;
 
@@ -429,14 +430,18 @@ mod tests {
 
     /// Note: If current_epoch is provided the [EpochService] will be automatically initialized
     async fn setup_certifier_service_with_network(
+        test_name: &str,
         network: CardanoNetwork,
         fixture: &MithrilFixture,
         epochs_with_signers: &[Epoch],
         current_epoch: Option<Epoch>,
     ) -> MithrilCertifierService {
-        let configuration = Configuration::new_sample();
+        let configuration = Configuration {
+            snapshot_directory: std::env::temp_dir()
+                .join(build_function_path(module_path!(), test_name)),
+            ..Configuration::new_sample()
+        };
         let mut dependency_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
-
         if let Some(epoch) = current_epoch {
             dependency_builder.epoch_service = Some(Arc::new(RwLock::new(
                 FakeEpochService::from_fixture(epoch, fixture),
@@ -455,11 +460,13 @@ mod tests {
     }
 
     async fn setup_certifier_service(
+        test_name: &str,
         fixture: &MithrilFixture,
         epochs_with_signers: &[Epoch],
         current_epoch: Option<Epoch>,
     ) -> MithrilCertifierService {
         setup_certifier_service_with_network(
+            test_name,
             fake_data::network(),
             fixture,
             epochs_with_signers,
@@ -476,7 +483,9 @@ mod tests {
         let epoch = beacon.epoch;
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         certifier_service
             .create_open_message(&signed_entity_type, &protocol_message)
             .await
@@ -496,7 +505,9 @@ mod tests {
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -528,7 +539,9 @@ mod tests {
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -555,7 +568,9 @@ mod tests {
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -582,8 +597,13 @@ mod tests {
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=3).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
-        let certifier_service =
-            setup_certifier_service(&fixture, &epochs_with_signers, Some(beacon.epoch)).await;
+        let certifier_service = setup_certifier_service(
+            current_function!(),
+            &fixture,
+            &epochs_with_signers,
+            Some(beacon.epoch),
+        )
+        .await;
 
         certifier_service
             .create_open_message(&signed_entity_type, &protocol_message)
@@ -615,8 +635,13 @@ mod tests {
         let mut protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
-        let certifier_service =
-            setup_certifier_service(&fixture, &epochs_with_signers, Some(beacon.epoch)).await;
+        let certifier_service = setup_certifier_service(
+            current_function!(),
+            &fixture,
+            &epochs_with_signers,
+            Some(beacon.epoch),
+        )
+        .await;
 
         certifier_service
             .create_open_message(&signed_entity_type, &protocol_message)
@@ -655,7 +680,9 @@ mod tests {
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -687,7 +714,9 @@ mod tests {
         let protocol_message = ProtocolMessage::new();
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(1).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         let mut open_message = certifier_service
             .open_message_repository
             .create_open_message(beacon.epoch, &signed_entity_type, &protocol_message)
@@ -722,6 +751,7 @@ mod tests {
         let epochs_with_signers = (1..=3).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
         let certifier_service = setup_certifier_service_with_network(
+            current_function!(),
             network,
             &fixture,
             &epochs_with_signers,
@@ -794,7 +824,9 @@ mod tests {
         let signed_entity_type = SignedEntityType::CardanoImmutableFilesFull(beacon.clone());
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         certifier_service
             .create_certificate(&signed_entity_type)
             .await
@@ -809,7 +841,9 @@ mod tests {
         let epoch = beacon.epoch;
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
-        let certifier_service = setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         certifier_service
             .open_message_repository
             .create_open_message(epoch, &signed_entity_type, &protocol_message)
@@ -833,7 +867,8 @@ mod tests {
         let epochs_with_signers = (1..=5).map(Epoch).collect::<Vec<_>>();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let mut certifier_service =
-            setup_certifier_service(&fixture, &epochs_with_signers, None).await;
+            setup_certifier_service(current_function!(), &fixture, &epochs_with_signers, None)
+                .await;
         certifier_service.multi_signer = Arc::new(mock_multi_signer);
         certifier_service
             .create_open_message(&signed_entity_type, &protocol_message)
@@ -849,7 +884,8 @@ mod tests {
     #[tokio::test]
     async fn test_epoch_gap_certificate_chain() {
         let builder = MithrilFixtureBuilder::default();
-        let certifier_service = setup_certifier_service(&builder.build(), &[], None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &builder.build(), &[], None).await;
         let certificate = fake_data::genesis_certificate("whatever");
         let epoch = certificate.epoch + 2;
         certifier_service
@@ -874,7 +910,8 @@ mod tests {
     #[tokio::test]
     async fn test_epoch_gap_certificate_chain_ok() {
         let builder = MithrilFixtureBuilder::default();
-        let certifier_service = setup_certifier_service(&builder.build(), &[], None).await;
+        let certifier_service =
+            setup_certifier_service(current_function!(), &builder.build(), &[], None).await;
         let certificate = fake_data::genesis_certificate("whatever");
         let epoch = certificate.epoch + 1;
         certifier_service

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -224,14 +224,17 @@ impl StakeDistributionService for MithrilStakeDistributionService {
 
 #[cfg(test)]
 mod tests {
+    use mithril_common::temp_dir;
+
     use crate::dependency_injection::DependenciesBuilder;
     use crate::tools::mocks::MockChainObserver;
 
     use super::*;
 
     async fn get_service(chain_observer: MockChainObserver) -> MithrilStakeDistributionService {
-        let mut builder =
-            DependenciesBuilder::new_with_stdout_logger(crate::Configuration::new_sample());
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(
+            crate::Configuration::new_sample(temp_dir!()),
+        );
         let stake_service = MithrilStakeDistributionService::new(
             builder.get_stake_store().await.unwrap(),
             Arc::new(chain_observer),

--- a/mithril-aggregator/tests/cardano_stake_distribution_verify_stakes.rs
+++ b/mithril-aggregator/tests/cardano_stake_distribution_verify_stakes.rs
@@ -2,6 +2,7 @@ mod test_extensions;
 
 use mithril_aggregator::Configuration;
 use mithril_common::entities::SignerWithStake;
+use mithril_common::temp_dir;
 use mithril_common::{
     entities::{
         BlockNumber, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
@@ -26,7 +27,7 @@ async fn cardano_stake_distribution_verify_stakes() {
             SignedEntityTypeDiscriminants::CardanoStakeDistribution.to_string(),
         ),
         data_stores_directory: get_test_dir("cardano_stake_distribution_verify_stakes"),
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint::new(

--- a/mithril-aggregator/tests/certificate_chain.rs
+++ b/mithril-aggregator/tests/certificate_chain.rs
@@ -7,6 +7,7 @@ use mithril_common::{
         SignedEntityTypeDiscriminants, SlotNumber, StakeDistribution, StakeDistributionParty,
         TimePoint,
     },
+    temp_dir,
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{
@@ -23,7 +24,7 @@ async fn certificate_chain() {
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
         data_stores_directory: get_test_dir("certificate_chain"),
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint::new(

--- a/mithril-aggregator/tests/create_certificate.rs
+++ b/mithril-aggregator/tests/create_certificate.rs
@@ -7,7 +7,8 @@ use mithril_common::{
         ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants, SlotNumber,
         StakeDistributionParty, TimePoint,
     },
-    test_utils::{MithrilFixtureBuilder, TempDir},
+    temp_dir,
+    test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{
     utilities::get_test_dir, ExpectedCertificate, ExpectedMetrics, RuntimeTester,
@@ -30,12 +31,11 @@ async fn create_certificate() {
             .join(","),
         ),
         data_stores_directory: get_test_dir("create_certificate"),
-        snapshot_directory: TempDir::create("aggregator-integration", "create_certificate"),
         cardano_transactions_signing_config: CardanoTransactionsSigningConfig {
             security_parameter: BlockNumber(0),
             step: BlockNumber(30),
         },
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint {

--- a/mithril-aggregator/tests/create_certificate_slave.rs
+++ b/mithril-aggregator/tests/create_certificate_slave.rs
@@ -7,6 +7,7 @@ use mithril_common::{
         SignedEntityType, SignedEntityTypeDiscriminants, SlotNumber, StakeDistribution,
         StakeDistributionParty, TimePoint,
     },
+    temp_dir,
     test_utils::{MithrilFixtureBuilder, TempDir},
 };
 use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
@@ -35,12 +36,11 @@ async fn create_certificate_slave() {
     let master_configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
         data_stores_directory: get_test_dir("create_certificate_master"),
-        snapshot_directory: TempDir::create("aggregator-integration", "create_certificate_master"),
         cardano_transactions_signing_config: CardanoTransactionsSigningConfig {
             security_parameter: BlockNumber(0),
             step: BlockNumber(30),
         },
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut master_tester =
         RuntimeTester::build(start_time_point.clone(), master_configuration.clone()).await;

--- a/mithril-aggregator/tests/create_certificate_with_buffered_signatures.rs
+++ b/mithril-aggregator/tests/create_certificate_with_buffered_signatures.rs
@@ -7,6 +7,7 @@ use mithril_common::{
         SignedEntityType, SignedEntityTypeDiscriminants, SlotNumber, StakeDistributionParty,
         TimePoint,
     },
+    temp_dir,
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{
@@ -28,7 +29,7 @@ async fn create_certificate_with_buffered_signatures() {
             security_parameter: BlockNumber(0),
             step: BlockNumber(30),
         },
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint {

--- a/mithril-aggregator/tests/era_checker.rs
+++ b/mithril-aggregator/tests/era_checker.rs
@@ -3,6 +3,7 @@ use mithril_aggregator::{Configuration, RuntimeError};
 use mithril_common::{
     entities::{BlockNumber, ChainPoint, Epoch, ProtocolParameters, SlotNumber, TimePoint},
     era::{EraMarker, SupportedEra},
+    temp_dir,
     test_utils::MithrilFixtureBuilder,
 };
 
@@ -21,7 +22,7 @@ async fn testing_eras() {
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
         data_stores_directory: get_test_dir("testing_eras"),
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint::new(

--- a/mithril-aggregator/tests/genesis_to_signing.rs
+++ b/mithril-aggregator/tests/genesis_to_signing.rs
@@ -3,6 +3,7 @@ mod test_extensions;
 use mithril_aggregator::Configuration;
 use mithril_common::{
     entities::{BlockNumber, ChainPoint, Epoch, ProtocolParameters, SlotNumber, TimePoint},
+    temp_dir,
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{utilities::get_test_dir, ExpectedCertificate, RuntimeTester};
@@ -17,7 +18,7 @@ async fn genesis_to_signing() {
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
         data_stores_directory: get_test_dir("genesis_to_signing"),
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint::new(

--- a/mithril-aggregator/tests/open_message_expiration.rs
+++ b/mithril-aggregator/tests/open_message_expiration.rs
@@ -8,6 +8,7 @@ use mithril_common::{
         BlockNumber, CardanoDbBeacon, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
         SignedEntityTypeDiscriminants, SlotNumber, TimePoint,
     },
+    temp_dir,
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{
@@ -24,7 +25,7 @@ async fn open_message_expiration() {
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
         data_stores_directory: get_test_dir("open_message_expiration"),
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint::new(

--- a/mithril-aggregator/tests/open_message_newer_exists.rs
+++ b/mithril-aggregator/tests/open_message_newer_exists.rs
@@ -6,6 +6,7 @@ use mithril_common::{
         BlockNumber, CardanoDbBeacon, ChainPoint, Epoch, ProtocolParameters, SignedEntityType,
         SignedEntityTypeDiscriminants, SlotNumber, StakeDistributionParty, TimePoint,
     },
+    temp_dir,
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{
@@ -22,7 +23,7 @@ async fn open_message_newer_exists() {
     let configuration = Configuration {
         protocol_parameters: protocol_parameters.clone(),
         data_stores_directory: get_test_dir("open_message_newer_exists"),
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint::new(

--- a/mithril-aggregator/tests/prove_transactions.rs
+++ b/mithril-aggregator/tests/prove_transactions.rs
@@ -4,6 +4,7 @@ use mithril_common::{
         BlockNumber, CardanoTransactionsSigningConfig, ChainPoint, Epoch, ProtocolMessagePartKey,
         ProtocolParameters, SignedEntityType, SignedEntityTypeDiscriminants, SlotNumber, TimePoint,
     },
+    temp_dir,
     test_utils::MithrilFixtureBuilder,
 };
 use test_extensions::{
@@ -29,7 +30,7 @@ async fn prove_transactions() {
             security_parameter: BlockNumber(0),
             step: BlockNumber(30),
         },
-        ..Configuration::new_sample()
+        ..Configuration::new_sample(temp_dir!())
     };
     let mut tester = RuntimeTester::build(
         TimePoint {

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.11"
+version = "0.5.12"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/test_utils/temp_dir.rs
+++ b/mithril-common/src/test_utils/temp_dir.rs
@@ -112,6 +112,28 @@ impl TempDir {
     }
 }
 
+/// Return a temporary directory based on the current function name.
+#[macro_export]
+macro_rules! temp_dir {
+    () => {{
+        fn f() {}
+        let current_function_path = $crate::test_utils::format_current_function_path(f);
+
+        $crate::test_utils::TempDir::new(current_function_path, "").build_path()
+    }};
+}
+
+/// Create and return a temporary directory based on the current function name.
+#[macro_export]
+macro_rules! temp_dir_create {
+    () => {{
+        fn f() {}
+        let current_function_path = $crate::test_utils::format_current_function_path(f);
+
+        $crate::test_utils::TempDir::new(current_function_path, "").build()
+    }};
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,6 +249,34 @@ mod tests {
         assert!(
             existing_dir.exists().not(),
             "should have cleaned up existing subdirectory"
+        );
+    }
+
+    #[test]
+    fn creating_temp_dir_base_on_current_function() {
+        assert_eq!(
+            std::env::temp_dir()
+                .join(TEMP_DIR_ROOT_NAME)
+                .join("mithril_common")
+                .join("test_utils")
+                .join("temp_dir")
+                .join("tests")
+                .join("creating_temp_dir_base_on_current_function"),
+            temp_dir!(),
+        );
+    }
+
+    #[tokio::test]
+    async fn creating_temp_dir_base_on_current_async_function() {
+        assert_eq!(
+            std::env::temp_dir()
+                .join(TEMP_DIR_ROOT_NAME)
+                .join("mithril_common")
+                .join("test_utils")
+                .join("temp_dir")
+                .join("tests")
+                .join("creating_temp_dir_base_on_current_async_function"),
+            temp_dir!(),
         );
     }
 }

--- a/mithril-common/src/test_utils/temp_dir.rs
+++ b/mithril-common/src/test_utils/temp_dir.rs
@@ -118,6 +118,7 @@ macro_rules! temp_dir {
     () => {{
         fn f() {}
         let current_function_path = $crate::test_utils::format_current_function_path(f);
+        let current_function_path = current_function_path.replace("/tests/", "/");
 
         $crate::test_utils::TempDir::new(current_function_path, "").build_path()
     }};
@@ -129,6 +130,7 @@ macro_rules! temp_dir_create {
     () => {{
         fn f() {}
         let current_function_path = $crate::test_utils::format_current_function_path(f);
+        let current_function_path = current_function_path.replace("/tests/", "/");
 
         $crate::test_utils::TempDir::new(current_function_path, "").build()
     }};
@@ -260,7 +262,6 @@ mod tests {
                 .join("mithril_common")
                 .join("test_utils")
                 .join("temp_dir")
-                .join("tests")
                 .join("creating_temp_dir_base_on_current_function"),
             temp_dir!(),
         );
@@ -274,7 +275,6 @@ mod tests {
                 .join("mithril_common")
                 .join("test_utils")
                 .join("temp_dir")
-                .join("tests")
                 .join("creating_temp_dir_base_on_current_async_function"),
             temp_dir!(),
         );


### PR DESCRIPTION
## Content

The flakiness comes from the use of the same temporary directory by different tests.

This PR includes:
* the creation of macros `temp_dir` that return a temporary path build from the current function path
* the creation of macros `temp_dir_create` that create and return a temporary path build from the current function path
* the addition of a new parameter to `new_sample` to indicate the snapshot directory. 
* creation of a macro `initialize_dependencies` that call the function with current module and current function name. 
* in tests, replacement uses the `initialize_dependencies` function to use `initialize_dependencies!` macro.
* adaptation of the tests using `new_sample` to pass a temporary path generated using `temp_dir!`

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [ ] No new TODOs introduced

## Issue(s)

Closes #2360
