### PR TITLE
feat: support for Cardano `10.7` snapshot converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 - Support for `Cardano node` `10.6.2` in the signer and the aggregator.
 
+- Support for `Cardano node` `10.7.0` in the signer, aggregator and client.
+
 - Update `release-mainnet` network configuration to SNARK-friendly protocol parameters.
 
 - Support for optional throttling of the Cardano transactions import in the signer and aggregator (enabled by default).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4208,7 +4208,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.13.5"
+version = "0.13.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.13.5"
+version = "0.13.6"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/shared_steps.rs
+++ b/mithril-client-cli/src/commands/cardano_db/shared_steps.rs
@@ -10,7 +10,8 @@ use mithril_client::{
 };
 
 use crate::utils::{
-    CARDANO_NODE_V10_6_2, CardanoDbUtils, LedgerFormat, ProgressPrinter, is_version_equal_or_upper,
+    CARDANO_NODE_V10_6_2, CARDANO_NODE_V10_7_0, CardanoDbUtils, LedgerFormat, ProgressPrinter,
+    is_version_equal_or_upper,
 };
 
 pub struct ComputeCardanoDatabaseMessageOptions {
@@ -192,6 +193,10 @@ pub fn log_download_information(
             json["run_docker_cmd"] = serde_json::Value::String(docker_cmd);
 
             if include_ancillary {
+                if is_version_at_least_10_7_0_or_latest(cardano_node_version) {
+                    json["snapshot_converter_cmd_to_lsm"] =
+                        serde_json::Value::String(snapshot_converter_cmd("LSM"));
+                }
                 json["snapshot_converter_cmd_to_lmdb"] =
                     serde_json::Value::String(snapshot_converter_cmd("LMDB"));
                 json["snapshot_converter_cmd_to_legacy"] =
@@ -220,6 +225,16 @@ pub fn log_download_information(
             );
 
             if include_ancillary {
+                if is_version_at_least_10_7_0_or_latest(cardano_node_version) {
+                    println!(
+                        r###"Upgrade and replace the restored ledger state snapshot to 'LSM' flavor by running the command:
+
+    {}
+    "###,
+                        snapshot_converter_cmd("LSM"),
+                    );
+                }
+
                 println!(
                     r###"Upgrade and replace the restored ledger state snapshot to 'LMDB' flavor by running the command:
 
@@ -230,7 +245,7 @@ pub fn log_download_information(
 
                 if !is_version_at_least_10_6_2_or_latest(cardano_node_version) {
                     println!(
-                        r###"Or to 'Legacy' flavor by running the command:
+                        r###"Upgrade and replace the restored ledger state snapshot to 'Legacy' flavor by running the command:
 
     {}
     "###,
@@ -242,6 +257,10 @@ pub fn log_download_information(
     }
 
     Ok(())
+}
+
+pub fn is_version_at_least_10_7_0_or_latest(version: &str) -> bool {
+    is_version_equal_or_upper(version, CARDANO_NODE_V10_7_0)
 }
 
 pub fn is_version_at_least_10_6_2_or_latest(version: &str) -> bool {

--- a/mithril-client-cli/src/commands/tools/utxo_hd/snapshot_converter.rs
+++ b/mithril-client-cli/src/commands/tools/utxo_hd/snapshot_converter.rs
@@ -19,7 +19,10 @@ use crate::utils::{
     ProgressOutputType, ProgressPrinter, ReqwestGitHubApiClient, ReqwestHttpDownloader, copy_dir,
     is_version_equal_or_upper, print_simple_warning, remove_dir_contents,
 };
-use crate::{CommandContext, utils::CARDANO_NODE_V10_6_2};
+use crate::{
+    CommandContext,
+    utils::{CARDANO_NODE_V10_6_2, CARDANO_NODE_V10_7_0},
+};
 
 const GITHUB_ORGANIZATION: &str = "IntersectMBO";
 const GITHUB_REPOSITORY: &str = "cardano-node";
@@ -38,6 +41,7 @@ const SNAPSHOT_CONVERTER_CONFIG_DIR: &str = "share";
 const SNAPSHOT_CONVERTER_CONFIG_FILE: &str = "config.json";
 
 const LEDGER_DIR: &str = "ledger";
+const LSM_DATABASE_DIR: &str = "lsm";
 const PROTOCOL_MAGIC_ID_FILE: &str = "protocolMagicId";
 
 const CONVERSION_FALLBACK_LIMIT: usize = 2;
@@ -48,6 +52,8 @@ enum UTxOHDFlavor {
     Legacy,
     #[clap(name = "LMDB")]
     Lmdb,
+    #[clap(name = "LSM")]
+    Lsm,
 }
 
 impl fmt::Display for UTxOHDFlavor {
@@ -55,6 +61,7 @@ impl fmt::Display for UTxOHDFlavor {
         match self {
             Self::Legacy => write!(f, "Legacy"),
             Self::Lmdb => write!(f, "LMDB"),
+            Self::Lsm => write!(f, "LSM"),
         }
     }
 }
@@ -64,6 +71,7 @@ impl From<&UTxOHDFlavor> for LedgerFormat {
         match value {
             UTxOHDFlavor::Legacy => LedgerFormat::Legacy,
             UTxOHDFlavor::Lmdb => LedgerFormat::Lmdb,
+            UTxOHDFlavor::Lsm => LedgerFormat::Lsm,
         }
     }
 }
@@ -115,14 +123,19 @@ struct SnapshotConverterConfig {
 }
 
 enum SnapshotConverterBin {
-    From10_6(SnapshotConverterConfig),
+    From10_7(SnapshotConverterConfig),
+    UpTo10_6(SnapshotConverterConfig),
     UpTo10_5(SnapshotConverterConfig),
 }
 
 impl SnapshotConverter for SnapshotConverterBin {
     fn convert(&self, input_path: &Path, output_path: &Path) -> MithrilResult<()> {
         let mut command = match self {
-            SnapshotConverterBin::From10_6(cfg) => {
+            SnapshotConverterBin::From10_7(cfg) => {
+                build_command_from_10_7(input_path, output_path, cfg.clone())?
+            }
+
+            SnapshotConverterBin::UpTo10_6(cfg) => {
                 build_command_from_10_6(input_path, output_path, cfg.clone())
             }
 
@@ -135,8 +148,9 @@ impl SnapshotConverter for SnapshotConverterBin {
             format!(
                 "Failed to execute snapshot-converter binary at {}",
                 match self {
-                    SnapshotConverterBin::From10_6(cfg) | SnapshotConverterBin::UpTo10_5(cfg) =>
-                        cfg.converter_bin.display(),
+                    SnapshotConverterBin::From10_7(cfg)
+                    | SnapshotConverterBin::UpTo10_6(cfg)
+                    | SnapshotConverterBin::UpTo10_5(cfg) => cfg.converter_bin.display(),
                 }
             )
         })?;
@@ -150,6 +164,48 @@ impl SnapshotConverter for SnapshotConverterBin {
 
         Ok(())
     }
+}
+
+fn build_command_from_10_7(
+    input_path: &Path,
+    output_path: &Path,
+    cfg: SnapshotConverterConfig,
+) -> MithrilResult<Command> {
+    let mut command = Command::new(cfg.converter_bin);
+
+    command.arg("--input-mem").arg(input_path);
+
+    if cfg.utxo_hd_flavor == UTxOHDFlavor::Lsm {
+        let output_database_path =
+            output_path.parent().unwrap_or(output_path).join(LSM_DATABASE_DIR);
+        if !output_database_path.exists() {
+            create_dir(&output_database_path).with_context(|| {
+                format!(
+                    "Failed to create output LSM database directory: {}",
+                    output_database_path.display()
+                )
+            })?;
+        }
+        command
+            .arg("--output-lsm-snapshot")
+            .arg(output_path)
+            .arg("--output-lsm-database")
+            .arg(output_database_path);
+    } else {
+        let flavor = cfg.utxo_hd_flavor.to_string().to_lowercase();
+        command.arg(format!("--output-{flavor}")).arg(output_path);
+    }
+
+    command
+        .arg("--config")
+        .arg(cfg.config_path)
+        .stdout(if cfg.hide_output {
+            Stdio::null()
+        } else {
+            std::io::stderr().into()
+        });
+
+    Ok(command)
 }
 
 fn build_command_from_10_6(
@@ -337,6 +393,7 @@ impl SnapshotConverterCommand {
                     &progress_printer,
                     &self.db_directory,
                     &converted_snapshot_path,
+                    &self.utxo_hd_flavor,
                 )
                 .with_context(
                     || "Failed to overwrite the ledger state with the converted snapshot.",
@@ -682,8 +739,10 @@ Snapshot location: {}
         progress_printer: &ProgressPrinter,
         db_dir: &Path,
         converted_snapshot_path: &Path,
+        utxo_hd_flavor: &UTxOHDFlavor,
     ) -> MithrilResult<()> {
         let ledger_dir = db_dir.join(LEDGER_DIR);
+
         progress_printer.report_step(
             step_number,
             &format!(
@@ -700,19 +759,53 @@ Snapshot location: {}
         let (slot_number, _) = filename
             .split_once('_')
             .with_context(|| format!("Invalid converted snapshot name format: {}", filename))?;
+
+        let destination_name = if *utxo_hd_flavor == UTxOHDFlavor::Lsm {
+            format!("{slot_number}_lsm")
+        } else {
+            slot_number.to_string()
+        };
+
         remove_dir_contents(&ledger_dir).with_context(|| {
             format!(
                 "Failed to remove contents of ledger directory: {}",
                 ledger_dir.display()
             )
         })?;
-        let destination = ledger_dir.join(slot_number);
+        let destination = ledger_dir.join(destination_name);
         rename(converted_snapshot_path, &destination).with_context(|| {
             format!(
                 "Failed to move converted snapshot to ledger directory: {}",
                 destination.display()
             )
         })?;
+
+        if *utxo_hd_flavor == UTxOHDFlavor::Lsm {
+            let lsm_source = converted_snapshot_path
+                .parent()
+                .with_context(|| {
+                    format!(
+                        "Missing parent directory for converted snapshot: {}",
+                        converted_snapshot_path.display()
+                    )
+                })?
+                .join(LSM_DATABASE_DIR);
+            let lsm_destination = db_dir.join(LSM_DATABASE_DIR);
+            if lsm_destination.exists() {
+                remove_dir_all(&lsm_destination).with_context(|| {
+                    format!(
+                        "Failed to remove existing LSM directory: {}",
+                        lsm_destination.display()
+                    )
+                })?;
+            }
+            rename(&lsm_source, &lsm_destination).with_context(|| {
+                format!(
+                    "Failed to move LSM database to: {}",
+                    lsm_destination.display()
+                )
+            })?;
+        }
 
         Ok(())
     }
@@ -762,11 +855,17 @@ fn get_snapshot_converter_bin_by_version(
     cardano_node_version: &str,
     converter_bin_config: SnapshotConverterConfig,
 ) -> SnapshotConverterBin {
-    if is_version_at_least_10_6_2_or_latest(cardano_node_version) {
-        SnapshotConverterBin::From10_6(converter_bin_config)
+    if is_version_at_least_10_7_0_or_latest(cardano_node_version) {
+        SnapshotConverterBin::From10_7(converter_bin_config)
+    } else if is_version_at_least_10_6_2_or_latest(cardano_node_version) {
+        SnapshotConverterBin::UpTo10_6(converter_bin_config)
     } else {
         SnapshotConverterBin::UpTo10_5(converter_bin_config)
     }
+}
+
+fn is_version_at_least_10_7_0_or_latest(version: &str) -> bool {
+    is_version_equal_or_upper(version, CARDANO_NODE_V10_7_0)
 }
 
 fn is_version_at_least_10_6_2_or_latest(version: &str) -> bool {
@@ -815,7 +914,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_return_error_if_htx0_hd_flavor_is_legacy_and_cardano_node_version_10_6_2() {
+        async fn should_return_error_if_utxo_hd_flavor_is_legacy_and_cardano_node_version_10_6_2() {
             let command = SnapshotConverterCommand {
                 cardano_node_version: "10.6.2".to_string(),
                 utxo_hd_flavor: UTxOHDFlavor::Legacy,
@@ -832,7 +931,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_return_error_if_htx0_hd_flavor_is_legacy_and_cardano_node_version_10_6_2_or_upper()
+        async fn should_return_error_if_utxo_hd_flavor_is_legacy_and_cardano_node_version_10_6_2_or_upper()
          {
             let command = SnapshotConverterCommand {
                 cardano_node_version: "10.7.7".to_string(),
@@ -850,7 +949,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn should_return_error_if_htx0_hd_flavor_is_legacy_and_cardano_node_version_latest() {
+        async fn should_return_error_if_utxo_hd_flavor_is_legacy_and_cardano_node_version_latest() {
             let command = SnapshotConverterCommand {
                 cardano_node_version: "latest".to_string(),
                 utxo_hd_flavor: UTxOHDFlavor::Legacy,
@@ -1165,6 +1264,18 @@ mod tests {
 
                 assert_eq!(snapshot_path, snapshots_dir.join("123456_legacy"));
             }
+
+            {
+                let snapshot_path =
+                    SnapshotConverterCommand::compute_converted_snapshot_output_path(
+                        &snapshots_dir,
+                        &input_snapshot,
+                        &UTxOHDFlavor::Lsm,
+                    )
+                    .unwrap();
+
+                assert_eq!(snapshot_path, snapshots_dir.join("123456_lsm"));
+            }
         }
 
         #[test]
@@ -1201,11 +1312,80 @@ mod tests {
                 &ProgressPrinter::new(ProgressOutputType::Hidden, 1),
                 &tmp_dir,
                 &converted_snapshot,
+                &UTxOHDFlavor::Lmdb,
             )
             .unwrap();
 
             assert!(!previous_snapshot.exists());
             assert!(ledger_dir.join("456").exists());
+        }
+
+        #[test]
+        fn moves_lsm_converted_snapshot_to_ledger_directory_with_lsm_suffix() {
+            let tmp_dir = temp_dir_create!();
+            let snapshots_dir = tmp_dir.join("snapshots");
+            create_dir(&snapshots_dir).unwrap();
+
+            let converted_snapshot = snapshots_dir.join("456_lsm");
+            create_dir(&converted_snapshot).unwrap();
+            File::create(converted_snapshot.join("some_file")).unwrap();
+
+            let lsm_source = snapshots_dir.join(LSM_DATABASE_DIR);
+            create_dir(&lsm_source).unwrap();
+            File::create(lsm_source.join("lsm_data")).unwrap();
+
+            let db_dir = tmp_dir.join("db");
+            create_dir(&db_dir).unwrap();
+            let ledger_dir = db_dir.join(LEDGER_DIR);
+            create_dir(&ledger_dir).unwrap();
+
+            SnapshotConverterCommand::commit_converted_snapshot(
+                1,
+                &ProgressPrinter::new(ProgressOutputType::Hidden, 1),
+                &db_dir,
+                &converted_snapshot,
+                &UTxOHDFlavor::Lsm,
+            )
+            .unwrap();
+
+            assert!(ledger_dir.join("456_lsm").exists());
+            assert!(ledger_dir.join("456_lsm").join("some_file").exists());
+            assert!(db_dir.join(LSM_DATABASE_DIR).join("lsm_data").exists());
+        }
+
+        #[test]
+        fn lsm_commit_replaces_existing_lsm_directory() {
+            let tmp_dir = temp_dir_create!();
+            let snapshots_dir = tmp_dir.join("snapshots");
+            create_dir(&snapshots_dir).unwrap();
+
+            let converted_snapshot = snapshots_dir.join("456_lsm");
+            create_dir(&converted_snapshot).unwrap();
+
+            let lsm_source = snapshots_dir.join(LSM_DATABASE_DIR);
+            create_dir(&lsm_source).unwrap();
+            File::create(lsm_source.join("new_data")).unwrap();
+
+            let db_dir = tmp_dir.join("db");
+            create_dir(&db_dir).unwrap();
+            let ledger_dir = db_dir.join(LEDGER_DIR);
+            create_dir(&ledger_dir).unwrap();
+            let existing_lsm = db_dir.join(LSM_DATABASE_DIR);
+            create_dir(&existing_lsm).unwrap();
+            File::create(existing_lsm.join("old_data")).unwrap();
+
+            SnapshotConverterCommand::commit_converted_snapshot(
+                1,
+                &ProgressPrinter::new(ProgressOutputType::Hidden, 1),
+                &db_dir,
+                &converted_snapshot,
+                &UTxOHDFlavor::Lsm,
+            )
+            .unwrap();
+
+            let lsm_destination = db_dir.join(LSM_DATABASE_DIR);
+            assert!(!lsm_destination.join("old_data").exists());
+            assert!(lsm_destination.join("new_data").exists());
         }
 
         #[test]
@@ -1224,6 +1404,7 @@ mod tests {
                 &ProgressPrinter::new(ProgressOutputType::Hidden, 1),
                 &tmp_dir,
                 &converted_snapshot,
+                &UTxOHDFlavor::Lmdb,
             )
             .expect_err("Should fail if converted snapshot has invalid filename");
 
@@ -1589,54 +1770,63 @@ mod tests {
             get_snapshot_converter_bin_by_version,
         };
 
-        #[test]
-        fn should_return_snapshot_converter_bin_new_with_cardano_version_10_6_2_or_upper() {
-            let config = SnapshotConverterConfig {
+        fn dummy_config() -> SnapshotConverterConfig {
+            SnapshotConverterConfig {
                 converter_bin: PathBuf::new(),
                 config_path: PathBuf::new(),
                 utxo_hd_flavor: UTxOHDFlavor::Lmdb,
                 hide_output: true,
-            };
+            }
+        }
 
-            let converter_bin = get_snapshot_converter_bin_by_version("10.6.2", config.clone());
+        #[test]
+        fn should_return_from_10_7_with_cardano_version_10_7_0_or_upper() {
+            let converter_bin = get_snapshot_converter_bin_by_version("10.7.0", dummy_config());
             assert!(
-                matches!(converter_bin, SnapshotConverterBin::From10_6(_)),
-                "returned type is not SnapshotConverterBin::From10_6"
+                matches!(converter_bin, SnapshotConverterBin::From10_7(_)),
+                "returned type is not SnapshotConverterBin::From10_7"
             );
 
-            let converter_bin = get_snapshot_converter_bin_by_version("10.7.0", config.clone());
+            let converter_bin = get_snapshot_converter_bin_by_version("10.8.0", dummy_config());
             assert!(
-                matches!(converter_bin, SnapshotConverterBin::From10_6(_)),
-                "returned type is not SnapshotConverterBin::From10_6"
+                matches!(converter_bin, SnapshotConverterBin::From10_7(_)),
+                "returned type is not SnapshotConverterBin::From10_7"
             );
         }
 
         #[test]
-        fn should_return_snapshot_converter_bin_new_with_cardano_version_latest() {
-            let config = SnapshotConverterConfig {
-                converter_bin: PathBuf::new(),
-                config_path: PathBuf::new(),
-                utxo_hd_flavor: UTxOHDFlavor::Lmdb,
-                hide_output: true,
-            };
-
-            let converter_bin = get_snapshot_converter_bin_by_version("latest", config.clone());
+        fn should_return_from_10_7_with_cardano_version_latest() {
+            let converter_bin = get_snapshot_converter_bin_by_version("latest", dummy_config());
             assert!(
-                matches!(converter_bin, SnapshotConverterBin::From10_6(_)),
-                "returned type is not SnapshotConverterBin::From10_6"
+                matches!(converter_bin, SnapshotConverterBin::From10_7(_)),
+                "returned type is not SnapshotConverterBin::From10_7"
             );
         }
 
         #[test]
-        fn should_return_snapshot_converter_bin_old_with_cardano_version_bellow_10_6_2() {
-            let config = SnapshotConverterConfig {
-                converter_bin: PathBuf::new(),
-                config_path: PathBuf::new(),
-                utxo_hd_flavor: UTxOHDFlavor::Lmdb,
-                hide_output: true,
-            };
+        fn should_return_up_to_10_6_with_cardano_version_10_6_2_to_10_6_x() {
+            let converter_bin = get_snapshot_converter_bin_by_version("10.6.2", dummy_config());
+            assert!(
+                matches!(converter_bin, SnapshotConverterBin::UpTo10_6(_)),
+                "returned type is not SnapshotConverterBin::UpTo10_6"
+            );
 
-            let converter_bin = get_snapshot_converter_bin_by_version("10.6.1", config);
+            let converter_bin = get_snapshot_converter_bin_by_version("10.6.9", dummy_config());
+            assert!(
+                matches!(converter_bin, SnapshotConverterBin::UpTo10_6(_)),
+                "returned type is not SnapshotConverterBin::UpTo10_6"
+            );
+        }
+
+        #[test]
+        fn should_return_up_to_10_5_with_cardano_version_below_10_6_2() {
+            let converter_bin = get_snapshot_converter_bin_by_version("10.6.1", dummy_config());
+            assert!(
+                matches!(converter_bin, SnapshotConverterBin::UpTo10_5(_)),
+                "returned type is not SnapshotConverterBin::UpTo10_5"
+            );
+
+            let converter_bin = get_snapshot_converter_bin_by_version("10.5.0", dummy_config());
             assert!(
                 matches!(converter_bin, SnapshotConverterBin::UpTo10_5(_)),
                 "returned type is not SnapshotConverterBin::UpTo10_5"

--- a/mithril-client-cli/src/utils/cardano_db.rs
+++ b/mithril-client-cli/src/utils/cardano_db.rs
@@ -17,8 +17,10 @@ pub enum LedgerFormat {
     Legacy,
     /// UTxO-HD in-memory format (since cardano-node `10.4.1`)
     InMemory,
-    /// UTxO-HD Lmdb format (since cardano-node `10.4.1`)
+    /// UTxO-HD LMDB format (since cardano-node `10.4.1`)
     Lmdb,
+    /// UTxO-HD LSM format (since cardano-node `10.7.0`)
+    Lsm,
 }
 
 impl CardanoDbUtils {
@@ -80,15 +82,23 @@ impl CardanoDbUtils {
             LedgerFormat::Lmdb => {
                 r#" -e CARDANO_CONFIG_JSON_MERGE='{"LedgerDB": { "Backend": "V1LMDB" }}'"#
             }
+            LedgerFormat::Lsm => {
+                r#" -e CARDANO_CONFIG_JSON_MERGE='{"LedgerDB": { "Backend": "V2LSM" }}'"#
+            }
             _ => "",
         };
 
-        let docker_cmd = format!(
-            "docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source=\"{db_path}\",target=/data/db/ -e NETWORK={cardano_network}{cardano_node_config} ghcr.io/intersectmbo/cardano-node:{cardano_node_version}",
-            db_path = db_path.display(),
-        );
+        let security_opt = if matches!(ledger_format, LedgerFormat::Lsm) {
+            // The LSM backend requires `seccomp=unconfined` to work properly, as it uses io_uring syscalls which is blocked by default in Docker.
+            " --security-opt seccomp=unconfined"
+        } else {
+            ""
+        };
 
-        docker_cmd
+        format!(
+            "docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source=\"{db_path}\",target=/data/db/ -e NETWORK={cardano_network}{cardano_node_config}{security_opt} ghcr.io/intersectmbo/cardano-node:{cardano_node_version}",
+            db_path = db_path.display(),
+        )
     }
 }
 
@@ -194,6 +204,21 @@ mod test {
         assert_eq!(
             run_command,
             r#"docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="/path/to/db",target=/data/db/ -e NETWORK=mainnet -e CARDANO_CONFIG_JSON_MERGE='{"LedgerDB": { "Backend": "V1LMDB" }}' ghcr.io/intersectmbo/cardano-node:10.6.2"#
+        )
+    }
+
+    #[test]
+    fn get_docker_run_command_for_lsm_ledger() {
+        let run_command = CardanoDbUtils::get_docker_run_command(
+            Path::new("/path/to/db"),
+            "mainnet",
+            "10.7.0",
+            LedgerFormat::Lsm,
+        );
+
+        assert_eq!(
+            run_command,
+            r#"docker run -v cardano-node-ipc:/ipc -v cardano-node-data:/data --mount type=bind,source="/path/to/db",target=/data/db/ -e NETWORK=mainnet -e CARDANO_CONFIG_JSON_MERGE='{"LedgerDB": { "Backend": "V2LSM" }}' --security-opt seccomp=unconfined ghcr.io/intersectmbo/cardano-node:10.7.0"#
         )
     }
 }

--- a/mithril-client-cli/src/utils/version.rs
+++ b/mithril-client-cli/src/utils/version.rs
@@ -3,6 +3,9 @@ use semver::Version;
 /// Version in which Cardano introduces a breaking change regarding the snapshot converter command
 pub const CARDANO_NODE_V10_6_2: Version = Version::new(10, 6, 2);
 
+/// Version in which Cardano introduces a breaking change regarding the snapshot converter command
+pub const CARDANO_NODE_V10_7_0: Version = Version::new(10, 7, 0);
+
 pub fn is_version_equal_or_upper(version_to_check: &str, version_reference: Version) -> bool {
     let normalized_version = version_to_check.trim().to_ascii_lowercase();
     if normalized_version == "latest" {
@@ -28,6 +31,7 @@ mod tests {
         assert!(!is_version_equal_or_upper("10.5.1", VERSION_10_6_2));
 
         assert!(is_version_equal_or_upper("10.6.2", VERSION_10_6_2));
+        assert!(is_version_equal_or_upper("10.7.0", VERSION_10_6_2));
         assert!(is_version_equal_or_upper("10.7.3", VERSION_10_6_2));
         assert!(is_version_equal_or_upper("latest", VERSION_10_6_2));
     }


### PR DESCRIPTION
## Content

This PR includes **support for Cardano `10.7` in the snapshot converter**:
  - **New `From10_7` variant in `SnapshotConverterBin`**: introduces a dedicated converter binary variant for Cardano `10.7+`, with its own command builder (`build_command_from_10_7`), while renaming the previous `From10_6` to `UpTo10_6` to reflect its actual version range                       
  - **LSM flavor support**: adds `Lsm` variant to `UTxOHDFlavor` and `LedgerFormat`, enabling conversion to the new LSM backend introduced in Cardano `10.7`
  - **LSM-specific converter arguments**: for LSM, the `10.7` converter uses `--output-lsm-snapshot` and `--output-lsm-database` instead of the single `--output-lsm` flag                                                                                                                              
  - **Version-gated LSM display**: the LSM conversion option is only shown (in both JSON and text output) for Cardano node versions `>= 10.7.0` or `latest`                                                                                                                                             
  - **LSM commit behavior**: the converted snapshot is stored as `ledger/<slot>_lsm` (with suffix), and the LSM database folder is moved as a sibling of `ledger` at `db_dir/lsm`                                                                                                                       
  - **Docker `--security-opt seccomp=unconfined`**: added to the Docker run command when using LSM

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2894 
