### PR TITLE
feat: read ancillary verification key from both clap arguments and configuration files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,7 +3893,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.12.3"
+version = "0.12.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.12.3"
+version = "0.12.4"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

Read argument ancillary_verification_key from both clap arguments and configuration files by : 
- removing clap requirement
- read ancillary_verification_key from both clap and configuration files
- add custom verification step and throw error if include_ancillary is true and ancillary_verification_key is not provided

in both v1 and v2.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2491 
