### PR TITLE
fix: add write access check for install path in one-line installer

### DIFF
--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -95,12 +95,17 @@ esac
 # Set temp file
 TEMP_FILE="${INSTALL_PATH}/temp.json"
 
-# Create the install path if it doesn't exist
-mkdir -p "$INSTALL_PATH"
-
 # Check if node and path are provided
 if [ -z "$NODE" ] || [ -z "$DISTRIBUTION" ] || [ -z "$INSTALL_PATH" ]; then
   usage
+fi
+
+# Create the install path if it doesn't exist
+mkdir -p "$INSTALL_PATH"
+
+# Check if install path is writable
+if [ ! -w "$INSTALL_PATH" ]; then
+  error_exit "Error: The specified install path '$INSTALL_PATH' is not writable."
 fi
 
 # Validate node


### PR DESCRIPTION
## Content

This PR includes a fix to the one-line installer script to ensure the provided install path is writable before proceeding. This avoids misleading errors when the path is not writable.
The creation of the install path directory has also been moved after the command-line argument parsing step to avoid attempting to create a directory with an undefined value.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced