### PR TITLE
feat: revise OpenAPI compatibility enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - `cardano_database_v2` in the `mithril-client` library is now stable
 
+- Support for loose enforcement of OpenAPI compatibility: a warning is displayed when a call to an aggregator may be incompatible.
+
 - Crates versions:
 
 | Crate | Version |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3819,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.61"
+version = "0.7.62"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3940,7 +3940,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.13"
+version = "0.12.14"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4223,7 +4223,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.2.252"
+version = "0.2.253"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4247,6 +4247,7 @@ dependencies = [
  "prometheus-parse",
  "rand_core 0.6.4",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "slog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3952,6 +3952,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "hex",
+ "http 1.3.1",
  "httpmock",
  "mithril-common",
  "mockall",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.61"
+version = "0.7.62"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/services/aggregator_client.rs
+++ b/mithril-aggregator/src/services/aggregator_client.rs
@@ -577,6 +577,11 @@ mod tests {
                 leader_aggregator_version,
             );
 
+            assert!(
+                Version::parse(leader_aggregator_version).unwrap()
+                    > Version::parse(aggregator_version).unwrap()
+            );
+
             client.warn_if_api_version_mismatch(&response);
 
             assert_api_version_warning_logged(
@@ -613,6 +618,11 @@ mod tests {
             let response = build_fake_response_with_header(
                 MITHRIL_API_VERSION_HEADER,
                 leader_aggregator_version,
+            );
+
+            assert!(
+                Version::parse(leader_aggregator_version).unwrap()
+                    < Version::parse(aggregator_version).unwrap()
             );
 
             client.warn_if_api_version_mismatch(&response);
@@ -676,6 +686,11 @@ mod tests {
                     .body(json!(epoch_settings_expected).to_string())
                     .header(MITHRIL_API_VERSION_HEADER, leader_aggregator_version);
             });
+
+            assert!(
+                Version::parse(leader_aggregator_version).unwrap()
+                    > Version::parse(aggregator_version).unwrap()
+            );
 
             client.retrieve_epoch_settings().await.unwrap();
 

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -88,6 +88,7 @@ uuid = { version = "1.17.0", features = ["v4", "js"] }
 [dev-dependencies]
 bon = "3.6.3"
 hex = { workspace = true }
+http = "1.3.1"
 httpmock = "0.7.0"
 mithril-common = { path = "../mithril-common", version = "=0.5", default-features = false, features = [
     "test_tools",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.12.13"
+version = "0.12.14"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/aggregator_client.rs
+++ b/mithril-client/src/aggregator_client.rs
@@ -925,6 +925,11 @@ mod tests {
             let response =
                 build_fake_response_with_header(MITHRIL_API_VERSION_HEADER, aggregator_version);
 
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(client_version).unwrap()
+            );
+
             client.warn_if_api_version_mismatch(&response).await;
 
             assert_api_version_warning_logged(&log_inspector, aggregator_version, client_version);
@@ -960,6 +965,11 @@ mod tests {
             client.logger = logger;
             let response =
                 build_fake_response_with_header(MITHRIL_API_VERSION_HEADER, aggregator_version);
+
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    < Version::parse(client_version).unwrap()
+            );
 
             client.warn_if_api_version_mismatch(&response).await;
 
@@ -1026,6 +1036,11 @@ mod tests {
                     .header(MITHRIL_API_VERSION_HEADER, aggregator_version);
             });
 
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(client_version).unwrap()
+            );
+
             client
                 .get(Url::parse(&server.base_url()).unwrap())
                 .await
@@ -1047,6 +1062,11 @@ mod tests {
                 then.status(StatusCode::OK.as_u16())
                     .header(MITHRIL_API_VERSION_HEADER, aggregator_version);
             });
+
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(client_version).unwrap()
+            );
 
             client
                 .post(Url::parse(&server.base_url()).unwrap(), "whatever")

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.2.252"
+version = "0.2.253"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -41,6 +41,7 @@ reqwest = { workspace = true, features = [
     "deflate",
     "brotli"
 ] }
+semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true, features = [

--- a/mithril-signer/src/services/aggregator_client.rs
+++ b/mithril-signer/src/services/aggregator_client.rs
@@ -1126,6 +1126,11 @@ mod tests {
             let response =
                 build_fake_response_with_header(MITHRIL_API_VERSION_HEADER, aggregator_version);
 
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(signer_version).unwrap()
+            );
+
             client.warn_if_api_version_mismatch(&response);
 
             assert_api_version_warning_logged(&log_inspector, aggregator_version, signer_version);
@@ -1157,6 +1162,11 @@ mod tests {
             client.logger = logger;
             let response =
                 build_fake_response_with_header(MITHRIL_API_VERSION_HEADER, aggregator_version);
+
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    < Version::parse(signer_version).unwrap()
+            );
 
             client.warn_if_api_version_mismatch(&response);
 
@@ -1221,6 +1231,11 @@ mod tests {
                     .body(json!(message_expected).to_string());
             });
 
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(signer_version).unwrap()
+            );
+
             client.retrieve_aggregator_features().await.unwrap();
 
             assert_api_version_warning_logged(&log_inspector, aggregator_version, signer_version);
@@ -1243,6 +1258,11 @@ mod tests {
                     .header(MITHRIL_API_VERSION_HEADER, aggregator_version)
                     .body(json!(epoch_settings_expected).to_string());
             });
+
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(signer_version).unwrap()
+            );
 
             client.retrieve_epoch_settings().await.unwrap();
 
@@ -1267,6 +1287,11 @@ mod tests {
                     .header(MITHRIL_API_VERSION_HEADER, aggregator_version);
             });
 
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(signer_version).unwrap()
+            );
+
             client.register_signer(epoch, single_signer).await.unwrap();
 
             assert_api_version_warning_logged(&log_inspector, aggregator_version, signer_version);
@@ -1287,6 +1312,11 @@ mod tests {
                 then.status(201)
                     .header(MITHRIL_API_VERSION_HEADER, aggregator_version);
             });
+
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(signer_version).unwrap()
+            );
 
             client
                 .register_signature(
@@ -1315,6 +1345,11 @@ mod tests {
                 then.status(202)
                     .header(MITHRIL_API_VERSION_HEADER, aggregator_version);
             });
+
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(signer_version).unwrap()
+            );
 
             client
                 .register_signature(
@@ -1350,6 +1385,11 @@ mod tests {
                     )
                     .header(MITHRIL_API_VERSION_HEADER, aggregator_version);
             });
+
+            assert!(
+                Version::parse(aggregator_version).unwrap()
+                    > Version::parse(signer_version).unwrap()
+            );
 
             client
                 .register_signature(

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -39,8 +39,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AggregatorFeaturesMessage"
-        "412":
-          description: API version mismatch
         default:
           description: root error
           content:
@@ -73,8 +71,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AggregatorStatusMessage"
-        "412":
-          description: API version mismatch
         default:
           description: root error
           content:
@@ -100,8 +96,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/EpochSettingsMessage"
-        "412":
-          description: API version mismatch
         default:
           description: epoch settings error
           content:
@@ -121,8 +115,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CertificateListMessage"
-        "412":
-          description: API version mismatch
         default:
           description: certificates retrieval error
           content:
@@ -154,8 +146,6 @@ paths:
                 $ref: "#/components/schemas/CertificateMessage"
         "404":
           description: certificate not found
-        "412":
-          description: API version mismatch
         default:
           description: get certificate error
           content:
@@ -175,8 +165,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SnapshotListMessage"
-        "412":
-          description: API version mismatch
         default:
           description: snapshots retrieval error
           content:
@@ -208,8 +196,6 @@ paths:
                 $ref: "#/components/schemas/SnapshotMessage"
         "404":
           description: snapshot not found
-        "412":
-          description: API version mismatch
         default:
           description: snapshot retrieval error
           content:
@@ -242,8 +228,6 @@ paths:
                 format: binary
         "404":
           description: snapshot not found
-        "412":
-          description: API version mismatch
         default:
           description: snapshot retrieval error
           content:
@@ -263,8 +247,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CardanoDatabaseSnapshotListMessage"
-        "412":
-          description: API version mismatch
         default:
           description: Cardano database snapshots retrieval error
           content:
@@ -284,8 +266,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CardanoDatabaseDigestListMessage"
-        "412":
-          description: API version mismatch
         default:
           description: Cardano database immutable files digest retrieval error
           content:
@@ -317,8 +297,6 @@ paths:
                 $ref: "#/components/schemas/CardanoDatabaseSnapshotMessage"
         "404":
           description: Cardano database snapshot not found
-        "412":
-          description: API version mismatch
         default:
           description: Cardano database snapshot retrieval error
           content:
@@ -338,8 +316,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/MithrilStakeDistributionListMessage"
-        "412":
-          description: API version mismatch
         default:
           description: Mithril stake distribution retrieval error
           content:
@@ -371,8 +347,6 @@ paths:
                 $ref: "#/components/schemas/MithrilStakeDistributionMessage"
         "404":
           description: Mithril stake distribution not found
-        "412":
-          description: API version mismatch
         default:
           description: Mithril stake distribution retrieval error
           content:
@@ -392,8 +366,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CardanoStakeDistributionListMessage"
-        "412":
-          description: API version mismatch
         default:
           description: Cardano stake distribution retrieval error
           content:
@@ -425,8 +397,6 @@ paths:
                 $ref: "#/components/schemas/CardanoStakeDistributionMessage"
         "404":
           description: Cardano stake distribution not found
-        "412":
-          description: API version mismatch
         default:
           description: Cardano stake distribution retrieval error
           content:
@@ -458,8 +428,6 @@ paths:
                 $ref: "#/components/schemas/CardanoStakeDistributionMessage"
         "404":
           description: Cardano stake distribution not found
-        "412":
-          description: API version mismatch
         default:
           description: Cardano stake distribution retrieval error
           content:
@@ -479,8 +447,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CardanoTransactionSnapshotListMessage"
-        "412":
-          description: API version mismatch
         default:
           description: Cardano transactions set snapshots retrieval error
           content:
@@ -512,8 +478,6 @@ paths:
                 $ref: "#/components/schemas/CardanoTransactionSnapshotMessage"
         "404":
           description: Cardano transactions set snapshot not found
-        "412":
-          description: API version mismatch
         default:
           description: Cardano transactions set snapshot retrieval error
           content:
@@ -548,8 +512,6 @@ paths:
                 $ref: "#/components/schemas/CardanoTransactionProofMessage"
         "404":
           description: No Cardano transactions were ever signed
-        "412":
-          description: API version mismatch
         default:
           description: Cardano transaction proofs retrieval error
           content:
@@ -584,8 +546,6 @@ paths:
                 $ref: "#/components/schemas/SignerRegistrationsMessage"
         "404":
           description: Registered Signers not found
-        "412":
-          description: API version mismatch
         default:
           description: Registered Signers retrieval error
           content:
@@ -605,8 +565,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SignersTickersMessage"
-        "412":
-          description: API version mismatch
         default:
           description: Signers retrieval error
           content:
@@ -635,8 +593,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        "412":
-          description: API version mismatch
         "550":
           description: signer registration is unavailable
           content:
@@ -681,8 +637,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        "412":
-          description: API version mismatch
         default:
           description: signatures registration error
           content:
@@ -709,8 +663,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-        "412":
-          description: API version mismatch
         default:
           description: Record event error
           content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.49
+  version: 0.1.50
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content

This PR removes the HTTP response status code `412 Precondition Failed` returned by the aggregator on OpenAPI version mismatch and adds a client-side warning log when a mismatch is detected.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2535 
