### PR TITLE
fix: apply `cargo sort -w` following release of version `2.1.1`

### DIFF
--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -9,10 +9,8 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [features]
-future_snark = [
-    "mithril-stm/future_snark",
-    "mithril-common/future_snark",
-] # For activating snark features
+# Enable experimental SNARK support in mithril-stm and mithril-common.
+future_snark = ["mithril-stm/future_snark", "mithril-common/future_snark"]
 
 [dependencies]
 clap = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -27,7 +27,8 @@ full = ["fs"]
 
 # Enable file system related functionality, right now that mean only snapshot download
 fs = ["flate2", "flume", "tar", "tokio/rt", "zstd"]
-portable = []                                       # deprecated, will be removed soon
+# DEPRECATED: The `portable` feature is deprecated and will be removed in a future release.
+portable = []
 unstable = []
 
 # These features are for support of dependent crates only.

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -30,7 +30,8 @@ num-integer-backend = ["mithril-stm/num-integer-backend"]
 # Disable signer certification, to be used only for tests
 allow_skip_signer_certification = []
 
-future_snark = ["mithril-stm/future_snark"] # For activating snark features
+# Enables the future SNARK implementation for the `mithril-stm` dependency
+future_snark = ["mithril-stm/future_snark"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -11,7 +11,8 @@ repository = { workspace = true }
 
 [features]
 bundle_tls = ["reqwest/native-tls-vendored"]
-future_snark = ["mithril-common/future_snark"] # For activating snark features
+# Enable support for future/experimental SNARK functionality in mithril-common.
+future_snark = ["mithril-common/future_snark"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -15,7 +15,9 @@ crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
 default = ["num-integer-backend"]
-benchmark-internals = [] # For benchmarking
+ # For benchmarking
+benchmark-internals = []
+# Enable experimental SNARK support 
 future_snark = [
     "dep:ff",
     "dep:group",
@@ -27,7 +29,7 @@ future_snark = [
     "dep:num-traits",
     "dep:rand",
     "dep:sha2",
-] # For activating snark features
+]
 num-integer-backend = ["dep:num-bigint", "dep:num-integer", "dep:num-rational", "dep:num-traits"]
 rug-backend = ["rug/default"]
 


### PR DESCRIPTION
## Content

This PR includes a formatting issue with the `cargo sort -w` following the release `2.1.1`.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

