### PR TITLE
chore: add and unify badges to all published projects

### DIFF
--- a/internal/cardano-node/mithril-cardano-node-internal-database/README.md
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/README.md
@@ -1,4 +1,4 @@
-# Mithril-cardano-node-internal-database
+# Mithril-cardano-node-internal-database [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![crates.io](https://img.shields.io/crates/v/mithril-cardano-node-internal-database.svg)](https://crates.io/crates/mithril-cardano-node-internal-database) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/input-output-hk/mithril/blob/main/LICENSE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
 
 This crate provides components to read the files of a Cardano node internal database, such as immutable files
 and ledger state snapshots, and compute digests from them.

--- a/internal/mithril-build-script/README.md
+++ b/internal/mithril-build-script/README.md
@@ -1,4 +1,4 @@
-# Mithril-build-script [crates.io](https://img.shields.io/crates/v/mithril-build-script.svg) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE-APACHE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
+# Mithril-build-script [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![crates.io](https://img.shields.io/crates/v/mithril-build-script.svg)](https://crates.io/crates/mithril-build-script) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/input-output-hk/mithril/blob/main/LICENSE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
 
 A toolbox for Mithril crates that need a [build scripts phase](https://doc.rust-lang.org/cargo/reference/build-scripts.html).
 

--- a/mithril-client-wasm/README.md
+++ b/mithril-client-wasm/README.md
@@ -1,4 +1,4 @@
-# Mithril-client-wasm ![cnpm](https://img.shields.io/npm/v/@mithril-dev/mithril-client-wasm.svg) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE-APACHE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
+# Mithril-client-wasm [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![cnpm](https://img.shields.io/npm/v/@mithril-dev/mithril-client-wasm.svg)](https://www.npmjs.com/package/@mithril-dev/mithril-client-wasm) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/input-output-hk/mithril/blob/main/LICENSE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
 
 **This is a work in progress** 🛠
 

--- a/mithril-client/README.md
+++ b/mithril-client/README.md
@@ -1,4 +1,4 @@
-# Mithril-client ![crates.io](https://img.shields.io/crates/v/mithril-client.svg) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE-APACHE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
+# Mithril-client [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![crates.io](https://img.shields.io/crates/v/mithril-client.svg)](https://crates.io/crates/mithril-client) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/input-output-hk/mithril/blob/main/LICENSE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
 
 **This is a work in progress** 🛠
 

--- a/mithril-common/README.md
+++ b/mithril-common/README.md
@@ -1,4 +1,4 @@
-# Mithril-common ![crates.io](https://img.shields.io/crates/v/mithril-common.svg) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
+# Mithril-common [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![crates.io](https://img.shields.io/crates/v/mithril-common.svg)](https://crates.io/crates/mithril-common) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/input-output-hk/mithril/blob/main/LICENSE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
 
 **This is a work in progress** 🛠
 

--- a/mithril-relay/README.md
+++ b/mithril-relay/README.md
@@ -1,4 +1,4 @@
-# Mithril-relay ![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
+# Mithril-relay [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/input-output-hk/mithril/blob/main/LICENSE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
 
 > [!WARNING]  
 > **Do not use in production** 🔥

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -1,4 +1,4 @@
-# Mithril-stm [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![crates.io](https://img.shields.io/crates/v/mithril_stm.svg)](https://crates.io/crates/mithril_stm) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
+# Mithril-stm [![CI workflow](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml/badge.svg)](https://github.com/input-output-hk/mithril/actions/workflows/ci.yml) [![crates.io](https://img.shields.io/crates/v/mithril-stm.svg)](https://crates.io/crates/mithril-stm) [![License](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](https://github.com/input-output-hk/mithril/blob/main/LICENSE) [![Discord](https://img.shields.io/discord/500028886025895936.svg?logo=discord&style=flat-square)](https://discord.gg/5kaErDKDRq)
 
 **This is a work in progress** 🛠
 


### PR DESCRIPTION
## Content

This PR includes make all published projects have the same set of badge in the same order:
- CI badge
- Package repository badge (crates.io or npmjs.com)
- License
- Discord (IOG tech community)

Also all badges now links to their associated page instead of a link to the badge image.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] No new TODOs introduced
