### PR TITLE
refactor(stm): Enhance selection in witness prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.4 (04-22-2026)
+
+### Changed
+
+- Enhanced the index selection mechanism of snark proof system.
+
 ## 0.10.1 (04-09-2026)
 
 ### Changed

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.3"
+version = "0.10.4"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -1,7 +1,8 @@
+use std::collections::{BTreeMap, btree_map::Entry};
+
 use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, btree_map::Entry};
 
 use crate::{
     AggregationError, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
@@ -75,7 +76,7 @@ impl SnarkClerk {
     pub(crate) fn select_valid_signatures_for_k_indices(
         parameters: &Parameters,
         signatures: &[SingleSignature],
-        message: &[BaseFieldElement; 2],
+        message_to_sign: &[BaseFieldElement; 2],
     ) -> StmResult<BTreeMap<LotteryIndex, SingleSignature>> {
         let mut unique_index_signature_map: BTreeMap<LotteryIndex, SingleSignature> =
             BTreeMap::new();
@@ -110,23 +111,45 @@ impl SnarkClerk {
         }
 
         let mut hasher = Sha256::new();
-        hasher.update(message[0].to_bytes());
-        hasher.update(message[1].to_bytes());
+        hasher.update(message_to_sign[0].to_bytes());
+        hasher.update(message_to_sign[1].to_bytes());
         let seed: [u8; 32] = hasher.finalize().into();
 
         let mut rng = ChaCha20Rng::from_seed(seed);
         let k = parameters.k as usize;
         let mut entries: Vec<(LotteryIndex, SingleSignature)> =
             unique_index_signature_map.into_iter().collect();
-        // Partial Fisher-Yates: randomly select k entries
+        // Randomly select k entries using Lemire's
+        // nearly divisionless method for unbiased index generation.
         for i in 0..k {
-            let j = i + (rng.next_u64() as usize % (entries.len() - i));
+            let range = (entries.len() - i) as u64;
+            let j = i + unbiased_random_below(&mut rng, range) as usize;
             entries.swap(i, j);
         }
         entries.truncate(k);
 
         Ok(entries.into_iter().collect())
     }
+}
+
+/// Generate a uniformly random `u64` in `[0, range)` without modulo bias.
+///
+/// Uses Lemire's "nearly divisionless" rejection sampling: draw a 128-bit
+/// product `rng.next_u64() * range`, reject only when the low 64 bits fall
+/// below `(-range) % range` (the remainder that causes bias). For typical
+/// ranges this rejects with probability < `range / 2^64`, so almost never.
+fn unbiased_random_below(rng: &mut ChaCha20Rng, range: u64) -> u64 {
+    debug_assert!(range > 0);
+    let mut product = (rng.next_u64() as u128) * (range as u128);
+    let mut low = product as u64;
+    if low < range {
+        let threshold = range.wrapping_neg() % range;
+        while low < threshold {
+            product = (rng.next_u64() as u128) * (range as u128);
+            low = product as u64;
+        }
+    }
+    (product >> 64) as u64
 }
 
 #[cfg(test)]

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -157,6 +157,7 @@ mod tests {
                 compute_winning_lottery_indices,
             },
         },
+        signature_scheme::BaseFieldElement,
     };
 
     type D = MithrilMembershipDigest;
@@ -193,16 +194,14 @@ mod tests {
         (signers, clerk)
     }
 
-    // Collect signatures and populate their SNARK winning indices.
+    // Collect signatures, populate their SNARK winning indices, and return
+    // the derived `message_to_sign` so callers can reuse it.
     fn collect_signatures_with_indices(
         signers: &[Signer<D>],
         clerk: &SnarkClerk,
         message: &[u8],
+        message_to_sign: &[BaseFieldElement; 2],
     ) -> Vec<SingleSignature> {
-        let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
-        let message_to_sign = build_snark_message(&avk.get_merkle_tree_commitment().root, message)
-            .expect("build_snark_message should succeed");
-
         signers
             .iter()
             .filter_map(|signer| {
@@ -212,7 +211,7 @@ mod tests {
                     clerk.get_snark_registration_entry(sig.signer_index).ok().flatten()?;
                 let indices = compute_winning_lottery_indices(
                     clerk.parameters.m,
-                    &message_to_sign,
+                    message_to_sign,
                     &snark_sig.get_schnorr_signature(),
                     reg_entry.1,
                 )
@@ -221,6 +220,12 @@ mod tests {
                 Some(sig)
             })
             .collect()
+    }
+
+    fn compute_message_to_sign(clerk: &SnarkClerk, message: &[u8]) -> [BaseFieldElement; 2] {
+        let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
+        build_snark_message(&avk.get_merkle_tree_commitment().root, message)
+            .expect("build_snark_message should succeed")
     }
 
     proptest! {
@@ -283,13 +288,10 @@ mod tests {
             let mut rng = ChaCha20Rng::from_seed(seed);
 
             let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-
-            let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
-            let message_to_sign = build_snark_message(&avk.get_merkle_tree_commitment().root, &msg)
-                .expect("build_snark_message should succeed");
+            let message_to_sign = compute_message_to_sign(&clerk, &msg);
 
             // Collect valid signatures with SNARK indices
-            let mut all_sigs = collect_signatures_with_indices(&signers, &clerk, &msg);
+            let mut all_sigs = collect_signatures_with_indices(&signers, &clerk, &msg, &message_to_sign);
 
             // Also create signatures for false messages
             for _ in 0..num_false_msgs {
@@ -298,8 +300,9 @@ mod tests {
                 if false_msg[..msg.len()] == msg[..] {
                     false_msg[0] = msg[0].wrapping_add(1);
                 }
+                let false_message_to_sign = compute_message_to_sign(&clerk, &false_msg);
                 let false_sigs =
-                    collect_signatures_with_indices(&signers, &clerk, &false_msg);
+                    collect_signatures_with_indices(&signers, &clerk, &false_msg, &false_message_to_sign);
                 all_sigs.extend(false_sigs);
             }
 
@@ -372,10 +375,8 @@ mod tests {
 
         let (signers, clerk) = setup_signers_and_clerk(params, 10, &mut rng);
         let msg = [7u8; 32];
-        let sigs = collect_signatures_with_indices(&signers, &clerk, &msg);
-        let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
-        let message_to_sign = build_snark_message(&avk.get_merkle_tree_commitment().root, &msg)
-            .expect("build_snark_message should succeed");
+        let message_to_sign = compute_message_to_sign(&clerk, &msg);
+        let sigs = collect_signatures_with_indices(&signers, &clerk, &msg, &message_to_sign);
 
         let result_1 =
             SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs, &message_to_sign)
@@ -410,10 +411,8 @@ mod tests {
             let mut msg = [0u8; 32];
             msg[0] = round;
 
-            let sigs = collect_signatures_with_indices(&signers, &clerk, &msg);
-            let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
-            let message_to_sign = build_snark_message(&avk.get_merkle_tree_commitment().root, &msg)
-                .expect("build_snark_message should succeed");
+            let message_to_sign = compute_message_to_sign(&clerk, &msg);
+            let sigs = collect_signatures_with_indices(&signers, &clerk, &msg, &message_to_sign);
 
             let result =
                 SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs, &message_to_sign);

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -5,11 +5,18 @@ use sha2::{Digest, Sha256};
 
 use crate::{
     AggregationError, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
-    RegistrationEntryForSnark, Signer, SingleSignature, StmResult,
+    RegistrationEntryForSnark, Signer, SignerIndex, SingleSignature, StmResult,
     signature_scheme::BaseFieldElement,
 };
 
 use super::AggregateVerificationKeyForSnark;
+
+/// Domain Separation Tag (DST) for deriving the selection seed from the signed message.
+const DOMAIN_SEPARATION_TAG_SELECTION_SEED: &[u8] = b"MITHRIL_SNARK_SELECTION_SEED";
+/// Domain Separation Tag (DST) for the index selection hash.
+const DOMAIN_SEPARATION_TAG_SELECTION_INDEX: &[u8] = b"MITHRIL_SNARK_SELECTION_INDEX";
+/// Domain Separation Tag (DST) for the deduplication hash.
+const DOMAIN_SEPARATION_TAG_SELECTION_DEDUP: &[u8] = b"MITHRIL_SNARK_SELECTION_DEDUP";
 
 /// Clerk for managing the SNARK proof system.
 ///
@@ -82,6 +89,7 @@ impl SnarkClerk {
         message_to_sign: &[BaseFieldElement; 2],
     ) -> StmResult<BTreeMap<LotteryIndex, SingleSignature>> {
         let mut seed_hasher = Sha256::new();
+        seed_hasher.update(DOMAIN_SEPARATION_TAG_SELECTION_SEED);
         seed_hasher.update(message_to_sign[0].to_bytes());
         seed_hasher.update(message_to_sign[1].to_bytes());
         let seed: [u8; 32] = seed_hasher.finalize().into();
@@ -89,10 +97,7 @@ impl SnarkClerk {
         // Collect all valid signatures grouped by lottery index.
         let mut index_to_signatures: BTreeMap<LotteryIndex, Vec<SingleSignature>> = BTreeMap::new();
         for signature in signatures {
-            let (Some(snark_indices), Some(_)) = (
-                signature.get_snark_signature_indices(),
-                signature.snark_signature.as_ref(),
-            ) else {
+            let Some(snark_indices) = signature.get_snark_signature_indices() else {
                 continue;
             };
 
@@ -106,56 +111,79 @@ impl SnarkClerk {
             return Err(AggregationError::NotEnoughSignatures(count, parameters.k).into());
         }
 
-        // Select: sort indices by `hash_index(seed, lottery_index)` and take the k smallest.
-        let mut indices: Vec<_> = index_to_signatures.keys().copied().collect();
-        indices.sort_by(|a, b| {
-            hash_index(&seed, *a)
-                .cmp(&hash_index(&seed, *b))
-                .then_with(|| a.cmp(b))
-        });
-        indices.truncate(parameters.k as usize);
+        // Select: rank indices by their hash and keep the k smallest.
+        let mut hashed_indices: Vec<HashedKey> = index_to_signatures
+            .keys()
+            .map(|&lottery_index| HashedKey::for_lottery_index(&seed, lottery_index))
+            .collect();
+        hashed_indices.sort();
+        hashed_indices.truncate(parameters.k as usize);
 
-        // Deduplicate: for each selected index, pick the signer with the smallest
-        // `hash_dedup(seed || lottery_index || signer_index)`.
+        // Deduplicate: for each selected index, keep the signer with the smallest hash.
         let mut result = BTreeMap::new();
-        for index in indices {
-            let candidates = index_to_signatures.remove(&index).ok_or_else(|| {
+        for hashed_index in hashed_indices {
+            let lottery_index = hashed_index.index;
+            let candidates = index_to_signatures.remove(&lottery_index).ok_or_else(|| {
                 anyhow!(
-                    "Unexpected deduplication state: signature map missing lottery index {index}"
+                    "Unexpected deduplication state: signature map missing lottery index {lottery_index}"
                 )
             })?;
             let winner = candidates
                 .into_iter()
-                .min_by_key(|sig| hash_dedup(&seed, index, sig.signer_index))
+                .min_by_key(|sig| HashedKey::for_signer_index(&seed, lottery_index, sig.signer_index))
                 .ok_or_else(|| {
                     anyhow!(
-                        "Unexpected deduplication state: no candidates for lottery index {index}"
+                        "Unexpected deduplication state: no candidates for lottery index {lottery_index}"
                     )
                 })?;
-            result.insert(index, winner);
+            result.insert(lottery_index, winner);
         }
 
         Ok(result)
     }
 }
 
-/// Hash for index selection: `SHA-256(seed || lottery_index)`.
-/// Determines which k indices are selected, independent of who signed them.
-fn hash_index(seed: &[u8; 32], lottery_index: LotteryIndex) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(seed);
-    hasher.update(lottery_index.to_le_bytes());
-    hasher.finalize().into()
+/// A hash paired with a tie-breaker for deterministic ordering.
+///
+/// Used in two contexts:
+/// - **Index selection:** hash is `SHA-256(seed || lottery_index)`, tie-breaker is the lottery index.
+/// - **Deduplication:** hash is `SHA-256(seed || lottery_index || signer_index)`, tie-breaker is
+///   the signer index.
+///
+/// Ordering is by hash first, then by the tie-breaker to ensure a total ordering.
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+struct HashedKey {
+    hash: [u8; 32],
+    index: u64,
 }
 
-/// Hash for deduplication: `SHA-256(seed || lottery_index || signer_index)`.
-/// When multiple signers claim the same lottery index, the smallest hash wins.
-fn hash_dedup(seed: &[u8; 32], lottery_index: LotteryIndex, signer_index: u64) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(seed);
-    hasher.update(lottery_index.to_le_bytes());
-    hasher.update(signer_index.to_le_bytes());
-    hasher.finalize().into()
+impl HashedKey {
+    fn for_lottery_index(seed: &[u8; 32], lottery_index: LotteryIndex) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(DOMAIN_SEPARATION_TAG_SELECTION_INDEX);
+        hasher.update(seed);
+        hasher.update(lottery_index.to_le_bytes());
+        Self {
+            hash: hasher.finalize().into(),
+            index: lottery_index,
+        }
+    }
+
+    fn for_signer_index(
+        seed: &[u8; 32],
+        lottery_index: LotteryIndex,
+        signer_index: SignerIndex,
+    ) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(DOMAIN_SEPARATION_TAG_SELECTION_DEDUP);
+        hasher.update(seed);
+        hasher.update(lottery_index.to_le_bytes());
+        hasher.update(signer_index.to_le_bytes());
+        Self {
+            hash: hasher.finalize().into(),
+            index: signer_index,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -163,8 +191,10 @@ mod tests {
     use proptest::prelude::*;
     use rand_chacha::ChaCha20Rng;
     use rand_core::{RngCore, SeedableRng};
+    use sha2::{Digest, Sha256};
     use std::collections::HashSet;
 
+    use super::{DOMAIN_SEPARATION_TAG_SELECTION_SEED, HashedKey};
     use crate::{
         AggregationError, Initializer, KeyRegistration, LotteryIndex, MithrilMembershipDigest,
         Parameters, RegistrationEntry, Signer, SingleSignature,
@@ -212,8 +242,8 @@ mod tests {
         (signers, clerk)
     }
 
-    // Collect signatures, populate their SNARK winning indices, and return
-    // the derived `message_to_sign` so callers can reuse it.
+    // Collect signatures and populate their SNARK winning indices using the
+    // provided `message_to_sign`.
     fn collect_signatures_with_indices(
         signers: &[Signer<D>],
         clerk: &SnarkClerk,
@@ -412,6 +442,74 @@ mod tests {
     }
 
     #[test]
+    fn different_messages_produce_different_selections() {
+        let mut rng = ChaCha20Rng::from_seed([17u8; 32]);
+        let params = Parameters {
+            m: 200,
+            k: 5,
+            phi_f: 0.8,
+        };
+
+        let (signers, clerk) = setup_signers_and_clerk(params, 10, &mut rng);
+
+        let msg_a = [1u8; 32];
+        let msg_b = [2u8; 32];
+        let message_to_sign_a = compute_message_to_sign(&clerk, &msg_a);
+        let message_to_sign_b = compute_message_to_sign(&clerk, &msg_b);
+        let sigs_a = collect_signatures_with_indices(&signers, &clerk, &msg_a, &message_to_sign_a);
+        let sigs_b = collect_signatures_with_indices(&signers, &clerk, &msg_b, &message_to_sign_b);
+
+        let selection_a =
+            SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs_a, &message_to_sign_a)
+                .expect("should succeed");
+        let selection_b =
+            SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs_b, &message_to_sign_b)
+                .expect("should succeed");
+
+        let indices_a: Vec<LotteryIndex> = selection_a.keys().copied().collect();
+        let indices_b: Vec<LotteryIndex> = selection_b.keys().copied().collect();
+        assert_ne!(
+            indices_a, indices_b,
+            "Different messages should produce different selections"
+        );
+    }
+
+    #[test]
+    fn selection_is_independent_of_input_order() {
+        let mut rng = ChaCha20Rng::from_seed([21u8; 32]);
+        let params = Parameters {
+            m: 200,
+            k: 5,
+            phi_f: 0.8,
+        };
+
+        let (signers, clerk) = setup_signers_and_clerk(params, 10, &mut rng);
+        let msg = [9u8; 32];
+        let message_to_sign = compute_message_to_sign(&clerk, &msg);
+        let sigs = collect_signatures_with_indices(&signers, &clerk, &msg, &message_to_sign);
+
+        let mut sigs_shuffled = sigs.clone();
+        sigs_shuffled.reverse();
+
+        let selection =
+            SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs, &message_to_sign)
+                .expect("should succeed");
+        let selection_shuffled = SnarkClerk::select_valid_signatures_for_k_indices(
+            &params,
+            &sigs_shuffled,
+            &message_to_sign,
+        )
+        .expect("should succeed");
+
+        let indices: Vec<LotteryIndex> = selection.keys().copied().collect();
+        let indices_shuffled: Vec<LotteryIndex> = selection_shuffled.keys().copied().collect();
+        assert_eq!(
+            indices, indices_shuffled,
+            "Selection must be independent of input signature order"
+        );
+    }
+
+    #[test]
     fn selection_distributes_fairly_across_index_range() {
         let mut rng = ChaCha20Rng::from_seed([99u8; 32]);
         let m = 200_u64;
@@ -453,10 +551,58 @@ mod tests {
         );
         let lower_ratio = lower_half_count as f64 / total as f64;
         assert!(
-            (0.2..=0.8).contains(&lower_ratio),
+            (0.4..=0.6).contains(&lower_ratio),
             "Selection is biased: lower half got {lower_half_count}/{total} \
              ({:.1}%), expected roughly even distribution",
             lower_ratio * 100.0,
         );
+    }
+
+    #[test]
+    fn deduplication_picks_smaller_hash_winner() {
+        let mut rng = ChaCha20Rng::from_seed([33u8; 32]);
+        let params = Parameters {
+            m: 200,
+            k: 1,
+            phi_f: 0.8,
+        };
+
+        let (signers, clerk) = setup_signers_and_clerk(params, 10, &mut rng);
+        let msg = [11u8; 32];
+        let message_to_sign = compute_message_to_sign(&clerk, &msg);
+        let mut sigs = collect_signatures_with_indices(&signers, &clerk, &msg, &message_to_sign);
+        assert!(sigs.len() >= 2, "need at least two valid signatures");
+
+        // Force the first two signatures to both claim the same lottery index.
+        let contested_index: LotteryIndex = 7;
+        sigs[0].set_snark_signature_indices(&[contested_index]);
+        sigs[1].set_snark_signature_indices(&[contested_index]);
+        let contested_sigs = vec![sigs[0].clone(), sigs[1].clone()];
+
+        // Recompute the seed the same way production does.
+        let mut seed_hasher = Sha256::new();
+        seed_hasher.update(DOMAIN_SEPARATION_TAG_SELECTION_SEED);
+        seed_hasher.update(message_to_sign[0].to_bytes());
+        seed_hasher.update(message_to_sign[1].to_bytes());
+        let seed: [u8; 32] = seed_hasher.finalize().into();
+
+        let expected_winner_signer_index = contested_sigs
+            .iter()
+            .min_by_key(|sig| HashedKey::for_signer_index(&seed, contested_index, sig.signer_index))
+            .expect("at least one candidate")
+            .signer_index;
+
+        let result = SnarkClerk::select_valid_signatures_for_k_indices(
+            &params,
+            &contested_sigs,
+            &message_to_sign,
+        )
+        .expect("selection should succeed");
+
+        assert_eq!(result.len(), 1);
+        let winner = result
+            .get(&contested_index)
+            .expect("contested index should be selected");
+        assert_eq!(winner.signer_index, expected_winner_signer_index);
     }
 }

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -1,5 +1,6 @@
-use std::collections::{BTreeMap, btree_map::Entry};
+use std::collections::BTreeMap;
 
+use anyhow::anyhow;
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -61,21 +62,20 @@ impl SnarkClerk {
         Ok(closed_registration_entry.into())
     }
 
-    /// Deduplicate signatures by lottery index and select exactly `k` winners.
+    /// Select exactly `k` winning lottery indices and resolve contested indices.
     ///
-    /// Each candidate is assigned a priority hash `SHA-256(seed || index || commitment_point)`
-    /// where the seed is derived from the signed message. Only the commitment point (the
-    /// deterministic component of the signature, fixed per signer+message) is included in
-    /// the hash, so grinding via nonce variation has no effect. This single hash drives both
-    /// deduplication and selection: when multiple signatures claim the same lottery index the
-    /// one with the smallest hash wins, and the `k` candidates with the smallest hashes
-    /// overall are selected. This ensures uniform selection across the full index range,
-    /// avoiding bias toward any region of `[0, m)`. The seed depends only on public inputs,
-    /// so the selection is publicly verifiable. The returned `BTreeMap` preserves strictly
-    /// increasing lottery index order.
+    /// Uses separate hashes derived from public inputs only:
+    /// 1. **Index selection:** `SHA-256(seed || lottery_index)` assigns a priority to each
+    ///    lottery index independent of who signed it. The `k` indices with the smallest
+    ///    hashes are selected.
+    /// 2. **Deduplication:** for each selected index claimed by multiple signers,
+    ///    `SHA-256(seed || lottery_index || signer_index)` picks the winner.
     ///
-    /// Returns `AggregationError::NotEnoughSignatures` if fewer than `k` unique winning indices
-    /// can be collected.
+    /// The selection is fully deterministic from public inputs, publicly verifiable, and immune to
+    /// grinding. The returned `BTreeMap` preserves strictly increasing lottery index order.
+    ///
+    /// Returns `AggregationError::NotEnoughSignatures` if fewer than `k` unique winning
+    /// indices can be collected.
     pub(crate) fn select_valid_signatures_for_k_indices(
         parameters: &Parameters,
         signatures: &[SingleSignature],
@@ -86,57 +86,75 @@ impl SnarkClerk {
         seed_hasher.update(message_to_sign[1].to_bytes());
         let seed: [u8; 32] = seed_hasher.finalize().into();
 
-        let mut candidates: BTreeMap<LotteryIndex, ([u8; 32], SingleSignature)> = BTreeMap::new();
-
+        // Collect all valid signatures grouped by lottery index.
+        let mut index_to_signatures: BTreeMap<LotteryIndex, Vec<SingleSignature>> = BTreeMap::new();
         for signature in signatures {
-            let (Some(snark_indices), Some(snark_signature)) = (
+            let (Some(snark_indices), Some(_)) = (
                 signature.get_snark_signature_indices(),
                 signature.snark_signature.as_ref(),
             ) else {
                 continue;
             };
 
-            let commitment_bytes =
-                snark_signature.get_schnorr_signature().commitment_point.to_bytes();
             for index in snark_indices {
-                let hash = hash_candidate(&seed, index, &commitment_bytes);
-                match candidates.entry(index) {
-                    Entry::Occupied(mut existing) => {
-                        if existing.get().0 > hash {
-                            existing.insert((hash, signature.clone()));
-                        }
-                    }
-                    Entry::Vacant(vacant) => {
-                        vacant.insert((hash, signature.clone()));
-                    }
-                }
+                index_to_signatures.entry(index).or_default().push(signature.clone());
             }
         }
 
-        let count = candidates.len() as u64;
+        let count = index_to_signatures.len() as u64;
         if count < parameters.k {
             return Err(AggregationError::NotEnoughSignatures(count, parameters.k).into());
         }
 
-        let mut entries: Vec<_> = candidates.into_iter().collect();
-        entries.sort_by(|(index_a, (hash_a, _)), (index_b, (hash_b, _))| {
-            hash_a.cmp(hash_b).then_with(|| index_a.cmp(index_b))
+        // Select: sort indices by `hash_index(seed, lottery_index)` and take the k smallest.
+        let mut indices: Vec<_> = index_to_signatures.keys().copied().collect();
+        indices.sort_by(|a, b| {
+            hash_index(&seed, *a)
+                .cmp(&hash_index(&seed, *b))
+                .then_with(|| a.cmp(b))
         });
-        entries.truncate(parameters.k as usize);
+        indices.truncate(parameters.k as usize);
 
-        Ok(entries.into_iter().map(|(index, (_, sig))| (index, sig)).collect())
+        // Deduplicate: for each selected index, pick the signer with the smallest
+        // `hash_dedup(seed || lottery_index || signer_index)`.
+        let mut result = BTreeMap::new();
+        for index in indices {
+            let candidates = index_to_signatures.remove(&index).ok_or_else(|| {
+                anyhow!(
+                    "Unexpected deduplication state: signature map missing lottery index {index}"
+                )
+            })?;
+            let winner = candidates
+                .into_iter()
+                .min_by_key(|sig| hash_dedup(&seed, index, sig.signer_index))
+                .ok_or_else(|| {
+                    anyhow!(
+                        "Unexpected deduplication state: no candidates for lottery index {index}"
+                    )
+                })?;
+            result.insert(index, winner);
+        }
+
+        Ok(result)
     }
 }
 
-/// Hash a candidate (lottery index + commitment point) with a seed for deterministic
-/// deduplication tie-breaking and selection priority. Only the commitment point is
-/// used because it is the sole deterministic component of the signature (fixed per
-/// signer+message), making the hash immune to grinding via nonce variation.
-fn hash_candidate(seed: &[u8; 32], index: LotteryIndex, commitment_point_bytes: &[u8]) -> [u8; 32] {
+/// Hash for index selection: `SHA-256(seed || lottery_index)`.
+/// Determines which k indices are selected, independent of who signed them.
+fn hash_index(seed: &[u8; 32], lottery_index: LotteryIndex) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(seed);
-    hasher.update(index.to_le_bytes());
-    hasher.update(commitment_point_bytes);
+    hasher.update(lottery_index.to_le_bytes());
+    hasher.finalize().into()
+}
+
+/// Hash for deduplication: `SHA-256(seed || lottery_index || signer_index)`.
+/// When multiple signers claim the same lottery index, the smallest hash wins.
+fn hash_dedup(seed: &[u8; 32], lottery_index: LotteryIndex, signer_index: u64) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(seed);
+    hasher.update(lottery_index.to_le_bytes());
+    hasher.update(signer_index.to_le_bytes());
     hasher.finalize().into()
 }
 

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -1,8 +1,12 @@
+use rand_chacha::ChaCha20Rng;
+use rand_core::{RngCore, SeedableRng};
+use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, btree_map::Entry};
 
 use crate::{
     AggregationError, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
     RegistrationEntryForSnark, Signer, SingleSignature, StmResult,
+    signature_scheme::BaseFieldElement,
 };
 
 use super::AggregateVerificationKeyForSnark;
@@ -69,6 +73,7 @@ impl SnarkClerk {
     pub(crate) fn select_valid_signatures_for_k_indices(
         parameters: &Parameters,
         signatures: &[SingleSignature],
+        message: &[BaseFieldElement; 2],
     ) -> StmResult<BTreeMap<LotteryIndex, SingleSignature>> {
         let mut unique_index_signature_map: BTreeMap<LotteryIndex, SingleSignature> =
             BTreeMap::new();
@@ -102,11 +107,23 @@ impl SnarkClerk {
             return Err(AggregationError::NotEnoughSignatures(count, parameters.k).into());
         }
 
-        while unique_index_signature_map.len() as u64 > parameters.k {
-            unique_index_signature_map.pop_last();
-        }
+        let mut hasher = Sha256::new();
+        hasher.update(message[0].to_bytes());
+        hasher.update(message[1].to_bytes());
+        let seed: [u8; 32] = hasher.finalize().into();
 
-        Ok(unique_index_signature_map)
+        let mut rng = ChaCha20Rng::from_seed(seed);
+        let k = parameters.k as usize;
+        let mut entries: Vec<(LotteryIndex, SingleSignature)> =
+            unique_index_signature_map.into_iter().collect();
+        // Partial Fisher-Yates: randomly select k entries
+        for i in 0..k {
+            let j = i + (rng.next_u64() as usize % (entries.len() - i));
+            entries.swap(i, j);
+        }
+        entries.truncate(k);
+
+        Ok(entries.into_iter().collect())
     }
 }
 
@@ -118,8 +135,8 @@ mod tests {
     use std::collections::HashSet;
 
     use crate::{
-        AggregationError, Initializer, KeyRegistration, MithrilMembershipDigest, Parameters,
-        RegistrationEntry, Signer, SingleSignature,
+        AggregationError, Initializer, KeyRegistration, LotteryIndex, MithrilMembershipDigest,
+        Parameters, RegistrationEntry, Signer, SingleSignature,
         proof_system::{
             SnarkClerk,
             halo2_snark::{
@@ -254,6 +271,10 @@ mod tests {
 
             let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
 
+            let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
+            let message_to_sign = build_snark_message(&avk.get_merkle_tree_commitment().root, &msg)
+                .expect("build_snark_message should succeed");
+
             // Collect valid signatures with SNARK indices
             let mut all_sigs = collect_signatures_with_indices(&signers, &clerk, &msg);
 
@@ -270,7 +291,7 @@ mod tests {
             }
 
             let dedup_result =
-                SnarkClerk::select_valid_signatures_for_k_indices(&params, &all_sigs);
+                SnarkClerk::select_valid_signatures_for_k_indices(&params, &all_sigs, &message_to_sign);
 
             match dedup_result {
                 Ok(unique_index_map) => {
@@ -324,6 +345,86 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    #[test]
+    fn selection_is_deterministic() {
+        let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+        let params = Parameters {
+            m: 200,
+            k: 5,
+            phi_f: 0.8,
+        };
+
+        let (signers, clerk) = setup_signers_and_clerk(params, 10, &mut rng);
+        let msg = [7u8; 32];
+        let sigs = collect_signatures_with_indices(&signers, &clerk, &msg);
+        let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
+        let message_to_sign = build_snark_message(&avk.get_merkle_tree_commitment().root, &msg)
+            .expect("build_snark_message should succeed");
+
+        let result_1 =
+            SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs, &message_to_sign)
+                .expect("should succeed");
+        let result_2 =
+            SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs, &message_to_sign)
+                .expect("should succeed");
+
+        let indices_1: Vec<LotteryIndex> = result_1.keys().copied().collect();
+        let indices_2: Vec<LotteryIndex> = result_2.keys().copied().collect();
+        assert_eq!(
+            indices_1, indices_2,
+            "Same inputs must produce the same selection"
+        );
+    }
+
+    #[test]
+    fn selection_distributes_fairly_across_index_range() {
+        let mut rng = ChaCha20Rng::from_seed([99u8; 32]);
+        let m = 200_u64;
+        let k = 5_u64;
+        let params = Parameters { m, k, phi_f: 0.8 };
+
+        let (signers, clerk) = setup_signers_and_clerk(params, 10, &mut rng);
+
+        let midpoint = m / 2;
+        let mut lower_half_count: u64 = 0;
+        let mut upper_half_count: u64 = 0;
+        let num_rounds = 100;
+
+        for round in 0..num_rounds {
+            let mut msg = [0u8; 32];
+            msg[0] = round;
+
+            let sigs = collect_signatures_with_indices(&signers, &clerk, &msg);
+            let avk = clerk.compute_aggregate_verification_key_for_snark::<D>();
+            let message_to_sign = build_snark_message(&avk.get_merkle_tree_commitment().root, &msg)
+                .expect("build_snark_message should succeed");
+
+            let result =
+                SnarkClerk::select_valid_signatures_for_k_indices(&params, &sigs, &message_to_sign);
+
+            if let Ok(selected) = result {
+                for &index in selected.keys() {
+                    if index < midpoint {
+                        lower_half_count += 1;
+                    } else {
+                        upper_half_count += 1;
+                    }
+                }
+            }
+        }
+
+        let total = lower_half_count + upper_half_count;
+        if total > 0 {
+            let lower_ratio = lower_half_count as f64 / total as f64;
+            assert!(
+                (0.2..=0.8).contains(&lower_ratio),
+                "Selection is biased: lower half got {lower_half_count}/{total} \
+                 ({:.1}%), expected roughly even distribution",
+                lower_ratio * 100.0,
+            );
         }
     }
 }

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -80,11 +80,15 @@ impl SnarkClerk {
         signatures: &[SingleSignature],
         message_to_sign: &[BaseFieldElement; 2],
     ) -> StmResult<BTreeMap<LotteryIndex, SingleSignature>> {
+        let mut sig_bytes_list: Vec<_> = signatures
+            .iter()
+            .filter_map(|s| s.snark_signature.as_ref())
+            .map(|snark_sig| snark_sig.get_schnorr_signature().to_bytes())
+            .collect();
+        sig_bytes_list.sort();
         let mut sig_set_hasher = Sha256::new();
-        for signature in signatures {
-            if let Some(snark_sig) = signature.snark_signature.as_ref() {
-                sig_set_hasher.update(snark_sig.get_schnorr_signature().to_bytes());
-            }
+        for sig_bytes in &sig_bytes_list {
+            sig_set_hasher.update(sig_bytes);
         }
         let sig_set_commitment: [u8; 32] = sig_set_hasher.finalize().into();
 
@@ -126,7 +130,9 @@ impl SnarkClerk {
         }
 
         let mut entries: Vec<_> = candidates.into_iter().collect();
-        entries.sort_by(|(_, (hash_a, _)), (_, (hash_b, _))| hash_a.cmp(hash_b));
+        entries.sort_by(|(index_a, (hash_a, _)), (index_b, (hash_b, _))| {
+            hash_a.cmp(hash_b).then_with(|| index_a.cmp(index_b))
+        });
         entries.truncate(parameters.k as usize);
 
         Ok(entries.into_iter().map(|(index, (_, sig))| (index, sig)).collect())
@@ -433,14 +439,16 @@ mod tests {
         }
 
         let total = lower_half_count + upper_half_count;
-        if total > 0 {
-            let lower_ratio = lower_half_count as f64 / total as f64;
-            assert!(
-                (0.2..=0.8).contains(&lower_ratio),
-                "Selection is biased: lower half got {lower_half_count}/{total} \
-                 ({:.1}%), expected roughly even distribution",
-                lower_ratio * 100.0,
-            );
-        }
+        assert!(
+            total > 0,
+            "Expected at least one successful signature selection across {num_rounds} rounds",
+        );
+        let lower_ratio = lower_half_count as f64 / total as f64;
+        assert!(
+            (0.2..=0.8).contains(&lower_ratio),
+            "Selection is biased: lower half got {lower_half_count}/{total} \
+             ({:.1}%), expected roughly even distribution",
+            lower_ratio * 100.0,
+        );
     }
 }

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -63,15 +63,16 @@ impl SnarkClerk {
 
     /// Deduplicate signatures by lottery index and select exactly `k` winners.
     ///
-    /// Each candidate is assigned a priority hash `SHA-256(seed || index || signature)` where
-    /// the seed is derived from the signed message and a commitment to the collected signature
-    /// set. This single hash drives both deduplication and selection: when multiple signatures
-    /// claim the same lottery index the one with the smallest hash wins, and the `k` candidates
-    /// with the smallest hashes overall are selected. This ensures uniform selection across the
-    /// full index range, avoiding bias toward any region of `[0, m)`. Including the signature
-    /// set in the seed prevents grinding, since a signer cannot predict the final seed without
-    /// knowing every other signature that will be collected. The returned `BTreeMap` preserves
-    /// strictly increasing lottery index order.
+    /// Each candidate is assigned a priority hash `SHA-256(seed || index || commitment_point)`
+    /// where the seed is derived from the signed message. Only the commitment point (the
+    /// deterministic component of the signature, fixed per signer+message) is included in
+    /// the hash, so grinding via nonce variation has no effect. This single hash drives both
+    /// deduplication and selection: when multiple signatures claim the same lottery index the
+    /// one with the smallest hash wins, and the `k` candidates with the smallest hashes
+    /// overall are selected. This ensures uniform selection across the full index range,
+    /// avoiding bias toward any region of `[0, m)`. The seed depends only on public inputs,
+    /// so the selection is publicly verifiable. The returned `BTreeMap` preserves strictly
+    /// increasing lottery index order.
     ///
     /// Returns `AggregationError::NotEnoughSignatures` if fewer than `k` unique winning indices
     /// can be collected.
@@ -80,22 +81,9 @@ impl SnarkClerk {
         signatures: &[SingleSignature],
         message_to_sign: &[BaseFieldElement; 2],
     ) -> StmResult<BTreeMap<LotteryIndex, SingleSignature>> {
-        let mut sig_bytes_list: Vec<_> = signatures
-            .iter()
-            .filter_map(|s| s.snark_signature.as_ref())
-            .map(|snark_sig| snark_sig.get_schnorr_signature().to_bytes())
-            .collect();
-        sig_bytes_list.sort();
-        let mut sig_set_hasher = Sha256::new();
-        for sig_bytes in &sig_bytes_list {
-            sig_set_hasher.update(sig_bytes);
-        }
-        let sig_set_commitment: [u8; 32] = sig_set_hasher.finalize().into();
-
         let mut seed_hasher = Sha256::new();
         seed_hasher.update(message_to_sign[0].to_bytes());
         seed_hasher.update(message_to_sign[1].to_bytes());
-        seed_hasher.update(sig_set_commitment);
         let seed: [u8; 32] = seed_hasher.finalize().into();
 
         let mut candidates: BTreeMap<LotteryIndex, ([u8; 32], SingleSignature)> = BTreeMap::new();
@@ -108,9 +96,10 @@ impl SnarkClerk {
                 continue;
             };
 
-            let sig_bytes = snark_signature.get_schnorr_signature().to_bytes();
+            let commitment_bytes =
+                snark_signature.get_schnorr_signature().commitment_point.to_bytes();
             for index in snark_indices {
-                let hash = hash_candidate(&seed, index, &sig_bytes);
+                let hash = hash_candidate(&seed, index, &commitment_bytes);
                 match candidates.entry(index) {
                     Entry::Occupied(mut existing) => {
                         if existing.get().0 > hash {
@@ -139,13 +128,15 @@ impl SnarkClerk {
     }
 }
 
-/// Hash a candidate (lottery index + signature) with a seed for deterministic
-/// deduplication tie-breaking and selection priority.
-fn hash_candidate(seed: &[u8; 32], index: LotteryIndex, signature_bytes: &[u8]) -> [u8; 32] {
+/// Hash a candidate (lottery index + commitment point) with a seed for deterministic
+/// deduplication tie-breaking and selection priority. Only the commitment point is
+/// used because it is the sole deterministic component of the signature (fixed per
+/// signer+message), making the hash immune to grinding via nonce variation.
+fn hash_candidate(seed: &[u8; 32], index: LotteryIndex, commitment_point_bytes: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(seed);
     hasher.update(index.to_le_bytes());
-    hasher.update(signature_bytes);
+    hasher.update(commitment_point_bytes);
     hasher.finalize().into()
 }
 

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -65,8 +65,10 @@ impl SnarkClerk {
     /// Deduplicate signatures by lottery index and select exactly `k` winners.
     ///
     /// When multiple signatures claim the same lottery index, the one with the smallest Schnorr
-    /// signature (by `Ord` on `UniqueSchnorrSignature`) is kept. After all signatures have been
-    /// processed, the map is trimmed to the `k` smallest lottery indices.
+    /// signature (by `Ord` on `UniqueSchnorrSignature`) is kept. After deduplication, `k` indices
+    /// are selected via a deterministic pseudo-random shuffle seeded by the signed message. This
+    /// ensures uniform selection across the full index range, avoiding bias toward any region of
+    /// `[0, m)`. The returned `BTreeMap` preserves strictly increasing lottery index order.
     ///
     /// Returns `AggregationError::NotEnoughSignatures` if fewer than `k` unique winning indices
     /// can be collected.

--- a/mithril-stm/src/proof_system/halo2_snark/clerk.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/clerk.rs
@@ -1,7 +1,5 @@
 use std::collections::{BTreeMap, btree_map::Entry};
 
-use rand_chacha::ChaCha20Rng;
-use rand_core::{RngCore, SeedableRng};
 use sha2::{Digest, Sha256};
 
 use crate::{
@@ -65,11 +63,15 @@ impl SnarkClerk {
 
     /// Deduplicate signatures by lottery index and select exactly `k` winners.
     ///
-    /// When multiple signatures claim the same lottery index, the one with the smallest Schnorr
-    /// signature (by `Ord` on `UniqueSchnorrSignature`) is kept. After deduplication, `k` indices
-    /// are selected via a deterministic pseudo-random shuffle seeded by the signed message. This
-    /// ensures uniform selection across the full index range, avoiding bias toward any region of
-    /// `[0, m)`. The returned `BTreeMap` preserves strictly increasing lottery index order.
+    /// Each candidate is assigned a priority hash `SHA-256(seed || index || signature)` where
+    /// the seed is derived from the signed message and a commitment to the collected signature
+    /// set. This single hash drives both deduplication and selection: when multiple signatures
+    /// claim the same lottery index the one with the smallest hash wins, and the `k` candidates
+    /// with the smallest hashes overall are selected. This ensures uniform selection across the
+    /// full index range, avoiding bias toward any region of `[0, m)`. Including the signature
+    /// set in the seed prevents grinding, since a signer cannot predict the final seed without
+    /// knowing every other signature that will be collected. The returned `BTreeMap` preserves
+    /// strictly increasing lottery index order.
     ///
     /// Returns `AggregationError::NotEnoughSignatures` if fewer than `k` unique winning indices
     /// can be collected.
@@ -78,8 +80,21 @@ impl SnarkClerk {
         signatures: &[SingleSignature],
         message_to_sign: &[BaseFieldElement; 2],
     ) -> StmResult<BTreeMap<LotteryIndex, SingleSignature>> {
-        let mut unique_index_signature_map: BTreeMap<LotteryIndex, SingleSignature> =
-            BTreeMap::new();
+        let mut sig_set_hasher = Sha256::new();
+        for signature in signatures {
+            if let Some(snark_sig) = signature.snark_signature.as_ref() {
+                sig_set_hasher.update(snark_sig.get_schnorr_signature().to_bytes());
+            }
+        }
+        let sig_set_commitment: [u8; 32] = sig_set_hasher.finalize().into();
+
+        let mut seed_hasher = Sha256::new();
+        seed_hasher.update(message_to_sign[0].to_bytes());
+        seed_hasher.update(message_to_sign[1].to_bytes());
+        seed_hasher.update(sig_set_commitment);
+        let seed: [u8; 32] = seed_hasher.finalize().into();
+
+        let mut candidates: BTreeMap<LotteryIndex, ([u8; 32], SingleSignature)> = BTreeMap::new();
 
         for signature in signatures {
             let (Some(snark_indices), Some(snark_signature)) = (
@@ -89,67 +104,43 @@ impl SnarkClerk {
                 continue;
             };
 
+            let sig_bytes = snark_signature.get_schnorr_signature().to_bytes();
             for index in snark_indices {
-                match unique_index_signature_map.entry(index) {
+                let hash = hash_candidate(&seed, index, &sig_bytes);
+                match candidates.entry(index) {
                     Entry::Occupied(mut existing) => {
-                        if existing.get().snark_signature.as_ref().is_some_and(|s| {
-                            s.get_schnorr_signature() > snark_signature.get_schnorr_signature()
-                        }) {
-                            existing.insert(signature.clone());
+                        if existing.get().0 > hash {
+                            existing.insert((hash, signature.clone()));
                         }
                     }
                     Entry::Vacant(vacant) => {
-                        vacant.insert(signature.clone());
+                        vacant.insert((hash, signature.clone()));
                     }
                 }
             }
         }
 
-        let count = unique_index_signature_map.len() as u64;
+        let count = candidates.len() as u64;
         if count < parameters.k {
             return Err(AggregationError::NotEnoughSignatures(count, parameters.k).into());
         }
 
-        let mut hasher = Sha256::new();
-        hasher.update(message_to_sign[0].to_bytes());
-        hasher.update(message_to_sign[1].to_bytes());
-        let seed: [u8; 32] = hasher.finalize().into();
+        let mut entries: Vec<_> = candidates.into_iter().collect();
+        entries.sort_by(|(_, (hash_a, _)), (_, (hash_b, _))| hash_a.cmp(hash_b));
+        entries.truncate(parameters.k as usize);
 
-        let mut rng = ChaCha20Rng::from_seed(seed);
-        let k = parameters.k as usize;
-        let mut entries: Vec<(LotteryIndex, SingleSignature)> =
-            unique_index_signature_map.into_iter().collect();
-        // Randomly select k entries using Lemire's
-        // nearly divisionless method for unbiased index generation.
-        for i in 0..k {
-            let range = (entries.len() - i) as u64;
-            let j = i + unbiased_random_below(&mut rng, range) as usize;
-            entries.swap(i, j);
-        }
-        entries.truncate(k);
-
-        Ok(entries.into_iter().collect())
+        Ok(entries.into_iter().map(|(index, (_, sig))| (index, sig)).collect())
     }
 }
 
-/// Generate a uniformly random `u64` in `[0, range)` without modulo bias.
-///
-/// Uses Lemire's "nearly divisionless" rejection sampling: draw a 128-bit
-/// product `rng.next_u64() * range`, reject only when the low 64 bits fall
-/// below `(-range) % range` (the remainder that causes bias). For typical
-/// ranges this rejects with probability < `range / 2^64`, so almost never.
-fn unbiased_random_below(rng: &mut ChaCha20Rng, range: u64) -> u64 {
-    debug_assert!(range > 0);
-    let mut product = (rng.next_u64() as u128) * (range as u128);
-    let mut low = product as u64;
-    if low < range {
-        let threshold = range.wrapping_neg() % range;
-        while low < threshold {
-            product = (rng.next_u64() as u128) * (range as u128);
-            low = product as u64;
-        }
-    }
-    (product >> 64) as u64
+/// Hash a candidate (lottery index + signature) with a seed for deterministic
+/// deduplication tie-breaking and selection priority.
+fn hash_candidate(seed: &[u8; 32], index: LotteryIndex, signature_bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(seed);
+    hasher.update(index.to_le_bytes());
+    hasher.update(signature_bytes);
+    hasher.finalize().into()
 }
 
 #[cfg(test)]

--- a/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
@@ -60,6 +60,7 @@ impl SnarkProverInput {
         let unique_index_signature_map = SnarkClerk::select_valid_signatures_for_k_indices(
             &clerk.parameters,
             &valid_signatures_with_indices,
+            &message_to_sign,
         )?;
 
         let witness = Self::create_witness::<D>(unique_index_signature_map, clerk)?;


### PR DESCRIPTION
## Content

This PR enhances `select_valid_signatures_for_k_indices` to provide a fairer and grinding-resistant selection strategy.

Selection and deduplication use separate hashes derived from public inputs only:
- **Index selection:** `SHA-256(seed || lottery_index)` assigns a priority to each lottery index independent of who signed it. The `k` indices with the smallest hashes are selected.
- **Deduplication:** for each selected index claimed by multiple signers, `SHA-256(seed || lottery_index || signer_index)` picks the winner.

The selection is fully deterministic from public inputs, publicly verifiable, and immune to grinding. The seed is derived from the message fields only.


## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3178 
