### PR TITLE
test: use a in memory logger for tests that needs to check logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.43"
+version = "0.7.44"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.11.23"
+version = "0.11.24"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.26"
+version = "0.5.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.41"
+version = "0.1.42"
 dependencies = [
  "anyhow",
  "clap",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.242"
+version = "0.2.243"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.43"
+version = "0.7.44"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -17,7 +17,7 @@ use crate::{
     DumbUploader, FileUploader,
 };
 
-fn immmutable_file_number_extractor(file_uri: &str) -> StdResult<Option<String>> {
+fn immutable_file_number_extractor(file_uri: &str) -> StdResult<Option<String>> {
     let regex = Regex::new(r".*(\d{5})")?;
 
     Ok(regex
@@ -63,7 +63,7 @@ impl ImmutableFilesUploader for DumbUploader {
 
         let template_uri = MultiFilesUri::extract_template_from_uris(
             vec![self.upload(last_file_path).await?.into()],
-            immmutable_file_number_extractor,
+            immutable_file_number_extractor,
         )?
         .ok_or_else(|| {
             anyhow!("No matching template found in the uploaded files with 'DumbUploader'")
@@ -89,7 +89,7 @@ impl ImmutableFilesUploader for LocalUploader {
         }
 
         let template_uri =
-            MultiFilesUri::extract_template_from_uris(file_uris, immmutable_file_number_extractor)?
+            MultiFilesUri::extract_template_from_uris(file_uris, immutable_file_number_extractor)?
                 .ok_or_else(|| {
                     anyhow!("No matching template found in the uploaded files with 'LocalUploader'")
                 })?;
@@ -114,7 +114,7 @@ impl ImmutableFilesUploader for GcpUploader {
         }
 
         let template_uri =
-            MultiFilesUri::extract_template_from_uris(file_uris, immmutable_file_number_extractor)?
+            MultiFilesUri::extract_template_from_uris(file_uris, immutable_file_number_extractor)?
                 .ok_or_else(|| {
                     anyhow!("No matching template found in the uploaded files with 'GcpUploader'")
                 })?;
@@ -943,15 +943,14 @@ mod tests {
 
         #[test]
         fn returns_none_when_not_templatable_without_5_digits() {
-            let template = immmutable_file_number_extractor("not-templatable.tar.gz").unwrap();
+            let template = immutable_file_number_extractor("not-templatable.tar.gz").unwrap();
 
             assert!(template.is_none());
         }
 
         #[test]
         fn returns_template() {
-            let template =
-                immmutable_file_number_extractor("http://whatever/00001.tar.gz").unwrap();
+            let template = immutable_file_number_extractor("http://whatever/00001.tar.gz").unwrap();
 
             assert_eq!(
                 template,
@@ -962,7 +961,7 @@ mod tests {
         #[test]
         fn replaces_last_occurence_of_5_digits() {
             let template =
-                immmutable_file_number_extractor("http://00001/whatever/00001.tar.gz").unwrap();
+                immutable_file_number_extractor("http://00001/whatever/00001.tar.gz").unwrap();
 
             assert_eq!(
                 template,
@@ -973,7 +972,7 @@ mod tests {
         #[test]
         fn replaces_last_occurence_when_more_than_5_digits() {
             let template =
-                immmutable_file_number_extractor("http://whatever/123456789.tar.gz").unwrap();
+                immutable_file_number_extractor("http://whatever/123456789.tar.gz").unwrap();
 
             assert_eq!(
                 template,

--- a/mithril-aggregator/src/lib.rs
+++ b/mithril-aggregator/src/lib.rs
@@ -70,13 +70,14 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[cfg(test)]
 pub(crate) mod test_tools {
-    use std::fs::File;
     use std::io;
     use std::sync::Arc;
 
     use slog::{Drain, Logger};
     use slog_async::Async;
     use slog_term::{CompactFormat, PlainDecorator};
+
+    use mithril_common::test_utils::{MemoryDrainForTest, MemoryDrainForTestInspector};
 
     pub struct TestLogger;
 
@@ -92,8 +93,9 @@ pub(crate) mod test_tools {
             Self::from_writer(slog_term::TestStdoutWriter)
         }
 
-        pub fn file(filepath: &std::path::Path) -> Logger {
-            Self::from_writer(File::create(filepath).unwrap())
+        pub fn memory() -> (Logger, MemoryDrainForTestInspector) {
+            let (drain, inspector) = MemoryDrainForTest::new();
+            (Logger::root(drain.fuse(), slog::o!()), inspector)
         }
     }
 }

--- a/mithril-aggregator/src/runtime/error.rs
+++ b/mithril-aggregator/src/runtime/error.rs
@@ -92,19 +92,10 @@ impl From<StdError> for RuntimeError {
 #[cfg(test)]
 mod tests {
     use anyhow::anyhow;
-    use std::path::Path;
-
-    use mithril_common::test_utils::TempDir;
 
     use crate::test_tools::TestLogger;
 
     use super::*;
-
-    /// Separate function so the logger is dropped and flushed before the assertion.
-    fn write_log(log_file: &Path, error: &RuntimeError) {
-        let logger = TestLogger::file(log_file);
-        error.write_to_log(&logger);
-    }
 
     fn nested_error_debug_string(error: &RuntimeError) -> String {
         let error = match error {
@@ -122,28 +113,21 @@ mod tests {
 
     #[test]
     fn log_critical_without_nested_error() {
-        let log_file = TempDir::create(
-            "aggregator_runtime_error",
-            "log_critical_without_nested_error",
-        )
-        .join("file.log");
+        let (logger, log_inspector) = TestLogger::memory();
 
         let error = RuntimeError::Critical {
             message: "Critical error".to_string(),
             nested_error: None,
         };
-        write_log(&log_file, &error);
+        error.write_to_log(&logger);
 
-        let log_content = std::fs::read_to_string(&log_file).unwrap();
-        assert!(log_content.contains(&format!("{error}")));
-        assert!(!log_content.contains("nested_error"));
+        assert!(log_inspector.contains_log(&format!("{error}")));
+        assert!(!log_inspector.contains_log("nested_error"));
     }
 
     #[test]
     fn log_critical_with_nested_error() {
-        let log_file =
-            TempDir::create("aggregator_runtime_error", "log_critical_with_nested_error")
-                .join("file.log");
+        let (logger, log_inspector) = TestLogger::memory();
 
         let error = RuntimeError::Critical {
             message: "Critical error".to_string(),
@@ -153,39 +137,29 @@ mod tests {
                     .context("Critical nested error"),
             ),
         };
-        write_log(&log_file, &error);
+        error.write_to_log(&logger);
 
-        let log_content = std::fs::read_to_string(&log_file).unwrap();
-        assert!(log_content.contains(&format!("{error}")));
-        assert!(log_content.contains(&nested_error_debug_string(&error)));
+        assert!(log_inspector.contains_log(&format!("{error}")));
+        assert!(log_inspector.contains_log(&nested_error_debug_string(&error)));
     }
 
     #[test]
     fn log_keep_state_without_nested_error() {
-        let log_file = TempDir::create(
-            "aggregator_runtime_error",
-            "log_keep_state_without_nested_error",
-        )
-        .join("file.log");
+        let (logger, log_inspector) = TestLogger::memory();
 
         let error = RuntimeError::KeepState {
             message: "KeepState error".to_string(),
             nested_error: None,
         };
-        write_log(&log_file, &error);
+        error.write_to_log(&logger);
 
-        let log_content = std::fs::read_to_string(&log_file).unwrap();
-        assert!(log_content.contains(&format!("{error}")));
-        assert!(!log_content.contains("nested_error"));
+        assert!(log_inspector.contains_log(&format!("{error}")));
+        assert!(!log_inspector.contains_log("nested_error"));
     }
 
     #[test]
     fn log_keep_state_with_nested_error() {
-        let log_file = TempDir::create(
-            "aggregator_runtime_error",
-            "log_keep_state_with_nested_error",
-        )
-        .join("file.log");
+        let (logger, log_inspector) = TestLogger::memory();
 
         let error = RuntimeError::KeepState {
             message: "KeepState error".to_string(),
@@ -195,36 +169,29 @@ mod tests {
                     .context("KeepState nested error"),
             ),
         };
-        write_log(&log_file, &error);
+        error.write_to_log(&logger);
 
-        let log_content = std::fs::read_to_string(&log_file).unwrap();
-        assert!(log_content.contains(&format!("{error}")));
-        assert!(log_content.contains(&nested_error_debug_string(&error)));
+        assert!(log_inspector.contains_log(&format!("{error}")));
+        assert!(log_inspector.contains_log(&nested_error_debug_string(&error)));
     }
 
     #[test]
     fn log_reinit_without_nested_error() {
-        let log_file = TempDir::create(
-            "aggregator_runtime_error",
-            "log_reinit_without_nested_error",
-        )
-        .join("file.log");
+        let (logger, log_inspector) = TestLogger::memory();
 
         let error = RuntimeError::ReInit {
             message: "ReInit error".to_string(),
             nested_error: None,
         };
-        write_log(&log_file, &error);
+        error.write_to_log(&logger);
 
-        let log_content = std::fs::read_to_string(&log_file).unwrap();
-        assert!(log_content.contains(&format!("{error}")));
-        assert!(!log_content.contains("nested_error"));
+        assert!(log_inspector.contains_log(&format!("{error}")));
+        assert!(!log_inspector.contains_log("nested_error"));
     }
 
     #[test]
     fn log_reinit_with_nested_error() {
-        let log_file = TempDir::create("aggregator_runtime_error", "log_reinit_with_nested_error")
-            .join("file.log");
+        let (logger, log_inspector) = TestLogger::memory();
 
         let error = RuntimeError::ReInit {
             message: "ReInit error".to_string(),
@@ -234,10 +201,9 @@ mod tests {
                     .context("ReInit nested error"),
             ),
         };
-        write_log(&log_file, &error);
+        error.write_to_log(&logger);
 
-        let log_content = std::fs::read_to_string(&log_file).unwrap();
-        assert!(log_content.contains(&format!("{error}")));
-        assert!(log_content.contains(&nested_error_debug_string(&error)));
+        assert!(log_inspector.contains_log(&format!("{error}")));
+        assert!(log_inspector.contains_log(&nested_error_debug_string(&error)));
     }
 }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -72,10 +72,6 @@ mithril-common = { path = "../mithril-common", version = "=0.5", default-feature
 ] }
 mockall = { workspace = true }
 sha2 = "0.10.8"
-slog = { workspace = true, features = [
-    "max_level_trace",
-    "release_max_level_warn",
-] }
 slog-async = { workspace = true }
 slog-term = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.11.23"
+version = "0.11.24"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/lib.rs
+++ b/mithril-client/src/lib.rs
@@ -144,13 +144,14 @@ pub use type_alias::*;
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use std::fs::File;
     use std::io;
     use std::sync::Arc;
 
     use slog::{Drain, Logger};
     use slog_async::Async;
     use slog_term::{CompactFormat, PlainDecorator};
+
+    use mithril_common::test_utils::{MemoryDrainForTest, MemoryDrainForTestInspector};
 
     pub struct TestLogger;
 
@@ -167,8 +168,9 @@ pub(crate) mod test_utils {
             Self::from_writer(slog_term::TestStdoutWriter)
         }
 
-        pub fn file(filepath: &std::path::Path) -> Logger {
-            Self::from_writer(File::create(filepath).unwrap())
+        pub fn memory() -> (Logger, MemoryDrainForTestInspector) {
+            let (drain, inspector) = MemoryDrainForTest::new();
+            (Logger::root(drain.fuse(), slog::o!()), inspector)
         }
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.26"
+version = "0.5.27"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/logging.rs
+++ b/mithril-common/src/logging.rs
@@ -36,7 +36,7 @@ fn component_name<T>() -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_utils::{TempDir, TestLogger};
+    use crate::test_utils::TestLogger;
     use slog::info;
 
     struct TestStruct;
@@ -89,37 +89,26 @@ mod tests {
 
     #[test]
     fn logger_extension_new_with_component_name() {
-        let log_path =
-            TempDir::create("common_logging", "logger_extension_new_with_component_name")
-                .join("test.log");
-        {
-            let root_logger = TestLogger::file(&log_path);
-            let child_logger = root_logger.new_with_component_name::<TestStruct>();
-            info!(child_logger, "Child log");
-        }
+        let (root_logger, log_inspector) = TestLogger::memory();
+        let child_logger = root_logger.new_with_component_name::<TestStruct>();
+        info!(child_logger, "Child log");
 
-        let logs = std::fs::read_to_string(&log_path).unwrap();
         assert!(
-            logs.contains("src") && logs.contains("TestStruct"),
-            "log should contain `src` key for `TestStruct` as component name was provided, logs:\n{logs}"
+            log_inspector.contains_log("src") && log_inspector.contains_log("TestStruct"),
+            "log should contain `src` key for `TestStruct` as component name was provided, logs:\n{log_inspector}"
         );
     }
 
     #[test]
     fn logger_extension_new_with_name() {
         let expected_name = "my name";
-        let log_path =
-            TempDir::create("common_logging", "logger_extension_new_with_name").join("test.log");
-        {
-            let root_logger = TestLogger::file(&log_path);
-            let child_logger = root_logger.new_with_name(expected_name);
-            info!(child_logger, "Child log");
-        }
+        let (root_logger, log_inspector) = TestLogger::memory();
+        let child_logger = root_logger.new_with_name(expected_name);
+        info!(child_logger, "Child log");
 
-        let logs = std::fs::read_to_string(&log_path).unwrap();
         assert!(
-            logs.contains("src") && logs.contains(expected_name),
-            "log should contain `src` key for `{expected_name}` as a name was provided, logs:\n{logs}"
+            log_inspector.contains_log("src") && log_inspector.contains_log(expected_name),
+            "log should contain `src` key for `{expected_name}` as a name was provided, logs:\n{log_inspector}"
         );
     }
 }

--- a/mithril-common/src/test_utils/memory_logger.rs
+++ b/mithril-common/src/test_utils/memory_logger.rs
@@ -120,7 +120,7 @@ impl slog::Serializer for KVSerializer {
 
 #[cfg(test)]
 mod tests {
-    use slog::debug;
+    use slog::info;
 
     use super::*;
 
@@ -130,11 +130,11 @@ mod tests {
         let logger = slog::Logger::root(drain.clone().fuse(), slog::o!("shared" => "shared"));
 
         // Note: keys seem to be logged in invert order
-        debug!(logger, "test format"; "key_3" => "value three", "key_2" => "value two", "key_1" => "value one");
+        info!(logger, "test format"; "key_3" => "value three", "key_2" => "value two", "key_1" => "value one");
 
         let results = log_inspector.search_logs("test format");
         assert_eq!(
-            "DEBUG test format; key_1=value one, key_2=value two, key_3=value three, shared=shared",
+            "INFO test format; key_1=value one, key_2=value two, key_3=value three, shared=shared",
             results[0]
         );
     }
@@ -144,13 +144,13 @@ mod tests {
         let (drain, log_inspector) = MemoryDrainForTest::new();
         let logger = slog::Logger::root(drain.fuse(), slog::o!());
 
-        debug!(logger, "message one"; "key" => "value1");
-        debug!(logger, "message two"; "key" => "value2");
+        info!(logger, "message one"; "key" => "value1");
+        info!(logger, "message two"; "key" => "value2");
 
         let display = format!("{log_inspector}");
         assert_eq!(
             display,
-            "DEBUG message one; key=value1\nDEBUG message two; key=value2"
+            "INFO message one; key=value1\nINFO message two; key=value2"
         );
     }
 
@@ -159,8 +159,8 @@ mod tests {
         let (drain, log_inspector) = MemoryDrainForTest::new();
         let logger = slog::Logger::root(drain.clone().fuse(), slog::o!());
 
-        debug!(logger, "test message"; "key" => "value");
-        debug!(logger, "another message"; "key2" => "value2");
+        info!(logger, "test message"; "key" => "value");
+        info!(logger, "another message"; "key2" => "value2");
 
         let results = log_inspector.search_logs("test");
         assert_eq!(results.len(), 1);
@@ -176,11 +176,11 @@ mod tests {
 
         let handle1 = tokio::spawn(async move {
             let logger = slog::Logger::root(drain_clone1.fuse(), slog::o!());
-            debug!(logger, "async test 1"; "key" => "value");
+            info!(logger, "async test 1"; "key" => "value");
         });
         let handle2 = tokio::spawn(async move {
             let logger = slog::Logger::root(drain_clone2.fuse(), slog::o!());
-            debug!(logger, "async test 2"; "key" => "value");
+            info!(logger, "async test 2"; "key" => "value");
         });
 
         handle1.await.unwrap();
@@ -201,7 +201,7 @@ mod tests {
             let drain_clone = drain.clone();
             join_set.spawn(async move {
                 let logger = slog::Logger::root(drain_clone.fuse(), slog::o!());
-                debug!(logger, "multi thread test {i}"; "thread_id" => i);
+                info!(logger, "multi thread test {i}"; "thread_id" => i);
             });
         }
 

--- a/mithril-common/src/test_utils/memory_logger.rs
+++ b/mithril-common/src/test_utils/memory_logger.rs
@@ -1,0 +1,218 @@
+use std::fmt;
+use std::io;
+use std::sync::{Arc, RwLock};
+
+use slog::{Drain, OwnedKVList, Record, KV};
+
+/// A testing infrastructure for logging that consists of two main components:
+/// - [MemoryDrainForTest]: A slog Drain that stores records in memory
+/// - [MemoryDrainForTestInspector]: A component that provides methods to analyze stored logs
+///
+/// Records are stored as formatted strings in a thread-safe vector using `Arc<RwLock>`.
+/// Each log record follows the format:
+///
+/// `{LEVEL} {MESSAGE}; {KEY1}={VALUE1}, {KEY2}={VALUE2}, ...`
+///
+/// where:
+/// - LEVEL: The log level (DEBUG, INFO, etc.)
+/// - MESSAGE: The main log message
+/// - KEY=VALUE pairs: Additional context values attached to the log
+///
+/// # Performance Considerations
+///
+/// This drain implementation is designed for testing purposes and is not optimized for performance.
+/// It uses an RwLock for each log operation and string formatting, which may introduce significant overhead.
+#[derive(Default, Clone)]
+pub struct MemoryDrainForTest {
+    records: Arc<RwLock<Vec<String>>>,
+}
+
+impl MemoryDrainForTest {
+    /// Creates a new instance of `MemoryDrainForTest`
+    pub fn new() -> (Self, MemoryDrainForTestInspector) {
+        let drain = Self::default();
+        let inspector = MemoryDrainForTestInspector::new(&drain);
+        (drain, inspector)
+    }
+}
+
+/// A component that provides methods to analyze logs stored by [MemoryDrainForTest].
+pub struct MemoryDrainForTestInspector {
+    records: Arc<RwLock<Vec<String>>>,
+}
+
+impl MemoryDrainForTestInspector {
+    fn new(memory_drain: &MemoryDrainForTest) -> Self {
+        Self {
+            records: memory_drain.records.clone(),
+        }
+    }
+
+    /// Returns all log records that contain the specified text
+    ///
+    /// This method performs a case-sensitive search through all stored log records
+    /// and returns copies of the matching records.
+    pub fn search_logs(&self, text: &str) -> Vec<String> {
+        self.records
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|record| record.contains(text))
+            .cloned()
+            .collect()
+    }
+
+    /// Checks if any log record contains the specified text
+    ///
+    /// This method performs a case-sensitive search and returns true if any log
+    /// record contains the specified text.
+    pub fn contains_log(&self, text: &str) -> bool {
+        self.records
+            .read()
+            .unwrap()
+            .iter()
+            .any(|record| record.contains(text))
+    }
+}
+
+impl fmt::Display for MemoryDrainForTestInspector {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.records.read().unwrap().join("\n"))
+    }
+}
+
+impl Drain for MemoryDrainForTest {
+    type Ok = ();
+    type Err = io::Error;
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> Result<Self::Ok, Self::Err> {
+        let mut kv_serializer = KVSerializer::default();
+        record.kv().serialize(record, &mut kv_serializer)?;
+        values.serialize(record, &mut kv_serializer)?;
+
+        let msg = format!(
+            "{} {}; {}",
+            record.level().as_str(),
+            record.msg(),
+            kv_serializer.content
+        );
+
+        self.records.write().unwrap().push(msg);
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct KVSerializer {
+    content: String,
+}
+
+impl slog::Serializer for KVSerializer {
+    fn emit_arguments(&mut self, key: slog::Key, val: &std::fmt::Arguments) -> slog::Result {
+        use std::fmt::Write;
+
+        let prefix = if self.content.is_empty() { "" } else { ", " };
+        write!(self.content, "{prefix}{key}={val:?}")
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "Failed to serialize log"))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use slog::debug;
+
+    use super::*;
+
+    #[test]
+    fn test_log_format() {
+        let (drain, log_inspector) = MemoryDrainForTest::new();
+        let logger = slog::Logger::root(drain.clone().fuse(), slog::o!("shared" => "shared"));
+
+        // Note: keys seem to be logged in invert order
+        debug!(logger, "test format"; "key_3" => "value three", "key_2" => "value two", "key_1" => "value one");
+
+        let results = log_inspector.search_logs("test format");
+        assert_eq!(
+            "DEBUG test format; key_1=value one, key_2=value two, key_3=value three, shared=shared",
+            results[0]
+        );
+    }
+
+    #[test]
+    fn displaying_inspector_returns_all_log_messages() {
+        let (drain, log_inspector) = MemoryDrainForTest::new();
+        let logger = slog::Logger::root(drain.fuse(), slog::o!());
+
+        debug!(logger, "message one"; "key" => "value1");
+        debug!(logger, "message two"; "key" => "value2");
+
+        let display = format!("{log_inspector}");
+        assert_eq!(
+            display,
+            "DEBUG message one; key=value1\nDEBUG message two; key=value2"
+        );
+    }
+
+    #[test]
+    fn can_search_for_log_messages() {
+        let (drain, log_inspector) = MemoryDrainForTest::new();
+        let logger = slog::Logger::root(drain.clone().fuse(), slog::o!());
+
+        debug!(logger, "test message"; "key" => "value");
+        debug!(logger, "another message"; "key2" => "value2");
+
+        let results = log_inspector.search_logs("test");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].contains("test message"));
+        assert!(log_inspector.contains_log("test message"));
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_logging_from_two_tasks() {
+        let (drain, log_inspector) = MemoryDrainForTest::new();
+        let drain_clone1 = drain.clone();
+        let drain_clone2 = drain.clone();
+
+        let handle1 = tokio::spawn(async move {
+            let logger = slog::Logger::root(drain_clone1.fuse(), slog::o!());
+            debug!(logger, "async test 1"; "key" => "value");
+        });
+        let handle2 = tokio::spawn(async move {
+            let logger = slog::Logger::root(drain_clone2.fuse(), slog::o!());
+            debug!(logger, "async test 2"; "key" => "value");
+        });
+
+        handle1.await.unwrap();
+        handle2.await.unwrap();
+
+        let results = log_inspector.search_logs("async test");
+        assert_eq!(results.len(), 2);
+        assert!(results.iter().any(|r| r.contains("async test 1")));
+        assert!(results.iter().any(|r| r.contains("async test 2")));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn test_concurrent_logging_from_multiple_threads() {
+        let (drain, log_inspector) = MemoryDrainForTest::new();
+        let mut join_set = tokio::task::JoinSet::new();
+
+        for i in 0..10 {
+            let drain_clone = drain.clone();
+            join_set.spawn(async move {
+                let logger = slog::Logger::root(drain_clone.fuse(), slog::o!());
+                debug!(logger, "multi thread test {i}"; "thread_id" => i);
+            });
+        }
+
+        join_set.join_all().await;
+
+        let results = log_inspector.search_logs("multi thread test");
+        assert_eq!(results.len(), 10);
+        for i in 0..10 {
+            assert!(results
+                .iter()
+                .any(|r| r.contains(&format!("multi thread test {i}"))));
+        }
+    }
+}

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -126,7 +126,6 @@ pub use current_function_path;
 
 #[cfg(test)]
 mod utils {
-    use std::fs::File;
     use std::io;
     use std::sync::Arc;
     use std::{collections::HashSet, path::Path};
@@ -152,8 +151,9 @@ mod utils {
             Self::from_writer(slog_term::TestStdoutWriter)
         }
 
-        pub fn file(filepath: &std::path::Path) -> Logger {
-            Self::from_writer(File::create(filepath).unwrap())
+        pub fn memory() -> (Logger, MemoryDrainForTestInspector) {
+            let (drain, inspector) = MemoryDrainForTest::new();
+            (Logger::root(drain.fuse(), slog::o!()), inspector)
         }
     }
 

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -17,6 +17,7 @@ mod cardano_transactions_builder;
 mod certificate_chain_builder;
 mod dir_eq;
 mod fixture_builder;
+mod memory_logger;
 mod mithril_fixture;
 mod precomputed_kes_key;
 mod temp_dir;
@@ -31,6 +32,7 @@ pub use certificate_chain_builder::{
 };
 pub use dir_eq::*;
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};
+pub use memory_logger::*;
 pub use mithril_fixture::{MithrilFixture, SignerFixture};
 pub use temp_dir::*;
 #[cfg(test)]

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.41"
+version = "0.1.42"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -44,7 +44,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true, features = [
     "max_level_trace",
-    "release_max_level_trace",
+    "release_max_level_debug",
 ] }
 slog-async = { workspace = true }
 slog-bunyan = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.242"
+version = "0.2.243"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/lib.rs
+++ b/mithril-signer/src/lib.rs
@@ -41,7 +41,6 @@ static GLOBAL: Jemalloc = Jemalloc;
 
 #[cfg(test)]
 pub(crate) mod test_tools {
-    use std::fs::File;
     use std::io;
     use std::sync::Arc;
 
@@ -49,6 +48,7 @@ pub(crate) mod test_tools {
     use slog_async::Async;
     use slog_term::{CompactFormat, PlainDecorator};
 
+    use mithril_common::test_utils::{MemoryDrainForTest, MemoryDrainForTestInspector};
     pub struct TestLogger;
 
     impl TestLogger {
@@ -63,8 +63,9 @@ pub(crate) mod test_tools {
             Self::from_writer(slog_term::TestStdoutWriter)
         }
 
-        pub fn file(filepath: &std::path::Path) -> Logger {
-            Self::from_writer(File::create(filepath).unwrap())
+        pub fn memory() -> (Logger, MemoryDrainForTestInspector) {
+            let (drain, inspector) = MemoryDrainForTest::new();
+            (Logger::root(drain.fuse(), slog::o!()), inspector)
         }
     }
 }


### PR DESCRIPTION
## Content

This PR add the `MemoryDrainForTest` that write log to memory, it allow to remove the need to write logs to files for tests that needs to check log content.

Logging to file in test was error prone as it was difficult to guarantee that all logs were effectively flushed to the file before the assertions, leading to error, often in the hydra ci:

### Details

- `mithril-common`: Add `MemoryDrainForTest` in test tools
  - A [`slog::Drain`](https://docs.rs/slog/2.7.0/slog/trait.Drain.html) that write logs to in memory `Vec<String>` shared using a `Arc<RwLock<..>>`
  - Optimized for tests, not speed, **it should not be used in production**.
  - It's created along a `MemoryDrainForTestInspector`:
    - it can search for log entries or if a log was written
    - this struct allow to move the `MemoryDrainForTest` to the logger used by tested component while providing an api to do the check needed by tests
- Replace all `TestLogger::file` in all crates with a `TestLogger::memory` that returns a tuple containing a logger that logs to `MemoryDrainForTest` alongside a `MemoryDrainForTestInspector` to do assertions on logs
- `mithril-client`: Remove slog level configuration in dev-dependencies and use slog default instead. This was making the test `log_a_info_message_telling_that_the_feature_does_not_use_mithril_certification` fail because hydra run test in `--release` removing the log that was tested (cf: [hydra run](https://ci.iog.io/build/7552786/nixlog/1))
 
## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced


## Issue(s)

Relates to #2436
