### PR TITLE
fix: escape `$(pwd)` and format installation commands

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -154,13 +154,19 @@ runs:
         Use the following commands to install the Mithril nodes:
 
         - Download the **Mithril signer** in the current directory:
-        \`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d ${{ inputs.tag }} -p $(pwd)\`
+        \`\`\`bash
+        curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d ${{ inputs.tag }} -p \$(pwd)
+        \`\`\`
 
         - Download the **Mithril client CLI** in the current directory:
-        \`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-client -d ${{ inputs.tag }} -p $(pwd)\`
+        \`\`\`bash
+        curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-client -d ${{ inputs.tag }} -p \$(pwd)
+        \`\`\`
 
         - Download the **Mithril aggregator** in the current directory:
-        \`curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-aggregator -d ${{ inputs.tag }} -p $(pwd)\`
+        \`\`\`bash
+        curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-aggregator -d ${{ inputs.tag }} -p \$(pwd)
+        \`\`\`
         EOF
 
     - name: Create and sign sha256 checksum


### PR DESCRIPTION
## Content

This PR includes a fix for the release note following the merge of the PR https://github.com/input-output-hk/mithril/pull/2646.

<img width="910" height="568" alt="image" src="https://github.com/user-attachments/assets/e04b29a8-4e58-4a65-b8fe-715fa8fab8fa" />

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2638 
