### PR TITLE
fix(ci): crates already published guard was not working

### DIFF
--- a/.github/workflows/actions/publish-crate-package/action.yml
+++ b/.github/workflows/actions/publish-crate-package/action.yml
@@ -23,7 +23,7 @@ runs:
       shell: bash
       run: |
         echo "Check crate latest published version for '${{ inputs.package }}' package"
-        LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/${{ inputs.package }} | jq -r '.crate.newest_version')
+        LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/${{ inputs.package }}  --user-agent "iog/mithril (https://github.com/input-output-hk/mithril)" | jq -r '.crate.newest_version')
         LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="${{ inputs.package }}") | .version')
         echo "Latest crate.io version: $LATEST_REMOTE_VERSION"
         echo "Local version: $LOCAL_VERSION"


### PR DESCRIPTION
## Content

This PR includes a fix for the mechanism that avoid crates publication when a crate version is already published.

The retrieval of the remote version on crates.io api was failing. To request their api they ask for an user agent in order to have a contact point if needed, if missing the request is rejected.

More details on the fixed failure [here](https://github.com/input-output-hk/mithril/issues/2824#issuecomment-3633589354).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #2824
