### PR TITLE
Docs: add dev blog post for distribution `2513`

### DIFF
--- a/docs/website/blog/2025-03-28-distribution-2513.md
+++ b/docs/website/blog/2025-03-28-distribution-2513.md
@@ -7,28 +7,28 @@ tags: [release, distribution, 2513, security-advisory]
 
 ### Distribution `2513` is now available
 
-We have released the [`2513.0`](https://github.com/input-output-hk/mithril/releases/tag/2513.0) distribution, which includes the following:
+The [`2513.0`](https://github.com/input-output-hk/mithril/releases/tag/2513.0) distribution has been released, introducing the following changes:
 
 - ⚠️ **Breaking** changes in Mithril nodes:
-  - Upgraded the **minimum required** `glibc` version from `2.31` to `2.35` for the pre-built Linux binaries
-  - Mithril signer with versions `<=0.2.200` **must be updated** following the cleanup of `Thales` era legacy code
-  - Mithril client library `with_snapshot_uploader` function has been renamed to `with_file_uploader`.
-- Support for `Cardano node` `10.2.1` in the signer and the aggregator
-- End support for **macOS x64 pre-built binaries** for the client CLI
+  - The **minimum required** `glibc` version for pre-built Linux binaries has been upgraded from `2.31` to `2.35`
+  - Mithril signers running versions `<=0.2.200` **must be updated** due to the removal of Thales era legacy code
+  - The `with_snapshot_uploader` function in the Mithril client library has been renamed to `with_file_uploader`
+- Added support for Cardano node `10.2.1` in the signer and aggregator
+- Ended support for **macOS x64 pre-built binaries** for the client CLI
 - Bug fixes and performance improvements.
 
-This new distribution has been deployed to the **Mithril aggregator** of the `release-mainnet` and `release-preprod` networks.
+This new distribution has been deployed to the **Mithril aggregator** on the `release-mainnet` and `release-preprod` networks.
 
 If you are running a **Mithril signer**:
 
 - **pre-release-preview** network: no action is required at this time
 - **release-preprod** network: upgrade your signer node binary to version `0.2.237` – no configuration updates are required
-- **release-mainnet** network: upgrade your signer node binary to version `0.2.237` – no configuration updates are required.
+- **release-mainnet** network: upgrade your signer node binary to version `0.2.237`– no configuration updates are required.
 
-You can easily update the Mithril signer with this one-line command. It downloads to the current directory by default, but a custom folder can be specified using the -p option:
+You can update the Mithril signer using the one-line command below. It downloads to the current directory by default, but you can specify a custom folder using the -p option:
 
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2513.0 -p $(pwd)
 ```
 
-For any inquiries or assistance, feel free to contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).
+For any inquiries or assistance, contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).

--- a/docs/website/blog/2025-03-28-distribution-2513.md
+++ b/docs/website/blog/2025-03-28-distribution-2513.md
@@ -1,0 +1,34 @@
+---
+title: Distribution `2513` is now available
+authors:
+  - name: Mithril Team
+tags: [release, distribution, 2513, security-advisory]
+---
+
+### Distribution `2513` is now available
+
+We have released the [`2513.0`](https://github.com/input-output-hk/mithril/releases/tag/2513.0) distribution, which includes the following:
+
+- ⚠️ **Breaking** changes in Mithril nodes:
+  - Upgraded the **minimum required** `glibc` version from `2.31` to `2.35` for the pre-built Linux binaries
+  - Mithril signer with versions `<=0.2.200` **must be updated** following the cleanup of `Thales` era legacy code
+  - Mithril client library `with_snapshot_uploader` function has been renamed to `with_file_uploader`.
+- Support for `Cardano node` `10.2.1` in the signer and the aggregator
+- End support for **macOS x64 pre-built binaries** for the client CLI
+- Bug fixes and performance improvements.
+
+This new distribution has been deployed to the **Mithril aggregator** of the `release-mainnet` and `release-preprod` networks.
+
+If you are running a **Mithril signer**:
+
+- **pre-release-preview** network: no action is required at this time
+- **release-preprod** network: upgrade your signer node binary to version `0.2.237` – no configuration updates are required
+- **release-mainnet** network: upgrade your signer node binary to version `0.2.237` – no configuration updates are required.
+
+You can easily update the Mithril signer with this one-line command. It downloads to the current directory by default, but a custom folder can be specified using the -p option:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2513.0 -p $(pwd)
+```
+
+For any inquiries or assistance, feel free to contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).


### PR DESCRIPTION
## Content

This PR includes a **dev blog post announcing the release of the [`2513`](https://github.com/input-output-hk/mithril/releases/tag/2513.0) distribution**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Add dev blog post (if relevant)

## Issue(s)
Relates to #2332 
