### PR TITLE
ci: fix aggregator stress test parameters handling

### DIFF
--- a/.github/workflows/aggregator-stress-test.yml
+++ b/.github/workflows/aggregator-stress-test.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: |
           if [[ -n "${{ inputs.commit_sha }}" ]]; then
-            echo "sha=${{ inputs.commit_sha }}" >> $GITHUB_OUTPUT
+            echo "commit_sha=${{ inputs.commit_sha }}" >> $GITHUB_OUTPUT
           else
             echo "branch=main" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Content

This PR fixes arguments handling in the aggregator stress test ci workflow:

- Properly handle missing `commit_sha` to use the branch `main`: if it was missing, the `main` branch would only be used to download the end to end runner binary, for the aggregator binary the artifact of the latest `ci.yml` run was used.
- Properly pass `commit_sha` to download binary steps: if it was provided it was correctly used only to download the aggregator binary, for the end to end runner the artifact of the latest `ci.yml` run was used.
- Make `commit_sha` not mandatory to allow the fallback to the `main` branch even when running the worflow manually

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #2879
