### PR TITLE
fix: unstable signed entity hash computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.8.43"
+version = "0.8.44"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4265,7 +4265,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.6.64"
+version = "0.6.65"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.71"
+version = "0.2.72"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4500,7 +4500,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.3.30"
+version = "0.3.31"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.71"
+version = "0.2.72"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/database/hydrator.rs
+++ b/internal/mithril-persistence/src/database/hydrator.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 
 use mithril_common::entities::{
     BlockNumber, BlockNumberOffset, CardanoDbBeacon, Epoch, SignedEntityType,
-    SignedEntityTypeDiscriminants,
+    SignedEntityTypeDiscriminants, SignedEntityTypeId,
 };
 
 use crate::sqlite::HydrationError;
@@ -40,7 +40,7 @@ impl Hydrator {
 
     /// Create a [SignedEntityType] from data coming from the database
     pub fn hydrate_signed_entity_type(
-        signed_entity_type_id: usize,
+        signed_entity_type_id: SignedEntityTypeId,
         beacon_str: &str,
     ) -> Result<SignedEntityType, HydrationError> {
         let signed_entity = match SignedEntityTypeDiscriminants::from_id(signed_entity_type_id)

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.8.43"
+version = "0.8.44"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/record/buffered_single_signature_record.rs
+++ b/mithril-aggregator/src/database/record/buffered_single_signature_record.rs
@@ -1,7 +1,8 @@
 use chrono::{DateTime, Utc};
 
 use mithril_common::entities::{
-    HexEncodedSingleSignature, LotteryIndex, SignedEntityTypeDiscriminants, SingleSignature,
+    HexEncodedSingleSignature, LotteryIndex, SignedEntityTypeDiscriminants, SignedEntityTypeId,
+    SingleSignature,
 };
 #[cfg(test)]
 use mithril_common::test::entities_extensions::SingleSignatureTestExtension;
@@ -100,9 +101,10 @@ impl SqLiteEntity for BufferedSingleSignatureRecord {
     where
         Self: Sized,
     {
-        let signed_entity_type_id = usize::try_from(row.read::<i64, _>(0)).map_err(|e| {
-            panic!("Integer field signed_entity_type_id cannot be turned into usize: {e}")
-        })?;
+        let signed_entity_type_id =
+            SignedEntityTypeId::try_from(row.read::<i64, _>(0)).map_err(|e| {
+                panic!("Integer field signed_entity_type_id cannot be turned into u16: {e}")
+            })?;
         let party_id = row.read::<&str, _>(1).to_string();
         let lottery_indexes_str = row.read::<&str, _>(2);
         let signature = row.read::<&str, _>(3).to_string();

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -322,7 +322,7 @@ impl SqLiteEntity for CertificateRecord {
             signed_entity_type: Hydrator::hydrate_signed_entity_type(
                 signed_entity_type_id.try_into().map_err(|e| {
                     HydrationError::InvalidData(format!(
-                        "Could not cast i64 ({signed_entity_type_id}) to u64. Error: '{e}'"
+                        "Could not cast i64 ({signed_entity_type_id}) to u16. Error: '{e}'"
                     ))
                 })?,
                 &signed_entity_beacon_string,

--- a/mithril-aggregator/src/database/record/open_message.rs
+++ b/mithril-aggregator/src/database/record/open_message.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use sqlite::Row;
 use uuid::Uuid;
 
-use mithril_common::entities::{Epoch, ProtocolMessage, SignedEntityType};
+use mithril_common::entities::{Epoch, ProtocolMessage, SignedEntityType, SignedEntityTypeId};
 use mithril_persistence::database::Hydrator;
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
@@ -66,9 +66,9 @@ impl SqLiteEntity for OpenMessageRecord {
         let epoch_val = u64::try_from(epoch_settings_id)
             .map_err(|e| panic!("Integer field open_message.epoch_setting_id (value={epoch_settings_id}) is incompatible with u64 Epoch representation. Error = {e}"))?;
         let beacon_str = Hydrator::read_signed_entity_beacon_column(&row, 2);
-        let signed_entity_type_id = usize::try_from(row.read::<i64, _>(3)).map_err(|e| {
+        let signed_entity_type_id = SignedEntityTypeId::try_from(row.read::<i64, _>(3)).map_err(|e| {
             panic!(
-                "Integer field open_message.signed_entity_type_id cannot be turned into usize: {e}"
+                "Integer field open_message.signed_entity_type_id cannot be turned into u16: {e}"
             )
         })?;
         let signed_entity_type =

--- a/mithril-aggregator/src/database/record/signed_entity.rs
+++ b/mithril-aggregator/src/database/record/signed_entity.rs
@@ -518,7 +518,7 @@ impl SqLiteEntity for SignedEntityRecord {
             signed_entity_type: Hydrator::hydrate_signed_entity_type(
                 signed_entity_type_id_int.try_into().map_err(|e| {
                     HydrationError::InvalidData(format!(
-                        "Could not cast i64 ({signed_entity_type_id_int}) to u64. Error: '{e}'"
+                        "Could not cast i64 ({signed_entity_type_id_int}) to u16. Error: '{e}'"
                     ))
                 })?,
                 &beacon_str,

--- a/mithril-aggregator/src/database/test_helper.rs
+++ b/mithril-aggregator/src/database/test_helper.rs
@@ -256,9 +256,7 @@ pub fn insert_signed_entities(
                 (1, signed_entity_record.signed_entity_id.into()),
                 (
                     2,
-                    i64::try_from(signed_entity_record.signed_entity_type.index())
-                        .unwrap()
-                        .into(),
+                    i64::from(signed_entity_record.signed_entity_type.index()).into(),
                 ),
                 (3, signed_entity_record.certificate_id.into()),
                 (

--- a/mithril-aggregator/src/services/signable_builder/signable_seed_builder.rs
+++ b/mithril-aggregator/src/services/signable_builder/signable_seed_builder.rs
@@ -95,8 +95,10 @@ impl SignableSeedBuilder for AggregatorSignableSeedBuilder {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "future_snark")]
+    use mithril_common::entities::SignerWithStake;
     use mithril_common::{
-        entities::{Epoch, SignerWithStake, SupportedEra},
+        entities::{Epoch, SupportedEra},
         test::{
             builder::{MithrilFixture, MithrilFixtureBuilder},
             double::Dummy,

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.6.64"
+version = "0.6.65"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/entities/signed_entity_type.rs
+++ b/mithril-common/src/entities/signed_entity_type.rs
@@ -16,23 +16,28 @@ use crate::{
 
 use super::{BlockNumber, CardanoDbBeacon, Epoch};
 
+/// Unique numeric identifier of a [`SignedEntityType`] variant, as stored in the database.
+///
+/// These values are **immutable**: existing mappings must never change or be reused.
+pub type SignedEntityTypeId = u16;
+
 /// Database representation of the SignedEntityType::MithrilStakeDistribution value
-const ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION: usize = 0;
+const ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION: SignedEntityTypeId = 0;
 
 /// Database representation of the SignedEntityType::CardanoStakeDistribution value
-const ENTITY_TYPE_CARDANO_STAKE_DISTRIBUTION: usize = 1;
+const ENTITY_TYPE_CARDANO_STAKE_DISTRIBUTION: SignedEntityTypeId = 1;
 
 /// Database representation of the SignedEntityType::CardanoImmutableFilesFull value
-const ENTITY_TYPE_CARDANO_IMMUTABLE_FILES_FULL: usize = 2;
+const ENTITY_TYPE_CARDANO_IMMUTABLE_FILES_FULL: SignedEntityTypeId = 2;
 
 /// Database representation of the SignedEntityType::CardanoTransactions value
-const ENTITY_TYPE_CARDANO_TRANSACTIONS: usize = 3;
+const ENTITY_TYPE_CARDANO_TRANSACTIONS: SignedEntityTypeId = 3;
 
 /// Database representation of the SignedEntityType::CardanoDatabase value
-const ENTITY_TYPE_CARDANO_DATABASE: usize = 4;
+const ENTITY_TYPE_CARDANO_DATABASE: SignedEntityTypeId = 4;
 
 /// Database representation of the SignedEntityType::CardanoBlocksTransactions value
-const ENTITY_TYPE_CARDANO_BLOCKS_TRANSACTIONS: usize = 5;
+const ENTITY_TYPE_CARDANO_BLOCKS_TRANSACTIONS: SignedEntityTypeId = 5;
 
 /// The signed entity type that represents a type of data signed by the Mithril
 /// protocol Note: Each variant of this enum must be associated to an entry in
@@ -103,7 +108,7 @@ impl SignedEntityType {
     }
 
     /// Get the database value from enum's instance
-    pub fn index(&self) -> usize {
+    pub fn index(&self) -> SignedEntityTypeId {
         match self {
             Self::MithrilStakeDistribution(..) => ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION,
             Self::CardanoStakeDistribution(..) => ENTITY_TYPE_CARDANO_STAKE_DISTRIBUTION,
@@ -215,7 +220,7 @@ impl SignedEntityTypeDiscriminants {
     }
 
     /// Get the database value from enum's instance
-    pub fn index(&self) -> usize {
+    pub fn index(&self) -> SignedEntityTypeId {
         match self {
             Self::MithrilStakeDistribution => ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION,
             Self::CardanoStakeDistribution => ENTITY_TYPE_CARDANO_STAKE_DISTRIBUTION,
@@ -227,7 +232,9 @@ impl SignedEntityTypeDiscriminants {
     }
 
     /// Get the discriminant associated with the given id
-    pub fn from_id(signed_entity_type_id: usize) -> StdResult<SignedEntityTypeDiscriminants> {
+    pub fn from_id(
+        signed_entity_type_id: SignedEntityTypeId,
+    ) -> StdResult<SignedEntityTypeDiscriminants> {
         match signed_entity_type_id {
             ENTITY_TYPE_MITHRIL_STAKE_DISTRIBUTION => Ok(Self::MithrilStakeDistribution),
             ENTITY_TYPE_CARDANO_STAKE_DISTRIBUTION => Ok(Self::CardanoStakeDistribution),

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.3.30"
+version = "0.3.31"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/database/record/signed_beacon_record.rs
+++ b/mithril-signer/src/database/record/signed_beacon_record.rs
@@ -1,7 +1,7 @@
 use chrono::{DateTime, Utc};
 use sqlite::Row;
 
-use mithril_common::entities::{Epoch, SignedEntityType};
+use mithril_common::entities::{Epoch, SignedEntityType, SignedEntityTypeId};
 use mithril_persistence::database::Hydrator;
 use mithril_persistence::sqlite::{HydrationError, Projection, SqLiteEntity};
 
@@ -82,11 +82,12 @@ impl SqLiteEntity for SignedBeaconRecord {
     {
         let epoch = row.read::<i64, _>(0);
         let beacon_str = Hydrator::read_signed_entity_beacon_column(&row, 1);
-        let signed_entity_type_id = usize::try_from(row.read::<i64, _>(2)).map_err(|e| {
-            HydrationError::InvalidData(format!(
-                "signed_beacon.signed_entity_type_id cannot be turned into usize: {e}"
-            ))
-        })?;
+        let signed_entity_type_id =
+            SignedEntityTypeId::try_from(row.read::<i64, _>(2)).map_err(|e| {
+                HydrationError::InvalidData(format!(
+                    "signed_beacon.signed_entity_type_id cannot be turned into u16: {e}"
+                ))
+            })?;
         let initiated_at = &row.read::<&str, _>(3);
         let signed_at = &row.read::<&str, _>(4);
 


### PR DESCRIPTION
## Content

This PR includes a fix for signed entity hash computation which was unstable across target.

For `CardanoBlocksTransactions` only it feed the signed entity `index` to the hash, which was based on a `usize`. But `usize` representation change based on the target, e.g for a 32 bit target it would be an `u32` and for a 64 bit target a `u64`.

> [!TIP]
> This made the `wasm` based explorer certificate validation fails since we target a 32 bit target and the hashes were computed on linux which use a 64 target.

This PR fix this index type to an `u16`, ensuring stability across targets and giving us far enough available numbers for any future signed entity type (`65535`).

### Details

- add `SignedEntityTypeId` type alias for `u16`
- use `SignedEntityTypeId` instead of usize everywhere a signed entity type id/index was used
- `[additional]` fix a clippy issue in the aggregator when the `future_snark` feature was not used

> [!NOTE]
> In database conversion error message I replaced `usize` mention with `u16` instead of  `SignedEntityTypeId` but I wonder if the message should be reword instead to drop the concrete target type.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced
