### PR TITLE
fix: Rust `1.89` clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3928,7 +3928,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.7.78"
+version = "0.7.79"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4111,7 +4111,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.25"
+version = "0.12.26"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4149,7 +4149,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.12.24"
+version = "0.12.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4201,7 +4201,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.6.13"
+version = "0.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4243,7 +4243,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-dmq"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4279,7 +4279,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.98"
+version = "0.4.99"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.57"
+version = "0.2.58"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4454,7 +4454,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/internal/mithril-dmq/Cargo.toml
+++ b/internal/mithril-dmq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mithril-dmq"
 description = "Mechanisms to publish and consume messages of a 'Decentralized Message Queue network' through a DMQ node"
-version = "0.1.6"
+version = "0.1.7"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/mithril-dmq/src/consumer/pallas.rs
+++ b/internal/mithril-dmq/src/consumer/pallas.rs
@@ -51,7 +51,7 @@ impl<M: TryFromBytes + Debug> DmqConsumerPallas<M> {
     }
 
     /// Gets the cached `DmqClient`, creating a new one if it does not exist.
-    async fn get_client(&self) -> StdResult<MutexGuard<Option<DmqClient>>> {
+    async fn get_client(&self) -> StdResult<MutexGuard<'_, Option<DmqClient>>> {
         {
             // Run this in a separate block to avoid dead lock on the Mutex
             let client_lock = self.client.lock().await;

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.57"
+version = "0.2.58"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/version_checker.rs
+++ b/internal/mithril-persistence/src/database/version_checker.rs
@@ -317,7 +317,7 @@ mod tests {
             .read::<i64, _>(0)
     }
 
-    fn create_db_checker(connection: &ConnectionThreadSafe) -> DatabaseVersionChecker {
+    fn create_db_checker(connection: &ConnectionThreadSafe) -> DatabaseVersionChecker<'_> {
         DatabaseVersionChecker::new(
             discard_logger(),
             ApplicationNodeType::Aggregator,

--- a/internal/mithril-persistence/src/sqlite/connection_pool.rs
+++ b/internal/mithril-persistence/src/sqlite/connection_pool.rs
@@ -47,7 +47,7 @@ impl SqliteConnectionPool {
     }
 
     /// Get a connection from the pool
-    pub fn connection(&self) -> StdResult<ResourcePoolItem<SqlitePooledConnection>> {
+    pub fn connection(&self) -> StdResult<ResourcePoolItem<'_, SqlitePooledConnection>> {
         let timeout = Duration::from_millis(1000);
         let connection = self.connection_pool.acquire_resource(timeout)?;
 

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.7.78"
+version = "0.7.79"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/support/sqlite.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/sqlite.rs
@@ -53,10 +53,10 @@ impl DependenciesBuilder {
             let _ = connection.execute("pragma analysis_limit=400; pragma optimize;");
         }
 
-        if let Some(pool) = &self.sqlite_connection_cardano_transaction_pool {
-            if let Ok(connection) = pool.connection() {
-                let _ = connection.execute("pragma analysis_limit=400; pragma optimize;");
-            }
+        if let Some(pool) = &self.sqlite_connection_cardano_transaction_pool
+            && let Ok(connection) = pool.connection()
+        {
+            let _ = connection.execute("pragma analysis_limit=400; pragma optimize;");
         }
     }
 

--- a/mithril-aggregator/src/file_uploaders/cloud_uploader/api.rs
+++ b/mithril-aggregator/src/file_uploaders/cloud_uploader/api.rs
@@ -46,15 +46,14 @@ impl CloudUploader {
 impl FileUploader for CloudUploader {
     async fn upload_without_retry(&self, file_path: &Path) -> StdResult<FileUri> {
         let remote_file_path = self.remote_folder.join(get_file_name(file_path)?);
-        if !self.allow_overwrite {
-            if let Some(file_uri) = self
+        if !self.allow_overwrite
+            && let Some(file_uri) = self
                 .cloud_backend_uploader
                 .file_exists(&remote_file_path)
                 .await
                 .with_context(|| "checking if file exists in cloud")?
-            {
-                return Ok(file_uri);
-            }
+        {
+            return Ok(file_uri);
         }
 
         let file_uri = self

--- a/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
+++ b/mithril-aggregator/src/http_server/validators/prover_transactions_hash_validator.rs
@@ -96,7 +96,7 @@ mod tests {
         for invalid_char in ["g", "x", ";", " ", "à"].iter() {
             let hash = format!("{}{}", "a".repeat(63), invalid_char);
             let error = ProverTransactionsHashValidator::default()
-                .validate(&[hash.clone()])
+                .validate(std::slice::from_ref(&hash))
                 .expect_err("Should return an error");
             assert_eq!(
                 error,

--- a/mithril-aggregator/src/services/aggregator_client.rs
+++ b/mithril-aggregator/src/services/aggregator_client.rs
@@ -380,41 +380,6 @@ impl RemoteCertificateRetriever for AggregatorHTTPClient {
 }
 
 #[cfg(test)]
-pub(crate) mod dumb {
-    use tokio::sync::RwLock;
-
-    use mithril_common::test::double::Dummy;
-
-    use super::*;
-
-    /// This aggregator client is intended to be used by test services.
-    /// It actually does not communicate with an aggregator host but mimics this behavior.
-    /// It is driven by a Tester that controls the data it can return, and it can return its internal state for testing.
-    pub struct DumbAggregatorClient {
-        epoch_settings: RwLock<Option<LeaderAggregatorEpochSettings>>,
-    }
-
-    impl Default for DumbAggregatorClient {
-        fn default() -> Self {
-            Self {
-                epoch_settings: RwLock::new(Some(LeaderAggregatorEpochSettings::dummy())),
-            }
-        }
-    }
-
-    #[async_trait]
-    impl LeaderAggregatorClient for DumbAggregatorClient {
-        async fn retrieve_epoch_settings(
-            &self,
-        ) -> StdResult<Option<LeaderAggregatorEpochSettings>> {
-            let epoch_settings = self.epoch_settings.read().await.clone();
-
-            Ok(epoch_settings)
-        }
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use http::response::Builder as HttpResponseBuilder;
     use httpmock::prelude::*;

--- a/mithril-aggregator/src/services/certifier/buffered_certifier.rs
+++ b/mithril-aggregator/src/services/certifier/buffered_certifier.rs
@@ -131,16 +131,15 @@ impl CertifierService for BufferedCertifierService {
             .create_open_message(signed_entity_type, protocol_message)
             .await;
 
-        if creation_result.is_ok() {
-            if let Err(error) = self
+        if creation_result.is_ok()
+            && let Err(error) = self
                 .try_register_buffered_signatures_to_current_open_message(signed_entity_type)
                 .await
-            {
-                warn!(self.logger, "Failed to register buffered signatures to the new open message";
-                    "signed_entity_type" => ?signed_entity_type,
-                    "error" => ?error
-                );
-            }
+        {
+            warn!(self.logger, "Failed to register buffered signatures to the new open message";
+                "signed_entity_type" => ?signed_entity_type,
+                "error" => ?error
+            );
         }
 
         creation_result

--- a/mithril-aggregator/src/services/message.rs
+++ b/mithril-aggregator/src/services/message.rs
@@ -621,7 +621,7 @@ mod tests {
         async fn get_certificate() {
             let genesis_certificate = fake_data::genesis_certificate("genesis_hash");
             let service = MessageServiceBuilder::new()
-                .with_certificates(&[genesis_certificate.clone()])
+                .with_certificates(std::slice::from_ref(&genesis_certificate))
                 .build()
                 .await;
 
@@ -705,7 +705,7 @@ mod tests {
             let message: SnapshotMessage = record.clone().try_into().unwrap();
 
             let service = MessageServiceBuilder::new()
-                .with_signed_entity_records(&[record.clone()])
+                .with_signed_entity_records(std::slice::from_ref(&record))
                 .build()
                 .await;
 
@@ -778,7 +778,7 @@ mod tests {
             let message: CardanoDatabaseSnapshotMessage = record.clone().try_into().unwrap();
 
             let service = MessageServiceBuilder::new()
-                .with_signed_entity_records(&[record.clone()])
+                .with_signed_entity_records(std::slice::from_ref(&record))
                 .build()
                 .await;
 
@@ -869,7 +869,7 @@ mod tests {
             let message: MithrilStakeDistributionMessage = record.clone().try_into().unwrap();
 
             let service = MessageServiceBuilder::new()
-                .with_signed_entity_records(&[record.clone()])
+                .with_signed_entity_records(std::slice::from_ref(&record))
                 .build()
                 .await;
 
@@ -949,7 +949,7 @@ mod tests {
             let message: CardanoTransactionSnapshotMessage = record.clone().try_into().unwrap();
 
             let service = MessageServiceBuilder::new()
-                .with_signed_entity_records(&[record.clone()])
+                .with_signed_entity_records(std::slice::from_ref(&record))
                 .build()
                 .await;
 
@@ -1028,7 +1028,7 @@ mod tests {
             let message: CardanoStakeDistributionMessage = record.clone().try_into().unwrap();
 
             let service = MessageServiceBuilder::new()
-                .with_signed_entity_records(&[record.clone()])
+                .with_signed_entity_records(std::slice::from_ref(&record))
                 .build()
                 .await;
 
@@ -1066,7 +1066,7 @@ mod tests {
             let message: CardanoStakeDistributionMessage = record.clone().try_into().unwrap();
 
             let service = MessageServiceBuilder::new()
-                .with_signed_entity_records(&[record.clone()])
+                .with_signed_entity_records(std::slice::from_ref(&record))
                 .build()
                 .await;
 

--- a/mithril-aggregator/src/services/stake_distribution.rs
+++ b/mithril-aggregator/src/services/stake_distribution.rs
@@ -118,7 +118,7 @@ impl Default for UpdateToken {
 }
 
 impl UpdateToken {
-    pub fn update(&self, epoch: Epoch) -> StdResult<MutexGuard<()>> {
+    pub fn update(&self, epoch: Epoch) -> StdResult<MutexGuard<'_, ()>> {
         let update_semaphore = self.is_busy.try_lock().map_err(|_| {
             let last_updated_epoch = self.busy_on_epoch.read().unwrap();
 

--- a/mithril-aggregator/src/store/epoch_settings_storer.rs
+++ b/mithril-aggregator/src/store/epoch_settings_storer.rs
@@ -1,7 +1,9 @@
+#[cfg(test)]
 use std::collections::HashMap;
 
 use async_trait::async_trait;
 use mithril_common::StdResult;
+#[cfg(test)]
 use tokio::sync::RwLock;
 
 use mithril_common::entities::{Epoch, ProtocolParameters};
@@ -56,18 +58,20 @@ pub trait EpochSettingsStorer:
     }
 }
 
+#[cfg(test)]
 pub struct FakeEpochSettingsStorer {
     pub epoch_settings: RwLock<HashMap<Epoch, AggregatorEpochSettings>>,
 }
 
+#[cfg(test)]
 impl FakeEpochSettingsStorer {
-    #[cfg(test)]
     pub fn new(data: Vec<(Epoch, AggregatorEpochSettings)>) -> Self {
         let epoch_settings = RwLock::new(data.into_iter().collect());
         Self { epoch_settings }
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl ProtocolParametersRetriever for FakeEpochSettingsStorer {
     async fn get_protocol_parameters(&self, epoch: Epoch) -> StdResult<Option<ProtocolParameters>> {
@@ -78,6 +82,7 @@ impl ProtocolParametersRetriever for FakeEpochSettingsStorer {
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl EpochSettingsStorer for FakeEpochSettingsStorer {
     async fn save_epoch_settings(
@@ -97,6 +102,7 @@ impl EpochSettingsStorer for FakeEpochSettingsStorer {
     }
 }
 
+#[cfg(test)]
 #[async_trait]
 impl EpochPruningTask for FakeEpochSettingsStorer {
     fn pruned_data(&self) -> &'static str {

--- a/mithril-aggregator/src/tools/file_archiver/api.rs
+++ b/mithril-aggregator/src/tools/file_archiver/api.rs
@@ -69,16 +69,21 @@ impl FileArchiver {
         let temporary_archive_path = parameters.temporary_archive_path();
 
         let temporary_file_archive = self
-            .create_and_verify_archive(&temporary_archive_path, appender, parameters.compression_algorithm)
+            .create_and_verify_archive(
+                &temporary_archive_path,
+                appender,
+                parameters.compression_algorithm,
+            )
             .inspect_err(|_err| {
-                if temporary_archive_path.exists() {
-                    if let Err(remove_error) = fs::remove_file(&temporary_archive_path) {
-                        warn!(
-                            self.logger, " > Post FileArchiver.archive failure, could not remove temporary archive";
-                            "archive_path" => temporary_archive_path.display(),
-                            "error" => remove_error
-                        );
-                    }
+                if temporary_archive_path.exists()
+                    && let Err(remove_error) = fs::remove_file(&temporary_archive_path)
+                {
+                    warn!(
+                        self.logger,
+                        " > Post FileArchiver.archive failure, could not remove temporary archive";
+                        "archive_path" => temporary_archive_path.display(),
+                        "error" => remove_error
+                    );
                 }
             })
             .with_context(|| {

--- a/mithril-aggregator/src/tools/file_archiver/appender.rs
+++ b/mithril-aggregator/src/tools/file_archiver/appender.rs
@@ -24,18 +24,19 @@ pub trait TarAppender: Send {
     }
 }
 
+#[cfg(test)]
 pub struct AppenderDirAll {
     target_directory: PathBuf,
 }
-
+#[cfg(test)]
 impl AppenderDirAll {
     // Note: Not used anymore outside of tests but useful tool to keep around if we ever need to archive a directory
-    #[cfg(test)]
     pub fn new(target_directory: PathBuf) -> Self {
         Self { target_directory }
     }
 }
 
+#[cfg(test)]
 impl TarAppender for AppenderDirAll {
     fn append<T: Write>(&self, tar: &mut tar::Builder<T>) -> StdResult<()> {
         tar.append_dir_all(".", &self.target_directory).with_context(|| {

--- a/mithril-aggregator/tests/prove_transactions.rs
+++ b/mithril-aggregator/tests/prove_transactions.rs
@@ -115,7 +115,7 @@ async fn prove_transactions() {
     let proof_for_last_transaction = prover
         .compute_transactions_proofs(
             last_tx_snapshot.artifact.block_number,
-            &[last_transaction_hash.clone()],
+            std::slice::from_ref(&last_transaction_hash),
         )
         .await
         .unwrap()

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.12.24"
+version = "0.12.25"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/utils/archive_unpacker/zip_unpacker.rs
+++ b/mithril-client-cli/src/utils/archive_unpacker/zip_unpacker.rs
@@ -32,12 +32,12 @@ impl ArchiveFormat for ZipUnpacker {
                     format!("Could not create directory '{}'", outpath.display())
                 })?;
             } else {
-                if let Some(parent) = outpath.parent() {
-                    if !parent.exists() {
-                        fs::create_dir_all(parent).with_context(|| {
-                            format!("Could not create directory '{}'", parent.display())
-                        })?;
-                    }
+                if let Some(parent) = outpath.parent()
+                    && !parent.exists()
+                {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!("Could not create directory '{}'", parent.display())
+                    })?;
                 }
                 let mut outfile = File::create(&outpath)
                     .with_context(|| format!("Could not create file '{}'", outpath.display()))?;

--- a/mithril-client-cli/src/utils/feedback_receiver.rs
+++ b/mithril-client-cli/src/utils/feedback_receiver.rs
@@ -421,7 +421,8 @@ mod tests {
         #[tokio::test]
         async fn starting_full_immutables_and_ancillary_together_spawn_two_progress_bars() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db_v1, full_immutables_dl, started => sender, digest:"digest", size:123);
             send_event!(cardano_db_v1, ancillary_dl, started =>  sender, size:456);
@@ -433,7 +434,8 @@ mod tests {
         #[tokio::test]
         async fn start_and_progress_ancillary_download_with_a_size_of_zero_should_not_crash() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db_v1, ancillary_dl, started => sender, size:0);
             send_event!(cardano_db_v1, ancillary_dl, progress => sender, bytes:124, size:0);
@@ -444,7 +446,8 @@ mod tests {
         #[tokio::test]
         async fn start_then_complete_should_remove_immutables_progress_bar() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db_v1, full_immutables_dl, started => sender, digest:"digest", size:123);
             send_event!(cardano_db_v1, full_immutables_dl, completed => sender);
@@ -455,7 +458,8 @@ mod tests {
         #[tokio::test]
         async fn start_then_complete_should_remove_ancillary_progress_bar() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db_v1, ancillary_dl, started =>  sender, size:456);
             send_event!(cardano_db_v1, ancillary_dl, completed =>  sender);
@@ -470,7 +474,8 @@ mod tests {
         #[tokio::test]
         async fn starting_should_add_multi_progress_bar() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:99, ancillary:false);
 
@@ -480,7 +485,8 @@ mod tests {
         #[tokio::test]
         async fn start_then_complete_should_remove_multi_progress_bar() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:99, ancillary:false);
             send_event!(cardano_db, dl_completed => sender);
@@ -491,7 +497,8 @@ mod tests {
         #[tokio::test]
         async fn start_including_ancillary_add_one_to_total_downloads() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:99, ancillary:true);
 
@@ -509,7 +516,8 @@ mod tests {
         #[tokio::test]
         async fn starting_twice_should_supersede_first_multi_progress_bar() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:50, ancillary:false);
             send_event!(cardano_db, dl_started => sender, total:99, ancillary:false);
@@ -528,7 +536,8 @@ mod tests {
         #[tokio::test]
         async fn complete_without_start_should_not_panic() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_completed => sender);
         }
@@ -536,7 +545,8 @@ mod tests {
         #[tokio::test]
         async fn starting_immutable_downloads_should_not_add_progress_bars() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:50, ancillary:false);
 
@@ -551,7 +561,8 @@ mod tests {
         #[tokio::test]
         async fn completed_immutable_downloads_bump_progress() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:50, ancillary:false);
 
@@ -566,7 +577,8 @@ mod tests {
         #[tokio::test]
         async fn starting_digests_downloads_should_not_add_progress_bars() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:50, ancillary:false);
 
@@ -581,7 +593,8 @@ mod tests {
         #[tokio::test]
         async fn starting_ancillary_downloads_should_add_a_progress_bar() {
             let receiver = build_feedback_receiver(ProgressOutputType::Hidden);
-            let sender = FeedbackSender::new(&[receiver.clone()]);
+            let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+            let sender = FeedbackSender::new(&[receiver_clone]);
 
             send_event!(cardano_db, dl_started => sender, total:50, ancillary:false);
 

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.12.25"
+version = "0.12.26"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/certificate_client/verify.rs
+++ b/mithril-client/src/certificate_client/verify.rs
@@ -140,12 +140,12 @@ impl MithrilCertificateVerifier {
             .await?;
 
         #[cfg(feature = "unstable")]
-        if let Some(cache) = self.verifier_cache.as_ref() {
-            if !certificate.is_genesis() {
-                cache
-                    .store_validated_certificate(&certificate.hash, &certificate.previous_hash)
-                    .await?;
-            }
+        if let Some(cache) = self.verifier_cache.as_ref()
+            && !certificate.is_genesis()
+        {
+            cache
+                .store_validated_certificate(&certificate.hash, &certificate.previous_hash)
+                .await?;
         }
 
         trace!(self.logger, "Certificate validated"; "hash" => &certificate.hash, "previous_hash" => &certificate.previous_hash);

--- a/mithril-client/src/feedback.rs
+++ b/mithril-client/src/feedback.rs
@@ -590,7 +590,8 @@ mod tests {
     #[tokio::test]
     async fn send_event_same_thread() {
         let receiver = Arc::new(StackFeedbackReceiver::new());
-        let sender = FeedbackSender::new(&[receiver.clone()]);
+        let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
+        let sender = FeedbackSender::new(&[receiver_clone]);
 
         sender
             .send_event(SnapshotDownloadStarted {
@@ -716,8 +717,9 @@ mod tests {
     #[tokio::test]
     async fn send_event_in_one_thread_and_receive_in_another_thread() {
         let receiver = Arc::new(StackFeedbackReceiver::new());
+        let receiver_clone = receiver.clone() as Arc<dyn FeedbackReceiver>;
         let receiver2 = receiver.clone();
-        let sender = FeedbackSender::new(&[receiver.clone()]);
+        let sender = FeedbackSender::new(&[receiver_clone]);
         let mut join_set = JoinSet::new();
 
         join_set.spawn(async move {

--- a/mithril-client/src/file_downloader/http.rs
+++ b/mithril-client/src/file_downloader/http.rs
@@ -245,7 +245,9 @@ mod tests {
     use mithril_common::{entities::FileUri, test::TempDir};
 
     use crate::{
-        feedback::{MithrilEvent, MithrilEventCardanoDatabase, StackFeedbackReceiver},
+        feedback::{
+            FeedbackReceiver, MithrilEvent, MithrilEventCardanoDatabase, StackFeedbackReceiver,
+        },
         test_utils::TestLogger,
     };
 
@@ -288,8 +290,9 @@ mod tests {
                 .header(reqwest::header::CONTENT_LENGTH.as_str(), size.to_string());
         });
         let feedback_receiver = Arc::new(StackFeedbackReceiver::new());
+        let feedback_receiver_clone = feedback_receiver.clone() as Arc<dyn FeedbackReceiver>;
         let http_file_downloader = HttpFileDownloader::new(
-            FeedbackSender::new(&[feedback_receiver.clone()]),
+            FeedbackSender::new(&[feedback_receiver_clone]),
             TestLogger::stdout(),
         )
         .unwrap();
@@ -339,8 +342,9 @@ mod tests {
         file.write_all(content.as_bytes()).unwrap();
 
         let feedback_receiver = Arc::new(StackFeedbackReceiver::new());
+        let feedback_receiver_clone = feedback_receiver.clone() as Arc<dyn FeedbackReceiver>;
         let http_file_downloader = HttpFileDownloader::new(
-            FeedbackSender::new(&[feedback_receiver.clone()]),
+            FeedbackSender::new(&[feedback_receiver_clone]),
             TestLogger::stdout(),
         )
         .unwrap();

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.6.13"
+version = "0.6.14"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -228,10 +228,9 @@ impl MithrilCertificateVerifier {
         if let Some(signed_epoch) = &certificate
             .protocol_message
             .get_message_part(&ProtocolMessagePartKey::CurrentEpoch)
+            && **signed_epoch == certificate.epoch.to_string()
         {
-            if **signed_epoch == certificate.epoch.to_string() {
-                return Ok(());
-            }
+            return Ok(());
         }
 
         Err(anyhow!(CertificateVerifierError::CertificateEpochUnmatch))

--- a/mithril-common/src/crypto_helper/merkle_map.rs
+++ b/mithril-common/src/crypto_helper/merkle_map.rs
@@ -194,10 +194,10 @@ impl<K: MKMapKey, V: MKMapValue<K>, S: MKTreeStorer> MKMap<K, V, S> {
         let leaves_by_keys = self.group_leaves_by_keys(leaves);
         let mut sub_proofs = BTreeMap::<K, MKMapProof<K>>::default();
         for (key, sub_leaves) in leaves_by_keys {
-            if let Some(value) = self.get(&key) {
-                if let Some(proof) = value.compute_proof(&sub_leaves)? {
-                    sub_proofs.insert(key.to_owned(), proof);
-                }
+            if let Some(value) = self.get(&key)
+                && let Some(proof) = value.compute_proof(&sub_leaves)?
+            {
+                sub_proofs.insert(key.to_owned(), proof);
             }
         }
 

--- a/mithril-common/src/test/double/certificate_retriever.rs
+++ b/mithril-common/src/test/double/certificate_retriever.rs
@@ -53,7 +53,7 @@ mod tests {
         let certificate = fake_data::certificate("certificate-hash-123".to_string());
         let certificate_hash = certificate.hash.clone();
         let certificate_retriever =
-            FakeCertificaterRetriever::from_certificates(&[certificate.clone()]);
+            FakeCertificaterRetriever::from_certificates(std::slice::from_ref(&certificate));
 
         let retrieved_certificate = certificate_retriever
             .get_certificate_details(&certificate_hash)

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.4.10"
+version = "0.4.11"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -71,76 +71,74 @@ use mithril_stm::{Clerk, Parameters, SingleSignature, KeyRegistration, Initializ
 
 type H = Blake2b<U32>;
 
-fn main() {
-    let nparties = 32;
-    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-    let mut msg = [0u8; 16];
-    rng.fill_bytes(&mut msg);
+let nparties = 32;
+let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+let mut msg = [0u8; 16];
+rng.fill_bytes(&mut msg);
 
-    //////////////////////////
-    // initialization phase //
-    //////////////////////////
+//////////////////////////
+// initialization phase //
+//////////////////////////
 
-    let params = Parameters {
-        k: 357,
-        m: 2642,
-        phi_f: 0.2,
-    };
+let params = Parameters {
+    k: 357,
+    m: 2642,
+    phi_f: 0.2,
+};
 
-    let parties = (0..nparties)
-        .into_iter()
-        .map(|_| 1 + (rng.next_u64() % 9999))
-        .collect::<Vec<_>>();
+let parties = (0..nparties)
+    .into_iter()
+    .map(|_| 1 + (rng.next_u64() % 9999))
+    .collect::<Vec<_>>();
 
-    let mut key_reg = KeyRegistration::init();
+let mut key_reg = KeyRegistration::init();
 
-    let mut ps: Vec<Initializer> = Vec::with_capacity(nparties as usize);
-    for stake in parties {
-        let p = Initializer::setup(params, stake, &mut rng);
-        key_reg.register(stake, p.verification_key()).unwrap();
-        ps.push(p);
+let mut ps: Vec<Initializer> = Vec::with_capacity(nparties as usize);
+for stake in parties {
+    let p = Initializer::setup(params, stake, &mut rng);
+    key_reg.register(stake, p.verification_key()).unwrap();
+    ps.push(p);
+}
+
+let closed_reg = key_reg.close();
+
+let ps = ps
+    .into_par_iter()
+    .map(|p| p.new_signer(closed_reg.clone()).unwrap())
+    .collect::<Vec<Signer<H>>>();
+
+/////////////////////
+// operation phase //
+/////////////////////
+
+let sigs = ps
+    .par_iter()
+    .filter_map(|p| p.sign(&msg))
+    .collect::<Vec<SingleSignature>>();
+
+let clerk = Clerk::from_signer(&ps[0]);
+let avk = clerk.compute_avk();
+
+// Check all parties can verify every sig
+for (s, p) in sigs.iter().zip(ps.iter()) {
+    assert!(s.verify(&params, &p.verification_key(), &p.get_stake(), &avk, &msg).is_ok(), "Verification
+    failed");
+}
+
+// Aggregate with random parties
+let msig = clerk.aggregate(&sigs, &msg);
+
+match msig {
+    Ok(aggr) => {
+        println!("Aggregate ok");
+        assert!(aggr.verify(&msg, &clerk.compute_avk(), &params).is_ok());
     }
-
-    let closed_reg = key_reg.close();
-
-    let ps = ps
-        .into_par_iter()
-        .map(|p| p.new_signer(closed_reg.clone()).unwrap())
-        .collect::<Vec<Signer<H>>>();
-
-    /////////////////////
-    // operation phase //
-    /////////////////////
-
-    let sigs = ps
-        .par_iter()
-        .filter_map(|p| p.sign(&msg))
-        .collect::<Vec<SingleSignature>>();
-
-    let clerk = Clerk::from_signer(&ps[0]);
-    let avk = clerk.compute_avk();
-
-    // Check all parties can verify every sig
-    for (s, p) in sigs.iter().zip(ps.iter()) {
-        assert!(s.verify(&params, &p.verification_key(), &p.get_stake(), &avk, &msg).is_ok(), "Verification
-        failed");
+    Err(AggregationError::NotEnoughSignatures(n, k)) => {
+        println!("Not enough signatures");
+        assert!(n < params.k && k == params.k)
     }
-
-    // Aggregate with random parties
-    let msig = clerk.aggregate(&sigs, &msg);
-
-    match msig {
-        Ok(aggr) => {
-            println!("Aggregate ok");
-            assert!(aggr.verify(&msg, &clerk.compute_avk(), &params).is_ok());
-        }
-        Err(AggregationError::NotEnoughSignatures(n, k)) => {
-            println!("Not enough signatures");
-            assert!(n < params.k && k == params.k)
-        }
-        Err(AggregationError::UsizeConversionInvalid) => {
-            println!("Invalid usize conversion");
-        }
+    Err(AggregationError::UsizeConversionInvalid) => {
+        println!("Invalid usize conversion");
     }
 }
 ```

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.98"
+version = "0.4.99"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/fake_signer.rs
@@ -73,7 +73,7 @@ pub async fn try_register_signer_until_registration_round_is_open(
     timeout: Duration,
 ) -> StdResult<()> {
     let mut register_message =
-        payload_builder::generate_register_signer_message(&[signer.clone()], epoch);
+        payload_builder::generate_register_signer_message(std::slice::from_ref(signer), epoch);
     let register_message = register_message.swap_remove(0);
     let party_id = register_message.party_id.clone();
 


### PR DESCRIPTION
## Content

This PR includes fixes to the **new clippy warnings appeared with the release of Rust `1.89`**.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

