### PR TITLE
Fix: include the two latest ledger state snapshots in the ancillary archive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.51"
+version = "0.7.52"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.51"
+version = "0.7.52"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/snapshotter/interface.rs
+++ b/mithril-aggregator/src/services/snapshotter/interface.rs
@@ -17,7 +17,7 @@ pub trait Snapshotter: Sync + Send {
 
     /// Create a new snapshot of ancillary files.
     ///
-    /// Ancillary files include the last, uncompleted, immutable trio and the last ledger file.
+    /// Ancillary files include the last, uncompleted, immutable trio and the two last ledger files.
     async fn snapshot_ancillary(
         &self,
         immutable_file_number: ImmutableFileNumber,


### PR DESCRIPTION
## Content

This PR includes a fix that adds the two most recent ledger state snapshots to the ancillary archive. 
It improves the reliability of Cardano node fast bootstrap, preventing full chain replays when restarting the node.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2474 
