### PR TITLE
ci(client multiplatform test): add a new download + conversion case for conversion to legacy legder snapshot

### DIFF
--- a/.github/workflows/scripts/verify-cardano-db-restoration.sh
+++ b/.github/workflows/scripts/verify-cardano-db-restoration.sh
@@ -3,36 +3,34 @@
 set -e
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 <file containing 'mithril-client' CLI download output> [--include-ancillary]"
-  echo "The first argument must be the file path containing the raw output (stdout) of the mithril-client CLI download command."
-  echo "The second optional argument must be '--include-ancillary' if ancillary files are included."
+  echo "Usage: $0 --docker-cmd [docker run command string] [--include-ancillary] [--ledger-backend <in-memory|lmdb|legacy>]"
+  echo ""
+  echo "Parameters:"
+  echo "  --docker-cmd <command>            (Required) The 'docker run' command output in the result of a mithril-client CLI download or snapshot converter command."
+  echo "  --include-ancillary               (Optional) Does the ancillary files were included in the restoration."
+  echo "  --ledger-backend <in-memory|lmdb> (Optional) Specify the ledger backend. Default is 'in-memory'. Note: lmdb backend requires --include-ancillary to be set."
   exit 1
 fi
 
-if [[ ! -f "$1" ]]; then
-  echo "Error: File '$1' not found."
-  exit 1
-fi
-
-CLIENT_CMD_OUTPUT=$(cat "$1"); shift
+DOCKER_CMD=""
 INCLUDE_ANCILLARY="false"
 LEDGER_BACKEND="in-memory"
 
 while [[ "$#" -gt 0 ]]; do
     case $1 in
+        --docker-cmd) DOCKER_CMD="$2"; shift;;
         --include-ancillary) INCLUDE_ANCILLARY="true" ;;
         --ledger-backend) LEDGER_BACKEND="$2"; shift ;;
     esac
     shift
 done
 
-DOCKER_CMD=$(echo "$CLIENT_CMD_OUTPUT" | grep -E '^\s*docker run')
 if [[ -z "$DOCKER_CMD" ]]; then
-  echo "No Docker command found in mithril-client CLI command output."
+  echo "Error: argument '--docker-cmd \"docker run ...\"' is mandatory."
   exit 1
 fi
 
-echo "Extracted Docker command:"
+echo "Docker command:"
 echo "$DOCKER_CMD"
 
 # Note: ledger conversion to lmdb can only be executed if ancillary files are included

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -116,7 +116,7 @@ jobs:
 
           if [[ $CARDANO_DATABASE_V2_CAPABILITY == "true" ]]; then
             echo 'available_cardano_database_backends=["v1","v2"]' >> $GITHUB_OUTPUT
-            echo 'bin-cdb-download-matrix-include=[{"backend":"v2","os":"ubuntu-24.04","ledger_backend":"lmdb","extra_args":"--include-ancillary"}]' >> $GITHUB_OUTPUT
+            echo 'bin-cdb-download-matrix-include=[{"backend":"v2","os":"ubuntu-24.04","ledger_backend":"lmdb","extra_args":"--include-ancillary"},{"backend":"v2","os":"ubuntu-24.04","ledger_backend":"legacy","extra_args":"--include-ancillary"}]' >> $GITHUB_OUTPUT
           else
             echo 'available_cardano_database_backends=["v1"]' >> $GITHUB_OUTPUT
             echo 'bin-cdb-download-matrix-include=[]' >> $GITHUB_OUTPUT
@@ -293,16 +293,28 @@ jobs:
         shell: bash
         working-directory: ./bin
         run: |
-          ./mithril-client ${{ needs.prepare.outputs.debug_level }} --origin-tag CI cardano-db download ${{ steps.last_snapshot.outputs.hash }} --backend ${{ matrix.backend }} --download-dir "${{ matrix.backend }}" ${{ matrix.extra_args }} 2>&1 | tee cdb-${{ matrix.backend }}-download-output.txt
+          ./mithril-client ${{ needs.prepare.outputs.debug_level }} --origin-tag CI cardano-db download ${{ steps.last_snapshot.outputs.hash }} \
+                          --backend ${{ matrix.backend }} --download-dir "${{ matrix.backend }}" ${{ matrix.extra_args }} --json \
+                          | tee cdb-${{ matrix.backend }}-download-output.json
 
-      - name: Ledger state snapshot conversion from InMemory to LMDB
+      - name: Ledger state snapshot conversion from InMemory to ${{ matrix.ledger_backend }}
         # The 'snapshot-converter' binary is not currently supported on Linux ARM64 platforms.
-        if: matrix.os != 'ubuntu-24.04-arm' && matrix.extra_args == '--include-ancillary' && matrix.ledger_backend == 'lmdb'
+        if: matrix.os != 'ubuntu-24.04-arm' && matrix.extra_args == '--include-ancillary' && contains(fromJSON('["lmdb", "legacy"]'), matrix.ledger_backend)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         working-directory: ./bin
-        run: ./mithril-client ${{ needs.prepare.outputs.debug_level }} tools utxo-hd snapshot-converter --db-directory ${{ matrix.backend }}/db --cardano-node-version latest --utxo-hd-flavor LMDB --commit
+        run: |
+          LEDGER_BACKEND="${{ matrix.ledger_backend }}"
+          if [[ ${LEDGER_BACKEND,,} == "lmdb" ]]; then 
+            UTXO_HD_FLAVOR="LMDB"
+          elif [[ ${LEDGER_BACKEND,,} == "legacy" ]]; then
+            UTXO_HD_FLAVOR="Legacy"
+          fi
+
+          ./mithril-client ${{ needs.prepare.outputs.debug_level }} tools utxo-hd snapshot-converter --db-directory ${{ matrix.backend }}/db \
+                          --cardano-node-version latest --utxo-hd-flavor $UTXO_HD_FLAVOR --commit --json \
+                          | tee cdb-${{ matrix.backend }}-converter-output.json
 
       - name: Cardano Database V2 Snapshot / verify immutables
         if: matrix.backend == 'v2'
@@ -313,7 +325,14 @@ jobs:
       - name: Cardano Database Snapshot / verify Cardano node starts successfully
         if: matrix.os == 'ubuntu-24.04'
         shell: bash
-        run: .github/workflows/scripts/verify-cardano-db-restoration.sh ./bin/cdb-${{ matrix.backend }}-download-output.txt --ledger-backend ${{ matrix.ledger_backend }} ${{ matrix.extra_args }}
+        run: |
+          if [[ -e "./bin/cdb-${{ matrix.backend }}-converter-output.json" ]]; then
+            DOCKER_CMD=$(jq -r ".run_docker_cmd" ./bin/cdb-${{ matrix.backend }}-converter-output.json)
+          else
+            DOCKER_CMD=$(jq -r ".run_docker_cmd" ./bin/cdb-${{ matrix.backend }}-download-output.json)
+          fi
+
+          .github/workflows/scripts/verify-cardano-db-restoration.sh --docker-cmd "$DOCKER_CMD" --ledger-backend ${{ matrix.ledger_backend }} ${{ matrix.extra_args }}
 
       - name: Cardano Database V2 Snapshot / verify tampered and missing immutables from a specific range
         if: matrix.backend == 'v2'


### PR DESCRIPTION
## Content

This PR add a new test case to the `Mithril Client multi-platform test` workflow: download of a cardano database snapshot with ancillaries (v2) then conversion to the legacy ledger format and still passing start of the cardano node using docker.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #2823
