### PR TITLE
ci: optimize rust test disk space usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,16 +222,16 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build tests
-        run: cargo nextest run --no-run ${{ matrix.test-args }}
+        run: cargo nextest run --cargo-profile ci-tests --no-run ${{ matrix.test-args }}
 
       - name: Run tests
-        run: cargo nextest run --profile ci ${{ matrix.test-args }}
+        run: cargo nextest run --profile ci --cargo-profile ci-tests ${{ matrix.test-args }}
 
       - name: Run doc tests
-        run: cargo test --doc ${{ matrix.test-args }}
+        run: cargo test --profile ci-tests --doc ${{ matrix.test-args }}
 
       - name: Ensure examples build
-        run: cargo build --examples ${{ matrix.test-args }}
+        run: cargo build --profile ci-tests --examples ${{ matrix.test-args }}
 
       - name: Rename junit file to include runner info
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,3 +74,10 @@ thiserror = "2.0.17"
 tokio = { version = "1.48.0", features = ["rt", "sync", "time"] }
 tracing = "0.1.41"
 warp = { version = "0.4.2", features = ["server", "websocket"] }
+
+[profile.ci-tests]
+inherits = "dev"
+# Minimize the amount of debug info generated, this disables profiling (not needed in ci) but keeps backtraces with filename/line number info
+debug = "line-tables-only"
+# Not cached by `Swatinem/rust-cache`, so generating them is a waste of resources
+incremental = false


### PR DESCRIPTION
## Content

This PR add a cargo profile specific for the rust tests in the ci.

The `ci-tests` profile reduce drastically disk space usage from `25 Go` to only `7.1 Go` at minor cost for the ci (less detailed, but still present, backtraces, and disabled incremental compilation and profiling, the later both were not used in the CI anyway).

> [!NOTE]
> Additional tests were done using the [`opt-level` ](https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level) parameter, which control the compilation optimization level.
>
> _:pencil2: `0` is the value used by the default `dev` profile, `3` by the default `release` profile_
>
> | `opt-level` | build time | test run time | artifacts size |
> |--------|--------|--------|--------|
> | 0 | 2m 30s | 76s | 11 Go |
> | 1 | 5m 15s | 57s | 13 Go |
> | 2 | 6m | 56s | 14 Go |
>
> Since increasing the level by one at double the build times for a 10s test run reduction, and increase the artifact size, it was left at the default value of the inherited `dev` profile.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

 Closes #2906
