### PR TITLE
Test: execute full workspace tests on macOS/Windows excluding unsupported packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,11 +178,31 @@ jobs:
         include:
           - os: ubuntu-24.04
             test-args: --features full,unstable --workspace
-          # Only test client on windows & mac (since its the only binaries supported for those os for now)
+          # Exclude nodes not officially supported on Windows and macOS (only mithril-client is supported)
           - os: macos-14
-            test-args: --package mithril-client --package mithril-client-cli --features full,unstable
+            test-args: >
+              --features full,unstable --workspace
+              --exclude mithril-aggregator
+              --exclude mithril-signer
+              --exclude mithril-relay
+              --exclude mithril-client-wasm
+              --exclude mithril-aggregator-fake
+          # Windows has a larger list of exclusion because some tests are too slow (ie: mithril-stm) or can't compile (ie: mithril-common)
           - os: windows-latest
-            test-args: --package mithril-client --package mithril-client-cli --features full,unstable
+            test-args: >
+              --features full,unstable --workspace
+              --exclude mithril-aggregator
+              --exclude mithril-signer
+              --exclude mithril-relay
+              --exclude mithril-client-wasm
+              --exclude mithril-aggregator-fake
+              --exclude mithril-common
+              --exclude mithril-stm
+              --exclude mithril-metric
+              --exclude mithril-end-to-end
+              --exclude mithril-persistence
+              --exclude mithril-resource-pool
+              --exclude mithril-build-script
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Content

This PR includes updates to the `test` job in the CI. It now runs tests across the full workspace on macOS and Windows, skipping unsupported packages.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2486 