### PR TITLE
fix: restore missing section in unstable release notes

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -131,7 +131,7 @@ runs:
         EOF
 
     - name: Fetch the latest version of the unstable tag
-      if: contains(inputs.version-name, 'unstable')
+      if: contains(inputs.tag, 'unstable')
       shell: bash
       run: |
         cat >> ./release-notes-addon.txt << EOF


### PR DESCRIPTION
## Content

This PR includes a fix that restores a section missing from the `unstable` release notes (`Fetch the latest version of the unstable tag`) due to an incorrect input reference. The `version-name` input was removed in favor of `tag`.
This regression was introduced after the merge of #2646.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

Relates to #2638 
