### PR TITLE
Chore: bump `glibc` requirement to `2.35+` in one-line installer

### DIFF
--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -29,10 +29,8 @@ check_requirements() {
 check_glibc_min_version() {
   glibc_version=$(ldd --version | awk 'NR==1{print $NF}')
 
-  if [ "$(echo "$glibc_version" | grep -cE "2\.3[1-4]")" -gt 0 ]; then
-    echo "Warning: Mithril support for your GLIBC version $glibc_version is deprecated. The minimum required version will be bumped to 2.35 for distributions released from March 2025 onwards."
-  elif [ "$(echo "$glibc_version" | grep -cE -e "2\.[0-2][0-9]" -e "2\.30")" -gt 0 ]; then
-    error_exit "Error: Your GLIBC version is $glibc_version, but the minimum required version is 2.31."
+  if [ "$(echo "$glibc_version" | grep -cE -e "2\.[0-2][0-9]" -e "2\.3[0-4]")" -gt 0 ]; then
+    error_exit "Error: Your GLIBC version is $glibc_version, but the minimum required version is 2.35."
   fi
 }
 


### PR DESCRIPTION
## Content

This PR includes the **bump of the minimum `glibc` version to `2.35` in the one-line installer script**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Relates to #2332 
