### PR TITLE
Fix: Apply hot fix for client restoration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3888,7 +3888,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3922,7 +3922,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.12.0"
+version = "0.12.1"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.12.1"
+version = "0.12.2"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/cardano_database_client/download_unpack/internal_downloader.rs
+++ b/mithril-client/src/cardano_database_client/download_unpack/internal_downloader.rs
@@ -14,7 +14,7 @@ use mithril_common::messages::{
 use crate::cardano_database_client::ImmutableFileRange;
 use crate::feedback::{FeedbackSender, MithrilEvent, MithrilEventCardanoDatabase};
 use crate::file_downloader::{DownloadEvent, FileDownloader, FileDownloaderUri};
-use crate::utils::{AncillaryVerifier, VecDequeExtensions};
+use crate::utils::{create_bootstrap_node_files, AncillaryVerifier, VecDequeExtensions};
 use crate::MithrilResult;
 
 use super::download_task::{DownloadKind, DownloadTask, LocationToDownload};
@@ -85,6 +85,8 @@ impl InternalArtifactDownloader {
         }
         self.batch_download_unpack(tasks, download_unpack_options.max_parallel_downloads)
             .await?;
+
+        create_bootstrap_node_files(&self.logger, target_dir, &cardano_database_snapshot.network)?;
 
         self.feedback_sender
             .send_event(MithrilEvent::CardanoDatabase(

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -118,6 +118,8 @@ use crate::feedback::FeedbackSender;
 #[cfg(feature = "fs")]
 use crate::file_downloader::{DownloadEvent, FileDownloader};
 #[cfg(feature = "fs")]
+use crate::utils::create_bootstrap_node_files;
+#[cfg(feature = "fs")]
 use crate::utils::AncillaryVerifier;
 use crate::{MithrilResult, Snapshot, SnapshotListItem};
 
@@ -232,6 +234,11 @@ impl SnapshotClient {
                 .await?;
             self.download_unpack_ancillary(snapshot, target_dir, &download_id)
                 .await?;
+            create_bootstrap_node_files(
+                &self.logger,
+                target_dir,
+                &snapshot.network,
+            )?;
 
             Ok(())
         }
@@ -252,6 +259,11 @@ impl SnapshotClient {
             let download_id = MithrilEvent::new_snapshot_download_id();
             self.download_unpack_immutables_files(snapshot, target_dir, &download_id)
                 .await?;
+            create_bootstrap_node_files(
+                &self.logger,
+                target_dir,
+                &snapshot.network,
+            )?;
 
             Ok(())
         }

--- a/mithril-client/src/utils/bootstrap_files.rs
+++ b/mithril-client/src/utils/bootstrap_files.rs
@@ -1,0 +1,117 @@
+use std::{fs::File, io::Write, path::Path};
+
+use slog::{warn, Logger};
+
+use mithril_common::CardanoNetwork;
+
+use crate::MithrilResult;
+
+const CLEAN_FILE_NAME: &str = "clean";
+const PROTOCOL_MAGIC_ID_FILENAME: &str = "protocolMagicId";
+
+pub fn create_bootstrap_node_files(
+    logger: &Logger,
+    db_dir: &Path,
+    network: &str,
+) -> MithrilResult<()> {
+    if let Err(error) = File::create(db_dir.join(CLEAN_FILE_NAME)) {
+        warn!(
+            logger, "Could not create clean shutdown marker file in directory '{}'", db_dir.display();
+            "error" => error.to_string()
+        );
+    };
+
+    if let Ok(network) = CardanoNetwork::from_code(network.to_string(), None) {
+        let mut file = File::create(db_dir.join(PROTOCOL_MAGIC_ID_FILENAME))?;
+        file.write_all(format!("{}", network.code()).as_bytes())?;
+    };
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use mithril_common::{temp_dir, CardanoNetwork};
+    use slog::o;
+
+    use super::*;
+
+    #[test]
+    fn create_bootstrap_node_files_creates_protocol_magic_id_and_clean_files_for_mainnet() {
+        let db_dir = temp_dir!().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let network = CardanoNetwork::from_code("mainnet".to_string(), None).unwrap();
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        create_bootstrap_node_files(&logger, &db_dir, &network.to_string()).unwrap();
+
+        let file_content =
+            std::fs::read_to_string(db_dir.join(PROTOCOL_MAGIC_ID_FILENAME)).unwrap();
+        assert_eq!(file_content, network.code().to_string());
+
+        assert!(db_dir.join(CLEAN_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn create_bootstrap_node_files_creates_protocol_magic_id_and_clean_files_for_preprod() {
+        let db_dir = temp_dir!().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let network = CardanoNetwork::from_code("preprod".to_string(), None).unwrap();
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        create_bootstrap_node_files(&logger, &db_dir, &network.to_string()).unwrap();
+
+        let file_content =
+            std::fs::read_to_string(db_dir.join(PROTOCOL_MAGIC_ID_FILENAME)).unwrap();
+        assert_eq!(file_content, network.code().to_string());
+
+        assert!(db_dir.join(CLEAN_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn create_bootstrap_node_files_creates_protocol_magic_id_and_clean_files_for_preview() {
+        let db_dir = temp_dir!().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let network = CardanoNetwork::from_code("preview".to_string(), None).unwrap();
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        create_bootstrap_node_files(&logger, &db_dir, &network.to_string()).unwrap();
+
+        let file_content =
+            std::fs::read_to_string(db_dir.join(PROTOCOL_MAGIC_ID_FILENAME)).unwrap();
+        assert_eq!(file_content, network.code().to_string());
+
+        assert!(db_dir.join(CLEAN_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn create_bootstrap_node_files_creates_protocol_magic_id_and_clean_files_for_testnet() {
+        let db_dir = temp_dir!().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let network = CardanoNetwork::from_code("testnet".to_string(), None).unwrap();
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        create_bootstrap_node_files(&logger, &db_dir, &network.to_string()).unwrap();
+
+        let file_content =
+            std::fs::read_to_string(db_dir.join(PROTOCOL_MAGIC_ID_FILENAME)).unwrap();
+        assert_eq!(file_content, network.code().to_string());
+
+        assert!(db_dir.join(CLEAN_FILE_NAME).exists());
+    }
+
+    #[test]
+    fn create_bootstrap_node_files_does_not_create_protocol_magic_id_file_and_create_clean_file_for_devnet(
+    ) {
+        let db_dir = temp_dir!().join("db");
+        std::fs::create_dir_all(&db_dir).unwrap();
+        let network = CardanoNetwork::from_code("devnet".to_string(), Some(123)).unwrap();
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        create_bootstrap_node_files(&logger, &db_dir, &network.to_string()).unwrap();
+
+        assert!(!db_dir.join(PROTOCOL_MAGIC_ID_FILENAME).exists());
+
+        assert!(db_dir.join(CLEAN_FILE_NAME).exists());
+    }
+}

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -4,9 +4,11 @@
 cfg_fs! {
     mod ancillary_verifier;
     mod stream_reader;
+    mod bootstrap_files;
 
     pub use ancillary_verifier::AncillaryVerifier;
     pub use stream_reader::*;
+    pub use bootstrap_files::*;
 }
 
 cfg_fs_unstable! {


### PR DESCRIPTION
## Content

This PR includes the hotfix release in the distribution `2517.1`, adding the missing `protocolMagicId` file when restoring a snapshot.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2464 
