### PR TITLE
fix: install on aarch64

### DIFF
--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -85,6 +85,7 @@ case "$ARCH" in
     ARCH_NAME="x64"
     ;;
   arm64)
+  aarch64)
     ARCH_NAME="arm64"
     ;;
   *)


### PR DESCRIPTION
## Content

On some ARM machines, `uname -m` returns `aarch64` instead of `arm64`. Update the install script to be OK with that.

This PR includes...

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [ ] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Relates to #YYY or Closes #YYY
