### PR TITLE
Simplify injection container in aggregator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.36"
+version = "0.7.37"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3809,6 +3809,7 @@ dependencies = [
  "mithril-signed-entity-lock",
  "mithril-signed-entity-preloader",
  "mockall",
+ "paste",
  "rayon",
  "regex",
  "reqwest 0.12.15",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -35,6 +35,7 @@ mithril-persistence = { path = "../internal/mithril-persistence" }
 mithril-resource-pool = { path = "../internal/mithril-resource-pool" }
 mithril-signed-entity-lock = { path = "../internal/signed-entity/mithril-signed-entity-lock" }
 mithril-signed-entity-preloader = { path = "../internal/signed-entity/mithril-signed-entity-preloader" }
+paste = "1.0.15"
 rayon = "1.10.0"
 regex = "1.11.1"
 reqwest = { version = "0.12.15", features = [

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.36"
+version = "0.7.37"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
@@ -126,7 +126,7 @@ impl DependenciesBuilder {
             .compute_allowed_signed_entity_types_discriminants()?
             .contains(&SignedEntityTypeDiscriminants::CardanoTransactions);
         let cardano_transactions_preloader = CardanoTransactionsPreloader::new(
-            self.get_signed_entity_lock().await?,
+            self.get_signed_entity_type_lock().await?,
             self.get_transactions_importer().await?,
             self.configuration
                 .cardano_transactions_signing_config()

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
@@ -14,9 +14,9 @@ use mithril_signed_entity_preloader::{
 };
 
 use crate::dependency_injection::{DependenciesBuilder, Result};
+use crate::get_dependency;
 use crate::services::{MithrilStakeDistributionService, StakeDistributionService};
 use crate::ExecutionEnvironment;
-
 impl DependenciesBuilder {
     async fn build_chain_observer(&mut self) -> Result<Arc<dyn ChainObserver>> {
         let chain_observer: Arc<dyn ChainObserver> = match self.configuration.environment() {
@@ -47,11 +47,7 @@ impl DependenciesBuilder {
 
     /// Return a [ChainObserver]
     pub async fn get_chain_observer(&mut self) -> Result<Arc<dyn ChainObserver>> {
-        if self.chain_observer.is_none() {
-            self.chain_observer = Some(self.build_chain_observer().await?);
-        }
-
-        Ok(self.chain_observer.as_ref().cloned().unwrap())
+        get_dependency!(self.chain_observer)
     }
 
     async fn build_cardano_cli_runner(&mut self) -> Result<Box<CardanoCliRunner>> {
@@ -68,11 +64,7 @@ impl DependenciesBuilder {
 
     /// Return a [CardanoCliRunner]
     pub async fn get_cardano_cli_runner(&mut self) -> Result<Box<CardanoCliRunner>> {
-        if self.cardano_cli_runner.is_none() {
-            self.cardano_cli_runner = Some(self.build_cardano_cli_runner().await?);
-        }
-
-        Ok(self.cardano_cli_runner.as_ref().cloned().unwrap())
+        get_dependency!(self.cardano_cli_runner)
     }
 
     async fn build_chain_block_reader(&mut self) -> Result<Arc<Mutex<dyn ChainBlockReader>>> {
@@ -87,11 +79,7 @@ impl DependenciesBuilder {
 
     /// Chain reader
     pub async fn get_chain_block_reader(&mut self) -> Result<Arc<Mutex<dyn ChainBlockReader>>> {
-        if self.chain_block_reader.is_none() {
-            self.chain_block_reader = Some(self.build_chain_block_reader().await?);
-        }
-
-        Ok(self.chain_block_reader.as_ref().cloned().unwrap())
+        get_dependency!(self.chain_block_reader)
     }
 
     async fn build_block_scanner(&mut self) -> Result<Arc<dyn BlockScanner>> {
@@ -107,11 +95,7 @@ impl DependenciesBuilder {
 
     /// Block scanner
     pub async fn get_block_scanner(&mut self) -> Result<Arc<dyn BlockScanner>> {
-        if self.block_scanner.is_none() {
-            self.block_scanner = Some(self.build_block_scanner().await?);
-        }
-
-        Ok(self.block_scanner.as_ref().cloned().unwrap())
+        get_dependency!(self.block_scanner)
     }
 
     async fn build_immutable_digester(&mut self) -> Result<Arc<dyn ImmutableDigester>> {
@@ -130,11 +114,7 @@ impl DependenciesBuilder {
 
     /// Immutable digester.
     pub async fn get_immutable_digester(&mut self) -> Result<Arc<dyn ImmutableDigester>> {
-        if self.immutable_digester.is_none() {
-            self.immutable_digester = Some(self.build_immutable_digester().await?);
-        }
-
-        Ok(self.immutable_digester.as_ref().cloned().unwrap())
+        get_dependency!(self.immutable_digester)
     }
 
     /// Create a [CardanoTransactionsPreloader] instance.
@@ -174,11 +154,7 @@ impl DependenciesBuilder {
     pub async fn get_stake_distribution_service(
         &mut self,
     ) -> Result<Arc<dyn StakeDistributionService>> {
-        if self.stake_distribution_service.is_none() {
-            self.stake_distribution_service = Some(self.build_stake_distribution_service().await?);
-        }
-
-        Ok(self.stake_distribution_service.as_ref().cloned().unwrap())
+        get_dependency!(self.stake_distribution_service)
     }
 }
 

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/epoch.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/epoch.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 use crate::dependency_injection::{DependenciesBuilder, EpochServiceWrapper, Result};
+use crate::get_dependency;
 use crate::services::{EpochServiceDependencies, MithrilEpochService};
-
 impl DependenciesBuilder {
     async fn build_epoch_service(&mut self) -> Result<EpochServiceWrapper> {
         let verification_key_store = self.get_verification_key_store().await?;
@@ -34,10 +34,6 @@ impl DependenciesBuilder {
 
     /// [EpochService][crate::services::EpochService] service
     pub async fn get_epoch_service(&mut self) -> Result<EpochServiceWrapper> {
-        if self.epoch_service.is_none() {
-            self.epoch_service = Some(self.build_epoch_service().await?);
-        }
-
-        Ok(self.epoch_service.as_ref().cloned().unwrap())
+        get_dependency!(self.epoch_service)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/misc.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/misc.rs
@@ -11,23 +11,19 @@ use mithril_signed_entity_lock::SignedEntityTypeLock;
 
 use crate::database::repository::CertificateRepository;
 use crate::dependency_injection::{DependenciesBuilder, Result};
+use crate::get_dependency;
 use crate::services::{
     AggregatorClient, AggregatorHTTPClient, MessageService, MithrilMessageService,
 };
-
 impl DependenciesBuilder {
     async fn build_signed_entity_lock(&mut self) -> Result<Arc<SignedEntityTypeLock>> {
-        let signed_entity_type_lock = Arc::new(SignedEntityTypeLock::default());
-        Ok(signed_entity_type_lock)
+        let signed_entity_lock = Arc::new(SignedEntityTypeLock::default());
+        Ok(signed_entity_lock)
     }
 
     /// Get the [SignedEntityTypeLock] instance
     pub async fn get_signed_entity_lock(&mut self) -> Result<Arc<SignedEntityTypeLock>> {
-        if self.signed_entity_type_lock.is_none() {
-            self.signed_entity_type_lock = Some(self.build_signed_entity_lock().await?);
-        }
-
-        Ok(self.signed_entity_type_lock.as_ref().cloned().unwrap())
+        get_dependency!(self.signed_entity_lock)
     }
 
     /// build HTTP message service
@@ -50,11 +46,7 @@ impl DependenciesBuilder {
 
     /// [MessageService] service
     pub async fn get_message_service(&mut self) -> Result<Arc<dyn MessageService>> {
-        if self.message_service.is_none() {
-            self.message_service = Some(self.build_message_service().await?);
-        }
-
-        Ok(self.message_service.as_ref().cloned().unwrap())
+        get_dependency!(self.message_service)
     }
 
     /// build an [AggregatorClient]
@@ -76,10 +68,6 @@ impl DependenciesBuilder {
 
     /// Returns a leader [AggregatorClient]
     pub async fn get_leader_aggregator_client(&mut self) -> Result<Arc<dyn AggregatorClient>> {
-        if self.leader_aggregator_client.is_none() {
-            self.leader_aggregator_client = Some(self.build_leader_aggregator_client().await?);
-        }
-
-        Ok(self.leader_aggregator_client.as_ref().cloned().unwrap())
+        get_dependency!(self.leader_aggregator_client)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/misc.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/misc.rs
@@ -16,14 +16,14 @@ use crate::services::{
     AggregatorClient, AggregatorHTTPClient, MessageService, MithrilMessageService,
 };
 impl DependenciesBuilder {
-    async fn build_signed_entity_lock(&mut self) -> Result<Arc<SignedEntityTypeLock>> {
+    async fn build_signed_entity_type_lock(&mut self) -> Result<Arc<SignedEntityTypeLock>> {
         let signed_entity_lock = Arc::new(SignedEntityTypeLock::default());
         Ok(signed_entity_lock)
     }
 
     /// Get the [SignedEntityTypeLock] instance
-    pub async fn get_signed_entity_lock(&mut self) -> Result<Arc<SignedEntityTypeLock>> {
-        get_dependency!(self.signed_entity_lock)
+    pub async fn get_signed_entity_type_lock(&mut self) -> Result<Arc<SignedEntityTypeLock>> {
+        get_dependency!(self.signed_entity_type_lock)
     }
 
     /// build HTTP message service

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/ticker.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/ticker.rs
@@ -6,8 +6,8 @@ use mithril_common::digesters::{
 use mithril_common::{MithrilTickerService, TickerService};
 
 use crate::dependency_injection::{DependenciesBuilder, Result};
-use crate::ExecutionEnvironment;
 use crate::get_dependency;
+use crate::ExecutionEnvironment;
 impl DependenciesBuilder {
     /// Create [TickerService] instance.
     pub async fn build_ticker_service(&mut self) -> Result<Arc<dyn TickerService>> {
@@ -21,9 +21,9 @@ impl DependenciesBuilder {
     }
 
     /// [TickerService] service
-pub async fn get_ticker_service(&mut self) -> Result<Arc<dyn TickerService>> {
-    get_dependency!(self.ticker_service)
-}
+    pub async fn get_ticker_service(&mut self) -> Result<Arc<dyn TickerService>> {
+        get_dependency!(self.ticker_service)
+    }
 
     async fn build_immutable_file_observer(&mut self) -> Result<Arc<dyn ImmutableFileObserver>> {
         let immutable_file_observer: Arc<dyn ImmutableFileObserver> =
@@ -38,7 +38,7 @@ pub async fn get_ticker_service(&mut self) -> Result<Arc<dyn TickerService>> {
     }
 
     /// Return a [ImmutableFileObserver] instance.
-pub async fn get_immutable_file_observer(&mut self) -> Result<Arc<dyn ImmutableFileObserver>> {
-    get_dependency!(self.immutable_file_observer)
-}
+    pub async fn get_immutable_file_observer(&mut self) -> Result<Arc<dyn ImmutableFileObserver>> {
+        get_dependency!(self.immutable_file_observer)
+    }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/ticker.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/ticker.rs
@@ -7,7 +7,7 @@ use mithril_common::{MithrilTickerService, TickerService};
 
 use crate::dependency_injection::{DependenciesBuilder, Result};
 use crate::ExecutionEnvironment;
-
+use crate::get_dependency;
 impl DependenciesBuilder {
     /// Create [TickerService] instance.
     pub async fn build_ticker_service(&mut self) -> Result<Arc<dyn TickerService>> {
@@ -21,13 +21,9 @@ impl DependenciesBuilder {
     }
 
     /// [TickerService] service
-    pub async fn get_ticker_service(&mut self) -> Result<Arc<dyn TickerService>> {
-        if self.ticker_service.is_none() {
-            self.ticker_service = Some(self.build_ticker_service().await?);
-        }
-
-        Ok(self.ticker_service.as_ref().cloned().unwrap())
-    }
+pub async fn get_ticker_service(&mut self) -> Result<Arc<dyn TickerService>> {
+    get_dependency!(self.ticker_service)
+}
 
     async fn build_immutable_file_observer(&mut self) -> Result<Arc<dyn ImmutableFileObserver>> {
         let immutable_file_observer: Arc<dyn ImmutableFileObserver> =
@@ -42,11 +38,7 @@ impl DependenciesBuilder {
     }
 
     /// Return a [ImmutableFileObserver] instance.
-    pub async fn get_immutable_file_observer(&mut self) -> Result<Arc<dyn ImmutableFileObserver>> {
-        if self.immutable_file_observer.is_none() {
-            self.immutable_file_observer = Some(self.build_immutable_file_observer().await?);
-        }
-
-        Ok(self.immutable_file_observer.as_ref().cloned().unwrap())
-    }
+pub async fn get_immutable_file_observer(&mut self) -> Result<Arc<dyn ImmutableFileObserver>> {
+    get_dependency!(self.immutable_file_observer)
+}
 }

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -347,26 +347,13 @@ impl DependenciesBuilder {
         #[allow(deprecated)]
         let dependency_manager = DependencyContainer {
             root_logger: self.root_logger(),
-            sqlite_connection: self.get_sqlite_connection().await?,
-            sqlite_connection_cardano_transaction_pool: self
-                .get_sqlite_connection_cardano_transaction_pool()
-                .await?,
             stake_store: self.get_stake_store().await?,
-            snapshot_uploader: self.get_snapshot_uploader().await?,
-            multi_signer: self.get_multi_signer().await?,
             certificate_repository: self.get_certificate_repository().await?,
-            open_message_repository: self.get_open_message_repository().await?,
             verification_key_store: self.get_verification_key_store().await?,
             epoch_settings_storer: self.get_epoch_settings_store().await?,
             chain_observer: self.get_chain_observer().await?,
-            immutable_file_observer: self.get_immutable_file_observer().await?,
-            digester: self.get_immutable_digester().await?,
-            snapshotter: self.get_snapshotter().await?,
-            certificate_verifier: self.get_certificate_verifier().await?,
-            genesis_verifier: self.get_genesis_verifier().await?,
             signer_registerer: self.get_signer_registerer().await?,
             signer_synchronizer: self.get_signer_synchronizer().await?,
-            signer_registration_verifier: self.get_signer_registration_verifier().await?,
             signer_registration_round_opener: self.get_signer_registration_round_opener().await?,
             era_checker: self.get_era_checker().await?,
             era_reader: self.get_era_reader().await?,
@@ -382,14 +369,11 @@ impl DependenciesBuilder {
             signed_entity_storer: self.get_signed_entity_storer().await?,
             signer_getter: self.get_signer_store().await?,
             message_service: self.get_message_service().await?,
-            block_scanner: self.get_block_scanner().await?,
-            transaction_store: self.get_transaction_repository().await?,
             prover_service: self.get_prover_service().await?,
             signed_entity_type_lock: self.get_signed_entity_lock().await?,
             upkeep_service: self.get_upkeep_service().await?,
             single_signer_authenticator: self.get_single_signature_authenticator().await?,
             metrics_service: self.get_metrics_service().await?,
-            leader_aggregator_client: self.get_leader_aggregator_client().await?,
         };
 
         Ok(dependency_manager)

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -53,7 +53,7 @@ use crate::{
         StakeDistributionService, UpkeepService,
     },
     tools::file_archiver::FileArchiver,
-    AggregatorConfig, AggregatorRunner, AggregatorRuntime, DependencyContainer,
+    AggregatorConfig, AggregatorRunner, AggregatorRuntime, DependenciesContainer,
     ImmutableFileDigestMapper, MetricsService, MithrilSignerRegistrationLeader, MultiSigner,
     SignerRegisterer, SignerRegistrationRoundOpener, SignerRegistrationVerifier,
     SingleSignatureAuthenticator, VerificationKeyStorer,
@@ -342,10 +342,10 @@ impl DependenciesBuilder {
         Ok(cardano_db_artifacts_dir)
     }
 
-    /// Return an unconfigured [DependencyContainer]
-    pub async fn build_dependency_container(&mut self) -> Result<DependencyContainer> {
+    /// Return an unconfigured [DependenciesContainer]
+    pub async fn build_dependency_container(&mut self) -> Result<DependenciesContainer> {
         #[allow(deprecated)]
-        let dependency_manager = DependencyContainer {
+        let dependencies_manager = DependenciesContainer {
             root_logger: self.root_logger(),
             stake_store: self.get_stake_store().await?,
             certificate_repository: self.get_certificate_repository().await?,
@@ -376,7 +376,7 @@ impl DependenciesBuilder {
             metrics_service: self.get_metrics_service().await?,
         };
 
-        Ok(dependency_manager)
+        Ok(dependencies_manager)
     }
 
     /// Create the AggregatorRunner

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -59,13 +59,23 @@ use crate::{
     SingleSignatureAuthenticator, VerificationKeyStorer,
 };
 
-/// Retrieve attribute and initialize it if it is None
+/// Retrieve attribute stored in the builder.
+/// If not yet initialized, we instantiate it by calling the associated build function (build_<attribute_name>).
+/// If we don't want to to use the default build function, we can pass an expression that build the value.
+/// Usage examples:
+/// get_dependency!(self.signer_registerer)
+/// get_dependency!(self.signer_registerer = self.build_signer_registerer().await?)
 #[macro_export]
 macro_rules! get_dependency {
     ( $self:ident.$attribute:ident ) => {{
         paste::paste! {
+            get_dependency!($self.$attribute = $self.[<build_ $attribute>]().await?)
+        }
+    }};
+    ( $self:ident.$attribute:ident = $builder:expr ) => {{
+        paste::paste! {
             if $self.$attribute.is_none() {
-                    $self.$attribute = Some($self.[<build_ $attribute>]().await?);
+                $self.$attribute = Some($builder);
             }
 
             let r:Result<_> = Ok($self.$attribute.as_ref().cloned().unwrap());

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -59,6 +59,21 @@ use crate::{
     SingleSignatureAuthenticator, VerificationKeyStorer,
 };
 
+/// Retrieve attribute and initialize it if it is None
+#[macro_export]
+macro_rules! get_dependency {
+    ( $self:ident.$attribute:ident ) => {{
+        paste::paste! {
+            if $self.$attribute.is_none() {
+                    $self.$attribute = Some($self.[<build_ $attribute>]().await?);
+            }
+
+            let r:Result<_> = Ok($self.$attribute.as_ref().cloned().unwrap());
+            r
+        }
+    }};
+}
+
 const SQLITE_FILE: &str = "aggregator.sqlite3";
 const SQLITE_FILE_CARDANO_TRANSACTION: &str = "cardano-transaction.sqlite3";
 const SQLITE_MONITORING_FILE: &str = "monitoring.sqlite3";
@@ -229,7 +244,7 @@ pub struct DependenciesBuilder {
     pub prover_service: Option<Arc<dyn ProverService>>,
 
     /// Signed Entity Type Lock
-    pub signed_entity_type_lock: Option<Arc<SignedEntityTypeLock>>,
+    pub signed_entity_lock: Option<Arc<SignedEntityTypeLock>>,
 
     /// Transactions Importer
     pub transactions_importer: Option<Arc<dyn TransactionsImporter>>,
@@ -238,7 +253,7 @@ pub struct DependenciesBuilder {
     pub upkeep_service: Option<Arc<dyn UpkeepService>>,
 
     /// Single signer authenticator
-    pub single_signer_authenticator: Option<Arc<SingleSignatureAuthenticator>>,
+    pub single_signature_authenticator: Option<Arc<SingleSignatureAuthenticator>>,
 
     /// Metrics service
     pub metrics_service: Option<Arc<MetricsService>>,
@@ -300,10 +315,10 @@ impl DependenciesBuilder {
             signed_entity_storer: None,
             message_service: None,
             prover_service: None,
-            signed_entity_type_lock: None,
+            signed_entity_lock: None,
             transactions_importer: None,
             upkeep_service: None,
-            single_signer_authenticator: None,
+            single_signature_authenticator: None,
             metrics_service: None,
             leader_aggregator_client: None,
         }

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -254,7 +254,7 @@ pub struct DependenciesBuilder {
     pub prover_service: Option<Arc<dyn ProverService>>,
 
     /// Signed Entity Type Lock
-    pub signed_entity_lock: Option<Arc<SignedEntityTypeLock>>,
+    pub signed_entity_type_lock: Option<Arc<SignedEntityTypeLock>>,
 
     /// Transactions Importer
     pub transactions_importer: Option<Arc<dyn TransactionsImporter>>,
@@ -325,7 +325,7 @@ impl DependenciesBuilder {
             signed_entity_storer: None,
             message_service: None,
             prover_service: None,
-            signed_entity_lock: None,
+            signed_entity_type_lock: None,
             transactions_importer: None,
             upkeep_service: None,
             single_signature_authenticator: None,
@@ -380,7 +380,7 @@ impl DependenciesBuilder {
             signer_getter: self.get_signer_store().await?,
             message_service: self.get_message_service().await?,
             prover_service: self.get_prover_service().await?,
-            signed_entity_type_lock: self.get_signed_entity_lock().await?,
+            signed_entity_type_lock: self.get_signed_entity_type_lock().await?,
             upkeep_service: self.get_upkeep_service().await?,
             single_signer_authenticator: self.get_single_signature_authenticator().await?,
             metrics_service: self.get_metrics_service().await?,

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
@@ -70,7 +70,7 @@ impl DependenciesBuilder {
         let signed_entity_service = Arc::new(MithrilSignedEntityService::new(
             signed_entity_storer,
             dependencies,
-            self.get_signed_entity_lock().await?,
+            self.get_signed_entity_type_lock().await?,
             self.get_metrics_service().await?,
             logger,
         ));

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
@@ -110,11 +110,7 @@ impl DependenciesBuilder {
     }
 
     async fn get_file_archiver(&mut self) -> Result<Arc<FileArchiver>> {
-        if self.file_archiver.is_none() {
-            self.file_archiver = Some(self.build_file_archiver().await?);
-        }
-
-        Ok(self.file_archiver.as_ref().cloned().unwrap())
+        get_dependency!(self.file_archiver)
     }
 
     async fn get_ancillary_signer(&self) -> Result<Arc<dyn AncillarySigner>> {

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
@@ -18,6 +18,7 @@ use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError,
 use crate::file_uploaders::{
     CloudRemotePath, FileUploadRetryPolicy, GcpBackendUploader, GcpUploader, LocalUploader,
 };
+use crate::get_dependency;
 use crate::http_server::{CARDANO_DATABASE_DOWNLOAD_PATH, SNAPSHOT_DOWNLOAD_PATH};
 use crate::services::ancillary_signer::{
     AncillarySigner, AncillarySignerWithGcpKms, AncillarySignerWithSecretKey,
@@ -28,7 +29,6 @@ use crate::services::{
 };
 use crate::tools::file_archiver::FileArchiver;
 use crate::{DumbUploader, ExecutionEnvironment, FileUploader, SnapshotUploaderType};
-use crate::get_dependency;
 impl DependenciesBuilder {
     async fn build_signed_entity_service(&mut self) -> Result<Arc<dyn SignedEntityService>> {
         let logger = self.root_logger();

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
@@ -28,7 +28,7 @@ use crate::services::{
 };
 use crate::tools::file_archiver::FileArchiver;
 use crate::{DumbUploader, ExecutionEnvironment, FileUploader, SnapshotUploaderType};
-
+use crate::get_dependency;
 impl DependenciesBuilder {
     async fn build_signed_entity_service(&mut self) -> Result<Arc<dyn SignedEntityService>> {
         let logger = self.root_logger();
@@ -92,11 +92,7 @@ impl DependenciesBuilder {
 
     /// [SignedEntityService] service
     pub async fn get_signed_entity_service(&mut self) -> Result<Arc<dyn SignedEntityService>> {
-        if self.signed_entity_service.is_none() {
-            self.signed_entity_service = Some(self.build_signed_entity_service().await?);
-        }
-
-        Ok(self.signed_entity_service.as_ref().cloned().unwrap())
+        get_dependency!(self.signed_entity_service)
     }
 
     async fn build_file_archiver(&mut self) -> Result<Arc<FileArchiver>> {
@@ -190,11 +186,7 @@ impl DependenciesBuilder {
 
     /// [Snapshotter] service.
     pub async fn get_snapshotter(&mut self) -> Result<Arc<dyn Snapshotter>> {
-        if self.snapshotter.is_none() {
-            self.snapshotter = Some(self.build_snapshotter().await?);
-        }
-
-        Ok(self.snapshotter.as_ref().cloned().unwrap())
+        get_dependency!(self.snapshotter)
     }
 
     async fn build_snapshot_uploader(&mut self) -> Result<Arc<dyn FileUploader>> {
@@ -241,11 +233,7 @@ impl DependenciesBuilder {
 
     /// Get a [FileUploader]
     pub async fn get_snapshot_uploader(&mut self) -> Result<Arc<dyn FileUploader>> {
-        if self.snapshot_uploader.is_none() {
-            self.snapshot_uploader = Some(self.build_snapshot_uploader().await?);
-        }
-
-        Ok(self.snapshot_uploader.as_ref().cloned().unwrap())
+        get_dependency!(self.snapshot_uploader)
     }
 
     fn build_gcp_uploader(

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
@@ -8,6 +8,7 @@ use mithril_common::crypto_helper::{
 
 use crate::database::repository::{BufferedSingleSignatureRepository, SingleSignatureRepository};
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
+use crate::get_dependency;
 use crate::services::{
     BufferedCertifierService, CertifierService, MithrilCertifierService,
     MithrilSignerRegistrationFollower, SignerSynchronizer,
@@ -56,11 +57,7 @@ impl DependenciesBuilder {
 
     /// [CertifierService] service
     pub async fn get_certifier_service(&mut self) -> Result<Arc<dyn CertifierService>> {
-        if self.certifier_service.is_none() {
-            self.certifier_service = Some(self.build_certifier_service().await?);
-        }
-
-        Ok(self.certifier_service.as_ref().cloned().unwrap())
+        get_dependency!(self.certifier_service)
     }
 
     async fn build_multi_signer(&mut self) -> Result<Arc<dyn MultiSigner>> {
@@ -72,11 +69,7 @@ impl DependenciesBuilder {
 
     /// Get a configured multi signer
     pub async fn get_multi_signer(&mut self) -> Result<Arc<dyn MultiSigner>> {
-        if self.multi_signer.is_none() {
-            self.multi_signer = Some(self.build_multi_signer().await?);
-        }
-
-        Ok(self.multi_signer.as_ref().cloned().unwrap())
+        get_dependency!(self.multi_signer)
     }
 
     async fn build_certificate_verifier(&mut self) -> Result<Arc<dyn CertificateVerifier>> {
@@ -90,11 +83,7 @@ impl DependenciesBuilder {
 
     /// [CertificateVerifier] service.
     pub async fn get_certificate_verifier(&mut self) -> Result<Arc<dyn CertificateVerifier>> {
-        if self.certificate_verifier.is_none() {
-            self.certificate_verifier = Some(self.build_certificate_verifier().await?);
-        }
-
-        Ok(self.certificate_verifier.as_ref().cloned().unwrap())
+        get_dependency!(self.certificate_verifier)
     }
 
     async fn build_genesis_verifier(&mut self) -> Result<Arc<ProtocolGenesisVerifier>> {
@@ -119,11 +108,7 @@ impl DependenciesBuilder {
 
     /// Return a [ProtocolGenesisVerifier]
     pub async fn get_genesis_verifier(&mut self) -> Result<Arc<ProtocolGenesisVerifier>> {
-        if self.genesis_verifier.is_none() {
-            self.genesis_verifier = Some(self.build_genesis_verifier().await?);
-        }
-
-        Ok(self.genesis_verifier.as_ref().cloned().unwrap())
+        get_dependency!(self.genesis_verifier)
     }
 
     /// Return a [MithrilSignerRegistrationLeader] service
@@ -143,16 +128,7 @@ impl DependenciesBuilder {
     pub async fn get_mithril_signer_registration_leader(
         &mut self,
     ) -> Result<Arc<MithrilSignerRegistrationLeader>> {
-        if self.mithril_signer_registration_leader.is_none() {
-            self.mithril_signer_registration_leader =
-                Some(self.build_mithril_signer_registration_leader().await?);
-        }
-
-        Ok(self
-            .mithril_signer_registration_leader
-            .as_ref()
-            .cloned()
-            .unwrap())
+        get_dependency!(self.mithril_signer_registration_leader)
     }
 
     /// Return a [MithrilSignerRegistrationFollower] service
@@ -175,16 +151,7 @@ impl DependenciesBuilder {
     pub async fn get_mithril_signer_registration_follower(
         &mut self,
     ) -> Result<Arc<MithrilSignerRegistrationFollower>> {
-        if self.mithril_signer_registration_follower.is_none() {
-            self.mithril_signer_registration_follower =
-                Some(self.build_mithril_signer_registration_follower().await?);
-        }
-
-        Ok(self
-            .mithril_signer_registration_follower
-            .as_ref()
-            .cloned()
-            .unwrap())
+        get_dependency!(self.mithril_signer_registration_follower)
     }
 
     /// Return a [SignerRegisterer]
@@ -225,12 +192,7 @@ impl DependenciesBuilder {
     pub async fn get_signer_registration_verifier(
         &mut self,
     ) -> Result<Arc<dyn SignerRegistrationVerifier>> {
-        if self.signer_registration_verifier.is_none() {
-            self.signer_registration_verifier =
-                Some(self.build_signer_registration_verifier().await?);
-        }
-
-        Ok(self.signer_registration_verifier.as_ref().cloned().unwrap())
+        get_dependency!(self.signer_registration_verifier)
     }
 
     /// Return a [SignerRegistrationRoundOpener]
@@ -267,11 +229,15 @@ impl DependenciesBuilder {
     pub async fn get_single_signature_authenticator(
         &mut self,
     ) -> Result<Arc<SingleSignatureAuthenticator>> {
-        if self.single_signer_authenticator.is_none() {
-            self.single_signer_authenticator =
+        if self.single_signature_authenticator.is_none() {
+            self.single_signature_authenticator =
                 Some(self.build_single_signature_authenticator().await?);
         }
 
-        Ok(self.single_signer_authenticator.as_ref().cloned().unwrap())
+        Ok(self
+            .single_signature_authenticator
+            .as_ref()
+            .cloned()
+            .unwrap())
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/proving.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/proving.rs
@@ -3,8 +3,8 @@ use std::sync::Arc;
 use mithril_common::crypto_helper::MKTreeStoreInMemory;
 
 use crate::dependency_injection::{DependenciesBuilder, Result};
-use crate::services::{MithrilProverService, ProverService};
 use crate::get_dependency;
+use crate::services::{MithrilProverService, ProverService};
 impl DependenciesBuilder {
     /// Build Prover service
     pub async fn build_prover_service(&mut self) -> Result<Arc<dyn ProverService>> {

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/proving.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/proving.rs
@@ -4,7 +4,7 @@ use mithril_common::crypto_helper::MKTreeStoreInMemory;
 
 use crate::dependency_injection::{DependenciesBuilder, Result};
 use crate::services::{MithrilProverService, ProverService};
-
+use crate::get_dependency;
 impl DependenciesBuilder {
     /// Build Prover service
     pub async fn build_prover_service(&mut self) -> Result<Arc<dyn ProverService>> {
@@ -26,10 +26,6 @@ impl DependenciesBuilder {
 
     /// [ProverService] service
     pub async fn get_prover_service(&mut self) -> Result<Arc<dyn ProverService>> {
-        if self.prover_service.is_none() {
-            self.prover_service = Some(self.build_prover_service().await?);
-        }
-
-        Ok(self.prover_service.as_ref().cloned().unwrap())
+        get_dependency!(self.prover_service)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/signables.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/signables.rs
@@ -9,8 +9,8 @@ use mithril_common::signable_builder::{
 };
 
 use crate::dependency_injection::{DependenciesBuilder, Result};
+use crate::get_dependency;
 use crate::services::{AggregatorSignableSeedBuilder, CardanoTransactionsImporter};
-
 impl DependenciesBuilder {
     async fn build_signable_builder_service(&mut self) -> Result<Arc<dyn SignableBuilderService>> {
         let seed_signable_builder = self.get_signable_seed_builder().await?;
@@ -57,11 +57,7 @@ impl DependenciesBuilder {
     pub async fn get_signable_builder_service(
         &mut self,
     ) -> Result<Arc<dyn SignableBuilderService>> {
-        if self.signable_builder_service.is_none() {
-            self.signable_builder_service = Some(self.build_signable_builder_service().await?);
-        }
-
-        Ok(self.signable_builder_service.as_ref().cloned().unwrap())
+        get_dependency!(self.signable_builder_service)
     }
 
     async fn build_signable_seed_builder(&mut self) -> Result<Arc<dyn SignableSeedBuilder>> {
@@ -74,11 +70,7 @@ impl DependenciesBuilder {
 
     /// [SignableSeedBuilder] service
     pub async fn get_signable_seed_builder(&mut self) -> Result<Arc<dyn SignableSeedBuilder>> {
-        if self.signable_seed_builder.is_none() {
-            self.signable_seed_builder = Some(self.build_signable_seed_builder().await?);
-        }
-
-        Ok(self.signable_seed_builder.as_ref().cloned().unwrap())
+        get_dependency!(self.signable_seed_builder)
     }
 
     async fn build_transactions_importer(&mut self) -> Result<Arc<dyn TransactionsImporter>> {
@@ -93,10 +85,6 @@ impl DependenciesBuilder {
 
     /// Get the [TransactionsImporter] instance
     pub async fn get_transactions_importer(&mut self) -> Result<Arc<dyn TransactionsImporter>> {
-        if self.transactions_importer.is_none() {
-            self.transactions_importer = Some(self.build_transactions_importer().await?);
-        }
-
-        Ok(self.transactions_importer.as_ref().cloned().unwrap())
+        get_dependency!(self.transactions_importer)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/support/compatibility.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/compatibility.rs
@@ -6,8 +6,8 @@ use mithril_common::era::adapters::{EraReaderAdapterBuilder, EraReaderDummyAdapt
 use mithril_common::era::{EraChecker, EraMarker, EraReader, EraReaderAdapter, SupportedEra};
 
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
-use crate::ExecutionEnvironment;
 use crate::get_dependency;
+use crate::ExecutionEnvironment;
 impl DependenciesBuilder {
     async fn build_api_version_provider(&mut self) -> Result<Arc<APIVersionProvider>> {
         let api_version_provider = Arc::new(APIVersionProvider::new(self.get_era_checker().await?));

--- a/mithril-aggregator/src/dependency_injection/builder/support/compatibility.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/compatibility.rs
@@ -7,7 +7,7 @@ use mithril_common::era::{EraChecker, EraMarker, EraReader, EraReaderAdapter, Su
 
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
 use crate::ExecutionEnvironment;
-
+use crate::get_dependency;
 impl DependenciesBuilder {
     async fn build_api_version_provider(&mut self) -> Result<Arc<APIVersionProvider>> {
         let api_version_provider = Arc::new(APIVersionProvider::new(self.get_era_checker().await?));
@@ -17,11 +17,7 @@ impl DependenciesBuilder {
 
     /// [APIVersionProvider] service
     pub async fn get_api_version_provider(&mut self) -> Result<Arc<APIVersionProvider>> {
-        if self.api_version_provider.is_none() {
-            self.api_version_provider = Some(self.build_api_version_provider().await?);
-        }
-
-        Ok(self.api_version_provider.as_ref().cloned().unwrap())
+        get_dependency!(self.api_version_provider)
     }
 
     async fn build_era_reader(&mut self) -> Result<Arc<EraReader>> {
@@ -46,11 +42,7 @@ impl DependenciesBuilder {
 
     /// [EraReader] service
     pub async fn get_era_reader(&mut self) -> Result<Arc<EraReader>> {
-        if self.era_reader.is_none() {
-            self.era_reader = Some(self.build_era_reader().await?);
-        }
-
-        Ok(self.era_reader.as_ref().cloned().unwrap())
+        get_dependency!(self.era_reader)
     }
 
     async fn build_era_checker(&mut self) -> Result<Arc<EraChecker>> {
@@ -87,10 +79,6 @@ impl DependenciesBuilder {
 
     /// [EraReader] service
     pub async fn get_era_checker(&mut self) -> Result<Arc<EraChecker>> {
-        if self.era_checker.is_none() {
-            self.era_checker = Some(self.build_era_checker().await?);
-        }
-
-        Ok(self.era_checker.as_ref().cloned().unwrap())
+        get_dependency!(self.era_checker)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/support/observability.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/observability.rs
@@ -4,9 +4,9 @@ use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
 use crate::event_store::{EventMessage, EventStore, TransmitterService};
+use crate::get_dependency;
 use crate::services::UsageReporter;
 use crate::MetricsService;
-
 impl DependenciesBuilder {
     /// Return a copy of the root logger.
     pub fn root_logger(&self) -> Logger {
@@ -33,11 +33,7 @@ impl DependenciesBuilder {
 
     /// [MetricsService] service
     pub async fn get_metrics_service(&mut self) -> Result<Arc<MetricsService>> {
-        if self.metrics_service.is_none() {
-            self.metrics_service = Some(self.build_metrics_service().await?);
-        }
-
-        Ok(self.metrics_service.as_ref().cloned().unwrap())
+        get_dependency!(self.metrics_service)
     }
 
     /// Create dependencies for the [EventStore] task.
@@ -105,10 +101,6 @@ impl DependenciesBuilder {
 
     /// [TransmitterService] service
     pub async fn get_event_transmitter(&mut self) -> Result<Arc<TransmitterService<EventMessage>>> {
-        if self.event_transmitter.is_none() {
-            self.event_transmitter = Some(self.build_event_transmitter().await?);
-        }
-
-        Ok(self.event_transmitter.as_ref().cloned().unwrap())
+        get_dependency!(self.event_transmitter)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/support/sqlite.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/sqlite.rs
@@ -10,7 +10,7 @@ use crate::dependency_injection::builder::{
     SQLITE_FILE, SQLITE_FILE_CARDANO_TRANSACTION, SQLITE_MONITORING_FILE,
 };
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
-use crate::ExecutionEnvironment;
+use crate::{get_dependency, ExecutionEnvironment};
 
 impl DependenciesBuilder {
     fn build_sqlite_connection(
@@ -62,29 +62,21 @@ impl DependenciesBuilder {
 
     /// Get SQLite connection
     pub async fn get_sqlite_connection(&mut self) -> Result<Arc<SqliteConnection>> {
-        if self.sqlite_connection.is_none() {
-            self.sqlite_connection = Some(Arc::new(self.build_sqlite_connection(
+        get_dependency!(
+            self.sqlite_connection = Arc::new(self.build_sqlite_connection(
                 SQLITE_FILE,
                 crate::database::migration::get_migrations(),
-            )?));
-        }
-
-        Ok(self.sqlite_connection.as_ref().cloned().unwrap())
+            )?)
+        )
     }
     /// Get EventStore SQLite connection
     pub async fn get_event_store_sqlite_connection(&mut self) -> Result<Arc<SqliteConnection>> {
-        if self.sqlite_connection_event_store.is_none() {
-            self.sqlite_connection_event_store = Some(Arc::new(self.build_sqlite_connection(
+        get_dependency!(
+            self.sqlite_connection_event_store = Arc::new(self.build_sqlite_connection(
                 SQLITE_MONITORING_FILE,
                 crate::event_store::database::migration::get_migrations(),
-            )?));
-        }
-
-        Ok(self
-            .sqlite_connection_event_store
-            .as_ref()
-            .cloned()
-            .unwrap())
+            )?)
+        )
     }
 
     async fn build_sqlite_connection_cardano_transaction_pool(
@@ -115,17 +107,6 @@ impl DependenciesBuilder {
     pub async fn get_sqlite_connection_cardano_transaction_pool(
         &mut self,
     ) -> Result<Arc<SqliteConnectionPool>> {
-        if self.sqlite_connection_cardano_transaction_pool.is_none() {
-            self.sqlite_connection_cardano_transaction_pool = Some(
-                self.build_sqlite_connection_cardano_transaction_pool()
-                    .await?,
-            );
-        }
-
-        Ok(self
-            .sqlite_connection_cardano_transaction_pool
-            .as_ref()
-            .cloned()
-            .unwrap())
+        get_dependency!(self.sqlite_connection_cardano_transaction_pool)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/support/stores.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/stores.rs
@@ -12,6 +12,7 @@ use crate::database::repository::{
     SignerStore, StakePoolStore,
 };
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
+use crate::get_dependency;
 use crate::{
     CExplorerSignerRetriever, EpochSettingsStorer, ImmutableFileDigestMapper, SignersImporter,
     VerificationKeyStorer,
@@ -29,11 +30,7 @@ impl DependenciesBuilder {
 
     /// Return a [StakePoolStore]
     pub async fn get_stake_store(&mut self) -> Result<Arc<StakePoolStore>> {
-        if self.stake_store.is_none() {
-            self.stake_store = Some(self.build_stake_store().await?);
-        }
-
-        Ok(self.stake_store.as_ref().cloned().unwrap())
+        get_dependency!(self.stake_store)
     }
 
     async fn build_certificate_repository(&mut self) -> Result<Arc<CertificateRepository>> {
@@ -44,11 +41,7 @@ impl DependenciesBuilder {
 
     /// Get a configured [CertificateRepository].
     pub async fn get_certificate_repository(&mut self) -> Result<Arc<CertificateRepository>> {
-        if self.certificate_repository.is_none() {
-            self.certificate_repository = Some(self.build_certificate_repository().await?);
-        }
-
-        Ok(self.certificate_repository.as_ref().cloned().unwrap())
+        get_dependency!(self.certificate_repository)
     }
 
     async fn build_open_message_repository(&mut self) -> Result<Arc<OpenMessageRepository>> {
@@ -59,11 +52,7 @@ impl DependenciesBuilder {
 
     /// Get a configured [OpenMessageRepository].
     pub async fn get_open_message_repository(&mut self) -> Result<Arc<OpenMessageRepository>> {
-        if self.open_message_repository.is_none() {
-            self.open_message_repository = Some(self.build_open_message_repository().await?);
-        }
-
-        Ok(self.open_message_repository.as_ref().cloned().unwrap())
+        get_dependency!(self.open_message_repository)
     }
 
     async fn build_verification_key_store(&mut self) -> Result<Arc<dyn VerificationKeyStorer>> {
@@ -75,11 +64,7 @@ impl DependenciesBuilder {
 
     /// Get a configured [VerificationKeyStorer].
     pub async fn get_verification_key_store(&mut self) -> Result<Arc<dyn VerificationKeyStorer>> {
-        if self.verification_key_store.is_none() {
-            self.verification_key_store = Some(self.build_verification_key_store().await?);
-        }
-
-        Ok(self.verification_key_store.as_ref().cloned().unwrap())
+        get_dependency!(self.verification_key_store)
     }
 
     async fn build_epoch_settings_store(&mut self) -> Result<Arc<EpochSettingsStore>> {
@@ -128,11 +113,7 @@ impl DependenciesBuilder {
 
     /// Get a configured [EpochSettingsStorer].
     pub async fn get_epoch_settings_store(&mut self) -> Result<Arc<EpochSettingsStore>> {
-        if self.epoch_settings_store.is_none() {
-            self.epoch_settings_store = Some(self.build_epoch_settings_store().await?);
-        }
-
-        Ok(self.epoch_settings_store.as_ref().cloned().unwrap())
+        get_dependency!(self.epoch_settings_store)
     }
 
     async fn build_immutable_cache_provider(
@@ -154,11 +135,7 @@ impl DependenciesBuilder {
     pub async fn get_immutable_cache_provider(
         &mut self,
     ) -> Result<Arc<dyn ImmutableFileDigestCacheProvider>> {
-        if self.immutable_cache_provider.is_none() {
-            self.immutable_cache_provider = Some(self.build_immutable_cache_provider().await?);
-        }
-
-        Ok(self.immutable_cache_provider.as_ref().cloned().unwrap())
+        get_dependency!(self.immutable_cache_provider)
     }
 
     async fn build_transaction_repository(&mut self) -> Result<Arc<CardanoTransactionRepository>> {
@@ -174,11 +151,7 @@ impl DependenciesBuilder {
     pub async fn get_transaction_repository(
         &mut self,
     ) -> Result<Arc<CardanoTransactionRepository>> {
-        if self.transaction_repository.is_none() {
-            self.transaction_repository = Some(self.build_transaction_repository().await?);
-        }
-
-        Ok(self.transaction_repository.as_ref().cloned().unwrap())
+        get_dependency!(self.transaction_repository)
     }
 
     async fn build_immutable_file_digest_mapper(
@@ -193,12 +166,7 @@ impl DependenciesBuilder {
     pub async fn get_immutable_file_digest_mapper(
         &mut self,
     ) -> Result<Arc<dyn ImmutableFileDigestMapper>> {
-        if self.immutable_file_digest_mapper.is_none() {
-            self.immutable_file_digest_mapper =
-                Some(self.build_immutable_file_digest_mapper().await?);
-        }
-
-        Ok(self.immutable_file_digest_mapper.as_ref().cloned().unwrap())
+        get_dependency!(self.immutable_file_digest_mapper)
     }
 
     async fn build_signer_store(&mut self) -> Result<Arc<SignerStore>> {
@@ -209,14 +177,7 @@ impl DependenciesBuilder {
 
     /// [SignerStore] service
     pub async fn get_signer_store(&mut self) -> Result<Arc<SignerStore>> {
-        match self.signer_store.as_ref().cloned() {
-            None => {
-                let store = self.build_signer_store().await?;
-                self.signer_store = Some(store.clone());
-                Ok(store)
-            }
-            Some(store) => Ok(store),
-        }
+        get_dependency!(self.signer_store)
     }
 
     async fn build_signed_entity_storer(&mut self) -> Result<Arc<dyn SignedEntityStorer>> {
@@ -228,11 +189,7 @@ impl DependenciesBuilder {
 
     /// [SignedEntityStorer] service
     pub async fn get_signed_entity_storer(&mut self) -> Result<Arc<dyn SignedEntityStorer>> {
-        if self.signed_entity_storer.is_none() {
-            self.signed_entity_storer = Some(self.build_signed_entity_storer().await?);
-        }
-
-        Ok(self.signed_entity_storer.as_ref().cloned().unwrap())
+        get_dependency!(self.signed_entity_storer)
     }
 
     /// Create a [SignersImporter] instance.

--- a/mithril-aggregator/src/dependency_injection/builder/support/upkeep.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/upkeep.rs
@@ -26,7 +26,7 @@ impl DependenciesBuilder {
             self.get_sqlite_connection_cardano_transaction_pool()
                 .await?,
             self.get_event_store_sqlite_connection().await?,
-            self.get_signed_entity_lock().await?,
+            self.get_signed_entity_type_lock().await?,
             vec![
                 stake_pool_pruning_task,
                 epoch_settings_pruning_task,

--- a/mithril-aggregator/src/dependency_injection/builder/support/upkeep.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/upkeep.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::database::repository::SignerRegistrationStore;
 use crate::dependency_injection::{DependenciesBuilder, Result};
+use crate::get_dependency;
 use crate::services::{AggregatorUpkeepService, EpochPruningTask, UpkeepService};
 
 impl DependenciesBuilder {
@@ -39,10 +40,6 @@ impl DependenciesBuilder {
 
     /// Get the [UpkeepService] instance
     pub async fn get_upkeep_service(&mut self) -> Result<Arc<dyn UpkeepService>> {
-        if self.upkeep_service.is_none() {
-            self.upkeep_service = Some(self.build_upkeep_service().await?);
-        }
-
-        Ok(self.upkeep_service.as_ref().cloned().unwrap())
+        get_dependency!(self.upkeep_service)
     }
 }

--- a/mithril-aggregator/src/dependency_injection/containers/dependencies_container.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/dependencies_container.rs
@@ -36,7 +36,7 @@ use crate::{
 pub type EpochServiceWrapper = Arc<RwLock<dyn EpochService>>;
 
 /// DependencyManager handles the dependencies
-pub struct DependencyContainer {
+pub struct DependenciesContainer {
     /// Application root logger
     pub(crate) root_logger: Logger,
 
@@ -125,7 +125,7 @@ pub struct DependencyContainer {
 }
 
 #[doc(hidden)]
-impl DependencyContainer {
+impl DependenciesContainer {
     /// `TEST METHOD ONLY`
     ///
     /// Get the first two epochs that will be used by a newly started aggregator
@@ -255,7 +255,7 @@ pub(crate) mod tests {
     use std::{path::PathBuf, sync::Arc};
 
     use crate::{
-        dependency_injection::DependenciesBuilder, DependencyContainer, ServeCommandConfiguration,
+        dependency_injection::DependenciesBuilder, DependenciesContainer, ServeCommandConfiguration,
     };
 
     /// Initialize dependency container with a unique temporary snapshot directory build from test path.
@@ -267,7 +267,7 @@ pub(crate) mod tests {
         }};
     }
 
-    pub async fn initialize_dependencies(tmp_path: PathBuf) -> DependencyContainer {
+    pub async fn initialize_dependencies(tmp_path: PathBuf) -> DependenciesContainer {
         let config = ServeCommandConfiguration::new_sample(tmp_path);
 
         let mut builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(config));

--- a/mithril-aggregator/src/dependency_injection/containers/dependency_container.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/dependency_container.rs
@@ -88,7 +88,7 @@ pub struct DependencyContainer {
     pub signable_builder_service: Arc<dyn SignableBuilderService>,
 
     /// Signed Entity Service
-    pub signed_entity_service: Arc<dyn SignedEntityService>,
+    pub(crate) signed_entity_service: Arc<dyn SignedEntityService>,
 
     /// Certifier Service
     pub certifier_service: Arc<dyn CertifierService>,

--- a/mithril-aggregator/src/dependency_injection/containers/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/mod.rs
@@ -1,7 +1,7 @@
-mod dependency_container;
+mod dependencies_container;
 mod genesis;
 
-pub use dependency_container::*;
+pub use dependencies_container::*;
 pub use genesis::GenesisToolsDependency;
 
 use std::sync::Arc;

--- a/mithril-aggregator/src/http_server/routes/router.rs
+++ b/mithril-aggregator/src/http_server/routes/router.rs
@@ -4,7 +4,7 @@ use crate::http_server::routes::{
 };
 use crate::http_server::SERVER_BASE_PATH;
 use crate::tools::url_sanitizer::SanitizedUrlWithTrailingSlash;
-use crate::DependencyContainer;
+use crate::DependenciesContainer;
 
 use mithril_common::api_version::APIVersionProvider;
 use mithril_common::entities::SignedEntityTypeDiscriminants;
@@ -76,13 +76,13 @@ impl RouterConfig {
 
 /// Shared state for the router
 pub struct RouterState {
-    pub dependencies: Arc<DependencyContainer>,
+    pub dependencies: Arc<DependenciesContainer>,
     pub configuration: RouterConfig,
 }
 
 impl RouterState {
     /// `RouterState` factory
-    pub fn new(dependencies: Arc<DependencyContainer>, configuration: RouterConfig) -> Self {
+    pub fn new(dependencies: Arc<DependenciesContainer>, configuration: RouterConfig) -> Self {
         Self {
             dependencies,
             configuration,
@@ -92,7 +92,7 @@ impl RouterState {
 
 #[cfg(test)]
 impl RouterState {
-    pub fn new_with_dummy_config(dependencies: Arc<DependencyContainer>) -> Self {
+    pub fn new_with_dummy_config(dependencies: Arc<DependenciesContainer>) -> Self {
         Self {
             dependencies,
             configuration: RouterConfig::dummy(),
@@ -100,7 +100,7 @@ impl RouterState {
     }
 
     pub fn new_with_origin_tag_white_list(
-        dependencies: Arc<DependencyContainer>,
+        dependencies: Arc<DependenciesContainer>,
         origin_tag_white_list: &[&str],
     ) -> Self {
         Self {

--- a/mithril-aggregator/src/http_server/routes/statistics_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/statistics_routes.rs
@@ -220,7 +220,7 @@ mod tests {
     };
 
     use crate::event_store::EventMessage;
-    use crate::DependencyContainer;
+    use crate::DependenciesContainer;
     use crate::{
         dependency_injection::DependenciesBuilder, initialize_dependencies,
         ServeCommandConfiguration,
@@ -417,12 +417,12 @@ mod tests {
 
     async fn setup_dependencies(
         snapshot_directory: PathBuf,
-    ) -> (Arc<DependencyContainer>, UnboundedReceiver<EventMessage>) {
+    ) -> (Arc<DependenciesContainer>, UnboundedReceiver<EventMessage>) {
         let config = ServeCommandConfiguration::new_sample(snapshot_directory);
         let mut builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(config));
         let rx = builder.get_event_transmitter_receiver().await.unwrap();
-        let dependency_manager = Arc::new(builder.build_dependency_container().await.unwrap());
-        (dependency_manager, rx)
+        let dependencies_manager = Arc::new(builder.build_dependency_container().await.unwrap());
+        (dependencies_manager, rx)
     }
 
     mod post_cardano_database_complete_restoration {

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -36,7 +36,7 @@ pub use crate::configuration::{
 };
 pub use crate::multi_signer::{MultiSigner, MultiSignerImpl};
 pub use commands::{CommandType, MainOpts};
-pub use dependency_injection::DependencyContainer;
+pub use dependency_injection::DependenciesContainer;
 pub use file_uploaders::{DumbUploader, FileUploader};
 pub use message_adapters::FromRegisterSignerAdapter;
 pub use metrics::*;

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -10,7 +10,7 @@ use mithril_common::StdResult;
 use mithril_persistence::store::StakeStorer;
 
 use crate::entities::OpenMessage;
-use crate::DependencyContainer;
+use crate::DependenciesContainer;
 
 /// Configuration structure dedicated to the AggregatorRuntime.
 #[derive(Debug, Clone)]
@@ -136,13 +136,13 @@ pub trait AggregatorRunnerTrait: Sync + Send {
 /// The runner responsibility is to expose a code API for the state machine. It
 /// holds services and configuration.
 pub struct AggregatorRunner {
-    dependencies: Arc<DependencyContainer>,
+    dependencies: Arc<DependenciesContainer>,
     logger: Logger,
 }
 
 impl AggregatorRunner {
     /// Create a new instance of the Aggregator Runner.
-    pub fn new(dependencies: Arc<DependencyContainer>) -> Self {
+    pub fn new(dependencies: Arc<DependenciesContainer>) -> Self {
         let logger = dependencies.root_logger.new_with_component_name::<Self>();
         Self {
             dependencies,
@@ -529,7 +529,7 @@ pub mod tests {
         initialize_dependencies,
         runtime::{AggregatorRunner, AggregatorRunnerTrait},
         services::{MithrilStakeDistributionService, MockCertifierService},
-        DependencyContainer, MithrilSignerRegistrationLeader, ServeCommandConfiguration,
+        DependenciesContainer, MithrilSignerRegistrationLeader, ServeCommandConfiguration,
         SignerRegistrationRound,
     };
     use async_trait::async_trait;
@@ -569,7 +569,7 @@ pub mod tests {
         }
     }
 
-    async fn build_runner_with_fixture_data(deps: DependencyContainer) -> AggregatorRunner {
+    async fn build_runner_with_fixture_data(deps: DependenciesContainer) -> AggregatorRunner {
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
         let current_epoch = deps
             .chain_observer

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -683,14 +683,16 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_update_stake_distribution() {
-        let mut deps = initialize_dependencies!().await;
         let chain_observer = Arc::new(FakeObserver::default());
-        deps.chain_observer = chain_observer.clone();
-        deps.stake_distribution_service = Arc::new(MithrilStakeDistributionService::new(
-            deps.stake_store.clone(),
-            chain_observer.clone(),
-        ));
-        let deps = Arc::new(deps);
+        let deps = {
+            let mut deps = initialize_dependencies!().await;
+            deps.chain_observer = chain_observer.clone();
+            deps.stake_distribution_service = Arc::new(MithrilStakeDistributionService::new(
+                deps.stake_store.clone(),
+                chain_observer.clone(),
+            ));
+            Arc::new(deps)
+        };
         let runner = AggregatorRunner::new(deps.clone());
         let time_point = runner.get_time_point_from_chain().await.unwrap();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
@@ -721,12 +723,15 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_open_signer_registration_round() {
-        let mut deps = initialize_dependencies!().await;
+        let config = ServeCommandConfiguration::new_sample(mithril_common::temp_dir!());
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(config));
+
         let signer_registration_round_opener = Arc::new(MithrilSignerRegistrationLeader::new(
-            deps.verification_key_store.clone(),
-            deps.signer_recorder.clone(),
-            deps.signer_registration_verifier.clone(),
+            builder.get_verification_key_store().await.unwrap(),
+            builder.get_signer_store().await.unwrap(),
+            builder.get_signer_registration_verifier().await.unwrap(),
         ));
+        let mut deps = builder.build_dependency_container().await.unwrap();
         deps.signer_registration_round_opener = signer_registration_round_opener.clone();
         let stake_store = deps.stake_store.clone();
         let deps = Arc::new(deps);
@@ -760,12 +765,15 @@ pub mod tests {
 
     #[tokio::test]
     async fn test_close_signer_registration_round() {
-        let mut deps = initialize_dependencies!().await;
+        let config = ServeCommandConfiguration::new_sample(mithril_common::temp_dir!());
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(config));
+
         let signer_registration_round_opener = Arc::new(MithrilSignerRegistrationLeader::new(
-            deps.verification_key_store.clone(),
-            deps.signer_recorder.clone(),
-            deps.signer_registration_verifier.clone(),
+            builder.get_verification_key_store().await.unwrap(),
+            builder.get_signer_store().await.unwrap(),
+            builder.get_signer_registration_verifier().await.unwrap(),
         ));
+        let mut deps = builder.build_dependency_container().await.unwrap();
         deps.signer_registration_round_opener = signer_registration_round_opener.clone();
         let deps = Arc::new(deps);
         let runner = AggregatorRunner::new(deps.clone());

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -7,7 +7,7 @@ use mithril_aggregator::{
     database::{record::SignedEntityRecord, repository::OpenMessageRepository},
     dependency_injection::DependenciesBuilder,
     services::FakeSnapshotter,
-    AggregatorRuntime, ConfigurationSource, DependencyContainer, DumbUploader,
+    AggregatorRuntime, ConfigurationSource, DependenciesContainer, DumbUploader,
     ServeCommandConfiguration, SignerRegistrationError,
 };
 use mithril_common::test_utils::test_http_server::{test_http_server, TestHttpServer};
@@ -110,7 +110,7 @@ pub struct RuntimeTester {
     pub immutable_file_observer: Arc<DumbImmutableFileObserver>,
     pub digester: Arc<DumbImmutableDigester>,
     pub genesis_signer: Arc<ProtocolGenesisSigner>,
-    pub dependencies: DependencyContainer,
+    pub dependencies: DependenciesContainer,
     pub runtime: AggregatorRuntime,
     pub era_reader_adapter: Arc<EraReaderDummyAdapter>,
     pub observer: Arc<AggregatorObserver>,


### PR DESCRIPTION
## Content

This PR includes:
* creation of a macro to create getter functions
* renaming of `DependencyContainer` to `DependenciesContainer`
* change `DependencyContainer attributes visibility from 'pub' to 'pub(crate)' to identify unused attribute for those which are not used in integration test
* remove unused attribute in `DependenciesContainer`
* refactor some function to align `attribute`, `getter` and `build` names
* refactor test to avoid usage of container attribute only for test
* remove dead functions in integration tests

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [ ] No new TODOs introduced

## Comments

We looked into the possibility of deleting code for attributes used only once. 
In the end, this removes very little code and makes it more difficult to detect the double creation of an instance.

Similarly, the creation of sub-structures to build object clusters doesn't seem to add much. There are no obvious clusters, as there are many dependencies between structures. Above all, it may make it more difficult to find the function to retrieve the instance.

## Issue(s)

Relates to #2366
