### PR TITLE
fix(nix): nix check CA certificates failures

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1771438068,
-        "narHash": "sha256-nGBbXvEZVe/egCPVPFcu89RFtd8Rf6J+4RFoVCFec0A=",
+        "lastModified": 1775790182,
+        "narHash": "sha256-pG2RWVQY0Pe+rmmXJx+Jpyi+JcgjWzS18m7fcD1B64Q=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b5090e53e9d68c523a4bb9ad42b4737ee6747597",
+        "rev": "534982f1c41834b101e381b07b1121a4f065a374",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1771207753,
-        "narHash": "sha256-b9uG8yN50DRQ6A7JdZBfzq718ryYrlmGgqkRm9OOwCE=",
+        "lastModified": 1775763530,
+        "narHash": "sha256-BuTK9z1QEwWPOIakQ1gCN4pa4VwVJpfptYCviy2uOGc=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "d1c15b7d5806069da59e819999d70e1cec0760bf",
+        "rev": "b0188973b4b2a5b6bdba8b65381d6cd09a533da0",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1769909678,
-        "narHash": "sha256-cBEymOf4/o3FD5AZnzC3J9hLbiZ+QDT/KDuyHXVJOpM=",
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "72716169fe93074c333e8d0173151350670b824c",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
         "type": "github"
       },
       "original": {
@@ -80,11 +80,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771556776,
-        "narHash": "sha256-zKprqMQDl3xVfhSSYvgru1IGXjFdxryWk+KqK0I20Xk=",
+        "lastModified": 1775790837,
+        "narHash": "sha256-RAHjn8sjgfF3D17BaV8iv69o3P+L9aCuE36PFwzoqHU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8b3f46b8a6d17ab46e533a5e3d5b1cc2ff228860",
+        "rev": "c913e0b9525311f103b7e1463ebb0f28c6865d8d",
         "type": "github"
       },
       "original": {
@@ -100,11 +100,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770228511,
-        "narHash": "sha256-wQ6NJSuFqAEmIg2VMnLdCnUc0b7vslUohqqGGD+Fyxk=",
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "337a4fe074be1042a35086f15481d763b8ddc0e7",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,7 @@
             pkgsRustOverlay.pkg-config
             pkgsRustOverlay.gnum4
             pkgsRustOverlay.openssl
+            pkgsRustOverlay.cacert
           ]
           ++ lib.optionals (pkgsRustOverlay.stdenv.isDarwin) [
             pkgsRustOverlay.libiconv
@@ -112,6 +113,7 @@
           src = clean ./.;
           inherit buildInputs;
           CARGO_TERM_VERBOSE = "true";
+          SSL_CERT_FILE = "${pkgsRustOverlay.cacert}/etc/ssl/certs/ca-bundle.crt";
         };
 
         commonsArgsMusl =
@@ -125,6 +127,7 @@
             OPENSSL_STATIC = "1";
             OPENSSL_LIB_DIR = "${opensslMusl.out}/lib";
             OPENSSL_INCLUDE_DIR = "${opensslMusl.dev}/include";
+            SSL_CERT_FILE = "${pkgsRustOverlay.cacert}/etc/ssl/certs/ca-bundle.crt";
           }
           else {};
 

--- a/flake.nix
+++ b/flake.nix
@@ -81,29 +81,17 @@
           [
             pkgsRustOverlay.pkg-config
             pkgsRustOverlay.gnum4
-            pkgsRustOverlay.openssl
             pkgsRustOverlay.cacert
           ]
           ++ lib.optionals (pkgsRustOverlay.stdenv.isDarwin) [
             pkgsRustOverlay.libiconv
           ];
 
-        opensslMusl =
-          if pkgsMusl != null then
-            pkgsMusl.openssl.override { static = true; }
-          else null;
-
         nativeBuildInputsMusl =
           if pkgsMusl != null then [
             pkgsMusl.stdenv.cc
             pkgsMusl.pkg-config
             pkgsMusl.gnum4
-          ]
-          else [];
-
-        buildInputsMusl =
-          if pkgsMusl != null then [
-            opensslMusl
           ]
           else [];
 
@@ -122,11 +110,7 @@
             version = "0.0.1";
             src = cleanMusl ./.;
             nativeBuildInputs = nativeBuildInputsMusl;
-            buildInputs = buildInputsMusl;
             CARGO_TERM_VERBOSE = "true";
-            OPENSSL_STATIC = "1";
-            OPENSSL_LIB_DIR = "${opensslMusl.out}/lib";
-            OPENSSL_INCLUDE_DIR = "${opensslMusl.dev}/include";
             SSL_CERT_FILE = "${pkgsRustOverlay.cacert}/etc/ssl/certs/ca-bundle.crt";
           }
           else {};


### PR DESCRIPTION
## Content

This PR includes a fix for nix check phase, notably run in hydra CI, which were failing after merge of #3117 with the following error in tests that used networking:

```shell
---- dependency_injection::builder::tests::set_signer_version_header_to_built_aggregator_client stdout ----

thread 'dependency_injection::builder::tests::set_signer_version_header_to_built_aggregator_client' (13469) panicked at mithril-signer/src/dependency_injection/builder.rs:631:14:
called `Result::unwrap()` on an `Err` value: HTTP client creation failed

Caused by:
    0: builder error
    1: unexpected error: No CA certificates were loaded from the system

---- tests::test_http_compression_is_enabled_and_send_accept_encoding_header_with_correct_values stdout ----

thread 'tests::test_http_compression_is_enabled_and_send_accept_encoding_header_with_correct_values' (13605) panicked at mithril-signer/src/lib.rs:59:5:
called `Result::unwrap()` on an `Err` value: HTTP client creation failed

Caused by:
    0: builder error
    1: unexpected error: No CA certificates were loaded from the system
```

### Root cause

This problem is due to the switch of reqwest to [rustls-platform-verifier](https://github.com/rustls/rustls-platform-verifier) to fetch and validate the system CA certificates from the system.
But nix run tests and builds in a sandboxed environment, meaning that the certificates from the system were not available, leading to the error.

### Changes

- fix: CA certs unavailable issue by providing explicilty the system CA certificates in the build and check phases
- refactor: remove unneeded OpenSSL dependency from the MUSL builds as we have switched to rustls
- chore: upgrade flake.lock

## Pre-submit checklist

- Branch
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #3161
