### PR TITLE
Fix: Simplify `TestHttpServer` `Drop` logic to prevent test flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3939,7 +3939,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.30"
+version = "0.5.31"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.30"
+version = "0.5.31"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes an update to the `Drop` implementation of `TestHttpServer`, removing the `recv_timeout` call that was previously used to wait for the server thread to signal its shutdown.

This change fixes flakiness in CI tests, likely caused by the blocking behavior of `block_on`, which can delay the server thread's shutdown signal.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced