### PR TITLE
Fix missing signed entity types enum of aggregator features message schema

### DIFF
--- a/mithril-aggregator/src/http_server/routes/root_routes.rs
+++ b/mithril-aggregator/src/http_server/routes/root_routes.rs
@@ -125,7 +125,10 @@ mod tests {
                 SignedEntityTypeDiscriminants::CardanoStakeDistribution,
                 SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
                 SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+                SignedEntityTypeDiscriminants::CardanoTransactions,
+                SignedEntityTypeDiscriminants::CardanoDatabase,
             ]),
+            cardano_transactions_prover_max_hashes_allowed_by_request: 500,
             ..RouterConfig::dummy()
         };
         let dependency_manager = initialize_dependencies!().await;
@@ -161,9 +164,13 @@ mod tests {
                         SignedEntityTypeDiscriminants::CardanoStakeDistribution,
                         SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
                         SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+                        SignedEntityTypeDiscriminants::CardanoTransactions,
+                        SignedEntityTypeDiscriminants::CardanoDatabase,
                     ]),
                     aggregate_signature_type: AggregateSignatureType::Concatenation,
-                    cardano_transactions_prover: None,
+                    cardano_transactions_prover: Some(CardanoTransactionsProverCapabilities {
+                        max_hashes_allowed_by_request: 500
+                    }),
                 },
             }
         );

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -919,13 +919,8 @@ components:
               type: array
               minItems: 1
               items:
-                description: Signed entity types that can be signed
-                type: string
-                enum:
-                  - MithrilStakeDistribution
-                  - CardanoStakeDistribution
-                  - CardanoImmutableFilesFull
-                  - CardanoTransactions
+                $ref: "#/components/schemas/SignedEntityTypes"
+              
             aggregate_signature_type:
               description: Aggregate signature type used by the aggregator to create certificates
               type: string
@@ -982,6 +977,16 @@ components:
             - "latest"
             - "latest-5"
 
+    SignedEntityTypes:
+        description: Signed entity types that can be signed
+        type: string
+        enum:
+          - MithrilStakeDistribution
+          - CardanoStakeDistribution
+          - CardanoImmutableFilesFull
+          - CardanoTransactions
+          - CardanoDatabase
+      
     EpochSettingsMessage:
       description: Epoch settings
       type: object
@@ -1066,14 +1071,7 @@ components:
           type: array
           minItems: 1
           items:
-            description: Signed entity types that can be signed
-            type: string
-            enum:
-              - MithrilStakeDistribution
-              - CardanoStakeDistribution
-              - CardanoImmutableFilesFull
-              - CardanoTransactions
-              - CardanoDatabase
+            $ref: "#/components/schemas/SignedEntityTypes"
       examples:
         - {
             "protocol_parameters": { "k": 9, "m": 77, "phi_f": 0.5 },


### PR DESCRIPTION
## Content

TODO, to rebase after the merge of [PR 2741](https://github.com/input-output-hk/mithril/pull/2741)

This PR includes : 
- Adding the missing "CardanoDatabase" enum value to the property `signed_entity_types` of `AggregatorFeaturesMessage`
- improve `root_routes.rs` test with all `SignedEntityTypeDiscriminants values`


## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [ ] No new TODOs introduced

Closes #YYY
