### PR TITLE
chore(ci): upgrade actions versions

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -19,7 +19,7 @@ runs:
       run: echo "short_sha=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: "3.x"
 
@@ -39,7 +39,7 @@ runs:
       run: cargo build --lib --release ${{ inputs.libraries-build-args }} ${{ inputs.common-build-args }}
 
     - name: Publish Mithril Distribution (${{ runner.os }}-${{ runner.arch }})
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
         path: |

--- a/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
+++ b/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
@@ -211,7 +211,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout sources
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@v3

--- a/.github/workflows/aggregator-stress-test.yml
+++ b/.github/workflows/aggregator-stress-test.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare environment variables
         id: prepare
@@ -60,7 +60,7 @@ jobs:
           toolchain: stable
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-X64
           path: ./bin
@@ -70,7 +70,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download test runners
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-tooling-Linux-X64
           path: ./bin
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload stress test artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: aggregator-stress-test-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}
           path: |

--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -64,7 +64,7 @@ jobs:
       tags: ${{ steps.tags-test-lab.outputs.tags }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -90,7 +90,7 @@ jobs:
           cp ./target/release/mithril-end-to-end ./mithril-binaries/e2e-${{ inputs.e2e-release }}
 
       - name: Upload Mithril binaries
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-binaries
           path: ./mithril-binaries
@@ -116,10 +116,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-binaries
           path: ./mithril-binaries
@@ -201,14 +201,14 @@ jobs:
 
       - name: Upload test result JSON
         if: success() || failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: ${{ env.RESULT_FILE_NAME }}
           path: ./${{ env.RESULT_FILE_NAME }}.json
 
       - name: Upload E2E Tests Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-tag_${{ matrix.tag }}-node-${{ matrix.node }}-cardano-${{ matrix.cardano_node_version }}-run_id_${{ matrix.run_id }}
           path: |
@@ -226,7 +226,7 @@ jobs:
 
     steps:
       - name: Download all test result artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           path: ./test-results
           pattern: e2e-test-result*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       eras: ${{ steps.eras-test-lab.outputs.eras }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -55,7 +55,7 @@ jobs:
           cargo deb --no-build --package mithril-relay
 
       - name: Publish Debian packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-deb-packages-${{ runner.os }}-${{ runner.arch }}
           path: target/debian/*.deb
@@ -63,7 +63,7 @@ jobs:
 
       - name: Publish End-to-end runner (${{ runner.os }}-${{ runner.arch }})
         if: matrix.os == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-tooling-${{ runner.os }}-${{ runner.arch }}
           path: |
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -118,10 +118,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
 
@@ -170,7 +170,7 @@ jobs:
           wasm-pack test --node mithril-client-wasm --release --features test-node
 
       - name: Publish Mithril Distribution (WASM)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-distribution-wasm
           path: |
@@ -212,7 +212,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -240,7 +240,7 @@ jobs:
           mv target/nextest/ci/tests-result.junit.xml test-results${{ matrix.artifact-suffix }}-${{ runner.os }}-${{ runner.arch }}.xml
 
       - name: Upload Tests Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         if: success() || failure()
         with:
           name: test-results-${{ runner.os }}-${{ runner.arch }}
@@ -250,7 +250,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -284,7 +284,7 @@ jobs:
 
       - name: Upload clippy analysis results to GitHub
         if: success() || failure()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: rust-clippy-results.sarif
           wait-for-processing: true
@@ -382,16 +382,16 @@ jobs:
             extra_args: "--mithril-era-regenesis-on-switch --aggregate-signature-type=Concatenation"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
           path: ./bin
 
       - name: Download rust test runner
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-tooling-${{ runner.os }}-${{ runner.arch }}
           path: ./
@@ -436,7 +436,7 @@ jobs:
 
       - name: Upload E2E Tests Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-mode_${{ matrix.mode }}-era_${{ matrix.era }}-cardano-${{ matrix.cardano_node_version }}-fork-${{  matrix.hard_fork_latest_era_at_epoch }}-run_id_${{ matrix.run_id }}
           path: |
@@ -455,7 +455,7 @@ jobs:
     steps:
       - name: Download Tests Results
         if: success() || failure()
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           pattern: test-results-*
           merge-multiple: true
@@ -464,7 +464,7 @@ jobs:
         if: success() || failure()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          junit_files: ./**/test-results-*.xml
+          files: ./**/test-results-*.xml
 
   docker-mithril:
     runs-on: ubuntu-24.04
@@ -501,7 +501,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get short SHA
         id: slug
@@ -530,13 +530,13 @@ jobs:
             type=raw,value=${{ github.base_ref || github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-X64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
 
       - name: Download built artifacts (Linux-ARM64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64
@@ -573,7 +573,7 @@ jobs:
       - check
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -603,7 +603,7 @@ jobs:
       - build-test-wasm
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -632,7 +632,7 @@ jobs:
       - check
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare packaging
         run: mkdir package
@@ -642,43 +642,43 @@ jobs:
         run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Download built artifacts (Linux-X64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-Linux-X64
           path: ./package-Linux-X64
 
       - name: Download Debian packages (Linux-X64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-deb-packages-Linux-X64
           path: ./package
 
       - name: Download built artifacts (Linux-ARM64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-Linux-ARM64
           path: ./package-Linux-ARM64
 
       - name: Download Debian packages (Linux-ARM64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-deb-packages-Linux-ARM64
           path: ./package
 
       - name: Download built artifacts (macOS-ARM64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-macOS-ARM64
           path: ./package-macOS-ARM64
 
       - name: Download built artifacts (Windows-X64)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-Windows-X64
           path: ./package-Windows-X64
 
       - name: Download built artifacts (Explorer)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: explorer-build
           path: ./package-explorer
@@ -761,7 +761,7 @@ jobs:
         working-directory: mithril-infra
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Docker image id
         run: echo "DOCKER_IMAGE_ID=${{ github.base_ref || github.ref_name }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
@@ -828,7 +828,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -866,13 +866,13 @@ jobs:
 
       - name: Upload cargo-doc results to GitHub
         if: success() || failure()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: rust-cargo-doc-results.sarif
           wait-for-processing: true
 
       - name: Publish Mithril-rust-doc
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-rust-doc
           if-no-files-found: error
@@ -883,10 +883,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"
@@ -902,7 +902,7 @@ jobs:
           npm run build
 
       - name: Publish Docusaurus build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: docusaurus-build
           if-no-files-found: error
@@ -914,10 +914,10 @@ jobs:
     needs: build-test-wasm
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download built artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-distribution-wasm
           path: mithril-client-wasm
@@ -927,7 +927,7 @@ jobs:
         run: tar -xvzf *.tgz && mv package/dist .
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: "npm"
@@ -946,7 +946,7 @@ jobs:
         run: make build
 
       - name: Publish Explorer build (stable)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: explorer-build
           if-no-files-found: error
@@ -961,7 +961,7 @@ jobs:
         run: make build
 
       - name: Publish Explorer build (unstable)
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: explorer-build-unstable
           if-no-files-found: error
@@ -972,7 +972,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build OpenAPI UI
         uses: Legion2/swagger-ui-action@v1
@@ -983,7 +983,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish OpenAPI UI build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: openapi-ui-build
           if-no-files-found: error
@@ -1001,13 +1001,13 @@ jobs:
       - check
     steps:
       - name: Download mithril-rust-doc artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: mithril-rust-doc
           path: ./github-pages/rust-doc
 
       - name: Download Docusaurus build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: docusaurus-build
           path: ./github-pages/doc
@@ -1025,13 +1025,13 @@ jobs:
           tar xvf mithril-explorer-${LAST_DISTRIBUTION}.tar.gz --directory=./github-pages/explorer/
 
       - name: Download Explorer build (unstable)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: explorer-build-unstable
           path: ./github-pages/explorer/unstable
 
       - name: Download OpenAPI UI build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: openapi-ui-build
           path: ./github-pages/openapi-ui

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/manual-publish-crates.yml
+++ b/.github/workflows/manual-publish-crates.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Checkout sources
         if: inputs.package == matrix.package || inputs.package == 'all'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.commit_sha }}
 

--- a/.github/workflows/manual-publish-npm.yml
+++ b/.github/workflows/manual-publish-npm.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Checkout sources
         if: inputs.package == matrix.package || inputs.package == 'all'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.commit_sha }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,13 +13,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Prepare packaging
         run: mkdir package
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-X64
           path: ./package-Linux-X64
@@ -28,7 +28,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download Debian packages (Linux-X64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-deb-packages-Linux-X64
           path: ./package
@@ -37,7 +37,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Linux-ARM64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-ARM64
           path: ./package-Linux-ARM64
@@ -46,7 +46,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download Debian packages (Linux-ARM64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-deb-packages-Linux-ARM64
           path: ./package
@@ -55,7 +55,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (macOS-ARM64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-macOS-ARM64
           path: ./package-macOS-ARM64
@@ -64,7 +64,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Windows-x64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Windows-X64
           path: ./package-Windows-X64
@@ -73,7 +73,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Explorer)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: explorer-build
           path: ./package-explorer
@@ -128,7 +128,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get short SHA
         id: slug
@@ -157,7 +157,7 @@ jobs:
             type=raw,value=${{ github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
@@ -166,7 +166,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Linux-arm64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64
@@ -224,7 +224,7 @@ jobs:
         working-directory: mithril-infra
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Docker image id
         run: echo "DOCKER_IMAGE_ID=${{ github.ref_name }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
@@ -303,7 +303,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -331,7 +331,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get short SHA
         id: slug
@@ -58,7 +58,7 @@ jobs:
             type=raw,value=${{ github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
@@ -67,7 +67,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Linux-arm64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64
@@ -146,7 +146,7 @@ jobs:
         working-directory: mithril-infra
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get Docker image id
         run: echo "DOCKER_IMAGE_ID=${{ github.ref_name }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
@@ -234,7 +234,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -263,7 +263,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -135,10 +135,10 @@ jobs:
       ANCILLARY_VERIFICATION_KEY: ${{ needs.prepare.outputs.ancillary_verification_key }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout binary
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
           path: ./bin
@@ -261,10 +261,10 @@ jobs:
       ANCILLARY_VERIFICATION_KEY: ${{ needs.prepare.outputs.ancillary_verification_key }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Checkout binary
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
           path: ./bin
@@ -502,10 +502,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download built artifacts
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-wasm
           path: ./mithril-client-wasm
@@ -571,7 +571,7 @@ jobs:
 
       - name: Upload Results Artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: mithril-client-wasm-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-os_${{ matrix.os }}
           path: |

--- a/.github/workflows/test-deploy-network.yml
+++ b/.github/workflows/test-deploy-network.yml
@@ -139,7 +139,7 @@ jobs:
     steps:
       - name: Checkout sources
         if: inputs.environment == matrix.environment
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: ${{ inputs.dry_run == true && 'Plan' || 'Apply' }} terraform infrastructure
         if: inputs.environment == matrix.environment

--- a/.github/workflows/test-docker-distribution.yml
+++ b/.github/workflows/test-docker-distribution.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Get short SHA
         id: slug
@@ -80,7 +80,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
@@ -89,7 +89,7 @@ jobs:
           workflow_conclusion: completed
 
       - name: Download built artifacts (Linux-arm64)
-        uses: dawidd6/action-download-artifact@v6
+        uses: dawidd6/action-download-artifact@v11
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64

--- a/.github/workflows/test-notify-on-failure.yml
+++ b/.github/workflows/test-notify-on-failure.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Write HTML body to file
         run: |


### PR DESCRIPTION
## Content

This PR includes upgrade our ci workflows actions versions.

This prepare the migration to node 24 and remove two warnings in ci logs:
- `CodeQL Action v3 will be deprecated in December 2026.`
- `Input 'junit_files' has been deprecated with message: Use "files" option instead`

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

