### PR TITLE
Fix: improve error handling in `mithril-install` script

### DIFF
--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -142,5 +142,6 @@ tar -xz -f "$ASSETS_FILE_PATH" -C "$INSTALL_PATH" "$NODE"
 chmod +x "$INSTALL_PATH/$NODE"
 rm -f "$ASSETS_FILE_PATH"
 
-VERSION=$("$INSTALL_PATH/$NODE" --version | awk '{print $NF}')
+VERSION_OUTPUT=$("$INSTALL_PATH/$NODE" --version)
+VERSION=$(echo "$VERSION_OUTPUT" | awk '{print $NF}')
 echo "Congrats! ${NODE} has been upgraded to ${VERSION} from distribution ${DISTRIBUTION} and installed at ${INSTALL_PATH}!"


### PR DESCRIPTION
## Content

This PR includes enhancements to the `mithril-install` script to ensure proper error handling when executing the downloaded binary (with `--version` argument), preventing misleading success messages.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced