### PR TITLE
ci: accelerate hydra ci

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
               cargoArtifacts = buildDeps cargoToml baseCargoArtifacts;
             }
             // {
-              cargoTestCommand = "RUST_BACKTRACE=1 cargo test";
+              cargoTestCommand = "RUST_BACKTRACE=1 cargo test --profile release";
             }
             // args);
 
@@ -108,8 +108,8 @@
           mithril-client-cli = buildPackage ./mithril-client-cli/Cargo.toml mithril.cargoArtifacts {
             pname = "mithril-client";
           };
-          mithril-aggregator = buildPackage ./mithril-aggregator/Cargo.toml mithril.cargoArtifacts { cargoTestCommand = "cargo test --no-default-features"; };
-          mithril-signer = buildPackage ./mithril-signer/Cargo.toml mithril.cargoArtifacts { cargoTestCommand = "cargo test --no-default-features"; };
+          mithril-aggregator = buildPackage ./mithril-aggregator/Cargo.toml mithril.cargoArtifacts { cargoTestExtraArgs = "--no-default-features"; };
+          mithril-signer = buildPackage ./mithril-signer/Cargo.toml mithril.cargoArtifacts { cargoTestExtraArgs = "--no-default-features"; };
           mithril-end-to-end = buildPackage ./mithril-test-lab/mithril-end-to-end/Cargo.toml null {};
         };
 


### PR DESCRIPTION
## Content

This PR includes adjustments to the nix based hydra ci to address the frequent timeout encountered:

- build test in release mode to allow reuse of built artifact from the build phase (this revert 0e92798b31794bef9458f0062d5f549e18363e6b)
- remove unneeded projects (`mithrildemo` and `mithril-persistence`) to keep only released binaries and libraries + tools eventually useful to third party (only the end to end at that time)

Here is a successful hydra evaluation based on the modification: https://ci.iog.io/eval/94135

We can see that the check phase reuse artifacts, speeding up the process (example from [`mithril-aggregator linux x86_64`](https://ci.iog.io/build/10373119/log)):
```
Running phase: checkPhase
+++ command cargo test --profile release -p mithril-aggregator --no-default-features
       Fresh unicode-ident v1.0.19
       Fresh smallvec v1.15.1
       [...]
    Finished `release` profile [optimized] target(s) in 1m 45s
```
For comparison, [a previous run](https://ci.iog.io/build/10367464/log) on the same job without the changes took 2m 39s and everything was recompiled in the check phase.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #2822
