### PR TITLE
fix(ci): temporary enforce `softprops/action-gh-release` v2.2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -643,7 +643,7 @@ jobs:
           fi
 
       - name: Update unstable release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: unstable

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -76,7 +76,7 @@ jobs:
           compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "⛔" }'
 
       - name: Create pre-release ${{ github.ref_name }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref_name }}


### PR DESCRIPTION
## Content

This PR temporary enforce `softprops/action-gh-release` v2.2.2 as latest version, v2.3, have an issue.

This allow our workflows to still run until a fix is published for the action, after that we will need to revert to version `@2`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
