### PR TITLE
feat: cleanup unexpected files in immutable folder after download

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.5"
+version = "0.12.6"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.12.5"
+version = "0.12.6"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -120,8 +120,7 @@ use crate::file_downloader::{DownloadEvent, FileDownloader};
 #[cfg(feature = "fs")]
 use crate::utils::create_bootstrap_node_files;
 #[cfg(feature = "fs")]
-use crate::utils::AncillaryVerifier;
-use crate::utils::ANCILLARIES_NOT_SIGNED_BY_MITHRIL;
+use crate::utils::{AncillaryVerifier, ANCILLARIES_NOT_SIGNED_BY_MITHRIL};
 use crate::{MithrilResult, Snapshot, SnapshotListItem};
 
 /// Error for the Snapshot client

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -1,9 +1,9 @@
 //! Utilities module
 //! This module contains tools needed mostly for the snapshot download and unpack.
 
-pub const ANCILLARIES_NOT_SIGNED_BY_MITHRIL:&str = "Ancillary verification does not use the Mithril certification: as a mitigation, IOG owned keys are used to sign these files.";
-
 cfg_fs! {
+    pub const ANCILLARIES_NOT_SIGNED_BY_MITHRIL:&str = "Ancillary verification does not use the Mithril certification: as a mitigation, IOG owned keys are used to sign these files.";
+
     mod ancillary_verifier;
     mod stream_reader;
     mod bootstrap_files;

--- a/mithril-client/src/utils/mod.rs
+++ b/mithril-client/src/utils/mod.rs
@@ -7,8 +7,10 @@ cfg_fs! {
     mod ancillary_verifier;
     mod stream_reader;
     mod bootstrap_files;
+    mod unexpected_downloaded_file_verifier;
 
     pub use ancillary_verifier::AncillaryVerifier;
+    pub(crate) use unexpected_downloaded_file_verifier::*;
     pub use stream_reader::*;
     pub use bootstrap_files::*;
 }

--- a/mithril-client/src/utils/unexpected_downloaded_file_verifier.rs
+++ b/mithril-client/src/utils/unexpected_downloaded_file_verifier.rs
@@ -9,10 +9,12 @@
 //! * Found offenders should be reported
 //!
 use std::collections::HashSet;
+use std::ffi::OsString;
 use std::ops::RangeInclusive;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
+use slog::Logger;
 
 use mithril_common::digesters::{immutable_trio_names, IMMUTABLE_DIR};
 use mithril_common::entities::ImmutableFileNumber;
@@ -24,12 +26,14 @@ const BASE_ERROR: &str = "Unexpected downloaded file check failed";
 pub struct UnexpectedDownloadedFileVerifier {
     target_cardano_db_dir: PathBuf,
     immutable_files_range_to_expect: RangeInclusive<ImmutableFileNumber>,
+    logger: Logger,
 }
 
 /// List of expected files after downloading and unpacking, yielded by `UnexpectedDownloadedFileVerifier::compute_expected_state_after_download`
 pub struct ExpectedFilesAfterDownload {
-    target_immutable_files_dir: PathBuf,
-    expected_files: HashSet<PathBuf>,
+    target_cardano_db_dir: PathBuf,
+    expected_filenames_in_immutable_dir: HashSet<OsString>,
+    logger: Logger,
 }
 
 impl UnexpectedDownloadedFileVerifier {
@@ -39,6 +43,7 @@ impl UnexpectedDownloadedFileVerifier {
         network_kind: &str,
         include_ancillary: bool,
         last_downloaded_immutable_file_number: ImmutableFileNumber,
+        logger: &Logger,
     ) -> Self {
         Self {
             target_cardano_db_dir: target_cardano_db_dir.as_ref().to_path_buf(),
@@ -47,46 +52,45 @@ impl UnexpectedDownloadedFileVerifier {
                 include_ancillary,
                 last_downloaded_immutable_file_number,
             ),
+            logger: logger.clone(),
         }
-    }
-
-    fn target_immutable_files_dir(&self) -> PathBuf {
-        self.target_cardano_db_dir.join(IMMUTABLE_DIR)
     }
 
     /// Compute the expected state of the folder after download finish
     pub async fn compute_expected_state_after_download(
         &self,
     ) -> StdResult<ExpectedFilesAfterDownload> {
-        let immutable_files_dir = self.target_immutable_files_dir();
+        let immutable_files_dir = self.target_cardano_db_dir.join(IMMUTABLE_DIR);
         let immutable_files_range_to_expect = self.immutable_files_range_to_expect.clone();
         // target databases can be quite large, avoid blocking the main thread
-        let expected_files = tokio::task::spawn_blocking(move || -> StdResult<HashSet<PathBuf>> {
-            let mut files: HashSet<PathBuf> = if immutable_files_dir.exists() {
-                std::fs::read_dir(&immutable_files_dir)
-                    .with_context(|| {
-                        format!("Failed to read directory {}", immutable_files_dir.display())
-                    })?
-                    .flat_map(|e| e.map(|e| e.path()))
-                    .collect()
-            } else {
-                HashSet::new()
-            };
+        let expected_files =
+            tokio::task::spawn_blocking(move || -> StdResult<HashSet<OsString>> {
+                let mut files: HashSet<OsString> = if immutable_files_dir.exists() {
+                    std::fs::read_dir(&immutable_files_dir)
+                        .with_context(|| {
+                            format!("Failed to read directory {}", immutable_files_dir.display())
+                        })?
+                        .flat_map(|e| e.map(|e| e.file_name()))
+                        .collect()
+                } else {
+                    HashSet::new()
+                };
 
-            // Complete the list with all rightfully downloaded immutable files
-            for immutable_file_name in
-                immutable_files_range_to_expect.flat_map(immutable_trio_names)
-            {
-                files.insert(immutable_files_dir.join(immutable_file_name));
-            }
-            Ok(files)
-        })
-        .await?
-        .with_context(|| BASE_ERROR)?;
+                // Complete the list with all rightfully downloaded immutable files
+                for immutable_file_name in
+                    immutable_files_range_to_expect.flat_map(immutable_trio_names)
+                {
+                    files.insert(OsString::from(immutable_file_name));
+                }
+                Ok(files)
+            })
+            .await?
+            .with_context(|| BASE_ERROR)?;
 
         Ok(ExpectedFilesAfterDownload {
-            target_immutable_files_dir: self.target_immutable_files_dir(),
-            expected_files,
+            target_cardano_db_dir: self.target_cardano_db_dir.clone(),
+            expected_filenames_in_immutable_dir: expected_files,
+            logger: self.logger.clone(),
         })
     }
 }
@@ -110,19 +114,25 @@ fn compute_immutable_files_range_to_expect(
 impl ExpectedFilesAfterDownload {
     /// Identify and delete unexpected files and folder
     ///
-    /// Returns the name of the deleted items
+    /// Returns the name of the deleted items relative to the target download directory and
+    /// write a warning to the logger.
     ///
     /// *Note: removed directories names are suffixed with a "/"*
-    pub async fn remove_unexpected_files(self) -> StdResult<Vec<String>> {
+    pub async fn remove_unexpected_files(self) -> StdResult<Option<Vec<String>>> {
         tokio::task::spawn_blocking(move || {
-            let unexpected_entries: Vec<_> = std::fs::read_dir(&self.target_immutable_files_dir)
-                .with_context(|| BASE_ERROR)?
-                .flatten()
-                .filter(|f| !self.expected_files.contains(&f.path().to_path_buf()))
-                .collect();
+            let unexpected_entries_in_immutable_dir: Vec<_> =
+                std::fs::read_dir(self.target_cardano_db_dir.join(IMMUTABLE_DIR))
+                    .with_context(|| BASE_ERROR)?
+                    .flatten()
+                    .filter(|entry| {
+                        !self
+                            .expected_filenames_in_immutable_dir
+                            .contains(&entry.file_name())
+                    })
+                    .collect();
             let mut removed_entries = Vec::new();
 
-            for unexpected_entry in &unexpected_entries {
+            for unexpected_entry in &unexpected_entries_in_immutable_dir {
                 let unexpected_path = unexpected_entry.path();
                 if unexpected_path.is_dir() {
                     std::fs::remove_dir_all(&unexpected_path)
@@ -135,7 +145,7 @@ impl ExpectedFilesAfterDownload {
                         .with_context(|| BASE_ERROR)?;
                     // Join a "/" to the end to make explicit that it's a directory
                     removed_entries.push(format!(
-                        "{}/",
+                        "{IMMUTABLE_DIR}/{}/",
                         unexpected_entry.file_name().to_string_lossy()
                     ));
                 } else {
@@ -147,14 +157,26 @@ impl ExpectedFilesAfterDownload {
                             )
                         })
                         .with_context(|| BASE_ERROR)?;
-                    removed_entries
-                        .push(unexpected_entry.file_name().to_string_lossy().to_string());
+                    removed_entries.push(format!(
+                        "{IMMUTABLE_DIR}/{}",
+                        unexpected_entry.file_name().to_string_lossy()
+                    ));
                 }
             }
 
-            // Sort removed entries to ensure consistent output when reporting to users
-            removed_entries.sort();
-            Ok(removed_entries)
+            if removed_entries.is_empty() {
+                Ok(None)
+            } else {
+                // Sort removed entries to ensure consistent output when reporting to users
+                removed_entries.sort();
+
+                slog::warn!(
+                    self.logger, "Unexpected files removed after downloads";
+                    "directory" => self.target_cardano_db_dir.display(),
+                    "removed_entries" => ?removed_entries
+                );
+                Ok(Some(removed_entries))
+            }
         })
         .await?
     }
@@ -166,6 +188,8 @@ mod tests {
     use std::time::Instant;
 
     use mithril_common::temp_dir_create;
+
+    use crate::test_utils::TestLogger;
 
     use super::*;
 
@@ -221,43 +245,64 @@ mod tests {
         ) {
             let temp_dir = temp_dir_create!();
             create_immutable_files_dir(&temp_dir);
-            let existing_files =
-                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 0)
-                    .compute_expected_state_after_download()
-                    .await
-                    .unwrap();
+            let existing_files = UnexpectedDownloadedFileVerifier::new(
+                &temp_dir,
+                "network",
+                false,
+                0,
+                &TestLogger::stdout(),
+            )
+            .compute_expected_state_after_download()
+            .await
+            .unwrap();
 
-            assert_eq!(existing_files.expected_files, HashSet::<PathBuf>::new());
+            assert_eq!(
+                existing_files.expected_filenames_in_immutable_dir,
+                HashSet::<OsString>::new()
+            );
         }
 
         #[tokio::test]
         async fn when_dir_empty_return_empty_if_immutable_files_dir_exist_and_range_is_empty() {
             let temp_dir = temp_dir_create!();
-            let existing_files =
-                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 0)
-                    .compute_expected_state_after_download()
-                    .await
-                    .unwrap();
+            let existing_files = UnexpectedDownloadedFileVerifier::new(
+                &temp_dir,
+                "network",
+                false,
+                0,
+                &TestLogger::stdout(),
+            )
+            .compute_expected_state_after_download()
+            .await
+            .unwrap();
 
-            assert_eq!(existing_files.expected_files, HashSet::<PathBuf>::new());
+            assert_eq!(
+                existing_files.expected_filenames_in_immutable_dir,
+                HashSet::<OsString>::new()
+            );
         }
 
         #[tokio::test]
         async fn when_immutable_files_dir_does_not_exist_return_immutables_trios_if_immutable_files_range_is_not_empty(
         ) {
             let temp_dir = temp_dir_create!();
-            let existing_files =
-                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 1)
-                    .compute_expected_state_after_download()
-                    .await
-                    .unwrap();
+            let existing_files = UnexpectedDownloadedFileVerifier::new(
+                &temp_dir,
+                "network",
+                false,
+                1,
+                &TestLogger::stdout(),
+            )
+            .compute_expected_state_after_download()
+            .await
+            .unwrap();
 
             assert_eq!(
-                existing_files.expected_files,
+                existing_files.expected_filenames_in_immutable_dir,
                 HashSet::from([
-                    temp_dir.join(IMMUTABLE_DIR).join("00001.chunk"),
-                    temp_dir.join(IMMUTABLE_DIR).join("00001.primary"),
-                    temp_dir.join(IMMUTABLE_DIR).join("00001.secondary"),
+                    OsString::from("00001.chunk"),
+                    OsString::from("00001.primary"),
+                    OsString::from("00001.secondary"),
                 ])
             );
         }
@@ -266,19 +311,24 @@ mod tests {
         async fn when_immutable_files_dir_empty_return_immutables_trios_if_immutable_files_range_is_not_empty(
         ) {
             let temp_dir = temp_dir_create!();
-            let immutable_files_dir = create_immutable_files_dir(&temp_dir);
-            let existing_files =
-                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 1)
-                    .compute_expected_state_after_download()
-                    .await
-                    .unwrap();
+            create_immutable_files_dir(&temp_dir);
+            let existing_files = UnexpectedDownloadedFileVerifier::new(
+                &temp_dir,
+                "network",
+                false,
+                1,
+                &TestLogger::stdout(),
+            )
+            .compute_expected_state_after_download()
+            .await
+            .unwrap();
 
             assert_eq!(
-                existing_files.expected_files,
+                existing_files.expected_filenames_in_immutable_dir,
                 HashSet::from([
-                    immutable_files_dir.join("00001.chunk"),
-                    immutable_files_dir.join("00001.primary"),
-                    immutable_files_dir.join("00001.secondary"),
+                    OsString::from("00001.chunk"),
+                    OsString::from("00001.primary"),
+                    OsString::from("00001.secondary"),
                 ])
             );
         }
@@ -293,19 +343,24 @@ mod tests {
             File::create(immutable_files_dir.join("file_2.txt")).unwrap();
             File::create(immutable_files_dir.join("dir_2").join("file_3.txt")).unwrap();
 
-            let existing_files =
-                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 0)
-                    .compute_expected_state_after_download()
-                    .await
-                    .unwrap();
+            let existing_files = UnexpectedDownloadedFileVerifier::new(
+                &temp_dir,
+                "network",
+                false,
+                0,
+                &TestLogger::stdout(),
+            )
+            .compute_expected_state_after_download()
+            .await
+            .unwrap();
 
             assert_eq!(
-                existing_files.expected_files,
+                existing_files.expected_filenames_in_immutable_dir,
                 HashSet::from([
-                    immutable_files_dir.join("dir_1"),
-                    immutable_files_dir.join("dir_2"),
-                    immutable_files_dir.join("file_1.txt"),
-                    immutable_files_dir.join("file_2.txt"),
+                    OsString::from("dir_1"),
+                    OsString::from("dir_2"),
+                    OsString::from("file_1.txt"),
+                    OsString::from("file_2.txt"),
                 ])
             );
         }
@@ -319,60 +374,81 @@ mod tests {
         #[tokio::test]
         async fn when_dir_empty_do_nothing_and_return_none() {
             let temp_dir = temp_dir_create!();
+            create_immutable_files_dir(&temp_dir);
+
             let existing_before = ExpectedFilesAfterDownload {
-                target_immutable_files_dir: temp_dir.clone(),
-                expected_files: HashSet::new(),
+                target_cardano_db_dir: temp_dir.clone(),
+                expected_filenames_in_immutable_dir: HashSet::new(),
+                logger: TestLogger::stdout(),
             };
 
             let removed_entries = existing_before.remove_unexpected_files().await.unwrap();
-            assert_eq!(removed_entries, Vec::<String>::new());
-            assert_dir_eq!(&temp_dir, "");
+            assert_eq!(removed_entries, None);
+            assert_dir_eq!(&temp_dir, format!("* {IMMUTABLE_DIR}/"));
         }
 
         #[tokio::test]
         async fn when_no_unexpected_file_and_folder_delete_nothing_and_return_none() {
             let temp_dir = temp_dir_create!();
-            create_dir(temp_dir.join("dir_1")).unwrap();
-            File::create(temp_dir.join("file_1.txt")).unwrap();
+            let immutable_files_dir = create_immutable_files_dir(&temp_dir);
+            create_dir(immutable_files_dir.join("dir_1")).unwrap();
+            File::create(immutable_files_dir.join("file_1.txt")).unwrap();
+
             let existing_before = ExpectedFilesAfterDownload {
-                target_immutable_files_dir: temp_dir.clone(),
-                expected_files: HashSet::from([
-                    temp_dir.join("file_1.txt"),
-                    temp_dir.join("dir_1"),
+                target_cardano_db_dir: temp_dir.clone(),
+                expected_filenames_in_immutable_dir: HashSet::from([
+                    OsString::from("file_1.txt"),
+                    OsString::from("dir_1"),
                 ]),
+                logger: TestLogger::stdout(),
             };
 
             let removed_entries = existing_before.remove_unexpected_files().await.unwrap();
-            assert_eq!(removed_entries, Vec::<String>::new());
-            assert_dir_eq!(&temp_dir, "* dir_1/\n* file_1.txt");
+            assert_eq!(removed_entries, None);
+            assert_dir_eq!(
+                &temp_dir,
+                format!(
+                    "* {IMMUTABLE_DIR}/
+                     ** dir_1/
+                     ** file_1.txt"
+                )
+            );
         }
 
         #[tokio::test]
-        async fn when_unexpected_dirs_and_files_are_downloaded_remove_them_and_return_their_filenames(
+        async fn when_unexpected_dirs_and_files_are_downloaded_remove_them_return_their_filenames_and_log_offenders(
         ) {
             let temp_dir = temp_dir_create!();
+            let immutable_files_dir = create_immutable_files_dir(&temp_dir);
+            let (logger, log_inspector) = TestLogger::memory();
             let existing_before = ExpectedFilesAfterDownload {
-                target_immutable_files_dir: temp_dir.clone(),
-                expected_files: HashSet::new(),
+                target_cardano_db_dir: temp_dir.clone(),
+                expected_filenames_in_immutable_dir: HashSet::new(),
+                logger,
             };
 
-            create_dir(temp_dir.join("dir_1")).unwrap();
-            create_dir(temp_dir.join("dir_2")).unwrap();
-            File::create(temp_dir.join("file_1.txt")).unwrap();
-            File::create(temp_dir.join("file_2.txt")).unwrap();
-            File::create(temp_dir.join("dir_2").join("file_3.txt")).unwrap();
+            create_dir(immutable_files_dir.join("dir_1")).unwrap();
+            create_dir(immutable_files_dir.join("dir_2")).unwrap();
+            File::create(immutable_files_dir.join("file_1.txt")).unwrap();
+            File::create(immutable_files_dir.join("file_2.txt")).unwrap();
+            File::create(immutable_files_dir.join("dir_2").join("file_3.txt")).unwrap();
 
             let removed_entries = existing_before.remove_unexpected_files().await.unwrap();
             assert_eq!(
                 removed_entries,
-                vec![
-                    "dir_1/".to_string(),
-                    "dir_2/".to_string(),
-                    "file_1.txt".to_string(),
-                    "file_2.txt".to_string()
-                ]
+                Some(vec![
+                    format!("{IMMUTABLE_DIR}/dir_1/"),
+                    format!("{IMMUTABLE_DIR}/dir_2/"),
+                    format!("{IMMUTABLE_DIR}/file_1.txt"),
+                    format!("{IMMUTABLE_DIR}/file_2.txt")
+                ])
             );
-            assert_dir_eq!(&temp_dir, "");
+            assert_dir_eq!(&temp_dir, format!("* {IMMUTABLE_DIR}/"));
+            assert!(
+                log_inspector
+                    .contains_log(&format!(r#"WARN Unexpected files removed after downloads; removed_entries=["{IMMUTABLE_DIR}/dir_1/", "{IMMUTABLE_DIR}/dir_2/", "{IMMUTABLE_DIR}/file_1.txt", "{IMMUTABLE_DIR}/file_2.txt"]"#)),
+                "Expected log message not found, logs: {log_inspector}"
+            );
         }
     }
 
@@ -382,7 +458,13 @@ mod tests {
     #[tokio::test]
     async fn checking_unexpected_file_against_a_large_immutable_directory() {
         let temp_dir = temp_dir_create!();
-        let verifier = UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 19999);
+        let verifier = UnexpectedDownloadedFileVerifier::new(
+            &temp_dir,
+            "network",
+            false,
+            19999,
+            &TestLogger::stdout(),
+        );
 
         let immutable_files_dir = create_immutable_files_dir(&temp_dir);
         for immutable_file_number in 0..=30000 {

--- a/mithril-client/src/utils/unexpected_downloaded_file_verifier.rs
+++ b/mithril-client/src/utils/unexpected_downloaded_file_verifier.rs
@@ -1,0 +1,355 @@
+//! Toolbox to verify if unexpected files are included when downloading and unpacking
+//! Mithril archives and delete found offenders.
+//!
+//! This reduces the ability of adversarial aggregators to leverage Mithril archives for side
+//! channel attacks.
+//!
+//! Requirements:
+//! * Existing extra files added by users should be kept
+//! * Found offenders should be reported
+//!
+use std::collections::HashSet;
+use std::ops::RangeInclusive;
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use mithril_common::digesters::immutable_trio_names;
+use mithril_common::entities::ImmutableFileNumber;
+use mithril_common::StdResult;
+
+const BASE_ERROR: &str = "Unexpected downloaded file check failed";
+
+/// Tool to check and remove unexpected files when downloading and unpacking Mithril archives
+pub struct UnexpectedDownloadedFileVerifier {
+    dir_to_check: PathBuf,
+    immutable_files_range_to_expect: RangeInclusive<ImmutableFileNumber>,
+}
+
+/// List of expected files after downloading and unpacking, yielded by `UnexpectedDownloadedFileVerifier::compute_expected_state_after_download`
+pub struct ExpectedFilesAfterDownload {
+    dir_to_check: PathBuf,
+    expected_files: HashSet<PathBuf>,
+}
+
+impl UnexpectedDownloadedFileVerifier {
+    /// `UnexpectedDownloadedFileVerifier` factory
+    pub fn new<P: AsRef<Path>>(
+        dir_to_check: P,
+        network_kind: &str,
+        include_ancillary: bool,
+        last_downloaded_immutable_file_number: ImmutableFileNumber,
+    ) -> Self {
+        Self {
+            dir_to_check: dir_to_check.as_ref().to_path_buf(),
+            immutable_files_range_to_expect: compute_immutable_files_range_to_expect(
+                network_kind,
+                include_ancillary,
+                last_downloaded_immutable_file_number,
+            ),
+        }
+    }
+
+    /// Compute the expected state of the folder after download finish
+    pub async fn compute_expected_state_after_download(
+        &self,
+    ) -> StdResult<ExpectedFilesAfterDownload> {
+        let dir_to_check = self.dir_to_check.to_path_buf();
+        let immutable_files_range_to_expect = self.immutable_files_range_to_expect.clone();
+        // target databases can be quite large, avoid blocking the main thread
+        let expected_files = tokio::task::spawn_blocking(move || -> StdResult<HashSet<PathBuf>> {
+            let mut files: HashSet<PathBuf> = std::fs::read_dir(&dir_to_check)
+                .with_context(|| format!("Failed to read directory {}", dir_to_check.display()))?
+                .flat_map(|e| e.map(|e| e.path()))
+                .collect();
+
+            // Complete the list with all rightfully downloaded immutable files
+            for immutable_file_name in
+                immutable_files_range_to_expect.flat_map(immutable_trio_names)
+            {
+                files.insert(dir_to_check.join(immutable_file_name));
+            }
+            Ok(files)
+        })
+        .await?
+        .with_context(|| BASE_ERROR)?;
+
+        Ok(ExpectedFilesAfterDownload {
+            dir_to_check: self.dir_to_check.clone(),
+            expected_files,
+        })
+    }
+}
+
+fn compute_immutable_files_range_to_expect(
+    network_kind: &str,
+    include_ancillary: bool,
+    last_downloaded_immutable_file_number: ImmutableFileNumber,
+) -> RangeInclusive<ImmutableFileNumber> {
+    let is_devnet_network = network_kind.contains("devnet");
+    let lower_bound = if is_devnet_network { 0 } else { 1 };
+    let upper_bound = if include_ancillary {
+        last_downloaded_immutable_file_number + 1
+    } else {
+        last_downloaded_immutable_file_number
+    };
+
+    lower_bound..=upper_bound
+}
+
+impl ExpectedFilesAfterDownload {
+    /// Identify and delete unexpected files and folder
+    ///
+    /// Returns the name of the deleted items
+    ///
+    /// *Note: removed directories names are suffixed with a "/"*
+    pub async fn remove_unexpected_files(self) -> StdResult<Vec<String>> {
+        tokio::task::spawn_blocking(move || {
+            let unexpected_entries: Vec<_> = std::fs::read_dir(&self.dir_to_check)
+                .with_context(|| BASE_ERROR)?
+                .flatten()
+                .filter(|f| !self.expected_files.contains(&f.path().to_path_buf()))
+                .collect();
+            let mut removed_entries = Vec::new();
+
+            for unexpected_entry in &unexpected_entries {
+                let unexpected_path = unexpected_entry.path();
+                if unexpected_path.is_dir() {
+                    std::fs::remove_dir_all(&unexpected_path)
+                        .with_context(|| {
+                            format!(
+                                "failed to remove unexpected directory `{}`",
+                                unexpected_path.display()
+                            )
+                        })
+                        .with_context(|| BASE_ERROR)?;
+                    // Join a "/" to the end to make explicit that it's a directory
+                    removed_entries.push(format!(
+                        "{}/",
+                        unexpected_entry.file_name().to_string_lossy()
+                    ));
+                } else {
+                    std::fs::remove_file(&unexpected_path)
+                        .with_context(|| {
+                            format!(
+                                "failed to remove unexpected file `{}`",
+                                unexpected_path.display()
+                            )
+                        })
+                        .with_context(|| BASE_ERROR)?;
+                    removed_entries
+                        .push(unexpected_entry.file_name().to_string_lossy().to_string());
+                }
+            }
+
+            // Sort removed entries to ensure consistent output when reporting to users
+            removed_entries.sort();
+            Ok(removed_entries)
+        })
+        .await?
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{create_dir, File};
+    use std::time::Instant;
+
+    use mithril_common::temp_dir_create;
+
+    use super::*;
+
+    fn create_immutable_trio(dir: &Path, immutable_file_number: ImmutableFileNumber) {
+        for immutable_file_name in immutable_trio_names(immutable_file_number) {
+            File::create(dir.join(immutable_file_name)).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_compute_immutable_files_range_to_expect() {
+        // Specs:
+        // - start at 1 on all networks except 0 for devnet
+        // - if ancillaries are included, the end bound must be increased by one (to take in an
+        // account the additional immutable trio downloaded with them)
+
+        // Without ancillaries, network is not devnet
+        assert_eq!(
+            compute_immutable_files_range_to_expect("network", false, 143),
+            1..=143
+        );
+
+        // Without ancillaries, network is devnet
+        assert_eq!(
+            compute_immutable_files_range_to_expect("devnet", false, 143),
+            0..=143
+        );
+
+        // With ancillaries, network is not devnet
+        assert_eq!(
+            compute_immutable_files_range_to_expect("network", true, 143),
+            1..=144
+        );
+
+        // With ancillaries, network is devnet
+        assert_eq!(
+            compute_immutable_files_range_to_expect("devnet", true, 143),
+            0..=144
+        );
+    }
+
+    mod compute_expected_state_after_download {
+        use super::*;
+
+        #[tokio::test]
+        async fn when_dir_empty_return_empty_if_immutable_files_range_is_empty() {
+            let temp_dir = temp_dir_create!();
+            let existing_files =
+                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 0)
+                    .compute_expected_state_after_download()
+                    .await
+                    .unwrap();
+
+            assert_eq!(existing_files.expected_files, HashSet::<PathBuf>::new());
+        }
+
+        #[tokio::test]
+        async fn when_dir_empty_return_immutables_trios_if_immutable_files_range_is_not_empty() {
+            let temp_dir = temp_dir_create!();
+            let existing_files =
+                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 1)
+                    .compute_expected_state_after_download()
+                    .await
+                    .unwrap();
+
+            assert_eq!(
+                existing_files.expected_files,
+                HashSet::from([
+                    temp_dir.join("00001.chunk"),
+                    temp_dir.join("00001.primary"),
+                    temp_dir.join("00001.secondary"),
+                ])
+            );
+        }
+
+        #[tokio::test]
+        async fn add_existing_files_and_dirs() {
+            let temp_dir = temp_dir_create!();
+            create_dir(temp_dir.join("dir_1")).unwrap();
+            create_dir(temp_dir.join("dir_2")).unwrap();
+            File::create(temp_dir.join("file_1.txt")).unwrap();
+            File::create(temp_dir.join("file_2.txt")).unwrap();
+            File::create(temp_dir.join("dir_2").join("file_3.txt")).unwrap();
+
+            let existing_files =
+                UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 0)
+                    .compute_expected_state_after_download()
+                    .await
+                    .unwrap();
+
+            assert_eq!(
+                existing_files.expected_files,
+                HashSet::from([
+                    temp_dir.join("dir_1"),
+                    temp_dir.join("dir_2"),
+                    temp_dir.join("file_1.txt"),
+                    temp_dir.join("file_2.txt"),
+                ])
+            );
+        }
+    }
+
+    mod removing_unexpected_files {
+        use mithril_common::assert_dir_eq;
+
+        use super::*;
+
+        #[tokio::test]
+        async fn when_dir_empty_do_nothing_and_return_none() {
+            let temp_dir = temp_dir_create!();
+            let existing_before = ExpectedFilesAfterDownload {
+                dir_to_check: temp_dir.clone(),
+                expected_files: HashSet::new(),
+            };
+
+            let removed_entries = existing_before.remove_unexpected_files().await.unwrap();
+            assert_eq!(removed_entries, Vec::<String>::new());
+            assert_dir_eq!(&temp_dir, "");
+        }
+
+        #[tokio::test]
+        async fn when_no_unexpected_file_and_folder_delete_nothing_and_return_none() {
+            let temp_dir = temp_dir_create!();
+            create_dir(temp_dir.join("dir_1")).unwrap();
+            File::create(temp_dir.join("file_1.txt")).unwrap();
+            let existing_before = ExpectedFilesAfterDownload {
+                dir_to_check: temp_dir.clone(),
+                expected_files: HashSet::from([
+                    temp_dir.join("file_1.txt"),
+                    temp_dir.join("dir_1"),
+                ]),
+            };
+
+            let removed_entries = existing_before.remove_unexpected_files().await.unwrap();
+            assert_eq!(removed_entries, Vec::<String>::new());
+            assert_dir_eq!(&temp_dir, "* dir_1/\n* file_1.txt");
+        }
+
+        #[tokio::test]
+        async fn when_unexpected_dirs_and_files_are_downloaded_remove_them_and_return_their_filenames(
+        ) {
+            let temp_dir = temp_dir_create!();
+            let existing_before = ExpectedFilesAfterDownload {
+                dir_to_check: temp_dir.clone(),
+                expected_files: HashSet::new(),
+            };
+
+            create_dir(temp_dir.join("dir_1")).unwrap();
+            create_dir(temp_dir.join("dir_2")).unwrap();
+            File::create(temp_dir.join("file_1.txt")).unwrap();
+            File::create(temp_dir.join("file_2.txt")).unwrap();
+            File::create(temp_dir.join("dir_2").join("file_3.txt")).unwrap();
+
+            let removed_entries = existing_before.remove_unexpected_files().await.unwrap();
+            assert_eq!(
+                removed_entries,
+                vec![
+                    "dir_1/".to_string(),
+                    "dir_2/".to_string(),
+                    "file_1.txt".to_string(),
+                    "file_2.txt".to_string()
+                ]
+            );
+            assert_dir_eq!(&temp_dir, "");
+        }
+    }
+
+    // Note: this test does not have assertion, it's used is to measure time taken over a large
+    // database to ensure that's doable without particular optimization.
+    #[ignore]
+    #[tokio::test]
+    async fn checking_unexpected_file_against_a_large_immutable_directory() {
+        let temp_dir = temp_dir_create!();
+        let verifier = UnexpectedDownloadedFileVerifier::new(&temp_dir, "network", false, 19999);
+
+        for immutable_file_number in 0..=30000 {
+            create_immutable_trio(&temp_dir, immutable_file_number);
+        }
+
+        let now = Instant::now();
+        let existing_files = verifier
+            .compute_expected_state_after_download()
+            .await
+            .unwrap();
+        println!(
+            "elapsed time on list_existing_file (30k files): {:?}",
+            now.elapsed()
+        );
+
+        let now = Instant::now();
+        let _removed_entries = existing_files.remove_unexpected_files().await.unwrap();
+        println!(
+            "elapsed time on remove_unexpected_files (10k files to remove): {:?}",
+            now.elapsed()
+        );
+    }
+}


### PR DESCRIPTION
## Content

This PR add a two phase tool in the `mithril-client` that:

1. compute the expected state of the immutable folder after download
2. remove any file or directory that is not in the expectation
3. report offenders in a warning log

The removal is executed even if the download fail.

### caveats

- The tool can be tricked in some specific case, i.e: download of a Range of immutable, if a downloaded immutable archive contains a immutable below the downloaded range it won't be identified
- The tool enforce the current directory structure of the Cardano node immutable directory: if the node change it's immutable naming scheme this tool will need to be adapted, else it will remove the files with the new scheme
- The reported offenders are only in a warning log, if library users don't enable the logs they won't see the message

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #2429
