### PR TITLE
Refactor: Simplify the configuration of genesis command in aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.37"
+version = "0.7.38"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/docs/runbook/genesis-manually/README.md
+++ b/docs/runbook/genesis-manually/README.md
@@ -27,13 +27,17 @@ ssh curry@$MITHRIL_VM
 Once connected to the aggregator VM, export the environment variables:
 
 ```bash
-export CARDANO_NETWORK=**CARDANO_NETWORK**
+export NETWORK=**CARDANO_NETWORK**
+export NETWORK_MAGIC=**NETWORK_MAGIC**
+export DATA_STORES_DIRECTORY=**DATA_STORES_DIRECTORY**
+export CARDANO_NODE_SOCKET_PATH=**CARDANO_NODE_SOCKET_PATH**
+export CHAIN_OBSERVER_TYPE=**CHAIN_OBSERVER_TYPE**
 ```
 
 And create genesis dir:
 
 ```bash
-mkdir -p /home/curry/data/$CARDANO_NETWORK/mithril-aggregator/mithril/genesis
+mkdir -p /home/curry/data/$NETWORK/mithril-aggregator/mithril/genesis
 ```
 
 And connect to the aggregator container:
@@ -93,7 +97,12 @@ ssh curry@$MITHRIL_VM
 Export the environment variable:
 
 ```bash
-export CARDANO_NETWORK=**CARDANO_NETWORK**
+export NETWORK=**CARDANO_NETWORK**
+export MITHRIL_NETWORK=**MITHRIL_NETWORK**
+export NETWORK_MAGIC=**NETWORK_MAGIC**
+export DATA_STORES_DIRECTORY=**DATA_STORES_DIRECTORY**
+export CARDANO_NODE_SOCKET_PATH=**CARDANO_NODE_SOCKET_PATH**
+export CHAIN_OBSERVER_TYPE=**CHAIN_OBSERVER_TYPE**
 ```
 
 And connect back to the aggregator container:
@@ -105,5 +114,5 @@ docker exec -it mithril-aggregator bash
 Once connected to the aggregator container, import the signed genesis payload:
 
 ```bash
-/app/bin/mithril-aggregator -vvv genesis import --signed-payload-path /mithril-aggregator/mithril/genesis/genesis-payload-signed.txt
+/app/bin/mithril-aggregator -vvv genesis import --signed-payload-path /mithril-aggregator/mithril/genesis/genesis-payload-signed.txt --genesis-verification-key $(curl -s "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/$MITHRIL_NETWORK/genesis.vkey")
 ```

--- a/docs/website/root/manual/develop/nodes/mithril-aggregator.md
+++ b/docs/website/root/manual/develop/nodes/mithril-aggregator.md
@@ -516,21 +516,40 @@ Here is a list of the available parameters:
 
 `genesis bootstrap` command:
 
-| Parameter            | Command line (long) | Command line (short) | Environment variable | Description                                 | Default value | Example | Mandatory |
-| -------------------- | ------------------- | :------------------: | -------------------- | ------------------------------------------- | ------------- | ------- | :-------: |
-| `genesis_secret_key` | -                   |          -           | `GENESIS_SECRET_KEY` | Genesis secret key, :warning: for test only | -             | -       |     -     |
+| Parameter                  | Command line (long) | Command line (short) | Environment variable       | Description                                                                          | Default value | Example                            |     Mandatory      |
+| -------------------------- | ------------------- | :------------------: | -------------------------- | ------------------------------------------------------------------------------------ | ------------- | ---------------------------------- | :----------------: |
+| `genesis_secret_key`       | -                   |          -           | `GENESIS_SECRET_KEY`       | Genesis secret key, :warning: for test only                                          | -             | -                                  | :heavy_check_mark: |
+| `data_stores_directory`    | -                   |          -           | `DATA_STORES_DIRECTORY`    | Directory to store aggregator databases                                              | -             | `./mithril-aggregator/stores`      | :heavy_check_mark: |
+| `cardano_node_socket_path` | -                   |          -           | `CARDANO_NODE_SOCKET_PATH` | Path of the socket used by the Cardano CLI tool to communicate with the Cardano node | -             | `/tmp/cardano.sock`                | :heavy_check_mark: |
+| `cardano_cli_path`         | -                   |          -           | `CARDANO_CLI_PATH`         | Cardano CLI tool path                                                                | -             | `cardano-cli`                      |         -          |
+| `chain_observer_type`      | -                   |          -           | `CHAIN_OBSERVER_TYPE`      | Chain observer type that can be `cardano-cli`, `pallas` or `fake`.                   | `pallas`      | -                                  | :heavy_check_mark: |
+| `network`                  | -                   |          -           | `NETWORK`                  | Cardano network                                                                      | -             | `testnet` or `mainnet` or `devnet` | :heavy_check_mark: |
+| `network_magic`            | -                   |          -           | `NETWORK_MAGIC`            | Cardano network magic number (for `testnet` and `devnet`)                            | -             | `1097911063` or `42`               |         -          |
 
 `genesis export` command:
 
-| Parameter     | Command line (long) | Command line (short) | Environment variable | Description                                | Default value | Example | Mandatory |
-| ------------- | ------------------- | :------------------: | -------------------- | ------------------------------------------ | ------------- | ------- | :-------: |
-| `target_path` | `--target-path`     |          -           | -                    | Path of the file to export the payload to. | -             | -       |     -     |
+| Parameter                  | Command line (long) | Command line (short) | Environment variable       | Description                                                                          | Default value | Example                            |     Mandatory      |
+| -------------------------- | ------------------- | :------------------: | -------------------------- | ------------------------------------------------------------------------------------ | ------------- | ---------------------------------- | :----------------: |
+| `target_path`              | `--target-path`     |          -           | -                          | Path of the file to export the payload to.                                           | -             | -                                  | :heavy_check_mark: |
+| `data_stores_directory`    | -                   |          -           | `DATA_STORES_DIRECTORY`    | Directory to store aggregator databases                                              | -             | `./mithril-aggregator/stores`      | :heavy_check_mark: |
+| `cardano_node_socket_path` | -                   |          -           | `CARDANO_NODE_SOCKET_PATH` | Path of the socket used by the Cardano CLI tool to communicate with the Cardano node | -             | `/tmp/cardano.sock`                | :heavy_check_mark: |
+| `cardano_cli_path`         | -                   |          -           | `CARDANO_CLI_PATH`         | Cardano CLI tool path                                                                | -             | `cardano-cli`                      |         -          |
+| `chain_observer_type`      | -                   |          -           | `CHAIN_OBSERVER_TYPE`      | Chain observer type that can be `cardano-cli`, `pallas` or `fake`.                   | `pallas`      | -                                  | :heavy_check_mark: |
+| `network`                  | -                   |          -           | `NETWORK`                  | Cardano network                                                                      | -             | `testnet` or `mainnet` or `devnet` | :heavy_check_mark: |
+| `network_magic`            | -                   |          -           | `NETWORK_MAGIC`            | Cardano network magic number (for `testnet` and `devnet`)                            | -             | `1097911063` or `42`               |         -          |
 
 `genesis import` command:
 
-| Parameter             | Command line (long)     | Command line (short) | Environment variable | Description                    | Default value | Example | Mandatory |
-| --------------------- | ----------------------- | :------------------: | -------------------- | ------------------------------ | ------------- | ------- | :-------: |
-| `signed_payload_path` | `--signed-payload-path` |          -           | -                    | Path of the payload to import. | -             | -       |     -     |
+| Parameter                  | Command line (long)          | Command line (short) | Environment variable       | Description                                                                          | Default value | Example                            |     Mandatory      |
+| -------------------------- | ---------------------------- | :------------------: | -------------------------- | ------------------------------------------------------------------------------------ | ------------- | ---------------------------------- | :----------------: |
+| `signed_payload_path`      | `--signed-payload-path`      |          -           | -                          | Path of the payload to import.                                                       | -             | -                                  | :heavy_check_mark: |
+| `genesis_verification_key` | `--genesis-verification-key` |          -           | -                          | Genesis verification key                                                             | -             | -                                  | :heavy_check_mark: |
+| `data_stores_directory`    | -                            |          -           | `DATA_STORES_DIRECTORY`    | Directory to store aggregator databases                                              | -             | `./mithril-aggregator/stores`      | :heavy_check_mark: |
+| `cardano_node_socket_path` | -                            |          -           | `CARDANO_NODE_SOCKET_PATH` | Path of the socket used by the Cardano CLI tool to communicate with the Cardano node | -             | `/tmp/cardano.sock`                | :heavy_check_mark: |
+| `cardano_cli_path`         | -                            |          -           | `CARDANO_CLI_PATH`         | Cardano CLI tool path                                                                | -             | `cardano-cli`                      |         -          |
+| `chain_observer_type`      | -                            |          -           | `CHAIN_OBSERVER_TYPE`      | Chain observer type that can be `cardano-cli`, `pallas` or `fake`.                   | `pallas`      | -                                  | :heavy_check_mark: |
+| `network`                  | -                            |          -           | `NETWORK`                  | Cardano network                                                                      | -             | `testnet` or `mainnet` or `devnet` | :heavy_check_mark: |
+| `network_magic`            | -                            |          -           | `NETWORK_MAGIC`            | Cardano network magic number (for `testnet` and `devnet`)                            | -             | `1097911063` or `42`               |         -          |
 
 `genesis sign` command:
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.37"
+version = "0.7.38"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -23,7 +23,7 @@ use crate::{
 pub struct GenesisCommandConfiguration {
     /// Cardano CLI tool path
     #[example = "`cardano-cli`"]
-    pub cardano_cli_path: PathBuf,
+    pub cardano_cli_path: Option<PathBuf>,
 
     /// Path of the socket used by the Cardano CLI tool
     /// to communicate with the Cardano node
@@ -57,7 +57,16 @@ impl ConfigurationSource for GenesisCommandConfiguration {
     }
 
     fn cardano_cli_path(&self) -> PathBuf {
-        self.cardano_cli_path.clone()
+        match self.chain_observer_type {
+            ChainObserverType::CardanoCli => {
+                if let Some(path) = &self.cardano_cli_path {
+                    path.clone()
+                } else {
+                    panic!("Cardano CLI path must be set when using Cardano CLI chain observer")
+                }
+            }
+            _ => PathBuf::new(),
+        }
     }
 
     fn cardano_node_socket_path(&self) -> PathBuf {
@@ -348,7 +357,7 @@ mod tests {
             .to_verification_key();
 
         let config = GenesisCommandConfiguration {
-            cardano_cli_path: PathBuf::new(),
+            cardano_cli_path: None,
             cardano_node_socket_path: PathBuf::new(),
             network_magic: Some(42),
             network: "devnet".to_string(),

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -62,8 +62,8 @@ impl GenesisSubCommand {
             Self::Bootstrap(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Export(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Import(cmd) => cmd.execute(root_logger, config_builder).await,
-            Self::Sign(cmd) => cmd.execute(root_logger, config_builder).await,
-            Self::GenerateKeypair(cmd) => cmd.execute(root_logger, config_builder).await,
+            Self::Sign(cmd) => cmd.execute(root_logger).await,
+            Self::GenerateKeypair(cmd) => cmd.execute(root_logger).await,
         }
     }
 }
@@ -174,11 +174,7 @@ pub struct SignGenesisSubCommand {
 }
 
 impl SignGenesisSubCommand {
-    pub async fn execute(
-        &self,
-        root_logger: Logger,
-        _config_builder: ConfigBuilder<DefaultState>,
-    ) -> StdResult<()> {
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
         debug!(root_logger, "SIGN GENESIS command");
         println!(
             "Genesis sign payload from {} to {}",
@@ -251,11 +247,7 @@ pub struct GenerateKeypairGenesisSubCommand {
 }
 
 impl GenerateKeypairGenesisSubCommand {
-    pub async fn execute(
-        &self,
-        root_logger: Logger,
-        _config_builder: ConfigBuilder<DefaultState>,
-    ) -> StdResult<()> {
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
         debug!(root_logger, "GENERATE KEYPAIR GENESIS command");
         println!(
             "Genesis generate keypair to {}",

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -46,9 +46,6 @@ pub struct GenesisCommandConfiguration {
     /// Cardano chain observer type
     pub chain_observer_type: ChainObserverType,
 
-    /// Directory of the Cardano node store.
-    pub db_directory: PathBuf,
-
     /// Directory to store aggregator data (Certificates, Snapshots, Protocol Parameters, ...)
     #[example = "`./mithril-aggregator/stores`"]
     pub data_stores_directory: PathBuf,
@@ -88,10 +85,6 @@ impl ConfigurationSource for GenesisCommandConfiguration {
 
     fn chain_observer_type(&self) -> ChainObserverType {
         self.chain_observer_type.clone()
-    }
-
-    fn db_directory(&self) -> PathBuf {
-        self.db_directory.clone()
     }
 
     fn data_stores_directory(&self) -> PathBuf {
@@ -379,7 +372,6 @@ mod tests {
             network_magic: Some(42),
             network: "devnet".to_string(),
             chain_observer_type: ChainObserverType::Fake,
-            db_directory: PathBuf::new(),
             data_stores_directory: temp_dir!().join("stores"),
             genesis_verification_key: genesis_verification_key.to_json_hex().unwrap(),
             protocol_parameters: ProtocolParameters {

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -9,10 +9,7 @@ use slog::{debug, Logger};
 use mithril_common::{
     chain_observer::ChainObserverType,
     crypto_helper::{ProtocolGenesisSecretKey, ProtocolGenesisSigner},
-    entities::{
-        CardanoTransactionsSigningConfig, HexEncodedGenesisSecretKey,
-        HexEncodedGenesisVerificationKey, ProtocolParameters,
-    },
+    entities::{HexEncodedGenesisSecretKey, HexEncodedGenesisVerificationKey},
     StdResult,
 };
 use mithril_doc::{Documenter, StructDoc};
@@ -52,14 +49,6 @@ pub struct GenesisCommandConfiguration {
 
     /// Genesis verification key
     pub genesis_verification_key: HexEncodedGenesisVerificationKey,
-
-    /// Protocol parameters
-    #[example = "`{ k: 5, m: 100, phi_f: 0.65 }`"]
-    pub protocol_parameters: ProtocolParameters,
-
-    /// Cardano transactions signing configuration
-    #[example = "`{ security_parameter: 3000, step: 120 }`"]
-    pub cardano_transactions_signing_config: CardanoTransactionsSigningConfig,
 }
 
 impl ConfigurationSource for GenesisCommandConfiguration {
@@ -97,14 +86,6 @@ impl ConfigurationSource for GenesisCommandConfiguration {
 
     fn store_retention_limit(&self) -> Option<usize> {
         None
-    }
-
-    fn protocol_parameters(&self) -> ProtocolParameters {
-        self.protocol_parameters.clone()
-    }
-
-    fn cardano_transactions_signing_config(&self) -> CardanoTransactionsSigningConfig {
-        self.cardano_transactions_signing_config.clone()
     }
 }
 
@@ -354,7 +335,7 @@ impl GenerateKeypairGenesisSubCommand {
 mod tests {
     use std::sync::Arc;
 
-    use mithril_common::{entities::BlockNumber, temp_dir};
+    use mithril_common::temp_dir;
 
     use crate::test_tools::TestLogger;
 
@@ -374,15 +355,6 @@ mod tests {
             chain_observer_type: ChainObserverType::Fake,
             data_stores_directory: temp_dir!().join("stores"),
             genesis_verification_key: genesis_verification_key.to_json_hex().unwrap(),
-            protocol_parameters: ProtocolParameters {
-                k: 5,
-                m: 100,
-                phi_f: 0.95,
-            },
-            cardano_transactions_signing_config: CardanoTransactionsSigningConfig {
-                security_parameter: BlockNumber(120),
-                step: BlockNumber(15),
-            },
         };
         let mut dependencies_builder =
             DependenciesBuilder::new(TestLogger::stdout(), Arc::new(config));

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -55,8 +55,8 @@ use crate::{
     tools::file_archiver::FileArchiver,
     AggregatorConfig, AggregatorRunner, AggregatorRuntime, DependenciesContainer,
     ImmutableFileDigestMapper, MetricsService, MithrilSignerRegistrationLeader, MultiSigner,
-    SignerRegisterer, SignerRegistrationRoundOpener, SignerRegistrationVerifier,
-    SingleSignatureAuthenticator, VerificationKeyStorer,
+    ProtocolParametersRetriever, SignerRegisterer, SignerRegistrationRoundOpener,
+    SignerRegistrationVerifier, SingleSignatureAuthenticator, VerificationKeyStorer,
 };
 
 /// Retrieve attribute stored in the builder.
@@ -270,6 +270,9 @@ pub struct DependenciesBuilder {
 
     /// Leader aggregator client
     pub leader_aggregator_client: Option<Arc<dyn AggregatorClient>>,
+
+    /// Protocol parameters retriever
+    pub protocol_parameters_retriever: Option<Arc<dyn ProtocolParametersRetriever>>,
 }
 
 impl DependenciesBuilder {
@@ -331,6 +334,7 @@ impl DependenciesBuilder {
             single_signature_authenticator: None,
             metrics_service: None,
             leader_aggregator_client: None,
+            protocol_parameters_retriever: None,
         }
     }
 
@@ -452,7 +456,7 @@ impl DependenciesBuilder {
             certificate_repository: self.get_certificate_repository().await?,
             certificate_verifier: self.get_certificate_verifier().await?,
             genesis_verifier: self.get_genesis_verifier().await?,
-            epoch_settings_storer: self.get_epoch_settings_store().await?,
+            protocol_parameters_retriever: self.get_protocol_parameters_retriever().await?,
             verification_key_store: self.get_verification_key_store().await?,
         };
 

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -455,7 +455,6 @@ impl DependenciesBuilder {
             chain_observer: self.get_chain_observer().await?,
             certificate_repository: self.get_certificate_repository().await?,
             certificate_verifier: self.get_certificate_verifier().await?,
-            genesis_verifier: self.get_genesis_verifier().await?,
             protocol_parameters_retriever: self.get_protocol_parameters_retriever().await?,
             verification_key_store: self.get_verification_key_store().await?,
         };

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -448,7 +448,7 @@ impl DependenciesBuilder {
 
         let dependencies = GenesisToolsDependency {
             network,
-            ticker_service: self.get_ticker_service().await?,
+            chain_observer: self.get_chain_observer().await?,
             certificate_repository: self.get_certificate_repository().await?,
             certificate_verifier: self.get_certificate_verifier().await?,
             genesis_verifier: self.get_genesis_verifier().await?,

--- a/mithril-aggregator/src/dependency_injection/containers/genesis.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/genesis.rs
@@ -1,9 +1,7 @@
 use std::sync::Arc;
 
 use mithril_common::chain_observer::ChainObserver;
-use mithril_common::{
-    certificate_chain::CertificateVerifier, crypto_helper::ProtocolGenesisVerifier, CardanoNetwork,
-};
+use mithril_common::{certificate_chain::CertificateVerifier, CardanoNetwork};
 
 use crate::database::repository::CertificateRepository;
 use crate::{ProtocolParametersRetriever, VerificationKeyStorer};
@@ -18,9 +16,6 @@ pub struct GenesisToolsDependency {
 
     /// Chain observer
     pub chain_observer: Arc<dyn ChainObserver>,
-
-    /// Genesis signature verifier service.
-    pub genesis_verifier: Arc<ProtocolGenesisVerifier>,
 
     /// Certificate verifier service.
     pub certificate_verifier: Arc<dyn CertificateVerifier>,

--- a/mithril-aggregator/src/dependency_injection/containers/genesis.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/genesis.rs
@@ -6,7 +6,7 @@ use mithril_common::{
 };
 
 use crate::database::repository::CertificateRepository;
-use crate::{EpochSettingsStorer, VerificationKeyStorer};
+use crate::{ProtocolParametersRetriever, VerificationKeyStorer};
 
 /// Dependency container for the genesis commands
 pub struct GenesisToolsDependency {
@@ -25,8 +25,8 @@ pub struct GenesisToolsDependency {
     /// Certificate verifier service.
     pub certificate_verifier: Arc<dyn CertificateVerifier>,
 
-    /// Epoch settings storer.
-    pub epoch_settings_storer: Arc<dyn EpochSettingsStorer>,
+    /// Protocol parameters retriever service.
+    pub protocol_parameters_retriever: Arc<dyn ProtocolParametersRetriever>,
 
     /// Certificate store.
     pub certificate_repository: Arc<CertificateRepository>,

--- a/mithril-aggregator/src/dependency_injection/containers/genesis.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/genesis.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
+use mithril_common::chain_observer::ChainObserver;
 use mithril_common::{
     certificate_chain::CertificateVerifier, crypto_helper::ProtocolGenesisVerifier, CardanoNetwork,
-    TickerService,
 };
 
 use crate::database::repository::CertificateRepository;
@@ -16,8 +16,8 @@ pub struct GenesisToolsDependency {
     /// Verification key store
     pub verification_key_store: Arc<dyn VerificationKeyStorer>,
 
-    /// Ticker service.
-    pub ticker_service: Arc<dyn TickerService>,
+    /// Chain observer
+    pub chain_observer: Arc<dyn ChainObserver>,
 
     /// Genesis signature verifier service.
     pub genesis_verifier: Arc<ProtocolGenesisVerifier>,

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -49,7 +49,7 @@ pub use services::{
     SignerRegistrationRound, SignerRegistrationRoundOpener, SignerRegistrationVerifier,
     SignerSynchronizer,
 };
-pub use store::{EpochSettingsStorer, VerificationKeyStorer};
+pub use store::{EpochSettingsStorer, ProtocolParametersRetriever, VerificationKeyStorer};
 pub use tools::{
     CExplorerSignerRetriever, SignersImporter, SignersImporterPersister, SignersImporterRetriever,
     SingleSignatureAuthenticator,

--- a/mithril-aggregator/src/store/mod.rs
+++ b/mithril-aggregator/src/store/mod.rs
@@ -1,7 +1,7 @@
 mod epoch_settings_storer;
 mod verification_key_store;
 
-pub use epoch_settings_storer::EpochSettingsStorer;
+pub use epoch_settings_storer::{EpochSettingsStorer, ProtocolParametersRetriever};
 pub use verification_key_store::VerificationKeyStorer;
 
 #[cfg(test)]

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -61,9 +61,9 @@ impl GenesisTools {
         let genesis_verifier = dependencies.genesis_verifier.clone();
         let certificate_verifier = dependencies.certificate_verifier.clone();
         let certificate_repository = dependencies.certificate_repository.clone();
-        let epoch_settings_storer = dependencies.epoch_settings_storer.clone();
+        let protocol_parameters_retriever = dependencies.protocol_parameters_retriever.clone();
         let genesis_avk_epoch = epoch.offset_to_next_signer_retrieval_epoch();
-        let genesis_protocol_parameters = epoch_settings_storer
+        let genesis_protocol_parameters = protocol_parameters_retriever
             .get_protocol_parameters(epoch.offset_to_signer_retrieval_epoch()?)
             .await?
             .ok_or_else(|| anyhow!("Missing protocol parameters for epoch {genesis_avk_epoch}"))?;


### PR DESCRIPTION
## Content

This PR introduces a specific configuration for the aggregator's `genesis` command to avoid relying on the `serve` configuration.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [x] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2384 
