### PR TITLE
fix(ci): support hotfix branches in backcompat workflow

### DIFF
--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -259,7 +259,7 @@ jobs:
           # Transform summary.json into Markdown table rows
           jq -r --arg CHECK_MARK "$CHECK_MARK" --arg CROSS_MARK "$CROSS_MARK" \
             'group_by(.tag) |
-            sort_by(.[0].tag | tonumber) | reverse |
+            sort_by(.[0].tag | sub("-[a-z]+$"; "") | tonumber) | reverse |
             .[] |
             {
               tag: .[0].tag, 


### PR DESCRIPTION
## Content

This PR includes a fix to the backward compatibility github actions workflow in order to make it support hotfix branches.

Without this fix the summary job of the workflow fails with the following error:
```
jq: error (at ./test-results/summary.json:83): Invalid numeric literal at EOF at line 1, column 13 (while parsing '2543.1-hotfix')
```

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced
