### PR TITLE
Implement cardano blocks and transactions in WASM client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4101,7 +4101,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-build-script"
-version = "0.2.30"
+version = "0.2.31"
 dependencies = [
  "saphyr",
  "semver",
@@ -4245,7 +4245,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-wasm"
-version = "0.10.2"
+version = "0.10.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/examples/client-wasm-nodejs/package-lock.json
+++ b/examples/client-wasm-nodejs/package-lock.json
@@ -16,7 +16,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0"
     },
     "node_modules/@mithril-dev/mithril-client-wasm": {

--- a/examples/client-wasm-web/package-lock.json
+++ b/examples/client-wasm-web/package-lock.json
@@ -20,7 +20,7 @@
     },
     "../../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/internal/mithril-build-script/Cargo.toml
+++ b/internal/mithril-build-script/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-build-script"
-version = "0.2.30"
+version = "0.2.31"
 description = "A toolbox for Mithril crates build scripts"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-build-script/src/fake_aggregator.rs
+++ b/internal/mithril-build-script/src/fake_aggregator.rs
@@ -175,6 +175,12 @@ impl FakeAggregatorData {
                     ),
                 ),
                 generate_ids_array(
+                    "cardano_blocks_transactions_snapshot_hashes",
+                    BTreeSet::from_iter(
+                        self.individual_cardano_blocks_transactions_snapshots.keys().cloned(),
+                    ),
+                ),
+                generate_ids_array(
                     "proof_transaction_hashes",
                     BTreeSet::from_iter(self.cardano_transaction_proofs.keys().cloned()),
                 ),

--- a/mithril-client-wasm/Cargo.toml
+++ b/mithril-client-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-wasm"
-version = "0.10.2"
+version = "0.10.3"
 description = "Mithril client WASM"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-wasm/ci-test/README.md
+++ b/mithril-client-wasm/ci-test/README.md
@@ -34,6 +34,15 @@ echo "AGGREGATOR_ENDPOINT=https://aggregator.testing-preview.api.mithril.network
 echo "GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/testing-preview/genesis.vkey)" >> ci-test/.env
 ```
 
+Specify blocks and/or transactions hashes to certify using comma separated values (examples with `testing-preview` hash) :
+
+```bash
+echo "TRANSACTIONS_HASHES_TO_CERTIFY=70606a33c7a140e8fa91095ffa79b8a5c2e0514dbc06a5cc0e5aaffee92665c4,ca177d5f6bc63ff72bb346594be0a8b5fccd2d7ca5066e9b083a449bb6dcec1a,74a0639c898b61cddb52795bca931ff54bad7e5ddb2eb82067bb7a97087bc053
+" >> ci-test/.env
+echo "BLOCKS_HASHES_TO_CERTIFY=e722eec9d464c576274f803cd38569fdba34f22bd404a5a35bb705d8b6f4b44b,c33a8b9a9a261bb6b11df976c404bfca94622c0326c5fbdc90a7af06074115f3,5118997b31cc5fe2ad2f15277f6707f08bbbab54d7786cf0642657a14a838720
+" >> ci-test/.env
+```
+
 Then execute the command to run the tests:
 
 ```bash

--- a/mithril-client-wasm/ci-test/README.md
+++ b/mithril-client-wasm/ci-test/README.md
@@ -37,10 +37,8 @@ echo "GENESIS_VERIFICATION_KEY=$(curl -s https://raw.githubusercontent.com/input
 Specify blocks and/or transactions hashes to certify using comma separated values (examples with `testing-preview` hash) :
 
 ```bash
-echo "TRANSACTIONS_HASHES_TO_CERTIFY=70606a33c7a140e8fa91095ffa79b8a5c2e0514dbc06a5cc0e5aaffee92665c4,ca177d5f6bc63ff72bb346594be0a8b5fccd2d7ca5066e9b083a449bb6dcec1a,74a0639c898b61cddb52795bca931ff54bad7e5ddb2eb82067bb7a97087bc053
-" >> ci-test/.env
-echo "BLOCKS_HASHES_TO_CERTIFY=e722eec9d464c576274f803cd38569fdba34f22bd404a5a35bb705d8b6f4b44b,c33a8b9a9a261bb6b11df976c404bfca94622c0326c5fbdc90a7af06074115f3,5118997b31cc5fe2ad2f15277f6707f08bbbab54d7786cf0642657a14a838720
-" >> ci-test/.env
+echo "TRANSACTIONS_HASHES_TO_CERTIFY=70606a33c7a140e8fa91095ffa79b8a5c2e0514dbc06a5cc0e5aaffee92665c4,ca177d5f6bc63ff72bb346594be0a8b5fccd2d7ca5066e9b083a449bb6dcec1a,74a0639c898b61cddb52795bca931ff54bad7e5ddb2eb82067bb7a97087bc053" >> ci-test/.env
+echo "BLOCKS_HASHES_TO_CERTIFY=e722eec9d464c576274f803cd38569fdba34f22bd404a5a35bb705d8b6f4b44b,c33a8b9a9a261bb6b11df976c404bfca94622c0326c5fbdc90a7af06074115f3,5118997b31cc5fe2ad2f15277f6707f08bbbab54d7786cf0642657a14a838720" >> ci-test/.env
 ```
 
 Then execute the command to run the tests:

--- a/mithril-client-wasm/ci-test/index.js
+++ b/mithril-client-wasm/ci-test/index.js
@@ -14,9 +14,8 @@ function display_test_result_in_dom(test_name, test_number, result, error) {
   let div = document.createElement("div");
   div.id = test_name;
   div.title = result;
-  div.innerHTML = `Result test n°${test_number}: ${result}; function_name: ${test_name}${
-    error ? `; reason: ${error}` : ""
-  }`;
+  div.innerHTML = `Result test n°${test_number}: ${result}; function_name: ${test_name}${error ? `; reason: ${error}` : ""
+    }`;
   document.body.appendChild(div);
 }
 
@@ -53,6 +52,71 @@ await run_test("constructor", test_number, async () => {
     unstable: true,
   });
 });
+
+if (aggregator_capabilities.includes("CardanoBlocksTransactions")) {
+  const transactions_hashes_to_certify =
+    process.env.TRANSACTIONS_HASHES_TO_CERTIFY?.split(",") ?? [];
+
+  let ctx_sets;
+  test_number++;
+  await run_test("list_cardano_transactions_v2_snapshots", test_number, async () => {
+    ctx_sets = await client.list_cardano_transactions_v2_snapshots();
+    console.log("cardano_blocks_transactions_sets", ctx_sets);
+  });
+
+  test_number++;
+  await run_test("get_cardano_transactions_v2_snapshot", test_number, async () => {
+    const ctx_set = await client.get_cardano_transactions_v2_snapshot(ctx_sets[0].hash);
+    console.log("cardano_blocks_transactions_set", ctx_set);
+  });
+
+  console.log("Testing transactions V2 certification with txs:", transactions_hashes_to_certify);
+  if (transactions_hashes_to_certify.length > 0) {
+
+    let ctx_proof;
+    test_number++;
+    await run_test("get_cardano_transaction_v2_proof", test_number, async () => {
+      ctx_proof = await client.get_cardano_transaction_v2_proof(transactions_hashes_to_certify);
+      console.log(
+        "got proof for transactions V2: ",
+        ctx_proof.transactions_hashes,
+        "\nnon_certified_transactions V2: ",
+        ctx_proof.non_certified_transactions,
+      );
+    });
+
+    let proof_certificate;
+    test_number++;
+    await run_test("proof_v2_verify_certificate_chain", test_number, async () => {
+      console.log("gonna verify certificate chain for certificate hash: ", ctx_proof.certificate_hash);
+      proof_certificate = await client.verify_certificate_chain(ctx_proof.certificate_hash);
+      console.log("proof_certificate", proof_certificate);
+    });
+
+    let ctx_proof_message;
+    test_number++;
+    await run_test(
+      "verify_cardano_transaction_v2_proof_then_compute_message",
+      test_number,
+      async () => {
+        ctx_proof_message = await client.verify_cardano_transaction_v2_proof_then_compute_message(
+          ctx_proof,
+          proof_certificate,
+        );
+        console.log("verify_cardano_transaction_v2_proof_then_compute_message", ctx_proof_message);
+      },
+    );
+
+    test_number++;
+    await run_test("proof_v2_verify_message_match_certificate", test_number, async () => {
+      const valid_stake_distribution_message = await client.verify_message_match_certificate(
+        ctx_proof_message,
+        proof_certificate,
+      );
+      console.log("valid_stake_distribution_message", valid_stake_distribution_message);
+    });
+  }
+}
 
 let mithril_stake_distributions;
 test_number++;

--- a/mithril-client-wasm/ci-test/index.js
+++ b/mithril-client-wasm/ci-test/index.js
@@ -14,8 +14,9 @@ function display_test_result_in_dom(test_name, test_number, result, error) {
   let div = document.createElement("div");
   div.id = test_name;
   div.title = result;
-  div.innerHTML = `Result test n°${test_number}: ${result}; function_name: ${test_name}${error ? `; reason: ${error}` : ""
-    }`;
+  div.innerHTML = `Result test n°${test_number}: ${result}; function_name: ${test_name}${
+    error ? `; reason: ${error}` : ""
+  }`;
   document.body.appendChild(div);
 }
 
@@ -56,6 +57,7 @@ await run_test("constructor", test_number, async () => {
 if (aggregator_capabilities.includes("CardanoBlocksTransactions")) {
   const transactions_hashes_to_certify =
     process.env.TRANSACTIONS_HASHES_TO_CERTIFY?.split(",") ?? [];
+  const blocks_hashes_to_certify = process.env.BLOCKS_HASHES_TO_CERTIFY?.split(",") ?? [];
 
   let ctx_sets;
   test_number++;
@@ -70,8 +72,8 @@ if (aggregator_capabilities.includes("CardanoBlocksTransactions")) {
     console.log("cardano_blocks_transactions_set", ctx_set);
   });
 
-  console.log("Testing transactions V2 certification with txs:", transactions_hashes_to_certify);
   if (transactions_hashes_to_certify.length > 0) {
+    console.log("Testing transactions V2 certification with txs:", transactions_hashes_to_certify);
 
     let ctx_proof;
     test_number++;
@@ -88,7 +90,6 @@ if (aggregator_capabilities.includes("CardanoBlocksTransactions")) {
     let proof_certificate;
     test_number++;
     await run_test("proof_v2_verify_certificate_chain", test_number, async () => {
-      console.log("gonna verify certificate chain for certificate hash: ", ctx_proof.certificate_hash);
       proof_certificate = await client.verify_certificate_chain(ctx_proof.certificate_hash);
       console.log("proof_certificate", proof_certificate);
     });
@@ -111,6 +112,65 @@ if (aggregator_capabilities.includes("CardanoBlocksTransactions")) {
     await run_test("proof_v2_verify_message_match_certificate", test_number, async () => {
       const valid_stake_distribution_message = await client.verify_message_match_certificate(
         ctx_proof_message,
+        proof_certificate,
+      );
+      console.log("valid_stake_distribution_message", valid_stake_distribution_message);
+    });
+  }
+
+  let cardano_blocks_sets;
+  test_number++;
+  await run_test("list_cardano_blocks_snapshots", test_number, async () => {
+    cardano_blocks_sets = await client.list_cardano_blocks_snapshots();
+    console.log("cardano_blocks_sets", cardano_blocks_sets);
+  });
+
+  test_number++;
+  await run_test("get_cardano_blocks_snapshot", test_number, async () => {
+    const cardano_blocks_set = await client.get_cardano_blocks_snapshot(
+      cardano_blocks_sets[0].hash,
+    );
+    console.log("cardano_blocks_set", cardano_blocks_set);
+  });
+
+  if (blocks_hashes_to_certify.length > 0) {
+    console.log("Testing blocks certification with blocks hashes:", blocks_hashes_to_certify);
+
+    let cardano_block_proof;
+    test_number++;
+    await run_test("get_cardano_block_proof", test_number, async () => {
+      cardano_block_proof = await client.get_cardano_block_proof(blocks_hashes_to_certify);
+      console.log(
+        "got proof for blocks: ",
+        cardano_block_proof.blocks_hashes,
+        "\nnon_certified_blocks: ",
+        cardano_block_proof.non_certified_blocks,
+      );
+    });
+
+    let proof_certificate;
+    test_number++;
+    await run_test("proof_v2_verify_certificate_chain", test_number, async () => {
+      proof_certificate = await client.verify_certificate_chain(
+        cardano_block_proof.certificate_hash,
+      );
+      console.log("proof_certificate", proof_certificate);
+    });
+
+    let cardano_block_proof_message;
+    test_number++;
+    await run_test("verify_cardano_block_proof_then_compute_message", test_number, async () => {
+      cardano_block_proof_message = await client.verify_cardano_block_proof_then_compute_message(
+        cardano_block_proof,
+        proof_certificate,
+      );
+      console.log("verify_cardano_block_proof_then_compute_message", cardano_block_proof_message);
+    });
+
+    test_number++;
+    await run_test("proof_v2_verify_message_match_certificate", test_number, async () => {
+      const valid_stake_distribution_message = await client.verify_message_match_certificate(
+        cardano_block_proof_message,
         proof_certificate,
       );
       console.log("valid_stake_distribution_message", valid_stake_distribution_message);

--- a/mithril-client-wasm/ci-test/package-lock.json
+++ b/mithril-client-wasm/ci-test/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "client-wasm-ci-test",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "client-wasm-ci-test",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../"
       },
@@ -21,7 +21,7 @@
     },
     "..": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0"
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/mithril-client-wasm/ci-test/package.json
+++ b/mithril-client-wasm/ci-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "client-wasm-ci-test",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "private": true,
   "scripts": {
     "build": "webpack --config webpack.config.js",

--- a/mithril-client-wasm/package.json
+++ b/mithril-client-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mithril-dev/mithril-client-wasm",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Mithril client WASM",
   "license": "Apache-2.0",
   "collaborators": [

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -6,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use mithril_client::{
-    AggregatorDiscoveryType, CardanoTransactionsProofs, Client, ClientBuilder, ClientOptions,
-    GenesisVerificationKey, MessageBuilder, MithrilCertificate,
+    AggregatorDiscoveryType, CardanoTransactionsProofs, CardanoTransactionsProofsV2, Client,
+    ClientBuilder, ClientOptions, GenesisVerificationKey, MessageBuilder, MithrilCertificate,
     certificate_client::CertificateVerifierCache,
     common::Epoch,
     feedback::{FeedbackReceiver, MithrilEvent},
@@ -355,6 +355,35 @@ impl MithrilClient {
         Ok(serde_wasm_bindgen::to_value(&result)?)
     }
 
+    /// Call the client for the list of available Cardano transactions V2 snapshots
+    #[wasm_bindgen]
+    pub async fn list_cardano_transactions_v2_snapshots(&self) -> WasmResult {
+        let result = self
+            .client
+            .cardano_transaction_v2()
+            .list_snapshots()
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// Call the client to get a Cardano transactions V2 snapshot from a hash
+    #[wasm_bindgen]
+    pub async fn get_cardano_transactions_v2_snapshot(&self, hash: &str) -> WasmResult {
+        let result = self
+            .client
+            .cardano_transaction_v2()
+            .get_snapshot(hash)
+            .await
+            .map_err(|err| format!("{err:?}"))?
+            .ok_or(JsValue::from_str(&format!(
+                "No cardano transactions V2 snapshot found for hash: '{hash}'"
+            )))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
     /// Call the client to get a Cardano transactions proofs
     #[wasm_bindgen]
     pub async fn get_cardano_transaction_proofs(
@@ -381,6 +410,32 @@ impl MithrilClient {
         Ok(result)
     }
 
+    /// Call the client to get a Cardano transactions V2 proof
+    #[wasm_bindgen]
+    pub async fn get_cardano_transaction_v2_proof(
+        &self,
+        ctx_hashes: Box<[JsValue]>,
+    ) -> Result<CardanoTransactionsProofsV2, JsValue> {
+        let hashes = ctx_hashes
+            .iter()
+            .map(|h| {
+                h.as_string().ok_or(JsValue::from_str(&format!(
+                    "All transaction hashes must be strings: '{h:?}'"
+                )))
+            })
+            .collect::<Result<Vec<String>, JsValue>>()
+            .map_err(|err| format!("{err:?}"))?;
+
+        let result = self
+            .client
+            .cardano_transaction_v2()
+            .get_proof(&hashes)
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(result)
+    }
+
     /// Call the client to verify a cardano transaction proof and compute a message
     #[wasm_bindgen]
     pub async fn verify_cardano_transaction_proof_then_compute_message(
@@ -394,6 +449,23 @@ impl MithrilClient {
             cardano_transaction_proof.verify().map_err(|err| format!("{err:?}"))?;
         let result = MessageBuilder::new()
             .compute_cardano_transactions_proofs_message(&certificate, &verified_proof);
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// Call the client to verify a cardano transaction V2 proof and compute a message
+    #[wasm_bindgen]
+    pub async fn verify_cardano_transaction_v2_proof_then_compute_message(
+        &self,
+        cardano_transaction_proof: &CardanoTransactionsProofsV2,
+        certificate: JsValue,
+    ) -> WasmResult {
+        let certificate: MithrilCertificate =
+            serde_wasm_bindgen::from_value(certificate).map_err(|err| format!("{err:?}"))?;
+        let verified_proof =
+            cardano_transaction_proof.verify().map_err(|err| format!("{err:?}"))?;
+        let result = MessageBuilder::new()
+            .compute_cardano_transactions_proofs_v2_message(&certificate, &verified_proof);
 
         Ok(serde_wasm_bindgen::to_value(&result)?)
     }
@@ -539,7 +611,8 @@ mod tests {
     use wasm_bindgen_test::*;
 
     use mithril_client::{
-        CardanoDatabaseSnapshot, CardanoDatabaseSnapshotListItem, CardanoStakeDistribution,
+        CardanoBlocksTransactionsSnapshot, CardanoDatabaseSnapshot,
+        CardanoDatabaseSnapshotListItem, CardanoStakeDistribution,
         CardanoStakeDistributionListItem, CardanoTransactionSnapshot, MithrilCertificateListItem,
         MithrilStakeDistribution, MithrilStakeDistributionListItem, common::ProtocolMessage,
         common::SupportedEra, era::FetchedEra,
@@ -796,6 +869,24 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    async fn list_cardano_transactions_v2_snapshots_should_return_value_convertible_in_rust_type() {
+        let cardano_tx_sets_js_value = get_mithril_client_stable()
+            .list_cardano_transactions_v2_snapshots()
+            .await
+            .expect("list_cardano_transactions_v2_snapshots should not fail");
+        let cardano_tx_sets = serde_wasm_bindgen::from_value::<
+            Vec<CardanoBlocksTransactionsSnapshot>,
+        >(cardano_tx_sets_js_value)
+        .expect("conversion should not fail");
+
+        assert_eq!(
+            cardano_tx_sets.len(),
+            // Aggregator return up to 20 items for a list route
+            test_data::cardano_blocks_transactions_snapshot_hashes().len().min(20)
+        );
+    }
+
+    #[wasm_bindgen_test]
     async fn get_cardano_transactions_snapshot_should_return_value_convertible_in_rust_type() {
         let cardano_tx_set_js_value = get_mithril_client_stable()
             .get_cardano_transactions_snapshot(test_data::cardano_transaction_snapshot_hashes()[0])
@@ -812,11 +903,38 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    async fn get_cardano_transactions_v2_snapshot_should_return_value_convertible_in_rust_type() {
+        let cardano_blocks_transactions_set_js_value = get_mithril_client_stable()
+            .get_cardano_transactions_v2_snapshot(
+                test_data::cardano_blocks_transactions_snapshot_hashes()[0],
+            )
+            .await
+            .expect("get_cardano_transactions_v2_snapshot should not fail");
+        let cardano_blocks_transactions_set = serde_wasm_bindgen::from_value::<
+            CardanoBlocksTransactionsSnapshot,
+        >(cardano_blocks_transactions_set_js_value)
+        .expect("conversion should not fail");
+
+        assert_eq!(
+            cardano_blocks_transactions_set.hash,
+            test_data::cardano_blocks_transactions_snapshot_hashes()[0]
+        );
+    }
+
+    #[wasm_bindgen_test]
     async fn get_cardano_transactions_snapshot_should_fail_with_unknown_digest() {
         get_mithril_client_stable()
             .get_cardano_transactions_snapshot("whatever")
             .await
             .expect_err("get_cardano_transactions_snapshot should fail");
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_transactions_v2_snapshot_should_fail_with_unknown_digest() {
+        get_mithril_client_stable()
+            .get_cardano_transactions_v2_snapshot("whatever")
+            .await
+            .expect_err("get_cardano_transactions_v2_snapshot should fail");
     }
 
     #[wasm_bindgen_test]
@@ -836,6 +954,27 @@ mod tests {
 
         client
             .verify_cardano_transaction_proof_then_compute_message(&tx_proof, certificate)
+            .await
+            .expect("Compute tx proof message for matching cert failed");
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_transaction_v2_proof_should_return_value_convertible_in_rust_type() {
+        let tx_hash = test_data::proof_v2_transaction_hashes()[0];
+        let ctx_hashes = Box::new([JsValue::from(tx_hash)]);
+        let client = get_mithril_client_stable();
+
+        let tx_proof = client
+            .get_cardano_transaction_v2_proof(ctx_hashes)
+            .await
+            .expect("get_verified_cardano_transaction_v2_proof should not fail");
+        let certificate = client
+            .get_mithril_certificate(&tx_proof.certificate_hash)
+            .await
+            .unwrap();
+
+        client
+            .verify_cardano_transaction_v2_proof_then_compute_message(&tx_proof, certificate)
             .await
             .expect("Compute tx proof message for matching cert failed");
     }

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -356,64 +356,6 @@ impl MithrilClient {
         Ok(serde_wasm_bindgen::to_value(&result)?)
     }
 
-    /// Call the client for the list of available Cardano transactions V2 snapshots
-    #[wasm_bindgen]
-    pub async fn list_cardano_transactions_v2_snapshots(&self) -> WasmResult {
-        let result = self
-            .client
-            .cardano_transaction_v2()
-            .list_snapshots()
-            .await
-            .map_err(|err| format!("{err:?}"))?;
-
-        Ok(serde_wasm_bindgen::to_value(&result)?)
-    }
-
-    /// Call the client to get a Cardano transactions V2 snapshot from a hash
-    #[wasm_bindgen]
-    pub async fn get_cardano_transactions_v2_snapshot(&self, hash: &str) -> WasmResult {
-        let result = self
-            .client
-            .cardano_transaction_v2()
-            .get_snapshot(hash)
-            .await
-            .map_err(|err| format!("{err:?}"))?
-            .ok_or(JsValue::from_str(&format!(
-                "No cardano transactions V2 snapshot found for hash: '{hash}'"
-            )))?;
-
-        Ok(serde_wasm_bindgen::to_value(&result)?)
-    }
-
-    /// Call the client for the list of available Cardano blocks snapshots
-    #[wasm_bindgen]
-    pub async fn list_cardano_blocks_snapshots(&self) -> WasmResult {
-        let result = self
-            .client
-            .cardano_block()
-            .list_snapshots()
-            .await
-            .map_err(|err| format!("{err:?}"))?;
-
-        Ok(serde_wasm_bindgen::to_value(&result)?)
-    }
-
-    /// Call the client to get a Cardano blocks snapshot from a hash
-    #[wasm_bindgen]
-    pub async fn get_cardano_blocks_snapshot(&self, hash: &str) -> WasmResult {
-        let result = self
-            .client
-            .cardano_block()
-            .get_snapshot(hash)
-            .await
-            .map_err(|err| format!("{err:?}"))?
-            .ok_or(JsValue::from_str(&format!(
-                "No cardano blocks snapshot found for hash: '{hash}'"
-            )))?;
-
-        Ok(serde_wasm_bindgen::to_value(&result)?)
-    }
-
     /// Call the client to get a Cardano transactions proofs
     #[wasm_bindgen]
     pub async fn get_cardano_transaction_proofs(
@@ -440,58 +382,6 @@ impl MithrilClient {
         Ok(result)
     }
 
-    /// Call the client to get a Cardano transactions V2 proof
-    #[wasm_bindgen]
-    pub async fn get_cardano_transaction_v2_proof(
-        &self,
-        ctx_hashes: Box<[JsValue]>,
-    ) -> Result<CardanoTransactionsProofsV2, JsValue> {
-        let hashes = ctx_hashes
-            .iter()
-            .map(|h| {
-                h.as_string().ok_or(JsValue::from_str(&format!(
-                    "All transaction hashes must be strings: '{h:?}'"
-                )))
-            })
-            .collect::<Result<Vec<String>, JsValue>>()
-            .map_err(|err| format!("{err:?}"))?;
-
-        let result = self
-            .client
-            .cardano_transaction_v2()
-            .get_proof(&hashes)
-            .await
-            .map_err(|err| format!("{err:?}"))?;
-
-        Ok(result)
-    }
-
-    /// Call the client to get a Cardano block proof
-    #[wasm_bindgen]
-    pub async fn get_cardano_block_proof(
-        &self,
-        ctx_hashes: Box<[JsValue]>,
-    ) -> Result<CardanoBlocksProofs, JsValue> {
-        let hashes = ctx_hashes
-            .iter()
-            .map(|h| {
-                h.as_string().ok_or(JsValue::from_str(&format!(
-                    "All transaction hashes must be strings: '{h:?}'"
-                )))
-            })
-            .collect::<Result<Vec<String>, JsValue>>()
-            .map_err(|err| format!("{err:?}"))?;
-
-        let result = self
-            .client
-            .cardano_block()
-            .get_proof(&hashes)
-            .await
-            .map_err(|err| format!("{err:?}"))?;
-
-        Ok(result)
-    }
-
     /// Call the client to verify a cardano transaction proof and compute a message
     #[wasm_bindgen]
     pub async fn verify_cardano_transaction_proof_then_compute_message(
@@ -505,39 +395,6 @@ impl MithrilClient {
             cardano_transaction_proof.verify().map_err(|err| format!("{err:?}"))?;
         let result = MessageBuilder::new()
             .compute_cardano_transactions_proofs_message(&certificate, &verified_proof);
-
-        Ok(serde_wasm_bindgen::to_value(&result)?)
-    }
-
-    /// Call the client to verify a cardano transaction V2 proof and compute a message
-    #[wasm_bindgen]
-    pub async fn verify_cardano_transaction_v2_proof_then_compute_message(
-        &self,
-        cardano_transaction_proof: &CardanoTransactionsProofsV2,
-        certificate: JsValue,
-    ) -> WasmResult {
-        let certificate: MithrilCertificate =
-            serde_wasm_bindgen::from_value(certificate).map_err(|err| format!("{err:?}"))?;
-        let verified_proof =
-            cardano_transaction_proof.verify().map_err(|err| format!("{err:?}"))?;
-        let result = MessageBuilder::new()
-            .compute_cardano_transactions_proofs_v2_message(&certificate, &verified_proof);
-
-        Ok(serde_wasm_bindgen::to_value(&result)?)
-    }
-
-    /// Call the client to verify a cardano block proof and compute a message
-    #[wasm_bindgen]
-    pub async fn verify_cardano_block_proof_then_compute_message(
-        &self,
-        cardano_block_proof: &CardanoBlocksProofs,
-        certificate: JsValue,
-    ) -> WasmResult {
-        let certificate: MithrilCertificate =
-            serde_wasm_bindgen::from_value(certificate).map_err(|err| format!("{err:?}"))?;
-        let verified_proof = cardano_block_proof.verify().map_err(|err| format!("{err:?}"))?;
-        let result = MessageBuilder::new()
-            .compute_cardano_blocks_proofs_message(&certificate, &verified_proof);
 
         Ok(serde_wasm_bindgen::to_value(&result)?)
     }
@@ -674,6 +531,165 @@ impl MithrilClient {
         self.guard_unstable()?;
 
         Ok(self.certificate_verifier_cache.is_some())
+    }
+
+    /// `unstable` Call the client for the list of available Cardano transactions V2 snapshots
+    #[wasm_bindgen]
+    pub async fn list_cardano_transactions_v2_snapshots(&self) -> WasmResult {
+        self.guard_unstable()?;
+
+        let result = self
+            .client
+            .cardano_transaction_v2()
+            .list_snapshots()
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// `unstable` Call the client to get a Cardano transactions V2 snapshot from a hash
+    #[wasm_bindgen]
+    pub async fn get_cardano_transactions_v2_snapshot(&self, hash: &str) -> WasmResult {
+        self.guard_unstable()?;
+
+        let result = self
+            .client
+            .cardano_transaction_v2()
+            .get_snapshot(hash)
+            .await
+            .map_err(|err| format!("{err:?}"))?
+            .ok_or(JsValue::from_str(&format!(
+                "No cardano transactions V2 snapshot found for hash: '{hash}'"
+            )))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// `unstable` Call the client to get a Cardano transactions V2 proof
+    #[wasm_bindgen]
+    pub async fn get_cardano_transaction_v2_proof(
+        &self,
+        ctx_hashes: Box<[JsValue]>,
+    ) -> Result<CardanoTransactionsProofsV2, JsValue> {
+        self.guard_unstable()?;
+
+        let hashes = ctx_hashes
+            .iter()
+            .map(|h| {
+                h.as_string().ok_or(JsValue::from_str(&format!(
+                    "All transaction hashes must be strings: '{h:?}'"
+                )))
+            })
+            .collect::<Result<Vec<String>, JsValue>>()
+            .map_err(|err| format!("{err:?}"))?;
+
+        let result = self
+            .client
+            .cardano_transaction_v2()
+            .get_proof(&hashes)
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(result)
+    }
+
+    /// `unstable` Call the client to verify a cardano transaction V2 proof and compute a message
+    #[wasm_bindgen]
+    pub async fn verify_cardano_transaction_v2_proof_then_compute_message(
+        &self,
+        cardano_transaction_proof: &CardanoTransactionsProofsV2,
+        certificate: JsValue,
+    ) -> WasmResult {
+        self.guard_unstable()?;
+
+        let certificate: MithrilCertificate =
+            serde_wasm_bindgen::from_value(certificate).map_err(|err| format!("{err:?}"))?;
+        let verified_proof =
+            cardano_transaction_proof.verify().map_err(|err| format!("{err:?}"))?;
+        let result = MessageBuilder::new()
+            .compute_cardano_transactions_proofs_v2_message(&certificate, &verified_proof);
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// `unstable` Call the client for the list of available Cardano blocks snapshots
+    #[wasm_bindgen]
+    pub async fn list_cardano_blocks_snapshots(&self) -> WasmResult {
+        self.guard_unstable()?;
+
+        let result = self
+            .client
+            .cardano_block()
+            .list_snapshots()
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// `unstable` Call the client to get a Cardano blocks snapshot from a hash
+    #[wasm_bindgen]
+    pub async fn get_cardano_blocks_snapshot(&self, hash: &str) -> WasmResult {
+        self.guard_unstable()?;
+
+        let result = self
+            .client
+            .cardano_block()
+            .get_snapshot(hash)
+            .await
+            .map_err(|err| format!("{err:?}"))?
+            .ok_or(JsValue::from_str(&format!(
+                "No cardano blocks snapshot found for hash: '{hash}'"
+            )))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// `unstable` Call the client to get a Cardano block proof
+    #[wasm_bindgen]
+    pub async fn get_cardano_block_proof(
+        &self,
+        ctx_hashes: Box<[JsValue]>,
+    ) -> Result<CardanoBlocksProofs, JsValue> {
+        self.guard_unstable()?;
+
+        let hashes = ctx_hashes
+            .iter()
+            .map(|h| {
+                h.as_string().ok_or(JsValue::from_str(&format!(
+                    "All block hashes must be strings: '{h:?}'"
+                )))
+            })
+            .collect::<Result<Vec<String>, JsValue>>()
+            .map_err(|err| format!("{err:?}"))?;
+
+        let result = self
+            .client
+            .cardano_block()
+            .get_proof(&hashes)
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(result)
+    }
+
+    /// `unstable` Call the client to verify a cardano block proof and compute a message
+    #[wasm_bindgen]
+    pub async fn verify_cardano_block_proof_then_compute_message(
+        &self,
+        cardano_block_proof: &CardanoBlocksProofs,
+        certificate: JsValue,
+    ) -> WasmResult {
+        self.guard_unstable()?;
+
+        let certificate: MithrilCertificate =
+            serde_wasm_bindgen::from_value(certificate).map_err(|err| format!("{err:?}"))?;
+        let verified_proof = cardano_block_proof.verify().map_err(|err| format!("{err:?}"))?;
+        let result = MessageBuilder::new()
+            .compute_cardano_blocks_proofs_message(&certificate, &verified_proof);
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
     }
 }
 
@@ -941,24 +957,6 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    async fn list_cardano_transactions_v2_snapshots_should_return_value_convertible_in_rust_type() {
-        let cardano_tx_sets_js_value = get_mithril_client_stable()
-            .list_cardano_transactions_v2_snapshots()
-            .await
-            .expect("list_cardano_transactions_v2_snapshots should not fail");
-        let cardano_tx_sets = serde_wasm_bindgen::from_value::<
-            Vec<CardanoBlocksTransactionsSnapshot>,
-        >(cardano_tx_sets_js_value)
-        .expect("conversion should not fail");
-
-        assert_eq!(
-            cardano_tx_sets.len(),
-            // Aggregator return up to 20 items for a list route
-            test_data::cardano_blocks_transactions_snapshot_hashes().len().min(20)
-        );
-    }
-
-    #[wasm_bindgen_test]
     async fn get_cardano_transactions_snapshot_should_return_value_convertible_in_rust_type() {
         let cardano_tx_set_js_value = get_mithril_client_stable()
             .get_cardano_transactions_snapshot(test_data::cardano_transaction_snapshot_hashes()[0])
@@ -975,38 +973,11 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
-    async fn get_cardano_transactions_v2_snapshot_should_return_value_convertible_in_rust_type() {
-        let cardano_blocks_transactions_set_js_value = get_mithril_client_stable()
-            .get_cardano_transactions_v2_snapshot(
-                test_data::cardano_blocks_transactions_snapshot_hashes()[0],
-            )
-            .await
-            .expect("get_cardano_transactions_v2_snapshot should not fail");
-        let cardano_blocks_transactions_set = serde_wasm_bindgen::from_value::<
-            CardanoBlocksTransactionsSnapshot,
-        >(cardano_blocks_transactions_set_js_value)
-        .expect("conversion should not fail");
-
-        assert_eq!(
-            cardano_blocks_transactions_set.hash,
-            test_data::cardano_blocks_transactions_snapshot_hashes()[0]
-        );
-    }
-
-    #[wasm_bindgen_test]
     async fn get_cardano_transactions_snapshot_should_fail_with_unknown_digest() {
         get_mithril_client_stable()
             .get_cardano_transactions_snapshot("whatever")
             .await
             .expect_err("get_cardano_transactions_snapshot should fail");
-    }
-
-    #[wasm_bindgen_test]
-    async fn get_cardano_transactions_v2_snapshot_should_fail_with_unknown_digest() {
-        get_mithril_client_stable()
-            .get_cardano_transactions_v2_snapshot("whatever")
-            .await
-            .expect_err("get_cardano_transactions_v2_snapshot should fail");
     }
 
     #[wasm_bindgen_test]
@@ -1026,27 +997,6 @@ mod tests {
 
         client
             .verify_cardano_transaction_proof_then_compute_message(&tx_proof, certificate)
-            .await
-            .expect("Compute tx proof message for matching cert failed");
-    }
-
-    #[wasm_bindgen_test]
-    async fn get_cardano_transaction_v2_proof_should_return_value_convertible_in_rust_type() {
-        let tx_hash = test_data::proof_v2_transaction_hashes()[0];
-        let ctx_hashes = Box::new([JsValue::from(tx_hash)]);
-        let client = get_mithril_client_stable();
-
-        let tx_proof = client
-            .get_cardano_transaction_v2_proof(ctx_hashes)
-            .await
-            .expect("get_cardano_transaction_v2_proof should not fail");
-        let certificate = client
-            .get_mithril_certificate(&tx_proof.certificate_hash)
-            .await
-            .unwrap();
-
-        client
-            .verify_cardano_transaction_v2_proof_then_compute_message(&tx_proof, certificate)
             .await
             .expect("Compute tx proof message for matching cert failed");
     }
@@ -1280,8 +1230,53 @@ mod tests {
     }
 
     #[wasm_bindgen_test]
+    async fn list_cardano_transactions_v2_snapshots_should_return_value_convertible_in_rust_type() {
+        let cardano_tx_sets_js_value = get_mithril_client_unstable()
+            .list_cardano_transactions_v2_snapshots()
+            .await
+            .expect("list_cardano_transactions_v2_snapshots should not fail");
+        let cardano_tx_sets = serde_wasm_bindgen::from_value::<
+            Vec<CardanoBlocksTransactionsSnapshot>,
+        >(cardano_tx_sets_js_value)
+        .expect("conversion should not fail");
+
+        assert_eq!(
+            cardano_tx_sets.len(),
+            // Aggregator return up to 20 items for a list route
+            test_data::cardano_blocks_transactions_snapshot_hashes().len().min(20)
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_transactions_v2_snapshot_should_return_value_convertible_in_rust_type() {
+        let cardano_blocks_transactions_set_js_value = get_mithril_client_unstable()
+            .get_cardano_transactions_v2_snapshot(
+                test_data::cardano_blocks_transactions_snapshot_hashes()[0],
+            )
+            .await
+            .expect("get_cardano_transactions_v2_snapshot should not fail");
+        let cardano_blocks_transactions_set = serde_wasm_bindgen::from_value::<
+            CardanoBlocksTransactionsSnapshot,
+        >(cardano_blocks_transactions_set_js_value)
+        .expect("conversion should not fail");
+
+        assert_eq!(
+            cardano_blocks_transactions_set.hash,
+            test_data::cardano_blocks_transactions_snapshot_hashes()[0]
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_transactions_v2_snapshot_should_fail_with_unknown_digest() {
+        get_mithril_client_unstable()
+            .get_cardano_transactions_v2_snapshot("whatever")
+            .await
+            .expect_err("get_cardano_transactions_v2_snapshot should fail");
+    }
+
+    #[wasm_bindgen_test]
     async fn list_blocks_snapshots_should_return_value_convertible_in_rust_type() {
-        let cardano_blocks_sets_js_value = get_mithril_client_stable()
+        let cardano_blocks_sets_js_value = get_mithril_client_unstable()
             .list_cardano_blocks_snapshots()
             .await
             .expect("list_cardano_blocks_snapshots should not fail");
@@ -1299,7 +1294,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn get_cardano_blocks_snapshot_should_return_value_convertible_in_rust_type() {
-        let cardano_blocks_transactions_set_js_value = get_mithril_client_stable()
+        let cardano_blocks_transactions_set_js_value = get_mithril_client_unstable()
             .get_cardano_blocks_snapshot(
                 test_data::cardano_blocks_transactions_snapshot_hashes()[0],
             )
@@ -1319,29 +1314,50 @@ mod tests {
 
     #[wasm_bindgen_test]
     async fn get_cardano_blocks_snapshot_should_fail_with_unknown_digest() {
-        get_mithril_client_stable()
+        get_mithril_client_unstable()
             .get_cardano_blocks_snapshot("whatever")
             .await
             .expect_err("get_cardano_blocks_snapshot should fail");
     }
 
     #[wasm_bindgen_test]
-    async fn get_cardano_blocks_proof_should_return_value_convertible_in_rust_type() {
-        let tx_hash = test_data::proof_v2_block_hashes()[0];
+    async fn get_cardano_transaction_v2_proof_should_return_value_convertible_in_rust_type() {
+        let tx_hash = test_data::proof_v2_transaction_hashes()[0];
         let ctx_hashes = Box::new([JsValue::from(tx_hash)]);
-        let client = get_mithril_client_stable();
+        let client = get_mithril_client_unstable();
 
         let tx_proof = client
-            .get_cardano_block_proof(ctx_hashes)
+            .get_cardano_transaction_v2_proof(ctx_hashes)
             .await
-            .expect("get_cardano_blocks_proof should not fail");
+            .expect("get_cardano_transaction_v2_proof should not fail");
         let certificate = client
             .get_mithril_certificate(&tx_proof.certificate_hash)
             .await
             .unwrap();
 
         client
-            .verify_cardano_block_proof_then_compute_message(&tx_proof, certificate)
+            .verify_cardano_transaction_v2_proof_then_compute_message(&tx_proof, certificate)
+            .await
+            .expect("Compute tx proof message for matching cert failed");
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_blocks_proof_should_return_value_convertible_in_rust_type() {
+        let block_hash = test_data::proof_v2_block_hashes()[0];
+        let block_hashes = Box::new([JsValue::from(block_hash)]);
+        let client = get_mithril_client_unstable();
+
+        let block_proof = client
+            .get_cardano_block_proof(block_hashes)
+            .await
+            .expect("get_cardano_blocks_proof should not fail");
+        let certificate = client
+            .get_mithril_certificate(&block_proof.certificate_hash)
+            .await
+            .unwrap();
+
+        client
+            .verify_cardano_block_proof_then_compute_message(&block_proof, certificate)
             .await
             .expect("Compute block proof message for matching cert failed");
     }

--- a/mithril-client-wasm/src/client_wasm.rs
+++ b/mithril-client-wasm/src/client_wasm.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen::prelude::*;
 
 use mithril_client::{
-    AggregatorDiscoveryType, CardanoTransactionsProofs, CardanoTransactionsProofsV2, Client,
-    ClientBuilder, ClientOptions, GenesisVerificationKey, MessageBuilder, MithrilCertificate,
+    AggregatorDiscoveryType, CardanoBlocksProofs, CardanoTransactionsProofs,
+    CardanoTransactionsProofsV2, Client, ClientBuilder, ClientOptions, GenesisVerificationKey,
+    MessageBuilder, MithrilCertificate,
     certificate_client::CertificateVerifierCache,
     common::Epoch,
     feedback::{FeedbackReceiver, MithrilEvent},
@@ -384,6 +385,35 @@ impl MithrilClient {
         Ok(serde_wasm_bindgen::to_value(&result)?)
     }
 
+    /// Call the client for the list of available Cardano blocks snapshots
+    #[wasm_bindgen]
+    pub async fn list_cardano_blocks_snapshots(&self) -> WasmResult {
+        let result = self
+            .client
+            .cardano_block()
+            .list_snapshots()
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// Call the client to get a Cardano blocks snapshot from a hash
+    #[wasm_bindgen]
+    pub async fn get_cardano_blocks_snapshot(&self, hash: &str) -> WasmResult {
+        let result = self
+            .client
+            .cardano_block()
+            .get_snapshot(hash)
+            .await
+            .map_err(|err| format!("{err:?}"))?
+            .ok_or(JsValue::from_str(&format!(
+                "No cardano blocks snapshot found for hash: '{hash}'"
+            )))?;
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
     /// Call the client to get a Cardano transactions proofs
     #[wasm_bindgen]
     pub async fn get_cardano_transaction_proofs(
@@ -436,6 +466,32 @@ impl MithrilClient {
         Ok(result)
     }
 
+    /// Call the client to get a Cardano block proof
+    #[wasm_bindgen]
+    pub async fn get_cardano_block_proof(
+        &self,
+        ctx_hashes: Box<[JsValue]>,
+    ) -> Result<CardanoBlocksProofs, JsValue> {
+        let hashes = ctx_hashes
+            .iter()
+            .map(|h| {
+                h.as_string().ok_or(JsValue::from_str(&format!(
+                    "All transaction hashes must be strings: '{h:?}'"
+                )))
+            })
+            .collect::<Result<Vec<String>, JsValue>>()
+            .map_err(|err| format!("{err:?}"))?;
+
+        let result = self
+            .client
+            .cardano_block()
+            .get_proof(&hashes)
+            .await
+            .map_err(|err| format!("{err:?}"))?;
+
+        Ok(result)
+    }
+
     /// Call the client to verify a cardano transaction proof and compute a message
     #[wasm_bindgen]
     pub async fn verify_cardano_transaction_proof_then_compute_message(
@@ -466,6 +522,22 @@ impl MithrilClient {
             cardano_transaction_proof.verify().map_err(|err| format!("{err:?}"))?;
         let result = MessageBuilder::new()
             .compute_cardano_transactions_proofs_v2_message(&certificate, &verified_proof);
+
+        Ok(serde_wasm_bindgen::to_value(&result)?)
+    }
+
+    /// Call the client to verify a cardano block proof and compute a message
+    #[wasm_bindgen]
+    pub async fn verify_cardano_block_proof_then_compute_message(
+        &self,
+        cardano_block_proof: &CardanoBlocksProofs,
+        certificate: JsValue,
+    ) -> WasmResult {
+        let certificate: MithrilCertificate =
+            serde_wasm_bindgen::from_value(certificate).map_err(|err| format!("{err:?}"))?;
+        let verified_proof = cardano_block_proof.verify().map_err(|err| format!("{err:?}"))?;
+        let result = MessageBuilder::new()
+            .compute_cardano_blocks_proofs_message(&certificate, &verified_proof);
 
         Ok(serde_wasm_bindgen::to_value(&result)?)
     }
@@ -967,7 +1039,7 @@ mod tests {
         let tx_proof = client
             .get_cardano_transaction_v2_proof(ctx_hashes)
             .await
-            .expect("get_verified_cardano_transaction_v2_proof should not fail");
+            .expect("get_cardano_transaction_v2_proof should not fail");
         let certificate = client
             .get_mithril_certificate(&tx_proof.certificate_hash)
             .await
@@ -1205,5 +1277,72 @@ mod tests {
         let era = fetched_era.to_supported_era().expect("conversion should not fail");
 
         assert_eq!(era, SupportedEra::Pythagoras);
+    }
+
+    #[wasm_bindgen_test]
+    async fn list_blocks_snapshots_should_return_value_convertible_in_rust_type() {
+        let cardano_blocks_sets_js_value = get_mithril_client_stable()
+            .list_cardano_blocks_snapshots()
+            .await
+            .expect("list_cardano_blocks_snapshots should not fail");
+        let cardano_blocks_sets = serde_wasm_bindgen::from_value::<
+            Vec<CardanoBlocksTransactionsSnapshot>,
+        >(cardano_blocks_sets_js_value)
+        .expect("conversion should not fail");
+
+        assert_eq!(
+            cardano_blocks_sets.len(),
+            // Aggregator return up to 20 items for a list route
+            test_data::cardano_blocks_transactions_snapshot_hashes().len().min(20)
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_blocks_snapshot_should_return_value_convertible_in_rust_type() {
+        let cardano_blocks_transactions_set_js_value = get_mithril_client_stable()
+            .get_cardano_blocks_snapshot(
+                test_data::cardano_blocks_transactions_snapshot_hashes()[0],
+            )
+            .await
+            .expect("get_cardano_blocks_snapshot should not fail");
+        let cardano_blocks_set =
+            serde_wasm_bindgen::from_value::<CardanoBlocksTransactionsSnapshot>(
+                cardano_blocks_transactions_set_js_value,
+            )
+            .expect("conversion should not fail");
+
+        assert_eq!(
+            cardano_blocks_set.hash,
+            test_data::cardano_blocks_transactions_snapshot_hashes()[0]
+        );
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_blocks_snapshot_should_fail_with_unknown_digest() {
+        get_mithril_client_stable()
+            .get_cardano_blocks_snapshot("whatever")
+            .await
+            .expect_err("get_cardano_blocks_snapshot should fail");
+    }
+
+    #[wasm_bindgen_test]
+    async fn get_cardano_blocks_proof_should_return_value_convertible_in_rust_type() {
+        let tx_hash = test_data::proof_v2_block_hashes()[0];
+        let ctx_hashes = Box::new([JsValue::from(tx_hash)]);
+        let client = get_mithril_client_stable();
+
+        let tx_proof = client
+            .get_cardano_block_proof(ctx_hashes)
+            .await
+            .expect("get_cardano_blocks_proof should not fail");
+        let certificate = client
+            .get_mithril_certificate(&tx_proof.certificate_hash)
+            .await
+            .unwrap();
+
+        client
+            .verify_cardano_block_proof_then_compute_message(&tx_proof, certificate)
+            .await
+            .expect("Compute block proof message for matching cert failed");
     }
 }

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -35,7 +35,7 @@
     },
     "../mithril-client-wasm": {
       "name": "@mithril-dev/mithril-client-wasm",
-      "version": "0.10.2",
+      "version": "0.10.3",
       "license": "Apache-2.0"
     },
     "node_modules/@adobe/css-tools": {
@@ -866,9 +866,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -884,9 +881,6 @@
       "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -904,9 +898,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -922,9 +913,6 @@
       "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -942,9 +930,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -958,9 +943,6 @@
       "version": "1.2.4",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -978,9 +960,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -997,9 +976,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1015,9 +991,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1041,9 +1014,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1065,9 +1035,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1091,9 +1058,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1116,9 +1080,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1138,9 +1099,6 @@
       "version": "0.34.5",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1164,9 +1122,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1188,9 +1143,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1933,9 +1885,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1951,9 +1900,6 @@
       "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1971,9 +1917,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1989,9 +1932,6 @@
       "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2867,9 +2807,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2884,9 +2821,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2901,9 +2835,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2918,9 +2849,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2935,9 +2863,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2952,9 +2877,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2967,9 +2889,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2984,9 +2903,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Content

Implement cardano blocks and transactions in WASM client
- transactions v2 :
  - list_cardano_transactions_v2_snapshots
  - get_cardano_transactions_v2_snapshot
  - get_cardano_transaction_v2_proof
  - verify_cardano_transaction_v2_proof_then_compute_message
- blocks :
  - list_cardano_blocks_snapshots
  - get_cardano_blocks_snapshot
  - get_cardano_block_proof
  - verify_cardano_block_proof_then_compute_message

All new functions needs 'unstable' option to be true tu be used

client-wasm's Readme has been improved with blocks ans transactions hashes example.


- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

Closes #3078 
