### PR TITLE
docs(website): fix `k` protocol parameter description

### DIFF
--- a/docs/website/root/mithril/advanced/mithril-protocol/protocol.md
+++ b/docs/website/root/mithril/advanced/mithril-protocol/protocol.md
@@ -50,7 +50,7 @@ Note that all three phases require a set of parties (`P` in the paper) to be fix
 three important parameters are generated:
 
 - `m`: defines the number of lotteries that a single user can participate in to sign a message
-- `k`: defines the required number of signatures for a valid certificate
+- `k`: defines the the required number of distinct lottery indices slots needed to create a valid multi-signature
 - `phi_f` (as denoted in the library): defines the chance of a signer to win a lottery.
 
 :::

--- a/docs/website/versioned_docs/version-maintained/mithril/advanced/mithril-protocol/protocol.md
+++ b/docs/website/versioned_docs/version-maintained/mithril/advanced/mithril-protocol/protocol.md
@@ -50,7 +50,7 @@ Note that all three phases require a set of parties (`P` in the paper) to be fix
 three important parameters are generated:
 
 - `m`: defines the number of lotteries that a single user can participate in to sign a message
-- `k`: defines the required number of signatures for a valid certificate
+- `k`: defines the the required number of distinct lottery indices slots needed to create a valid multi-signature
 - `phi_f` (as denoted in the library): defines the chance of a signer to win a lottery.
 
 :::


### PR DESCRIPTION
## Content

This PR includes a **fix to the documentation of the `k` protocol parameter which was inaccurate**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update documentation website (if relevant
