### PR TITLE
fix: rename artifact on wasm test failure in `Mithril Client multi-platform test` workflow.

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -484,7 +484,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-run_id_${{ matrix.run_id }}
+          name: mithril-client-wasm-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-os_${{ matrix.os }}
           path: |
             chrome-results.html
             firefox-results.html


### PR DESCRIPTION
## Content

This PR includes the renaming of the uploaded artifact in case of a failure in the `test-mithril-client-wasm` job of the `Mithril Client multi-platform test` GitHub workflow.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
