### PR TITLE
feat(client-cli): add feedbacks for blocks and transactions certification commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.13.4"
+version = "0.13.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.13.4"
+version = "0.13.5"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_block/certify.rs
+++ b/mithril-client-cli/src/commands/cardano_block/certify.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use cli_table::{Cell, Table, print_stdout};
 use slog::debug;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use mithril_client::common::{BlockHash, SignedEntityTypeDiscriminants};
 use mithril_client::{
@@ -10,7 +11,7 @@ use mithril_client::{
     VerifyProofsV2Error,
 };
 
-use crate::utils::{ProgressOutputType, ProgressPrinter, compute_depth};
+use crate::utils::{IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter, compute_depth};
 use crate::{
     CommandContext,
     configuration::{ConfigError, ConfigSource},
@@ -42,6 +43,10 @@ impl CardanoBlocksCertifyCommand {
         let progress_printer = ProgressPrinter::new(progress_output_type, 4);
         let client = context
             .setup_mithril_client_builder_with_fallback_genesis_key()?
+            .add_feedback_receiver(Arc::new(IndicatifFeedbackReceiver::new(
+                progress_output_type,
+                logger.clone(),
+            )))
             .with_capabilities(SignedEntityTypeDiscriminants::CardanoBlocksTransactions.into())
             .build()?;
 

--- a/mithril-client-cli/src/commands/cardano_transaction/certify/mod.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/certify/mod.rs
@@ -5,13 +5,14 @@ use v1::execute as certify_v1;
 use v2::execute as certify_v2;
 
 use clap::Parser;
-use mithril_client::common::SignedEntityTypeDiscriminants;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use mithril_client::MithrilResult;
+use mithril_client::common::SignedEntityTypeDiscriminants;
 
 use crate::commands::cardano_transaction::CardanoTransactionCommandsBackend;
-use crate::utils::{ProgressOutputType, ProgressPrinter};
+use crate::utils::{IndicatifFeedbackReceiver, ProgressOutputType, ProgressPrinter};
 use crate::{
     CommandContext,
     configuration::{ConfigError, ConfigSource},
@@ -45,12 +46,17 @@ impl CardanoTransactionsCertifyCommand {
             ProgressOutputType::Tty
         };
         let progress_printer = ProgressPrinter::new(progress_output_type, 4);
+        let feedback_receiver = Arc::new(IndicatifFeedbackReceiver::new(
+            progress_output_type,
+            logger.clone(),
+        ));
 
         match self.backend {
             CardanoTransactionCommandsBackend::V1 => {
                 let client = context
                     .setup_mithril_client_builder_with_fallback_genesis_key()?
                     .with_capabilities(SignedEntityTypeDiscriminants::CardanoTransactions.into())
+                    .add_feedback_receiver(feedback_receiver)
                     .build()?;
                 certify_v1(
                     &self.transactions_hashes,
@@ -71,6 +77,7 @@ impl CardanoTransactionsCertifyCommand {
                     .with_capabilities(
                         SignedEntityTypeDiscriminants::CardanoBlocksTransactions.into(),
                     )
+                    .add_feedback_receiver(feedback_receiver)
                     .build()?;
                 certify_v2(
                     &self.transactions_hashes,


### PR DESCRIPTION
## Content

This PR add feedbacks in the Mithril Client CLI when running certifications of transactions (for both v1 or v2 backends) or blocks. Like what it's shown for Cardano database certification.

Screenshot (last line is new):
<img width="1683" height="215" alt="image" src="https://github.com/user-attachments/assets/e643b096-9dfc-4062-b681-f6cae38299f7" />

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced
