### PR TITLE
chore: anticipate rust `1.87`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1007,7 +1007,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-database"
-version = "0.1.32"
+version = "0.1.33"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1020,7 +1020,7 @@ dependencies = [
 
 [[package]]
 name = "client-cardano-database-v2"
-version = "0.0.7"
+version = "0.0.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.49"
+version = "0.7.50"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-fake"
-version = "0.4.7"
+version = "0.4.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-build-script"
-version = "0.2.21"
+version = "0.2.22"
 dependencies = [
  "semver",
  "serde_json",
@@ -3850,7 +3850,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-cli-helper"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "config",
  "serde",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.4"
+version = "0.12.5"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.12.2"
+version = "0.12.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.28"
+version = "0.5.29"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-doc"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "clap",
  "config",
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.85"
+version = "0.4.86"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4031,7 +4031,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-metric"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "axum",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.52"
+version = "0.2.53"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4066,7 +4066,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.1.42"
+version = "0.1.43"
 dependencies = [
  "anyhow",
  "clap",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.246"
+version = "0.2.247"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.45"
+version = "0.3.46"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/examples/client-cardano-database-v2/Cargo.toml
+++ b/examples/client-cardano-database-v2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-database-v2"
 description = "Mithril client Cardano database example"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-database-v2/src/main.rs
+++ b/examples/client-cardano-database-v2/src/main.rs
@@ -131,7 +131,7 @@ async fn main() -> MithrilResult<()> {
         )
         .await
     {
-        println!("Could not send usage statistics to the aggregator: {:?}", e);
+        println!("Could not send usage statistics to the aggregator: {e:?}");
     }
 
     println!(

--- a/examples/client-cardano-database/Cargo.toml
+++ b/examples/client-cardano-database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "client-cardano-database"
 description = "Mithril client Cardano database example"
-version = "0.1.32"
+version = "0.1.33"
 authors = ["dev@iohk.io", "mithril-dev@iohk.io"]
 documentation = "https://mithril.network/doc"
 edition = "2021"

--- a/examples/client-cardano-database/src/main.rs
+++ b/examples/client-cardano-database/src/main.rs
@@ -89,7 +89,7 @@ async fn main() -> MithrilResult<()> {
         .await?;
 
     if let Err(e) = client.cardano_database().add_statistics(&snapshot).await {
-        println!("Could not increment snapshot download statistics: {:?}", e);
+        println!("Could not increment snapshot download statistics: {e:?}");
     }
 
     println!("Computing snapshot '{}' message ...", snapshot.digest);
@@ -234,7 +234,7 @@ impl FeedbackReceiver for IndicatifFeedbackReceiver {
                 }
                 *certificate_validation_pb = None;
             }
-            _ => panic!("Unexpected event: {:?}", event),
+            _ => panic!("Unexpected event: {event:?}"),
         }
     }
 }

--- a/internal/mithril-build-script/Cargo.toml
+++ b/internal/mithril-build-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-build-script"
-version = "0.2.21"
+version = "0.2.22"
 description = "A toolbox for Mithril crates build scripts"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-build-script/src/fake_aggregator.rs
+++ b/internal/mithril-build-script/src/fake_aggregator.rs
@@ -286,17 +286,14 @@ pub fn extract_cardano_stake_distribution_epochs(
         .map(|content| {
             let json_value: serde_json::Value =
                 serde_json::from_str(content).unwrap_or_else(|err| {
-                    panic!(
-                        "Failed to parse JSON in csd content: {}\nError: {}",
-                        content, err
-                    );
+                    panic!("Failed to parse JSON in csd content: {content}\nError: {err}");
                 });
 
             json_value
                 .get("epoch")
                 .and_then(|epoch| epoch.as_u64().map(|s| s.to_string()))
                 .unwrap_or_else(|| {
-                    panic!("Epoch not found or invalid in csd content: {}", content);
+                    panic!("Epoch not found or invalid in csd content: {content}");
                 })
         })
         .collect()
@@ -327,33 +324,30 @@ pub fn generate_artifact_getter(
             artifacts_list,
             r###"
         (
-            "{}",
-            r#"{}"#
-        ),"###,
-            artifact_id, file_content
+            "{artifact_id}",
+            r#"{file_content}"#
+        ),"###
         )
         .unwrap();
     }
 
     format!(
-        r###"pub(crate) fn {}() -> BTreeMap<String, String> {{
-    [{}
+        r###"pub(crate) fn {fun_name}() -> BTreeMap<String, String> {{
+    [{artifacts_list}
     ]
     .into_iter()
     .map(|(k, v)| (k.to_owned(), v.to_owned()))
     .collect()
-}}"###,
-        fun_name, artifacts_list
+}}"###
     )
 }
 
 /// pub(crate) fn $fun_name() -> &'static str
 pub fn generate_list_getter(fun_name: &str, source_json: FileContent) -> String {
     format!(
-        r###"pub(crate) fn {}() -> &'static str {{
-    r#"{}"#
-}}"###,
-        fun_name, source_json
+        r###"pub(crate) fn {fun_name}() -> &'static str {{
+    r#"{source_json}"#
+}}"###
     )
 }
 
@@ -365,8 +359,7 @@ pub fn generate_ids_array(array_name: &str, ids: BTreeSet<ArtifactId>) -> String
         write!(
             ids_list,
             r#"
-        "{}","#,
-            id
+        "{id}","#
         )
         .unwrap();
     }

--- a/internal/mithril-build-script/src/open_api.rs
+++ b/internal/mithril-build-script/src/open_api.rs
@@ -60,11 +60,10 @@ pub fn generate_open_api_versions_mapping(open_api_spec_files: &[PathBuf]) -> St
 /// Build Open API versions mapping
 pub fn get_open_api_versions_mapping() -> HashMap<OpenAPIFileName, semver::Version> {{
     HashMap::from([
-        {}
+        {open_api_versions_hashmap}
     ])
 }}
-        "#,
-        open_api_versions_hashmap
+        "#
     )
 }
 

--- a/internal/mithril-cli-helper/Cargo.toml
+++ b/internal/mithril-cli-helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-cli-helper"
-version = "0.0.5"
+version = "0.0.6"
 description = "An internal crate to provide tools for cli."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-cli-helper/src/source_config.rs
+++ b/internal/mithril-cli-helper/src/source_config.rs
@@ -142,7 +142,7 @@ mod tests {
             map,
             &"namespace".to_string(),
             fake.string_value,
-            |v: String| { format!("mapped_value from {}", v) }
+            |v: String| { format!("mapped_value from {v}") }
         );
 
         let expected = HashMap::from([(
@@ -200,7 +200,7 @@ mod tests {
             map,
             &"namespace".to_string(),
             fake.option_with_value,
-            |v: String| format!("mapped_value from {}", v)
+            |v: String| format!("mapped_value from {v}")
         );
         register_config_value_option!(map, &"namespace".to_string(), fake.option_none);
 

--- a/internal/mithril-doc/Cargo.toml
+++ b/internal/mithril-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-doc"
-version = "0.1.23"
+version = "0.1.24"
 description = "An internal crate to generate documentation."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-doc/src/extract_clap_info.rs
+++ b/internal/mithril-doc/src/extract_clap_info.rs
@@ -5,8 +5,8 @@ use super::{FieldDoc, StructDoc};
 /// Extract information of an command line argument.
 fn extract_arg(arg: &Arg) -> FieldDoc {
     let parameter = arg.get_id().to_string();
-    let short_option = arg.get_short().map_or("".into(), |c| format!("-{}", c));
-    let long_option = arg.get_long().map_or("".into(), |c| format!("--{}", c));
+    let short_option = arg.get_short().map_or("".into(), |c| format!("-{c}"));
+    let long_option = arg.get_long().map_or("".into(), |c| format!("--{c}"));
     let env_variable = arg.get_env().map(|s| format!("{}", s.to_string_lossy()));
     let description = arg.get_help().map_or("-".into(), StyledStr::to_string);
     let default_value = if arg.get_default_values().iter().count() == 0 {

--- a/internal/mithril-doc/src/lib.rs
+++ b/internal/mithril-doc/src/lib.rs
@@ -158,19 +158,19 @@ pub struct GenerateDocCommands {
 impl GenerateDocCommands {
     fn save_doc(&self, cmd_name: &str, doc: &str) -> Result<(), String> {
         let output = if self.output.as_str() == DEFAULT_OUTPUT_FILE_TEMPLATE {
-            format!("{}-command-line.md", cmd_name)
+            format!("{cmd_name}-command-line.md")
         } else {
             self.output.clone()
         };
 
         match File::create(&output) {
             Ok(mut buffer) => {
-                if write!(buffer, "\n{}", doc).is_err() {
-                    return Err(format!("Error writing in {}", output));
+                if write!(buffer, "\n{doc}").is_err() {
+                    return Err(format!("Error writing in {output}"));
                 }
                 println!("Documentation generated in file `{}`", &output);
             }
-            _ => return Err(format!("Could not create {}", output)),
+            _ => return Err(format!("Could not create {output}")),
         };
         Ok(())
     }
@@ -190,7 +190,7 @@ impl GenerateDocCommands {
         let cmd_name = cmd_to_document.get_name();
 
         println!("Please note: the documentation generated is not able to indicate the environment variables used by the commands.");
-        self.save_doc(cmd_name, format!("\n{}", doc).as_str())
+        self.save_doc(cmd_name, format!("\n{doc}").as_str())
     }
 }
 

--- a/internal/mithril-doc/src/markdown_formatter.rs
+++ b/internal/mithril-doc/src/markdown_formatter.rs
@@ -87,7 +87,7 @@ pub fn doc_markdown_with_config(cmd: &mut Command, configs: HashMap<String, Stru
 
             let parameters_table = doc_config_to_markdown(&command_parameters);
 
-            format!("{}\n{}", parameters_explanation, parameters_table)
+            format!("{parameters_explanation}\n{parameters_table}")
         } else {
             "".to_string()
         }
@@ -145,7 +145,7 @@ pub fn doc_markdown_with_config(cmd: &mut Command, configs: HashMap<String, Stru
         level: usize,
         parameters_explanation: &str,
     ) -> String {
-        let parent_path = parent.map(|s| format!("{} ", s)).unwrap_or_default();
+        let parent_path = parent.map(|s| format!("{s} ")).unwrap_or_default();
         let command_path = format!("{}{}", parent_path, cmd.get_name());
 
         let title = format!("{} {}\n", "#".repeat(level), command_path);
@@ -204,11 +204,11 @@ pub fn doc_config_to_markdown(struct_doc: &StructDoc) -> String {
                 },
                 config
                     .environment_variable
-                    .map_or_else(|| "-".to_string(), |x| format!("`{}`", x)),
+                    .map_or_else(|| "-".to_string(), |x| format!("`{x}`")),
                 config.description.replace('\n', "<br/>"),
                 config
                     .default_value
-                    .map(|value| format!("`{}`", value))
+                    .map(|value| format!("`{value}`"))
                     .unwrap_or("-".to_string()),
                 config
                     .example
@@ -509,7 +509,7 @@ mod tests {
 
         let mut command = MyCommand::command();
         let crate_name = format_clap_command_name_to_key(env!("CARGO_PKG_NAME"));
-        let configs = HashMap::from([(format!("{} subcommanda", crate_name), struct_doc)]);
+        let configs = HashMap::from([(format!("{crate_name} subcommanda"), struct_doc)]);
         let doc = doc_markdown_with_config(&mut command, configs);
 
         assert!(doc.contains("| `ConfigA` |"), "Generated doc: {doc}");

--- a/internal/mithril-metric/Cargo.toml
+++ b/internal/mithril-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-metric"
-version = "0.1.12"
+version = "0.1.13"
 description = "Common tools to expose metrics."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-metric/src/server.rs
+++ b/internal/mithril-metric/src/server.rs
@@ -31,7 +31,7 @@ impl IntoResponse for MetricsServerError {
     fn into_response(self) -> Response<Body> {
         match self {
             Self::Internal(e) => {
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {:?}", e)).into_response()
+                (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {e:?}")).into_response()
             }
         }
     }

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.52"
+version = "0.2.53"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/query/cardano_transaction/get_cardano_transaction.rs
+++ b/internal/mithril-persistence/src/database/query/cardano_transaction/get_cardano_transaction.rs
@@ -125,10 +125,10 @@ mod tests {
         slot_number: SlotNumber,
     ) -> CardanoTransactionRecord {
         CardanoTransactionRecord::new(
-            format!("tx-hash-{}", slot_number),
+            format!("tx-hash-{slot_number}"),
             block_number,
             slot_number,
-            format!("block-hash-{}", block_number),
+            format!("block-hash-{block_number}"),
         )
     }
 

--- a/internal/mithril-persistence/src/database/record/block_range_root.rs
+++ b/internal/mithril-persistence/src/database/record/block_range_root.rs
@@ -111,8 +111,7 @@ mod tests {
 
             assert!(
                 format!("{res:?}").contains("Invalid block range"),
-                "Expected 'Invalid block range' error, got {:?}",
-                res
+                "Expected 'Invalid block range' error, got {res:?}"
             );
         }
     }

--- a/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
+++ b/internal/mithril-persistence/src/database/repository/cardano_transaction_repository.rs
@@ -1253,7 +1253,7 @@ mod tests {
                 tx_hash,
                 block_number,
                 slot_number,
-                format!("block-hash-{}", block_number),
+                format!("block-hash-{block_number}"),
             )
         }
 

--- a/internal/mithril-persistence/src/sqlite/cleaner.rs
+++ b/internal/mithril-persistence/src/sqlite/cleaner.rs
@@ -115,7 +115,7 @@ mod tests {
         connection
             .execute(format!(
                 "INSERT INTO test (id, text) VALUES {}",
-                ids.map(|i| format!("({}, 'some text to fill the db')", i))
+                ids.map(|i| format!("({i}, 'some text to fill the db')"))
                     .collect::<Vec<String>>()
                     .join(", ")
             ))

--- a/internal/mithril-persistence/src/sqlite/mod.rs
+++ b/internal/mithril-persistence/src/sqlite/mod.rs
@@ -56,8 +56,7 @@ mod test {
 
         assert!(
             requirement.matches(&version),
-            "Sqlite version {} is lower than 3.42.0",
-            version
+            "Sqlite version {version} is lower than 3.42.0"
         )
     }
 }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.49"
+version = "0.7.50"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/benches/cardano_transactions_get.rs
+++ b/mithril-aggregator/benches/cardano_transactions_get.rs
@@ -32,10 +32,10 @@ fn generate_transactions(nb_transactions: usize) -> Vec<CardanoTransaction> {
     (0..nb_transactions)
         .map(|i| {
             CardanoTransaction::new(
-                format!("tx_hash-{}", i),
+                format!("tx_hash-{i}"),
                 BlockNumber(i as u64),
                 SlotNumber(i as u64 * 100),
-                format!("block_hash-{}", i),
+                format!("block_hash-{i}"),
             )
         })
         .collect()

--- a/mithril-aggregator/benches/cardano_transactions_import.rs
+++ b/mithril-aggregator/benches/cardano_transactions_import.rs
@@ -27,10 +27,10 @@ fn generate_transactions(nb_transactions: usize) -> Vec<CardanoTransaction> {
     (0..nb_transactions)
         .map(|i| {
             CardanoTransaction::new(
-                format!("tx_hash-{}", i),
+                format!("tx_hash-{i}"),
                 BlockNumber(i as u64),
                 SlotNumber(i as u64 + 1),
-                format!("block_hash-{}", i),
+                format!("block_hash-{i}"),
             )
         })
         .collect()

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/digest.rs
@@ -690,15 +690,13 @@ mod tests {
             let remaining_files = path_content(&digests_dir);
             assert!(
                 remaining_files.is_empty(),
-                "There should be no remaining files in digests folder, but found: {:?}",
-                remaining_files
+                "There should be no remaining files in digests folder, but found: {remaining_files:?}"
             );
 
             let remaining_files = path_content(&digests_archive_dir);
             assert!(
                 remaining_files.is_empty(),
-                "There should be no remaining files in archive folder, but found: {:?}",
-                remaining_files
+                "There should be no remaining files in archive folder, but found: {remaining_files:?}"
             );
         }
     }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/cardano_node.rs
@@ -202,8 +202,7 @@ mod tests {
         let is_activated = cardano_transactions_preloader.is_activated().await.unwrap();
         assert_eq!(
             expected_activation, is_activated,
-            "'is_activated' expected {}, but was {}",
-            expected_activation, is_activated
+            "'is_activated' expected {expected_activation}, but was {is_activated}"
         );
     }
 }

--- a/mithril-aggregator/src/http_server/routes/signer_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signer_routes.rs
@@ -535,7 +535,7 @@ mod tests {
 
         let response = request()
             .method(method)
-            .path(&format!("{base_path}/{}", asked_epoch))
+            .path(&format!("{base_path}/{asked_epoch}"))
             .reply(&setup_router(RouterState::new_with_dummy_config(Arc::new(
                 dependency_manager,
             ))))

--- a/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
+++ b/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
@@ -104,8 +104,7 @@ mod tests {
                     "invalid_transaction_hashes",
                     "Transaction hash must contain only hexadecimal characters"
                 ),
-                "Invalid hash: {}",
-                hash
+                "Invalid hash: {hash}"
             );
         }
     }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -402,10 +402,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
             .read_era_epoch_token(epoch)
             .await
             .with_context(|| {
-                format!(
-                    "EraReader can not get era epoch token for current epoch: '{}'",
-                    epoch
-                )
+                format!("EraReader can not get era epoch token for current epoch: '{epoch}'")
             })?;
 
         let current_era = token

--- a/mithril-aggregator/src/services/aggregator_client.rs
+++ b/mithril-aggregator/src/services/aggregator_client.rs
@@ -119,11 +119,11 @@ impl AggregatorClientError {
             } else if json_value.is_null() {
                 canonical_reason.to_string()
             } else {
-                format!("{}: {}", canonical_reason, json_value)
+                format!("{canonical_reason}: {json_value}")
             }
         } else {
             let response_text = response.text().await.unwrap_or_default();
-            format!("{}: {}", canonical_reason, response_text)
+            format!("{canonical_reason}: {response_text}")
         }
     }
 }

--- a/mithril-aggregator/src/services/cardano_transactions_importer.rs
+++ b/mithril-aggregator/src/services/cardano_transactions_importer.rs
@@ -266,7 +266,7 @@ mod tests {
         (*start_block_number..*(start_block_number + number_of_consecutive_block))
             .map(|block_number| {
                 ScannedBlock::new(
-                    format!("block_hash-{}", block_number),
+                    format!("block_hash-{block_number}"),
                     BlockNumber(block_number),
                     SlotNumber(block_number * 100),
                     vec![format!("tx_hash-{}", block_number)],

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -291,8 +291,7 @@ impl MithrilSignedEntityService {
             .await
             .with_context(|| {
                 format!(
-                    "Signed Entity Service can not get last signed entities with type: '{:?}'",
-                    discriminants
+                    "Signed Entity Service can not get last signed entities with type: '{discriminants:?}'"
                 )
             })
     }
@@ -1082,8 +1081,7 @@ mod tests {
         let error = join_handle.await.unwrap().unwrap_err();
         assert!(
             error.to_string().contains("CardanoImmutableFilesFull"),
-            "Error should contains CardanoImmutableFilesFull but was: {}",
-            error
+            "Error should contains CardanoImmutableFilesFull but was: {error}"
         );
 
         assert!(
@@ -1111,8 +1109,7 @@ mod tests {
         let error = join_handle.await.unwrap().unwrap_err();
         assert!(
             error.to_string().contains("CardanoImmutableFilesFull"),
-            "Error should contains CardanoImmutableFilesFull but was: {}",
-            error
+            "Error should contains CardanoImmutableFilesFull but was: {error}"
         );
 
         assert!(

--- a/mithril-aggregator/src/services/signer_registration/verifier.rs
+++ b/mithril-aggregator/src/services/signer_registration/verifier.rs
@@ -62,8 +62,7 @@ impl SignerRegistrationVerifier for MithrilSignerRegistrationVerifier {
             )
             .with_context(|| {
                 format!(
-                    "KeyRegwrapper can not register signer with party_id: '{:?}'",
-                    party_id_register
+                    "KeyRegwrapper can not register signer with party_id: '{party_id_register:?}'"
                 )
             })
             .map_err(|e| anyhow!(e))?;

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -159,7 +159,7 @@ impl CertificatesHashMigrator {
                 .await
                 .with_context(||
                     format!(
-                        "Certificates Hash Migrator can not get signed entities by certificates ids with hashes: '{:?}'", old_hashes
+                        "Certificates Hash Migrator can not get signed entities by certificates ids with hashes: '{old_hashes:?}'"
                     )
                 )?;
 

--- a/mithril-aggregator/src/tools/file_size.rs
+++ b/mithril-aggregator/src/tools/file_size.rs
@@ -45,18 +45,18 @@ pub(crate) fn compute_size(paths: Vec<PathBuf>) -> StdResult<u64> {
 pub(crate) fn compute_size_of_path(path: &Path) -> StdResult<u64> {
     if path.is_file() {
         let metadata = std::fs::metadata(path)
-            .with_context(|| format!("Failed to read metadata for file: {:?}", path))?;
+            .with_context(|| format!("Failed to read metadata for file: {path:?}"))?;
 
         return Ok(metadata.len());
     }
 
     if path.is_dir() {
         let entries = std::fs::read_dir(path)
-            .with_context(|| format!("Failed to read directory: {:?}", path))?;
+            .with_context(|| format!("Failed to read directory: {path:?}"))?;
         let mut directory_size = 0;
         for entry in entries {
             let path = entry
-                .with_context(|| format!("Failed to read directory entry in {:?}", path))?
+                .with_context(|| format!("Failed to read directory entry in {path:?}"))?
                 .path();
             directory_size += compute_size_of_path(&path)?;
         }

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -176,8 +176,7 @@ impl GenesisTools {
             .await
             .with_context(|| {
                 format!(
-                    "Genesis tool can not create certificate with genesis signature: '{:?}'",
-                    genesis_signature
+                    "Genesis tool can not create certificate with genesis signature: '{genesis_signature:?}'"
                 )
             })?;
         Ok(())

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -238,10 +238,7 @@ impl RuntimeTester {
             .create_certificate(genesis_certificate)
             .await
             .with_context(|| {
-                format!(
-                    "Runtime Tester can not create certificate with fixture: '{:?}'",
-                    fixture
-                )
+                format!("Runtime Tester can not create certificate with fixture: '{fixture:?}'")
             })?;
 
         Ok(())

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.12.2"
+version = "0.12.3"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db/download.rs
@@ -200,8 +200,7 @@ impl CardanoDbDownloadCommand {
             .await
             .with_context(|| {
                 format!(
-                    "Can not verify the certificate chain from certificate_hash: '{}'",
-                    certificate_hash
+                    "Can not verify the certificate chain from certificate_hash: '{certificate_hash}'"
                 )
             })?;
 
@@ -260,10 +259,7 @@ impl CardanoDbDownloadCommand {
         )
         .await
         .with_context(|| {
-            format!(
-                "Can not compute the cardano db message from the directory: '{:?}'",
-                db_dir
-            )
+            format!("Can not compute the cardano db message from the directory: '{db_dir:?}'")
         })?;
 
         Ok(message)

--- a/mithril-client-cli/src/commands/cardano_db_v2/download.rs
+++ b/mithril-client-cli/src/commands/cardano_db_v2/download.rs
@@ -313,8 +313,7 @@ impl CardanoDbV2DownloadCommand {
             .await
             .with_context(|| {
                 format!(
-                    "Can not verify the certificate chain from certificate_hash: '{}'",
-                    certificate_hash
+                    "Can not verify the certificate chain from certificate_hash: '{certificate_hash}'"
                 )
             })?;
 

--- a/mithril-client-cli/src/commands/cardano_db_v2/show.rs
+++ b/mithril-client-cli/src/commands/cardano_db_v2/show.rs
@@ -109,11 +109,11 @@ impl CardanoDbShowCommand {
 
 fn digest_location_iter(locations: &[DigestLocation]) -> impl Iterator<Item = String> + use<'_> {
     locations.iter().filter_map(|location| match location {
-        DigestLocation::Aggregator { uri } => Some(format!("Aggregator, uri: \"{}\"", uri)),
+        DigestLocation::Aggregator { uri } => Some(format!("Aggregator, uri: \"{uri}\"")),
         DigestLocation::CloudStorage {
             uri,
             compression_algorithm: _,
-        } => Some(format!("CloudStorage, uri: \"{}\"", uri)),
+        } => Some(format!("CloudStorage, uri: \"{uri}\"")),
         DigestLocation::Unknown => None,
     })
 }

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -130,8 +130,7 @@ impl CardanoStakeDistributionDownloadCommand {
             &filepath,
             serde_json::to_string(&cardano_stake_distribution).with_context(|| {
                 format!(
-                    "Can not serialize Cardano stake distribution artifact '{:?}'",
-                    cardano_stake_distribution
+                    "Can not serialize Cardano stake distribution artifact '{cardano_stake_distribution:?}'"
                 )
             })?,
         )?;
@@ -169,8 +168,7 @@ impl CardanoStakeDistributionDownloadCommand {
                 .await
                 .with_context(|| {
                     format!(
-                        "Can not download and verify the artifact for hash: '{}'",
-                        unique_identifier
+                        "Can not download and verify the artifact for hash: '{unique_identifier}'"
                     )
                 })?
                 .ok_or(anyhow!(
@@ -198,7 +196,7 @@ impl CardanoStakeDistributionDownloadCommand {
 
                 Epoch(
                     epoch.parse().with_context(|| {
-                        format!("Can not convert: '{}' into a valid Epoch", epoch)
+                        format!("Can not convert: '{epoch}' into a valid Epoch")
                     })?,
                 )
             };
@@ -208,10 +206,7 @@ impl CardanoStakeDistributionDownloadCommand {
                 .get_by_epoch(epoch)
                 .await
                 .with_context(|| {
-                    format!(
-                        "Can not download and verify the artifact for epoch: '{}'",
-                        epoch
-                    )
+                    format!("Can not download and verify the artifact for epoch: '{epoch}'")
                 })?
                 .ok_or(anyhow!(
                     "No Cardano stake distribution could be found for epoch: '{}'",

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
@@ -144,8 +144,7 @@ impl MithrilStakeDistributionDownloadCommand {
             &filepath,
             serde_json::to_string(&mithril_stake_distribution).with_context(|| {
                 format!(
-                    "Can not serialize stake distribution artifact '{:?}'",
-                    mithril_stake_distribution
+                    "Can not serialize stake distribution artifact '{mithril_stake_distribution:?}'"
                 )
             })?,
         )?;

--- a/mithril-client-cli/src/main.rs
+++ b/mithril-client-cli/src/main.rs
@@ -32,7 +32,7 @@ impl LogOutputType {
             LogOutputType::StdErr => Box::new(std::io::stderr()),
             LogOutputType::File(filepath) => Box::new(
                 File::create(filepath)
-                    .with_context(|| format!("Can not create output log file: {}", filepath))?,
+                    .with_context(|| format!("Can not create output log file: {filepath}"))?,
             ),
         };
 
@@ -236,9 +236,8 @@ impl ArtifactCommands {
 
     fn unstable_flag_missing_message(sub_command: &str, command_example: &str) -> String {
         format!(
-            "The \"{}\" subcommand is only accepted using the --unstable flag.\n\n\
-                ie: \"mithril-client --unstable {} {}\"",
-            sub_command, sub_command, command_example
+            "The \"{sub_command}\" subcommand is only accepted using the --unstable flag.\n\n\
+                ie: \"mithril-client --unstable {sub_command} {command_example}\""
         )
     }
 }

--- a/mithril-client-cli/src/utils/cardano_db.rs
+++ b/mithril-client-cli/src/utils/cardano_db.rs
@@ -15,7 +15,7 @@ impl CardanoDbUtils {
         match error.downcast_ref::<CardanoDbDownloadCheckerError>() {
             Some(CardanoDbDownloadCheckerError::NotEnoughSpaceForArchive { .. })
             | Some(CardanoDbDownloadCheckerError::NotEnoughSpaceForUncompressedData { .. }) => {
-                Ok(format!("Warning: {}", error))
+                Ok(format!("Warning: {error}"))
             }
             _ => Err(error),
         }
@@ -43,7 +43,7 @@ impl CardanoDbUtils {
     pub fn format_bytes_to_gigabytes(bytes: u64) -> String {
         let size_in_giga = bytes as f64 / (1024.0 * 1024.0 * 1024.0);
 
-        format!("{:.2} GiB", size_in_giga)
+        format!("{size_in_giga:.2} GiB")
     }
 }
 
@@ -78,7 +78,7 @@ mod test {
             pathdir: PathBuf::new(),
             archive_size: 2_f64,
         };
-        let expected = format!("Warning: {}", not_enough_space_error);
+        let expected = format!("Warning: {not_enough_space_error}");
 
         let result = CardanoDbUtils::check_disk_space_error(anyhow!(not_enough_space_error))
             .expect("check_disk_space_error should not error");
@@ -95,7 +95,7 @@ mod test {
                 pathdir: PathBuf::new(),
                 db_size: 2_f64,
             };
-        let expected = format!("Warning: {}", not_enough_space_error);
+        let expected = format!("Warning: {not_enough_space_error}");
 
         let result = CardanoDbUtils::check_disk_space_error(anyhow!(not_enough_space_error))
             .expect("check_disk_space_error should not error");
@@ -115,8 +115,7 @@ mod test {
                 error.downcast_ref::<CardanoDbDownloadCheckerError>(),
                 Some(CardanoDbDownloadCheckerError::UnpackDirectoryNotEmpty(_))
             ),
-            "Unexpected error: {:?}",
-            error
+            "Unexpected error: {error:?}"
         );
     }
 

--- a/mithril-client-cli/src/utils/cardano_db_download_checker.rs
+++ b/mithril-client-cli/src/utils/cardano_db_download_checker.rs
@@ -227,8 +227,7 @@ mod test {
                 error.downcast_ref::<CardanoDbDownloadCheckerError>(),
                 Some(CardanoDbDownloadCheckerError::UnpackDirectoryNotEmpty(_))
             ),
-            "Unexpected error: {:?}",
-            error
+            "Unexpected error: {error:?}"
         );
     }
 
@@ -255,8 +254,7 @@ mod test {
                     archive_size: _
                 })
             ),
-            "Unexpected error: {:?}",
-            error
+            "Unexpected error: {error:?}"
         );
     }
 
@@ -300,8 +298,7 @@ mod test {
                     }
                 )
             ),
-            "Unexpected error: {:?}",
-            error
+            "Unexpected error: {error:?}"
         );
     }
 
@@ -338,8 +335,7 @@ mod test {
                 error.downcast_ref::<CardanoDbDownloadCheckerError>(),
                 Some(CardanoDbDownloadCheckerError::UnpackDirectoryNotEmpty(_))
             ),
-            "Unexpected error: {:?}",
-            error
+            "Unexpected error: {error:?}"
         );
     }
 
@@ -385,8 +381,7 @@ mod test {
                         _
                     ))
                 ),
-                "Unexpected error: {:?}",
-                error
+                "Unexpected error: {error:?}"
             );
         }
 
@@ -410,8 +405,7 @@ mod test {
                         _
                     ))
                 ),
-                "Unexpected error: {:?}",
-                error
+                "Unexpected error: {error:?}"
             );
         }
     }

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -355,13 +355,11 @@ mod tests {
 
         assert!(
             json_string.contains(r#""seconds_left": 7.006"#),
-            "Not expected value in json output: {}",
-            json_string
+            "Not expected value in json output: {json_string}"
         );
         assert!(
             json_string.contains(r#""seconds_elapsed": 5.004"#),
-            "Not expected value in json output: {}",
-            json_string
+            "Not expected value in json output: {json_string}"
         );
     }
 
@@ -379,13 +377,11 @@ mod tests {
 
         assert!(
             json_string.contains(r#""seconds_left": 7.200"#),
-            "Not expected value in json output: {}",
-            json_string
+            "Not expected value in json output: {json_string}"
         );
         assert!(
             json_string.contains(r#""seconds_elapsed": 5.100"#),
-            "Not expected value in json output: {}",
-            json_string
+            "Not expected value in json output: {json_string}"
         );
     }
 

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.12.4"
+version = "0.12.5"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -161,7 +161,7 @@ impl AggregatorRequest {
                 "artifact/mithril-stake-distributions".to_string()
             }
             AggregatorRequest::GetSnapshot { digest } => {
-                format!("artifact/snapshot/{}", digest)
+                format!("artifact/snapshot/{digest}")
             }
             AggregatorRequest::ListSnapshots => "artifact/snapshots".to_string(),
             AggregatorRequest::IncrementSnapshotStatistic { snapshot: _ } => {
@@ -169,7 +169,7 @@ impl AggregatorRequest {
             }
             #[cfg(feature = "unstable")]
             AggregatorRequest::GetCardanoDatabaseSnapshot { hash } => {
-                format!("artifact/cardano-database/{}", hash)
+                format!("artifact/cardano-database/{hash}")
             }
             #[cfg(feature = "unstable")]
             AggregatorRequest::ListCardanoDatabaseSnapshots => {

--- a/mithril-client/src/cardano_database_client/download_unpack/internal_downloader.rs
+++ b/mithril-client/src/cardano_database_client/download_unpack/internal_downloader.rs
@@ -562,7 +562,7 @@ mod tests {
                 .await;
 
             assert!(
-                log_inspector.contains_log(&format!("WARN {}", ANCILLARIES_NOT_SIGNED_BY_MITHRIL)),
+                log_inspector.contains_log(&format!("WARN {ANCILLARIES_NOT_SIGNED_BY_MITHRIL}")),
                 "Expected log message not found, logs: {log_inspector}"
             );
         }

--- a/mithril-client/src/certificate_client/verify.rs
+++ b/mithril-client/src/certificate_client/verify.rs
@@ -124,7 +124,7 @@ impl MithrilCertificateVerifier {
             }))
         } else {
             let certificate = match certificate {
-                CertificateToVerify::Downloaded { certificate } => certificate,
+                CertificateToVerify::Downloaded { certificate } => *certificate,
                 CertificateToVerify::ToDownload { hash } => {
                     self.retriever.get_certificate_details(&hash).await?
                 }
@@ -170,7 +170,7 @@ impl MithrilCertificateVerifier {
 
 enum CertificateToVerify {
     /// The certificate is already downloaded.
-    Downloaded { certificate: Certificate },
+    Downloaded { certificate: Box<Certificate> },
     /// The certificate is not downloaded yet (since its parent was cached).
     ToDownload { hash: String },
 }
@@ -186,7 +186,9 @@ impl CertificateToVerify {
 
 impl From<Certificate> for CertificateToVerify {
     fn from(value: Certificate) -> Self {
-        Self::Downloaded { certificate: value }
+        Self::Downloaded {
+            certificate: Box::new(value),
+        }
     }
 }
 
@@ -375,7 +377,7 @@ mod tests {
                 .verify_with_cache_enabled(
                     "certificate_chain_validation_id",
                     CertificateToVerify::Downloaded {
-                        certificate: genesis_certificate.clone(),
+                        certificate: Box::new(genesis_certificate.clone()),
                     },
                 )
                 .await
@@ -411,7 +413,7 @@ mod tests {
                 .verify_with_cache_enabled(
                     "certificate_chain_validation_id",
                     CertificateToVerify::Downloaded {
-                        certificate: certificate.clone(),
+                        certificate: Box::new(certificate.clone()),
                     },
                 )
                 .await

--- a/mithril-client/src/file_downloader/http.rs
+++ b/mithril-client/src/file_downloader/http.rs
@@ -95,8 +95,7 @@ impl HttpFileDownloader {
             buffer.truncate(bytes_read);
             sender.send_async(buffer).await.with_context(|| {
                 format!(
-                    "Local file read: could not write {} bytes to stream.",
-                    bytes_read
+                    "Local file read: could not write {bytes_read} bytes to stream."
                 )
             })?;
             downloaded_bytes += bytes_read as u64;

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -691,7 +691,7 @@ mod tests {
                 .unwrap();
 
             assert!(
-                log_inspector.contains_log(&format!("WARN {}", ANCILLARIES_NOT_SIGNED_BY_MITHRIL)),
+                log_inspector.contains_log(&format!("WARN {ANCILLARIES_NOT_SIGNED_BY_MITHRIL}")),
                 "Expected log message not found, logs: {log_inspector}"
             );
         }

--- a/mithril-client/src/utils/ancillary_verifier.rs
+++ b/mithril-client/src/utils/ancillary_verifier.rs
@@ -300,7 +300,7 @@ mod tests {
         #[tokio::test]
         async fn move_only_files_in_structure_to_final_location() {
             let temp_dir = temp_dir_create!();
-            println!("temp_dir: {:?}", temp_dir);
+            println!("temp_dir: {temp_dir:?}");
             let source_dir = temp_dir.join("source");
             let target_dir = temp_dir.join("target");
             for dir in &[&source_dir.join("subdir"), &target_dir] {

--- a/mithril-client/tests/extensions/snapshot_archives.rs
+++ b/mithril-client/tests/extensions/snapshot_archives.rs
@@ -125,9 +125,9 @@ pub async fn build_ancillary_files_archive(
             "ledger/{}",
             last_ledger_file_path.file_name().unwrap().to_string_lossy()
         )),
-        PathBuf::from(IMMUTABLE_DIR).join(format!("{:05}.chunk", ancillary_immutable_number)),
-        PathBuf::from(IMMUTABLE_DIR).join(format!("{:05}.primary", ancillary_immutable_number)),
-        PathBuf::from(IMMUTABLE_DIR).join(format!("{:05}.secondary", ancillary_immutable_number)),
+        PathBuf::from(IMMUTABLE_DIR).join(format!("{ancillary_immutable_number:05}.chunk")),
+        PathBuf::from(IMMUTABLE_DIR).join(format!("{ancillary_immutable_number:05}.primary")),
+        PathBuf::from(IMMUTABLE_DIR).join(format!("{ancillary_immutable_number:05}.secondary")),
     ];
     let ancillary_manifest = build_ancillary_manifest(
         db_dir,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.28"
+version = "0.5.29"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/digesters/cardano_immutable_digester.rs
+++ b/mithril-common/src/digesters/cardano_immutable_digester.rs
@@ -776,7 +776,7 @@ mod tests {
         cache.expect_get().returning(|_| Ok(BTreeMap::new()));
         cache.expect_store().returning(|_| {
             Err(ImmutableDigesterCacheProviderError::Store(
-                ImmutableDigesterCacheStoreError::Io(io::Error::new(io::ErrorKind::Other, "error")),
+                ImmutableDigesterCacheStoreError::Io(io::Error::other("error")),
             ))
         });
         let logger = TestLogger::stdout();
@@ -807,7 +807,7 @@ mod tests {
         let mut cache = MockImmutableFileDigestCacheProvider::new();
         cache.expect_get().returning(|_| {
             Err(ImmutableDigesterCacheProviderError::Get(
-                ImmutableDigesterCacheGetError::Io(io::Error::new(io::ErrorKind::Other, "error")),
+                ImmutableDigesterCacheGetError::Io(io::Error::other("error")),
             ))
         });
         cache.expect_store().returning(|_| Ok(()));

--- a/mithril-common/src/entities/file_uri.rs
+++ b/mithril-common/src/entities/file_uri.rs
@@ -78,7 +78,7 @@ impl MultiFilesUri {
             MultiFilesUri::Template(template) => {
                 let mut file_uri = template.0.clone();
                 for (key, value) in variable {
-                    file_uri = file_uri.replace(&format!("{{{}}}", key), &value);
+                    file_uri = file_uri.replace(&format!("{{{key}}}"), &value);
                 }
 
                 FileUri(file_uri)
@@ -95,7 +95,7 @@ impl MultiFilesUri {
     ) -> FileUri {
         self.expand_to_file_uri(HashMap::from([(
             "immutable_file_number".to_string(),
-            format!("{:05}", immutable_file_number),
+            format!("{immutable_file_number:05}"),
         )]))
     }
 }

--- a/mithril-common/src/messages/cardano_transactions_proof.rs
+++ b/mithril-common/src/messages/cardano_transactions_proof.rs
@@ -205,8 +205,7 @@ mod tests {
                 error,
                 VerifyCardanoTransactionsProofsError::MalformedData(_)
             ),
-            "Expected 'MalformedData' error but got '{:?}'",
-            error
+            "Expected 'MalformedData' error but got '{error:?}'"
         );
     }
 
@@ -223,8 +222,7 @@ mod tests {
                 error,
                 VerifyCardanoTransactionsProofsError::NoCertifiedTransaction
             ),
-            "Expected 'NoCertifiedTransactions' error but got '{:?}'",
-            error
+            "Expected 'NoCertifiedTransactions' error but got '{error:?}'"
         );
     }
 
@@ -273,8 +271,7 @@ mod tests {
                 error,
                 VerifyCardanoTransactionsProofsError::InvalidSetProof { .. },
             ),
-            "Expected 'InvalidSetProof' error but got '{:?}'",
-            error
+            "Expected 'InvalidSetProof' error but got '{error:?}'"
         );
     }
 
@@ -309,8 +306,7 @@ mod tests {
                 error,
                 VerifyCardanoTransactionsProofsError::NonMatchingMerkleRoot,
             ),
-            "Expected 'NonMatchingMerkleRoot' error but got '{:?}'",
-            error
+            "Expected 'NonMatchingMerkleRoot' error but got '{error:?}'"
         );
     }
 

--- a/mithril-common/src/signable_builder/cardano_transactions.rs
+++ b/mithril-common/src/signable_builder/cardano_transactions.rs
@@ -148,7 +148,7 @@ mod tests {
         );
         signable_expected.set_message_part(
             ProtocolMessagePartKey::LatestBlockNumber,
-            format!("{}", block_number),
+            format!("{block_number}"),
         );
         assert_eq!(signable_expected, signable);
     }

--- a/mithril-common/src/test_utils/apispec.rs
+++ b/mithril-common/src/test_utils/apispec.rs
@@ -109,7 +109,7 @@ impl<'a> APISpec<'a> {
         operation_object: &Value,
     ) -> Result<&'a APISpec<'a>, String> {
         let fake_base_url = "http://0.0.0.1";
-        let url = Url::parse(&format!("{}{}", fake_base_url, path)).unwrap();
+        let url = Url::parse(&format!("{fake_base_url}{path}")).unwrap();
 
         check_query_parameter_limitations(&url, operation_object);
 
@@ -250,7 +250,7 @@ impl<'a> APISpec<'a> {
 
     /// Get spec file for era
     pub fn get_era_spec_file(era: SupportedEra) -> String {
-        format!("../openapi-{}", era)
+        format!("../openapi-{era}")
     }
 
     /// Get all spec files
@@ -261,7 +261,7 @@ impl<'a> APISpec<'a> {
     /// Get all spec files in the directory
     pub fn get_all_spec_files_from(root_path: &str) -> Vec<String> {
         let mut open_api_spec_files = Vec::new();
-        for entry in glob(&format!("{}/openapi*.yaml", root_path)).unwrap() {
+        for entry in glob(&format!("{root_path}/openapi*.yaml")).unwrap() {
             let entry_path = entry.unwrap().to_str().unwrap().to_string();
             open_api_spec_files.push(entry_path.clone());
             open_api_spec_files.push(entry_path);
@@ -307,7 +307,7 @@ impl<'a> APISpec<'a> {
         ) {
             let result = apispec.validate_conformity(example, component_definition);
             if let Err(e) = result {
-                errors.push(format!("    {}\n    Example: {}\n", e, example));
+                errors.push(format!("    {e}\n    Example: {example}\n"));
             }
         }
 
@@ -325,8 +325,7 @@ impl<'a> APISpec<'a> {
                 }
             } else {
                 errors.push(format!(
-                    "    Examples should be an array\n    Examples: {}\n",
-                    examples
+                    "    Examples should be an array\n    Examples: {examples}\n"
                 ));
             }
         }
@@ -447,9 +446,7 @@ components:
         for expected_message in expected_error_messages {
             assert!(
                 error_message.contains(expected_message),
-                "Error message: {:?}\nshould contains: {}\n",
-                errors,
-                expected_message
+                "Error message: {errors:?}\nshould contains: {expected_message}\n"
             );
         }
     }
@@ -824,7 +821,7 @@ components:
         let errors: Vec<String> = api_spec.verify_examples();
 
         let error_messages = errors.join("\n");
-        assert_eq!(0, errors.len(), "Error messages: {}", error_messages);
+        assert_eq!(0, errors.len(), "Error messages: {error_messages}");
     }
 
     #[test]

--- a/mithril-common/src/test_utils/cardano_transactions_builder.rs
+++ b/mithril-common/src/test_utils/cardano_transactions_builder.rs
@@ -139,7 +139,7 @@ impl CardanoTransactionsBuilder {
         block_number: BlockNumber,
     ) -> CardanoTransaction {
         CardanoTransaction::new(
-            format!("tx-hash-{}-{}", block_number, slot_number),
+            format!("tx-hash-{block_number}-{slot_number}"),
             block_number,
             slot_number,
             format!("block-hash-{block_number}"),

--- a/mithril-common/src/test_utils/certificate_chain_builder.rs
+++ b/mithril-common/src/test_utils/certificate_chain_builder.rs
@@ -958,7 +958,7 @@ mod test {
         let total_certificates = 5;
         let expected_signed_messages = (1..total_certificates)
             .rev()
-            .map(|i| format!("altered-msg-{}", i))
+            .map(|i| format!("altered-msg-{i}"))
             .collect::<Vec<_>>();
 
         let (certificates, _) = CertificateChainBuilder::new()

--- a/mithril-common/src/test_utils/fixture_builder.rs
+++ b/mithril-common/src/test_utils/fixture_builder.rs
@@ -156,8 +156,7 @@ impl MithrilFixtureBuilder {
             (kes_bytes, kes_verification_key)
         } else {
             println!(
-                "KES key not found in test cache, generating a new one for the seed {:?}.",
-                kes_key_seed
+                "KES key not found in test cache, generating a new one for the seed {kes_key_seed:?}."
             );
             MithrilFixtureBuilder::generate_kes_key(kes_key_seed)
         }
@@ -370,15 +369,13 @@ mod tests {
 
         assert_eq!(
             computed_keys_key, cached_kes_key,
-            "Precomputed KES keys should be:\n{}\nbut seems to be:\n{}",
-            expected_code, actual_code
+            "Precomputed KES keys should be:\n{expected_code}\nbut seems to be:\n{actual_code}"
         );
 
         let kes_key_seed = fixture.generate_cold_key_seed(precomputed_number);
         assert!(
             MithrilFixtureBuilder::cached_kes_key(kes_key_seed.as_slice()).is_none(),
-            "We checked precomputed KES keys up to {} but it seems to be more.",
-            precomputed_number
+            "We checked precomputed KES keys up to {precomputed_number} but it seems to be more."
         );
     }
 }

--- a/mithril-common/src/test_utils/memory_logger.rs
+++ b/mithril-common/src/test_utils/memory_logger.rs
@@ -113,7 +113,7 @@ impl slog::Serializer for KVSerializer {
 
         let prefix = if self.content.is_empty() { "" } else { ", " };
         write!(self.content, "{prefix}{key}={val:?}")
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, "Failed to serialize log"))?;
+            .map_err(|_| io::Error::other("Failed to serialize log"))?;
         Ok(())
     }
 }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.1.42"
+version = "0.1.43"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/tests/register_signer_signature.rs
+++ b/mithril-relay/tests/register_signer_signature.rs
@@ -121,7 +121,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     let mut signer_message_sent = RegisterSignerMessage::dummy();
     signer_message_sent.party_id = format!("{}-new", signer_message_sent.party_id);
     let response = reqwest::Client::new()
-        .post(format!("http://{}/register-signer", relay_address))
+        .post(format!("http://{relay_address}/register-signer"))
         .json(&signer_message_sent)
         .send()
         .await;
@@ -168,7 +168,7 @@ async fn should_receive_registrations_from_signers_when_subscribed_to_pubsub() {
     let mut signature_message_sent = RegisterSignatureMessage::dummy();
     signature_message_sent.party_id = format!("{}-new", signature_message_sent.party_id);
     let response = reqwest::Client::new()
-        .post(format!("http://{}/register-signatures", relay_address))
+        .post(format!("http://{relay_address}/register-signatures"))
         .json(&signature_message_sent)
         .send()
         .await;

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.246"
+version = "0.2.247"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/database/query/protocol_initializer/get_protocol_initializer.rs
+++ b/mithril-signer/src/database/query/protocol_initializer/get_protocol_initializer.rs
@@ -47,7 +47,7 @@ impl Query for GetProtocolInitializerQuery {
         let projection = Self::Entity::get_projection().expand(aliases);
         let limit = self
             .limit
-            .map_or("".to_string(), |limit| format!(" limit {}", limit));
+            .map_or("".to_string(), |limit| format!(" limit {limit}"));
         format!("select {projection} from protocol_initializer where {condition} order by rowid desc{limit}")
     }
 }

--- a/mithril-signer/src/database/record/protocol_initializer_record.rs
+++ b/mithril-signer/src/database/record/protocol_initializer_record.rs
@@ -28,8 +28,7 @@ impl SqLiteEntity for ProtocolInitializerRecord {
         let record = Self {
             protocol_initializer: serde_json::from_str(protocol).map_err(|e| {
                 HydrationError::InvalidData(format!(
-                    "Could not cast string ({}) to ProtocolInitializer. Error: '{e}'",
-                    protocol
+                    "Could not cast string ({protocol}) to ProtocolInitializer. Error: '{e}'"
                 ))
             })?,
             epoch: Epoch(epoch_int.try_into().map_err(|e| {

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -309,7 +309,7 @@ impl StateMachine {
         self.runner.update_stake_distribution(epoch)
             .await
             .map_err(|e| RuntimeError::KeepState {
-                message: format!("Could not update stake distribution in 'unregistered → registered' phase for epoch {:?}.", epoch),
+                message: format!("Could not update stake distribution in 'unregistered → registered' phase for epoch {epoch:?}."),
                 nested_error: Some(e),
             })?;
 
@@ -318,8 +318,7 @@ impl StateMachine {
             .await
             .map_err(|e| RuntimeError::KeepState {
                 message: format!(
-                    "Could not register epoch information in 'unregistered → registered' phase for epoch {:?}.",
-                    epoch
+                    "Could not register epoch information in 'unregistered → registered' phase for epoch {epoch:?}."
                 ),
                 nested_error: Some(e),
             })?;
@@ -334,9 +333,9 @@ impl StateMachine {
                 {
                     Ok(Some(SignerState::Unregistered { epoch }))
                 } else if e.downcast_ref::<ProtocolInitializerError>().is_some() {
-                    Err(RuntimeError::Critical { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {:?}.", epoch), nested_error: Some(e) })
+                    Err(RuntimeError::Critical { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {epoch:?}."), nested_error: Some(e) })
                 } else {
-                    Err(RuntimeError::KeepState { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {:?}.", epoch), nested_error: Some(e) })
+                    Err(RuntimeError::KeepState { message: format!("Could not register to aggregator in 'unregistered → registered' phase for epoch {epoch:?}."), nested_error: Some(e) })
                 }
             } else {
                 Ok(None)

--- a/mithril-signer/src/services/aggregator_client.rs
+++ b/mithril-signer/src/services/aggregator_client.rs
@@ -131,11 +131,11 @@ impl AggregatorClientError {
             } else if json_value.is_null() {
                 canonical_reason.to_string()
             } else {
-                format!("{}: {}", canonical_reason, json_value)
+                format!("{canonical_reason}: {json_value}")
             }
         } else {
             let response_text = response.text().await.unwrap_or_default();
-            format!("{}: {}", canonical_reason, response_text)
+            format!("{canonical_reason}: {response_text}")
         }
     }
 }

--- a/mithril-signer/src/services/cardano_transactions/importer/importer_with_vacuum.rs
+++ b/mithril-signer/src/services/cardano_transactions/importer/importer_with_vacuum.rs
@@ -99,7 +99,7 @@ mod tests {
             .execute(format!(
                 "INSERT INTO test (id, text) VALUES {}",
                 (0..10_000)
-                    .map(|i| format!("({}, 'some text to fill the db')", i))
+                    .map(|i| format!("({i}, 'some text to fill the db')"))
                     .collect::<Vec<String>>()
                     .join(", ")
             ))

--- a/mithril-signer/src/services/cardano_transactions/importer/service.rs
+++ b/mithril-signer/src/services/cardano_transactions/importer/service.rs
@@ -266,7 +266,7 @@ mod tests {
         (*start_block_number..*(start_block_number + number_of_consecutive_block))
             .map(|block_number| {
                 ScannedBlock::new(
-                    format!("block_hash-{}", block_number),
+                    format!("block_hash-{block_number}"),
                     BlockNumber(block_number),
                     SlotNumber(block_number * 100),
                     vec![format!("tx_hash-{}", block_number)],

--- a/mithril-signer/src/services/signature_publisher/signature_publisher_delayer.rs
+++ b/mithril-signer/src/services/signature_publisher/signature_publisher_delayer.rs
@@ -218,9 +218,7 @@ mod tests {
         let elapsed_time = start_time.elapsed();
         assert!(
             elapsed_time >= delay,
-            "Expected at least {:?} time elapsed, but got {:?}",
-            delay,
-            elapsed_time
+            "Expected at least {delay:?} time elapsed, but got {elapsed_time:?}"
         );
         assert!(
             elapsed_time < delay * 2,

--- a/mithril-signer/src/services/signature_publisher/signature_publisher_retrier.rs
+++ b/mithril-signer/src/services/signature_publisher/signature_publisher_retrier.rs
@@ -222,9 +222,7 @@ mod tests {
         let elapsed_time = start_time.elapsed();
         assert!(
             elapsed_time >= delay_between_attempts,
-            "Expected at least {:?} time elapsed, but got {:?}",
-            delay_between_attempts,
-            elapsed_time
+            "Expected at least {delay_between_attempts:?} time elapsed, but got {elapsed_time:?}"
         );
         assert!(
             elapsed_time < delay_between_attempts * 2,

--- a/mithril-signer/src/services/single_signer.rs
+++ b/mithril-signer/src/services/single_signer.rs
@@ -135,8 +135,7 @@ impl SingleSigner for MithrilSingleSigner {
             .sign(protocol_message)
             .with_context(|| {
                 format!(
-                    "Mithril Single Signer can not sign protocol_message: '{:?}'",
-                    protocol_message
+                    "Mithril Single Signer can not sign protocol_message: '{protocol_message:?}'"
                 )
             })
             .map_err(SingleSignerError::SignatureFailed)?;

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.3.45"
+version = "0.3.46"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -121,10 +121,7 @@ where
         size_sigs += sig.to_bytes().len();
     }
 
-    println!(
-        "k = {} | m = {} | nr parties = {}; {} bytes",
-        k, m, nparties, size_sigs,
-    );
+    println!("k = {k} | m = {m} | nr parties = {nparties}; {size_sigs} bytes",);
 }
 
 fn main() {

--- a/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
+++ b/mithril-test-lab/mithril-aggregator-fake/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator-fake"
-version = "0.4.7"
+version = "0.4.8"
 description = "Mithril Fake Aggregator for client testing"
 authors = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-aggregator-fake/src/application.rs
+++ b/mithril-test-lab/mithril-aggregator-fake/src/application.rs
@@ -71,7 +71,7 @@ impl Application {
             debug!("binding on {connection_string}");
             tokio::net::TcpListener::bind(&connection_string)
                 .await
-                .with_context(|| format!("Could not listen on '{}'.", connection_string))?
+                .with_context(|| format!("Could not listen on '{connection_string}'."))?
         };
 
         trace!("starting server…");

--- a/mithril-test-lab/mithril-aggregator-fake/src/error.rs
+++ b/mithril-test-lab/mithril-aggregator-fake/src/error.rs
@@ -22,7 +22,7 @@ impl IntoResponse for AppError {
             Self::Internal(e) => {
                 error!("{}", e);
 
-                (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {:?}", e)).into_response()
+                (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {e:?}")).into_response()
             }
             Self::NotFound => (StatusCode::NOT_FOUND).into_response(),
         }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.85"
+version = "0.4.86"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -424,7 +424,7 @@ impl MithrilInfrastructure {
                 .join(format!("mithril-client-aggregator-{}", aggregator.name()));
             if self.use_era_specific_work_dir {
                 let current_era = self.current_era.read().await;
-                artifacts_dir = artifacts_dir.join(format!("era.{}", current_era));
+                artifacts_dir = artifacts_dir.join(format!("era.{current_era}"));
             }
             if !artifacts_dir.exists() {
                 fs::create_dir_all(&artifacts_dir)?;

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_aggregator.rs
@@ -32,7 +32,7 @@ impl RelayAggregator {
         let args = vec!["-vvv", "aggregator"];
 
         let mut command = MithrilCommand::new("mithril-relay", work_dir, bin_dir, env, &args)?;
-        command.set_log_name(&format!("mithril-relay-aggregator-{}", name,));
+        command.set_log_name(&format!("mithril-relay-aggregator-{name}",));
 
         Ok(Self {
             name_suffix: name,

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_passive.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_passive.rs
@@ -28,7 +28,7 @@ impl RelayPassive {
         let args = vec!["-vvv", "passive"];
 
         let mut command = MithrilCommand::new("mithril-relay", work_dir, bin_dir, env, &args)?;
-        command.set_log_name(&format!("mithril-relay-passive-{}", relay_id));
+        command.set_log_name(&format!("mithril-relay-passive-{relay_id}"));
 
         Ok(Self {
             listen_port,

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_client.rs
@@ -42,7 +42,7 @@ pub async fn download_latest_snasphot(
     http_client: Arc<reqwest::Client>,
     endpoint: &str,
 ) -> StdResult<SnapshotListItemMessage> {
-    let http_request = http_client.get(format!("{}/artifact/snapshots", endpoint));
+    let http_request = http_client.get(format!("{endpoint}/artifact/snapshots"));
     let response = http_request.send().await;
     let snapshots: SnapshotListMessage = match response {
         Ok(response) => match response.status() {
@@ -68,7 +68,7 @@ pub async fn download_latest_snasphot(
     match response {
         Ok(response) => match response.status() {
             StatusCode::OK => {
-                let http_request = http_client.post(format!("{}/statistics/snapshot", endpoint));
+                let http_request = http_client.post(format!("{endpoint}/statistics/snapshot"));
                 let _ = http_request.send().await;
 
                 Ok(last_snapshot.to_owned())
@@ -92,7 +92,7 @@ pub async fn download_certificate_chain(
     endpoint: &str,
     certificate_hash: &str,
 ) -> StdResult<()> {
-    let http_request = http_client.get(format!("{}/certificate/{}", endpoint, certificate_hash));
+    let http_request = http_client.get(format!("{endpoint}/certificate/{certificate_hash}"));
     let response = http_request.send().await;
     let certificate: CertificateMessage = match response {
         Ok(response) => match response.status() {

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
@@ -155,7 +155,7 @@ pub async fn register_signatures_to_aggregator(
     for register in register_messages {
         let endpoint = aggregator.endpoint();
         let http_request = http_client
-            .post(format!("{}/register-signatures", endpoint))
+            .post(format!("{endpoint}/register-signatures"))
             .json(&register);
 
         join_set.spawn(async move {

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/wait.rs
@@ -39,10 +39,8 @@ where
                 Err(err) => Err(anyhow!("Invalid list body : {err}")),
             },
             s if s.is_server_error() => {
-                let message = format!(
-                    "Server error while waiting for the Aggregator, http code: {}",
-                    s
-                );
+                let message =
+                    format!("Server error while waiting for the Aggregator, http code: {s}");
                 warn!("{message}");
                 Err(anyhow!(message))
             }

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mithril_command.rs
@@ -148,7 +148,7 @@ impl MithrilCommand {
             ));
         }
 
-        self.print_header(name, &format!("LAST {} LINES", number_of_line));
+        self.print_header(name, &format!("LAST {number_of_line} LINES"));
 
         println!(
             "{}",
@@ -174,7 +174,7 @@ impl MithrilCommand {
             ));
         }
 
-        self.print_header(name, &format!("LAST {} ERROR(S)", number_of_error));
+        self.print_header(name, &format!("LAST {number_of_error} ERROR(S)"));
 
         println!(
             "{}",


### PR DESCRIPTION
## Content

This PR fix preemptively clippy lint added or updated with `rust 1.87`:

- [`uninlined_format_args` ](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args): use `format!("{foo}")` instead of `format!("{}", foo)`
- [`io_other_error`](https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error): use shorthand initializer for io error when applicable, ie: `io::Error::other("error")` instead of `io::Error::new(io::ErrorKind::Other, "error")`
- [`large_enum_variant`](https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant): already existed but its parameter must have changed since it was raised on a existing enum
                
## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced
