### PR TITLE
test:enhance certificate chain builder and mock build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.68"
+version = "0.7.69"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.17"
+version = "0.12.18"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4138,7 +4138,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.68"
+version = "0.7.69"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/query/certificate/get_certificate.rs
+++ b/mithril-aggregator/src/database/query/certificate/get_certificate.rs
@@ -123,7 +123,7 @@ mod tests {
     #[test]
     fn test_get_all_genesis_certificate_records() {
         // Two chains with different protocol parameters so generated certificates are different.
-        let (first_certificates_chain, _) = CertificateChainBuilder::new()
+        let first_certificates_chain = CertificateChainBuilder::new()
             .with_total_certificates(2)
             .with_protocol_parameters(ProtocolParameters {
                 m: 90,
@@ -131,9 +131,11 @@ mod tests {
                 phi_f: 0.65,
             })
             .build();
-        let first_chain_genesis: CertificateRecord =
-            first_certificates_chain.last().unwrap().clone().into();
-        let (second_certificates_chain, _) = CertificateChainBuilder::new()
+        let first_chain_genesis: CertificateRecord = first_certificates_chain
+            .genesis_certificate()
+            .clone()
+            .into();
+        let second_certificates_chain = CertificateChainBuilder::new()
             .with_total_certificates(2)
             .with_protocol_parameters(ProtocolParameters {
                 m: 100,
@@ -141,8 +143,10 @@ mod tests {
                 phi_f: 0.65,
             })
             .build();
-        let second_chain_genesis: CertificateRecord =
-            second_certificates_chain.last().unwrap().clone().into();
+        let second_chain_genesis: CertificateRecord = second_certificates_chain
+            .genesis_certificate()
+            .clone()
+            .into();
         assert_ne!(first_chain_genesis, second_chain_genesis);
 
         let connection = main_db_connection().unwrap();
@@ -151,14 +155,14 @@ mod tests {
             .unwrap();
         assert_eq!(Vec::<CertificateRecord>::new(), certificate_records);
 
-        insert_certificate_records(&connection, first_certificates_chain);
+        insert_certificate_records(&connection, first_certificates_chain.certificates_chained);
 
         let certificate_records: Vec<CertificateRecord> = connection
             .fetch_collect(GetCertificateRecordQuery::all_genesis())
             .unwrap();
         assert_eq!(vec![first_chain_genesis.to_owned()], certificate_records);
 
-        insert_certificate_records(&connection, second_certificates_chain);
+        insert_certificate_records(&connection, second_certificates_chain.certificates_chained);
 
         let certificate_records: Vec<CertificateRecord> = connection
             .fetch_collect(GetCertificateRecordQuery::all_genesis())

--- a/mithril-aggregator/src/database/query/certificate/get_certificate.rs
+++ b/mithril-aggregator/src/database/query/certificate/get_certificate.rs
@@ -71,18 +71,18 @@ mod tests {
 
     #[test]
     fn test_get_certificate_records_by_epoch() {
-        let (certificates, _) = setup_certificate_chain(20, 7);
+        let certificates = setup_certificate_chain(20, 7);
 
         let connection = main_db_connection().unwrap();
-        insert_certificate_records(&connection, certificates.clone());
+        insert_certificate_records(&connection, certificates.certificates_chained.clone());
 
         let certificate_records: Vec<CertificateRecord> = connection
             .fetch_collect(GetCertificateRecordQuery::by_epoch(Epoch(1)).unwrap())
             .unwrap();
         let expected_certificate_records: Vec<CertificateRecord> = certificates
-            .iter()
+            .reversed_chain()
+            .into_iter()
             .filter_map(|c| (c.epoch == Epoch(1)).then_some(c.to_owned().into()))
-            .rev()
             .collect();
         assert_eq!(expected_certificate_records, certificate_records);
 
@@ -90,9 +90,9 @@ mod tests {
             .fetch_collect(GetCertificateRecordQuery::by_epoch(Epoch(3)).unwrap())
             .unwrap();
         let expected_certificate_records: Vec<CertificateRecord> = certificates
-            .iter()
+            .reversed_chain()
+            .into_iter()
             .filter_map(|c| (c.epoch == Epoch(3)).then_some(c.to_owned().into()))
-            .rev()
             .collect();
         assert_eq!(expected_certificate_records, certificate_records);
 
@@ -104,15 +104,15 @@ mod tests {
 
     #[test]
     fn test_get_all_certificate_records() {
-        let (certificates, _) = setup_certificate_chain(5, 2);
+        let certificates = setup_certificate_chain(5, 2);
         let expected_certificate_records: Vec<CertificateRecord> = certificates
-            .iter()
-            .map(|c| c.to_owned().into())
-            .rev()
+            .reversed_chain()
+            .into_iter()
+            .map(Into::into)
             .collect();
 
         let connection = main_db_connection().unwrap();
-        insert_certificate_records(&connection, certificates.clone());
+        insert_certificate_records(&connection, certificates.certificates_chained.clone());
 
         let certificate_records: Vec<CertificateRecord> = connection
             .fetch_collect(GetCertificateRecordQuery::all())

--- a/mithril-aggregator/src/database/query/certificate/insert_certificate.rs
+++ b/mithril-aggregator/src/database/query/certificate/insert_certificate.rs
@@ -111,11 +111,11 @@ mod tests {
 
     #[test]
     fn test_insert_certificate_record() {
-        let (certificates, _) = setup_certificate_chain(5, 2);
+        let certificates = setup_certificate_chain(5, 2);
 
         let connection = main_db_connection().unwrap();
 
-        for certificate in certificates {
+        for certificate in certificates.certificates_chained {
             let certificate_record: CertificateRecord = certificate.into();
             let certificate_record_saved = connection
                 .fetch_first(InsertCertificateRecordQuery::one(
@@ -128,9 +128,8 @@ mod tests {
 
     #[test]
     fn test_insert_many_certificates_records() {
-        let (certificates, _) = setup_certificate_chain(5, 2);
-        let certificates_records: Vec<CertificateRecord> =
-            certificates.into_iter().map(|cert| cert.into()).collect();
+        let certificates = setup_certificate_chain(5, 2);
+        let certificates_records: Vec<CertificateRecord> = certificates.into();
 
         let connection = main_db_connection().unwrap();
 

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -390,16 +390,16 @@ mod tests {
 
     #[test]
     fn test_convert_certificates() {
-        let (certificates, _) = setup_certificate_chain(20, 3);
+        let certificates = setup_certificate_chain(20, 3);
         let mut certificate_records: Vec<CertificateRecord> = Vec::new();
-        for certificate in certificates.clone() {
+        for certificate in certificates.certificates_chained.clone() {
             certificate_records.push(certificate.into());
         }
         let mut certificates_new: Vec<Certificate> = Vec::new();
         for certificate_record in certificate_records {
             certificates_new.push(certificate_record.into());
         }
-        assert_eq!(certificates, certificates_new);
+        assert_eq!(certificates.certificates_chained, certificates_new);
     }
 
     #[test]

--- a/mithril-aggregator/src/database/repository/certificate_repository.rs
+++ b/mithril-aggregator/src/database/repository/certificate_repository.rs
@@ -245,10 +245,10 @@ mod tests {
 
     #[tokio::test]
     async fn repository_get_certificate() {
-        let (certificates, _) = setup_certificate_chain(5, 2);
+        let certificates = setup_certificate_chain(5, 2);
         let expected_hash = certificates[0].hash.clone();
         let connection = Arc::new(main_db_connection().unwrap());
-        insert_certificate_records(&connection, certificates.clone());
+        insert_certificate_records(&connection, certificates.certificates_chained.clone());
 
         let repository: CertificateRepository = CertificateRepository::new(connection);
         let certificate = repository
@@ -268,29 +268,28 @@ mod tests {
 
     #[tokio::test]
     async fn repository_get_latest_certificates() {
-        let (certificates, _) = setup_certificate_chain(5, 2);
+        let certificates = setup_certificate_chain(5, 2);
         let connection = Arc::new(main_db_connection().unwrap());
-        insert_certificate_records(&connection, certificates.clone());
+        insert_certificate_records(&connection, certificates.certificates_chained.clone());
 
         let repository = CertificateRepository::new(connection);
         let latest_certificates = repository
             .get_latest_certificates(certificates.len())
             .await
             .unwrap();
-        let expected: Vec<Certificate> = certificates.into_iter().rev().collect();
 
-        assert_eq!(expected, latest_certificates);
+        assert_eq!(certificates.reversed_chain(), latest_certificates);
     }
 
     #[tokio::test]
     async fn repository_get_latest_genesis_certificate() {
-        let (certificates, _) = setup_certificate_chain(5, 2);
+        let certificates = setup_certificate_chain(5, 2);
         let connection = Arc::new(main_db_connection().unwrap());
-        insert_certificate_records(&connection, certificates.clone());
+        insert_certificate_records(&connection, certificates.certificates_chained.clone());
 
         let repository = CertificateRepository::new(connection);
         let latest_certificates = repository.get_latest_genesis_certificate().await.unwrap();
-        let expected = Some(certificates.last().unwrap().clone());
+        let expected = Some(certificates.genesis_certificate().clone());
 
         assert_eq!(expected, latest_certificates);
     }
@@ -509,11 +508,11 @@ mod tests {
 
     #[tokio::test]
     async fn get_master_certificate_for_epoch() {
-        let (certificates, _) = setup_certificate_chain(3, 1);
+        let certificates = setup_certificate_chain(3, 1);
         let expected_certificate_id = &certificates[2].hash;
         let epoch = &certificates[2].epoch;
         let connection = Arc::new(main_db_connection().unwrap());
-        insert_certificate_records(&connection, certificates.clone());
+        insert_certificate_records(&connection, certificates.certificates_chained.clone());
 
         let repository: CertificateRepository = CertificateRepository::new(connection);
         let certificate = repository
@@ -527,7 +526,7 @@ mod tests {
 
     #[tokio::test]
     async fn save_certificate() {
-        let (certificates, _) = setup_certificate_chain(5, 3);
+        let certificates = setup_certificate_chain(5, 3);
         let connection = Arc::new(main_db_connection().unwrap());
         let repository: CertificateRepository = CertificateRepository::new(connection.clone());
         let certificate = repository

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.12.17"
+version = "0.12.18"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.6.2"
+version = "0.6.3"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -813,7 +813,7 @@ mod tests {
         }
 
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) = CertificateChainBuilder::new()
+        let fake_certificates = CertificateChainBuilder::new()
             .with_total_certificates(total_certificates)
             .with_certificates_per_epoch(certificates_per_epoch)
             .with_standard_certificate_processor(&|certificate, context| {
@@ -1125,7 +1125,7 @@ mod tests {
         }
 
         let (total_certificates, certificates_per_epoch) = (7, 2);
-        let (fake_certificates, genesis_verifier) = CertificateChainBuilder::new()
+        let fake_certificates = CertificateChainBuilder::new()
             .with_total_certificates(total_certificates)
             .with_certificates_per_epoch(certificates_per_epoch)
             .with_standard_certificate_processor(&|certificate, context| {
@@ -1146,7 +1146,7 @@ mod tests {
         let error = verifier
             .verify_certificate(
                 &certificate_to_verify,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await
             .expect_err("verify_certificate_chain should fail");

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -531,15 +531,14 @@ mod tests {
     #[tokio::test]
     async fn verify_genesis_certificate_success() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
-        let genesis_certificate = fake_certificates.last().unwrap().clone();
+        let genesis_certificate = fake_certificates.genesis_certificate();
 
         let verify = verifier
             .verify_genesis_certificate(
-                &genesis_certificate,
-                &genesis_verifier.to_verification_key(),
+                genesis_certificate,
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await;
 
@@ -549,18 +548,17 @@ mod tests {
     #[tokio::test]
     async fn verify_genesis_certificate_fails_if_is_not_genesis() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let standard_certificate = fake_certificates[0].clone();
-        let mut genesis_certificate = fake_certificates.last().unwrap().clone();
+        let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.signature = standard_certificate.signature.clone();
         genesis_certificate.hash = genesis_certificate.compute_hash();
 
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -574,16 +572,15 @@ mod tests {
     #[tokio::test]
     async fn verify_genesis_certificate_fails_if_hash_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
-        let mut genesis_certificate = fake_certificates.last().unwrap().clone();
+        let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.hash = "another-hash".to_string();
 
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -594,10 +591,9 @@ mod tests {
     #[tokio::test]
     async fn verify_genesis_certificate_fails_if_protocol_message_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
-        let mut genesis_certificate = fake_certificates.last().unwrap().clone();
+        let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.protocol_message.set_message_part(
             ProtocolMessagePartKey::CurrentEpoch,
             "another-value".to_string(),
@@ -607,7 +603,7 @@ mod tests {
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -621,17 +617,16 @@ mod tests {
     #[tokio::test]
     async fn verify_genesis_certificate_fails_if_epoch_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
-        let mut genesis_certificate = fake_certificates.last().unwrap().clone();
+        let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.epoch -= 1;
         genesis_certificate.hash = genesis_certificate.compute_hash();
 
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -642,8 +637,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_success_with_different_epochs_as_previous() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let certificate = fake_certificates[0].clone();
         let previous_certificate = fake_certificates[1].clone();
@@ -658,8 +652,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_success_with_same_epoch_as_previous() {
         let (total_certificates, certificates_per_epoch) = (5, 2);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let certificate = fake_certificates[0].clone();
         let previous_certificate = fake_certificates[1].clone();
@@ -674,10 +667,9 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_is_not_genesis() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
-        let genesis_certificate = fake_certificates.last().unwrap().clone();
+        let genesis_certificate = fake_certificates.genesis_certificate();
         let mut standard_certificate = fake_certificates[0].clone();
         standard_certificate.signature = genesis_certificate.signature.clone();
         standard_certificate.hash = standard_certificate.compute_hash();
@@ -697,8 +689,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_infinite_loop() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut certificate = fake_certificates[0].clone();
         certificate.previous_hash = certificate.hash.clone();
@@ -718,8 +709,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_hash_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut certificate = fake_certificates[0].clone();
         certificate.hash = "another-hash".to_string();
@@ -736,8 +726,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_protocol_message_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut certificate = fake_certificates[0].clone();
         certificate.protocol_message.set_message_part(
@@ -761,8 +750,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_epoch_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut certificate = fake_certificates[0].clone();
         certificate.epoch -= 1;
@@ -842,8 +830,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_certificate_previous_hash_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let certificate = fake_certificates[0].clone();
         let mut previous_certificate = fake_certificates[1].clone();
@@ -864,8 +851,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_certificate_chain_avk_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut certificate = fake_certificates[0].clone();
         let mut previous_certificate = fake_certificates[1].clone();
@@ -890,8 +876,7 @@ mod tests {
     #[tokio::test]
     async fn verify_standard_certificate_fails_if_certificate_chain_protocol_parameters_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, _) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut certificate = fake_certificates[0].clone();
         let mut previous_certificate = fake_certificates[1].clone();
@@ -919,16 +904,15 @@ mod tests {
     #[tokio::test]
     async fn verify_certificate_success_when_certificate_is_genesis_and_valid() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let genesis_certificate = fake_certificates.last().unwrap().clone();
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let genesis_certificate = fake_certificates.genesis_certificate();
         let mock_container = MockDependencyInjector::new();
         let verifier = mock_container.build_certificate_verifier();
 
         let verify = verifier
             .verify_certificate(
-                &genesis_certificate,
-                &genesis_verifier.to_verification_key(),
+                genesis_certificate,
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await;
 
@@ -938,8 +922,7 @@ mod tests {
     #[tokio::test]
     async fn verify_certificate_success_when_certificate_is_standard_and_valid() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let certificate = fake_certificates[0].clone();
         let previous_certificate = fake_certificates[1].clone();
         let mut mock_container = MockDependencyInjector::new();
@@ -951,7 +934,10 @@ mod tests {
         let verifier = mock_container.build_certificate_verifier();
 
         let verify = verifier
-            .verify_certificate(&certificate, &genesis_verifier.to_verification_key())
+            .verify_certificate(
+                &certificate,
+                &fake_certificates.genesis_verifier.to_verification_key(),
+            )
             .await;
 
         verify.expect("verify_certificate should not fail");
@@ -1013,8 +999,7 @@ mod tests {
         }
 
         let (total_certificates, certificates_per_epoch) = (10, 1);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let fake_certificate_to_verify = fake_certificates[0].clone();
         let verifier = CertificateVerifierTest::from_certificates(&fake_certificates);
         assert!(verifier.has_unverified_certificates().await);
@@ -1022,7 +1007,7 @@ mod tests {
         let verify = verifier
             .verify_certificate_chain(
                 fake_certificate_to_verify,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await;
 
@@ -1033,8 +1018,7 @@ mod tests {
     #[tokio::test]
     async fn verify_certificate_chain_success_when_chain_is_valid() {
         let (total_certificates, certificates_per_epoch) = (7, 2);
-        let (fake_certificates, genesis_verifier) =
-            setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let certificate_retriever =
             FakeCertificaterRetriever::from_certificates(&fake_certificates);
         let verifier =
@@ -1044,7 +1028,7 @@ mod tests {
         let verify = verifier
             .verify_certificate_chain(
                 certificate_to_verify,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await;
         verify.expect("verify_certificate_chain should not fail");
@@ -1053,7 +1037,7 @@ mod tests {
     #[tokio::test]
     async fn verify_certificate_chain_fails_when_chain_is_tampered() {
         let (total_certificates, certificates_per_epoch) = (7, 2);
-        let (mut fake_certificates, genesis_verifier) =
+        let mut fake_certificates =
             setup_certificate_chain(total_certificates, certificates_per_epoch);
         let index_certificate_fail = (total_certificates / 2) as usize;
         fake_certificates[index_certificate_fail].signed_message = "tampered-message".to_string();
@@ -1066,7 +1050,7 @@ mod tests {
         let error = verifier
             .verify_certificate_chain(
                 certificate_to_verify,
-                &genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_verification_key(),
             )
             .await
             .expect_err("verify_certificate_chain should fail");

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -192,14 +192,19 @@ pub fn setup_signers_from_stake_distribution(
 }
 
 /// Instantiate a certificate chain, use this for tests only.
+/// Todo: update to CertificateChainFixture
 pub fn setup_certificate_chain(
     total_certificates: u64,
     certificates_per_epoch: u64,
 ) -> (Vec<Certificate>, ProtocolGenesisVerifier) {
-    let certificate_chain_builder = CertificateChainBuilder::new()
+    let certificate_chain_fixture = CertificateChainBuilder::new()
         .with_total_certificates(total_certificates)
         .with_certificates_per_epoch(certificates_per_epoch)
-        .with_protocol_parameters(setup_protocol_parameters());
+        .with_protocol_parameters(setup_protocol_parameters())
+        .build();
 
-    certificate_chain_builder.build()
+    (
+        certificate_chain_fixture.certificates_chained,
+        certificate_chain_fixture.genesis_verifier,
+    )
 }

--- a/mithril-common/src/crypto_helper/tests_setup.rs
+++ b/mithril-common/src/crypto_helper/tests_setup.rs
@@ -6,11 +6,11 @@ use rand_core::SeedableRng;
 
 use crate::{
     crypto_helper::{cardano::KesSignerStandard, KesSigner},
-    entities::{Certificate, ProtocolMessage, ProtocolMessagePartKey, SignerWithStake, Stake},
-    test_utils::{CertificateChainBuilder, SignerFixture, TempDir},
+    entities::{ProtocolMessage, ProtocolMessagePartKey, SignerWithStake, Stake},
+    test_utils::{CertificateChainBuilder, CertificateChainFixture, SignerFixture, TempDir},
 };
 
-use super::{ed25519_alias::genesis::*, types::*, OpCert, SerDeShelleyFileFormat};
+use super::{types::*, OpCert, SerDeShelleyFileFormat};
 
 /// Create or retrieve a temporary directory for storing cryptographic material for a signer, use this for tests only.
 pub fn setup_temp_directory_for_signer(
@@ -192,19 +192,13 @@ pub fn setup_signers_from_stake_distribution(
 }
 
 /// Instantiate a certificate chain, use this for tests only.
-/// Todo: update to CertificateChainFixture
 pub fn setup_certificate_chain(
     total_certificates: u64,
     certificates_per_epoch: u64,
-) -> (Vec<Certificate>, ProtocolGenesisVerifier) {
-    let certificate_chain_fixture = CertificateChainBuilder::new()
+) -> CertificateChainFixture {
+    CertificateChainBuilder::new()
         .with_total_certificates(total_certificates)
         .with_certificates_per_epoch(certificates_per_epoch)
         .with_protocol_parameters(setup_protocol_parameters())
-        .build();
-
-    (
-        certificate_chain_fixture.certificates_chained,
-        certificate_chain_fixture.genesis_verifier,
-    )
+        .build()
 }

--- a/mithril-common/src/test_utils/mock_extensions.rs
+++ b/mithril-common/src/test_utils/mock_extensions.rs
@@ -1,0 +1,61 @@
+//! A set of tools for working with `automock`
+//!
+//! IMPORTANT: To avoid polluting production code, those tools do not expose or reexpose any
+//! `automock`types, users need to add them themselves to their crates.
+use std::sync::Arc;
+
+/// Helper to create configured Mockall mock.
+///
+/// This allows creation of the mock in a dedicated block isolated from the remaining test method
+/// code.
+pub struct MockBuilder<M: Default> {
+    phantom: std::marker::PhantomData<M>,
+}
+
+impl<M: Default> MockBuilder<M> {
+    /// Create a new instance of the mock with the given configuration
+    ///
+    /// The type must be specified either:
+    /// ```
+    /// use mithril_common::test_utils::mock_extensions::MockBuilder;
+    /// # #[derive(Default)] struct MockType {};
+    ///
+    /// // from the builder generic
+    /// let mock = MockBuilder::<MockType>::configure(|mock| {});
+    ///
+    /// // or from the closure parameter
+    /// let mock = MockBuilder::configure(|mock: &mut MockType| {});
+    /// ```
+    pub fn configure(mock_config: impl FnOnce(&mut M)) -> Arc<M> {
+        let mut mock = M::default();
+        mock_config(&mut mock);
+        Arc::new(mock)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[mockall::automock]
+    trait TestTrait {
+        fn test_method(&self) -> String;
+    }
+
+    #[test]
+    fn using_mock_builder() {
+        // specify the type on the closure parameter
+        let mock = MockBuilder::configure(|mock: &mut MockTestTrait| {
+            mock.expect_test_method()
+                .returning(|| "test explicit type".to_string());
+        });
+        assert_eq!("test explicit type".to_string(), mock.test_method());
+
+        // specify the type on the builder generic
+        let mock = MockBuilder::<MockTestTrait>::configure(|mock| {
+            mock.expect_test_method()
+                .returning(|| "test turbofish".to_string());
+        });
+        assert_eq!("test turbofish".to_string(), mock.test_method());
+    }
+}

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -20,7 +20,8 @@ mod temp_dir;
 
 pub use cardano_transactions_builder::CardanoTransactionsBuilder;
 pub use certificate_chain_builder::{
-    CertificateChainBuilder, CertificateChainBuilderContext, CertificateChainingMethod,
+    CertificateChainBuilder, CertificateChainBuilderContext, CertificateChainFixture,
+    CertificateChainingMethod,
 };
 pub use dir_eq::*;
 pub use fixture_builder::{MithrilFixtureBuilder, StakeDistributionGenerationMethod};

--- a/mithril-common/src/test_utils/mod.rs
+++ b/mithril-common/src/test_utils/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod fake_data;
 pub mod fake_keys;
+pub mod mock_extensions;
 
 mod cardano_transactions_builder;
 mod certificate_chain_builder;


### PR DESCRIPTION
## Content

This PR enhance the certificate chain builder and add propose a tooling to create mock in a standardized way.

### Changes

- Rework `CertificateChainBuilder`:
  - Now `.build()` return a `CertificateChainFixture` that's contains the same data as the previous returned tuple (the chain ordered from latest to genesis and the genesis verifier)
  - The addition of `CertificateChainFixture` allow to attach utility methods related to the produced certificates:
    - `genesis_certificate(&self)`: shortcut to get the generated genesis
    - `chain_reversed`: return a copy of the generated chain reversed
    - `certificate_path_to_genesis`: return a list with the given certificate hash  and all it's previous certificates, useful when testing certificate chain validation
  - Additionally `CertificateChainFixture` implement:
    -  `Deref` and `DerefMut` to `[Certificate]` allowing to avoid directly operating on the stored `certificates_chained` list most of the time.
    - `impl<C: From<Certificate>> From<CertificateChainFixture> for Vec<C>` to allow conversion of the full list to a list of another type that can be converted from `Certificate` (mostly useful in db layer when handling `CertificateRecord`)
- Add `mock_extensions` module with a `MockBuilder` tool that allow to create mock instance with a block dedicated to the mock configuration, avoiding pollution of the test code, exemple:
```rust
let mock = MockBuilder::<MockType>::configure(|mock| {
    mock.expect_foo().returning(|| Bar::new());
});
``` 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2534
