### PR TITLE
CI: include `CardanoDatabase` in the backward compatibility test 

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -17,7 +17,7 @@ on:
         description: "Signed entity types parameters (discriminants names in an ordered comma separated list)"
         required: true
         type: string
-        default: "CardanoTransactions,CardanoStakeDistribution"
+        default: "CardanoTransactions,CardanoStakeDistribution,CardanoDatabase"
   workflow_call:
     inputs:
       total-releases:
@@ -28,7 +28,7 @@ on:
         default: "10.2.1"
       signed-entity-types:
         type: string
-        default: "CardanoTransactions,CardanoStakeDistribution"
+        default: "CardanoTransactions,CardanoStakeDistribution,CardanoDatabase"
 
 jobs:
   prepare-env-variables:


### PR DESCRIPTION
## Content

This PR adds `CardanoDatabase` in the list of default signed entity type to verify in the Backward compatibility Github workflow (manual trigger and nightly scheduled). 

Result of a backward compatibility test that asses the signer node compatibility with `CardanoDatabase` from release `2450.0` (signer node version `0.2.221`): https://github.com/input-output-hk/mithril/actions/runs/14336068335

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #2409 
