### PR TITLE
fix(aggregator): incorrect immutable files average and total size in cardano database v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3651,7 +3651,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.30"
+version = "0.7.31"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.30"
+version = "0.7.31"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/snapshotter/interface.rs
+++ b/mithril-aggregator/src/services/snapshotter/interface.rs
@@ -31,6 +31,13 @@ pub trait Snapshotter: Sync + Send {
         archive_name_without_extension: &str,
     ) -> StdResult<FileArchive>;
 
+    /// Compute the total and average uncompressed size of all immutables up to the given immutable
+    /// file number.
+    async fn compute_immutable_files_total_uncompressed_size(
+        &self,
+        up_to_immutable_file_number: ImmutableFileNumber,
+    ) -> StdResult<u64>;
+
     /// Return the compression algorithm used by the snapshotter.
     fn compression_algorithm(&self) -> CompressionAlgorithm;
 }

--- a/mithril-aggregator/src/services/snapshotter/test_doubles.rs
+++ b/mithril-aggregator/src/services/snapshotter/test_doubles.rs
@@ -92,6 +92,13 @@ impl Snapshotter for DumbSnapshotter {
             .await
     }
 
+    async fn compute_immutable_files_total_uncompressed_size(
+        &self,
+        _up_to_immutable_file_number: ImmutableFileNumber,
+    ) -> StdResult<u64> {
+        Ok(0)
+    }
+
     fn compression_algorithm(&self) -> CompressionAlgorithm {
         self.compression_algorithm
     }
@@ -161,6 +168,13 @@ impl Snapshotter for FakeSnapshotter {
     ) -> StdResult<FileArchive> {
         self.snapshot_all_completed_immutables(archive_name_without_extension)
             .await
+    }
+
+    async fn compute_immutable_files_total_uncompressed_size(
+        &self,
+        _up_to_immutable_file_number: ImmutableFileNumber,
+    ) -> StdResult<u64> {
+        Ok(0)
     }
 
     fn compression_algorithm(&self) -> CompressionAlgorithm {


### PR DESCRIPTION
## Content

This PR fix the computation of the immutable files average and total size in cardano database v2.

It was incorrectly based on the `immutables_storage_dir` of the artifact builder, since this directory contains the archives of each immutable trio the computation always returned `0`.
As the artifact builder has no knowledge of the cardano node database, the actual computation was moved to the snapshotter.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)

Relates to #2415
