### PR TITLE
Optimize signer and aggregator state machines run interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.45"
+version = "0.7.46"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.243"
+version = "0.2.244"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.45"
+version = "0.7.46"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.243"
+version = "0.2.244"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR changes the type of wait that is done between cycles of aggregator and signer states machines.

Instead of using a simple `sleep` that will always wait, they now uses `interval` so the time that was passed running the last cycle is taken into account in the amount of time to sleep.
This means that if the last cycle was longer that the set `run_interval` the state machines will execute their next cycle immediately.

### Logs update

The logs at the end of each cycle has been updated to this change:

```json
{
  "msg": "… Cycle finished", "time": "2025-04-30T16:31:33.83372259+02:00",
  "run_interval_in_ms": 125, "approximate_next_cycle_time": "16:31:33.957",
  "name": "mithril-signer", "level": 30, "src": "StateMachine" 
}
{
  "msg": "New cycle: ReadyToSign - 27", "time": "2025-04-30T16:31:33.95800507+02:00",
  "name": "mithril-signer", "level": 30, "src": "StateMachine"
}
``` 

> [!NOTE]
> Special care have been given so the same timezone is used in the print  scheduled time and logs `time` property

> [!WARNING]
> Given scheduled time may have some inaccuracy since there's no way to get it from the interval itself so we have to compute it manually. This is especially true in fast running environment such as end to end tests.


## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2428