### PR TITLE
fix: check of unexpected file too eager on all network except devnet

### DIFF
--- a/mithril-client/src/cardano_database_client/download_unpack/internal_downloader.rs
+++ b/mithril-client/src/cardano_database_client/download_unpack/internal_downloader.rs
@@ -75,7 +75,6 @@ impl InternalArtifactDownloader {
 
         let expected_files_after_download = UnexpectedDownloadedFileVerifier::new(
             target_dir,
-            &cardano_database_snapshot.network,
             download_unpack_options.include_ancillary,
             last_immutable_file_number,
             &self.logger,

--- a/mithril-client/src/snapshot_client.rs
+++ b/mithril-client/src/snapshot_client.rs
@@ -233,7 +233,6 @@ impl SnapshotClient {
             let include_ancillary = true;
             let expected_files_after_download = UnexpectedDownloadedFileVerifier::new(
                 target_dir,
-                &snapshot.network,
                 include_ancillary,
                 snapshot.beacon.immutable_file_number,
                 &self.logger
@@ -271,7 +270,6 @@ impl SnapshotClient {
             let include_ancillary = false;
             let expected_files_after_download = UnexpectedDownloadedFileVerifier::new(
                 target_dir,
-                &snapshot.network,
                 include_ancillary,
                 snapshot.beacon.immutable_file_number,
                 &self.logger


### PR DESCRIPTION
## Content

This PR make the unexpected download verifier to always expect immutable files starting from `0` on all network.

After checking it appears that all network starts at 0, but it was expecting the first immutable to be `1` on network that were not devnet, meaning that the first immutable files trio was removed after download, making impossible for the message verifier to compute the expected message.

Note: as this remove what was expected to be a business case, this change allow to simplify the unexpected download verifier api and code a bit.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] No new TODOs introduced

## Issue(s)
Relates to #2429
