### PR TITLE
chore: remove uneeded crates type from most `Cargo.toml`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3655,7 +3655,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-client"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3720,7 +3720,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-cardano-node-chain"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-cardano-node-internal-database"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3869,7 +3869,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.6.27"
+version = "0.6.28"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3911,7 +3911,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-dmq"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-era"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-metric"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "axum",
@@ -4007,7 +4007,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.59"
+version = "0.2.60"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4069,7 +4069,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-resource-pool"
-version = "0.0.8"
+version = "0.0.9"
 dependencies = [
  "anyhow",
  "mithril-common",
@@ -4079,7 +4079,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signed-entity-lock"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "mithril-common",
  "tokio",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signed-entity-preloader"
-version = "0.0.10"
+version = "0.0.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4178,7 +4178,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-ticker"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/cardano-node/mithril-cardano-node-chain/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-chain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-cardano-node-chain"
-version = "0.1.9"
+version = "0.1.10"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-cardano-node-internal-database"
-version = "0.1.7"
+version = "0.1.8"
 description = "Mechanisms that allow Mithril nodes to read the files of a Cardano node internal database and compute digests from them"
 authors.workspace = true
 documentation.workspace = true

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator-client"
-version = "0.1.2"
+version = "0.1.3"
 description = "Client to request data from a Mithril Aggregator"
 authors.workspace = true
 documentation.workspace = true

--- a/internal/mithril-dmq/Cargo.toml
+++ b/internal/mithril-dmq/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mithril-dmq"
 description = "Mechanisms to publish and consume messages of a 'Decentralized Message Queue network' through a DMQ node"
-version = "0.1.13"
+version = "0.1.14"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/mithril-era/Cargo.toml
+++ b/internal/mithril-era/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-era"
-version = "0.1.5"
+version = "0.1.6"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/mithril-metric/Cargo.toml
+++ b/internal/mithril-metric/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-metric"
-version = "0.1.19"
+version = "0.1.20"
 description = "Common tools to expose metrics."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.59"
+version = "0.2.60"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-resource-pool/Cargo.toml
+++ b/internal/mithril-resource-pool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-resource-pool"
-version = "0.0.8"
+version = "0.0.9"
 description = "Provide a resource pool for Mithril."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-ticker/Cargo.toml
+++ b/internal/mithril-ticker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-ticker"
-version = "0.1.3"
+version = "0.1.4"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/signed-entity/mithril-signed-entity-lock/Cargo.toml
+++ b/internal/signed-entity/mithril-signed-entity-lock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signed-entity-lock"
-version = "0.0.4"
+version = "0.0.5"
 description = "A non-blocking lock mechanism for signed entity type."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/signed-entity/mithril-signed-entity-preloader/Cargo.toml
+++ b/internal/signed-entity/mithril-signed-entity-preloader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signed-entity-preloader"
-version = "0.0.10"
+version = "0.0.11"
 description = "A preload mechanism for Cardano Transaction signed entity."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.6.27"
+version = "0.6.28"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR remove the `crate-type` field from all crates except `mithril-stm` and `mithril-client` (and `mithril-client-wasm` where the `crate-type = ["cdylib"]` is mandatory for compilation).

Addition of `staticlib` add a lot of disk usage and build time and is not reasonable for crates that are not intended to be directly used by third parties.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2782