### PR TITLE
ci: add `--locked` to clippy in check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,13 @@ jobs:
         shell: bash
         run: npm install -g prettier
 
+      - name: Ensure Cargo.lock is up to date
+        if: success() || failure()
+        # Notes:
+        # - this step MUST run before any other cargo steps to avoid them updating the `Cargo.lock` file
+        # - `mithril-build-script` is targeted as it's the project with the fewest dependencies in the workspace
+        run: cargo check --locked -p mithril-build-script
+
       - name: Clippy Check
         if: success() || failure()
         run: |


### PR DESCRIPTION
## Content

This PR includes add  `--locked` to clippy in check step, this will make the CI fail if `Cargo.lock` was not updated after a change in a `Cargo.toml` such as a version bump.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #2549
