### PR TITLE
fix: flakiness in DMQ integration tests in CI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-dmq"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-dmq/Cargo.toml
+++ b/internal/mithril-dmq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mithril-dmq"
 description = "Mechanisms to publish and consume messages of a 'Decentralized Message Queue network' through a DMQ node"
-version = "0.1.11"
+version = "0.1.12"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/mithril-dmq/src/test/double/mod.rs
+++ b/internal/mithril-dmq/src/test/double/mod.rs
@@ -4,6 +4,8 @@
 
 mod consumer;
 mod publisher;
+mod timestamp;
 
 pub use consumer::*;
 pub use publisher::*;
+pub use timestamp::*;

--- a/internal/mithril-dmq/src/test/double/timestamp.rs
+++ b/internal/mithril-dmq/src/test/double/timestamp.rs
@@ -1,0 +1,26 @@
+use mithril_common::StdResult;
+
+use crate::model::UnixTimestampProvider;
+
+/// Fake implementation of a Unix current timestamp provider. For testing purposes only.
+pub struct FakeUnixTimestampProvider(u64);
+
+impl FakeUnixTimestampProvider {
+    /// Creates a new `FakeUnixTimestampProvider` with the given timestamp.
+    pub fn new(timestamp: u64) -> Self {
+        Self(timestamp)
+    }
+
+    /// Computes the maximum timestamp that can be used with the given TTL and builds a new FakeUnixTimestampProvider.
+    ///
+    /// This is useful to create messages that are valid for the maximum possible time.
+    pub fn max_timestamp_for_ttl(ttl: u16) -> Self {
+        Self(u32::MAX as u64 - ttl as u64 - 1)
+    }
+}
+
+impl UnixTimestampProvider for FakeUnixTimestampProvider {
+    fn current_timestamp(&self) -> StdResult<u64> {
+        Ok(self.0)
+    }
+}

--- a/internal/mithril-dmq/src/test/fake_message.rs
+++ b/internal/mithril-dmq/src/test/fake_message.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use mithril_cardano_node_chain::test::double::FakeChainObserver;
 use mithril_common::{crypto_helper::TryToBytes, test::crypto_helper::KesSignerFake};
 
-use crate::{DmqMessage, DmqMessageBuilder, test::payload::DmqMessageTestPayload};
+use crate::{
+    DmqMessage, DmqMessageBuilder,
+    test::{double::FakeUnixTimestampProvider, payload::DmqMessageTestPayload},
+};
 
 /// Computes a fake DMQ message for testing purposes.
 pub async fn compute_fake_msg(bytes: &[u8], test_directory: &str) -> DmqMessage {
@@ -20,7 +23,10 @@ pub async fn compute_fake_msg(bytes: &[u8], test_directory: &str) -> DmqMessage 
         },
         Arc::new(FakeChainObserver::default()),
     )
-    .set_ttl(100);
+    .set_ttl(100)
+    .set_timestamp_provider(Arc::new(FakeUnixTimestampProvider::max_timestamp_for_ttl(
+        100,
+    )));
     let message = DmqMessageTestPayload::new(bytes);
     dmq_builder.build(&message.to_bytes_vec().unwrap()).await.unwrap()
 }

--- a/internal/mithril-dmq/tests/publisher_client_server.rs
+++ b/internal/mithril-dmq/tests/publisher_client_server.rs
@@ -11,7 +11,10 @@ use mithril_common::{
 use mithril_dmq::{
     DmqMessage, DmqMessageBuilder, DmqPublisherClient, DmqPublisherClientPallas,
     DmqPublisherServer, DmqPublisherServerPallas,
-    test::{fake_message::compute_fake_msg, payload::DmqMessageTestPayload},
+    test::{
+        double::FakeUnixTimestampProvider, fake_message::compute_fake_msg,
+        payload::DmqMessageTestPayload,
+    },
 };
 
 #[tokio::test]
@@ -59,7 +62,10 @@ async fn dmq_publisher_client_server() {
                 },
                 Arc::new(FakeChainObserver::default()),
             )
-            .set_ttl(100);
+            .set_ttl(100)
+            .set_timestamp_provider(Arc::new(
+                FakeUnixTimestampProvider::max_timestamp_for_ttl(100),
+            ));
             let publisher_client = DmqPublisherClientPallas::<DmqMessageTestPayload>::new(
                 socket_path,
                 cardano_network,
@@ -101,7 +107,10 @@ async fn dmq_publisher_client_server() {
                 },
                 Arc::new(FakeChainObserver::default()),
             )
-            .set_ttl(100);
+            .set_ttl(100)
+            .set_timestamp_provider(Arc::new(
+                FakeUnixTimestampProvider::max_timestamp_for_ttl(100),
+            ));
             let publisher_client = DmqPublisherClientPallas::<DmqMessageTestPayload>::new(
                 socket_path,
                 cardano_network,


### PR DESCRIPTION
## Content

This PR includes a **fix for the DMQ integration tests flakiness which was due to non deterministic timestamp provider when signing DMQ messages with KES keys**.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #2728 
