### PR TITLE
Docs: add dev blog post for distribution `2517`

### DIFF
--- a/docs/website/blog/2025-03-28-distribution-2513.md
+++ b/docs/website/blog/2025-03-28-distribution-2513.md
@@ -2,7 +2,7 @@
 title: Distribution `2513` is now available
 authors:
   - name: Mithril Team
-tags: [release, distribution, 2513, security-advisory]
+tags: [release, distribution, 2513]
 ---
 
 ### Distribution `2513` is now available

--- a/docs/website/blog/2025-05-05-distribution-2517.md
+++ b/docs/website/blog/2025-05-05-distribution-2517.md
@@ -1,0 +1,35 @@
+---
+title: Distribution `2517` is now available
+authors:
+  - name: Mithril Team
+tags: [release, distribution, 2517, security-advisory]
+---
+
+### Distribution `2517` is now available
+
+The [`2517.0`](https://github.com/input-output-hk/mithril/releases/tag/2517.0) distribution has been released, introducing the following changes:
+
+- ⚠️ **Breaking** changes in Mithril client CLI and library:
+  - To fast bootstrap a Cardano node, the new `--include-ancillary` option has been added to the _Cardano node database_ command in the Mithril client CLI.
+  - Without this option, only final immutable files are downloaded, and the ledger state must be computed from the genesis block when the Cardano node starts.
+  - The `--include-ancillary` option requires the usage of an **ancillary verification key** (`--ancillary-verification-key` or `ANCILLARY_VERIFICATION_KEY`) which is specified in the [Networks configuration](https://mithril.network/doc/next/manual/getting-started/network-configurations) page.
+  - Clients from distribution [`2513`] and earlier are **not compatible** with this change and **must be updated**.
+- Support for `Cardano node` `10.3.1` in the signer and the aggregator
+- Support for origin tags in Mithril client library, CLI and WASM to record the origin of client requests.
+- Bug fixes and performance improvements.
+
+This new distribution has been deployed to the **Mithril aggregator** on the `release-mainnet` and `release-preprod` networks.
+
+If you are running a **Mithril signer**:
+
+- **pre-release-preview** network: no action is required at this time
+- **release-preprod** network: upgrade your signer node binary to version `0.2.243` – no configuration updates are required
+- **release-mainnet** network: upgrade your signer node binary to version `0.2.243`– no configuration updates are required.
+
+You can update the Mithril signer using the one-line command below. It downloads to the current directory by default, but you can specify a custom folder using the -p option:
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2517.0 -p $(pwd)
+```
+
+For any inquiries or assistance, contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).


### PR DESCRIPTION
## Content

This PR includes a **dev blog post announcing the release of the [`2517`](https://github.com/input-output-hk/mithril/releases/tag/2517.0) distribution**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Add dev blog post (if relevant)

## Issue(s)
Relates to #2410
