### PR TITLE
chore: bump `mithril-stm` dependency version constraint in `mithril-common`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4027,7 +4027,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.38"
+version = "0.5.39"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -60,7 +60,7 @@ kes-summed-ed25519 = { version = "0.2.1", features = [
     "serde_enabled",
     "sk_clone_enabled",
 ] }
-mithril-stm = { path = "../mithril-stm", version = ">=0.3", default-features = false, features = [
+mithril-stm = { path = "../mithril-stm", version = "=0.4", default-features = false, features = [
     "batch-verify-aggregates"
 ] }
 nom = "8.0.0"

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.5.38"
+version = "0.5.39"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes the **update of the `mithril-stm` package version constraint in the `mithril-common` crate**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2488 
