### PR TITLE
ci: add extra information to release notes

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -5,8 +5,8 @@ description: |
   The artifacts for all supported environments must have been downloaded
   in "package-{EnvName}-x64" subfolders before calling this action.
 inputs:
-  version-name:
-    description: Name of the version to package
+  tag:
+    description: The tag to use for the distribution
     required: true
   download-url-base:
     description: Base url where the released distribution will be downloadable
@@ -20,13 +20,28 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Get short SHA
+      id: slug
+      shell: bash
+      run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
+    - name: Compute version name
+      id: compute-version-name
+      shell: bash
+      run: |
+        if [[ "${{ inputs.tag }}" == "unstable" ]]; then
+          echo "version-name=unstable-${{ steps.slug.outputs.sha8 }}" >> $GITHUB_OUTPUT
+        else
+          echo "version-name=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Package distribution (Linux-X64)
       shell: bash
       run: |
         python3 ./.github/workflows/scripts/package-distribution.py \
         --input package-Linux-X64/ \
         --dest package/ \
-        --version "${{ inputs.version-name }}" \
+        --version "${{ steps.compute-version-name.outputs.version-name }}" \
         --target "linux-x64"
 
     - name: Package distribution (Linux-ARM64)
@@ -35,7 +50,7 @@ runs:
         python3 ./.github/workflows/scripts/package-distribution.py \
         --input package-Linux-ARM64/ \
         --dest package/ \
-        --version "${{ inputs.version-name }}" \
+        --version "${{ steps.compute-version-name.outputs.version-name }}" \
         --target "linux-arm64"
 
     - name: Package distribution (macOS-ARM64)
@@ -44,7 +59,7 @@ runs:
         python3 ./.github/workflows/scripts/package-distribution.py \
         --input package-macOS-ARM64/ \
         --dest package/ \
-        --version "${{ inputs.version-name }}" \
+        --version "${{ steps.compute-version-name.outputs.version-name }}" \
         --target "macos-arm64"
 
     - name: Package distribution (Windows-X64)
@@ -53,7 +68,7 @@ runs:
         python3 ./.github/workflows/scripts/package-distribution.py \
         --input package-Windows-X64/ \
         --dest package/ \
-        --version "${{ inputs.version-name }}" \
+        --version "${{ steps.compute-version-name.outputs.version-name }}" \
         --target "windows-x64"
 
     - name: Package Explorer
@@ -63,7 +78,7 @@ runs:
         --input package-explorer/ \
         --dest package/ \
         --name "mithril-explorer" \
-        --version "${{ inputs.version-name }}"
+        --version "${{ steps.compute-version-name.outputs.version-name }}"
 
     - name: Prepare crates versions table
       shell: bash
@@ -140,6 +155,27 @@ runs:
         PROCEDURE_FILE_PATH: ./release-notes-addon.txt
         DOWNLOAD_URL_BASE: ${{ inputs.download-url-base }}
       run: ./.github/workflows/scripts/verify-distribution.sh
+
+    - name: Download a Docker image
+      shell: bash
+      run: |
+        if [[ "${{ inputs.tag }}" == "unstable" ]]; then
+          MITHRIL_IMAGE_ID="main-${{ steps.slug.outputs.sha8 }}"
+        else
+          MITHRIL_IMAGE_ID="${{ inputs.tag }}-${{ steps.slug.outputs.sha8 }}"
+        fi
+
+        cat >> ./release-notes-addon.txt << EOF
+
+        ## Download a Docker image
+        You can directly pull prebuilt Mithril Docker images:
+
+        | Binary             |              Image name              |                             URL                              |
+        | ------------------ | :----------------------------------: | :----------------------------------------------------------: |
+        | mithril-aggregator | mithril-aggregator:$MITHRIL_IMAGE_ID | ghcr.io/input-output-hk/mithril-aggregator:$MITHRIL_IMAGE_ID |
+        | mithril-signer     |   mithril-signer:$MITHRIL_IMAGE_ID   |   ghcr.io/input-output-hk/mithril-signer:$MITHRIL_IMAGE_ID   |
+        | mithril-client     |   mithril-client:$MITHRIL_IMAGE_ID   |   ghcr.io/input-output-hk/mithril-client:$MITHRIL_IMAGE_ID   |
+        EOF
 
     - name: List packaged assets
       shell: bash

--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -142,6 +142,27 @@ runs:
         \`git tag -d unstable && git fetch origin tag unstable\`
         EOF
 
+    - name: Download a binary asset
+      shell: bash
+      run: |
+        cat >> ./release-notes-addon.txt << EOF
+
+        ## Download a binary asset
+        To simplify the installation and updating of Mithril binaries, we have created a one line installer that downloads and installs the Mithril binaries for you.
+        This installer is available for Linux and macOS and supports the Mithril signer, Mithril aggregator, and Mithril client CLI.
+
+        Use the following commands to install the Mithril nodes:
+
+        - Download the **Mithril signer** in the current directory:
+        \`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d ${{ inputs.tag }} -p $(pwd)\`
+
+        - Download the **Mithril client CLI** in the current directory:
+        \`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-client -d ${{ inputs.tag }} -p $(pwd)\`
+
+        - Download the **Mithril aggregator** in the current directory:
+        \`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-aggregator -d ${{ inputs.tag }} -p $(pwd)\`
+        EOF
+
     - name: Create and sign sha256 checksum
       shell: bash
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,6 +503,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get short SHA
+        id: slug
+        run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -523,7 +527,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
             unstable
-            type=raw,value=${{ github.base_ref || github.ref_name }}-{{sha}}
+            type=raw,value=${{ github.base_ref || github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-X64)
         uses: actions/download-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -688,7 +688,7 @@ jobs:
       - name: Prepare distribution package
         uses: ./.github/workflows/actions/prepare-distribution
         with:
-          version-name: unstable-${{ steps.slug.outputs.sha8 }}
+          tag: unstable
           download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/unstable
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
           compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "⛔", "testing-preview": "✔" }'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -130,6 +130,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get short SHA
+        id: slug
+        run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -150,7 +154,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
             pre-release
-            type=raw,value=${{ github.ref_name }}-{{sha}}
+            type=raw,value=${{ github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-x64)
         uses: dawidd6/action-download-artifact@v6

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Prepare distribution package
         uses: ./.github/workflows/actions/prepare-distribution
         with:
-          version-name: ${{ github.ref_name }}
+          tag: ${{ github.ref_name }}
           download-url-base: ${{ github.server_url }}/${{ github.repository }}/releases/download/${{ github.ref_name }}
           gpg-secret-key: ${{ secrets.GPG_SECRET_KEY }}
           compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "⛔" }'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Get short SHA
+        id: slug
+        run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -51,7 +55,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
             latest
-            type=raw,value=${{ github.ref_name }}-{{sha}}
+            type=raw,value=${{ github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-x64)
         uses: dawidd6/action-download-artifact@v6


### PR DESCRIPTION
## Content

This PR includes improvements to the GitHub release notes by adding missing information:
- A `Download a binary asset` section explaining how to use the one-line installer
- A `Download a Docker image` section with a table listing Docker image tags and registry URLs

---

### `unstable`
<img width="1200" height="697" alt="Screenshot 2025-07-21 at 21 25 14" src="https://github.com/user-attachments/assets/650b9b17-8886-4a3f-be05-7d1adfcbbd83" />

---

### `release`
<img width="1205" height="704" alt="Screenshot 2025-07-21 at 21 27 37" src="https://github.com/user-attachments/assets/e4780fca-00f6-4d0d-9c96-a664f55e74e8" />

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2638 
