### PR TITLE
client-lib/client-cli: calibrate max parallel dl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3909,7 +3909,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -3943,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.12.10"
+version = "0.12.11"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.12.10"
+version = "0.12.11"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.12.10"
+version = "0.12.11"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/cardano_database_client/download_unpack/download_unpack_options.rs
+++ b/mithril-client/src/cardano_database_client/download_unpack/download_unpack_options.rs
@@ -26,7 +26,7 @@ impl Default for DownloadUnpackOptions {
         Self {
             allow_override: false,
             include_ancillary: false,
-            max_parallel_downloads: 100,
+            max_parallel_downloads: 20,
         }
     }
 }


### PR DESCRIPTION
## Content

This PR lower the default value of `DownloadUnpackOptions.max_parallel_downloads` from `100` to `20`.

Investigation (cf: [this comment](https://github.com/input-output-hk/mithril/issues/2493#issuecomment-2959330896)) found that starting from 5, the `max_parallel_downloads` value did not really matter for download total time, as such lowering it will have no impact on those times and may lower overhead of the client-cli.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2493