### PR TITLE
Split `mithril-common` phase 2: extract Mithril ticker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,7 @@ dependencies = [
  "mithril-resource-pool",
  "mithril-signed-entity-lock",
  "mithril-signed-entity-preloader",
+ "mithril-ticker",
  "mockall",
  "paste",
  "percent-encoding",
@@ -4199,6 +4200,7 @@ dependencies = [
  "mithril-persistence",
  "mithril-signed-entity-lock",
  "mithril-signed-entity-preloader",
+ "mithril-ticker",
  "mockall",
  "prometheus-parse",
  "rand_core 0.6.4",
@@ -4241,6 +4243,13 @@ dependencies = [
 [[package]]
 name = "mithril-ticker"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "mithril-common",
+ "thiserror 2.0.12",
+ "tokio",
+]
 
 [[package]]
 name = "mithrildemo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.58"
+version = "0.7.59"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3996,7 +3996,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.35"
+version = "0.5.36"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4182,7 +4182,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.249"
+version = "0.2.250"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,6 +4239,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "mithril-ticker"
+version = "0.1.0"
+
+[[package]]
 name = "mithrildemo"
 version = "0.1.52"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "internal/mithril-metric",
     "internal/mithril-persistence",
     "internal/mithril-resource-pool",
+    "internal/mithril-ticker",
     "internal/signed-entity/mithril-signed-entity-lock",
     "internal/signed-entity/mithril-signed-entity-preloader",
     "mithril-aggregator",

--- a/README.md
+++ b/README.md
@@ -83,13 +83,23 @@ This repository consists of the following parts:
 
   - [**Mithril build script**](./internal/mithril-build-script): a toolbox for Mithril crates using a build scripts phase.
 
+  - [**Mithril cli helper**](./internal/mithril-cli-helper): **CLI** tools for **Mithril** binaries.
+
   - [**Mithril doc**](./internal/mithril-doc): an API that generates markdown documentation for a crate command lines arguments.
 
   - [**Mithril doc derive**](./internal/mithril-doc-derive): a macro implementation used by **Mithril doc**.
 
+  - [**Mithril metric**](./internal/mithril-metric): materials to expose **metrics** in the **Mithril network** nodes.
+
   - [**Mithril persistence**](./internal/mithril-persistence): the **persistence** library that is used by the **Mithril network** nodes.
 
+  - [**Mithril resource pool**](./internal/mithril-resource-pool): a **resource pool** mechanism that is used by the **Mithril network** nodes.
+
   - [**Mithril ticker**](./internal/mithril-ticker): a **ticker** mechanism that reads time information from the chain and is used by the **Mithril network** nodes.
+
+  - [**Mithril signed entity lock**](./internal/signed-entity/mithril-signed-entity-lock): a non-blocking **lock** mechanism for signed entity types, used by the **Mithril network** nodes.
+
+  - [**Mithril signed entity prealoader**](./internal/signed-entity/mithril-signed-entity-preloader): a **preload** mechanism for Cardano Transaction signed entity, used by the **Mithril network** nodes.
 
 - [**Mithril test lab**](./mithril-test-lab): the suite of tools that allow us to test and stress the **Mithril** protocol implementations.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ This repository consists of the following parts:
 
   - [**Mithril persistence**](./internal/mithril-persistence): the **persistence** library that is used by the **Mithril network** nodes.
 
+  - [**Mithril ticker**](./internal/mithril-ticker): a **ticker** mechanism that reads time information from the chain and is used by the **Mithril network** nodes.
+
 - [**Mithril test lab**](./mithril-test-lab): the suite of tools that allow us to test and stress the **Mithril** protocol implementations.
 
   - [**Mithril devnet**](./mithril-test-lab/mithril-devnet): the private **Mithril/Cardano network** used to scaffold a **Mithril network** on top of a **Cardano network**.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In a nutshell, **Mithril** can be summarized as:
 
 In other words, an adversarial participant with less than this share of the total stake will be unable to produce valid multi-signatures. :closed_lock_with_key:.
 
-The goal of the first implementation of the Mithril network protocol is to provide a way to fast bootstrap a fully operating Cardano node in less than two hours, compared to the days it used to take before.
+The goal of the first implementation of the Mithril network protocol is to provide a way to quickly bootstrap a fully operating Cardano node in less than two hours, compared to the days it used to take before.
 
 To unleash the power of Mithril and leverage new use cases, we have also implemented a framework in the Mithril network that allows the certification of multiple types of data, provided they can be computed deterministically.
 
@@ -42,9 +42,9 @@ To unleash the power of Mithril and leverage new use cases, we have also impleme
 
 ### Disclaimer
 
-By using Mithril protocol, you understand the protocol is in development and that use of the `mithril-signer`, `mithril-aggregator` and `mithril-client` on mainnet is entirely at your own risk.
+By using the Mithril protocol, you understand it is in development and that using the `mithril-signer`, `mithril-aggregator`, and `mithril-client` on mainnet is entirely at your own risk.
 
-You also acknowledge and agree to have an adequate understanding of the risks associated with use of the Mithril network and that all information and materials published, distributed or otherwise made available on mithril.network and Mithril Github Repository is available on an ‘AS IS’ and ‘AS AVAILABLE’ basis, without any representations or warranties of any kind. All implied terms are excluded to the fullest extent permitted by law. For details, see also sections 7, 8 and 9 of the [Apache 2.0 License](./LICENSE).
+You also acknowledge and agree to have an adequate understanding of the risks associated with use of the Mithril network and that all information and materials published, distributed or otherwise made available on the Mithril site and Mithril GitHub repository is available on an ‘AS IS’ and ‘AS AVAILABLE’ basis, without any representations or warranties of any kind. All implied terms are excluded to the fullest extent permitted by law. For details, see also sections 7, 8, and 9 of the [Apache 2.0 License](./LICENSE).
 
 ## :rocket: Getting started with Mithril
 
@@ -53,7 +53,7 @@ Additionally, you can find detailed instructions for running a **signer node** i
 
 If you are interested in **fast bootstrapping** of a Cardano node, please refer to [this guide](https://mithril.network/doc/manual/getting-started/bootstrap-cardano-node).
 
-Get access to tutorials, user manual, guides and plenty of documentation on our [website](https://mithril.network/doc)!
+You can access tutorials, the user manual, guides, and plenty of documentation on our [website](https://mithril.network/doc)!
 
 Mithril wiki is also available [here](https://github.com/input-output-hk/mithril/wiki).
 
@@ -63,17 +63,17 @@ This repository consists of the following parts:
 
 - [**Mithril aggregator**](./mithril-aggregator): the node of the **Mithril network** responsible for collecting individual signatures from the **Mithril signers** and aggregating them into a multi-signature. The **Mithril aggregator** uses this ability to provide certified snapshots of the **Cardano** blockchain.
 
-- [**Mithril client**](./mithril-client): this is the **client** library that can be used by developers to interact with Mithril certified data in their applications.
+- [**Mithril client**](./mithril-client): the **client** library that developers can use to interact with Mithril-certified data in their applications.
 
-- [**Mithril client CLI**](./mithril-client-cli): the CLI used for retrieving the certified artifacts produced by the **Mithril network**, eg the **Cardano** chain certified snapshots used to securely restore a **Cardano node**.
+- [**Mithril client CLI**](./mithril-client-cli): the CLI used for retrieving the certified artifacts produced by the **Mithril network**, eg, the **Cardano** chain certified snapshots used to securely restore a **Cardano node**.
 
-- [**Mithril client WASM**](./mithril-client-wasm): the WASM compatible library used for retrieving the certified artifacts produced by the **Mithril network**.
+- [**Mithril client WASM**](./mithril-client-wasm): the WASM-compatible library used for retrieving the certified artifacts produced by the **Mithril network**.
 
-- [**Mithril common**](./mithril-common): this is the **common** library that is used by the **Mithril network** nodes.
+- [**Mithril common**](./mithril-common): the **common** library used by the **Mithril network** nodes.
 
-- [**Mithril STM**](./mithril-stm): the **core** library that implements **Mithril** protocol cryptographic engine.
+- [**Mithril STM**](./mithril-stm): the **core** library that implements the **Mithril** protocol cryptographic engine.
 
-- [**Mithril explorer**](./mithril-explorer): the **explorer** website that connects to a **Mithril aggregator** and displays its **Certificate chain** and artifacts.
+- [**Mithril explorer**](./mithril-explorer): the **explorer** website that connects to a **Mithril aggregator** and displays its **certificate chain** and artifacts.
 
 - [**Mithril infrastructure**](./mithril-infra): the infrastructure used to power a **Mithril network** in the cloud.
 
@@ -81,48 +81,48 @@ This repository consists of the following parts:
 
 - [**Internal**](./internal): the shared tools and API used by **Mithril** crates.
 
-  - [**Mithril build script**](./internal/mithril-build-script): a toolbox for Mithril crates using a build scripts phase.
+  - [**Mithril build script**](./internal/mithril-build-script): a toolbox for Mithril crates that uses a build script phase.
 
   - [**Mithril cli helper**](./internal/mithril-cli-helper): **CLI** tools for **Mithril** binaries.
 
-  - [**Mithril doc**](./internal/mithril-doc): an API that generates markdown documentation for a crate command lines arguments.
+  - [**Mithril doc**](./internal/mithril-doc): an API that generates Markdown documentation for crate command line arguments.
 
   - [**Mithril doc derive**](./internal/mithril-doc-derive): a macro implementation used by **Mithril doc**.
 
-  - [**Mithril metric**](./internal/mithril-metric): materials to expose **metrics** in the **Mithril network** nodes.
+  - [**Mithril metric**](./internal/mithril-metric): materials to expose **metrics** in **Mithril network** nodes.
 
-  - [**Mithril persistence**](./internal/mithril-persistence): the **persistence** library that is used by the **Mithril network** nodes.
+  - [**Mithril persistence**](./internal/mithril-persistence): the **persistence** library that is used by **Mithril network** nodes.
 
-  - [**Mithril resource pool**](./internal/mithril-resource-pool): a **resource pool** mechanism that is used by the **Mithril network** nodes.
+  - [**Mithril resource pool**](./internal/mithril-resource-pool): a **resource pool** mechanism that is used by **Mithril network** nodes.
 
-  - [**Mithril ticker**](./internal/mithril-ticker): a **ticker** mechanism that reads time information from the chain and is used by the **Mithril network** nodes.
+  - [**Mithril ticker**](./internal/mithril-ticker): a **ticker** mechanism that reads time information from the chain and is used by **Mithril network** nodes.
 
-  - [**Mithril signed entity lock**](./internal/signed-entity/mithril-signed-entity-lock): a non-blocking **lock** mechanism for signed entity types, used by the **Mithril network** nodes.
+  - [**Mithril signed entity lock**](./internal/signed-entity/mithril-signed-entity-lock): a non-blocking **lock** mechanism for signed entity types, used by **Mithril network** nodes.
 
-  - [**Mithril signed entity prealoader**](./internal/signed-entity/mithril-signed-entity-preloader): a **preload** mechanism for Cardano Transaction signed entity, used by the **Mithril network** nodes.
+  - [**Mithril signed entity prealoader**](./internal/signed-entity/mithril-signed-entity-preloader): a **preload** mechanism for the Cardano transaction signed entity, used by **Mithril network** nodes.
 
 - [**Mithril test lab**](./mithril-test-lab): the suite of tools that allow us to test and stress the **Mithril** protocol implementations.
 
   - [**Mithril devnet**](./mithril-test-lab/mithril-devnet): the private **Mithril/Cardano network** used to scaffold a **Mithril network** on top of a **Cardano network**.
 
-  - [**Mithril end to end**](./mithril-test-lab/mithril-end-to-end): the tool used to run tests scenarios against a **Mithril devnet**.
+  - [**Mithril end to end**](./mithril-test-lab/mithril-end-to-end): the tool used to run test scenarios against a **Mithril devnet**.
 
 - [**Protocol demonstration**](./demo/protocol-demo): a simple CLI that helps understand how the **Mithril** protocol works and the role of its **protocol parameters**.
 
-- [**Examples**](./examples): out of the box working examples to get familiar with **Mithril**.
+- [**Examples**](./examples): out-of-the-box working examples to get familiar with **Mithril**.
 
 ## :bridge_at_night: Contributing
 
-The best way to contribute right now is to provide feedback. Start by giving a look at our [documentation](https://mithril.network/doc).
+The best way to contribute right now is to provide feedback. Start by looking at our [documentation](https://mithril.network/doc).
 
-Should you have any questions, ideas or issues, we would like to hear from you:
+Should you have any questions, ideas, or issues, we would like to hear from you:
 
 - #ask-mithril on the IOG [Discord server](https://discord.gg/5kaErDKDRq)
-- Create a GitHub [Discussion](https://github.com/input-output-hk/mithril/discussions)
-- Create a GitHub [Issue](https://github.com/input-output-hk/mithril/issues/new)
-- Ask on Cardano [StackExchange](https://cardano.stackexchange.com/search?q=mithril) using the `mithril` tag
+- Create a GitHub [discussion](https://github.com/input-output-hk/mithril/discussions)
+- Create a GitHub [issue](https://github.com/input-output-hk/mithril/issues/new)
+- Ask on Cardano [StackExchange](https://cardano.stackexchange.com/search?q=mithril) using the `mithril` tag.
 
-When contributing to this project and interacting with others, please follow our [Code of Conduct](./CODE-OF-CONDUCT.md) and our [Contributing Guidelines](./CONTRIBUTING.md).
+When contributing to this project and interacting with others, please follow our [code of conduct](./CODE-OF-CONDUCT.md) and our [contributing guidelines](./CONTRIBUTING.md).
 
 ## 🙏 Credits
 

--- a/internal/mithril-ticker/Cargo.toml
+++ b/internal/mithril-ticker/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mithril-ticker"
+version = "0.1.0"
+authors.workspace = true
+documentation.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[dependencies]

--- a/internal/mithril-ticker/Cargo.toml
+++ b/internal/mithril-ticker/Cargo.toml
@@ -12,3 +12,10 @@ repository.workspace = true
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+mithril-common = { path = "../../mithril-common", features = ["fs"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros"] }

--- a/internal/mithril-ticker/Makefile
+++ b/internal/mithril-ticker/Makefile
@@ -1,0 +1,19 @@
+.PHONY: all build test check doc
+
+CARGO = cargo
+
+all: test build
+
+build:
+	${CARGO} build --release
+
+test:
+	${CARGO} test
+
+check:
+	${CARGO} check --release --all-features --all-targets
+	${CARGO} clippy --release --all-features --all-targets
+	${CARGO} fmt --check
+
+doc:
+	${CARGO} doc --no-deps --open

--- a/internal/mithril-ticker/README.md
+++ b/internal/mithril-ticker/README.md
@@ -1,0 +1,4 @@
+# Mithril-ticker
+
+This crate provides a ticker mechanism that reads time information from the chain and helps create beacons
+for every message type.

--- a/internal/mithril-ticker/src/lib.rs
+++ b/internal/mithril-ticker/src/lib.rs
@@ -1,0 +1,14 @@
+pub fn add(left: u64, right: u64) -> u64 {
+    left + right
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_works() {
+        let result = add(2, 2);
+        assert_eq!(result, 4);
+    }
+}

--- a/internal/mithril-ticker/src/lib.rs
+++ b/internal/mithril-ticker/src/lib.rs
@@ -1,14 +1,7 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
-}
+#![warn(missing_docs)]
+//! Provides the [TickerService] that reads time information from the chain and helps
+//! create beacons for every message type.
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+mod ticker_service;
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
-    }
-}
+pub use ticker_service::*;

--- a/internal/mithril-ticker/src/ticker_service.rs
+++ b/internal/mithril-ticker/src/ticker_service.rs
@@ -8,10 +8,10 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use thiserror::Error;
 
-use crate::chain_observer::ChainObserver;
-use crate::digesters::ImmutableFileObserver;
-use crate::entities::{Epoch, TimePoint};
-use crate::StdResult;
+use mithril_common::chain_observer::ChainObserver;
+use mithril_common::digesters::ImmutableFileObserver;
+use mithril_common::entities::{Epoch, TimePoint};
+use mithril_common::StdResult;
 
 /// ## TickerService
 ///
@@ -104,10 +104,13 @@ impl TickerService for MithrilTickerService {
 
 #[cfg(test)]
 mod tests {
-    use crate::chain_observer::{ChainAddress, ChainObserver, ChainObserverError, TxDatum};
-    use crate::digesters::DumbImmutableFileObserver;
-    use crate::entities::{BlockNumber, ChainPoint, Epoch, SlotNumber, StakeDistribution};
     use anyhow::anyhow;
+
+    use mithril_common::chain_observer::{
+        ChainAddress, ChainObserver, ChainObserverError, TxDatum,
+    };
+    use mithril_common::digesters::DumbImmutableFileObserver;
+    use mithril_common::entities::{BlockNumber, ChainPoint, Epoch, SlotNumber, StakeDistribution};
 
     use super::*;
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.58"
+version = "0.7.59"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -33,6 +33,7 @@ mithril-persistence = { path = "../internal/mithril-persistence" }
 mithril-resource-pool = { path = "../internal/mithril-resource-pool" }
 mithril-signed-entity-lock = { path = "../internal/signed-entity/mithril-signed-entity-lock" }
 mithril-signed-entity-preloader = { path = "../internal/signed-entity/mithril-signed-entity-preloader" }
+mithril-ticker = { path = "../internal/mithril-ticker" }
 paste = "1.0.15"
 percent-encoding = "2.3.1"
 rayon = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/enablers/ticker.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/enablers/ticker.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use mithril_common::digesters::{
     DumbImmutableFileObserver, ImmutableFileObserver, ImmutableFileSystemObserver,
 };
-use mithril_common::{MithrilTickerService, TickerService};
+use mithril_ticker::{MithrilTickerService, TickerService};
 
 use crate::dependency_injection::{DependenciesBuilder, Result};
 use crate::get_dependency;

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -26,13 +26,13 @@ use mithril_common::{
     },
     era::{EraChecker, EraReader, EraReaderAdapter},
     signable_builder::{SignableBuilderService, SignableSeedBuilder, TransactionsImporter},
-    TickerService,
 };
 use mithril_persistence::{
     database::repository::CardanoTransactionRepository,
     sqlite::{SqliteConnection, SqliteConnectionPool},
 };
 use mithril_signed_entity_lock::SignedEntityTypeLock;
+use mithril_ticker::TickerService;
 
 use super::{
     DatabaseCommandDependenciesContainer, DependenciesBuilderError, EpochServiceWrapper,

--- a/mithril-aggregator/src/dependency_injection/containers/serve.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/serve.rs
@@ -12,11 +12,11 @@ use mithril_common::{
     era::{EraChecker, EraReader},
     signable_builder::SignableBuilderService,
     test_utils::MithrilFixture,
-    TickerService,
 };
 
 use mithril_persistence::store::StakeStorer;
 use mithril_signed_entity_lock::SignedEntityTypeLock;
+use mithril_ticker::TickerService;
 
 use crate::{
     database::repository::{

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -542,10 +542,11 @@ pub mod tests {
         entities::{ProtocolMessage, SignedEntityType, StakeDistribution, TimePoint},
         signable_builder::SignableBuilderService,
         test_utils::{fake_data, MithrilFixtureBuilder},
-        MithrilTickerService, StdResult,
+        StdResult,
     };
     use mithril_persistence::store::StakeStorer;
     use mithril_signed_entity_lock::SignedEntityTypeLock;
+    use mithril_ticker::MithrilTickerService;
     use mockall::predicate::eq;
     use mockall::{mock, Sequence};
     use std::path::PathBuf;

--- a/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
+++ b/mithril-aggregator/tests/test_extensions/aggregator_observer.rs
@@ -1,4 +1,6 @@
 use anyhow::{anyhow, Context};
+use std::{collections::BTreeSet, sync::Arc};
+
 use mithril_aggregator::{
     dependency_injection::{DependenciesBuilder, EpochServiceWrapper},
     entities::OpenMessage,
@@ -11,9 +13,9 @@ use mithril_common::{
     },
     messages::EpochSettingsMessage,
     signable_builder::SignedEntity,
-    StdResult, TickerService,
+    StdResult,
 };
-use std::{collections::BTreeSet, sync::Arc};
+use mithril_ticker::TickerService;
 
 // An observer that allow to inspect currently available open messages.
 pub struct AggregatorObserver {

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.35"
+version = "0.5.36"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -47,12 +47,9 @@ cfg_test_tools! {
 }
 
 cfg_fs! {
-    mod ticker_service;
     pub mod digesters;
     pub mod cardano_block_scanner;
     pub mod chain_reader;
-
-    pub use ticker_service::{TickerService, MithrilTickerService};
 }
 
 pub use entities::{CardanoNetwork, MagicId};

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -29,6 +29,7 @@ mithril-metric = { path = "../internal/mithril-metric" }
 mithril-persistence = { path = "../internal/mithril-persistence" }
 mithril-signed-entity-lock = { path = "../internal/signed-entity/mithril-signed-entity-lock" }
 mithril-signed-entity-preloader = { path = "../internal/signed-entity/mithril-signed-entity-preloader" }
+mithril-ticker = { path = "../internal/mithril-ticker" }
 rand_core = { workspace = true }
 reqwest = { workspace = true, features = [
     "default",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.249"
+version = "0.2.250"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/dependency_injection/builder.rs
+++ b/mithril-signer/src/dependency_injection/builder.rs
@@ -26,9 +26,11 @@ use mithril_common::signable_builder::{
     MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
     SignableBuilderServiceDependencies,
 };
-use mithril_common::{MithrilTickerService, StdResult, TickerService};
+use mithril_common::StdResult;
+
 use mithril_signed_entity_lock::SignedEntityTypeLock;
 use mithril_signed_entity_preloader::CardanoTransactionsPreloader;
+use mithril_ticker::{MithrilTickerService, TickerService};
 
 use mithril_persistence::database::repository::CardanoTransactionRepository;
 use mithril_persistence::database::{ApplicationNodeType, SqlMigration};

--- a/mithril-signer/src/dependency_injection/containers.rs
+++ b/mithril-signer/src/dependency_injection/containers.rs
@@ -5,11 +5,11 @@ use mithril_common::chain_observer::ChainObserver;
 use mithril_common::digesters::ImmutableDigester;
 use mithril_common::era::{EraChecker, EraReader};
 use mithril_common::signable_builder::SignableBuilderService;
-use mithril_common::TickerService;
 use mithril_signed_entity_lock::SignedEntityTypeLock;
 use mithril_signed_entity_preloader::CardanoTransactionsPreloader;
 
 use mithril_persistence::store::StakeStorer;
+use mithril_ticker::TickerService;
 use tokio::sync::RwLock;
 
 use crate::services::{

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -351,12 +351,12 @@ mod tests {
             MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
         },
         test_utils::{fake_data, MithrilFixtureBuilder},
-        MithrilTickerService, TickerService,
     };
     use mithril_signed_entity_lock::SignedEntityTypeLock;
     use mithril_signed_entity_preloader::{
         CardanoTransactionsPreloader, CardanoTransactionsPreloaderActivation,
     };
+    use mithril_ticker::{MithrilTickerService, TickerService};
 
     use crate::database::repository::{
         ProtocolInitializerRepository, SignedBeaconRepository, StakePoolStore,

--- a/mithril-signer/tests/test_extensions/certificate_handler.rs
+++ b/mithril-signer/tests/test_extensions/certificate_handler.rs
@@ -11,8 +11,8 @@ use mithril_common::{
     },
     messages::AggregatorFeaturesMessage,
     test_utils::fake_data,
-    MithrilTickerService, TickerService,
 };
+use mithril_ticker::{MithrilTickerService, TickerService};
 
 use mithril_signer::{
     entities::SignerEpochSettings,

--- a/mithril-signer/tests/test_extensions/state_machine_tester.rs
+++ b/mithril-signer/tests/test_extensions/state_machine_tester.rs
@@ -31,7 +31,7 @@ use mithril_common::{
         MithrilSignableBuilderService, MithrilStakeDistributionSignableBuilder,
         SignableBuilderServiceDependencies,
     },
-    MithrilTickerService, StdError, TickerService,
+    StdError,
 };
 use mithril_persistence::{
     database::repository::CardanoTransactionRepository, sqlite::SqliteConnectionPool,
@@ -41,6 +41,7 @@ use mithril_signed_entity_lock::SignedEntityTypeLock;
 use mithril_signed_entity_preloader::{
     CardanoTransactionsPreloader, CardanoTransactionsPreloaderActivation,
 };
+use mithril_ticker::{MithrilTickerService, TickerService};
 
 use mithril_signer::{
     database::repository::{ProtocolInitializerRepository, SignedBeaconRepository, StakePoolStore},


### PR DESCRIPTION
## Content

This PR extract the `TickerService` from `mithril-common` into a dedicated `mithril-ticker` internal crate. This allow to remove a unused dependency for `mithril-client`.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2392