### PR TITLE
refactor(aggregator): remove deprecated `configuration` field from `DependencyContainer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3639,7 +3639,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.21"
+version = "0.7.22"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.21"
+version = "0.7.22"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -327,7 +327,6 @@ impl DependenciesBuilder {
     pub async fn build_dependency_container(&mut self) -> Result<DependencyContainer> {
         #[allow(deprecated)]
         let dependency_manager = DependencyContainer {
-            config: self.configuration.clone(),
             root_logger: self.root_logger(),
             sqlite_connection: self.get_sqlite_connection().await?,
             sqlite_connection_cardano_transaction_pool: self

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -26,7 +26,6 @@ use mithril_persistence::{
 use mithril_signed_entity_lock::SignedEntityTypeLock;
 
 use crate::{
-    configuration::*,
     database::repository::{
         CertificateRepository, OpenMessageRepository, SignedEntityStorer, SignerGetter,
         StakePoolStore,
@@ -49,11 +48,6 @@ pub type EpochServiceWrapper = Arc<RwLock<dyn EpochService>>;
 
 /// DependencyManager handles the dependencies
 pub struct DependencyContainer {
-    /// Configuration structure.
-    // TODO: remove this field and only use the `Configuration` in the dependencies builder
-    #[deprecated]
-    pub config: Configuration,
-
     /// Application root logger
     pub root_logger: Logger,
 

--- a/mithril-aggregator/src/dependency_injection/containers.rs
+++ b/mithril-aggregator/src/dependency_injection/containers.rs
@@ -209,17 +209,19 @@ impl DependencyContainer {
     ///
     /// Fill the stores of a [DependencyManager] in a way to simulate an aggregator state
     /// using the data from a precomputed fixture.
-    pub async fn init_state_from_fixture(&self, fixture: &MithrilFixture, target_epochs: &[Epoch]) {
+    pub async fn init_state_from_fixture(
+        &self,
+        fixture: &MithrilFixture,
+        cardano_transactions_signing_config: &CardanoTransactionsSigningConfig,
+        target_epochs: &[Epoch],
+    ) {
         for epoch in target_epochs {
             self.epoch_settings_storer
                 .save_epoch_settings(
                     *epoch,
-                    #[allow(deprecated)]
                     AggregatorEpochSettings {
                         protocol_parameters: fixture.protocol_parameters(),
-                        cardano_transactions_signing_config: self
-                            .config
-                            .cardano_transactions_signing_config
+                        cardano_transactions_signing_config: cardano_transactions_signing_config
                             .clone(),
                     },
                 )

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -532,7 +532,8 @@ pub mod tests {
     use async_trait::async_trait;
     use chrono::{DateTime, Utc};
     use mithril_common::entities::{
-        ChainPoint, Epoch, SignedEntityConfig, SignedEntityTypeDiscriminants,
+        CardanoTransactionsSigningConfig, ChainPoint, Epoch, SignedEntityConfig,
+        SignedEntityTypeDiscriminants,
     };
     use mithril_common::temp_dir;
     use mithril_common::{
@@ -575,6 +576,7 @@ pub mod tests {
             .unwrap();
         deps.init_state_from_fixture(
             &fixture,
+            &CardanoTransactionsSigningConfig::dummy(),
             &[
                 current_epoch.offset_to_signer_retrieval_epoch().unwrap(),
                 current_epoch,

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -439,6 +439,8 @@ mod tests {
         current_epoch: Option<Epoch>,
     ) -> MithrilCertifierService {
         let configuration = Configuration::new_sample(snapshot_directory);
+        let cardano_transactions_signing_config =
+            configuration.cardano_transactions_signing_config.clone();
         let mut dependency_builder = DependenciesBuilder::new_with_stdout_logger(configuration);
         if let Some(epoch) = current_epoch {
             dependency_builder.epoch_service = Some(Arc::new(RwLock::new(
@@ -451,7 +453,11 @@ mod tests {
             .await
             .unwrap();
         dependency_manager
-            .init_state_from_fixture(fixture, epochs_with_signers)
+            .init_state_from_fixture(
+                fixture,
+                &cardano_transactions_signing_config,
+                epochs_with_signers,
+            )
             .await;
 
         MithrilCertifierService::from_deps(network, dependency_builder).await


### PR DESCRIPTION
## Content

This PR remove the deprecated `configuration` field from `DependencyContainer`.

This field was problematic as the `Configuration` structure is not fully validated, meaning that consumer of this attribute may have to re-validate the fields they needed, something not necessary as the field should have been validated when constructing the dependency builder.

Also, leaving this field as is would complicate #2384 work as the `Configuration` structure will likely not be used anymore in the `DependenciesBuilder` (used to build the container).

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #2384
