### PR TITLE
Record signatures origin in the signature processor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3769,7 +3769,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.52"
+version = "0.7.53"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.52"
+version = "0.7.53"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/misc.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/misc.rs
@@ -87,6 +87,7 @@ impl DependenciesBuilder {
             self.get_certifier_service().await?,
             stop_rx,
             self.root_logger(),
+            self.get_metrics_service().await?,
         );
 
         Ok(Arc::new(signature_processor))

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -40,6 +40,8 @@ mod handlers {
         unwrap_to_internal_server_error, MetricsService, SingleSignatureAuthenticator,
     };
 
+    const METRICS_HTTP_ORIGIN: &str = "HTTP";
+
     /// Register Signatures
     pub async fn register_signatures(
         origin_tag: Option<String>,
@@ -53,7 +55,7 @@ mod handlers {
 
         metrics_service
             .get_signature_registration_total_received_since_startup()
-            .increment(&[origin_tag.as_deref().unwrap_or_default()]);
+            .increment(&[METRICS_HTTP_ORIGIN]);
 
         let signed_entity_type = message.signed_entity_type.clone();
         let signed_message = message.signed_message.clone();
@@ -158,16 +160,14 @@ mod tests {
         let initial_counter_value = dependency_manager
             .metrics_service
             .get_signature_registration_total_received_since_startup()
-            .get(&["TEST"]);
+            .get(&["HTTP"]);
 
         request()
             .method(method)
             .path(path)
             .json(&RegisterSignatureMessage::dummy())
-            .header(MITHRIL_ORIGIN_TAG_HEADER, "TEST")
-            .reply(&setup_router(RouterState::new_with_origin_tag_white_list(
+            .reply(&setup_router(RouterState::new_with_dummy_config(
                 dependency_manager.clone(),
-                &["TEST"],
             )))
             .await;
 
@@ -176,7 +176,7 @@ mod tests {
             dependency_manager
                 .metrics_service
                 .get_signature_registration_total_received_since_startup()
-                .get(&["TEST"])
+                .get(&["HTTP"])
         );
     }
 

--- a/mithril-aggregator/src/http_server/routes/signatures_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/signatures_routes.rs
@@ -14,7 +14,6 @@ fn register_signatures(
 ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
     warp::path!("register-signatures")
         .and(warp::post())
-        .and(middlewares::with_origin_tag(router_state))
         .and(warp::body::json())
         .and(middlewares::with_logger(router_state))
         .and(middlewares::with_certifier_service(router_state))
@@ -44,7 +43,6 @@ mod handlers {
 
     /// Register Signatures
     pub async fn register_signatures(
-        origin_tag: Option<String>,
         message: RegisterSignatureMessage,
         logger: Logger,
         certifier_service: Arc<dyn CertifierService>,
@@ -122,7 +120,6 @@ mod handlers {
 mod tests {
     use anyhow::anyhow;
     use mithril_common::entities::ClientError;
-    use mithril_common::MITHRIL_ORIGIN_TAG_HEADER;
     use std::sync::Arc;
     use warp::http::{Method, StatusCode};
     use warp::test::request;

--- a/mithril-aggregator/src/metrics/service.rs
+++ b/mithril-aggregator/src/metrics/service.rs
@@ -5,7 +5,10 @@ use mithril_metric::{build_metrics_service, MetricCounterWithLabels, MetricsServ
 use mithril_metric::metric::{MetricCollector, MetricCounter};
 use prometheus::proto::{LabelPair, MetricFamily};
 
-static ORIGIN_TAG_LABEL: &str = "origin_tag";
+// Those are three differents dimensions, they use the same value to simplify usage in Grafana
+static CLIENT_ORIGIN_TAG_LABEL: &str = "origin_tag";
+static SIGNER_REGISTRATION_ORIGIN_TAG_LABEL: &str = "origin_tag";
+static SIGNER_SIGNATURE_ORIGIN_TAG_LABEL: &str = "origin_tag";
 
 build_metrics_service!(
     MetricsService,
@@ -13,77 +16,77 @@ build_metrics_service!(
     certificate_detail_total_served_since_startup:MetricCounterWithLabels(
         "certificate_detail_total_served_since_startup",
         "Number of certificate details served since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     artifact_detail_cardano_immutable_files_full_total_served_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_artifact_detail_cardano_db_total_served_since_startup",
         "Number of Cardano immutable files full artifact details served since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     cardano_immutable_files_full_total_restoration_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_cardano_db_total_restoration_since_startup",
         "Number of Cardano immutable files full restorations since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     cardano_database_immutable_files_restored_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_cardano_db_immutable_files_restored_since_startup",
         "Number of Cardano immutable files restored since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     cardano_database_ancillary_files_restored_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_cardano_db_ancillary_files_restored_since_startup",
         "Number of Cardano ancillary files restored since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     cardano_database_complete_restoration_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_cardano_db_complete_restoration_since_startup",
         "Number of complete Cardano database restoration since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     cardano_database_partial_restoration_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_cardano_db_partial_restoration_since_startup",
         "Number of partial Cardano database restoration since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     artifact_detail_cardano_database_total_served_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_artifact_detail_cardano_database_total_served_since_startup",
         "Number of Cardano database artifact details served since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     artifact_detail_mithril_stake_distribution_total_served_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_artifact_detail_mithril_stake_distribution_total_served_since_startup",
         "Number of Mithril stake distribution artifact details served since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     artifact_detail_cardano_stake_distribution_total_served_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_artifact_detail_cardano_stake_distribution_total_served_since_startup",
         "Number of Cardano stake distribution artifact details served since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     artifact_detail_cardano_transaction_total_served_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_artifact_detail_cardano_transaction_total_served_since_startup",
         "Number of Cardano transaction artifact details served since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     proof_cardano_transaction_total_proofs_served_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_proof_cardano_transaction_total_proofs_served_since_startup",
         "Number of Cardano transaction proofs served since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     proof_cardano_transaction_total_transactions_served_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_proof_cardano_transaction_total_transactions_served_since_startup",
         "Number of Cardano transaction hashes requested for proof since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[CLIENT_ORIGIN_TAG_LABEL]
     ),
     signer_registration_total_received_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_signer_registration_total_received_since_startup",
         "Number of signer registrations received since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[SIGNER_REGISTRATION_ORIGIN_TAG_LABEL]
     ),
     signature_registration_total_received_since_startup:MetricCounterWithLabels(
         "mithril_aggregator_signature_registration_total_received_since_startup",
         "Number of signature registrations received since startup on a Mithril aggregator node",
-        &[ORIGIN_TAG_LABEL]
+        &[SIGNER_SIGNATURE_ORIGIN_TAG_LABEL]
     ),
     certificate_total_produced_since_startup:MetricCounter(
         "mithril_aggregator_certificate_total_produced_since_startup",

--- a/mithril-aggregator/src/services/signature_consumer/fake.rs
+++ b/mithril-aggregator/src/services/signature_consumer/fake.rs
@@ -37,6 +37,9 @@ impl SignatureConsumer for FakeSignatureConsumer {
             }
         }
     }
+    fn get_origin_tag(&self) -> String {
+        "FAKE".to_string()
+    }
 }
 
 #[cfg(test)]

--- a/mithril-aggregator/src/services/signature_consumer/interface.rs
+++ b/mithril-aggregator/src/services/signature_consumer/interface.rs
@@ -9,4 +9,7 @@ use mithril_common::{
 pub trait SignatureConsumer: Sync + Send {
     /// Returns signatures when available
     async fn get_signatures(&self) -> StdResult<Vec<(SingleSignature, SignedEntityType)>>;
+
+    /// Returns the origin tag of the consumer (e.g. HTTP or DMQ)
+    fn get_origin_tag(&self) -> String;
 }

--- a/mithril-aggregator/src/services/signature_consumer/noop.rs
+++ b/mithril-aggregator/src/services/signature_consumer/noop.rs
@@ -19,6 +19,10 @@ impl SignatureConsumer for SignatureConsumerNoop {
     > {
         future::pending().await
     }
+
+    fn get_origin_tag(&self) -> String {
+        "NOOP".to_string()
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Content

We want to record the number of incoming signatures coming from the DMQ network. Once the DMQ is delivering enough signatures to reach the quorum, we will be able to sunset signature publication to the aggregator REST API.

- Extend the `SignatureConsumer` trait to expose the origin metric of the consumer
- increment the `get_signature_registration_total_received_since_startup` metric with the origin for every signature processed
- Modify usage of metric `signature_registration_total_received_since_startup` incremented in HTTP server when calling register-signatures with `HTTP` value instead of `origin_tag`
- remove usage of `origin_tag` header in register-signatures endpoint

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

Closes #2478 
