### PR TITLE
Set correct package name for mithril-client-cli

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -106,7 +106,9 @@
           default = mithril;
           inherit mithril mithril-stm mithril-common;
           mithril-client = buildPackage ./mithril-client/Cargo.toml mithril.cargoArtifacts { cargoExtraArgs = "-p mithril-client --features full"; };
-          mithril-client-cli = buildPackage ./mithril-client-cli/Cargo.toml mithril.cargoArtifacts {};
+          mithril-client-cli = buildPackage ./mithril-client-cli/Cargo.toml mithril.cargoArtifacts {
+            pname = "mithril-client";
+          };
           mithril-aggregator = buildPackage ./mithril-aggregator/Cargo.toml mithril.cargoArtifacts {};
           mithril-signer = buildPackage ./mithril-signer/Cargo.toml mithril.cargoArtifacts {};
           mithril-persistence = buildPackage ./internal/mithril-persistence/Cargo.toml mithril.cargoArtifacts {};


### PR DESCRIPTION
Now it matches the binary name as defined in the cargo, so `nix run ...` commands work correctly.

To test this, without this change the following command fails (run in a checkout of this repo):

```
nix run .#mithril-client-cli
```

After, it succeeds :)
