### PR TITLE
Feat: extend documentation tool for subcommand configurations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3799,7 +3799,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.46"
+version = "0.7.47"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3968,7 +3968,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.27"
+version = "0.5.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4020,7 +4020,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-doc"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "clap",
  "config",
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-doc-derive"
-version = "0.1.17"
+version = "0.1.18"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.244"
+version = "0.2.245"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-doc-derive/Cargo.toml
+++ b/internal/mithril-doc-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-doc-derive"
-version = "0.1.17"
+version = "0.1.18"
 description = "An internal macro to support documentation generation."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-doc/Cargo.toml
+++ b/internal/mithril-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-doc"
-version = "0.1.22"
+version = "0.1.23"
 description = "An internal crate to generate documentation."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-doc/src/extract_clap_info.rs
+++ b/internal/mithril-doc/src/extract_clap_info.rs
@@ -35,12 +35,8 @@ fn extract_arg(arg: &Arg) -> FieldDoc {
 }
 
 pub fn extract_parameters(cmd: &Command) -> StructDoc {
-    StructDoc {
-        data: cmd
-            .get_arguments()
-            .map(extract_arg)
-            .collect::<Vec<FieldDoc>>(),
-    }
+    let fields = cmd.get_arguments().map(extract_arg).collect();
+    StructDoc::new(fields)
 }
 
 #[cfg(test)]
@@ -95,7 +91,11 @@ mod tests {
         //assert_eq!(1, command_parameters.data.len());
         assert_eq!(
             "run_mode",
-            command_parameters.data.first().unwrap().parameter
+            command_parameters
+                .get_ordered_data()
+                .first()
+                .unwrap()
+                .parameter
         );
         for arg in command.get_arguments() {
             println!("{} {}", arg.get_id(), arg.is_required_set());

--- a/internal/mithril-doc/src/lib.rs
+++ b/internal/mithril-doc/src/lib.rs
@@ -69,6 +69,7 @@ impl StructDoc {
         environment_variable: Option<String>,
         default: Option<String>,
         example: Option<String>,
+        is_mandatory: bool,
     ) {
         let field_doc = FieldDoc {
             parameter: name.to_string(),
@@ -78,7 +79,7 @@ impl StructDoc {
             description: description.to_string(),
             default_value: default,
             example,
-            is_mandatory: false,
+            is_mandatory,
         };
         self.parameter_order.push(field_doc.parameter.to_string());
         self.parameters
@@ -194,8 +195,8 @@ mod tests {
     #[test]
     fn test_get_field_must_return_first_field_by_parameter_name() {
         let mut struct_doc = StructDoc::default();
-        struct_doc.add_param("A", "Param first A", None, None, None);
-        struct_doc.add_param("B", "Param first B", None, None, None);
+        struct_doc.add_param("A", "Param first A", None, None, None, true);
+        struct_doc.add_param("B", "Param first B", None, None, None, true);
 
         let retrieved_field = struct_doc.get_field("A").unwrap();
 
@@ -205,8 +206,8 @@ mod tests {
     #[test]
     fn test_get_field_must_return_none_if_parameter_does_not_exist() {
         let mut struct_doc = StructDoc::default();
-        struct_doc.add_param("A", "Param first A", None, None, None);
-        struct_doc.add_param("B", "Param first B", None, None, None);
+        struct_doc.add_param("A", "Param first A", None, None, None, true);
+        struct_doc.add_param("B", "Param first B", None, None, None, true);
 
         let retrieved_field = struct_doc.get_field("X");
 
@@ -223,36 +224,40 @@ mod tests {
                 Some("env A".to_string()),
                 Some("default A".to_string()),
                 Some("example A".to_string()),
+                true,
             );
-            s.add_param("B", "Param first B", None, None, None);
+            s.add_param("B", "Param first B", None, None, None, true);
             s.add_param(
                 "C",
                 "Param first C",
                 Some("env C".to_string()),
                 Some("default C".to_string()),
                 Some("example C".to_string()),
+                true,
             );
-            s.add_param("D", "Param first D", None, None, None);
+            s.add_param("D", "Param first D", None, None, None, true);
             s
         };
 
         let s2 = {
             let mut s = StructDoc::default();
-            s.add_param("A", "Param second A", None, None, None);
+            s.add_param("A", "Param second A", None, None, None, true);
             s.add_param(
                 "B",
                 "Param second B",
                 Some("env B".to_string()),
                 Some("default B".to_string()),
                 Some("example B".to_string()),
+                true,
             );
-            s.add_param("E", "Param second E", None, None, None);
+            s.add_param("E", "Param second E", None, None, None, true);
             s.add_param(
                 "F",
                 "Param second F",
                 Some("env F".to_string()),
                 Some("default F".to_string()),
                 Some("example F".to_string()),
+                true,
             );
             s
         };
@@ -331,7 +336,7 @@ mod tests {
         fn build_struct_doc(values: &[&str]) -> StructDoc {
             let mut struct_doc = StructDoc::default();
             for value in values.iter() {
-                struct_doc.add_param(value, value, None, None, None);
+                struct_doc.add_param(value, value, None, None, None, true);
             }
 
             assert_eq!(

--- a/internal/mithril-doc/src/lib.rs
+++ b/internal/mithril-doc/src/lib.rs
@@ -170,28 +170,11 @@ impl GenerateDocCommands {
 
     /// Generate the command line documentation.
     pub fn execute(&self, cmd_to_document: &mut Command) -> Result<(), String> {
-        self.execute_with_configurations(cmd_to_document, &[])
+        self.execute_with_configurations(cmd_to_document, HashMap::new())
     }
 
     /// Generate the command line documentation with config info.
     pub fn execute_with_configurations(
-        &self,
-        cmd_to_document: &mut Command,
-        configs_info: &[StructDoc],
-    ) -> Result<(), String> {
-        let mut iter_config = configs_info.iter();
-        let mut merged_struct_doc = StructDoc::default();
-        for next_config in &mut iter_config {
-            merged_struct_doc = merged_struct_doc.merge_struct_doc(next_config);
-        }
-
-        let mut map = HashMap::new();
-        map.insert("".to_string(), merged_struct_doc);
-        self.execute_with_configurations_new(cmd_to_document, map)
-    }
-
-    /// Generate the command line documentation with config info.
-    pub fn execute_with_configurations_new(
         &self,
         cmd_to_document: &mut Command,
         configs_info: HashMap<String, StructDoc>,

--- a/internal/mithril-doc/src/lib.rs
+++ b/internal/mithril-doc/src/lib.rs
@@ -9,7 +9,7 @@ mod markdown_formatter;
 mod test_doc_macro;
 
 use clap::{Command, Parser};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs::File;
 use std::io::Write;
 
@@ -165,18 +165,53 @@ impl GenerateDocCommands {
         cmd_to_document: &mut Command,
         configs_info: &[StructDoc],
     ) -> Result<(), String> {
-        let mut iter_config = configs_info.iter();
+        let mut map = HashMap::new();
+        map.insert("".to_string(), configs_info);
+        self.execute_with_configurations_new(cmd_to_document, map)
+        // let mut iter_config = configs_info.iter();
+        // let mut merged_struct_doc = StructDoc::new();
+        // for next_config in &mut iter_config {
+        //     merged_struct_doc = merged_struct_doc.merge_struct_doc(next_config);
+        // }
+
+        // let doc =
+        //     markdown_formatter::doc_markdown_with_config(cmd_to_document, Some(&merged_struct_doc));
+        // let cmd_name = cmd_to_document.get_name();
+
+        // println!("Please note: the documentation generated is not able to indicate the environment variables used by the commands.");
+        // self.save_doc(cmd_name, format!("\n{}", doc).as_str())
+    }
+
+    /// Generate the command line documentation with config info.
+    pub fn execute_with_configurations_new(
+        &self,
+        cmd_to_document: &mut Command,
+        configs_info: HashMap<String, &[StructDoc]>,
+    ) -> Result<(), String> {
+        let mut iter_config = configs_info.get("").unwrap().iter();
         let mut merged_struct_doc = StructDoc::new();
         for next_config in &mut iter_config {
             merged_struct_doc = merged_struct_doc.merge_struct_doc(next_config);
         }
 
-        let doc =
-            markdown_formatter::doc_markdown_with_config(cmd_to_document, Some(&merged_struct_doc));
+        let doc = markdown_formatter::doc_markdown_with_config(
+            cmd_to_document,
+            Self::merge_commands_struct_docs(configs_info),
+        );
+        // let doc =
+        //     markdown_formatter::doc_markdown_with_config(cmd_to_document, Some(&merged_struct_doc));
         let cmd_name = cmd_to_document.get_name();
 
         println!("Please note: the documentation generated is not able to indicate the environment variables used by the commands.");
         self.save_doc(cmd_name, format!("\n{}", doc).as_str())
+    }
+
+    fn merge_commands_struct_docs(
+        configs_info: HashMap<String, &[StructDoc]>,
+    ) -> HashMap<String, StructDoc> {
+        let mut merged_struct_doc = HashMap::new();
+
+        merged_struct_doc
     }
 }
 
@@ -186,6 +221,27 @@ mod tests {
     use std::collections::HashMap;
 
     use super::*;
+
+    #[test]
+    fn test_merge_commands_struct_docs() {
+        let s1 = {
+            let mut s = StructDoc::default();
+            s.add_param("A", "Param first A", None, None, None);
+            s.add_param("B", "Param first B", None, None, None);
+            s.add_param("C", "Param first C", None, None, None);
+            s.add_param("D", "Param first D", None, None, None);
+            s
+        };
+
+        let s2 = {
+            let mut s = StructDoc::default();
+            s.add_param("A", "Param second A", None, None, None);
+            s.add_param("B", "Param second B", None, None, None);
+            s.add_param("E", "Param second E", None, None, None);
+            s.add_param("F", "Param second F", None, None, None);
+            s
+        };
+    }
 
     #[test]
     fn test_merge_struct_doc() {

--- a/internal/mithril-doc/src/lib.rs
+++ b/internal/mithril-doc/src/lib.rs
@@ -93,12 +93,8 @@ impl StructDoc {
 
     /// Merge two StructDoc into a third one.
     pub fn merge_struct_doc(&self, s2: &StructDoc) -> StructDoc {
-        let mut struct_doc_merged = StructDoc::new(
-            self.get_ordered_data()
-                .into_iter()
-                .map(|field| field.clone())
-                .collect(),
-        );
+        let mut struct_doc_merged =
+            StructDoc::new(self.get_ordered_data().into_iter().cloned().collect());
         for (key, field_doc) in s2.parameters.iter() {
             if let Some(parameter) = struct_doc_merged.parameters.get_mut(key) {
                 if parameter.default_value.is_none() {
@@ -183,53 +179,28 @@ impl GenerateDocCommands {
         cmd_to_document: &mut Command,
         configs_info: &[StructDoc],
     ) -> Result<(), String> {
+        let mut iter_config = configs_info.iter();
+        let mut merged_struct_doc = StructDoc::default();
+        for next_config in &mut iter_config {
+            merged_struct_doc = merged_struct_doc.merge_struct_doc(next_config);
+        }
+
         let mut map = HashMap::new();
-        map.insert("".to_string(), configs_info);
+        map.insert("".to_string(), merged_struct_doc);
         self.execute_with_configurations_new(cmd_to_document, map)
-        // let mut iter_config = configs_info.iter();
-        // let mut merged_struct_doc = StructDoc::default();
-        // for next_config in &mut iter_config {
-        //     merged_struct_doc = merged_struct_doc.merge_struct_doc(next_config);
-        // }
-
-        // let doc =
-        //     markdown_formatter::doc_markdown_with_config(cmd_to_document, Some(&merged_struct_doc));
-        // let cmd_name = cmd_to_document.get_name();
-
-        // println!("Please note: the documentation generated is not able to indicate the environment variables used by the commands.");
-        // self.save_doc(cmd_name, format!("\n{}", doc).as_str())
     }
 
     /// Generate the command line documentation with config info.
     pub fn execute_with_configurations_new(
         &self,
         cmd_to_document: &mut Command,
-        configs_info: HashMap<String, &[StructDoc]>,
+        configs_info: HashMap<String, StructDoc>,
     ) -> Result<(), String> {
-        let mut iter_config = configs_info.get("").unwrap().iter();
-        let mut merged_struct_doc = StructDoc::default();
-        for next_config in &mut iter_config {
-            merged_struct_doc = merged_struct_doc.merge_struct_doc(next_config);
-        }
-
-        let doc = markdown_formatter::doc_markdown_with_config(
-            cmd_to_document,
-            Self::merge_commands_struct_docs(configs_info),
-        );
-        // let doc =
-        //     markdown_formatter::doc_markdown_with_config(cmd_to_document, Some(&merged_struct_doc));
+        let doc = markdown_formatter::doc_markdown_with_config(cmd_to_document, configs_info);
         let cmd_name = cmd_to_document.get_name();
 
         println!("Please note: the documentation generated is not able to indicate the environment variables used by the commands.");
         self.save_doc(cmd_name, format!("\n{}", doc).as_str())
-    }
-
-    fn merge_commands_struct_docs(
-        configs_info: HashMap<String, &[StructDoc]>,
-    ) -> HashMap<String, StructDoc> {
-        let mut merged_struct_doc = HashMap::new();
-
-        merged_struct_doc
     }
 }
 
@@ -257,27 +228,6 @@ mod tests {
         let retrieved_field = struct_doc.get_field("X");
 
         assert_eq!(retrieved_field, None);
-    }
-
-    #[test]
-    fn test_merge_commands_struct_docs() {
-        let s1 = {
-            let mut s = StructDoc::default();
-            s.add_param("A", "Param first A", None, None, None);
-            s.add_param("B", "Param first B", None, None, None);
-            s.add_param("C", "Param first C", None, None, None);
-            s.add_param("D", "Param first D", None, None, None);
-            s
-        };
-
-        let s2 = {
-            let mut s = StructDoc::default();
-            s.add_param("A", "Param second A", None, None, None);
-            s.add_param("B", "Param second B", None, None, None);
-            s.add_param("E", "Param second E", None, None, None);
-            s.add_param("F", "Param second F", None, None, None);
-            s
-        };
     }
 
     #[test]

--- a/internal/mithril-doc/src/markdown_formatter.rs
+++ b/internal/mithril-doc/src/markdown_formatter.rs
@@ -443,8 +443,9 @@ mod tests {
                     Some("CONFIGA".to_string()),
                     Some("default config A".to_string()),
                     None,
+                    true,
                 );
-                s.add_param("ConfigB", "Param B from config", None, None, None);
+                s.add_param("ConfigB", "Param B from config", None, None, None, true);
                 s
             };
 
@@ -476,8 +477,9 @@ mod tests {
                     Some("CONFIGA".to_string()),
                     Some("default config A".to_string()),
                     None,
+                    true,
                 );
-                s.add_param("ConfigB", "Param B from config", None, None, None);
+                s.add_param("ConfigB", "Param B from config", None, None, None, true);
                 s
             };
 
@@ -500,8 +502,8 @@ mod tests {
     fn test_doc_markdown_include_config_parameters_for_subcommands() {
         let struct_doc = {
             let mut s = StructDoc::default();
-            s.add_param("ConfigA", "", None, None, None);
-            s.add_param("ConfigB", "", None, None, None);
+            s.add_param("ConfigA", "", None, None, None, true);
+            s.add_param("ConfigB", "", None, None, None, true);
             s
         };
 

--- a/internal/mithril-doc/src/markdown_formatter.rs
+++ b/internal/mithril-doc/src/markdown_formatter.rs
@@ -81,9 +81,7 @@ pub fn doc_markdown_with_config(
         {
             let mut command_parameters = extract_clap_info::extract_parameters(cmd);
             if let Some(config_doc) = struct_doc {
-                if !config_doc.data.is_empty() {
-                    command_parameters = command_parameters.merge_struct_doc(config_doc);
-                }
+                command_parameters = command_parameters.merge_struct_doc(config_doc);
             }
 
             let parameters_table = doc_config_to_markdown(&command_parameters);
@@ -189,8 +187,8 @@ pub fn doc_markdown_with_config(
 
 pub fn doc_config_to_markdown(struct_doc: &StructDoc) -> String {
     let subcommands_lines = struct_doc
-        .data
-        .iter()
+        .get_ordered_data()
+        .into_iter()
         .map(|config| {
             let config = config.clone();
             vec![
@@ -316,7 +314,7 @@ mod tests {
     #[test]
     fn test_format_arg_with_empty_struct_doc() {
         let mut command = MyCommand::command();
-        let merged_struct_doc = StructDoc::new();
+        let merged_struct_doc = StructDoc::default();
         let configs = HashMap::from([("".to_string(), merged_struct_doc)]);
         let doc = doc_markdown_with_config(&mut command, configs);
 

--- a/internal/mithril-doc/src/test_doc_macro.rs
+++ b/internal/mithril-doc/src/test_doc_macro.rs
@@ -44,7 +44,7 @@ mod tests {
     #[test]
     fn test_extract_struct_of_default_configuration() {
         let doc = MyDefaultConfiguration::extract();
-        let field = doc.get_field("environment");
+        let field = doc.get_field("environment").unwrap();
 
         assert_eq!("environment", field.parameter);
         assert_eq!("ENVIRONMENT", field.environment_variable.as_ref().unwrap());
@@ -55,7 +55,7 @@ mod tests {
     #[test]
     fn test_extract_struct_of_configuration() {
         let doc = MyConfiguration::extract();
-        let field = doc.get_field("environment");
+        let field = doc.get_field("environment").unwrap();
 
         assert_eq!("environment", field.parameter);
         assert_eq!("ENVIRONMENT", field.environment_variable.as_ref().unwrap());
@@ -67,12 +67,12 @@ mod tests {
     fn test_extract_example_of_configuration() {
         {
             let doc_with_example = MyConfiguration::extract();
-            let field = doc_with_example.get_field("environment");
+            let field = doc_with_example.get_field("environment").unwrap();
             assert_eq!(Some("dev".to_string()), field.example);
         }
         {
             let doc_without_example = MyDefaultConfiguration::extract();
-            let field = doc_without_example.get_field("environment");
+            let field = doc_without_example.get_field("environment").unwrap();
             assert_eq!(None, field.example);
         }
     }

--- a/internal/mithril-doc/src/test_doc_macro.rs
+++ b/internal/mithril-doc/src/test_doc_macro.rs
@@ -7,6 +7,9 @@ mod tests {
     #[allow(dead_code)]
     #[derive(Debug, Clone, mithril_doc_derive::Documenter)]
     struct MyConfiguration {
+        /// Optional parameter
+        version: Option<String>,
+
         /// Execution environment
         #[example = "dev"]
         environment: String,
@@ -75,5 +78,17 @@ mod tests {
             let field = doc_without_example.get_field("environment").unwrap();
             assert_eq!(None, field.example);
         }
+    }
+
+    #[test]
+    fn test_extract_configuration_optional_field() {
+        let doc_with_example = MyConfiguration::extract();
+        assert!(!doc_with_example.get_field("version").unwrap().is_mandatory);
+        assert!(
+            doc_with_example
+                .get_field("environment")
+                .unwrap()
+                .is_mandatory
+        );
     }
 }

--- a/internal/mithril-doc/src/test_doc_macro.rs
+++ b/internal/mithril-doc/src/test_doc_macro.rs
@@ -91,4 +91,14 @@ mod tests {
                 .is_mandatory
         );
     }
+
+    #[test]
+    fn test_extract_configuration_fields_in_declaration_order() {
+        let doc_with_example = MyConfiguration::extract();
+
+        let fields = doc_with_example.get_ordered_data();
+
+        assert_eq!(fields[0].parameter, "version");
+        assert_eq!(fields[1].parameter, "environment");
+    }
 }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.46"
+version = "0.7.47"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/config_association.rs
+++ b/mithril-aggregator/src/commands/config_association.rs
@@ -91,7 +91,7 @@ mod tests {
     impl PseudoCommandA {
         pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
             let mut struct_doc = StructDoc::default();
-            struct_doc.add_param("field_command_a", "", None, None, None);
+            struct_doc.add_param("field_command_a", "", None, None, None, true);
             HashMap::from([(command_path, struct_doc)])
         }
     }
@@ -128,7 +128,7 @@ mod tests {
     impl PseudoSubCommandE {
         pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
             let mut struct_doc = StructDoc::default();
-            struct_doc.add_param("field_sub_command_e", "", None, None, None);
+            struct_doc.add_param("field_sub_command_e", "", None, None, None, true);
             HashMap::from([(command_path, struct_doc)])
         }
     }
@@ -141,7 +141,7 @@ mod tests {
         impl PseudoCommandB {
             pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
                 let mut struct_doc = StructDoc::default();
-                struct_doc.add_param("field_command_b", "", None, None, None);
+                struct_doc.add_param("field_command_b", "", None, None, None, true);
                 HashMap::from([(command_path, struct_doc)])
             }
         }

--- a/mithril-aggregator/src/commands/config_association.rs
+++ b/mithril-aggregator/src/commands/config_association.rs
@@ -1,0 +1,193 @@
+/// Call `extract_config` on each SubCommand so it could not be forget to implement it.
+/// All variant must be listed otherwise there is a compilation error.
+/// The associated command to the variant must be the right one otherwise there is a compilation error.
+///
+/// # Example
+///
+/// ```ignore
+/// # use std::collections::HashMap;
+/// # use mithril_doc::StructDoc;
+/// # use mithril_aggregator::extract_all;
+/// fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+///     extract_all!(
+///         command_path,
+///         PseudoCommand,
+///         CommandA = { PseudoCommandA },
+///         CommandB = { pseudo_module::PseudoCommandB },
+///     )
+/// }
+/// ```
+#[macro_export]
+macro_rules! extract_all {
+    (@check_type $variant_val:ident, { $type:ident }) => {
+        {let _:$type = $variant_val;}
+    };
+    (@check_type $variant_val:ident, { $module:ident::$type:ident }) => {
+        {let _:$module::$type = $variant_val;}
+    };
+    (@check_type $variant_val:ident, {}) => {
+        let _ = $variant_val;
+    };
+
+    (@extract_config $config_id:ident, { $type:ident }) => {
+        $type::extract_config($config_id)
+    };
+    (@extract_config $config_id:ident, { $module:ident::$type:ident }) => {
+        $module::$type::extract_config($config_id)
+    };
+    (@extract_config $config_id:ident, {}) => {
+        {
+            let _ = $config_id;
+            std::collections::HashMap::new()
+        }
+    };
+
+    ($command_path: ident, $E:path, $($variant:ident = $cmd:tt,)*) => {
+        {
+            // Check that all enum variants are used and the associated variant value
+            use $E as E;
+            let _ = |dummy: E| {
+                match dummy {
+                    $(E::$variant(x) => {
+                        extract_all!(@check_type x, $cmd);
+                    }),*
+                }
+            };
+
+            // Build config HashMap
+            let mut configs = HashMap::new();
+            $(
+                let config_id = format!(
+                    "{} {}",
+                    $command_path, stringify!($variant).to_lowercase()
+                );
+                configs.extend(extract_all!(@extract_config config_id, $cmd));
+            )*
+            configs
+        }
+
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use mithril_common::assert_equivalent_macro;
+    use mithril_doc::StructDoc;
+
+    #[allow(dead_code)]
+    #[derive(Debug, Clone)]
+    enum PseudoCommand {
+        CommandA(PseudoCommandA),
+        CommandB(pseudo_module::PseudoCommandB),
+        CommandWithoutConfig(PseudoCommandWithoutConfig),
+        CommandConfigUnwanted(PseudoCommandConfigUnwanted),
+        CommandE(EnumCommandE),
+    }
+
+    #[derive(Debug, Clone)]
+    struct PseudoCommandA {}
+    impl PseudoCommandA {
+        pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+            let mut struct_doc = StructDoc::default();
+            struct_doc.add_param("field_command_a", "", None, None, None);
+            HashMap::from([(command_path, struct_doc)])
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct PseudoCommandWithoutConfig {}
+    impl PseudoCommandWithoutConfig {
+        pub fn extract_config(_command_path: String) -> HashMap<String, StructDoc> {
+            HashMap::new()
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct PseudoCommandConfigUnwanted {}
+
+    #[allow(dead_code)]
+    #[derive(Debug, Clone)]
+    enum EnumCommandE {
+        SubCommandE(PseudoSubCommandE),
+    }
+
+    impl EnumCommandE {
+        pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+            extract_all!(
+                command_path,
+                EnumCommandE,
+                SubCommandE = { PseudoSubCommandE },
+            )
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct PseudoSubCommandE {}
+    impl PseudoSubCommandE {
+        pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+            let mut struct_doc = StructDoc::default();
+            struct_doc.add_param("field_sub_command_e", "", None, None, None);
+            HashMap::from([(command_path, struct_doc)])
+        }
+    }
+
+    mod pseudo_module {
+        use super::*;
+
+        #[derive(Debug, Clone)]
+        pub struct PseudoCommandB {}
+        impl PseudoCommandB {
+            pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+                let mut struct_doc = StructDoc::default();
+                struct_doc.add_param("field_command_b", "", None, None, None);
+                HashMap::from([(command_path, struct_doc)])
+            }
+        }
+    }
+
+    #[test]
+    fn test_extract_all_should_construct_hashmap_with_subcommand() {
+        let command_path = "mithril".to_string();
+        let configs = extract_all!(
+            command_path,
+            PseudoCommand,
+            CommandA = { PseudoCommandA },
+            CommandB = { pseudo_module::PseudoCommandB },
+            CommandWithoutConfig = { PseudoCommandWithoutConfig },
+            CommandConfigUnwanted = {},
+            CommandE = { EnumCommandE },
+        );
+
+        let keys: Vec<String> = configs.clone().into_keys().collect();
+        let expected = vec![
+            "mithril commanda".to_string(),
+            "mithril commandb".to_string(),
+            "mithril commande subcommande".to_string(),
+        ];
+
+        assert_equivalent_macro!(expected, keys);
+    }
+
+    #[test]
+    fn test_extract_all_should_associate_struct_doc() {
+        let command_path = "mithril".to_string();
+        let configs = extract_all!(
+            command_path,
+            PseudoCommand,
+            CommandA = { PseudoCommandA },
+            CommandB = { pseudo_module::PseudoCommandB },
+            CommandWithoutConfig = { PseudoCommandWithoutConfig },
+            CommandConfigUnwanted = {},
+            CommandE = { EnumCommandE },
+        );
+        let doc_command_b = configs.get("mithril commandb").unwrap();
+        assert!(doc_command_b.get_field("field_command_b").is_some());
+        assert_eq!(1, doc_command_b.get_ordered_data().len());
+
+        let doc_sub_command_e = configs.get("mithril commande subcommande").unwrap();
+        assert!(doc_sub_command_e.get_field("field_sub_command_e").is_some());
+        assert_eq!(1, doc_sub_command_e.get_ordered_data().len());
+    }
+}

--- a/mithril-aggregator/src/commands/era_command.rs
+++ b/mithril-aggregator/src/commands/era_command.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Write, path::PathBuf};
+use std::{collections::HashMap, fs::File, io::Write, path::PathBuf};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
@@ -7,9 +7,10 @@ use mithril_common::{
     entities::{Epoch, HexEncodedEraMarkersSecretKey},
     StdResult,
 };
+use mithril_doc::StructDoc;
 use slog::{debug, Logger};
 
-use crate::tools::EraTools;
+use crate::{extract_all, tools::EraTools};
 
 /// Era tools
 #[derive(Parser, Debug, Clone)]
@@ -22,6 +23,16 @@ pub struct EraCommand {
 impl EraCommand {
     pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
         self.era_subcommand.execute(root_logger).await
+    }
+
+    pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+        extract_all!(
+            command_path,
+            EraSubCommand,
+            List = { ListEraSubCommand },
+            GenerateTxDatum = { GenerateTxDatumEraSubCommand },
+            GenerateKeypair = { GenerateKeypairEraSubCommand },
+        )
     }
 }
 
@@ -71,6 +82,10 @@ impl ListEraSubCommand {
 
         Ok(())
     }
+
+    pub fn extract_config(_parent: String) -> HashMap<String, StructDoc> {
+        HashMap::new()
+    }
 }
 
 /// Era tx datum generate command
@@ -113,6 +128,10 @@ impl GenerateTxDatumEraSubCommand {
 
         Ok(())
     }
+
+    pub fn extract_config(_parent: String) -> HashMap<String, StructDoc> {
+        HashMap::new()
+    }
 }
 
 /// Era keypair generation command.
@@ -135,5 +154,9 @@ impl GenerateKeypairEraSubCommand {
             .with_context(|| "era-tools: keypair generation error")?;
 
         Ok(())
+    }
+
+    pub fn extract_config(_parent: String) -> HashMap<String, StructDoc> {
+        HashMap::new()
     }
 }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, sync::Arc};
+use std::{collections::HashMap, path::PathBuf, sync::Arc};
 
 use anyhow::Context;
 use clap::{Parser, Subcommand};
@@ -17,8 +17,8 @@ use mithril_common::{
 use mithril_doc::{Documenter, StructDoc};
 
 use crate::{
-    dependency_injection::DependenciesBuilder, tools::GenesisTools, ConfigurationSource,
-    ExecutionEnvironment,
+    dependency_injection::DependenciesBuilder, extract_all, tools::GenesisTools,
+    ConfigurationSource, ExecutionEnvironment,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize, Documenter)]
@@ -111,6 +111,18 @@ impl GenesisCommand {
             .execute(root_logger, config_builder)
             .await
     }
+
+    pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+        extract_all!(
+            command_path,
+            GenesisSubCommand,
+            Export = { ExportGenesisSubCommand },
+            Import = { ImportGenesisSubCommand },
+            Sign = { SignGenesisSubCommand },
+            Bootstrap = { BootstrapGenesisSubCommand },
+            GenerateKeypair = { GenerateKeypairGenesisSubCommand },
+        )
+    }
 }
 
 /// Genesis tools commands.
@@ -189,6 +201,10 @@ impl ExportGenesisSubCommand {
             .with_context(|| "genesis-tools: export error")?;
         Ok(())
     }
+
+    pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+        HashMap::from([(command_path, GenesisCommandConfiguration::extract())])
+    }
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -239,6 +255,10 @@ impl ImportGenesisSubCommand {
             .with_context(|| "genesis-tools: import error")?;
         Ok(())
     }
+
+    pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+        HashMap::from([(command_path, GenesisCommandConfiguration::extract())])
+    }
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -274,6 +294,10 @@ impl SignGenesisSubCommand {
         .with_context(|| "genesis-tools: sign error")?;
 
         Ok(())
+    }
+
+    pub fn extract_config(_command_path: String) -> HashMap<String, StructDoc> {
+        HashMap::new()
     }
 }
 #[derive(Parser, Debug, Clone)]
@@ -317,6 +341,10 @@ impl BootstrapGenesisSubCommand {
             .with_context(|| "genesis-tools: bootstrap error")?;
         Ok(())
     }
+
+    pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+        HashMap::from([(command_path, GenesisCommandConfiguration::extract())])
+    }
 }
 
 /// Genesis keypair generation command.
@@ -339,6 +367,10 @@ impl GenerateKeypairGenesisSubCommand {
             .with_context(|| "genesis-tools: keypair generation error")?;
 
         Ok(())
+    }
+
+    pub fn extract_config(_parent: String) -> HashMap<String, StructDoc> {
+        HashMap::new()
     }
 }
 

--- a/mithril-aggregator/src/commands/mod.rs
+++ b/mithril-aggregator/src/commands/mod.rs
@@ -52,7 +52,7 @@ impl MainCommand {
                 let commands_configs =
                     Self::extract_config(Self::format_crate_name_to_config_key());
 
-                cmd.execute_with_configurations_new(&mut MainOpts::command(), commands_configs)
+                cmd.execute_with_configurations(&mut MainOpts::command(), commands_configs)
                     .map_err(|message| anyhow!(message))
             }
         }

--- a/mithril-aggregator/src/commands/mod.rs
+++ b/mithril-aggregator/src/commands/mod.rs
@@ -1,3 +1,4 @@
+mod config_association;
 mod database_command;
 mod era_command;
 mod genesis_command;
@@ -9,12 +10,11 @@ use clap::{CommandFactory, Parser, Subcommand};
 use config::{builder::DefaultState, ConfigBuilder, Map, Source, Value};
 use mithril_cli_helper::{register_config_value, register_config_value_option};
 use mithril_common::StdResult;
-use mithril_doc::{Documenter, DocumenterDefault, StructDoc};
+use mithril_doc::{Documenter, GenerateDocCommands, StructDoc};
 use slog::{debug, Level, Logger};
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
-use crate::{DefaultConfiguration, ServeCommandConfiguration};
-use mithril_doc::GenerateDocCommands;
+use crate::{extract_all, DefaultConfiguration};
 
 /// Main command selector
 #[derive(Debug, Clone, Subcommand)]
@@ -49,14 +49,30 @@ impl MainCommand {
             Self::Tools(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Database(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::GenerateDoc(cmd) => {
-                let config_infos = vec![
-                    ServeCommandConfiguration::extract(),
-                    DefaultConfiguration::extract(),
-                ];
-                cmd.execute_with_configurations(&mut MainOpts::command(), &config_infos)
+                let commands_configs =
+                    Self::extract_config(Self::format_crate_name_to_config_key());
+
+                cmd.execute_with_configurations_new(&mut MainOpts::command(), commands_configs)
                     .map_err(|message| anyhow!(message))
             }
         }
+    }
+
+    pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+        extract_all!(
+            command_path,
+            MainCommand,
+            Database = { database_command::DatabaseCommand },
+            Era = { era_command::EraCommand },
+            Genesis = { genesis_command::GenesisCommand },
+            Serve = { serve_command::ServeCommand },
+            Tools = { tools_command::ToolsCommand },
+            GenerateDoc = {},
+        )
+    }
+
+    fn format_crate_name_to_config_key() -> String {
+        env!("CARGO_PKG_NAME").replace("-", "")
     }
 
     pub fn command_type(&self) -> CommandType {
@@ -142,5 +158,17 @@ impl MainOpts {
             3 => Level::Debug,
             _ => Level::Trace,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_crate_name_as_config_key() {
+        let crate_name = MainCommand::format_crate_name_to_config_key();
+
+        assert_eq!(crate_name, "mithrilaggregator");
     }
 }

--- a/mithril-aggregator/src/commands/serve_command.rs
+++ b/mithril-aggregator/src/commands/serve_command.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     net::IpAddr,
     path::{Path, PathBuf},
     sync::Arc,
@@ -18,10 +19,12 @@ use mithril_cli_helper::{
     register_config_value, register_config_value_bool, register_config_value_option,
 };
 use mithril_common::StdResult;
+use mithril_doc::{Documenter, DocumenterDefault, StructDoc};
 use mithril_metric::MetricsServer;
 
 use crate::{
-    dependency_injection::DependenciesBuilder, tools::VacuumTracker, ServeCommandConfiguration,
+    dependency_injection::DependenciesBuilder, tools::VacuumTracker, DefaultConfiguration,
+    ServeCommandConfiguration,
 };
 
 const VACUUM_MINIMUM_INTERVAL: TimeDelta = TimeDelta::weeks(1);
@@ -322,5 +325,12 @@ impl ServeCommand {
         }
 
         Ok(())
+    }
+
+    pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
+        HashMap::from([(
+            command_path,
+            ServeCommandConfiguration::extract().merge_struct_doc(&DefaultConfiguration::extract()),
+        )])
     }
 }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.27"
+version = "0.5.28"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -74,7 +74,19 @@ where
     assert_eq!(a, b);
 }
 
-fn as_sorted_vec<T: Ord, I: IntoIterator<Item = T> + Clone>(iter: I) -> Vec<T> {
+/// Assert that two iterators are equivalent
+#[macro_export]
+macro_rules! assert_equivalent_macro {
+    ( $expected:expr, $actual:expr ) => {{
+        let expected = $crate::test_utils::as_sorted_vec($expected);
+        let actual = $crate::test_utils::as_sorted_vec($actual);
+        assert_eq!(expected, actual);
+    }};
+}
+pub use assert_equivalent_macro;
+
+/// Create a sorted clone af an iterable.
+pub fn as_sorted_vec<T: Ord, I: IntoIterator<Item = T> + Clone>(iter: I) -> Vec<T> {
     let mut list: Vec<T> = iter.clone().into_iter().collect();
     list.sort();
     list

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.244"
+version = "0.2.245"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/main.rs
+++ b/mithril-signer/src/main.rs
@@ -152,7 +152,7 @@ async fn main() -> StdResult<()> {
                 configs_map.insert(format_crate_name_to_config_key(), merged_struct_doc);
 
                 return cmd
-                    .execute_with_configurations_new(&mut Args::command(), configs_map)
+                    .execute_with_configurations(&mut Args::command(), configs_map)
                     .map_err(|message| anyhow!(message));
             }
         }


### PR DESCRIPTION
## Content

This PR includes enhancements to the documentation tool, enabling it to support subcommand configurations.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Comments

Additionally, an assessment of the differences between the documentation generated by `mithril-doc` and the currently published website documentation has been completed. The identified differences are as follows:
- Default configuration discrepancies: There are mismatches between the default configuration structure and the serve command configuration structure (fields are not exactly the same). In addition, default configuration details for subcommands are missing. The `mithril-doc` merge mechanism for default configurations may need improvement.
- Environment variable representation: The generated documentation does not take into account environment variables for configuration structures such as `protocol_parameters` and `cardano_transactions_signing_config`, which use double underscores (`__`) as separators.
- Line breaks in clap command output: The generated documentation handles line breaks differently from the website documentation.
- Markdown formatting: The generated Markdown differs from the website version, which is formatted with `prettier`.
- Order of command sections: The sequence of command sections in the generated documentation does not match the one on the website.
- `--help` command entries: Each subcommand table includes a help command entry, which may be unnecessary.

## Issue(s)

Closes #2450 
