### PR TITLE
fix(signer): handle missing/behind KES period on registration

### DIFF
--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -214,7 +214,9 @@ impl Runner for SignerRunner {
                         "current_kes_period" => u64::from(current_kes_period),
                         "start_kes_period" => u64::from(start_kes_period)
                     );
-                    Err(RunnerError::NoValueError("kes_period_underflow".to_string()))
+                    Err(RunnerError::NoValueError(
+                        "kes_period_underflow".to_string(),
+                    ))
                 } else {
                     Ok(current_kes_period - start_kes_period)
                 }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -205,20 +205,15 @@ impl Runner for SignerRunner {
         let (current_kes_period, kes_evolutions) = loop {
             attempt += 1;
 
-            let kes_period = self
-                .services
-                .chain_observer
-                .get_current_kes_period()
-                .await?;
+            let kes_period = self.services.chain_observer.get_current_kes_period().await?;
 
             let kes_period = match kes_period {
                 Some(kes_period) => kes_period,
                 None => {
                     if attempt >= max_retries {
-                        return Err(RunnerError::NoValueError(
-                            "current_kes_period".to_string(),
-                        )
-                        .into());
+                        return Err(
+                            RunnerError::NoValueError("current_kes_period".to_string()).into()
+                        );
                     }
                     warn!(
                         self.logger,
@@ -253,10 +248,9 @@ impl Runner for SignerRunner {
                             "current_kes_period" => u64::from(kes_period),
                             "start_kes_period" => u64::from(start_kes_period)
                         );
-                        return Err(RunnerError::NoValueError(
-                            "kes_period_underflow".to_string(),
-                        )
-                        .into());
+                        return Err(
+                            RunnerError::NoValueError("kes_period_underflow".to_string()).into(),
+                        );
                     }
                     warn!(
                         self.logger,

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -198,30 +198,78 @@ impl Runner for SignerRunner {
             }
             _ => (None, None),
         };
-        let current_kes_period = self
-            .services
-            .chain_observer
-            .get_current_kes_period()
-            .await?
-            .ok_or_else(|| RunnerError::NoValueError("current_kes_period".to_string()))?;
-        let kes_evolutions = operational_certificate
-            .map(|operational_certificate| {
-                let start_kes_period = operational_certificate.get_start_kes_period();
-                if current_kes_period < start_kes_period {
+        let mut attempt = 0;
+        let max_retries = 5;
+        let retry_delay = std::time::Duration::from_secs(1);
+
+        let (current_kes_period, kes_evolutions) = loop {
+            attempt += 1;
+
+            let kes_period = self
+                .services
+                .chain_observer
+                .get_current_kes_period()
+                .await?;
+
+            let kes_period = match kes_period {
+                Some(kes_period) => kes_period,
+                None => {
+                    if attempt >= max_retries {
+                        return Err(RunnerError::NoValueError(
+                            "current_kes_period".to_string(),
+                        )
+                        .into());
+                    }
                     warn!(
                         self.logger,
-                        "Current KES period is behind operational certificate start period.";
-                        "current_kes_period" => u64::from(current_kes_period),
-                        "start_kes_period" => u64::from(start_kes_period)
+                        "Current KES period is not available yet. Retrying...";
+                        "attempt" => attempt,
+                        "max_retries" => max_retries
                     );
-                    Err(RunnerError::NoValueError(
-                        "kes_period_underflow".to_string(),
-                    ))
-                } else {
-                    Ok(current_kes_period - start_kes_period)
+                    tokio::time::sleep(retry_delay).await;
+                    continue;
                 }
-            })
-            .transpose()?;
+            };
+
+            let check_result = match &operational_certificate {
+                Some(op_cert) => {
+                    let start_kes_period = op_cert.get_start_kes_period();
+                    if kes_period < start_kes_period {
+                        Err(start_kes_period)
+                    } else {
+                        Ok(Some(kes_period - start_kes_period))
+                    }
+                }
+                None => Ok(None),
+            };
+
+            match check_result {
+                Ok(evolutions) => break (kes_period, evolutions),
+                Err(start_kes_period) => {
+                    if attempt >= max_retries {
+                        warn!(
+                            self.logger,
+                            "Current KES period is behind operational certificate start period.";
+                            "current_kes_period" => u64::from(kes_period),
+                            "start_kes_period" => u64::from(start_kes_period)
+                        );
+                        return Err(RunnerError::NoValueError(
+                            "kes_period_underflow".to_string(),
+                        )
+                        .into());
+                    }
+                    warn!(
+                        self.logger,
+                        "KES period mismatch. Retrying...";
+                        "current_kes_period" => u64::from(kes_period),
+                        "start_kes_period" => u64::from(start_kes_period),
+                        "attempt" => attempt,
+                        "max_retries" => max_retries
+                    );
+                    tokio::time::sleep(retry_delay).await;
+                }
+            }
+        };
 
         let protocol_initializer = self
             .services


### PR DESCRIPTION
## Content

This PR hardens signer registration by avoiding implicit defaults for the KES period.

Previously, `get_current_kes_period()` returning `None` would fall back to `KesPeriod(0)` (via `unwrap_or_default`), which could produce incorrect kes_evolutions.

**Changes**
- Return `RunnerError::NoValueError` when the KES period is missing (`None`), so the signer retries safely instead of defaulting to 0.
- Guards against `current < start` by logging a warning and returning an error, preventing registration with invalid data.

**Impact** 
Prevents registration with invalid KES evolution data during sync or stale chain info.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Comments

## Issue(s)
N/A