### PR TITLE
fix(ci): publish of wasm packages to npm when Cargo.toml version dont match package.json

### DIFF
--- a/.github/workflows/actions/publish-crate-package/action.yml
+++ b/.github/workflows/actions/publish-crate-package/action.yml
@@ -22,9 +22,9 @@ runs:
       id: check_version
       shell: bash
       run: |
-        echo "Check crate latest published version for '${{ inputs.package}}' package"
-        LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/${{ inputs.package}} | jq -r '.crate.newest_version')
-        LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="${{ inputs.package}}") | .version')
+        echo "Check crate latest published version for '${{ inputs.package }}' package"
+        LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/${{ inputs.package }} | jq -r '.crate.newest_version')
+        LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="${{ inputs.package }}") | .version')
         echo "Latest crate.io version: $LATEST_REMOTE_VERSION"
         echo "Local version: $LOCAL_VERSION"
 
@@ -41,7 +41,7 @@ runs:
       shell: bash
       run: |
         echo "Copy OpenAPI specs files"
-        cp openapi*.yaml ./${{ inputs.package}}
+        cp openapi*.yaml ./${{ inputs.package }}
 
     - name: Cargo publish dry run
       shell: bash

--- a/.github/workflows/actions/publish-npm-package/action.yml
+++ b/.github/workflows/actions/publish-npm-package/action.yml
@@ -30,14 +30,14 @@ runs:
       id: check_version
       shell: bash
       run: |
-        echo "Check crate latest published version for '${{ inputs.package}}' package"
+        echo "Check crate latest published version for '${{ inputs.package }}' package"
 
         if [ "${{ inputs.tag }}" != "latest" -a "${{ inputs.tag }}" != "next" ]; then
           echo "Tag '${{ inputs.tag }}' is not valid. It should be one of 'latest' or 'next'"
           exit 1
         fi
 
-        LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="${{ inputs.package}}") | .version')
+        LOCAL_VERSION=$(cat ${{ inputs.package }}/package.json | jq -r '.version')
         NEXT_REMOTE_VERSION=$(npm view @${{ inputs.scope }}/${{ inputs.package }} dist-tags.next 2> /dev/null || true)
         LATEST_REMOTE_VERSION=$(npm view @${{ inputs.scope }}/${{ inputs.package }} dist-tags.latest 2> /dev/null || true)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,20 @@ jobs:
         if: success() || failure()
         run: jq . networks.json
 
+      - name: Check `mithril-client-wasm` Cargo.toml and package.json versions matches
+        if: success() || failure()
+        shell: bash
+        run: |
+          WASM_PACKAGE_JSON_VERSION=$(cat mithril-client-wasm/package.json | jq -r '.version')
+          WASM_CRATE_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="mithril-client-wasm") | .version')
+
+          if [[ $WASM_CRATE_VERSION != $WASM_PACKAGE_JSON_VERSION ]]; then
+            echo "::error ::Version mismatch detected for mithril-client-wasm!"
+            echo "Cargo.toml version: $WASM_CRATE_VERSION"
+            echo "package.json version: $WASM_PACKAGE_JSON_VERSION"
+            exit 1
+          fi
+
       - name: Check code formatting
         if: success() || failure()
         run: make check-format


### PR DESCRIPTION
## Content

This PR publish of wasm packages to npm when Cargo.toml version dont match package.json.

Also it adds a new check step in the CI to ensure that both version matches (only for `mithril-client-wasm` as it's the only wasm crate right now).

Failure example: https://github.com/input-output-hk/mithril/actions/runs/15685837062/job/44188672258#step:13:26

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #2585
