### PR TITLE
docs: add dev blog post for distribution `2524`

### DIFF
--- a/docs/website/blog/2025-06-16-distribution-2524.md
+++ b/docs/website/blog/2025-06-16-distribution-2524.md
@@ -9,19 +9,19 @@ tags: [release, distribution, 2524]
 
 The [`2524.0`](https://github.com/input-output-hk/mithril/releases/tag/2524.0) distribution has been released, introducing the following changes:
 
-- Support for `Cardano node` `10.4.1` in the signer and the aggregator
-- Support for recording client types origin (library, CLI and WASM) in the aggregator metrics.
-- **Unstable** Support for UTxO-HD snapshot converter `tools utxo-hd snapshot-converter` command in client CLI.
-- **Unstable** Support for partial cardano database restoration in `cardano-database` command with `--backend v2` parameter.
+- Support for Cardano node v.10.4.1 in the signer and aggregator
+- Support for recording client origin types (library, CLI, WASM) in aggregator metrics
+- **Unstable** support for UTXO-HD snapshot converter `tools utxo-hd snapshot-converter` command in the client CLI
+- **Unstable** support for partial Cardano database restoration using the `cardano-database` command with the `--backend v2` parameter
 - Bug fixes and performance improvements.
 
 This new distribution has been deployed to the **Mithril aggregator** on the `release-mainnet` and `release-preprod` networks.
 
-If you are running a **Mithril signer**:
+If running a **Mithril signer**:
 
-- **pre-release-preview** network: no action is required at this time
-- **release-preprod** network: upgrade your signer node binary to version `0.2.249` – no configuration updates are required
-- **release-mainnet** network: upgrade your signer node binary to version `0.2.249`– no configuration updates are required.
+- **pre-release-preview** network: no action required at this time
+- **release-preprod** network: upgrade the signer node binary to version `0.2.249` – no configuration changes required
+- **release-mainnet** network: upgrade the signer node binary to version `0.2.249`– no configuration changes required.
 
 You can update the Mithril signer using the one-line command below. It downloads to the current directory by default, but you can specify a custom folder using the -p option:
 


### PR DESCRIPTION
## Content

This PR includes a **dev blog post announcing the release of the [`2524`](https://github.com/input-output-hk/mithril/releases/tag/2524.0) distribution**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] No clippy warnings in the CI
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Add dev blog post (if relevant)

## Issue(s)
Relates to #2488 
