### PR TITLE
ci(test-client): check fast bootstrap after lmdb conversion

### DIFF
--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -88,6 +88,7 @@ jobs:
       cardano_stake_distribution_enabled: ${{ steps.prepare.outputs.cardano_stake_distribution_enabled }}
       cardano_database_v2_enabled: ${{ steps.prepare.outputs.cardano_database_v2_enabled }}
       available_cardano_database_backends: ${{ steps.prepare.outputs.available_cardano_database_backends }}
+      bin-cdb-download-matrix-include: ${{ steps.prepare.outputs.bin-cdb-download-matrix-include }}
     steps:
       - name: Prepare
         id: prepare
@@ -115,8 +116,10 @@ jobs:
 
           if [[ $CARDANO_DATABASE_V2_CAPABILITY == "true" ]]; then
             echo 'available_cardano_database_backends=["v1","v2"]' >> $GITHUB_OUTPUT
+            echo 'bin-cdb-download-matrix-include=[{"backend":"v2","os":"ubuntu-24.04","ledger_backend":"lmdb","extra_args":"--include-ancillary"}]' >> $GITHUB_OUTPUT
           else
             echo 'available_cardano_database_backends=["v1"]' >> $GITHUB_OUTPUT
+            echo 'bin-cdb-download-matrix-include=[]' >> $GITHUB_OUTPUT
           fi
 
   bin:
@@ -247,7 +250,10 @@ jobs:
       matrix:
         backend: ${{ fromJson(needs.prepare.outputs.available_cardano_database_backends) }}
         os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14, windows-latest]
+        ledger_backend: ["in-memory"]
         extra_args: ["", "--include-ancillary"]
+
+        include: ${{ fromJson(needs.prepare.outputs.bin-cdb-download-matrix-include) }}
 
     runs-on: ${{ matrix.os }}
     env:
@@ -291,12 +297,12 @@ jobs:
 
       - name: Ledger state snapshot conversion from InMemory to LMDB
         # The 'snapshot-converter' binary is not currently supported on Linux ARM64 platforms.
-        if: matrix.os != 'ubuntu-24.04-arm' && matrix.extra_args == '--include-ancillary' && matrix.backend == 'v2'
+        if: matrix.os != 'ubuntu-24.04-arm' && matrix.extra_args == '--include-ancillary' && matrix.ledger_backend == 'lmdb'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         working-directory: ./bin
-        run: ./mithril-client ${{ needs.prepare.outputs.debug_level }} tools utxo-hd snapshot-converter --db-directory v2/db --cardano-node-version latest --utxo-hd-flavor LMDB --commit
+        run: ./mithril-client ${{ needs.prepare.outputs.debug_level }} tools utxo-hd snapshot-converter --db-directory ${{ matrix.backend }}/db --cardano-node-version latest --utxo-hd-flavor LMDB --commit
 
       - name: Cardano Database V2 Snapshot / verify immutables
         if: matrix.backend == 'v2'
@@ -307,7 +313,7 @@ jobs:
       - name: Cardano Database Snapshot / verify Cardano node starts successfully
         if: matrix.os == 'ubuntu-24.04'
         shell: bash
-        run: .github/workflows/scripts/verify-cardano-db-restoration.sh ./bin/cdb-${{ matrix.backend }}-download-output.txt "${{ matrix.extra_args }}"
+        run: .github/workflows/scripts/verify-cardano-db-restoration.sh ./bin/cdb-${{ matrix.backend }}-download-output.txt --ledger-backend ${{ matrix.ledger_backend }} ${{ matrix.extra_args }}
 
       - name: Cardano Database V2 Snapshot / verify tampered and missing immutables from a specific range
         if: matrix.backend == 'v2'


### PR DESCRIPTION
## Content

This PR rework the `test-client` workflow and add a new test case: verification of the node startup after conversion of the ledger to lmbd backend.

### `test-client` refactor details

- add a `prepare` job, on which all other jobs depends, to share the prepare steps that was done previously on all jobs.
- use the [global env](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#env) and the [job env](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idenv) keys to populate the environment variables instead of using `GITHUB_ENV`
- simplify the jobs names so the matrix combinatory is more visable in run: `test-binaries` -> `bin`, `test-docker` -> `docker`, `test-mithril-client-wasm` -> `wasm`
- extract the cardano database download checks from the `bin` and `docker` jobs into a `bin-cdb-download` and `docker-cdb-download` jobs: this remove the `extra_args` dimension from the `bin` and `docker` matrixes, and allow better controls and coverage of the cardano database downloads cases

### new test case: verification of the node startup after conversion of the ledger to lmbd

- update `.github/workflows/scripts/verify-cardano-db-restoration.sh`:
  - add a parameter analysis steps to allow easy addition of future parameters to the script
  - `--include-ancillary` must now be passed without double quote
  - add `--ledger-backend` parameter, when the next passed value is `lmdb` it update the docker run command to configure the correct ledger backend
- add `ledger_backend` matrix dimension to the `bin-cdb-download` job with one item: `in-memory`, the `lmdb` variant is passed through a `matrix.include` to avoid multiplication of the matrix since we run it in only one specific configuration (with ubuntu 24.04 x86, ancillary included, and v2 backend)

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #2679
