### PR TITLE
Feat: move database vacuum to aggregator startup to avoid API interruptions during epoch transitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.16"
+version = "0.7.17"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.16"
+version = "0.7.17"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/database_command.rs
+++ b/mithril-aggregator/src/commands/database_command.rs
@@ -26,12 +26,16 @@ impl DatabaseCommand {
 pub enum DatabaseSubCommand {
     /// Migrate databases located in the given stores directory
     Migrate(MigrateCommand),
+
+    /// Vacuum the aggregator main database
+    Vacuum(VacuumCommand),
 }
 
 impl DatabaseSubCommand {
     pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
         match self {
             Self::Migrate(cmd) => cmd.execute(root_logger).await,
+            Self::Vacuum(cmd) => cmd.execute(root_logger).await,
         }
     }
 }
@@ -75,6 +79,41 @@ impl MigrateCommand {
             .with_context(|| {
                 "Dependencies Builder can not get cardano transaction pool sqlite connection"
             })?;
+
+        Ok(())
+    }
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct VacuumCommand {
+    /// Stores directory
+    #[clap(long, env = "STORES_DIRECTORY")]
+    stores_directory: PathBuf,
+}
+
+impl VacuumCommand {
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        let config = Configuration {
+            environment: ExecutionEnvironment::Production,
+            data_stores_directory: self.stores_directory.clone(),
+            // Temporary solution to avoid the need to provide a full configuration
+            ..Configuration::new_sample(std::env::temp_dir())
+        };
+        debug!(root_logger, "DATABASE VACUUM command"; "config" => format!("{config:?}"));
+        println!(
+            "Vacuuming database from stores directory: {}",
+            self.stores_directory.to_string_lossy()
+        );
+        let mut dependencies_builder =
+            DependenciesBuilder::new(root_logger.clone(), config.clone());
+
+        dependencies_builder
+            .get_upkeep_service()
+            .await
+            .with_context(|| "Dependencies Builder can not get upkeep service")?
+            .vacuum()
+            .await
+            .with_context(|| "Upkeep service can not vacuum")?;
 
         Ok(())
     }

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -1,14 +1,20 @@
+use std::{
+    net::IpAddr,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
 use anyhow::{anyhow, Context};
+use chrono::TimeDelta;
 use clap::Parser;
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value, ValueKind};
-use mithril_common::StdResult;
-use mithril_metric::MetricsServer;
 use slog::{crit, debug, info, warn, Logger};
-use std::time::Duration;
-use std::{net::IpAddr, path::PathBuf};
 use tokio::{sync::oneshot, task::JoinSet};
 
-use crate::{dependency_injection::DependenciesBuilder, Configuration};
+use mithril_common::StdResult;
+use mithril_metric::MetricsServer;
+
+use crate::{dependency_injection::DependenciesBuilder, tools::VacuumTracker, Configuration};
 
 /// Server runtime mode
 #[derive(Parser, Debug, Clone)]
@@ -170,6 +176,15 @@ impl ServeCommand {
             .with_context(|| "Dependencies Builder can not create event store")?;
         let event_store_thread = tokio::spawn(async move { event_store.run().await.unwrap() });
 
+        // start the database vacuum operation, if needed
+        self.perform_database_vacuum_if_needed(
+            &config.data_stores_directory,
+            &mut dependencies_builder,
+            TimeDelta::weeks(1),
+            &root_logger,
+        )
+        .await?;
+
         // start the aggregator runtime
         let mut runtime = dependencies_builder
             .create_aggregator_runner()
@@ -294,6 +309,53 @@ impl ServeCommand {
         info!(root_logger, "Event store is finishing...");
         event_store_thread.await.unwrap();
         println!("Services stopped, exiting.");
+
+        Ok(())
+    }
+
+    /// This function checks if a database vacuum is needed and performs it if necessary.
+    ///
+    /// Errors from [VacuumTracker] operations are logged but not propagated as errors.
+    async fn perform_database_vacuum_if_needed(
+        &self,
+        store_dir: &Path,
+        dependencies_builder: &mut DependenciesBuilder,
+        vacuum_min_interval: TimeDelta,
+        logger: &Logger,
+    ) -> StdResult<()> {
+        let vacuum_tracker = VacuumTracker::new(store_dir, vacuum_min_interval, logger.clone());
+        match vacuum_tracker.check_vacuum_needed() {
+            Ok((true, _)) => {
+                info!(logger, "Performing vacuum");
+
+                let upkeep = dependencies_builder
+                    .get_upkeep_service()
+                    .await
+                    .with_context(|| "Dependencies Builder can not create upkeep")?;
+
+                upkeep
+                    .vacuum()
+                    .await
+                    .with_context(|| "Upkeep service failed to vacuum database")?;
+
+                match vacuum_tracker.update_last_vacuum_time() {
+                    Ok(last_vacuum) => {
+                        info!(logger, "Vacuum performed"; "last_vacuum" => last_vacuum.to_rfc3339());
+                    }
+                    Err(e) => {
+                        warn!(logger, "Failed to update last vacuum time"; "error" => ?e);
+                    }
+                }
+            }
+            Ok((false, last_vacuum)) => {
+                let time_display =
+                    last_vacuum.map_or_else(|| "never".to_string(), |time| time.to_rfc3339());
+                info!(logger, "No vacuum needed"; "last_vacuum" => time_display);
+            }
+            Err(e) => {
+                warn!(logger, "Failed to check if vacuum is needed"; "error" => ?e);
+            }
+        }
 
         Ok(())
     }

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -16,6 +16,8 @@ use mithril_metric::MetricsServer;
 
 use crate::{dependency_injection::DependenciesBuilder, tools::VacuumTracker, Configuration};
 
+const VACUUM_MINIMUM_INTERVAL: TimeDelta = TimeDelta::weeks(1);
+
 /// Server runtime mode
 #[derive(Parser, Debug, Clone)]
 pub struct ServeCommand {
@@ -180,7 +182,7 @@ impl ServeCommand {
         self.perform_database_vacuum_if_needed(
             &config.data_stores_directory,
             &mut dependencies_builder,
-            TimeDelta::weeks(1),
+            VACUUM_MINIMUM_INTERVAL,
             &root_logger,
         )
         .await?;

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -9,6 +9,7 @@ pub mod mocks;
 mod signer_importer;
 mod single_signature_authenticator;
 pub mod url_sanitizer;
+mod vacuum_tracker;
 
 pub use certificates_hash_migrator::CertificatesHashMigrator;
 pub use digest_helpers::extract_digest_from_path;
@@ -18,6 +19,7 @@ pub use signer_importer::{
     CExplorerSignerRetriever, SignersImporter, SignersImporterPersister, SignersImporterRetriever,
 };
 pub use single_signature_authenticator::*;
+pub use vacuum_tracker::VacuumTracker;
 
 /// Downcast the error to the specified error type and check if the error satisfies the condition.
 pub(crate) fn downcast_check<E>(

--- a/mithril-aggregator/src/tools/vacuum_tracker.rs
+++ b/mithril-aggregator/src/tools/vacuum_tracker.rs
@@ -1,0 +1,183 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::Context;
+use chrono::{DateTime, TimeDelta, Utc};
+use slog::{debug, info, Logger};
+
+use mithril_common::StdResult;
+
+const LAST_VACUUM_FILENAME: &str = "last_vacuum_time";
+
+type LastVacuumTime = DateTime<Utc>;
+
+/// Helper to track when vacuum was last performed
+#[derive(Debug, Clone)]
+pub struct VacuumTracker {
+    tracker_file: PathBuf,
+    min_interval: TimeDelta,
+    logger: Logger,
+}
+
+impl VacuumTracker {
+    /// Create a new [VacuumTracker] for the given store directory
+    pub fn new(store_dir: &Path, interval: TimeDelta, logger: Logger) -> Self {
+        let last_vacuum_file = store_dir.join(LAST_VACUUM_FILENAME);
+
+        Self {
+            tracker_file: last_vacuum_file,
+            min_interval: interval,
+            logger,
+        }
+    }
+
+    /// Check if enough time has passed since last vacuum (returning the last vacuum timestamp)
+    pub fn check_vacuum_needed(&self) -> StdResult<(bool, Option<LastVacuumTime>)> {
+        if !self.tracker_file.exists() {
+            debug!(
+                self.logger,
+                "No previous vacuum timestamp found, vacuum can be performed"
+            );
+            return Ok((true, None));
+        }
+
+        let last_vacuum = fs::read_to_string(&self.tracker_file).with_context(|| {
+            format!(
+                "Failed to read vacuum timestamp file: {:?}",
+                self.tracker_file
+            )
+        })?;
+        let last_vacuum = DateTime::parse_from_rfc3339(&last_vacuum)?.with_timezone(&Utc);
+
+        let duration_since_last = Utc::now() - (last_vacuum);
+
+        let should_vacuum = duration_since_last >= self.min_interval;
+
+        if should_vacuum {
+            info!(
+                self.logger,
+                "Sufficient time has passed since last vacuum";
+                "last_vacuum" => last_vacuum.to_string(),
+                "elapsed_days" => duration_since_last.num_days(),
+                "min_interval_days" => self.min_interval.num_days()
+            );
+        } else {
+            info!(
+                self.logger,
+                "Not enough time elapsed since last vacuum";
+                "last_vacuum" => last_vacuum.to_string(),
+                "elapsed_days" => duration_since_last.num_days(),
+                "min_interval_days" => self.min_interval.num_days()
+            );
+        };
+
+        Ok((should_vacuum, Some(last_vacuum)))
+    }
+
+    /// Update the last vacuum time to now
+    pub fn update_last_vacuum_time(&self) -> StdResult<LastVacuumTime> {
+        let timestamp = Utc::now();
+
+        fs::write(&self.tracker_file, timestamp.to_rfc3339()).with_context(|| {
+            format!(
+                "Failed to write to last vacuum time file: {:?}",
+                self.tracker_file
+            )
+        })?;
+
+        Ok(timestamp)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::sleep;
+
+    use mithril_common::temp_dir_create;
+
+    use crate::test_tools::TestLogger;
+
+    use super::*;
+
+    const DUMMY_INTERVAL: TimeDelta = TimeDelta::milliseconds(99);
+
+    #[test]
+    fn update_last_vacuum_time_creates_file_with_current_timestamp() {
+        let tracker = VacuumTracker::new(&temp_dir_create!(), DUMMY_INTERVAL, TestLogger::stdout());
+
+        assert!(!tracker.tracker_file.exists());
+
+        let saved_timestamp = tracker.update_last_vacuum_time().unwrap();
+        let approximative_expected_saved_timestamp = Utc::now();
+
+        let vacuum_file_content = fs::read_to_string(tracker.tracker_file).unwrap();
+        let timestamp_retrieved = DateTime::parse_from_rfc3339(&vacuum_file_content).unwrap();
+        let diff = timestamp_retrieved
+            .signed_duration_since(approximative_expected_saved_timestamp)
+            .num_milliseconds();
+        assert!(diff < 1);
+        assert_eq!(timestamp_retrieved, saved_timestamp);
+    }
+
+    #[test]
+    fn update_last_vacuum_time_overwrites_previous_timestamp() {
+        let tracker = VacuumTracker::new(&temp_dir_create!(), DUMMY_INTERVAL, TestLogger::stdout());
+
+        let initial_saved_timestamp = tracker.update_last_vacuum_time().unwrap();
+        let last_saved_timestamp = tracker.update_last_vacuum_time().unwrap();
+
+        let vacuum_file_content = fs::read_to_string(tracker.tracker_file).unwrap();
+        let timestamp_retrieved = DateTime::parse_from_rfc3339(&vacuum_file_content).unwrap();
+        assert!(last_saved_timestamp > initial_saved_timestamp);
+        assert_eq!(timestamp_retrieved, last_saved_timestamp);
+    }
+
+    #[test]
+    fn update_last_vacuum_time_fails_on_write_error() {
+        let dir_not_exist = Path::new("path-does-not-exist");
+        let tracker = VacuumTracker::new(dir_not_exist, DUMMY_INTERVAL, TestLogger::stdout());
+
+        tracker
+            .update_last_vacuum_time()
+            .expect_err("Update last vacuum time should fail when error while writing to file");
+    }
+
+    #[test]
+    fn check_vacuum_needed_returns_true_when_no_previous_record() {
+        let tracker = VacuumTracker::new(&temp_dir_create!(), DUMMY_INTERVAL, TestLogger::stdout());
+
+        let (is_vacuum_needed, last_timestamp) = tracker.check_vacuum_needed().unwrap();
+
+        assert!(is_vacuum_needed);
+        assert!(last_timestamp.is_none());
+    }
+
+    #[test]
+    fn check_vacuum_needed_returns_true_after_interval_elapsed() {
+        let min_interval = TimeDelta::milliseconds(10);
+        let tracker = VacuumTracker::new(&temp_dir_create!(), min_interval, TestLogger::stdout());
+
+        let saved_timestamp = tracker.update_last_vacuum_time().unwrap();
+        sleep(min_interval.to_std().unwrap());
+
+        let (is_vacuum_needed, last_timestamp) = tracker.check_vacuum_needed().unwrap();
+
+        assert!(is_vacuum_needed);
+        assert_eq!(last_timestamp, Some(saved_timestamp));
+    }
+
+    #[test]
+    fn check_vacuum_needed_returns_false_within_interval() {
+        let min_interval = TimeDelta::minutes(2);
+        let tracker = VacuumTracker::new(&temp_dir_create!(), min_interval, TestLogger::stdout());
+
+        let saved_timestamp = tracker.update_last_vacuum_time().unwrap();
+
+        let (is_vacuum_needed, last_timestamp) = tracker.check_vacuum_needed().unwrap();
+
+        assert!(!is_vacuum_needed);
+        assert_eq!(last_timestamp, Some(saved_timestamp));
+    }
+}

--- a/mithril-aggregator/src/tools/vacuum_tracker.rs
+++ b/mithril-aggregator/src/tools/vacuum_tracker.rs
@@ -9,7 +9,7 @@ use slog::{debug, info, Logger};
 
 use mithril_common::StdResult;
 
-const LAST_VACUUM_FILENAME: &str = "last_vacuum_time";
+const LAST_VACUUM_TIME_FILENAME: &str = "last_vacuum_time";
 
 type LastVacuumTime = DateTime<Utc>;
 
@@ -24,7 +24,7 @@ pub struct VacuumTracker {
 impl VacuumTracker {
     /// Create a new [VacuumTracker] for the given store directory
     pub fn new(store_dir: &Path, interval: TimeDelta, logger: Logger) -> Self {
-        let last_vacuum_file = store_dir.join(LAST_VACUUM_FILENAME);
+        let last_vacuum_file = store_dir.join(LAST_VACUUM_TIME_FILENAME);
 
         Self {
             tracker_file: last_vacuum_file,


### PR DESCRIPTION
## Content

This PR includes a fix for the API unavailability during epoch transitions by moving database vacuum operation from the upkeep service to aggregator startup.

The main changes are:
- Removed vacuum operation from the epoch transition process
- Created a `VacuumTracker` utility that tracks when the last vacuum operation was performed
- Added a controlled vacuum process at aggregator startup with a minimum interval (1 week)
- Added a clap command to execute vacuum manually

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2364 
