### PR TITLE
Error messages as warning in signer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.19"
+version = "0.7.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3986,7 +3986,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.235"
+version = "0.2.236"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/DEV-ADR.md
+++ b/DEV-ADR.md
@@ -2,6 +2,50 @@
 
 ---
 
+<!--
+Template of ADR
+
+## ID. TITLE
+
+date: 2025-XX-XX
+status: Accepted
+
+### Context
+
+To complete
+
+### Decision
+
+To complete
+
+### Consequences
+
+To complete
+-->
+
+## 3. Specific Mithril status code
+
+date: 2025-03-21
+status: Accepted
+
+### Context
+
+In exchanges between the signer and the aggregator, we need to retrieve the reason why a request was unsuccessful.
+Error handling will depend on the specific functional case of Mithril.
+We could have reused existing HTTP codes, but they are too general and could be returned for cases other than the one we wish to isolate.
+
+### Decision
+
+We therefore decided to return specific server error codes starting at 550.
+
+Status codes introduced:
+
+- 550: registration round not yet opened
+
+### Consequences
+
+Specific Mithril HTTP status code on server error should be greater or equal to 550.
+
 ## 2. Remove Artifacts serialization support when compiling to WebAssembly
 
 date: 2025-02-26

--- a/DEV-ADR.md
+++ b/DEV-ADR.md
@@ -23,29 +23,6 @@ To complete
 To complete
 -->
 
-## 3. Specific Mithril status code
-
-date: 2025-03-21
-status: Accepted
-
-### Context
-
-In exchanges between the signer and the aggregator, we need to retrieve the reason why a request was unsuccessful.
-Error handling will depend on the specific functional case of Mithril.
-We could have reused existing HTTP codes, but they are too general and could be returned for cases other than the one we wish to isolate.
-
-### Decision
-
-We therefore decided to return specific server error codes starting at 550.
-
-Status codes introduced:
-
-- 550: registration round not yet opened
-
-### Consequences
-
-Specific Mithril HTTP status code on server error should be greater or equal to 550.
-
 ## 2. Remove Artifacts serialization support when compiling to WebAssembly
 
 date: 2025-02-26

--- a/docs/website/adr/010-http-status-code.md
+++ b/docs/website/adr/010-http-status-code.md
@@ -1,0 +1,29 @@
+---
+slug: 10
+title: |
+  10. Specific Mithril Http status code
+authors:
+  - name: Mithril Team
+tags: [Accepted]
+date: 2025-03-21
+---
+
+## Status
+
+Accepted
+
+## Context
+
+In exchanges between the signer and the aggregator, we need to retrieve the reason why a request was unsuccessful.
+Error handling will depend on the specific functional case of Mithril.
+We could have reused existing HTTP codes, but they are too general and could be returned for cases other than the one we wish to isolate.
+
+## Decision
+
+We therefore decided to return specific error codes when we need to identify the functional case.
+We start at 450 for client error codes and at 550 for server error codes.
+
+## Consequences
+
+Specific Mithril HTTP status code on server error should be between 550 and 599.
+For client error the HTTP status code should be between 450 and 499.

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.19"
+version = "0.7.20"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/http_server/routes/reply.rs
+++ b/mithril-aggregator/src/http_server/routes/reply.rs
@@ -14,6 +14,7 @@ pub struct MithrilStatusCode();
 
 impl MithrilStatusCode {
     pub fn registration_round_not_yet_opened() -> StatusCode {
+        // The unwrap is safe here because `from_16` function return error only for values outside of the range 100-999,
         StatusCode::from_u16(550).unwrap()
     }
 }

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -174,8 +174,8 @@ mod handlers {
             }
             Err(SignerRegistrationError::RegistrationRoundNotYetOpened) => {
                 warn!(logger, "register_signer::registration_round_not_yed_opened");
-                Ok(reply::service_unavailable(
-                    SignerRegistrationError::RegistrationRoundNotYetOpened.to_string(),
+                Ok(reply::server_error(
+                    SignerRegistrationError::RegistrationRoundNotYetOpened,
                 ))
             }
             Err(err) => {
@@ -275,6 +275,7 @@ mod tests {
 
     use crate::{
         database::{record::SignerRecord, repository::MockSignerGetter},
+        http_server::routes::reply::MithrilStatusCode,
         initialize_dependencies,
         services::{FakeEpochService, MockSignerRegisterer},
         store::MockVerificationKeyStorer,
@@ -478,7 +479,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_register_signer_post_ko_503() {
+    async fn test_register_signer_post_ko_550() {
         let mut mock_signer_registerer = MockSignerRegisterer::new();
         mock_signer_registerer
             .expect_register_signer()
@@ -506,7 +507,7 @@ mod tests {
             "application/json",
             &signer,
             &response,
-            &StatusCode::SERVICE_UNAVAILABLE,
+            &MithrilStatusCode::registration_round_not_yet_opened(),
         )
         .unwrap();
     }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.235"
+version = "0.2.236"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -318,7 +318,7 @@ impl StateMachine {
                 nested_error: Some(e),
             })?;
 
-        fn filter_error(
+        fn handle_registration_result(
             register_result: Result<(), Error>,
             epoch: Epoch,
         ) -> Result<Option<SignerState>, RuntimeError> {
@@ -338,7 +338,7 @@ impl StateMachine {
         }
 
         let register_result = self.runner.register_signer_to_aggregator().await;
-        let next_state_found = filter_error(register_result, epoch)?;
+        let next_state_found = handle_registration_result(register_result, epoch)?;
 
         self.metrics_service
             .get_signer_registration_success_since_startup_counter()

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -1,3 +1,4 @@
+use anyhow::Error;
 use slog::{debug, info, Logger};
 use std::{fmt::Display, ops::Deref, sync::Arc, time::Duration};
 use tokio::{sync::Mutex, time::sleep};
@@ -8,8 +9,11 @@ use mithril_common::{
     logging::LoggerExtensions,
 };
 
-use crate::entities::{BeaconToSign, SignerEpochSettings};
 use crate::MetricsService;
+use crate::{
+    entities::{BeaconToSign, SignerEpochSettings},
+    services::AggregatorClientError,
+};
 
 use super::{Runner, RuntimeError};
 
@@ -314,18 +318,35 @@ impl StateMachine {
                 nested_error: Some(e),
             })?;
 
-        self.runner.register_signer_to_aggregator()
-            .await.map_err(|e| {
-            if e.downcast_ref::<ProtocolInitializerError>().is_some() {
-                RuntimeError::Critical { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {:?}.", epoch), nested_error: Some(e) }
+        fn filter_error(
+            register_result: Result<(), Error>,
+            epoch: Epoch,
+        ) -> Result<Option<SignerState>, RuntimeError> {
+            if let Err(e) = register_result {
+                if let Some(AggregatorClientError::RegistrationRoundNotYetOpened(_)) =
+                    e.downcast_ref::<AggregatorClientError>()
+                {
+                    Ok(Some(SignerState::Unregistered { epoch }))
+                } else if e.downcast_ref::<ProtocolInitializerError>().is_some() {
+                    Err(RuntimeError::Critical { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {:?}.", epoch), nested_error: Some(e) })
+                } else {
+                    Err(RuntimeError::KeepState { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {:?}.", epoch), nested_error: Some(e) })
+                }
             } else {
-                RuntimeError::KeepState { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {:?}.", epoch), nested_error: Some(e) }
+                Ok(None)
             }
-        })?;
+        }
+
+        let register_result = self.runner.register_signer_to_aggregator().await;
+        let next_state_found = filter_error(register_result, epoch)?;
 
         self.metrics_service
             .get_signer_registration_success_since_startup_counter()
             .increment();
+
+        if let Some(state) = next_state_found {
+            return Ok(state);
+        }
 
         self.metrics_service
             .get_signer_registration_success_last_epoch_gauge()
@@ -452,6 +473,7 @@ impl StateMachine {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::anyhow;
     use chrono::DateTime;
     use mockall::predicate;
 
@@ -459,6 +481,7 @@ mod tests {
     use mithril_common::test_utils::fake_data;
 
     use crate::runtime::runner::MockSignerRunner;
+    use crate::services::AggregatorClientError;
     use crate::test_tools::TestLogger;
 
     use super::*;
@@ -644,6 +667,88 @@ mod tests {
                 epoch: TimePoint::dummy().epoch,
             },
             state_machine.get_state().await
+        );
+
+        let metrics_service = state_machine.metrics_service;
+        let success_since_startup =
+            metrics_service.get_runtime_cycle_success_since_startup_counter();
+        assert_eq!(1, success_since_startup.get());
+    }
+
+    #[tokio::test]
+    async fn unregistered_to_ready_to_sign_counter() {
+        let mut runner = MockSignerRunner::new();
+
+        runner
+            .expect_get_epoch_settings()
+            .once()
+            .returning(|| Ok(Some(SignerEpochSettings::dummy())));
+
+        runner
+            .expect_inform_epoch_settings()
+            .with(predicate::eq(SignerEpochSettings::dummy()))
+            .once()
+            .returning(|_| Ok(()));
+
+        runner
+            .expect_get_current_time_point()
+            .times(2)
+            .returning(|| Ok(TimePoint::dummy()));
+        runner
+            .expect_update_stake_distribution()
+            .once()
+            .returning(|_| Ok(()));
+        runner
+            .expect_register_signer_to_aggregator()
+            .once()
+            .returning(|| {
+                Err(AggregatorClientError::RegistrationRoundNotYetOpened(
+                    anyhow!("Not yet opened"),
+                ))?
+            });
+
+        runner.expect_upkeep().never();
+        runner.expect_can_sign_current_epoch().never();
+
+        let state_machine = init_state_machine(
+            SignerState::Unregistered {
+                epoch: TimePoint::dummy().epoch,
+            },
+            runner,
+        );
+
+        state_machine
+            .cycle()
+            .await
+            .expect("Cycling the state machine should not fail");
+
+        assert_eq!(
+            SignerState::Unregistered {
+                epoch: TimePoint::dummy().epoch,
+            },
+            state_machine.get_state().await
+        );
+
+        let metrics_service = state_machine.metrics_service;
+        assert_eq!(
+            1,
+            metrics_service
+                .get_signer_registration_success_since_startup_counter()
+                .get()
+        );
+
+        assert_eq!(
+            0 as f64,
+            metrics_service
+                .get_signer_registration_success_last_epoch_gauge()
+                .get()
+        );
+
+        assert_eq!(
+            1,
+            metrics_service
+                .get_runtime_cycle_total_since_startup_counter()
+                .get()
         );
     }
 

--- a/mithril-signer/src/services/aggregator_client.rs
+++ b/mithril-signer/src/services/aggregator_client.rs
@@ -69,6 +69,10 @@ pub enum AggregatorClientError {
     /// Adapter error
     #[error("adapter failed")]
     Adapter(#[source] StdError),
+
+    /// No signer registration round opened yet
+    #[error("a signer registration round is not opened yet, please try again later")]
+    RegistrationRoundNotYetOpened(#[source] StdError),
 }
 
 #[cfg(test)]
@@ -93,7 +97,10 @@ impl AggregatorClientError {
             Self::RemoteServerLogical(anyhow!(root_cause))
         } else if error_code.is_server_error() {
             let root_cause = Self::get_root_cause(response).await;
-            Self::RemoteServerTechnical(anyhow!(root_cause))
+            match error_code.as_u16() {
+                550 => Self::RegistrationRoundNotYetOpened(anyhow!(root_cause)),
+                _ => Self::RemoteServerTechnical(anyhow!(root_cause)),
+            }
         } else {
             let response_text = response.text().await.unwrap_or_default();
             Self::UnhandledStatusCode(error_code, response_text)
@@ -1005,6 +1012,20 @@ mod tests {
                 AggregatorClientError::RemoteServerTechnical(..)
             ),
             "Expected error to be RemoteServerLogical\ngot '{handled_error:?}'",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_550_error_is_handled_as_registration_round_not_yet_opened() {
+        let response = build_text_response(StatusCode::from_u16(550).unwrap(), "Not yet available");
+        let handled_error = AggregatorClientError::from_response(response).await;
+
+        assert!(
+            matches!(
+                handled_error,
+                AggregatorClientError::RegistrationRoundNotYetOpened(..)
+            ),
+            "Expected error to be RegistrationRoundNotYetOpened\ngot '{handled_error:?}'",
         );
     }
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -637,7 +637,7 @@ paths:
                 $ref: "#/components/schemas/Error"
         "412":
           description: API version mismatch
-        "503":
+        "550":
           description: signer registration is unavailable
           content:
             application/json:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.47
+  version: 0.1.48
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content

This PR includes:
- a new 550 error code in the aggregator when signer registration is not opened yet
- increment following metrics on errors considered as a warning: 
  - `signer_registration_success_since_startup_counter`
  - `get_signer_registration_total_since_startup_counter metric`
- Create ADR to specify the reserved ranges of 4XX and 5XX codes that we can use in the Mithril nodes (see https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml)

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [x] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

Closes #2363
