### PR TITLE
Fixing typo in bls PoP.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4522,7 +4522,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bincode",
  "blake2 0.10.6",

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.5.1"
+version = "0.5.2"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/bls_multi_signature/mod.rs
+++ b/mithril-stm/src/bls_multi_signature/mod.rs
@@ -158,7 +158,7 @@ mod tests {
             let vk_infinity = BlsVerificationKey(p2_affine_to_vk(&p2));
             let vkpop_infinity = BlsVerificationKeyProofOfPossession { vk: vk_infinity, pop };
 
-            let result = vkpop_infinity.verify_proof_of_possesion();
+            let result = vkpop_infinity.verify_proof_of_possession();
             assert_eq!(result, Err(MultiSignatureError::VerificationKeyInfinity(Box::new(vkpop_infinity.vk))));
         }
 

--- a/mithril-stm/src/bls_multi_signature/verification_key.rs
+++ b/mithril-stm/src/bls_multi_signature/verification_key.rs
@@ -136,7 +136,7 @@ impl BlsVerificationKeyProofOfPossession {
     /// manually.
     // If we are really looking for performance improvements, we can combine the
     // two final exponentiations (for verifying k1 and k2) into a single one.
-    pub(crate) fn verify_proof_of_possesion(&self) -> Result<(), MultiSignatureError> {
+    pub(crate) fn verify_proof_of_possession(&self) -> Result<(), MultiSignatureError> {
         match self.vk.to_blst_verification_key().validate() {
             Ok(_) => {
                 let result = verify_pairing(&self.vk, &self.pop);
@@ -164,9 +164,9 @@ impl BlsVerificationKeyProofOfPossession {
     /// manually.
     // If we are really looking for performance improvements, we can combine the
     // two final exponentiations (for verifying k1 and k2) into a single one.
-    #[deprecated(since = "0.5.0", note = "Use `verify_proof_of_possesion` instead")]
+    #[deprecated(since = "0.5.0", note = "Use `verify_proof_of_possession` instead")]
     pub fn check(&self) -> Result<(), MultiSignatureError> {
-        Self::verify_proof_of_possesion(self)
+        Self::verify_proof_of_possession(self)
     }
 
     /// Convert to a 144 byte string.

--- a/mithril-stm/src/bls_multi_signature/verification_key.rs
+++ b/mithril-stm/src/bls_multi_signature/verification_key.rs
@@ -164,7 +164,10 @@ impl BlsVerificationKeyProofOfPossession {
     /// manually.
     // If we are really looking for performance improvements, we can combine the
     // two final exponentiations (for verifying k1 and k2) into a single one.
-    #[deprecated(since = "0.5.0", note = "Use `verify_proof_of_possession` instead")]
+    #[deprecated(
+        since = "0.5.0",
+        note = "The verification of the proof of possession is not part of the public API any more"
+    )]
     pub fn check(&self) -> Result<(), MultiSignatureError> {
         Self::verify_proof_of_possession(self)
     }

--- a/mithril-stm/src/key_registration.rs
+++ b/mithril-stm/src/key_registration.rs
@@ -37,7 +37,7 @@ impl KeyRegistration {
         pk: BlsVerificationKeyProofOfPossession,
     ) -> Result<(), RegisterError> {
         if let Entry::Vacant(e) = self.keys.entry(pk.vk) {
-            pk.verify_proof_of_possesion()?;
+            pk.verify_proof_of_possession()?;
             e.insert(stake);
             return Ok(());
         }
@@ -136,7 +136,7 @@ mod tests {
                     }
                     Err(RegisterError::KeyInvalid(a)) => {
                         assert_eq!(fake_it, 0);
-                        assert!(a.verify_proof_of_possesion().is_err());
+                        assert!(a.verify_proof_of_possession().is_err());
                     }
                     Err(RegisterError::SerializationError) => unreachable!(),
                     _ => unreachable!(),


### PR DESCRIPTION
Fixing a typo in verify_proof_of_possession in mithril-stm/src/bls_multi_signature/verfication_key.rs.
