### PR TITLE
ci: improve `test-mithril-client-wasm` job debugging by uploading logs as artifacts

### DIFF
--- a/.github/workflows/scripts/run-wasm-tests-browser-headless.py
+++ b/.github/workflows/scripts/run-wasm-tests-browser-headless.py
@@ -13,7 +13,9 @@ def run_headless_test():
     if args.browser_type.lower() == 'chrome':
         options = webdriver.ChromeOptions()
         options.add_argument("--headless=new")
-        driver = webdriver.Chrome(options=options)
+        options.set_capability("goog:loggingPrefs", {"browser": "ALL"})
+        service = webdriver.ChromeService(log_output="chrome-driver.log")
+        driver = webdriver.Chrome(options=options, service=service)
     elif args.browser_type.lower() == 'firefox':
         options = webdriver.FirefoxOptions()
         options.add_argument("--headless")
@@ -35,6 +37,13 @@ def run_headless_test():
         result_file = f"{args.browser_type.lower()}-results.html"
         with open(result_file, "w", encoding="utf-8") as file:
             file.write(html)
+
+        if args.browser_type.lower() == 'chrome':
+            logs = driver.get_log('browser')
+            # Save console logs to a file for easier debugging
+            with open("chrome-console.log", "w", encoding="utf-8") as f:
+                for entry in logs:
+                    f.write(f"[{entry['level']}] {entry['message']}\n")
 
     finally:
         driver.quit()

--- a/.github/workflows/scripts/run-wasm-tests-browser-headless.py
+++ b/.github/workflows/scripts/run-wasm-tests-browser-headless.py
@@ -19,7 +19,8 @@ def run_headless_test():
     elif args.browser_type.lower() == 'firefox':
         options = webdriver.FirefoxOptions()
         options.add_argument("--headless")
-        driver = webdriver.Firefox(options=options)
+        service = webdriver.FirefoxService(log_output="firefox-driver.log", service_args=['--log', 'debug'])
+        driver = webdriver.Firefox(options=options, service=service)
     else:
         logging.error("Invalid browser type. Supported types are 'chrome' and 'firefox'.")
         return
@@ -44,6 +45,8 @@ def run_headless_test():
             with open("chrome-console.log", "w", encoding="utf-8") as f:
                 for entry in logs:
                     f.write(f"[{entry['level']}] {entry['message']}\n")
+        elif args.browser_type.lower() == 'firefox':
+            print("Console logs cannot be retrieved from Firefox via get_log('browser'). This feature is only supported in Chrome.")
 
     finally:
         driver.quit()

--- a/.github/workflows/scripts/run-wasm-tests-browser-headless.py
+++ b/.github/workflows/scripts/run-wasm-tests-browser-headless.py
@@ -1,6 +1,5 @@
 import logging
 import argparse
-import sys
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -490,5 +490,8 @@ jobs:
           name: mithril-client-wasm-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-os_${{ matrix.os }}
           path: |
             chrome-results.html
+            chrome-driver.log
+            chrome-console.log
             firefox-results.html
+            firefox-driver.log
           if-no-files-found: error


### PR DESCRIPTION
## Content

This PR uploads Chrome console and driver logs, and Firefox driver logs, when WASM headless tests fail in the `test-mithril-client-wasm` step of the `Mithril Client multi-platform test` workflow.
Note: Firefox WebDriver does not currently support retrieving browser console logs via `get_log('browser')`.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2579 
