### PR TITLE
fix: syntax error in shell script

### DIFF
--- a/mithril-install.sh
+++ b/mithril-install.sh
@@ -84,8 +84,7 @@ case "$ARCH" in
   x86_64)
     ARCH_NAME="x64"
     ;;
-  arm64)
-  aarch64)
+  arm64|aarch64)
     ARCH_NAME="arm64"
     ;;
   *)


### PR DESCRIPTION
## Content

My PR #2776 used invalid shell syntax which broke the installer script. I didn't notice because I was using it as part of a larger script, and that script kept working because I had mithril-client installed globally. My bad :sweat_smile: 

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [ ] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Relates to #YYY or Closes #YYY
