### PR TITLE
chore: anticipate rust `1.86`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.27"
+version = "0.7.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.18"
+version = "0.5.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3924,7 +3924,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.49"
+version = "0.2.50"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4001,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.237"
+version = "0.2.238"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.49"
+version = "0.2.50"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/query/block_range_root/insert_block_range.rs
+++ b/internal/mithril-persistence/src/database/query/block_range_root/insert_block_range.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat;
+use std::iter::repeat_n;
 
 use sqlite::Value;
 
@@ -16,9 +16,8 @@ impl InsertBlockRangeRootQuery {
     /// Query that insert multiples records.
     pub fn insert_many(block_range_records: Vec<BlockRangeRootRecord>) -> StdResult<Self> {
         let columns = "(start, end, merkle_root)";
-        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*)")
-            .take(block_range_records.len())
-            .collect();
+        let values_columns: Vec<&str> =
+            repeat_n("(?*, ?*, ?*)", block_range_records.len()).collect();
 
         let values: StdResult<Vec<Value>> =
             block_range_records

--- a/internal/mithril-persistence/src/database/query/cardano_transaction/insert_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/query/cardano_transaction/insert_cardano_transaction.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat;
+use std::iter::repeat_n;
 
 use sqlite::Value;
 
@@ -21,9 +21,8 @@ impl InsertCardanoTransactionQuery {
     /// Query that insert multiples records.
     pub fn insert_many(transactions_records: Vec<CardanoTransactionRecord>) -> StdResult<Self> {
         let columns = "(transaction_hash, block_number, slot_number, block_hash)";
-        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*, ?*)")
-            .take(transactions_records.len())
-            .collect();
+        let values_columns: Vec<&str> =
+            repeat_n("(?*, ?*, ?*, ?*)", transactions_records.len()).collect();
 
         let values: StdResult<Vec<Value>> =
             transactions_records

--- a/internal/mithril-persistence/src/sqlite/condition.rs
+++ b/internal/mithril-persistence/src/sqlite/condition.rs
@@ -1,5 +1,5 @@
 use sqlite::Value;
-use std::iter::repeat;
+use std::iter::repeat_n;
 
 /// Internal Boolean representation
 #[derive(Debug, Clone)]
@@ -90,7 +90,7 @@ impl WhereCondition {
 
     /// Instantiate a condition with a `IN` statement.
     pub fn where_in(field: &str, parameters: Vec<Value>) -> Self {
-        let params: Vec<&str> = repeat("?*").take(parameters.len()).collect();
+        let params: Vec<&str> = repeat_n("?*", parameters.len()).collect();
         let expression = format!("{} in ({})", field, params.join(", "));
 
         Self {

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.27"
+version = "0.7.28"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/query/certificate/insert_certificate.rs
+++ b/mithril-aggregator/src/database/query/certificate/insert_certificate.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat;
+use std::iter::repeat_n;
 
 use sqlite::Value;
 
@@ -33,10 +33,11 @@ impl InsertCertificateRecordQuery {
         signers, \
         initiated_at, \
         sealed_at)";
-        let values_columns: Vec<&str> =
-            repeat("(?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*)")
-                .take(certificates_records.len())
-                .collect();
+        let values_columns: Vec<&str> = repeat_n(
+            "(?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*)",
+            certificates_records.len(),
+        )
+        .collect();
 
         let values: Vec<Value> = certificates_records
             .into_iter()

--- a/mithril-aggregator/src/database/query/signer/import_signer.rs
+++ b/mithril-aggregator/src/database/query/signer/import_signer.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat;
+use std::iter::repeat_n;
 
 use sqlite::Value;
 
@@ -21,9 +21,8 @@ impl ImportSignerRecordQuery {
 
     pub fn many(signer_records: Vec<SignerRecord>) -> Self {
         let columns = "(signer_id, pool_ticker, created_at, updated_at, last_registered_at)";
-        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*, ?*, ?*)")
-            .take(signer_records.len())
-            .collect();
+        let values_columns: Vec<&str> =
+            repeat_n("(?*, ?*, ?*, ?*, ?*)", signer_records.len()).collect();
         let values = signer_records
             .into_iter()
             .flat_map(|signer_record| {

--- a/mithril-aggregator/src/database/query/stake_pool/insert_or_replace_stake_pool.rs
+++ b/mithril-aggregator/src/database/query/stake_pool/insert_or_replace_stake_pool.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat;
+use std::iter::repeat_n;
 
 use chrono::Utc;
 use sqlite::Value;
@@ -16,7 +16,7 @@ pub struct InsertOrReplaceStakePoolQuery {
 impl InsertOrReplaceStakePoolQuery {
     pub fn many(records: Vec<(PartyId, Epoch, Stake)>) -> Self {
         let columns = "(stake_pool_id, epoch, stake, created_at)";
-        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*, ?*)").take(records.len()).collect();
+        let values_columns: Vec<&str> = repeat_n("(?*, ?*, ?*, ?*)", records.len()).collect();
         let values = records
             .into_iter()
             .flat_map(|(stake_pool_id, epoch, stake)| {

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.18"
+version = "0.5.19"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/digesters/immutable_file_observer.rs
+++ b/mithril-common/src/digesters/immutable_file_observer.rs
@@ -51,7 +51,7 @@ impl ImmutableFileObserver for ImmutableFileSystemObserver {
             .map_err(|e| anyhow!(e))
             .with_context(|| "Immutable File System Observer can not list all immutable files")?
             .into_iter()
-            .last()
+            .next_back()
             .ok_or(anyhow!(ImmutableFileObserverError::Missing()))?
             .number;
 

--- a/mithril-common/src/messages/cardano_transactions_proof.rs
+++ b/mithril-common/src/messages/cardano_transactions_proof.rs
@@ -307,7 +307,7 @@ mod tests {
         assert!(
             matches!(
                 error,
-                VerifyCardanoTransactionsProofsError::NonMatchingMerkleRoot { .. },
+                VerifyCardanoTransactionsProofsError::NonMatchingMerkleRoot,
             ),
             "Expected 'NonMatchingMerkleRoot' error but got '{:?}'",
             error

--- a/mithril-common/src/test_utils/certificate_chain_builder.rs
+++ b/mithril-common/src/test_utils/certificate_chain_builder.rs
@@ -12,7 +12,7 @@ use crate::entities::CertificateMetadata;
 use std::{
     cmp::min,
     collections::{BTreeSet, HashMap},
-    iter::repeat,
+    iter::repeat_n,
     sync::Arc,
 };
 
@@ -335,7 +335,7 @@ impl<'a> CertificateChainBuilder<'a> {
                 } else {
                     certificates_per_epoch
                 };
-                repeat(Epoch(*epoch)).take(repeat_epoch)
+                repeat_n(Epoch(*epoch), repeat_epoch)
             })
             .take(total_certificates)
             .enumerate()
@@ -485,7 +485,7 @@ impl<'a> CertificateChainBuilder<'a> {
                             c.epoch == certificate.epoch
                         }
                     })
-                    .last()
+                    .next_back()
             }
             CertificateChainingMethod::Sequential => certificates_chained.last(),
         }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.237"
+version = "0.2.238"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/database/query/stake_pool/insert_or_replace_stake_pool.rs
+++ b/mithril-signer/src/database/query/stake_pool/insert_or_replace_stake_pool.rs
@@ -1,4 +1,4 @@
-use std::iter::repeat;
+use std::iter::repeat_n;
 
 use chrono::Utc;
 use sqlite::Value;
@@ -16,7 +16,7 @@ pub struct InsertOrReplaceStakePoolQuery {
 impl InsertOrReplaceStakePoolQuery {
     pub fn many(records: Vec<(PartyId, Epoch, Stake)>) -> Self {
         let columns = "(stake_pool_id, epoch, stake, created_at)";
-        let values_columns: Vec<&str> = repeat("(?*, ?*, ?*, ?*)").take(records.len()).collect();
+        let values_columns: Vec<&str> = repeat_n("(?*, ?*, ?*, ?*)", records.len()).collect();
         let values = records
             .into_iter()
             .flat_map(|(stake_pool_id, epoch, stake)| {

--- a/mithril-signer/src/store/mktree_store_sqlite.rs
+++ b/mithril-signer/src/store/mktree_store_sqlite.rs
@@ -1,4 +1,4 @@
-use std::{iter::repeat, sync::Arc};
+use std::{iter::repeat_n, sync::Arc};
 
 use anyhow::Context;
 use mithril_common::{
@@ -55,7 +55,7 @@ impl MKTreeStoreSqlite {
         position: u64,
         elements: Vec<Arc<MKTreeNode>>,
     ) -> StdResult<()> {
-        let values_columns: Vec<&str> = repeat("(?, ?)").take(elements.len()).collect();
+        let values_columns: Vec<&str> = repeat_n("(?, ?)", elements.len()).collect();
         let values: Vec<sqlite::Value> = elements
             .into_iter()
             .enumerate()


### PR DESCRIPTION
## Content

This PR fix preemptively clippy lint added with `rust 1.86`:

- use `repeat_n` instead of `repeat(..).take(n)`
- use `next_back` instead of `last` on iterator to avoid walking through
  the whole iterator
- simplify a `matches!` in `mithril-common::messages::cardano_transactions_proof`

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
