### PR TITLE
fix: doctests using deprecated functions in STM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.5.0"
+version = "0.5.1"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -53,7 +53,7 @@
 //! let mut ps: Vec<Initializer> = Vec::with_capacity(nparties);
 //! for stake in stakes {
 //!     // Create keys for this party
-//!     let p = Initializer::setup(params, stake, &mut rng);
+//!     let p = Initializer::new(params, stake, &mut rng);
 //!     // Register keys with the KeyRegistration service
 //!     key_reg
 //!         .register(p.stake, p.verification_key())


### PR DESCRIPTION
## Content

This PR includes a **fix to the doctests of the STM library which was using deprecated functions**.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
