### PR TITLE
chore(ci): update protocol parameters of `testing-preview`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -803,8 +803,8 @@ jobs:
             mithril_api_domain: api.mithril.network
             mithril_protocol_parameters: |
               {
-                k     = 2422
-                m     = 20973
+                k     = 1944
+                m     = 16948
                 phi_f = 0.2
               }
             mithril_signers: |


### PR DESCRIPTION
## Content

This PR includes the **update of the protocol parameters for the `testing-preview` network to use the full security SNARK-friendly parameters**:
- `k`: 1944
- `m`: 16948
- `phi_f`: 0.2

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2813 
