### PR TITLE
Feat(e2e): support multiple aggregators in the e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,7 +314,7 @@ jobs:
           # Include a test for full dedentralization P2P signer registration and P2P signature registration
           - mode: "decentralized"
             era: ${{ fromJSON(needs.build-ubuntu-X64.outputs.eras)[0] }}
-            next_era: [""]
+            next_era: ""
             cardano_node_version: "10.1.4"
             hard_fork_latest_era_at_epoch: 0
             run_id: "#1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,14 +303,22 @@ jobs:
         extra_args: [""]
 
         include:
-          # Include a test for the P2P mode
-          - mode: "p2p"
+          # Include a test for partial decentralization with master/slave signer registration and P2P signature registration
+          - mode: "master-slave"
             era: ${{ fromJSON(needs.build-ubuntu-X64.outputs.eras)[0] }}
             next_era: [""]
             cardano_node_version: "10.2.1"
             hard_fork_latest_era_at_epoch: 0
             run_id: "#1"
-            extra_args: "--use-p2p-network"
+            extra_args: "--number-of-aggregators=2 --use-relays --relay-signer-registration-mode=passthrough --relay-signature-registration-mode=p2p"
+          # Include a test for full dedentralization P2P signer registration and P2P signature registration
+          - mode: "decentralized"
+            era: ${{ fromJSON(needs.build-ubuntu-X64.outputs.eras)[0] }}
+            next_era: [""]
+            cardano_node_version: "10.1.4"
+            hard_fork_latest_era_at_epoch: 0
+            run_id: "#1"
+            extra_args: "--number-of-aggregators=2 --use-relays --relay-signer-registration-mode=p2p --relay-signature-registration-mode=p2p"
           # Include a test for the era switch without regenesis
           - mode: "std"
             era: ${{ fromJSON(needs.build-ubuntu-X64.outputs.eras)[0] }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,7 +3756,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
- "strum",
+ "strum 0.27.1",
  "tar",
  "thiserror 2.0.12",
  "tokio",
@@ -3854,7 +3854,7 @@ dependencies = [
  "slog",
  "slog-async",
  "slog-term",
- "strum",
+ "strum 0.27.1",
  "thiserror 2.0.12",
  "tokio",
  "typetag",
@@ -3957,6 +3957,7 @@ dependencies = [
  "slog-bunyan",
  "slog-scope",
  "slog-term",
+ "strum 0.26.3",
  "thiserror 2.0.12",
  "tokio",
  "warp",
@@ -6283,11 +6284,33 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.1",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.16"
+version = "0.5.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3884,7 +3884,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.74"
+version = "0.4.75"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.38"
+version = "0.1.39"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,6 +3892,7 @@ dependencies = [
  "indicatif",
  "mithril-common",
  "mithril-doc",
+ "mithril-relay",
  "reqwest 0.12.15",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,6 @@ dependencies = [
  "indicatif",
  "mithril-common",
  "mithril-doc",
- "mithril-relay",
  "reqwest 0.12.15",
  "serde",
  "serde_json",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.25"
+version = "0.7.26"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
@@ -161,6 +161,7 @@ impl DependenciesBuilder {
         &mut self,
     ) -> Result<Arc<MithrilSignerRegistrationSlave>> {
         let registerer = MithrilSignerRegistrationSlave::new(
+            self.get_epoch_service().await?,
             self.get_verification_key_store().await?,
             self.get_signer_store().await?,
             self.get_signer_registration_verifier().await?,

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -143,7 +143,6 @@ impl AggregatorRuntime {
                 info!(self.logger, "→ Trying to transition to READY"; "last_time_point" => ?last_time_point);
 
                 let can_try_transition_from_idle_to_ready = if self.config.is_slave {
-                    println!("Checking if slave aggregator is at the same epoch as master");
                     self.runner
                         .is_slave_aggregator_at_same_epoch_as_master(&last_time_point)
                         .await?
@@ -265,18 +264,19 @@ impl AggregatorRuntime {
             self.runner
                 .update_stake_distribution(&new_time_point)
                 .await?;
-            if self.config.is_slave {
-                self.runner
-                    .synchronize_slave_aggregator_signer_registration()
-                    .await?;
-            }
             self.runner.inform_new_epoch(new_time_point.epoch).await?;
-
             self.runner.upkeep(new_time_point.epoch).await?;
             self.runner
                 .open_signer_registration_round(&new_time_point)
                 .await?;
             self.runner.update_epoch_settings().await?;
+            if self.config.is_slave {
+                self.runner
+                    .synchronize_slave_aggregator_signer_registration()
+                    .await?;
+                // Needed to recompute epoch data for the next signing round on the slave
+                self.runner.inform_new_epoch(new_time_point.epoch).await?;
+            }
             self.runner.precompute_epoch_data().await?;
         }
 
@@ -940,7 +940,7 @@ mod tests {
             runner
                 .expect_inform_new_epoch()
                 .with(predicate::eq(new_time_point_clone.clone().epoch))
-                .once()
+                .times(2)
                 .returning(|_| Ok(()));
             runner
                 .expect_update_epoch_settings()

--- a/mithril-aggregator/src/runtime/state_machine.rs
+++ b/mithril-aggregator/src/runtime/state_machine.rs
@@ -274,8 +274,6 @@ impl AggregatorRuntime {
                 self.runner
                     .synchronize_slave_aggregator_signer_registration()
                     .await?;
-                // Needed to recompute epoch data for the next signing round on the slave
-                self.runner.inform_new_epoch(new_time_point.epoch).await?;
             }
             self.runner.precompute_epoch_data().await?;
         }
@@ -940,7 +938,7 @@ mod tests {
             runner
                 .expect_inform_new_epoch()
                 .with(predicate::eq(new_time_point_clone.clone().epoch))
-                .times(2)
+                .once()
                 .returning(|_| Ok(()));
             runner
                 .expect_update_epoch_settings()

--- a/mithril-aggregator/src/services/signer_registration/error.rs
+++ b/mithril-aggregator/src/services/signer_registration/error.rs
@@ -31,9 +31,13 @@ pub enum SignerRegistrationError {
     #[error("signer already registered")]
     ExistingSigner(Box<SignerWithStake>),
 
-    /// Store error.
+    /// Store.
     #[error("store error")]
-    StoreError(#[source] StdError),
+    Store(#[source] StdError),
+
+    /// Epoch service.
+    #[error("epoch service error")]
+    EpochService(#[source] StdError),
 
     /// Signer registration failed.
     #[error("signer registration failed")]

--- a/mithril-aggregator/src/services/signer_registration/master.rs
+++ b/mithril-aggregator/src/services/signer_registration/master.rs
@@ -147,7 +147,7 @@ impl SignerRegisterer for MithrilSignerRegistrationMaster {
                     registration_round.epoch
                 )
             })
-            .map_err(|e| SignerRegistrationError::StoreError(anyhow!(e)))?
+            .map_err(|e| SignerRegistrationError::Store(anyhow!(e)))?
         {
             Some(_) => Err(SignerRegistrationError::ExistingSigner(Box::new(
                 signer_save,

--- a/mithril-aggregator/tests/create_certificate_slave.rs
+++ b/mithril-aggregator/tests/create_certificate_slave.rs
@@ -44,6 +44,7 @@ impl EpochFixturesMapBuilder {
                         .with_stake_distribution(
                             StakeDistributionGenerationMethod::RandomDistribution {
                                 seed: [epoch as u8; 32],
+                                min_stake: 10,
                             },
                         )
                         .build(),

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.16"
+version = "0.5.17"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -157,7 +157,7 @@ impl Debug for Certificate {
             true => debug
                 .field(
                     "aggregate_verification_key",
-                    &format_args!("{:?}", self.aggregate_verification_key),
+                    &format_args!("{:?}", self.aggregate_verification_key.to_json_hex()),
                 )
                 .field("signature", &format_args!("{:?}", self.signature))
                 .finish(),

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -38,7 +38,7 @@ impl Epoch {
     pub const CARDANO_STAKE_DISTRIBUTION_SNAPSHOT_OFFSET: u64 = 2;
 
     /// The epoch offset used to retrieve the epoch at which a signer has registered to the master aggregator.
-    pub const SIGNER_MASTER_SYNCHRONIZATION_OFFSET: u64 = 1;
+    pub const SIGNER_MASTER_SYNCHRONIZATION_OFFSET: u64 = 0;
 
     /// Computes a new Epoch by applying an epoch offset.
     ///

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -171,6 +171,7 @@ mod test {
                 .with_signers(1)
                 .with_stake_distribution(StakeDistributionGenerationMethod::RandomDistribution {
                     seed: [3u8; 32],
+                    min_stake: 1,
                 })
                 .build(),
         );

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -218,6 +218,7 @@ mod test {
             .with_stake_distribution(
                 crate::test_utils::StakeDistributionGenerationMethod::RandomDistribution {
                     seed: [4u8; 32],
+                    min_stake: 1,
                 },
             )
             .build();

--- a/mithril-common/src/test_utils/fixture_builder.rs
+++ b/mithril-common/src/test_utils/fixture_builder.rs
@@ -29,7 +29,10 @@ impl Default for MithrilFixtureBuilder {
             enable_signers_certification: true,
             number_of_signers: 5,
             stake_distribution_generation_method:
-                StakeDistributionGenerationMethod::RandomDistribution { seed: [0u8; 32] },
+                StakeDistributionGenerationMethod::RandomDistribution {
+                    seed: [0u8; 32],
+                    min_stake: 1,
+                },
             party_id_seed: [0u8; 32],
         }
     }
@@ -41,6 +44,8 @@ pub enum StakeDistributionGenerationMethod {
     RandomDistribution {
         /// The randomizer seed
         seed: [u8; 32],
+        /// The minimum stake
+        min_stake: Stake,
     },
 
     /// Use a custom stake distribution
@@ -106,13 +111,13 @@ impl MithrilFixtureBuilder {
         let signers_party_ids = self.generate_party_ids();
 
         match &self.stake_distribution_generation_method {
-            StakeDistributionGenerationMethod::RandomDistribution { seed } => {
+            StakeDistributionGenerationMethod::RandomDistribution { seed, min_stake } => {
                 let mut stake_rng = ChaCha20Rng::from_seed(*seed);
 
                 signers_party_ids
                     .into_iter()
                     .map(|party_id| {
-                        let stake = 1 + stake_rng.next_u64() % 999;
+                        let stake = min_stake + stake_rng.next_u64() % 999;
                         (party_id, stake)
                     })
                     .collect::<Vec<_>>()
@@ -246,6 +251,7 @@ mod tests {
         let result = MithrilFixtureBuilder::default()
             .with_stake_distribution(StakeDistributionGenerationMethod::RandomDistribution {
                 seed: [0u8; 32],
+                min_stake: 1,
             })
             .with_signers(4)
             .build();
@@ -275,6 +281,7 @@ mod tests {
         let result = MithrilFixtureBuilder::default()
             .with_stake_distribution(StakeDistributionGenerationMethod::RandomDistribution {
                 seed: [0u8; 32],
+                min_stake: 1,
             })
             .with_signers(5)
             .build();

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -48,6 +48,7 @@ slog = { version = "2.7.0", features = [
 ] }
 slog-async = "2.8.0"
 slog-bunyan = "2.5.0"
+strum = { version = "0.26.3", features = ["derive"] }
 thiserror = "2.0.12"
 tokio = { version = "1.44.1", features = ["full"] }
 warp = "0.3.7"

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.38"
+version = "0.1.39"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/src/commands/signer.rs
+++ b/mithril-relay/src/commands/signer.rs
@@ -6,7 +6,7 @@ use mithril_common::StdResult;
 use slog::error;
 
 use super::CommandContext;
-use crate::SignerRelay;
+use crate::{SignerRelay, SignerRelayMode};
 
 #[derive(Parser, Debug, Clone)]
 pub struct SignerCommand {
@@ -26,6 +26,14 @@ pub struct SignerCommand {
     #[clap(long, env = "AGGREGATOR_ENDPOINT")]
     aggregator_endpoint: String,
 
+    /// Signer registration relay mode
+    #[clap(value_enum, env = "SIGNER_REGISTRATION_MODE", default_value_t = SignerRelayMode::Passthrough)]
+    signer_registration_mode: SignerRelayMode,
+
+    /// Signature registration relay mode
+    #[clap(value_enum, env = "SIGNATURE_REGISTRATION_MODE", default_value_t = SignerRelayMode::P2P)]
+    signature_registration_mode: SignerRelayMode,
+
     /// Interval at which a signer registration should be repeated in milliseconds (defaults to 1 hour)
     #[clap(long, env = "SIGNER_REPEATER_DELAY", default_value_t = 3_600 * 1_000)]
     signer_repeater_delay: u64,
@@ -38,12 +46,16 @@ impl SignerCommand {
         let server_port = self.server_port.to_owned();
         let dial_to = self.dial_to.to_owned();
         let addr: Multiaddr = format!("/ip4/0.0.0.0/tcp/{}", self.listen_port).parse()?;
+        let signer_registration_mode = &self.signer_registration_mode;
+        let signature_registration_mode = &self.signature_registration_mode;
         let aggregator_endpoint = self.aggregator_endpoint.to_owned();
         let signer_repeater_delay = Duration::from_millis(self.signer_repeater_delay);
 
         let mut relay = SignerRelay::start(
             &addr,
             &server_port,
+            signer_registration_mode,
+            signature_registration_mode,
             &aggregator_endpoint,
             &signer_repeater_delay,
             logger,

--- a/mithril-relay/src/lib.rs
+++ b/mithril-relay/src/lib.rs
@@ -12,6 +12,7 @@ pub use commands::RelayCommands;
 pub use relay::AggregatorRelay;
 pub use relay::PassiveRelay;
 pub use relay::SignerRelay;
+pub use relay::SignerRelayMode;
 
 /// The P2P topic names used by Mithril
 pub mod mithril_p2p_topic {

--- a/mithril-relay/src/relay/aggregator.rs
+++ b/mithril-relay/src/relay/aggregator.rs
@@ -42,13 +42,13 @@ impl AggregatorRelay {
             .await;
         match response {
             Ok(response) => match response.status() {
-                StatusCode::CREATED => {
+                StatusCode::CREATED | StatusCode::ACCEPTED => {
                     info!(self.logger, "Sent successfully signature message to aggregator"; "signature_message" => #?signature_message);
                     Ok(())
                 }
                 status => {
-                    error!(self.logger, "Post `/register-signatures` should have returned a 201 status code, got: {status}");
-                    Err(anyhow!("Post `/register-signatures` should have returned a 201 status code, got: {status}"))
+                    error!(self.logger, "Post `/register-signatures` should have returned a 201 or 202 status code, got: {status}");
+                    Err(anyhow!("Post `/register-signatures` should have returned a 201 or 202 status code, got: {status}"))
                 }
             },
             Err(err) => {

--- a/mithril-relay/src/relay/aggregator.rs
+++ b/mithril-relay/src/relay/aggregator.rs
@@ -154,7 +154,7 @@ mod tests {
     #[tokio::test]
     async fn sends_accept_encoding_header_with_correct_values() {
         let server = MockServer::start();
-        server.mock(|when, then| {
+        let mock = server.mock(|when, then| {
             when.matches(|req| {
                 let headers = req.headers.clone().expect("HTTP headers not found");
                 let accept_encoding_header = headers
@@ -179,5 +179,7 @@ mod tests {
             .notify_signature_to_aggregator(&RegisterSignatureMessage::dummy())
             .await
             .expect("Should succeed with Accept-Encoding header");
+
+        mock.assert();
     }
 }

--- a/mithril-relay/src/relay/mod.rs
+++ b/mithril-relay/src/relay/mod.rs
@@ -5,3 +5,4 @@ mod signer;
 pub use aggregator::AggregatorRelay;
 pub use passive::PassiveRelay;
 pub use signer::SignerRelay;
+pub use signer::SignerRelayMode;

--- a/mithril-relay/src/relay/signer.rs
+++ b/mithril-relay/src/relay/signer.rs
@@ -19,7 +19,7 @@ use warp::Filter;
 /// Signer relay mode
 ///
 /// The relay mode defines how the relay will behave when it receives a message
-#[derive(Debug, Clone, Display, ValueEnum)]
+#[derive(Debug, Clone, Display, PartialEq, Eq, ValueEnum)]
 #[strum(serialize_all = "mixed_case")]
 pub enum SignerRelayMode {
     /// Passthrough relay mode

--- a/mithril-relay/src/repeater.rs
+++ b/mithril-relay/src/repeater.rs
@@ -35,6 +35,7 @@ impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
     }
 
     /// Set the message to repeat
+    #[allow(dead_code)]
     pub async fn set_message(&self, message: M) {
         debug!(self.logger, "Set message"; "message" => #?message);
         *self.message.lock().await = Some(message);

--- a/mithril-relay/src/repeater.rs
+++ b/mithril-relay/src/repeater.rs
@@ -35,7 +35,6 @@ impl<M: Clone + Debug + Sync + Send + 'static> MessageRepeater<M> {
     }
 
     /// Set the message to repeat
-    #[allow(dead_code)]
     pub async fn set_message(&self, message: M) {
         debug!(self.logger, "Set message"; "message" => #?message);
         *self.message.lock().await = Some(message);

--- a/mithril-relay/tests/register_signer_signature.rs
+++ b/mithril-relay/tests/register_signer_signature.rs
@@ -4,7 +4,7 @@ use libp2p::{gossipsub, Multiaddr};
 use mithril_common::messages::{RegisterSignatureMessage, RegisterSignerMessage};
 use mithril_relay::{
     p2p::{BroadcastMessage, PeerBehaviourEvent, PeerEvent},
-    PassiveRelay, SignerRelay,
+    PassiveRelay, SignerRelay, SignerRelayMode,
 };
 use reqwest::StatusCode;
 use slog::{Drain, Level, Logger};
@@ -35,11 +35,15 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     let total_peers = 1 + total_p2p_client;
     let addr: Multiaddr = "/ip4/0.0.0.0/tcp/0".parse().unwrap();
     let server_port = 0;
+    let signer_registration_mode = SignerRelayMode::P2P;
+    let signature_registration_mode = SignerRelayMode::P2P;
     let aggregator_endpoint = "http://0.0.0.0:1234".to_string();
     let signer_repeater_delay = Duration::from_secs(100);
     let mut signer_relay = SignerRelay::start(
         &addr,
         &server_port,
+        &signer_registration_mode,
+        &signature_registration_mode,
         &aggregator_endpoint,
         &signer_repeater_delay,
         &logger,

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.74"
+version = "0.4.75"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.5.32", features = ["derive"] }
 indicatif = { version = "0.17.11", features = ["tokio"] }
 mithril-common = { path = "../../mithril-common", features = ["full"] }
 mithril-doc = { path = "../../internal/mithril-doc" }
+mithril-relay = { path = "../../mithril-relay" }
 reqwest = { version = "0.12.15", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -21,7 +21,6 @@ clap = { version = "4.5.32", features = ["derive"] }
 indicatif = { version = "0.17.11", features = ["tokio"] }
 mithril-common = { path = "../../mithril-common", features = ["full"] }
 mithril-doc = { path = "../../internal/mithril-doc" }
-mithril-relay = { path = "../../mithril-relay" }
 reqwest = { version = "0.12.15", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/check.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/check.rs
@@ -18,7 +18,7 @@ use mithril_common::{
 };
 
 use crate::{
-    attempt, utils::AttemptResult, CardanoDbCommand, CardanoDbV2Command,
+    attempt, utils::AttemptResult, Aggregator, CardanoDbCommand, CardanoDbV2Command,
     CardanoStakeDistributionCommand, CardanoTransactionCommand, Client, ClientCommand,
     MithrilStakeDistributionCommand,
 };
@@ -37,10 +37,13 @@ async fn get_json_response<T: DeserializeOwned>(url: String) -> StdResult<reqwes
 }
 
 pub async fn assert_node_producing_mithril_stake_distribution(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/mithril-stake-distributions");
-    info!("Waiting for the aggregator to produce a mithril stake distribution");
+    let url = format!(
+        "{}/artifact/mithril-stake-distributions",
+        aggregator.endpoint()
+    );
+    info!("Waiting for the aggregator to produce a mithril stake distribution"; "aggregator" => &aggregator.name());
 
     async fn fetch_last_mithril_stake_distribution_hash(url: String) -> StdResult<Option<String>> {
         match get_json_response::<MithrilStakeDistributionListMessage>(url)
@@ -49,7 +52,7 @@ pub async fn assert_node_producing_mithril_stake_distribution(
         {
             Ok([stake_distribution, ..]) => Ok(Some(stake_distribution.hash.clone())),
             Ok(&[]) => Ok(None),
-            Err(err) => Err(anyhow!("Invalid mithril stake distribution body : {err}",)),
+            Err(err) => Err(anyhow!("Invalid mithril stake distribution body: {err}",)),
         }
     }
 
@@ -64,35 +67,44 @@ pub async fn assert_node_producing_mithril_stake_distribution(
         AttemptResult::Timeout() => Err(anyhow!(
             "Timeout exhausted assert_node_producing_mithril_stake_distribution, no response from `{url}`"
         )),
-    }
+    }.with_context(|| {
+        format!(
+            "Requesting aggregator `{}`",
+            aggregator.name()
+        )
+    })
 }
 
 pub async fn assert_signer_is_signing_mithril_stake_distribution(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
     hash: &str,
     expected_epoch_min: Epoch,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/mithril-stake-distribution/{hash}");
+    let url = format!(
+        "{}/artifact/mithril-stake-distribution/{hash}",
+        aggregator.endpoint()
+    );
     info!(
         "Asserting the aggregator is signing the mithril stake distribution message `{}` with an expected min epoch of `{}`",
         hash,
-        expected_epoch_min
+        expected_epoch_min;
+        "aggregator" => &aggregator.name()
     );
 
     async fn fetch_mithril_stake_distribution_message(
         url: String,
         expected_epoch_min: Epoch,
     ) -> StdResult<Option<MithrilStakeDistributionMessage>> {
-        match get_json_response::<MithrilStakeDistributionMessage>(url)
+        match get_json_response::<MithrilStakeDistributionMessage>(url.clone())
             .await?
             {
                 Ok(stake_distribution) => match stake_distribution.epoch {
                     epoch if epoch >= expected_epoch_min => Ok(Some(stake_distribution)),
                     epoch => Err(anyhow!(
-                        "Minimum expected mithril stake distribution epoch not reached : {epoch} < {expected_epoch_min}"
+                        "Minimum expected mithril stake distribution epoch not reached: {epoch} < {expected_epoch_min}"
                     )),
                 },
-                Err(err) => Err(anyhow!("Invalid mithril stake distribution body : {err}",)),
+                Err(err) => Err(anyhow!("Invalid mithril stake distribution body: {err}",)),
             }
     }
 
@@ -107,12 +119,17 @@ pub async fn assert_signer_is_signing_mithril_stake_distribution(
         AttemptResult::Timeout() => Err(anyhow!(
             "Timeout exhausted assert_signer_is_signing_mithril_stake_distribution, no response from `{url}`"
         )),
-    }
+    }.with_context(|| {
+        format!(
+            "Requesting aggregator `{}`",
+            aggregator.name()
+        )
+    })
 }
 
-pub async fn assert_node_producing_snapshot(aggregator_endpoint: &str) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/snapshots");
-    info!("Waiting for the aggregator to produce a snapshot");
+pub async fn assert_node_producing_snapshot(aggregator: &Aggregator) -> StdResult<String> {
+    let url = format!("{}/artifact/snapshots", aggregator.endpoint());
+    info!("Waiting for the aggregator to produce a snapshot"; "aggregator" => &aggregator.name());
 
     async fn fetch_last_snapshot_digest(url: String) -> StdResult<Option<String>> {
         match get_json_response::<Vec<SnapshotMessage>>(url)
@@ -121,7 +138,7 @@ pub async fn assert_node_producing_snapshot(aggregator_endpoint: &str) -> StdRes
         {
             Ok([snapshot, ..]) => Ok(Some(snapshot.digest.clone())),
             Ok(&[]) => Ok(None),
-            Err(err) => Err(anyhow!("Invalid snapshot body : {err}",)),
+            Err(err) => Err(anyhow!("Invalid snapshot body: {err}",)),
         }
     }
 
@@ -137,18 +154,20 @@ pub async fn assert_node_producing_snapshot(aggregator_endpoint: &str) -> StdRes
             "Timeout exhausted assert_node_producing_snapshot, no response from `{url}`"
         )),
     }
+    .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
 }
 
 pub async fn assert_signer_is_signing_snapshot(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
     digest: &str,
     expected_epoch_min: Epoch,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/snapshot/{digest}");
+    let url = format!("{}/artifact/snapshot/{digest}", aggregator.endpoint());
     info!(
         "Asserting the aggregator is signing the snapshot message `{}` with an expected min epoch of `{}`",
         digest,
-        expected_epoch_min
+        expected_epoch_min;
+        "aggregator" => &aggregator.name()
     );
 
     async fn fetch_snapshot_message(
@@ -159,7 +178,7 @@ pub async fn assert_signer_is_signing_snapshot(
             Ok(snapshot) => match snapshot.beacon.epoch {
                 epoch if epoch >= expected_epoch_min => Ok(Some(snapshot)),
                 epoch => Err(anyhow!(
-                    "Minimum expected snapshot epoch not reached : {epoch} < {expected_epoch_min}"
+                    "Minimum expected snapshot epoch not reached: {epoch} < {expected_epoch_min}"
                 )),
             },
             Err(err) => Err(anyhow!(err).context("Invalid snapshot body")),
@@ -173,18 +192,21 @@ pub async fn assert_signer_is_signing_snapshot(
             info!("Signer signed a snapshot"; "certificate_hash" => &snapshot.certificate_hash);
             Ok(snapshot.certificate_hash)
         }
-        AttemptResult::Err(error) => Err(error),
+        AttemptResult::Err(error) => {
+            Err(error).with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
+        }
         AttemptResult::Timeout() => Err(anyhow!(
             "Timeout exhausted assert_signer_is_signing_snapshot, no response from `{url}`"
         )),
     }
+    .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
 }
 
 pub async fn assert_node_producing_cardano_database_snapshot(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/cardano-database");
-    info!("Waiting for the aggregator to produce a Cardano database snapshot");
+    let url = format!("{}/artifact/cardano-database", aggregator.endpoint());
+    info!("Waiting for the aggregator to produce a Cardano database snapshot"; "aggregator" => &aggregator.name());
 
     async fn fetch_last_cardano_database_snapshot_hash(url: String) -> StdResult<Option<String>> {
         match get_json_response::<CardanoDatabaseSnapshotListMessage>(url)
@@ -193,7 +215,7 @@ pub async fn assert_node_producing_cardano_database_snapshot(
         {
             Ok([cardano_database_snapshot, ..]) => Ok(Some(cardano_database_snapshot.hash.clone())),
             Ok(&[]) => Ok(None),
-            Err(err) => Err(anyhow!("Invalid Cardano database snapshot body : {err}",)),
+            Err(err) => Err(anyhow!("Invalid Cardano database snapshot body: {err}",)),
         }
     }
 
@@ -209,18 +231,20 @@ pub async fn assert_node_producing_cardano_database_snapshot(
             "Timeout exhausted assert_node_producing_snapshot, no response from `{url}`"
         )),
     }
+    .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
 }
 
 pub async fn assert_signer_is_signing_cardano_database_snapshot(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
     hash: &str,
     expected_epoch_min: Epoch,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/cardano-database/{hash}");
+    let url = format!("{}/artifact/cardano-database/{hash}", aggregator.endpoint());
     info!(
         "Asserting the aggregator is signing the Cardano database snapshot message `{}` with an expected min epoch of `{}`",
         hash,
-        expected_epoch_min
+        expected_epoch_min;
+        "aggregator" => &aggregator.name()
     );
 
     async fn fetch_cardano_database_snapshot_message(
@@ -233,7 +257,7 @@ pub async fn assert_signer_is_signing_cardano_database_snapshot(
                 Ok(cardano_database_snapshot) => match cardano_database_snapshot.beacon.epoch {
                     epoch if epoch >= expected_epoch_min => Ok(Some(cardano_database_snapshot)),
                     epoch => Err(anyhow!(
-                        "Minimum expected Cardano database snapshot epoch not reached : {epoch} < {expected_epoch_min}"
+                        "Minimum expected Cardano database snapshot epoch not reached: {epoch} < {expected_epoch_min}"
                     )),
                 },
                 Err(err) => Err(anyhow!(err).context("Invalid Cardano database snapshot body")),
@@ -252,13 +276,17 @@ pub async fn assert_signer_is_signing_cardano_database_snapshot(
             "Timeout exhausted assert_signer_is_signing_snapshot, no response from `{url}`"
         )),
     }
+    .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
 }
 
 pub async fn assert_node_producing_cardano_database_digests_map(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
 ) -> StdResult<Vec<(String, String)>> {
-    let url = format!("{aggregator_endpoint}/artifact/cardano-database/digests");
-    info!("Waiting for the aggregator to produce a Cardano database digests map");
+    let url = format!(
+        "{}/artifact/cardano-database/digests",
+        aggregator.endpoint()
+    );
+    info!("Waiting for the aggregator to produce a Cardano database digests map"; "aggregator" => &aggregator.name());
 
     async fn fetch_cardano_database_digests_map(
         url: String,
@@ -274,7 +302,7 @@ pub async fn assert_node_producing_cardano_database_digests_map(
                     .map(|item| (item.immutable_file_name.clone(), item.digest.clone()))
                     .collect(),
             )),
-            Err(err) => Err(anyhow!("Invalid Cardano database digests map body : {err}",)),
+            Err(err) => Err(anyhow!("Invalid Cardano database digests map body: {err}",)),
         }
     }
 
@@ -289,14 +317,19 @@ pub async fn assert_node_producing_cardano_database_digests_map(
         AttemptResult::Timeout() => Err(anyhow!(
             "Timeout exhausted assert_node_producing_cardano_database_digests_map, no response from `{url}`"
         )),
-    }
+    }.with_context(|| {
+        format!(
+            "Requesting aggregator `{}`",
+            aggregator.name()
+        )
+    })
 }
 
 pub async fn assert_node_producing_cardano_transactions(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/cardano-transactions");
-    info!("Waiting for the aggregator to produce a Cardano transactions artifact");
+    let url = format!("{}/artifact/cardano-transactions", aggregator.endpoint());
+    info!("Waiting for the aggregator to produce a Cardano transactions artifact"; "aggregator" => &aggregator.name());
 
     async fn fetch_last_cardano_transaction_snapshot_hash(
         url: String,
@@ -307,9 +340,7 @@ pub async fn assert_node_producing_cardano_transactions(
         {
             Ok([artifact, ..]) => Ok(Some(artifact.hash.clone())),
             Ok(&[]) => Ok(None),
-            Err(err) => Err(anyhow!(
-                "Invalid Cardano transactions artifact body : {err}",
-            )),
+            Err(err) => Err(anyhow!("Invalid Cardano transactions artifact body: {err}",)),
         }
     }
 
@@ -325,18 +356,23 @@ pub async fn assert_node_producing_cardano_transactions(
             "Timeout exhausted assert_node_producing_cardano_transactions, no response from `{url}`"
         )),
     }
+    .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
 }
 
 pub async fn assert_signer_is_signing_cardano_transactions(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
     hash: &str,
     expected_epoch_min: Epoch,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/cardano-transaction/{hash}");
+    let url = format!(
+        "{}/artifact/cardano-transaction/{hash}",
+        aggregator.endpoint()
+    );
     info!(
         "Asserting the aggregator is signing the Cardano transactions artifact `{}` with an expected min epoch of `{}`",
         hash,
-        expected_epoch_min
+        expected_epoch_min;
+        "aggregator" => &aggregator.name()
     );
 
     async fn fetch_cardano_transaction_snapshot_message(
@@ -347,7 +383,7 @@ pub async fn assert_signer_is_signing_cardano_transactions(
             Ok(artifact) => match artifact.epoch {
                 epoch if epoch >= expected_epoch_min => Ok(Some(artifact)),
                 epoch => Err(anyhow!(
-                    "Minimum expected artifact epoch not reached : {epoch} < {expected_epoch_min}"
+                    "Minimum expected artifact epoch not reached: {epoch} < {expected_epoch_min}"
                 )),
             },
             Err(err) => Err(anyhow!(err).context("Invalid Cardano transactions artifact body")),
@@ -365,14 +401,22 @@ pub async fn assert_signer_is_signing_cardano_transactions(
         AttemptResult::Timeout() => Err(anyhow!(
             "Timeout exhausted assert_signer_is_signing_cardano_transactions, no response from `{url}`"
         )),
-    }
+    }.with_context(|| {
+        format!(
+            "Requesting aggregator `{}`",
+            aggregator.name()
+        )
+    })
 }
 
 pub async fn assert_node_producing_cardano_stake_distribution(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
 ) -> StdResult<(String, Epoch)> {
-    let url = format!("{aggregator_endpoint}/artifact/cardano-stake-distributions");
-    info!("Waiting for the aggregator to produce a Cardano stake distribution");
+    let url = format!(
+        "{}/artifact/cardano-stake-distributions",
+        aggregator.endpoint()
+    );
+    info!("Waiting for the aggregator to produce a Cardano stake distribution"; "aggregator" => &aggregator.name());
 
     async fn fetch_last_cardano_stake_distribution_message(
         url: String,
@@ -386,7 +430,7 @@ pub async fn assert_node_producing_cardano_stake_distribution(
                 stake_distribution.epoch,
             ))),
             Ok(&[]) => Ok(None),
-            Err(err) => Err(anyhow!("Invalid Cardano stake distribution body : {err}",)),
+            Err(err) => Err(anyhow!("Invalid Cardano stake distribution body: {err}",)),
         }
     }
 
@@ -401,19 +445,28 @@ pub async fn assert_node_producing_cardano_stake_distribution(
         AttemptResult::Timeout() => Err(anyhow!(
             "Timeout exhausted assert_node_producing_cardano_stake_distribution, no response from `{url}`"
         )),
-    }
+    }.with_context(|| {
+        format!(
+            "Requesting aggregator `{}`",
+            aggregator.name()
+        )
+    })
 }
 
 pub async fn assert_signer_is_signing_cardano_stake_distribution(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
     hash: &str,
     expected_epoch_min: Epoch,
 ) -> StdResult<String> {
-    let url = format!("{aggregator_endpoint}/artifact/cardano-stake-distribution/{hash}");
+    let url = format!(
+        "{}/artifact/cardano-stake-distribution/{hash}",
+        aggregator.endpoint()
+    );
     info!(
         "Asserting the aggregator is signing the Cardano stake distribution message `{}` with an expected min epoch of `{}`",
         hash,
-        expected_epoch_min
+        expected_epoch_min;
+        "aggregator" => &aggregator.name()
     );
 
     async fn fetch_cardano_stake_distribution_message(
@@ -426,7 +479,7 @@ pub async fn assert_signer_is_signing_cardano_stake_distribution(
             Ok(stake_distribution) => match stake_distribution.epoch {
                 epoch if epoch >= expected_epoch_min => Ok(Some(stake_distribution)),
                 epoch => Err(anyhow!(
-                    "Minimum expected Cardano stake distribution epoch not reached : {epoch} < {expected_epoch_min}"
+                    "Minimum expected Cardano stake distribution epoch not reached: {epoch} < {expected_epoch_min}"
                 )),
             },
             Err(err) => Err(anyhow!(err).context("Invalid Cardano stake distribution body",)),
@@ -444,15 +497,21 @@ pub async fn assert_signer_is_signing_cardano_stake_distribution(
         AttemptResult::Timeout() => Err(anyhow!(
             "Timeout exhausted assert_signer_is_signing_cardano_stake_distribution, no response from `{url}`"
         )),
-    }
+    }.with_context(|| {
+        format!(
+            "Requesting aggregator `{}`",
+            aggregator.name()
+        )
+    })
 }
 
 pub async fn assert_is_creating_certificate_with_enough_signers(
-    aggregator_endpoint: &str,
+    aggregator: &Aggregator,
     certificate_hash: &str,
     total_signers_expected: usize,
 ) -> StdResult<()> {
-    let url = format!("{aggregator_endpoint}/certificate/{certificate_hash}");
+    let url = format!("{}/certificate/{certificate_hash}", aggregator.endpoint());
+    info!("Waiting for the aggregator to create a certificate with enough signers"; "aggregator" => &aggregator.name());
 
     async fn fetch_certificate_message(url: String) -> StdResult<Option<CertificateMessage>> {
         match get_json_response::<CertificateMessage>(url).await? {
@@ -486,6 +545,7 @@ pub async fn assert_is_creating_certificate_with_enough_signers(
             "Timeout exhausted assert_is_creating_certificate, no response from `{url}`"
         )),
     }
+    .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
 }
 
 pub async fn assert_client_can_verify_snapshot(client: &mut Client, digest: &str) -> StdResult<()> {

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/check.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/check.rs
@@ -60,7 +60,7 @@ pub async fn assert_node_producing_mithril_stake_distribution(
         fetch_last_mithril_stake_distribution_hash(url.clone()).await
     }) {
         AttemptResult::Ok(hash) => {
-            info!("Aggregator produced a mithril stake distribution"; "hash" => &hash);
+            info!("Aggregator produced a mithril stake distribution"; "hash" => &hash, "aggregator" => &aggregator.name());
             Ok(hash)
         }
         AttemptResult::Err(error) => Err(error),
@@ -112,7 +112,7 @@ pub async fn assert_signer_is_signing_mithril_stake_distribution(
         fetch_mithril_stake_distribution_message(url.clone(), expected_epoch_min).await
     }) {
         AttemptResult::Ok(stake_distribution) => {
-            info!("Signer signed a mithril stake distribution"; "certificate_hash" => &stake_distribution.certificate_hash);
+            info!("Signer signed a mithril stake distribution"; "certificate_hash" => &stake_distribution.certificate_hash, "aggregator" => &aggregator.name());
             Ok(stake_distribution.certificate_hash)
         }
         AttemptResult::Err(error) => Err(error),
@@ -146,7 +146,7 @@ pub async fn assert_node_producing_snapshot(aggregator: &Aggregator) -> StdResul
         fetch_last_snapshot_digest(url.clone()).await
     }) {
         AttemptResult::Ok(digest) => {
-            info!("Aggregator produced a snapshot"; "digest" => &digest);
+            info!("Aggregator produced a snapshot"; "digest" => &digest, "aggregator" => &aggregator.name());
             Ok(digest)
         }
         AttemptResult::Err(error) => Err(error),
@@ -189,7 +189,7 @@ pub async fn assert_signer_is_signing_snapshot(
         fetch_snapshot_message(url.clone(), expected_epoch_min).await
     }) {
         AttemptResult::Ok(snapshot) => {
-            info!("Signer signed a snapshot"; "certificate_hash" => &snapshot.certificate_hash);
+            info!("Signer signed a snapshot"; "certificate_hash" => &snapshot.certificate_hash, "aggregator" => &aggregator.name());
             Ok(snapshot.certificate_hash)
         }
         AttemptResult::Err(error) => {
@@ -223,7 +223,7 @@ pub async fn assert_node_producing_cardano_database_snapshot(
         fetch_last_cardano_database_snapshot_hash(url.clone()).await
     }) {
         AttemptResult::Ok(hash) => {
-            info!("Aggregator produced a Cardano database snapshot"; "hash" => &hash);
+            info!("Aggregator produced a Cardano database snapshot"; "hash" => &hash, "aggregator" => &aggregator.name());
             Ok(hash)
         }
         AttemptResult::Err(error) => Err(error),
@@ -268,7 +268,7 @@ pub async fn assert_signer_is_signing_cardano_database_snapshot(
         fetch_cardano_database_snapshot_message(url.clone(), expected_epoch_min).await
     }) {
         AttemptResult::Ok(snapshot) => {
-            info!("Signer signed a snapshot"; "certificate_hash" => &snapshot.certificate_hash);
+            info!("Signer signed a snapshot"; "certificate_hash" => &snapshot.certificate_hash, "aggregator" => &aggregator.name());
             Ok(snapshot.certificate_hash)
         }
         AttemptResult::Err(error) => Err(error),
@@ -310,7 +310,7 @@ pub async fn assert_node_producing_cardano_database_digests_map(
         fetch_cardano_database_digests_map(url.clone()).await
     }) {
         AttemptResult::Ok(cardano_database_digests_map) => {
-            info!("Aggregator produced a Cardano database digests map"; "total_digests" => &cardano_database_digests_map.len());
+            info!("Aggregator produced a Cardano database digests map"; "total_digests" => &cardano_database_digests_map.len(), "aggregator" => &aggregator.name());
             Ok(cardano_database_digests_map)
         }
         AttemptResult::Err(error) => Err(error),
@@ -329,7 +329,7 @@ pub async fn assert_node_producing_cardano_transactions(
     aggregator: &Aggregator,
 ) -> StdResult<String> {
     let url = format!("{}/artifact/cardano-transactions", aggregator.endpoint());
-    info!("Waiting for the aggregator to produce a Cardano transactions artifact"; "aggregator" => &aggregator.name());
+    info!("Waiting for the aggregator to produce a Cardano transactions artifact"; "aggregator" => &aggregator.name(), "aggregator" => &aggregator.name());
 
     async fn fetch_last_cardano_transaction_snapshot_hash(
         url: String,
@@ -348,7 +348,7 @@ pub async fn assert_node_producing_cardano_transactions(
         fetch_last_cardano_transaction_snapshot_hash(url.clone()).await
     }) {
         AttemptResult::Ok(hash) => {
-            info!("Aggregator produced a Cardano transactions artifact"; "hash" => &hash);
+            info!("Aggregator produced a Cardano transactions artifact"; "hash" => &hash, "aggregator" => &aggregator.name());
             Ok(hash)
         }
         AttemptResult::Err(error) => Err(error),
@@ -394,7 +394,7 @@ pub async fn assert_signer_is_signing_cardano_transactions(
         fetch_cardano_transaction_snapshot_message(url.clone(), expected_epoch_min).await
     }) {
         AttemptResult::Ok(artifact) => {
-            info!("Signer signed a Cardano transactions artifact"; "certificate_hash" => &artifact.certificate_hash);
+            info!("Signer signed a Cardano transactions artifact"; "certificate_hash" => &artifact.certificate_hash, "aggregator" => &aggregator.name());
             Ok(artifact.certificate_hash)
         }
         AttemptResult::Err(error) => Err(error),
@@ -438,7 +438,7 @@ pub async fn assert_node_producing_cardano_stake_distribution(
         fetch_last_cardano_stake_distribution_message(url.clone()).await
     }) {
         AttemptResult::Ok((hash, epoch)) => {
-            info!("Aggregator produced a Cardano stake distribution"; "hash" => &hash, "epoch" => #?epoch);
+            info!("Aggregator produced a Cardano stake distribution"; "hash" => &hash, "epoch" => #?epoch, "aggregator" => &aggregator.name());
             Ok((hash, epoch))
         }
         AttemptResult::Err(error) => Err(error),
@@ -490,7 +490,7 @@ pub async fn assert_signer_is_signing_cardano_stake_distribution(
         fetch_cardano_stake_distribution_message(url.clone(), expected_epoch_min).await
     }) {
         AttemptResult::Ok(cardano_stake_distribution) => {
-            info!("Signer signed a Cardano stake distribution"; "certificate_hash" => &cardano_stake_distribution.certificate_hash);
+            info!("Signer signed a Cardano stake distribution"; "certificate_hash" => &cardano_stake_distribution.certificate_hash, "aggregator" => &aggregator.name());
             Ok(cardano_stake_distribution.certificate_hash)
         }
         AttemptResult::Err(error) => Err(error),
@@ -529,7 +529,8 @@ pub async fn assert_is_creating_certificate_with_enough_signers(
                 info!(
                     "Certificate is signed by expected number of signers: {} >= {} ",
                     certificate.metadata.signers.len(),
-                    total_signers_expected
+                    total_signers_expected ;
+                    "aggregator" => &aggregator.name()
                 );
                 Ok(())
             } else {

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
@@ -6,7 +6,7 @@ use mithril_common::StdResult;
 use slog_scope::info;
 
 pub async fn bootstrap_genesis_certificate(aggregator: &Aggregator) -> StdResult<()> {
-    info!("Bootstrap genesis certificate");
+    info!("Bootstrap genesis certificate"; "aggregator" => &aggregator.name());
 
     // A slave aggregator needs to wait few cycles of the state machine to be able to bootstrap
     // This should be removed when the aggregator is able to synchronize its certificate chain from another aggregator
@@ -18,11 +18,11 @@ pub async fn bootstrap_genesis_certificate(aggregator: &Aggregator) -> StdResult
         .await;
     }
 
-    info!("> stopping aggregator");
+    info!("> stopping aggregator"; "aggregator" => &aggregator.name());
     aggregator.stop().await?;
-    info!("> bootstrapping genesis using signers registered two epochs ago...");
+    info!("> bootstrapping genesis using signers registered two epochs ago..."; "aggregator" => &aggregator.name());
     aggregator.bootstrap_genesis().await?;
-    info!("> done, restarting aggregator");
+    info!("> done, restarting aggregator"; "aggregator" => &aggregator.name());
     aggregator.serve().await?;
 
     Ok(())
@@ -34,9 +34,9 @@ pub async fn register_era_marker(
     mithril_era: &str,
     era_epoch: Epoch,
 ) -> StdResult<()> {
-    info!("Register '{mithril_era}' era marker");
+    info!("Register '{mithril_era}' era marker"; "aggregator" => &aggregator.name());
 
-    info!("> generating era marker tx datum...");
+    info!("> generating era marker tx datum..."; "aggregator" => &aggregator.name());
     let tx_datum_file_path = devnet
         .artifacts_dir()
         .join(PathBuf::from("era-tx-datum.txt".to_string()));
@@ -44,7 +44,7 @@ pub async fn register_era_marker(
         .era_generate_tx_datum(&tx_datum_file_path, mithril_era, era_epoch)
         .await?;
 
-    info!("> writing '{mithril_era}' era marker on the Cardano chain...");
+    info!("> writing '{mithril_era}' era marker on the Cardano chain..."; "aggregator" => &aggregator.name());
     devnet.write_era_marker(&tx_datum_file_path).await?;
 
     Ok(())
@@ -67,7 +67,7 @@ pub async fn transfer_funds(devnet: &Devnet) -> StdResult<()> {
 }
 
 pub async fn update_protocol_parameters(aggregator: &Aggregator) -> StdResult<()> {
-    info!("Update protocol parameters");
+    info!("Update protocol parameters"; "aggregator" => &aggregator.name());
 
     info!("> stopping aggregator");
     aggregator.stop().await?;
@@ -77,13 +77,12 @@ pub async fn update_protocol_parameters(aggregator: &Aggregator) -> StdResult<()
         phi_f: 0.80,
     };
     info!(
-        "> updating protocol parameters to {:?}...",
-        protocol_parameters_new
+        "> updating protocol parameters to {protocol_parameters_new:?}..."; "aggregator" => &aggregator.name()
     );
     aggregator
         .set_protocol_parameters(&protocol_parameters_new)
         .await;
-    info!("> done, restarting aggregator");
+    info!("> done, restarting aggregator"; "aggregator" => &aggregator.name());
     aggregator.serve().await?;
 
     Ok(())

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
@@ -5,7 +5,7 @@ use mithril_common::entities::{Epoch, ProtocolParameters};
 use mithril_common::StdResult;
 use slog_scope::info;
 
-pub async fn bootstrap_genesis_certificate(aggregator: &mut Aggregator) -> StdResult<()> {
+pub async fn bootstrap_genesis_certificate(aggregator: &Aggregator) -> StdResult<()> {
     info!("Bootstrap genesis certificate");
 
     info!("> stopping aggregator");
@@ -13,13 +13,13 @@ pub async fn bootstrap_genesis_certificate(aggregator: &mut Aggregator) -> StdRe
     info!("> bootstrapping genesis using signers registered two epochs ago...");
     aggregator.bootstrap_genesis().await?;
     info!("> done, restarting aggregator");
-    aggregator.serve()?;
+    aggregator.serve().await?;
 
     Ok(())
 }
 
 pub async fn register_era_marker(
-    aggregator: &mut Aggregator,
+    aggregator: &Aggregator,
     devnet: &Devnet,
     mithril_era: &str,
     era_epoch: Epoch,
@@ -56,7 +56,7 @@ pub async fn transfer_funds(devnet: &Devnet) -> StdResult<()> {
     Ok(())
 }
 
-pub async fn update_protocol_parameters(aggregator: &mut Aggregator) -> StdResult<()> {
+pub async fn update_protocol_parameters(aggregator: &Aggregator) -> StdResult<()> {
     info!("Update protocol parameters");
 
     info!("> stopping aggregator");
@@ -70,9 +70,11 @@ pub async fn update_protocol_parameters(aggregator: &mut Aggregator) -> StdResul
         "> updating protocol parameters to {:?}...",
         protocol_parameters_new
     );
-    aggregator.set_protocol_parameters(&protocol_parameters_new);
+    aggregator
+        .set_protocol_parameters(&protocol_parameters_new)
+        .await;
     info!("> done, restarting aggregator");
-    aggregator.serve()?;
+    aggregator.serve().await?;
 
     Ok(())
 }

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/exec.rs
@@ -8,6 +8,16 @@ use slog_scope::info;
 pub async fn bootstrap_genesis_certificate(aggregator: &Aggregator) -> StdResult<()> {
     info!("Bootstrap genesis certificate");
 
+    // A slave aggregator needs to wait few cycles of the state machine to be able to bootstrap
+    // This should be removed when the aggregator is able to synchronize its certificate chain from another aggregator
+    if !aggregator.is_first() {
+        const CYCLES_WAIT_SLAVE: u64 = 3;
+        tokio::time::sleep(std::time::Duration::from_millis(
+            CYCLES_WAIT_SLAVE * aggregator.mithril_run_interval() as u64,
+        ))
+        .await;
+    }
+
     info!("> stopping aggregator");
     aggregator.stop().await?;
     info!("> bootstrapping genesis using signers registered two epochs ago...");

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
@@ -1,12 +1,11 @@
 use crate::{attempt, utils::AttemptResult, Aggregator};
 use anyhow::{anyhow, Context};
 use mithril_common::{
-    chain_observer::ChainObserver, digesters::ImmutableFile, entities::Epoch,
-    messages::EpochSettingsMessage, StdResult,
+    digesters::ImmutableFile, entities::Epoch, messages::EpochSettingsMessage, StdResult,
 };
 use reqwest::StatusCode;
 use slog_scope::{info, warn};
-use std::{sync::Arc, time::Duration};
+use std::time::Duration;
 
 pub async fn wait_for_enough_immutable(aggregator: &Aggregator) -> StdResult<()> {
     info!("Waiting that enough immutable have been written in the devnet"; "aggregator" => aggregator.name());
@@ -68,9 +67,8 @@ pub async fn wait_for_epoch_settings(aggregator: &Aggregator) -> StdResult<Epoch
     }
 }
 
-pub async fn wait_for_target_epoch(
+pub async fn wait_for_aggregator_at_target_epoch(
     aggregator: &Aggregator,
-    chain_observer: Arc<dyn ChainObserver>,
     target_epoch: Epoch,
     wait_reason: String,
 ) -> StdResult<()> {
@@ -81,7 +79,8 @@ pub async fn wait_for_target_epoch(
     );
 
     match attempt!(90, Duration::from_millis(1000), {
-        match chain_observer
+        match aggregator
+            .chain_observer()
             .get_current_epoch()
             .await
             .with_context(|| "Could not query current epoch")?

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
@@ -1,4 +1,4 @@
-use crate::{attempt, utils::AttemptResult};
+use crate::{attempt, utils::AttemptResult, Aggregator};
 use anyhow::{anyhow, Context};
 use mithril_common::{
     chain_observer::ChainObserver, digesters::ImmutableFile, entities::Epoch,
@@ -6,11 +6,12 @@ use mithril_common::{
 };
 use reqwest::StatusCode;
 use slog_scope::{info, warn};
-use std::{path::Path, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
-pub async fn wait_for_enough_immutable(db_directory: &Path) -> StdResult<()> {
-    info!("Waiting that enough immutable have been written in the devnet");
+pub async fn wait_for_enough_immutable(aggregator: &Aggregator) -> StdResult<()> {
+    info!("Waiting that enough immutable have been written in the devnet"; "aggregator" => aggregator.name());
 
+    let db_directory = aggregator.db_directory();
     match attempt!(24, Duration::from_secs(5), {
         match ImmutableFile::list_completed_in_dir(db_directory)
             .with_context(|| {
@@ -34,9 +35,10 @@ pub async fn wait_for_enough_immutable(db_directory: &Path) -> StdResult<()> {
     }
 }
 
-pub async fn wait_for_epoch_settings(aggregator_endpoint: &str) -> StdResult<EpochSettingsMessage> {
+pub async fn wait_for_epoch_settings(aggregator: &Aggregator) -> StdResult<EpochSettingsMessage> {
+    let aggregator_endpoint = aggregator.endpoint();
     let url = format!("{aggregator_endpoint}/epoch-settings");
-    info!("Waiting for the aggregator to expose epoch settings");
+    info!("Waiting for the aggregator to expose epoch settings"; "aggregator" => aggregator.name());
 
     match attempt!(20, Duration::from_millis(1000), {
         match reqwest::get(url.clone()).await {
@@ -52,7 +54,8 @@ pub async fn wait_for_epoch_settings(aggregator_endpoint: &str) -> StdResult<Epo
                 s if s.is_server_error() => {
                     warn!(
                         "Server error while waiting for the Aggregator, http code: {}",
-                        s
+                        s;
+                        "aggregator" => aggregator.name()
                     );
                     Ok(None)
                 }
@@ -70,12 +73,14 @@ pub async fn wait_for_epoch_settings(aggregator_endpoint: &str) -> StdResult<Epo
 }
 
 pub async fn wait_for_target_epoch(
+    aggregator: &Aggregator,
     chain_observer: Arc<dyn ChainObserver>,
     target_epoch: Epoch,
     wait_reason: String,
 ) -> StdResult<()> {
     info!(
         "Waiting for the cardano network to be at the target epoch: {}", wait_reason;
+        "aggregator" => aggregator.name(),
         "target_epoch" => ?target_epoch
     );
 
@@ -96,7 +101,7 @@ pub async fn wait_for_target_epoch(
         }
     }) {
         AttemptResult::Ok(_) => {
-            info!("Target epoch reached!"; "target_epoch" => ?target_epoch);
+            info!("Target epoch reached!"; "aggregator" => aggregator.name(), "target_epoch" => ?target_epoch);
             Ok(())
         }
         AttemptResult::Err(error) => Err(error),

--- a/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/assertions/wait.rs
@@ -52,11 +52,7 @@ pub async fn wait_for_epoch_settings(aggregator: &Aggregator) -> StdResult<Epoch
                     Ok(Some(epoch_settings))
                 }
                 s if s.is_server_error() => {
-                    warn!(
-                        "Server error while waiting for the Aggregator, http code: {}",
-                        s;
-                        "aggregator" => aggregator.name()
-                    );
+                    warn!( "Server error while waiting for the Aggregator, http code: {s}"; "aggregator" => aggregator.name());
                     Ok(None)
                 }
                 _ => Ok(None),

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/mod.rs
@@ -1,3 +1,5 @@
 mod runner;
 
-pub use runner::{Devnet, DevnetBootstrapArgs, DevnetTopology, PoolNode, RetryableDevnetError};
+pub use runner::{
+    Devnet, DevnetBootstrapArgs, DevnetTopology, FullNode, PoolNode, RetryableDevnetError,
+};

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -1,12 +1,19 @@
-use crate::assertions;
-use crate::MithrilInfrastructure;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use tokio::sync::RwLock;
+use tokio::task::JoinSet;
+
 use mithril_common::{
+    chain_observer::ChainObserver,
     entities::{Epoch, SignedEntityTypeDiscriminants},
     StdResult,
 };
 
-pub struct Spec<'a> {
-    pub infrastructure: &'a MithrilInfrastructure,
+use crate::{assertions, Aggregator, MithrilInfrastructure};
+
+pub struct Spec {
+    pub infrastructure: Arc<RwLock<Option<MithrilInfrastructure>>>,
     is_signing_cardano_transactions: bool,
     is_signing_cardano_stake_distribution: bool,
     is_signing_cardano_database: bool,
@@ -14,9 +21,9 @@ pub struct Spec<'a> {
     regenesis_on_era_switch: bool,
 }
 
-impl<'a> Spec<'a> {
+impl Spec {
     pub fn new(
-        infrastructure: &'a MithrilInfrastructure,
+        infrastructure: Arc<RwLock<Option<MithrilInfrastructure>>>,
         signed_entity_types: Vec<String>,
         next_era: Option<String>,
         regenesis_on_era_switch: bool,
@@ -43,80 +50,134 @@ impl<'a> Spec<'a> {
         }
     }
 
-    pub async fn run(&self) -> StdResult<()> {
-        let aggregator_endpoint = self.infrastructure.master_aggregator().endpoint();
-        assertions::wait_for_enough_immutable(
-            self.infrastructure.master_aggregator().db_directory(),
-        )
-        .await?;
-        let start_epoch = self
-            .infrastructure
-            .master_chain_observer()
-            .get_current_epoch()
-            .await?
-            .unwrap_or_default();
+    pub async fn run(self) -> StdResult<()> {
+        let spec = Arc::new(self);
+        let infrastructure_guard = spec.infrastructure.read().await;
+        let infrastructure = infrastructure_guard
+            .as_ref()
+            .ok_or(anyhow!("No infrastructure found"))?;
 
         // Transfer some funds on the devnet to have some Cardano transactions to sign.
         // This step needs to be executed early in the process so that the transactions are available
         // for signing in the penultimate immutable chunk before the end of the test.
         // As we get closer to the tip of the chain when signing, we'll be able to relax this constraint.
-        assertions::transfer_funds(self.infrastructure.devnet()).await?;
+        assertions::transfer_funds(infrastructure.devnet()).await?;
+
+        let mut join_set = JoinSet::new();
+        let spec_clone = spec.clone();
+        join_set.spawn(async move { spec_clone.start_master().await });
+        for index in 0..infrastructure.slave_aggregators().len() {
+            let spec_clone = spec.clone();
+            join_set.spawn(async move { spec_clone.start_slave(index).await });
+        }
+        while let Some(res) = join_set.join_next().await {
+            res??;
+        }
+
+        Ok(())
+    }
+
+    pub async fn start_master(&self) -> StdResult<()> {
+        let infrastructure_guard = self.infrastructure.read().await;
+        let infrastructure = infrastructure_guard
+            .as_ref()
+            .ok_or(anyhow!("No infrastructure found"))?;
+
+        self.start_aggregator(
+            infrastructure.master_aggregator(),
+            infrastructure.master_chain_observer(),
+            infrastructure,
+        )
+        .await
+    }
+
+    pub async fn start_slave(&self, slave_index: usize) -> StdResult<()> {
+        let infrastructure_guard = self.infrastructure.read().await;
+        let infrastructure = infrastructure_guard
+            .as_ref()
+            .ok_or(anyhow!("No infrastructure found"))?;
+
+        self.start_aggregator(
+            infrastructure.slave_aggregator(slave_index),
+            infrastructure.slave_chain_observer(slave_index),
+            infrastructure,
+        )
+        .await
+    }
+
+    pub async fn start_aggregator(
+        &self,
+        aggregator: &Aggregator,
+        chain_observer: Arc<dyn ChainObserver>,
+        infrastructure: &MithrilInfrastructure,
+    ) -> StdResult<()> {
+        assertions::wait_for_enough_immutable(aggregator.db_directory()).await?;
+        let start_epoch = chain_observer
+            .get_current_epoch()
+            .await?
+            .unwrap_or_default();
 
         // Wait 4 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
         let mut target_epoch = start_epoch + 4;
+        /* if !aggregator.is_master() {
+            target_epoch += 2;
+        } */
         assertions::wait_for_target_epoch(
-            self.infrastructure.master_chain_observer(),
+            chain_observer.clone(),
             target_epoch,
             "minimal epoch for the aggregator to be able to bootstrap genesis certificate"
                 .to_string(),
         )
         .await?;
-        assertions::bootstrap_genesis_certificate(self.infrastructure.master_aggregator()).await?;
-        assertions::wait_for_epoch_settings(&aggregator_endpoint).await?;
+        assertions::bootstrap_genesis_certificate(aggregator).await?;
+        assertions::wait_for_epoch_settings(&aggregator.endpoint()).await?;
 
         // Wait 2 epochs before changing stake distribution, so that we use at least one original stake distribution
         target_epoch += 2;
         assertions::wait_for_target_epoch(
-            self.infrastructure.master_chain_observer(),
+            chain_observer.clone(),
             target_epoch,
             "epoch after which the stake distribution will change".to_string(),
         )
         .await?;
-        let delegation_round = 1;
-        assertions::delegate_stakes_to_pools(self.infrastructure.devnet(), delegation_round)
-            .await?;
+
+        if aggregator.is_master() {
+            // Delegate some stakes to pools
+            let delegation_round = 1;
+            assertions::delegate_stakes_to_pools(infrastructure.devnet(), delegation_round).await?;
+        }
 
         // Wait 2 epochs before changing protocol parameters
         target_epoch += 2;
         assertions::wait_for_target_epoch(
-            self.infrastructure.master_chain_observer(),
+            chain_observer.clone(),
             target_epoch,
             "epoch after which the protocol parameters will change".to_string(),
         )
         .await?;
-        assertions::update_protocol_parameters(self.infrastructure.master_aggregator()).await?;
+        assertions::update_protocol_parameters(aggregator).await?;
 
         // Wait 6 epochs after protocol parameters update, so that we make sure that we use new protocol parameters as well as new stake distribution a few times
         target_epoch += 6;
         assertions::wait_for_target_epoch(
-            self.infrastructure.master_chain_observer(),
+            chain_observer.clone(),
             target_epoch,
             "epoch after which the certificate chain will be long enough to catch most common troubles with stake distribution and protocol parameters".to_string(),
         )
         .await?;
 
         // Verify that artifacts are produced and signed correctly
-        let mut target_epoch = self.verify_artifacts_production(target_epoch).await?;
+        let mut target_epoch = self
+            .verify_artifacts_production(target_epoch, aggregator, infrastructure)
+            .await?;
 
         // Verify that artifacts are produced and signed correctly after era switch
         if let Some(next_era) = &self.next_era {
             // Switch to next era
-            self.infrastructure
-                .register_switch_to_next_era(next_era)
-                .await?;
+            infrastructure.register_switch_to_next_era(next_era).await?;
             target_epoch += 5;
             assertions::wait_for_target_epoch(
-                self.infrastructure.master_chain_observer(),
+                chain_observer.clone(),
                 target_epoch,
                 "epoch after which the era switch will have triggered".to_string(),
             )
@@ -124,11 +185,10 @@ impl<'a> Spec<'a> {
 
             // Proceed to a re-genesis of the certificate chain
             if self.regenesis_on_era_switch {
-                assertions::bootstrap_genesis_certificate(self.infrastructure.master_aggregator())
-                    .await?;
+                assertions::bootstrap_genesis_certificate(aggregator).await?;
                 target_epoch += 5;
                 assertions::wait_for_target_epoch(
-                    self.infrastructure.master_chain_observer(),
+                    chain_observer.clone(),
                     target_epoch,
                     "epoch after which the re-genesis on era switch will be completed".to_string(),
                 )
@@ -136,107 +196,113 @@ impl<'a> Spec<'a> {
             }
 
             // Verify that artifacts are produced and signed correctly
-            self.verify_artifacts_production(target_epoch).await?;
+            self.verify_artifacts_production(target_epoch, aggregator, infrastructure)
+                .await?;
         }
 
         Ok(())
     }
 
-    async fn verify_artifacts_production(&self, target_epoch: Epoch) -> StdResult<Epoch> {
-        let aggregator_endpoint = self.infrastructure.master_aggregator().endpoint();
+    async fn verify_artifacts_production(
+        &self,
+        target_epoch: Epoch,
+        aggregator: &Aggregator,
+        infrastructure: &MithrilInfrastructure,
+    ) -> StdResult<Epoch> {
         let expected_epoch_min = target_epoch - 3;
         // Verify that mithril stake distribution artifacts are produced and signed correctly
         {
-            let hash =
-                assertions::assert_node_producing_mithril_stake_distribution(&aggregator_endpoint)
-                    .await?;
+            let hash = assertions::assert_node_producing_mithril_stake_distribution(
+                &aggregator.endpoint(),
+            )
+            .await?;
             let certificate_hash = assertions::assert_signer_is_signing_mithril_stake_distribution(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &hash,
                 expected_epoch_min,
             )
             .await?;
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &certificate_hash,
-                self.infrastructure.signers().len(),
+                infrastructure.signers().len(),
             )
             .await?;
-            let mut client = self.infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client().await?;
             assertions::assert_client_can_verify_mithril_stake_distribution(&mut client, &hash)
                 .await?;
         }
 
         // Verify that snapshot artifacts are produced and signed correctly
         {
-            let digest = assertions::assert_node_producing_snapshot(&aggregator_endpoint).await?;
+            let digest = assertions::assert_node_producing_snapshot(&aggregator.endpoint()).await?;
             let certificate_hash = assertions::assert_signer_is_signing_snapshot(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &digest,
                 expected_epoch_min,
             )
             .await?;
 
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &certificate_hash,
-                self.infrastructure.signers().len(),
+                infrastructure.signers().len(),
             )
             .await?;
 
-            let mut client = self.infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client().await?;
             assertions::assert_client_can_verify_snapshot(&mut client, &digest).await?;
         }
 
         // Verify that Cardano database snapshot artifacts are produced and signed correctly
         if self.is_signing_cardano_database {
             let hash =
-                assertions::assert_node_producing_cardano_database_snapshot(&aggregator_endpoint)
+                assertions::assert_node_producing_cardano_database_snapshot(&aggregator.endpoint())
                     .await?;
             let certificate_hash = assertions::assert_signer_is_signing_cardano_database_snapshot(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &hash,
                 expected_epoch_min,
             )
             .await?;
 
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &certificate_hash,
-                self.infrastructure.signers().len(),
+                infrastructure.signers().len(),
             )
             .await?;
 
-            assertions::assert_node_producing_cardano_database_digests_map(&aggregator_endpoint)
+            assertions::assert_node_producing_cardano_database_digests_map(&aggregator.endpoint())
                 .await?;
 
-            let mut client = self.infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client().await?;
             assertions::assert_client_can_verify_cardano_database(&mut client, &hash).await?;
         }
 
         // Verify that Cardano transactions artifacts are produced and signed correctly
         if self.is_signing_cardano_transactions {
-            let hash = assertions::assert_node_producing_cardano_transactions(&aggregator_endpoint)
-                .await?;
+            let hash =
+                assertions::assert_node_producing_cardano_transactions(&aggregator.endpoint())
+                    .await?;
             let certificate_hash = assertions::assert_signer_is_signing_cardano_transactions(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &hash,
                 expected_epoch_min,
             )
             .await?;
 
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator_endpoint,
+                &aggregator.endpoint(),
                 &certificate_hash,
-                self.infrastructure.signers().len(),
+                infrastructure.signers().len(),
             )
             .await?;
 
-            let transaction_hashes = self
-                .infrastructure
+            let transaction_hashes = infrastructure
                 .devnet()
                 .mithril_payments_transaction_hashes()?;
-            let mut client = self.infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client().await?;
             assertions::assert_client_can_verify_transactions(&mut client, transaction_hashes)
                 .await?;
         }
@@ -245,24 +311,24 @@ impl<'a> Spec<'a> {
         if self.is_signing_cardano_stake_distribution {
             {
                 let (hash, epoch) = assertions::assert_node_producing_cardano_stake_distribution(
-                    &aggregator_endpoint,
+                    &aggregator.endpoint(),
                 )
                 .await?;
                 let certificate_hash =
                     assertions::assert_signer_is_signing_cardano_stake_distribution(
-                        &aggregator_endpoint,
+                        &aggregator.endpoint(),
                         &hash,
                         expected_epoch_min,
                     )
                     .await?;
                 assertions::assert_is_creating_certificate_with_enough_signers(
-                    &aggregator_endpoint,
+                    &aggregator.endpoint(),
                     &certificate_hash,
-                    self.infrastructure.signers().len(),
+                    infrastructure.signers().len(),
                 )
                 .await?;
 
-                let mut client = self.infrastructure.build_client().await?;
+                let mut client = infrastructure.build_client().await?;
                 assertions::assert_client_can_verify_cardano_stake_distribution(
                     &mut client,
                     &hash,

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -138,7 +138,7 @@ impl Spec {
         )
         .await?;
 
-        if aggregator.is_master() {
+        if aggregator.index() == 0 {
             // Delegate some stakes to pools
             let delegation_round = 1;
             assertions::delegate_stakes_to_pools(infrastructure.devnet(), delegation_round).await?;

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -119,9 +119,6 @@ impl Spec {
 
         // Wait 4 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
         let mut target_epoch = start_epoch + 4;
-        /* if !aggregator.is_master() {
-            target_epoch += 2;
-        } */
         assertions::wait_for_target_epoch(
             chain_observer.clone(),
             target_epoch,
@@ -212,18 +209,16 @@ impl Spec {
         let expected_epoch_min = target_epoch - 3;
         // Verify that mithril stake distribution artifacts are produced and signed correctly
         {
-            let hash = assertions::assert_node_producing_mithril_stake_distribution(
-                &aggregator.endpoint(),
-            )
-            .await?;
+            let hash =
+                assertions::assert_node_producing_mithril_stake_distribution(aggregator).await?;
             let certificate_hash = assertions::assert_signer_is_signing_mithril_stake_distribution(
-                &aggregator.endpoint(),
+                aggregator,
                 &hash,
                 expected_epoch_min,
             )
             .await?;
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator.endpoint(),
+                aggregator,
                 &certificate_hash,
                 infrastructure.signers().len(),
             )
@@ -235,16 +230,16 @@ impl Spec {
 
         // Verify that snapshot artifacts are produced and signed correctly
         {
-            let digest = assertions::assert_node_producing_snapshot(&aggregator.endpoint()).await?;
+            let digest = assertions::assert_node_producing_snapshot(aggregator).await?;
             let certificate_hash = assertions::assert_signer_is_signing_snapshot(
-                &aggregator.endpoint(),
+                aggregator,
                 &digest,
                 expected_epoch_min,
             )
             .await?;
 
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator.endpoint(),
+                aggregator,
                 &certificate_hash,
                 infrastructure.signers().len(),
             )
@@ -257,24 +252,22 @@ impl Spec {
         // Verify that Cardano database snapshot artifacts are produced and signed correctly
         if self.is_signing_cardano_database {
             let hash =
-                assertions::assert_node_producing_cardano_database_snapshot(&aggregator.endpoint())
-                    .await?;
+                assertions::assert_node_producing_cardano_database_snapshot(aggregator).await?;
             let certificate_hash = assertions::assert_signer_is_signing_cardano_database_snapshot(
-                &aggregator.endpoint(),
+                aggregator,
                 &hash,
                 expected_epoch_min,
             )
             .await?;
 
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator.endpoint(),
+                aggregator,
                 &certificate_hash,
                 infrastructure.signers().len(),
             )
             .await?;
 
-            assertions::assert_node_producing_cardano_database_digests_map(&aggregator.endpoint())
-                .await?;
+            assertions::assert_node_producing_cardano_database_digests_map(aggregator).await?;
 
             let mut client = infrastructure.build_client(aggregator).await?;
             assertions::assert_client_can_verify_cardano_database(&mut client, &hash).await?;
@@ -282,18 +275,16 @@ impl Spec {
 
         // Verify that Cardano transactions artifacts are produced and signed correctly
         if self.is_signing_cardano_transactions {
-            let hash =
-                assertions::assert_node_producing_cardano_transactions(&aggregator.endpoint())
-                    .await?;
+            let hash = assertions::assert_node_producing_cardano_transactions(aggregator).await?;
             let certificate_hash = assertions::assert_signer_is_signing_cardano_transactions(
-                &aggregator.endpoint(),
+                aggregator,
                 &hash,
                 expected_epoch_min,
             )
             .await?;
 
             assertions::assert_is_creating_certificate_with_enough_signers(
-                &aggregator.endpoint(),
+                aggregator,
                 &certificate_hash,
                 infrastructure.signers().len(),
             )
@@ -310,19 +301,18 @@ impl Spec {
         // Verify that Cardano stake distribution artifacts are produced and signed correctly
         if self.is_signing_cardano_stake_distribution {
             {
-                let (hash, epoch) = assertions::assert_node_producing_cardano_stake_distribution(
-                    &aggregator.endpoint(),
-                )
-                .await?;
+                let (hash, epoch) =
+                    assertions::assert_node_producing_cardano_stake_distribution(aggregator)
+                        .await?;
                 let certificate_hash =
                     assertions::assert_signer_is_signing_cardano_stake_distribution(
-                        &aggregator.endpoint(),
+                        aggregator,
                         &hash,
                         expected_epoch_min,
                     )
                     .await?;
                 assertions::assert_is_creating_certificate_with_enough_signers(
-                    &aggregator.endpoint(),
+                    aggregator,
                     &certificate_hash,
                     infrastructure.signers().len(),
                 )

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -163,7 +163,9 @@ impl Spec {
         // Verify that artifacts are produced and signed correctly after era switch
         if let Some(next_era) = &self.next_era {
             // Switch to next era
-            infrastructure.register_switch_to_next_era(next_era).await?;
+            if aggregator.is_first() {
+                infrastructure.register_switch_to_next_era(next_era).await?;
+            }
             target_epoch += 5;
             assertions::wait_for_target_epoch(
                 aggregator,

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -77,7 +77,7 @@ impl Spec {
                     .ok_or(anyhow!("No infrastructure found"))?;
 
                 spec_clone
-                    .start_aggregator(
+                    .run_scenario(
                         infrastructure.aggregator(index),
                         infrastructure.chain_observer(index),
                         infrastructure,
@@ -93,7 +93,7 @@ impl Spec {
         Ok(())
     }
 
-    pub async fn start_aggregator(
+    pub async fn run_scenario(
         &self,
         aggregator: &Aggregator,
         chain_observer: Arc<dyn ChainObserver>,

--- a/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/end_to_end_spec.rs
@@ -228,7 +228,7 @@ impl Spec {
                 infrastructure.signers().len(),
             )
             .await?;
-            let mut client = infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client(aggregator).await?;
             assertions::assert_client_can_verify_mithril_stake_distribution(&mut client, &hash)
                 .await?;
         }
@@ -250,7 +250,7 @@ impl Spec {
             )
             .await?;
 
-            let mut client = infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client(aggregator).await?;
             assertions::assert_client_can_verify_snapshot(&mut client, &digest).await?;
         }
 
@@ -276,7 +276,7 @@ impl Spec {
             assertions::assert_node_producing_cardano_database_digests_map(&aggregator.endpoint())
                 .await?;
 
-            let mut client = infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client(aggregator).await?;
             assertions::assert_client_can_verify_cardano_database(&mut client, &hash).await?;
         }
 
@@ -302,7 +302,7 @@ impl Spec {
             let transaction_hashes = infrastructure
                 .devnet()
                 .mithril_payments_transaction_hashes()?;
-            let mut client = infrastructure.build_client().await?;
+            let mut client = infrastructure.build_client(aggregator).await?;
             assertions::assert_client_can_verify_transactions(&mut client, transaction_hashes)
                 .await?;
         }
@@ -328,7 +328,7 @@ impl Spec {
                 )
                 .await?;
 
-                let mut client = infrastructure.build_client().await?;
+                let mut client = infrastructure.build_client(aggregator).await?;
                 assertions::assert_client_can_verify_cardano_stake_distribution(
                     &mut client,
                     &hash,

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -201,19 +201,19 @@ async fn main_exec() -> StdResult<()> {
     };
     let artifacts_dir = {
         let path = work_dir.join("artifacts");
-        fs::create_dir(&path).expect("Artifacts dir creation failure");
+        fs::create_dir(&path).with_context(|| "Artifacts dir creation failure")?;
         path
     };
     let store_dir = {
         let path = work_dir.join("stores");
-        fs::create_dir(&path).expect("Stores dir creation failure");
+        fs::create_dir(&path).with_context(|| "Stores dir creation failure")?;
         path
     };
 
     let mut app = App::new();
     let mut app_stopper = AppStopper::new(&app);
     let mut join_set = JoinSet::new();
-    with_gracefull_shutdown(&mut join_set);
+    with_graceful_shutdown(&mut join_set);
 
     join_set.spawn(async move { app.run(args, work_dir, store_dir, artifacts_dir).await });
 
@@ -446,7 +446,7 @@ fn create_workdir_if_not_exist_clean_otherwise(work_dir: &Path) {
 #[error("Signal received: `{0}`")]
 pub struct SignalError(pub String);
 
-fn with_gracefull_shutdown(join_set: &mut JoinSet<StdResult<()>>) {
+fn with_graceful_shutdown(join_set: &mut JoinSet<StdResult<()>>) {
     join_set.spawn(async move {
         let mut sigterm = signal(SignalKind::terminate()).expect("Failed to create SIGTERM signal");
         sigterm.recv().await;

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -340,7 +340,7 @@ impl App {
         .await?;
         *self.devnet.lock().await = Some(devnet.clone());
 
-        let mut infrastructure = MithrilInfrastructure::start(&MithrilInfrastructureConfig {
+        let infrastructure = MithrilInfrastructure::start(&MithrilInfrastructureConfig {
             number_of_aggregators: args.number_of_aggregators,
             number_of_signers: args.number_of_signers,
             server_port,
@@ -363,12 +363,12 @@ impl App {
 
         let runner: StdResult<()> = match run_only_mode {
             true => {
-                let mut run_only = RunOnly::new(&mut infrastructure);
+                let run_only = RunOnly::new(&infrastructure);
                 run_only.start().await
             }
             false => {
-                let mut spec = Spec::new(
-                    &mut infrastructure,
+                let spec = Spec::new(
+                    &infrastructure,
                     args.signed_entity_types,
                     args.mithril_next_era,
                     args.mithril_era_regenesis_on_switch,

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -335,7 +335,8 @@ impl App {
         let devnet = Devnet::bootstrap(&DevnetBootstrapArgs {
             devnet_scripts_dir: args.devnet_scripts_directory,
             artifacts_target_dir: work_dir.join("devnet"),
-            number_of_pool_nodes: args.number_of_aggregators + args.number_of_signers,
+            number_of_pool_nodes: args.number_of_signers,
+            number_of_full_nodes: args.number_of_aggregators,
             cardano_slot_length: args.cardano_slot_length,
             cardano_epoch_length: args.cardano_epoch_length,
             cardano_node_version: args.cardano_node_version.to_owned(),

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -1,6 +1,5 @@
 use anyhow::{anyhow, Context};
 use clap::{CommandFactory, Parser, Subcommand};
-use mithril_relay::SignerRelayMode;
 use slog::{Drain, Level, Logger};
 use slog_scope::{error, info};
 use std::{
@@ -112,13 +111,13 @@ pub struct Args {
     #[clap(long)]
     use_relays: bool,
 
-    /// Signer registration relay mode (used only when 'use_relays' is set)
-    #[clap(long, value_enum, default_value_t = SignerRelayMode::Passthrough)]
-    relay_signer_registration_mode: SignerRelayMode,
+    /// Signer registration relay mode (used only when 'use_relays' is set, can be 'passthrough' or 'p2p')
+    #[clap(long, default_value = "passthrough")]
+    relay_signer_registration_mode: String,
 
-    /// Signature registration relay mode (used only when 'use_relays' is set)
-    #[clap(long, value_enum, default_value_t = SignerRelayMode::P2P)]
-    relay_signature_registration_mode: SignerRelayMode,
+    /// Signature registration relay mode (used only when 'use_relays' is set, can be 'passthrough' or 'p2p')
+    #[clap(long, default_value = "p2p")]
+    relay_signature_registration_mode: String,
 
     /// Enable P2P passive relays in P2P mode (used only when 'use_relays' is set)
     #[clap(long, default_value = "true")]

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -53,11 +53,11 @@ pub struct Args {
     bin_directory: PathBuf,
 
     /// Number of aggregators
-    #[clap(long, default_value_t = 1)]
+    #[clap(long, default_value_t = 1, value_parser = clap::value_parser!(u8).range(1..))]
     number_of_aggregators: u8,
 
     /// Number of signers
-    #[clap(long, default_value_t = 2)]
+    #[clap(long, default_value_t = 2, value_parser = clap::value_parser!(u8).range(1..))]
     number_of_signers: u8,
 
     /// Length of a Cardano slot in the devnet (in s)
@@ -150,12 +150,6 @@ impl Args {
     }
 
     fn validate(&self) -> StdResult<()> {
-        if self.number_of_aggregators == 0 {
-            return Err(anyhow!("At least one aggregator is required"));
-        }
-        if self.number_of_signers == 0 {
-            return Err(anyhow!("At least one signer is required"));
-        }
         if !self.use_relays && self.number_of_aggregators >= 2 {
             return Err(anyhow!(
                 "The 'use_relays' parameter must be activated to run more than one aggregator"
@@ -520,14 +514,6 @@ mod tests {
 
     #[test]
     fn args_fails_validation() {
-        let args = Args::parse_from(["", "--number-of-signers", "0"]);
-        args.validate()
-            .expect_err("validate should fail without signers");
-
-        let args = Args::parse_from(["", "--number-of-aggregators", "0"]);
-        args.validate()
-            .expect_err("validate should fail without aggregators");
-
         let args = Args::parse_from(["", "--number-of-aggregators", "2"]);
         args.validate().expect_err(
             "validate should fail with more than one aggregator if p2p network is not used",

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -120,7 +120,7 @@ pub struct Args {
     relay_signature_registration_mode: String,
 
     /// Enable P2P passive relays in P2P mode (used only when 'use_relays' is set)
-    #[clap(long, default_value = "true")]
+    #[clap(long, default_value = "false")]
     use_p2p_passive_relays: bool,
 
     /// Skip cardano binaries download

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -201,13 +201,18 @@ async fn main_exec() -> StdResult<()> {
         fs::create_dir(&path).expect("Artifacts dir creation failure");
         path
     };
+    let store_dir = {
+        let path = work_dir.join("stores");
+        fs::create_dir(&path).expect("Stores dir creation failure");
+        path
+    };
 
     let mut app = App::new();
     let mut app_stopper = AppStopper::new(&app);
     let mut join_set = JoinSet::new();
     with_gracefull_shutdown(&mut join_set);
 
-    join_set.spawn(async move { app.run(args, work_dir, artifacts_dir).await });
+    join_set.spawn(async move { app.run(args, work_dir, store_dir, artifacts_dir).await });
 
     let res = match join_set.join_next().await {
         Some(Ok(tasks_result)) => tasks_result,
@@ -313,6 +318,7 @@ impl App {
         &mut self,
         args: Args,
         work_dir: PathBuf,
+        store_dir: PathBuf,
         artifacts_dir: PathBuf,
     ) -> StdResult<()> {
         let server_port = 8080;
@@ -339,8 +345,9 @@ impl App {
             number_of_signers: args.number_of_signers,
             server_port,
             devnet: devnet.clone(),
-            artifacts_dir,
             work_dir,
+            store_dir,
+            artifacts_dir,
             bin_dir: args.bin_directory,
             cardano_node_version: args.cardano_node_version,
             mithril_run_interval: args.mithril_run_interval,

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -1,6 +1,6 @@
 use crate::utils::MithrilCommand;
 use crate::{
-    PoolNode, RetryableDevnetError, DEVNET_MAGIC_ID, ERA_MARKERS_SECRET_KEY,
+    FullNode, RetryableDevnetError, DEVNET_MAGIC_ID, ERA_MARKERS_SECRET_KEY,
     ERA_MARKERS_VERIFICATION_KEY, GENESIS_SECRET_KEY, GENESIS_VERIFICATION_KEY,
 };
 use anyhow::{anyhow, Context};
@@ -22,7 +22,7 @@ pub struct AggregatorConfig<'a> {
     pub index: usize,
     pub name: &'a str,
     pub server_port: u64,
-    pub pool_node: &'a PoolNode,
+    pub full_node: &'a FullNode,
     pub cardano_cli_path: &'a Path,
     pub work_dir: &'a Path,
     pub store_dir: &'a Path,
@@ -88,7 +88,7 @@ impl Aggregator {
             ),
             (
                 "CARDANO_NODE_SOCKET_PATH",
-                aggregator_config.pool_node.socket_path.to_str().unwrap(),
+                aggregator_config.full_node.socket_path.to_str().unwrap(),
             ),
             ("STORE_RETENTION_LIMIT", "10"),
             (
@@ -122,7 +122,7 @@ impl Aggregator {
         }
         let args = vec![
             "--db-directory",
-            aggregator_config.pool_node.db_path.to_str().unwrap(),
+            aggregator_config.full_node.db_path.to_str().unwrap(),
             "-vvv",
         ];
 
@@ -134,7 +134,7 @@ impl Aggregator {
             &args,
         )?;
         let chain_observer = Arc::new(PallasChainObserver::new(
-            &aggregator_config.pool_node.socket_path,
+            &aggregator_config.full_node.socket_path,
             CardanoNetwork::DevNet(DEVNET_MAGIC_ID),
         ));
 
@@ -142,7 +142,7 @@ impl Aggregator {
             index: aggregator_config.index,
             name_suffix: aggregator_config.name.to_string(),
             server_port: aggregator_config.server_port,
-            db_directory: aggregator_config.pool_node.db_path.clone(),
+            db_directory: aggregator_config.full_node.db_path.clone(),
             mithril_run_interval: aggregator_config.mithril_run_interval,
             command: Arc::new(RwLock::new(command)),
             process: RwLock::new(None),

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -1,7 +1,7 @@
 use crate::utils::MithrilCommand;
 use crate::{
-    PoolNode, DEVNET_MAGIC_ID, ERA_MARKERS_SECRET_KEY, ERA_MARKERS_VERIFICATION_KEY,
-    GENESIS_SECRET_KEY, GENESIS_VERIFICATION_KEY,
+    PoolNode, RetryableDevnetError, DEVNET_MAGIC_ID, ERA_MARKERS_SECRET_KEY,
+    ERA_MARKERS_VERIFICATION_KEY, GENESIS_SECRET_KEY, GENESIS_VERIFICATION_KEY,
 };
 use anyhow::{anyhow, Context};
 use mithril_common::era::SupportedEra;
@@ -209,6 +209,7 @@ impl Aggregator {
                     anyhow!("`mithril-aggregator genesis bootstrap` was terminated with a signal")
                 }
             })
+            .map_err(|e| anyhow!(RetryableDevnetError(e.to_string())))
         }
     }
 

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -42,6 +42,7 @@ pub struct Aggregator {
     name_suffix: String,
     server_port: u64,
     db_directory: PathBuf,
+    mithril_run_interval: u32,
     command: Arc<RwLock<MithrilCommand>>,
     process: RwLock<Option<Child>>,
 }
@@ -136,6 +137,7 @@ impl Aggregator {
             name_suffix: aggregator_config.name.to_string(),
             server_port: aggregator_config.server_port,
             db_directory: aggregator_config.pool_node.db_path.clone(),
+            mithril_run_interval: aggregator_config.mithril_run_interval,
             command: Arc::new(RwLock::new(command)),
             process: RwLock::new(None),
         })
@@ -151,6 +153,7 @@ impl Aggregator {
             name_suffix: other.name_suffix.clone(),
             server_port: other.server_port,
             db_directory: other.db_directory.clone(),
+            mithril_run_interval: other.mithril_run_interval,
             command: other.command.clone(),
             process: RwLock::new(None),
         }
@@ -174,6 +177,10 @@ impl Aggregator {
 
     pub fn db_directory(&self) -> &Path {
         &self.db_directory
+    }
+
+    pub fn mithril_run_interval(&self) -> u32 {
+        self.mithril_run_interval
     }
 
     pub async fn serve(&self) -> StdResult<()> {

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -154,6 +154,10 @@ impl Aggregator {
         }
     }
 
+    pub fn is_master(&self) -> bool {
+        self.index == 0
+    }
+
     pub fn endpoint(&self) -> String {
         format!("http://localhost:{}/aggregator", &self.server_port)
     }
@@ -172,7 +176,7 @@ impl Aggregator {
     pub async fn bootstrap_genesis(&self) -> StdResult<()> {
         // Clone the command so we can alter it without affecting the original
         let mut command = self.command.write().await;
-        let command_name = if self.index == 0 {
+        let command_name = if self.is_master() {
             "mithril-aggregator-genesis-bootstrap"
         } else {
             &format!("mithril-aggregator-genesis-bootstrap-slave-{}", self.index)

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -17,7 +17,6 @@ use tokio::sync::RwLock;
 
 #[derive(Debug)]
 pub struct AggregatorConfig<'a> {
-    pub is_master: bool,
     pub index: usize,
     pub name: &'a str,
     pub server_port: u64,
@@ -39,7 +38,6 @@ pub struct AggregatorConfig<'a> {
 
 #[derive(Debug)]
 pub struct Aggregator {
-    is_master: bool,
     index: usize,
     name_suffix: String,
     server_port: u64,
@@ -134,7 +132,6 @@ impl Aggregator {
         )?;
 
         Ok(Self {
-            is_master: aggregator_config.is_master,
             index: aggregator_config.index,
             name_suffix: aggregator_config.name.to_string(),
             server_port: aggregator_config.server_port,
@@ -144,9 +141,12 @@ impl Aggregator {
         })
     }
 
+    pub fn name_suffix(index: usize) -> String {
+        format!("{}", index + 1)
+    }
+
     pub fn copy_configuration(other: &Aggregator) -> Self {
         Self {
-            is_master: other.is_master,
             index: other.index,
             name_suffix: other.name_suffix.clone(),
             server_port: other.server_port,
@@ -156,8 +156,8 @@ impl Aggregator {
         }
     }
 
-    pub fn is_master(&self) -> bool {
-        self.is_master
+    pub fn is_first(&self) -> bool {
+        self.index == 0
     }
 
     pub fn index(&self) -> usize {

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -18,6 +18,7 @@ use tokio::sync::RwLock;
 #[derive(Debug)]
 pub struct AggregatorConfig<'a> {
     pub is_master: bool,
+    pub index: usize,
     pub name: &'a str,
     pub server_port: u64,
     pub pool_node: &'a PoolNode,
@@ -39,6 +40,7 @@ pub struct AggregatorConfig<'a> {
 #[derive(Debug)]
 pub struct Aggregator {
     is_master: bool,
+    index: usize,
     name_suffix: String,
     server_port: u64,
     db_directory: PathBuf,
@@ -133,6 +135,7 @@ impl Aggregator {
 
         Ok(Self {
             is_master: aggregator_config.is_master,
+            index: aggregator_config.index,
             name_suffix: aggregator_config.name.to_string(),
             server_port: aggregator_config.server_port,
             db_directory: aggregator_config.pool_node.db_path.clone(),
@@ -144,6 +147,7 @@ impl Aggregator {
     pub fn copy_configuration(other: &Aggregator) -> Self {
         Self {
             is_master: other.is_master,
+            index: other.index,
             name_suffix: other.name_suffix.clone(),
             server_port: other.server_port,
             db_directory: other.db_directory.clone(),
@@ -154,6 +158,10 @@ impl Aggregator {
 
     pub fn is_master(&self) -> bool {
         self.is_master
+    }
+
+    pub fn index(&self) -> usize {
+        self.index
     }
 
     pub fn name(&self) -> String {

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -408,9 +408,12 @@ impl MithrilInfrastructure {
         self.cardano_chain_observers[index + 1].clone()
     }
 
-    pub async fn build_client(&self) -> StdResult<Client> {
+    pub async fn build_client(&self, aggregator: &Aggregator) -> StdResult<Client> {
         let work_dir = {
-            let mut artifacts_dir = self.artifacts_dir.join("mithril-client");
+            let mut artifacts_dir = self.artifacts_dir.join(format!(
+                "mithril-client-aggregator-{}",
+                Aggregator::name_suffix(aggregator.index())
+            ));
             if self.use_era_specific_work_dir {
                 let current_era = self.current_era.read().await;
                 artifacts_dir = artifacts_dir.join(format!("era.{}", current_era));

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -223,7 +223,7 @@ impl MithrilInfrastructure {
 
             aggregator
                 .set_protocol_parameters(&ProtocolParameters {
-                    k: 75,
+                    k: 70,
                     m: 105,
                     phi_f: 0.95,
                 })

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -6,7 +6,6 @@ use crate::{
 use mithril_common::chain_observer::{ChainObserver, PallasChainObserver};
 use mithril_common::entities::{Epoch, PartyId, ProtocolParameters};
 use mithril_common::{CardanoNetwork, StdResult};
-use mithril_relay::SignerRelayMode;
 use slog_scope::info;
 use std::fs;
 use std::path::PathBuf;
@@ -31,15 +30,15 @@ pub struct MithrilInfrastructureConfig {
     pub signed_entity_types: Vec<String>,
     pub run_only_mode: bool,
     pub use_relays: bool,
-    pub relay_signer_registration_mode: SignerRelayMode,
-    pub relay_signature_registration_mode: SignerRelayMode,
+    pub relay_signer_registration_mode: String,
+    pub relay_signature_registration_mode: String,
     pub use_p2p_passive_relays: bool,
     pub use_era_specific_work_dir: bool,
 }
 
 impl MithrilInfrastructureConfig {
     pub fn has_master_slave_signer_registration(&self) -> bool {
-        if self.relay_signer_registration_mode == SignerRelayMode::Passthrough {
+        if &self.relay_signer_registration_mode == "passthrough" {
             self.number_of_aggregators > 1
         } else {
             false
@@ -64,8 +63,8 @@ impl MithrilInfrastructureConfig {
             signed_entity_types: vec!["type1".to_string()],
             run_only_mode: false,
             use_relays: false,
-            relay_signer_registration_mode: SignerRelayMode::Passthrough,
-            relay_signature_registration_mode: SignerRelayMode::Passthrough,
+            relay_signer_registration_mode: "passthrough".to_string(),
+            relay_signature_registration_mode: "passthrough".to_string(),
             use_p2p_passive_relays: false,
             use_era_specific_work_dir: false,
         }
@@ -251,8 +250,8 @@ impl MithrilInfrastructure {
         config: &MithrilInfrastructureConfig,
         aggregator_endpoints: &[String],
         signers_party_ids: &[PartyId],
-        relay_signer_registration_mode: SignerRelayMode,
-        relay_signature_registration_mode: SignerRelayMode,
+        relay_signer_registration_mode: String,
+        relay_signature_registration_mode: String,
     ) -> StdResult<(Vec<RelayAggregator>, Vec<RelaySigner>, Vec<RelayPassive>)> {
         if !config.use_relays {
             return Ok((vec![], vec![], vec![]));
@@ -476,12 +475,10 @@ impl MithrilInfrastructure {
 mod tests {
     use crate::MithrilInfrastructureConfig;
 
-    use super::*;
-
     #[test]
     fn has_master_slave_signer_registration_succeeds() {
         let config = MithrilInfrastructureConfig {
-            relay_signer_registration_mode: SignerRelayMode::Passthrough,
+            relay_signer_registration_mode: "passthrough".to_string(),
             number_of_aggregators: 1,
             ..MithrilInfrastructureConfig::dummy()
         };
@@ -489,7 +486,7 @@ mod tests {
         assert!(!config.has_master_slave_signer_registration());
 
         let config = MithrilInfrastructureConfig {
-            relay_signer_registration_mode: SignerRelayMode::Passthrough,
+            relay_signer_registration_mode: "passthrough".to_string(),
             number_of_aggregators: 2,
             ..MithrilInfrastructureConfig::dummy()
         };
@@ -497,7 +494,7 @@ mod tests {
         assert!(config.has_master_slave_signer_registration());
 
         let config = MithrilInfrastructureConfig {
-            relay_signer_registration_mode: SignerRelayMode::P2P,
+            relay_signer_registration_mode: "p2p".to_string(),
             number_of_aggregators: 1,
             ..MithrilInfrastructureConfig::dummy()
         };
@@ -505,7 +502,7 @@ mod tests {
         assert!(!config.has_master_slave_signer_registration());
 
         let config = MithrilInfrastructureConfig {
-            relay_signer_registration_mode: SignerRelayMode::P2P,
+            relay_signer_registration_mode: "p2p".to_string(),
             number_of_aggregators: 2,
             ..MithrilInfrastructureConfig::dummy()
         };

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -16,6 +16,8 @@ use crate::{
 use super::signer::SignerConfig;
 
 pub struct MithrilInfrastructureConfig {
+    pub number_of_aggregators: u8,
+    pub number_of_signers: u8,
     pub server_port: u64,
     pub devnet: Devnet,
     pub work_dir: PathBuf,
@@ -54,8 +56,11 @@ impl MithrilInfrastructure {
         config.devnet.run().await?;
         let devnet_topology = config.devnet.topology();
         // Clap check that we always have at least 2 pools, no need to be defensive here
-        let aggregator_cardano_node = &devnet_topology.pool_nodes[0];
-        let signer_cardano_nodes = &devnet_topology.pool_nodes[1..];
+        let number_of_aggregators = config.number_of_aggregators as usize;
+        let number_of_signers = config.number_of_signers as usize;
+        let aggregator_cardano_nodes = &devnet_topology.pool_nodes[0..number_of_aggregators];
+        let signer_cardano_nodes = &devnet_topology.pool_nodes
+            [number_of_aggregators..number_of_aggregators + number_of_signers];
         let signer_party_ids = signer_cardano_nodes
             .iter()
             .map(|s| s.party_id())

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -494,9 +494,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn has_master_aggregator_succeeds() {
+    fn has_master_slave_signer_registration_succeeds() {
         let config = MithrilInfrastructureConfig {
-            use_relays: true,
+            relay_signer_registration_mode: SignerRelayMode::Passthrough,
+            number_of_aggregators: 1,
+            ..MithrilInfrastructureConfig::dummy()
+        };
+
+        assert!(!config.has_master_slave_signer_registration());
+
+        let config = MithrilInfrastructureConfig {
             relay_signer_registration_mode: SignerRelayMode::Passthrough,
             number_of_aggregators: 2,
             ..MithrilInfrastructureConfig::dummy()
@@ -505,17 +512,16 @@ mod tests {
         assert!(config.has_master_slave_signer_registration());
 
         let config = MithrilInfrastructureConfig {
-            use_relays: true,
             relay_signer_registration_mode: SignerRelayMode::P2P,
-            number_of_aggregators: 2,
+            number_of_aggregators: 1,
             ..MithrilInfrastructureConfig::dummy()
         };
 
         assert!(!config.has_master_slave_signer_registration());
 
         let config = MithrilInfrastructureConfig {
-            use_relays: false,
-            number_of_aggregators: 1,
+            relay_signer_registration_mode: SignerRelayMode::P2P,
+            number_of_aggregators: 2,
             ..MithrilInfrastructureConfig::dummy()
         };
 

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_aggregator.rs
@@ -32,7 +32,10 @@ impl RelayAggregator {
         let args = vec!["-vvv", "aggregator"];
 
         let mut command = MithrilCommand::new("mithril-relay", work_dir, bin_dir, env, &args)?;
-        command.set_log_name(&Self::command_name(index));
+        command.set_log_name(&format!(
+            "mithril-relay-aggregator-{}",
+            Self::name_suffix(index),
+        ));
 
         Ok(Self {
             index,
@@ -46,11 +49,11 @@ impl RelayAggregator {
         format!("/ip4/127.0.0.1/tcp/{}", self.listen_port)
     }
 
-    fn command_name(index: usize) -> String {
+    pub fn name_suffix(index: usize) -> String {
         if index == 0 {
-            "mithril-relay-aggregator".to_string()
+            "master".to_string()
         } else {
-            format!("mithril-relay-aggregator-slave-{}", index)
+            format!("slave-{}", index)
         }
     }
 
@@ -61,7 +64,13 @@ impl RelayAggregator {
 
     pub async fn tail_logs(&self, number_of_line: u64) -> StdResult<()> {
         self.command
-            .tail_logs(Some(&Self::command_name(self.index)), number_of_line)
+            .tail_logs(
+                Some(&format!(
+                    "mithril-relay-aggregator-{}",
+                    Self::name_suffix(self.index),
+                )),
+                number_of_line,
+            )
             .await
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_passive.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_passive.rs
@@ -15,16 +15,16 @@ pub struct RelayPassive {
 impl RelayPassive {
     pub fn new(
         listen_port: u64,
-        dial_to: String,
+        dial_to: Option<String>,
         relay_id: String,
         work_dir: &Path,
         bin_dir: &Path,
     ) -> StdResult<Self> {
         let listen_port_str = format!("{listen_port}");
-        let env = HashMap::from([
-            ("LISTEN_PORT", listen_port_str.as_str()),
-            ("DIAL_TO", &dial_to),
-        ]);
+        let mut env = HashMap::from([("LISTEN_PORT", listen_port_str.as_str())]);
+        if let Some(dial_to) = &dial_to {
+            env.insert("DIAL_TO", dial_to);
+        }
         let args = vec!["-vvv", "passive"];
 
         let mut command = MithrilCommand::new("mithril-relay", work_dir, bin_dir, env, &args)?;

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
@@ -1,9 +1,22 @@
 use crate::utils::MithrilCommand;
 use mithril_common::entities::PartyId;
 use mithril_common::StdResult;
+use mithril_relay::SignerRelayMode;
 use std::collections::HashMap;
 use std::path::Path;
 use tokio::process::Child;
+
+pub struct RelaySignerConfiguration<'a> {
+    pub listen_port: u64,
+    pub server_port: u64,
+    pub dial_to: Option<String>,
+    pub relay_signer_registration_mode: SignerRelayMode,
+    pub relay_signature_registration_mode: SignerRelayMode,
+    pub aggregator_endpoint: &'a str,
+    pub party_id: PartyId,
+    pub work_dir: &'a Path,
+    pub bin_dir: &'a Path,
+}
 
 #[derive(Debug)]
 pub struct RelaySigner {
@@ -15,35 +28,45 @@ pub struct RelaySigner {
 }
 
 impl RelaySigner {
-    pub fn new(
-        listen_port: u64,
-        server_port: u64,
-        dial_to: Option<String>,
-        aggregator_endpoint: &str,
-        party_id: PartyId,
-        work_dir: &Path,
-        bin_dir: &Path,
-    ) -> StdResult<Self> {
-        let listen_port_str = format!("{listen_port}");
-        let server_port_str = format!("{server_port}");
+    pub fn new(configuration: &RelaySignerConfiguration) -> StdResult<Self> {
+        let listen_port_str = format!("{}", configuration.listen_port);
+        let server_port_str = format!("{}", configuration.server_port);
+        let relay_signer_registration_mode =
+            configuration.relay_signer_registration_mode.to_string();
+        let relay_signature_registration_mode =
+            configuration.relay_signature_registration_mode.to_string();
         let mut env = HashMap::from([
             ("LISTEN_PORT", listen_port_str.as_str()),
             ("SERVER_PORT", server_port_str.as_str()),
-            ("AGGREGATOR_ENDPOINT", aggregator_endpoint),
+            ("AGGREGATOR_ENDPOINT", configuration.aggregator_endpoint),
             ("SIGNER_REPEATER_DELAY", "100"),
+            (
+                "SIGNER_REGISTRATION_MODE",
+                relay_signer_registration_mode.as_str(),
+            ),
+            (
+                "SIGNATURE_REGISTRATION_MODE",
+                relay_signature_registration_mode.as_str(),
+            ),
         ]);
-        if let Some(dial_to) = &dial_to {
+        if let Some(dial_to) = &configuration.dial_to {
             env.insert("DIAL_TO", dial_to);
         }
         let args = vec!["-vvv", "signer"];
 
-        let mut command = MithrilCommand::new("mithril-relay", work_dir, bin_dir, env, &args)?;
-        command.set_log_name(format!("mithril-relay-signer-{party_id}").as_str());
+        let mut command = MithrilCommand::new(
+            "mithril-relay",
+            configuration.work_dir,
+            configuration.bin_dir,
+            env,
+            &args,
+        )?;
+        command.set_log_name(format!("mithril-relay-signer-{}", configuration.party_id).as_str());
 
         Ok(Self {
-            listen_port,
-            server_port,
-            party_id,
+            listen_port: configuration.listen_port,
+            server_port: configuration.server_port,
+            party_id: configuration.party_id.to_owned(),
             command,
             process: None,
         })

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
@@ -18,7 +18,7 @@ impl RelaySigner {
     pub fn new(
         listen_port: u64,
         server_port: u64,
-        dial_to: String,
+        dial_to: Option<String>,
         aggregator_endpoint: &str,
         party_id: PartyId,
         work_dir: &Path,
@@ -26,13 +26,15 @@ impl RelaySigner {
     ) -> StdResult<Self> {
         let listen_port_str = format!("{listen_port}");
         let server_port_str = format!("{server_port}");
-        let env = HashMap::from([
+        let mut env = HashMap::from([
             ("LISTEN_PORT", listen_port_str.as_str()),
             ("SERVER_PORT", server_port_str.as_str()),
             ("AGGREGATOR_ENDPOINT", aggregator_endpoint),
-            ("DIAL_TO", &dial_to),
             ("SIGNER_REPEATER_DELAY", "100"),
         ]);
+        if let Some(dial_to) = &dial_to {
+            env.insert("DIAL_TO", dial_to);
+        }
         let args = vec!["-vvv", "signer"];
 
         let mut command = MithrilCommand::new("mithril-relay", work_dir, bin_dir, env, &args)?;

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
@@ -1,7 +1,6 @@
 use crate::utils::MithrilCommand;
 use mithril_common::entities::PartyId;
 use mithril_common::StdResult;
-use mithril_relay::SignerRelayMode;
 use std::collections::HashMap;
 use std::path::Path;
 use tokio::process::Child;
@@ -10,8 +9,8 @@ pub struct RelaySignerConfiguration<'a> {
     pub listen_port: u64,
     pub server_port: u64,
     pub dial_to: Option<String>,
-    pub relay_signer_registration_mode: SignerRelayMode,
-    pub relay_signature_registration_mode: SignerRelayMode,
+    pub relay_signer_registration_mode: String,
+    pub relay_signature_registration_mode: String,
     pub aggregator_endpoint: &'a str,
     pub party_id: PartyId,
     pub work_dir: &'a Path,

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/signer.rs
@@ -16,6 +16,7 @@ pub struct SignerConfig<'a> {
     pub pool_node: &'a PoolNode,
     pub cardano_cli_path: &'a Path,
     pub work_dir: &'a Path,
+    pub store_dir: &'a Path,
     pub bin_dir: &'a Path,
     pub mithril_run_interval: u32,
     pub mithril_era: &'a str,
@@ -36,7 +37,6 @@ impl Signer {
     pub fn new(signer_config: &SignerConfig) -> StdResult<Self> {
         let party_id = signer_config.pool_node.party_id()?;
         let magic_id = DEVNET_MAGIC_ID.to_string();
-        let data_stores_path = format!("./stores/signer-{party_id}");
         let era_reader_adapter_params =
             if signer_config.mithril_era_reader_adapter == "cardano-chain" {
                 format!(
@@ -58,7 +58,10 @@ impl Signer {
                 "DB_DIRECTORY",
                 signer_config.pool_node.db_path.to_str().unwrap(),
             ),
-            ("DATA_STORES_DIRECTORY", &data_stores_path),
+            (
+                "DATA_STORES_DIRECTORY",
+                signer_config.store_dir.to_str().unwrap(),
+            ),
             ("STORE_RETENTION_LIMIT", "10"),
             ("NETWORK_MAGIC", &magic_id),
             (

--- a/mithril-test-lab/mithril-end-to-end/src/run_only.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/run_only.rs
@@ -1,25 +1,83 @@
-use crate::assertions;
-use crate::MithrilInfrastructure;
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use mithril_common::chain_observer::ChainObserver;
+use tokio::sync::RwLock;
+use tokio::task::JoinSet;
+
 use mithril_common::StdResult;
 
-pub struct RunOnly<'a> {
-    pub infrastructure: &'a MithrilInfrastructure,
+use crate::{assertions, Aggregator, MithrilInfrastructure};
+
+pub struct RunOnly {
+    pub infrastructure: Arc<RwLock<Option<MithrilInfrastructure>>>,
 }
 
-impl<'a> RunOnly<'a> {
-    pub fn new(infrastructure: &'a MithrilInfrastructure) -> Self {
+impl RunOnly {
+    pub fn new(infrastructure: Arc<RwLock<Option<MithrilInfrastructure>>>) -> Self {
         Self { infrastructure }
     }
 
-    pub async fn start(&self) -> StdResult<()> {
-        let aggregator_endpoint = self.infrastructure.master_aggregator().endpoint();
-        assertions::wait_for_enough_immutable(
-            self.infrastructure.master_aggregator().db_directory(),
+    pub async fn run(self) -> StdResult<()> {
+        let run_only = Arc::new(self);
+        let mut join_set = JoinSet::new();
+
+        let run_only_clone = run_only.clone();
+        join_set.spawn(async move { run_only_clone.start_master().await });
+
+        let infrastructure_guard = run_only.infrastructure.read().await;
+        let slave_aggregators = infrastructure_guard
+            .as_ref()
+            .ok_or(anyhow!("No infrastructure found"))?
+            .slave_aggregators();
+        for index in 0..slave_aggregators.len() {
+            let run_only_clone = run_only.clone();
+            join_set.spawn(async move { run_only_clone.start_slave(index).await });
+        }
+
+        while let Some(res) = join_set.join_next().await {
+            res??;
+        }
+
+        Ok(())
+    }
+
+    pub async fn start_master(&self) -> StdResult<()> {
+        let infrastructure_guard = self.infrastructure.read().await;
+        let infrastructure = infrastructure_guard
+            .as_ref()
+            .ok_or(anyhow!("No infrastructure found"))?;
+
+        self.start_aggregator(
+            infrastructure.master_aggregator(),
+            infrastructure.master_chain_observer(),
+            infrastructure,
         )
-        .await?;
-        let start_epoch = self
-            .infrastructure
-            .master_chain_observer()
+        .await
+    }
+
+    pub async fn start_slave(&self, slave_index: usize) -> StdResult<()> {
+        let infrastructure_guard = self.infrastructure.read().await;
+        let infrastructure = infrastructure_guard
+            .as_ref()
+            .ok_or(anyhow!("No infrastructure found"))?;
+
+        self.start_aggregator(
+            infrastructure.slave_aggregator(slave_index),
+            infrastructure.slave_chain_observer(slave_index),
+            infrastructure,
+        )
+        .await
+    }
+
+    pub async fn start_aggregator(
+        &self,
+        aggregator: &Aggregator,
+        chain_observer: Arc<dyn ChainObserver>,
+        infrastructure: &MithrilInfrastructure,
+    ) -> StdResult<()> {
+        assertions::wait_for_enough_immutable(aggregator.db_directory()).await?;
+        let start_epoch = chain_observer
             .get_current_epoch()
             .await?
             .unwrap_or_default();
@@ -27,17 +85,19 @@ impl<'a> RunOnly<'a> {
         // Wait 3 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
         let target_epoch = start_epoch + 3;
         assertions::wait_for_target_epoch(
-            self.infrastructure.master_chain_observer(),
+            chain_observer,
             target_epoch,
             "minimal epoch for the aggregator to be able to bootstrap genesis certificate"
                 .to_string(),
         )
         .await?;
-        assertions::bootstrap_genesis_certificate(self.infrastructure.master_aggregator()).await?;
-        assertions::wait_for_epoch_settings(&aggregator_endpoint).await?;
+        assertions::bootstrap_genesis_certificate(aggregator).await?;
+        assertions::wait_for_epoch_settings(&aggregator.endpoint()).await?;
 
-        // Transfer some funds on the devnet to have some Cardano transactions to sign
-        assertions::transfer_funds(self.infrastructure.devnet()).await?;
+        if aggregator.is_master() {
+            // Transfer some funds on the devnet to have some Cardano transactions to sign
+            assertions::transfer_funds(infrastructure.devnet()).await?;
+        }
 
         Ok(())
     }

--- a/mithril-test-lab/mithril-end-to-end/src/run_only.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/run_only.rs
@@ -12,12 +12,14 @@ impl<'a> RunOnly<'a> {
     }
 
     pub async fn start(&mut self) -> StdResult<()> {
-        let aggregator_endpoint = self.infrastructure.aggregator().endpoint();
-        assertions::wait_for_enough_immutable(self.infrastructure.aggregator().db_directory())
-            .await?;
+        let aggregator_endpoint = self.infrastructure.master_aggregator().endpoint();
+        assertions::wait_for_enough_immutable(
+            self.infrastructure.master_aggregator().db_directory(),
+        )
+        .await?;
         let start_epoch = self
             .infrastructure
-            .chain_observer()
+            .master_chain_observer()
             .get_current_epoch()
             .await?
             .unwrap_or_default();
@@ -25,13 +27,14 @@ impl<'a> RunOnly<'a> {
         // Wait 3 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
         let target_epoch = start_epoch + 3;
         assertions::wait_for_target_epoch(
-            self.infrastructure.chain_observer(),
+            self.infrastructure.master_chain_observer(),
             target_epoch,
             "minimal epoch for the aggregator to be able to bootstrap genesis certificate"
                 .to_string(),
         )
         .await?;
-        assertions::bootstrap_genesis_certificate(self.infrastructure.aggregator_mut()).await?;
+        assertions::bootstrap_genesis_certificate(self.infrastructure.master_aggregator_mut())
+            .await?;
         assertions::wait_for_epoch_settings(&aggregator_endpoint).await?;
 
         // Transfer some funds on the devnet to have some Cardano transactions to sign

--- a/mithril-test-lab/mithril-end-to-end/src/run_only.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/run_only.rs
@@ -3,15 +3,15 @@ use crate::MithrilInfrastructure;
 use mithril_common::StdResult;
 
 pub struct RunOnly<'a> {
-    pub infrastructure: &'a mut MithrilInfrastructure,
+    pub infrastructure: &'a MithrilInfrastructure,
 }
 
 impl<'a> RunOnly<'a> {
-    pub fn new(infrastructure: &'a mut MithrilInfrastructure) -> Self {
+    pub fn new(infrastructure: &'a MithrilInfrastructure) -> Self {
         Self { infrastructure }
     }
 
-    pub async fn start(&mut self) -> StdResult<()> {
+    pub async fn start(&self) -> StdResult<()> {
         let aggregator_endpoint = self.infrastructure.master_aggregator().endpoint();
         assertions::wait_for_enough_immutable(
             self.infrastructure.master_aggregator().db_directory(),
@@ -33,8 +33,7 @@ impl<'a> RunOnly<'a> {
                 .to_string(),
         )
         .await?;
-        assertions::bootstrap_genesis_certificate(self.infrastructure.master_aggregator_mut())
-            .await?;
+        assertions::bootstrap_genesis_certificate(self.infrastructure.master_aggregator()).await?;
         assertions::wait_for_epoch_settings(&aggregator_endpoint).await?;
 
         // Transfer some funds on the devnet to have some Cardano transactions to sign

--- a/mithril-test-lab/mithril-end-to-end/src/run_only.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/run_only.rs
@@ -94,7 +94,7 @@ impl RunOnly {
         assertions::bootstrap_genesis_certificate(aggregator).await?;
         assertions::wait_for_epoch_settings(&aggregator.endpoint()).await?;
 
-        if aggregator.is_master() {
+        if aggregator.index() == 0 {
             // Transfer some funds on the devnet to have some Cardano transactions to sign
             assertions::transfer_funds(infrastructure.devnet()).await?;
         }

--- a/mithril-test-lab/mithril-end-to-end/src/run_only.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/run_only.rs
@@ -58,7 +58,7 @@ impl RunOnly {
         chain_observer: Arc<dyn ChainObserver>,
         infrastructure: &MithrilInfrastructure,
     ) -> StdResult<()> {
-        assertions::wait_for_enough_immutable(aggregator.db_directory()).await?;
+        assertions::wait_for_enough_immutable(aggregator).await?;
         let start_epoch = chain_observer
             .get_current_epoch()
             .await?
@@ -67,6 +67,7 @@ impl RunOnly {
         // Wait 3 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
         let target_epoch = start_epoch + 3;
         assertions::wait_for_target_epoch(
+            aggregator,
             chain_observer,
             target_epoch,
             "minimal epoch for the aggregator to be able to bootstrap genesis certificate"
@@ -74,7 +75,7 @@ impl RunOnly {
         )
         .await?;
         assertions::bootstrap_genesis_certificate(aggregator).await?;
-        assertions::wait_for_epoch_settings(&aggregator.endpoint()).await?;
+        assertions::wait_for_epoch_settings(aggregator).await?;
 
         if aggregator.is_first() {
             // Transfer some funds on the devnet to have some Cardano transactions to sign

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -19,7 +19,6 @@ pub async fn bootstrap_aggregator(
     let chain_observer_type = "cardano-cli";
 
     let mut aggregator = Aggregator::new(&AggregatorConfig {
-        is_master: false,
         index: 0,
         name: "genesis",
         server_port: args.server_port as u64,

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -19,7 +19,8 @@ pub async fn bootstrap_aggregator(
     let chain_observer_type = "cardano-cli";
 
     let mut aggregator = Aggregator::new(&AggregatorConfig {
-        index: 0,
+        is_master: false,
+        name: "genesis",
         server_port: args.server_port as u64,
         pool_node: &args.pool_node,
         cardano_cli_path: &args.cardano_cli_path,

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -19,10 +19,12 @@ pub async fn bootstrap_aggregator(
     let chain_observer_type = "cardano-cli";
 
     let mut aggregator = Aggregator::new(&AggregatorConfig {
+        index: 0,
         server_port: args.server_port as u64,
         pool_node: &args.pool_node,
         cardano_cli_path: &args.cardano_cli_path,
         work_dir: &args.work_dir,
+        store_dir: &args.work_dir,
         artifacts_dir: &args.work_dir,
         bin_dir: &args.bin_dir,
         cardano_node_version: "1.2.3",
@@ -32,6 +34,7 @@ pub async fn bootstrap_aggregator(
         mithril_era_reader_adapter: "dummy",
         signed_entity_types: &signed_entity_types,
         chain_observer_type,
+        master_aggregator_endpoint: &None,
     })
     .unwrap();
 

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -22,7 +22,7 @@ pub async fn bootstrap_aggregator(
         index: 0,
         name: "genesis",
         server_port: args.server_port as u64,
-        pool_node: &args.pool_node,
+        full_node: &args.full_node,
         cardano_cli_path: &args.cardano_cli_path,
         work_dir: &args.work_dir,
         store_dir: &args.work_dir,

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -20,6 +20,7 @@ pub async fn bootstrap_aggregator(
 
     let mut aggregator = Aggregator::new(&AggregatorConfig {
         is_master: false,
+        index: 0,
         name: "genesis",
         server_port: args.server_port as u64,
         pool_node: &args.pool_node,

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/entities.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/entities.rs
@@ -8,7 +8,7 @@ use std::{
 };
 use tokio::time::Instant;
 
-use crate::PoolNode;
+use crate::FullNode;
 
 #[derive(Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -62,7 +62,7 @@ impl MainOpts {
 #[derive(Debug)]
 pub struct AggregatorParameters {
     pub server_port: u32,
-    pub pool_node: PoolNode,
+    pub full_node: FullNode,
     pub cardano_cli_path: PathBuf,
     pub work_dir: PathBuf,
     pub bin_dir: PathBuf,
@@ -71,12 +71,9 @@ pub struct AggregatorParameters {
 
 impl AggregatorParameters {
     pub fn new(opts: &MainOpts, immutable_db_path: &Path) -> StdResult<Self> {
-        let pool_node = PoolNode {
+        let full_node = FullNode {
             db_path: immutable_db_path.to_path_buf(),
             socket_path: PathBuf::new(),
-            pool_env_path: PathBuf::new(),
-            kes_secret_key_path: PathBuf::new(),
-            operational_certificate_path: PathBuf::new(),
         };
         let tmp_dir = opts
             .temporary_path
@@ -112,7 +109,7 @@ impl AggregatorParameters {
         };
 
         let aggregator_parameters = AggregatorParameters {
-            pool_node,
+            full_node,
             bin_dir: opts.aggregator_dir.clone(),
             cardano_cli_path,
             server_port: opts.server_port,


### PR DESCRIPTION
## Content

This PR includes the **adaptation of the e2e tests to support multiple aggregators**:
- The relay has been updated to support both `Passthrough` (messages are sent to the configured aggregator endpoint) and `P2P` (messages are sent to the P2P network) modes for both the signer registration and signature registration. The configuration options have been updated in that sense
- The end to end test configuration has evolved:
  - `number_of_aggregators` and `number_of_signers` are specified 
  -  signers run on block producing nodes and aggregators on full nodes
  - `use_p2pmode` has been replaced by more appropriate `use_relays`
  - `relay_signer_registration_mode` and `relay-signature_registration_mode` have been added (used with the `use_relays` option)
  - `use_p2p_passive_relays` has been set to `false` by default
- `RunOnly` mode of the e2e test has been adapted to support concurrently multiple aggregators
- `Spec` mode of the e2e test has been adapted to support concurrently multiple aggregators
- Slave registration of the aggregator has been fixed as it was not targeting the correct verification keys. The associated integration test has been rewritten for finer testing of evolving Mithril stake distribution for each epoch.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Closes #2361
