### PR TITLE
chore: replace `serde_yaml` with `serde_yml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3728,6 +3728,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
+]
+
+[[package]]
 name = "libz-rs-sys"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4006,7 +4016,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
  "warp",
 ]
 
@@ -4016,7 +4026,7 @@ version = "0.2.25"
 dependencies = [
  "semver",
  "serde_json",
- "serde_yaml",
+ "serde_yml",
 ]
 
 [[package]]
@@ -6448,16 +6458,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",
+ "libyml",
+ "memchr",
  "ryu",
  "serde",
- "unsafe-libyaml",
+ "version_check",
 ]
 
 [[package]]
@@ -7514,12 +7526,6 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4009,7 +4009,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-api-spec"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "jsonschema",
  "mithril-common",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-build-script"
-version = "0.2.25"
+version = "0.2.26"
 dependencies = [
  "semver",
  "serde_json",

--- a/internal/mithril-build-script/Cargo.toml
+++ b/internal/mithril-build-script/Cargo.toml
@@ -12,4 +12,4 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 [dependencies]
 semver = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = "0.9.34"
+serde_yml = "0.0.12"

--- a/internal/mithril-build-script/Cargo.toml
+++ b/internal/mithril-build-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-build-script"
-version = "0.2.25"
+version = "0.2.26"
 description = "A toolbox for Mithril crates build scripts"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-build-script/src/open_api.rs
+++ b/internal/mithril-build-script/src/open_api.rs
@@ -29,7 +29,7 @@ pub fn list_all_open_api_spec_files(paths: &[&Path]) -> Vec<PathBuf> {
 
 fn read_version_from_open_api_spec_file<P: AsRef<Path>>(spec_file_path: P) -> OpenAPIVersionRaw {
     let yaml_spec = fs::read_to_string(spec_file_path).unwrap();
-    let open_api: serde_yaml::Value = serde_yaml::from_str(&yaml_spec).unwrap();
+    let open_api: serde_yml::Value = serde_yml::from_str(&yaml_spec).unwrap();
     open_api["info"]["version"].as_str().unwrap().to_owned()
 }
 

--- a/internal/tests/mithril-api-spec/Cargo.toml
+++ b/internal/tests/mithril-api-spec/Cargo.toml
@@ -13,7 +13,7 @@ jsonschema = { version = "0.30.0" }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-serde_yaml = { version = "0.9.34" }
+serde_yml = "0.0.12"
 warp = { workspace = true }
 
 [dev-dependencies]

--- a/internal/tests/mithril-api-spec/Cargo.toml
+++ b/internal/tests/mithril-api-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-api-spec"
-version = "0.1.2"
+version = "0.1.3"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/tests/mithril-api-spec/src/apispec.rs
+++ b/internal/tests/mithril-api-spec/src/apispec.rs
@@ -56,7 +56,7 @@ impl<'a> APISpec<'a> {
     /// APISpec factory from spec
     pub fn from_file(path: &str) -> APISpec<'a> {
         let yaml_spec = std::fs::read_to_string(path).unwrap();
-        let openapi: serde_json::Value = serde_yaml::from_str(&yaml_spec).unwrap();
+        let openapi: serde_json::Value = serde_yml::from_str(&yaml_spec).unwrap();
         APISpec {
             openapi,
             path: None,


### PR DESCRIPTION
## Content

This PR includes the replacement of [`serde_yaml`](https://crates.io/crates/serde-yaml) by [`serde_yml`](https://crates.io/crates/serde_yml) in `mithril-build-script` and `mithril-api-spec`, as `serde_yaml` is no longer maintained.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Closes #2639 
