### PR TITLE
fix(aggregator): ancillary signing on evolving files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,7 +3676,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.34"
+version = "0.7.35"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.11.20"
+version = "0.11.21"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3843,7 +3843,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.22"
+version = "0.5.23"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.34"
+version = "0.7.35"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/snapshotter/mod.rs
+++ b/mithril-aggregator/src/services/snapshotter/mod.rs
@@ -6,14 +6,3 @@ mod test_doubles;
 pub use compressed_archive_snapshotter::*;
 pub use interface::*;
 pub use test_doubles::*;
-
-#[cfg(test)]
-pub(crate) mod test_tools {
-    use std::path::PathBuf;
-
-    use mithril_common::test_utils::TempDir;
-
-    pub fn get_test_directory(dir_name: &str) -> PathBuf {
-        TempDir::create("snapshotter", dir_name)
-    }
-}

--- a/mithril-aggregator/src/services/snapshotter/test_doubles.rs
+++ b/mithril-aggregator/src/services/snapshotter/test_doubles.rs
@@ -184,7 +184,7 @@ impl Snapshotter for FakeSnapshotter {
 
 #[cfg(test)]
 mod tests {
-    use crate::services::snapshotter::test_tools::*;
+    use mithril_common::temp_dir_create;
 
     use super::*;
 
@@ -318,8 +318,8 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn test_fake_snasphotter() {
-            let test_dir = get_test_directory("test_fake_snasphotter");
+        async fn test_fake_snapshotter() {
+            let test_dir = temp_dir_create!();
             let fake_snapshotter = FakeSnapshotter::new(&test_dir)
                 .with_compression_algorithm(CompressionAlgorithm::Gzip);
 

--- a/mithril-aggregator/src/tools/file_archiver/appender.rs
+++ b/mithril-aggregator/src/tools/file_archiver/appender.rs
@@ -263,7 +263,7 @@ mod tests {
         DummyCardanoDbBuilder, IMMUTABLE_DIR, LEDGER_DIR, VOLATILE_DIR,
     };
     use mithril_common::entities::CompressionAlgorithm;
-    use mithril_common::temp_dir_create;
+    use mithril_common::{assert_dir_eq, temp_dir_create};
 
     use crate::tools::file_archiver::test_tools::*;
     use crate::tools::file_archiver::{ArchiveParameters, FileArchiver};
@@ -280,8 +280,8 @@ mod tests {
 
             let directory_to_archive_path = create_dir(&source, "directory_to_archive");
             let file_to_archive_path = create_file(&source, "file_to_archive.txt");
-            let directory_not_to_archive_path = create_dir(&source, "directory_not_to_archive");
-            let file_not_to_archive_path = create_file(&source, "file_not_to_archive.txt");
+            create_dir(&source, "directory_not_to_archive");
+            create_file(&source, "file_not_to_archive.txt");
 
             let file_archiver = FileArchiver::new_for_test(test_dir.join("verification"));
 
@@ -305,10 +305,11 @@ mod tests {
 
             let unpack_path = archive.unpack_gzip(&test_dir);
 
-            assert!(unpack_path.join(directory_to_archive_path).is_dir());
-            assert!(unpack_path.join(file_to_archive_path).is_file());
-            assert!(!unpack_path.join(directory_not_to_archive_path).exists());
-            assert!(!unpack_path.join(file_not_to_archive_path).exists());
+            assert_dir_eq!(
+                &unpack_path,
+                "* directory_to_archive/
+                 * file_to_archive.txt"
+            );
         }
 
         #[test]
@@ -371,8 +372,11 @@ mod tests {
 
             let unpack_path = archive.unpack_gzip(&test_dir);
 
-            assert!(unpack_path.join(directory_to_archive_path).is_dir());
-            assert!(unpack_path.join(file_to_archive_path).is_file());
+            assert_dir_eq!(
+                &unpack_path,
+                "* directory_to_archive/
+                 ** file_to_archive.txt"
+            );
         }
 
         #[test]
@@ -572,7 +576,7 @@ mod tests {
             let mtime = appended_entry.header().mtime().unwrap();
             assert!(
                 mtime >= start_time_stamp,
-                "entry mtime should be greater than or equal to the timestamp before the archive\
+                "entry mtime should be greater than or equal to the timestamp before the archive \
                 creation:\n {mtime} < {start_time_stamp}"
             );
         }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.11.20"
+version = "0.11.21"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/cardano_database_client/download_unpack/download_task.rs
+++ b/mithril-client/src/cardano_database_client/download_unpack/download_task.rs
@@ -163,7 +163,7 @@ pub struct LocationToDownload {
 #[cfg(test)]
 mod tests {
     use mithril_common::entities::FileUri;
-    use mithril_common::test_utils::{fake_keys, temp_dir_create};
+    use mithril_common::test_utils::{assert_dir_eq, fake_keys, temp_dir_create};
 
     use crate::file_downloader::MockFileDownloaderBuilder;
     use crate::test_utils::TestLogger;
@@ -467,9 +467,7 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert!(target_dir.join("dummy_ledger").exists());
-            assert!(!target_dir.join("not_in_ancillary").exists());
-            assert!(!temp_ancillary_target_dir(&target_dir, "download-id").exists());
+            assert_dir_eq!(&target_dir, "* dummy_ledger");
         }
     }
 }

--- a/mithril-client/src/file_downloader/mock_builder.rs
+++ b/mithril-client/src/file_downloader/mock_builder.rs
@@ -220,7 +220,7 @@ impl MockFileDownloaderBuilder {
 
 #[cfg(test)]
 mod tests {
-    use mithril_common::temp_dir_create;
+    use mithril_common::{assert_dir_eq, temp_dir_create};
 
     use crate::file_downloader::FileDownloader;
 
@@ -261,9 +261,6 @@ mod tests {
         )
         .unwrap();
 
-        assert!(target_dir.join("file1.txt").exists());
-        assert!(target_dir.join("file2.txt").exists());
-        assert!(target_dir.join("not_in_manifest.txt").exists());
         const EMPTY_SHA256_HASH: &str =
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
         assert_eq!(
@@ -281,5 +278,16 @@ mod tests {
                     .expect("Manifest should be signed"),
             )
             .expect("Signed manifest should have a valid signature");
+
+        assert_dir_eq!(
+            &target_dir,
+            format!(
+                "* {}
+                 * file1.txt
+                 * file2.txt
+                 * not_in_manifest.txt",
+                AncillaryFilesManifest::ANCILLARY_MANIFEST_FILE_NAME
+            )
+        );
     }
 }

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -427,7 +427,7 @@ mod tests {
 
     use super::*;
 
-    use mithril_common::temp_dir_create;
+    use mithril_common::{assert_dir_eq, temp_dir_create};
 
     fn dummy_download_event() -> DownloadEvent {
         DownloadEvent::Full {
@@ -771,9 +771,7 @@ mod tests {
                 .await
                 .expect("Should succeed when ancillary verification is successful");
 
-            assert!(test_dir.join("dummy_ledger").exists());
-            assert!(!test_dir.join("not_in_ancillary").exists());
-            assert!(!SnapshotClient::ancillary_subdir(&test_dir, "test-download-id").exists());
+            assert_dir_eq!(&test_dir, "* dummy_ledger");
         }
     }
 }

--- a/mithril-client/src/utils/ancillary_verifier.rs
+++ b/mithril-client/src/utils/ancillary_verifier.rs
@@ -118,7 +118,7 @@ impl ValidatedAncillaryManifest {
 mod tests {
     use std::io::Write;
 
-    use mithril_common::temp_dir_create;
+    use mithril_common::{assert_dir_eq, temp_dir_create};
 
     use super::*;
 
@@ -325,13 +325,17 @@ mod tests {
                 .await
                 .unwrap();
 
-            assert!(!source_dir.join(&file_in_root_dir).exists());
-            assert!(!source_dir.join(&file_in_subdir).exists());
-            assert!(source_dir.join(&not_moved_path).exists());
-
-            assert!(target_dir.join(&file_in_root_dir).exists());
-            assert!(target_dir.join(&file_in_subdir).exists());
-            assert!(!target_dir.join(&not_moved_path).exists());
+            assert_dir_eq!(
+                &source_dir,
+                "* subdir/
+                 * not_moved.txt"
+            );
+            assert_dir_eq!(
+                &target_dir,
+                "* subdir/
+                 ** file2.txt
+                 * file1.txt"
+            );
         }
 
         #[tokio::test]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.22"
+version = "0.5.23"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/test_utils/dir_eq.rs
+++ b/mithril-common/src/test_utils/dir_eq.rs
@@ -1,0 +1,352 @@
+use std::cmp::Ordering;
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// A structure to compare two directories in a human-readable way in tests.
+#[derive(Debug, Clone)]
+pub struct DirStructure {
+    content: String,
+}
+
+impl DirStructure {
+    /// Creates a new `DirStructure` from a given path by recursively traversing it.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Self {
+        let mut content = String::new();
+        let mut is_first_entry = true;
+
+        for dir_entry in WalkDir::new(path)
+            .sort_by(|l, r| {
+                (!l.file_type().is_dir())
+                    .cmp(&!r.file_type().is_dir())
+                    .then(l.file_name().cmp(r.file_name()))
+            })
+            .into_iter()
+            .filter_entry(|e| e.file_type().is_file() || e.file_type().is_dir())
+            .flatten()
+            // Skip the first entry as it yields the root directory
+            .skip(1)
+        {
+            if !is_first_entry {
+                content.push('\n')
+            } else {
+                is_first_entry = false;
+            }
+
+            let suffix = if dir_entry.file_type().is_dir() {
+                "/"
+            } else {
+                ""
+            };
+
+            content.push_str(&format!(
+                "{} {}{suffix}",
+                "*".repeat(dir_entry.depth()),
+                dir_entry.file_name().to_string_lossy()
+            ));
+        }
+
+        Self { content }
+    }
+
+    fn trimmed_lines(&self) -> Vec<&str> {
+        self.content.lines().map(|l| l.trim_start()).collect()
+    }
+
+    /// Computes a line-by-line diff between the content of `self` and `other`,
+    pub fn diff(&self, other: &Self) -> String {
+        let mut self_lines = self.trimmed_lines();
+        let mut other_lines = other.trimmed_lines();
+
+        let left_padding = self_lines.iter().map(|l| l.len()).max().unwrap_or(0);
+
+        // Equalize vector lengths by adding empty lines to the shorter one,
+        // else zip will stop at the first missing line
+        match self_lines.len().cmp(&other_lines.len()) {
+            Ordering::Less => {
+                let padding = vec![""; other_lines.len() - self_lines.len()];
+                self_lines.extend(padding);
+            }
+            Ordering::Greater => {
+                let padding = vec![""; self_lines.len() - other_lines.len()];
+                other_lines.extend(padding);
+            }
+            Ordering::Equal => {}
+        }
+
+        self_lines
+            .into_iter()
+            .zip(other_lines)
+            .map(|(left, right)| {
+                if left == right {
+                    format!("= {left}")
+                } else {
+                    format!("! {left:<left_padding$}  </>  {right}")
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+}
+
+impl From<&Path> for DirStructure {
+    fn from(path: &Path) -> Self {
+        Self::from_path(path)
+    }
+}
+
+impl PartialEq for DirStructure {
+    fn eq(&self, other: &Self) -> bool {
+        self.trimmed_lines() == other.trimmed_lines()
+    }
+}
+
+impl From<PathBuf> for DirStructure {
+    fn from(path: PathBuf) -> Self {
+        Self::from_path(path)
+    }
+}
+
+impl From<&PathBuf> for DirStructure {
+    fn from(path: &PathBuf) -> Self {
+        Self::from_path(path)
+    }
+}
+
+impl From<String> for DirStructure {
+    fn from(content: String) -> Self {
+        Self { content }
+    }
+}
+
+impl From<&str> for DirStructure {
+    fn from(str: &str) -> Self {
+        str.to_string().into()
+    }
+}
+
+/// Compare a directory against a string representing its expected structure or against another
+/// directory.
+///
+/// When comparing against a string, the string must be formatted as:
+/// - one line per file or directory
+/// - each line starts with a number of `*` representing the entry depth
+/// - directories must end with a `/` (i.e.: `* folder/`)
+/// - order rules are:
+///   - directories then files
+///   - alphanumeric order (i.e.: '20' comes before '3')
+///
+/// Example:
+/// ```no_run
+/// # use mithril_common::test_utils::assert_dir_eq;
+/// # use std::path::PathBuf;
+/// # let path = PathBuf::new();
+/// assert_dir_eq!(
+///   &path,
+///   "* folder_1/
+///    ** file_1
+///    ** file_2
+///    ** subfolder/
+///    *** subfolder_file
+///    * file"
+/// );
+/// ```
+#[macro_export]
+macro_rules! assert_dir_eq {
+    ($dir: expr, $expected_structure: expr) => {
+        $crate::test_utils::assert_dir_eq!($dir, $expected_structure, "");
+    };
+    ($dir: expr, $expected_structure: expr, $($arg:tt)+) => {
+        let actual = $crate::test_utils::DirStructure::from_path($dir);
+        let expected = $crate::test_utils::DirStructure::from($expected_structure);
+        let comment = format!($($arg)+);
+        assert!(
+            actual == expected,
+            "{}Directory `{}` does not match expected structure:
+{}",
+            if comment.is_empty() { String::new() } else { format!("{}:\n", comment) },
+            $dir.display(),
+            actual.diff(&expected)
+        );
+    };
+}
+pub use assert_dir_eq;
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{create_dir, File};
+
+    use crate::test_utils::temp_dir_create;
+
+    use super::*;
+
+    fn create_multiple_dirs<P: AsRef<Path>>(dirs: &[P]) {
+        for dir in dirs {
+            create_dir(dir).unwrap();
+        }
+    }
+
+    fn create_multiple_files<P: AsRef<Path>>(files: &[P]) {
+        for file in files {
+            File::create(file).unwrap();
+        }
+    }
+
+    #[test]
+    fn path_to_dir_structure() {
+        let test_dir = temp_dir_create!();
+
+        assert_eq!("", DirStructure::from(&test_dir).content);
+
+        create_dir(test_dir.join("folder1")).unwrap();
+        assert_eq!("* folder1/", DirStructure::from(&test_dir).content);
+
+        File::create(test_dir.join("folder1").join("file")).unwrap();
+        assert_eq!(
+            "* folder1/
+** file",
+            DirStructure::from(&test_dir).content
+        );
+
+        create_multiple_dirs(&[
+            test_dir.join("folder2"),
+            test_dir.join("folder2").join("f_subfolder"),
+            test_dir.join("folder2").join("1_subfolder"),
+        ]);
+        create_multiple_files(&[
+            test_dir.join("folder2").join("xyz"),
+            test_dir.join("folder2").join("abc"),
+            test_dir.join("folder2").join("100"),
+            test_dir.join("folder2").join("20"),
+            test_dir.join("folder2").join("300"),
+            test_dir.join("main_folder_file"),
+        ]);
+        assert_eq!(
+            "* folder1/
+** file
+* folder2/
+** 1_subfolder/
+** f_subfolder/
+** 100
+** 20
+** 300
+** abc
+** xyz
+* main_folder_file",
+            DirStructure::from(&test_dir).content
+        );
+    }
+
+    #[test]
+    fn dir_structure_diff() {
+        let structure = DirStructure {
+            content: "* line 1\n* line 2".to_string(),
+        };
+
+        assert_eq!(
+            "= * line 1
+= * line 2",
+            structure.diff(&structure)
+        );
+        assert_eq!(
+            "!   </>  * line 1
+!   </>  * line 2",
+            DirStructure {
+                content: String::new(),
+            }
+            .diff(&structure)
+        );
+        assert_eq!(
+            "= * line 1
+! * line 2  </>  ",
+            structure.diff(&DirStructure {
+                content: "* line 1".to_string(),
+            })
+        );
+        assert_eq!(
+            "! * line 1  </>  * line a
+= * line 2
+!           </>  * line b",
+            structure.diff(&DirStructure {
+                content: "* line a\n* line 2\n* line b".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn trim_whitespaces_at_lines_start() {
+        let structure = DirStructure {
+            content: "   * line1
+            * line 2"
+                .to_string(),
+        };
+
+        assert_eq!(vec!["* line1", "* line 2"], structure.trimmed_lines());
+    }
+
+    #[test]
+    fn dir_eq_single_file() {
+        let test_dir = temp_dir_create!();
+        File::create(test_dir.join("file")).unwrap();
+        assert_dir_eq!(&test_dir, "* file");
+    }
+
+    #[test]
+    fn dir_eq_single_dir() {
+        let test_dir = temp_dir_create!();
+        create_dir(test_dir.join("folder")).unwrap();
+        assert_dir_eq!(&test_dir, "* folder/");
+    }
+
+    #[test]
+    fn can_compare_two_path() {
+        let test_dir = temp_dir_create!();
+        let left_dir = test_dir.join("left");
+        let right_dir = test_dir.join("right");
+
+        create_multiple_dirs(&[&left_dir, &right_dir]);
+        create_multiple_files(&[left_dir.join("file"), right_dir.join("file")]);
+
+        assert_dir_eq!(&left_dir, right_dir);
+    }
+
+    #[test]
+    fn can_provide_additional_comment() {
+        let test_dir = temp_dir_create!();
+        assert_dir_eq!(&test_dir, "", "additional comment: {}", "formatted");
+    }
+
+    #[test]
+    fn dir_eq_multiple_files_and_dirs() {
+        let test_dir = temp_dir_create!();
+        let first_subfolder = test_dir.join("folder 1");
+        let second_subfolder = test_dir.join("folder 2");
+
+        create_multiple_dirs(&[&first_subfolder, &second_subfolder]);
+        create_multiple_files(&[
+            test_dir.join("xyz"),
+            test_dir.join("abc"),
+            test_dir.join("100"),
+            test_dir.join("20"),
+            test_dir.join("300"),
+            first_subfolder.join("file 1"),
+            first_subfolder.join("file 2"),
+            second_subfolder.join("file 3"),
+        ]);
+
+        assert_dir_eq!(
+            &test_dir,
+            "* folder 1/
+             ** file 1
+             ** file 2
+             * folder 2/
+             ** file 3
+             * 100
+             * 20
+             * 300
+             * abc
+             * xyz"
+        );
+    }
+}

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -15,6 +15,7 @@ pub mod fake_keys;
 
 mod cardano_transactions_builder;
 mod certificate_chain_builder;
+mod dir_eq;
 mod fixture_builder;
 mod mithril_fixture;
 mod precomputed_kes_key;
@@ -28,6 +29,7 @@ pub use cardano_transactions_builder::CardanoTransactionsBuilder;
 pub use certificate_chain_builder::{
     CertificateChainBuilder, CertificateChainBuilderContext, CertificateChainingMethod,
 };
+pub use dir_eq::*;
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};
 pub use mithril_fixture::{MithrilFixture, SignerFixture};
 pub use temp_dir::*;


### PR DESCRIPTION
## Content

This PR make the aggregator copy the files that are included in an ancillary archive into a temporary folder so those files doesn't evolve while the snapshotting of ancillary is in progress, avoiding mismatch between sha of files in the ancillary manifest and the sha of files in the archive.

This PR also add a new test macro: `assert_dir_eq!` that allow comparison of two directories together or, more interestingly,  against a string that codify the expected dir structure, i.e:
```
* folder 1/
** file 1
** file 2
* folder 2/
** file 3
* 100
* 20
* 300
* abc
* xyz
```

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2362 
