### PR TITLE
fix: apply `cargo sort -w` formatting following its 2.1 version

### DIFF
--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -30,6 +30,4 @@ mithril-stm = { path = "../../mithril-stm" }
 
 [target.'cfg(windows)'.dependencies]
 # Windows doesn't support rug backend, fallback to num-integer
-mithril-stm = { path = "../../mithril-stm", default-features = false, features = [
-    "num-integer-backend",
-] }
+mithril-stm = { path = "../../mithril-stm", default-features = false, features = ["num-integer-backend"] }

--- a/internal/cardano-node/mithril-cardano-node-chain/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-chain/Cargo.toml
@@ -28,10 +28,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["process"] }
 
 [dev-dependencies]
-kes-summed-ed25519 = { version = "0.2.1", features = [
-    "serde_enabled",
-    "sk_clone_enabled",
-] }
+kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mockall = { workspace = true }
 pallas-crypto = "0.35.0"
 slog-async = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -45,21 +45,12 @@ paste = "1.0.15"
 percent-encoding = "2.3.2"
 rayon = { workspace = true }
 regex = "1.12.3"
-reqwest = { workspace = true, features = [
-    "default",
-    "gzip",
-    "zstd",
-    "deflate",
-    "brotli"
-] }
+reqwest = { workspace = true, features = ["default", "gzip", "zstd", "deflate", "brotli"] }
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-slog = { workspace = true, features = [
-    "max_level_trace",
-    "release_max_level_debug",
-] }
+slog = { workspace = true, features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = { workspace = true }
 slog-bunyan = { workspace = true }
 sqlite = { version = "0.37.0", features = ["bundled"] }
@@ -67,11 +58,7 @@ tar = "0.4.44"
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tokio-util = { version = "0.7.18", features = ["codec"] }
-uuid = { version = "1.21.0", features = [
-    "v4",
-    "fast-rng",
-    "macro-diagnostics",
-] }
+uuid = { version = "1.21.0", features = ["v4", "fast-rng", "macro-diagnostics"] }
 warp = { workspace = true }
 zstd = { version = "0.13.3", features = ["zstdmt"] }
 

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -39,20 +39,11 @@ indicatif = { version = "0.18.4", features = ["tokio"] }
 mithril-cli-helper = { path = "../internal/mithril-cli-helper" }
 mithril-client = { path = "../mithril-client", features = ["fs", "unstable"] }
 mithril-doc = { path = "../internal/mithril-doc" }
-reqwest = { workspace = true, features = [
-    "default",
-    "gzip",
-    "zstd",
-    "deflate",
-    "brotli"
-] }
+reqwest = { workspace = true, features = ["default", "gzip", "zstd", "deflate", "brotli"] }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-slog = { workspace = true, features = [
-    "max_level_trace",
-    "release_max_level_debug",
-] }
+slog = { workspace = true, features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = { workspace = true }
 slog-bunyan = { workspace = true }
 slog-term = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -59,12 +59,7 @@ flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = ">=0.1.4" }
 mithril-common = { path = "../mithril-common", version = ">=0.6", default-features = false }
-reqwest = { workspace = true, default-features = false, features = [
-    "charset",
-    "http2",
-    "macos-system-configuration",
-    "stream",
-] }
+reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "macos-system-configuration", "stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 slog = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -45,10 +45,7 @@ digest = { workspace = true }
 ed25519-dalek = { version = "2.2.0", features = ["rand_core", "serde"] }
 fixed = "1.30.0"
 hex = { workspace = true }
-kes-summed-ed25519 = { version = "0.2.1", features = [
-    "serde_enabled",
-    "sk_clone_enabled",
-] }
+kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-stm = { path = "../mithril-stm", version = ">=0.5", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -17,40 +17,15 @@ future_snark = ["mithril-common/future_snark"] # For activating snark features
 anyhow = { workspace = true }
 clap = { workspace = true }
 config = { workspace = true }
-libp2p = { version = "0.56.0", features = [
-    "tokio",
-    "gossipsub",
-    "dns",
-    "identify",
-    "kad",
-    "macros",
-    "noise",
-    "ping",
-    "pnet",
-    "quic",
-    "tcp",
-    "tls",
-    "websocket-websys",
-    "websocket",
-    "yamux",
-] }
+libp2p = { version = "0.56.0", features = ["tokio", "gossipsub", "dns", "identify", "kad", "macros", "noise", "ping", "pnet", "quic", "tcp", "tls", "websocket-websys", "websocket", "yamux"] }
 mithril-common = { path = "../mithril-common" }
 mithril-dmq = { path = "../internal/mithril-dmq" }
 mithril-doc = { path = "../internal/mithril-doc" }
 mithril-test-http-server = { path = "../internal/tests/mithril-test-http-server" }
-reqwest = { workspace = true, features = [
-    "default",
-    "gzip",
-    "zstd",
-    "deflate",
-    "brotli"
-] }
+reqwest = { workspace = true, features = ["default", "gzip", "zstd", "deflate", "brotli"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-slog = { workspace = true, features = [
-    "max_level_trace",
-    "release_max_level_debug",
-] }
+slog = { workspace = true, features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = { workspace = true }
 slog-bunyan = { workspace = true }
 strum = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -42,20 +42,10 @@ mithril-signed-entity-lock = { path = "../internal/signed-entity/mithril-signed-
 mithril-signed-entity-preloader = { path = "../internal/signed-entity/mithril-signed-entity-preloader" }
 mithril-ticker = { path = "../internal/mithril-ticker" }
 rand_core = { workspace = true }
-reqwest = { workspace = true, features = [
-    "default",
-    "stream",
-    "gzip",
-    "zstd",
-    "deflate",
-    "brotli"
-] }
+reqwest = { workspace = true, features = ["default", "stream", "gzip", "zstd", "deflate", "brotli"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-slog = { workspace = true, features = [
-    "max_level_trace",
-    "release_max_level_debug",
-] }
+slog = { workspace = true, features = ["max_level_trace", "release_max_level_debug"] }
 slog-async = { workspace = true }
 slog-bunyan = { workspace = true }
 sqlite = { version = "0.37.0", features = ["bundled"] }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -33,10 +33,7 @@ reqwest = { workspace = true, features = ["default"] }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-slog = { workspace = true, features = [
-    "max_level_trace",
-    "release_max_level_trace",
-] }
+slog = { workspace = true, features = ["max_level_trace", "release_max_level_trace"] }
 slog-async = { workspace = true }
 slog-scope = "4.4.1"
 slog-term = { workspace = true }


### PR DESCRIPTION
## Content

This PR fix our `Cargo.toml` formatting following the release of version `2.1` of `cargo sort` which include updated rules.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced
