### PR TITLE
feat(stm): fixing merkle depth for all circuits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.5"
+version = "0.10.6"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.6 (04-23-2026)
+
+### Added
+
+- Updated the creation of merkle path during witness generation to use a constant length for the path by completing it with `0` padding.
+- Updated the non-recursive circuit to ignore `0` values during the check of the merkle path to exclude the padding from the computation of the root.
+
 ## 0.10.5 (04-23-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.5"
+version = "0.10.6"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2/circuit.rs
+++ b/mithril-stm/src/circuits/halo2/circuit.rs
@@ -241,6 +241,7 @@ impl Relation for StmCircuit {
                     merkle_tree_commitment: &merkle_tree_commitment,
                     merkle_siblings: &assigned_witness_entry.merkle_path.siblings,
                     merkle_positions: &assigned_witness_entry.merkle_path.positions,
+                    merkle_tree_depth: self.merkle_tree_depth,
                 },
             )?;
 

--- a/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
+++ b/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
@@ -7,7 +7,7 @@ use midnight_proofs::circuit::Layouter;
 use midnight_proofs::plonk::Error;
 use midnight_zk_stdlib::ZkStdLib;
 
-use crate::circuits::halo2::errors::to_synthesis_error;
+use crate::circuits::halo2::errors::{StmCircuitError, to_synthesis_error};
 use crate::circuits::halo2::types::{CircuitBase, CircuitCurve};
 
 /// Assigned inputs required to verify one Merkle authentication path inside the circuit.
@@ -22,6 +22,8 @@ pub(crate) struct MerklePathInputs<'a> {
     pub(crate) merkle_siblings: &'a [AssignedNative<CircuitBase>],
     /// Assigned sibling positions for each Merkle path level.
     pub(crate) merkle_positions: &'a [AssignedBit<CircuitBase>],
+    /// Assigned sibling positions for each Merkle path level.
+    pub(crate) merkle_tree_depth: u32,
 }
 
 /// Verifies that the assigned Merkle path opens the witness leaf to the public commitment.
@@ -46,12 +48,18 @@ pub(crate) fn verify_merkle_path(
     let first_sibling = inputs
         .merkle_siblings
         .first()
-        .ok_or(anyhow!("Missing siblings"))
+        .ok_or(anyhow!(StmCircuitError::MerkleSiblingLengthMismatch {
+            expected_depth: inputs.merkle_tree_depth,
+            actual: 0,
+        }))
         .map_err(to_synthesis_error)?;
     let first_position = inputs
         .merkle_positions
         .first()
-        .ok_or(anyhow!("Missing position!"))
+        .ok_or(anyhow!(StmCircuitError::MerklePositionLengthMismatch {
+            expected_depth: inputs.merkle_tree_depth,
+            actual: 0,
+        }))
         .map_err(to_synthesis_error)?;
     let first_left = std_lib.select(layouter, first_position, &leaf, first_sibling)?;
     let first_right = std_lib.select(layouter, first_position, first_sibling, &leaf)?;
@@ -152,6 +160,7 @@ mod tests {
                     merkle_tree_commitment: &merkle_tree_commitment,
                     merkle_siblings: &merkle_siblings,
                     merkle_positions: &merkle_positions,
+                    merkle_tree_depth: TEST_MERKLE_TREE_DEPTH as u32,
                 },
             )
         }

--- a/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
+++ b/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
@@ -1,5 +1,5 @@
 use midnight_circuits::instructions::{
-    AssertionInstructions, ControlFlowInstructions, EccInstructions,
+    AssertionInstructions, ControlFlowInstructions, EccInstructions, ZeroInstructions,
 };
 use midnight_circuits::types::{AssignedBit, AssignedNative, AssignedNativePoint};
 use midnight_proofs::circuit::Layouter;
@@ -38,14 +38,27 @@ pub(crate) fn verify_merkle_path(
             inputs.lottery_target_value.clone(),
         ],
     )?;
+    // Compute the first node after the leaves outside the loop
+    // to not ignore a potential padding zero leaf
+    // other zero leaf are ignored
+    let first_sibling = inputs.merkle_siblings.first().ok_or(Error::InvalidInstances)?;
+    let first_position = inputs.merkle_positions.first().ok_or(Error::InvalidInstances)?;
+    let first_left = std_lib.select(layouter, first_position, &leaf, first_sibling)?;
+    let first_right = std_lib.select(layouter, first_position, first_sibling, &leaf)?;
+    let first_node = std_lib.poseidon(layouter, &[first_left, first_right])?;
+
     let root = inputs
         .merkle_siblings
         .iter()
-        .zip(inputs.merkle_positions.iter())
-        .try_fold(leaf, |acc, (x, pos)| {
+        .skip(1)
+        .zip(inputs.merkle_positions.iter().skip(1))
+        .try_fold(first_node, |acc, (x, pos)| {
             let left = std_lib.select(layouter, pos, &acc, x)?;
             let right = std_lib.select(layouter, pos, x, &acc)?;
-            std_lib.poseidon(layouter, &[left, right])
+            let current_node = std_lib.poseidon(layouter, &[left, right])?;
+
+            let is_zero = std_lib.is_zero(layouter, x)?;
+            std_lib.select(layouter, &is_zero, &acc, &current_node)
         })?;
 
     std_lib.assert_equal(layouter, &root, inputs.merkle_tree_commitment)

--- a/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
+++ b/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
@@ -22,7 +22,7 @@ pub(crate) struct MerklePathInputs<'a> {
     pub(crate) merkle_siblings: &'a [AssignedNative<CircuitBase>],
     /// Assigned sibling positions for each Merkle path level.
     pub(crate) merkle_positions: &'a [AssignedBit<CircuitBase>],
-    /// Assigned sibling positions for each Merkle path level.
+    /// Expected Merkle tree depth, used for error reporting on empty paths.    
     pub(crate) merkle_tree_depth: u32,
 }
 
@@ -42,9 +42,41 @@ pub(crate) fn verify_merkle_path(
             inputs.lottery_target_value.clone(),
         ],
     )?;
-    // Compute the first node after the leaves outside the loop
-    // to not ignore a potential padding zero leaf
-    // other zero leaf are ignored
+
+    // Compute the root of the merkle tree by ignoring the padding of 0 values
+    // present in the merkle path.
+    //
+    // Example: A merkle tree of depth 2 with merkle path padded to depth 3
+    //
+    // Regular merkle tree of depth 2, the letter represent the hash of the leaves
+    //
+    //          root = H(H(A,B), H(C,H(0)))
+    //         /    \
+    //      H(A,B)   H(C,H(0))
+    //      /   \   /
+    //     A     B C
+    //
+    // In this context, the regular merkle path of C is: [H(0), H(A,B)]
+    //
+    // Padded merkle tree representation to a depth 3
+    //
+    //             fake root (never computed)
+    //             /       \
+    //            /         \
+    //          root         0
+    //         /    \
+    //      H(A,B)   H(C,H(0))
+    //      /   \   /
+    //     A     B C
+    //
+    // In this context, the merkle path of C is: [H(0), H(A,B), 0]. This process can be
+    // extended to any arbitrary depth.
+    //
+    //  During the computation of the root, the values 0 are ignored in the accumulator
+    // so the final result is the root of the original merkle tree.
+    //
+    // The first sibling can never be padding so there is not need to check for a 0 value.
+    // This saves a few constraints per loop.
     let first_sibling = inputs
         .merkle_siblings
         .first()

--- a/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
+++ b/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
@@ -1,3 +1,4 @@
+use anyhow::anyhow;
 use midnight_circuits::instructions::{
     AssertionInstructions, ControlFlowInstructions, EccInstructions, ZeroInstructions,
 };
@@ -6,6 +7,7 @@ use midnight_proofs::circuit::Layouter;
 use midnight_proofs::plonk::Error;
 use midnight_zk_stdlib::ZkStdLib;
 
+use crate::circuits::halo2::errors::to_synthesis_error;
 use crate::circuits::halo2::types::{CircuitBase, CircuitCurve};
 
 /// Assigned inputs required to verify one Merkle authentication path inside the circuit.
@@ -41,8 +43,16 @@ pub(crate) fn verify_merkle_path(
     // Compute the first node after the leaves outside the loop
     // to not ignore a potential padding zero leaf
     // other zero leaf are ignored
-    let first_sibling = inputs.merkle_siblings.first().ok_or(Error::InvalidInstances)?;
-    let first_position = inputs.merkle_positions.first().ok_or(Error::InvalidInstances)?;
+    let first_sibling = inputs
+        .merkle_siblings
+        .first()
+        .ok_or(anyhow!("Missing siblings"))
+        .map_err(to_synthesis_error)?;
+    let first_position = inputs
+        .merkle_positions
+        .first()
+        .ok_or(anyhow!("Missing position!"))
+        .map_err(to_synthesis_error)?;
     let first_left = std_lib.select(layouter, first_position, &leaf, first_sibling)?;
     let first_right = std_lib.select(layouter, first_position, first_sibling, &leaf)?;
     let first_node = std_lib.poseidon(layouter, &[first_left, first_right])?;

--- a/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
+++ b/mithril-stm/src/circuits/halo2/gadgets/merkle_path.rs
@@ -120,11 +120,12 @@ mod tests {
     use midnight_proofs::plonk::Error;
 
     use crate::circuits::halo2::tests::test_helpers::{
-        TEST_MERKLE_TREE_DEPTH, assert_relation_rejected, impl_focused_test_relation,
-        jubjub_poseidon_used_chips, prove_and_verify_relation, sample_valid_circuit_witness_entry,
+        TEST_MERKLE_TREE_DEPTH, TEST_MERKLE_TREE_DEPTH_FOR_PATH_PADDING, assert_relation_rejected,
+        impl_focused_test_relation, jubjub_poseidon_used_chips, prove_and_verify_relation,
+        sample_valid_circuit_witness_entry,
     };
-    use crate::circuits::halo2::types::CircuitBase;
-    use crate::circuits::halo2::witness::{CircuitWitnessEntry, MerkleRoot};
+    use crate::circuits::halo2::types::{CircuitBase, CircuitBaseField};
+    use crate::circuits::halo2::witness::{CircuitWitnessEntry, MerkleRoot, Position};
 
     use super::{MerklePathInputs, verify_merkle_path};
 
@@ -198,11 +199,82 @@ mod tests {
         }
     );
 
+    impl_focused_test_relation!(
+        MerklePathRelation,
+        (CircuitWitnessEntry, MerkleRoot),
+        jubjub_poseidon_used_chips(),
+        |std_lib, layouter, witness| {
+            let verification_key = std_lib.jubjub().assign(
+                layouter,
+                witness
+                    .clone()
+                    .map(|(entry, _)| entry.leaf.verification_key_point().0),
+            )?;
+            let lottery_target_value = std_lib.assign(
+                layouter,
+                witness
+                    .clone()
+                    .map(|(entry, _)| entry.leaf.lottery_target_value().into()),
+            )?;
+            let merkle_tree_commitment = std_lib.assign(
+                layouter,
+                witness.clone().map(|(_, commitment)| commitment.into()),
+            )?;
+            let merkle_siblings = std_lib.assign_many(
+                layouter,
+                witness
+                    .clone()
+                    .map(|(entry, _)| {
+                        entry
+                            .merkle_path
+                            .siblings
+                            .iter()
+                            .map(|(_, sibling)| (*sibling).into())
+                            .collect::<Vec<_>>()
+                    })
+                    .transpose_vec(TEST_MERKLE_TREE_DEPTH_FOR_PATH_PADDING)
+                    .as_slice(),
+            )?;
+            let merkle_positions = std_lib.assign_many(
+                layouter,
+                witness
+                    .map(|(entry, _)| {
+                        entry
+                            .merkle_path
+                            .siblings
+                            .iter()
+                            .map(|(position, _)| CircuitBase::from(*position))
+                            .collect::<Vec<_>>()
+                    })
+                    .transpose_vec(TEST_MERKLE_TREE_DEPTH_FOR_PATH_PADDING)
+                    .as_slice(),
+            )?;
+            let merkle_positions = merkle_positions
+                .iter()
+                .map(|position| std_lib.convert(layouter, position))
+                .collect::<Result<Vec<_>, Error>>()?;
+
+            verify_merkle_path(
+                std_lib,
+                layouter,
+                MerklePathInputs {
+                    verification_key: &verification_key,
+                    lottery_target_value: &lottery_target_value,
+                    merkle_tree_commitment: &merkle_tree_commitment,
+                    merkle_siblings: &merkle_siblings,
+                    merkle_positions: &merkle_positions,
+                    merkle_tree_depth: TEST_MERKLE_TREE_DEPTH as u32,
+                },
+            )
+        }
+    );
+
     #[test]
     fn merkle_path_accepts_valid_witness_entry() {
         let relation = MerkleRelation;
-        let (entry, merkle_tree_commitment, _) = sample_valid_circuit_witness_entry()
-            .expect("merkle_path_accepts_valid_witness_entry should build fixture");
+        let (entry, merkle_tree_commitment, _) =
+            sample_valid_circuit_witness_entry(TEST_MERKLE_TREE_DEPTH as u32)
+                .expect("merkle_path_accepts_valid_witness_entry should build fixture");
 
         prove_and_verify_relation(&relation, &(), (entry, merkle_tree_commitment))
             .expect("merkle_path_accepts_valid_witness_entry should succeed");
@@ -211,8 +283,42 @@ mod tests {
     #[test]
     fn merkle_path_rejects_wrong_merkle_tree_commitment() {
         let relation = MerkleRelation;
-        let (entry, _, _) = sample_valid_circuit_witness_entry()
+        let (entry, _, _) = sample_valid_circuit_witness_entry(TEST_MERKLE_TREE_DEPTH as u32)
             .expect("merkle_path_rejects_wrong_merkle_tree_commitment should build fixture");
+
+        assert_relation_rejected(prove_and_verify_relation(
+            &relation,
+            &(),
+            (entry, MerkleRoot::from(999u64)),
+        ));
+    }
+
+    #[test]
+    fn merkle_path_accepts_padding() {
+        let relation = MerklePathRelation;
+
+        let (entry, merkle_tree_commitment, _) =
+            sample_valid_circuit_witness_entry(TEST_MERKLE_TREE_DEPTH_FOR_PATH_PADDING as u32)
+                .expect("merkle_path_rejects_wrong_merkle_tree_commitment should build fixture");
+        assert_eq!(
+            entry.merkle_path.siblings.last().unwrap(),
+            &(Position::Right, CircuitBaseField::ZERO),
+            "The last element of the siblings should be a zero padding"
+        );
+
+        prove_and_verify_relation(&relation, &(), (entry.clone(), merkle_tree_commitment))
+            .expect("merkle_path_accepts_valid_witness_entry should succeed");
+    }
+
+    #[test]
+    fn merkle_path_rejects_wrong_padding() {
+        let relation = MerklePathRelation;
+        let (mut entry, _, _) =
+            sample_valid_circuit_witness_entry(TEST_MERKLE_TREE_DEPTH_FOR_PATH_PADDING as u32)
+                .expect("merkle_path_rejects_wrong_merkle_tree_commitment should build fixture");
+
+        let sibling_length = entry.merkle_path.siblings.len();
+        entry.merkle_path.siblings[sibling_length - 1] = (Position::Right, CircuitBaseField::ONE);
 
         assert_relation_rejected(prove_and_verify_relation(
             &relation,

--- a/mithril-stm/src/circuits/halo2/gadgets/unique_schnorr_signature.rs
+++ b/mithril-stm/src/circuits/halo2/gadgets/unique_schnorr_signature.rs
@@ -83,8 +83,8 @@ mod tests {
     use midnight_circuits::types::AssignedNative;
 
     use crate::circuits::halo2::tests::test_helpers::{
-        assert_relation_rejected, impl_focused_test_relation, jubjub_poseidon_used_chips,
-        prove_and_verify_relation, sample_valid_circuit_witness_entry,
+        TEST_MERKLE_TREE_DEPTH, assert_relation_rejected, impl_focused_test_relation,
+        jubjub_poseidon_used_chips, prove_and_verify_relation, sample_valid_circuit_witness_entry,
     };
     use crate::circuits::halo2::types::{CircuitBase, CircuitCurve};
     use crate::circuits::halo2::witness::{
@@ -167,8 +167,10 @@ mod tests {
     #[test]
     fn unique_schnorr_signature_accepts_valid_witness_entry() {
         let relation = UniqueSchnorrSignatureRelation;
-        let (entry, merkle_tree_commitment, message) = sample_valid_circuit_witness_entry()
-            .expect("unique_schnorr_signature_accepts_valid_witness_entry should build fixture");
+        let (entry, merkle_tree_commitment, message) = sample_valid_circuit_witness_entry(
+            TEST_MERKLE_TREE_DEPTH as u32,
+        )
+        .expect("unique_schnorr_signature_accepts_valid_witness_entry should build fixture");
 
         prove_and_verify_relation(&relation, &(), (entry, merkle_tree_commitment, message))
             .expect("unique_schnorr_signature_accepts_valid_witness_entry should succeed");
@@ -177,8 +179,9 @@ mod tests {
     #[test]
     fn unique_schnorr_signature_rejects_wrong_challenge() {
         let relation = UniqueSchnorrSignatureRelation;
-        let (mut entry, merkle_tree_commitment, message) = sample_valid_circuit_witness_entry()
-            .expect("unique_schnorr_signature_rejects_wrong_challenge should build fixture");
+        let (mut entry, merkle_tree_commitment, message) =
+            sample_valid_circuit_witness_entry(TEST_MERKLE_TREE_DEPTH as u32)
+                .expect("unique_schnorr_signature_rejects_wrong_challenge should build fixture");
         entry.unique_schnorr_signature.challenge =
             entry.unique_schnorr_signature.challenge + BaseFieldElement::from(1u64);
 

--- a/mithril-stm/src/circuits/halo2/tests/test_helpers.rs
+++ b/mithril-stm/src/circuits/halo2/tests/test_helpers.rs
@@ -26,6 +26,8 @@ use crate::signature_scheme::{BaseFieldElement, SchnorrSigningKey, SchnorrVerifi
 
 /// Small Merkle depth shared by focused gadget tests to keep proving cheap in CI.
 pub(crate) const TEST_MERKLE_TREE_DEPTH: usize = 3;
+/// Small Merkle depth to test the proper implementation of the merkle path padding.
+pub(crate) const TEST_MERKLE_TREE_DEPTH_FOR_PATH_PADDING: usize = 5;
 
 /// Proves and verifies a tiny test-only relation.
 pub(crate) fn prove_and_verify_relation<R>(
@@ -75,8 +77,9 @@ pub(crate) fn jubjub_poseidon_used_chips() -> midnight_zk_stdlib::ZkStdLibArch {
 }
 
 /// Builds one valid circuit witness entry for focused gadget tests.
-pub(crate) fn sample_valid_circuit_witness_entry()
--> Result<(CircuitWitnessEntry, MerkleRoot, SignedMessageWithoutPrefix)> {
+pub(crate) fn sample_valid_circuit_witness_entry(
+    merkle_path_length: u32,
+) -> Result<(CircuitWitnessEntry, MerkleRoot, SignedMessageWithoutPrefix)> {
     let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
     let signing_key = SchnorrSigningKey::generate(&mut rng);
     let verification_key = SchnorrVerificationKey::new_from_signing_key(signing_key.clone());
@@ -91,9 +94,8 @@ pub(crate) fn sample_valid_circuit_witness_entry()
     let message = SignedMessageWithoutPrefix::from(42u64);
     let transcript = [merkle_tree_commitment.into(), message.into()];
     let unique_schnorr_signature = signing_key.sign(&transcript, &mut rng)?;
-    let merkle_path: MerklePath = (&stm_tree
-        .compute_merkle_tree_path_fixed_length(0, TEST_MERKLE_TREE_DEPTH as u32))
-        .try_into()?;
+    let merkle_path: MerklePath =
+        (&stm_tree.compute_merkle_tree_path_fixed_length(0, merkle_path_length)).try_into()?;
     let entry = CircuitWitnessEntry {
         leaf: CircuitMerkleTreeLeaf(verification_key, circuit_lottery_target_value),
         merkle_path,

--- a/mithril-stm/src/circuits/halo2/tests/test_helpers.rs
+++ b/mithril-stm/src/circuits/halo2/tests/test_helpers.rs
@@ -91,7 +91,9 @@ pub(crate) fn sample_valid_circuit_witness_entry()
     let message = SignedMessageWithoutPrefix::from(42u64);
     let transcript = [merkle_tree_commitment.into(), message.into()];
     let unique_schnorr_signature = signing_key.sign(&transcript, &mut rng)?;
-    let merkle_path: MerklePath = (&stm_tree.compute_merkle_tree_path(0)).try_into()?;
+    let merkle_path: MerklePath = (&stm_tree
+        .compute_merkle_tree_path_fixed_length(0, TEST_MERKLE_TREE_DEPTH as u32))
+        .try_into()?;
     let entry = CircuitWitnessEntry {
         leaf: CircuitMerkleTreeLeaf(verification_key, circuit_lottery_target_value),
         merkle_path,

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -48,8 +48,8 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
             nodes[num_nodes - n + i] = D::digest(leaves[i].as_bytes_for_merkle_tree()).to_vec();
         }
 
+        let z = D::digest([0u8]).to_vec();
         for i in (0..num_nodes - n).rev() {
-            let z = D::digest([0u8]).to_vec();
             let left = if left_child(i) < num_nodes {
                 &nodes[left_child(i)]
             } else {
@@ -227,8 +227,6 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
     }
 
     #[cfg(feature = "future_snark")]
-    // TODO: remove this allow dead_code directive when function is called or future_snark is activated
-    #[allow(dead_code)]
     /// Get a path (hashes of siblings of the path to the root node)
     /// for the `i`th value stored in the tree and pad it to reach the
     /// given length.
@@ -623,7 +621,9 @@ mod tests {
             let leaves = make_leaves(4); // natural depth = 2
             let tree = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&leaves);
             let path_length = 5u32;
+
             let pf = tree.compute_merkle_tree_path_fixed_length(0, path_length);
+
             assert_eq!(pf.values.len(), path_length as usize);
         }
 

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -585,6 +585,59 @@ mod tests {
 
         type SnarkHash = <MithrilMembershipDigest as MembershipDigest>::SnarkHash;
 
+        fn make_leaves(n: usize) -> Vec<MerkleTreeSnarkLeaf> {
+            let pks = vec![VerificationKeyForSnark::default(); n];
+            pks.into_iter()
+                .zip(0u64..)
+                .map(|(key, stake)| MerkleTreeSnarkLeaf(key, BaseFieldElement(Fq::from(stake))))
+                .collect()
+        }
+
+        #[test]
+        fn padded_path_preserves_natural_prefix() {
+            // The first elements of the padded path must match the natural path exactly
+            let leaves = make_leaves(4); // natural depth = 2
+            let tree = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&leaves);
+            let natural = tree.compute_merkle_tree_path(0);
+            let padded = tree.compute_merkle_tree_path_fixed_length(0, 5);
+
+            assert_eq!(&padded.values[..natural.values.len()], &natural.values[..]);
+        }
+
+        #[test]
+        fn padding_elements_are_zero_vectors() {
+            // Elements added by padding must be zero vectors of the hash output size
+            let leaves = make_leaves(4); // natural depth = 2
+            let tree = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&leaves);
+            let natural_len = tree.compute_merkle_tree_path(0).values.len();
+            let padded = tree.compute_merkle_tree_path_fixed_length(0, 5);
+
+            let expected_zero = vec![0u8; <SnarkHash as Digest>::output_size()];
+            for pad_elem in &padded.values[natural_len..] {
+                assert_eq!(pad_elem, &expected_zero);
+            }
+        }
+
+        #[test]
+        fn padded_path_has_correct_length() {
+            let leaves = make_leaves(4); // natural depth = 2
+            let tree = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&leaves);
+            let path_length = 5u32;
+            let pf = tree.compute_merkle_tree_path_fixed_length(0, path_length);
+            assert_eq!(pf.values.len(), path_length as usize);
+        }
+
+        #[test]
+        fn no_truncation_when_path_length_not_larger_than_natural_depth() {
+            // When path_length <= natural depth, the path is returned unchanged
+            let leaves = make_leaves(8); // natural depth = 3
+            let tree = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&leaves);
+            let natural = tree.compute_merkle_tree_path(0);
+            let pf = tree.compute_merkle_tree_path_fixed_length(0, 2); // 2 < natural depth 3
+
+            assert_eq!(pf.values, natural.values);
+        }
+
         prop_compose! {
             fn arb_tree_poseidon(max_size: u32)
                        (v in vec(any::<u64>(), 2..max_size as usize)) -> (MerkleTree<SnarkHash, MerkleTreeSnarkLeaf>, Vec<MerkleTreeSnarkLeaf>) {
@@ -603,17 +656,6 @@ mod tests {
             fn test_create_proof((t, values) in arb_tree_poseidon(30)) {
                 values.iter().enumerate().for_each(|(i, _v)| {
                     let pf = t.compute_merkle_tree_path(i);
-                    assert!(t.to_merkle_tree_commitment().verify_leaf_membership_from_path(&values[i], &pf).is_ok());
-                })
-            }
-
-            #[cfg(feature = "future_snark")]
-            #[test]
-            fn test_path_length((t, values) in arb_tree_poseidon(30)) {
-                let merkle_path_length = 13;
-                values.iter().enumerate().for_each(|(i, _v)| {
-                    let pf = t.compute_merkle_tree_path_fixed_length(i, merkle_path_length);
-                    assert_eq!(pf.values.len(), merkle_path_length as usize);
                     assert!(t.to_merkle_tree_commitment().verify_leaf_membership_from_path(&values[i], &pf).is_ok());
                 })
             }

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -225,6 +225,41 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
 
         MerklePath::new(proof, i)
     }
+
+    #[cfg(feature = "future_snark")]
+    #[allow(dead_code)]
+    pub(crate) fn compute_merkle_tree_path_fixed_length(
+        &self,
+        i: usize,
+        path_length: u32,
+    ) -> MerklePath<D> {
+        assert!(
+            i < self.n,
+            "Proof index out of bounds: asked for {} out of {}",
+            i,
+            self.n
+        );
+        let mut idx = self.get_leaf_index(i);
+        let mut proof = Vec::new();
+
+        while idx > 0 {
+            let h = if sibling(idx) < self.nodes.len() {
+                self.nodes[sibling(idx)].clone()
+            } else {
+                D::digest([0u8]).to_vec()
+            };
+            proof.push(h.clone());
+            idx = parent(idx);
+        }
+        println!("base proof length{:?}", proof.len());
+
+        while proof.len() < path_length as usize {
+            proof.push(vec![0u8; 32]);
+        }
+        println!("padded proof length{:?}", proof.len());
+
+        MerklePath::new(proof, i)
+    }
 }
 
 #[cfg(test)]

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -219,7 +219,7 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
             } else {
                 D::digest([0u8]).to_vec()
             };
-            proof.push(h.clone());
+            proof.push(h);
             idx = parent(idx);
         }
 

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -230,6 +230,9 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
     /// Get a path (hashes of siblings of the path to the root node)
     /// for the `i`th value stored in the tree and pad it to reach the
     /// given length.
+    /// The padding is done by adding values of `0` to the path in the form
+    /// of `[0u8; hash_output_size]`. Since finding the preimage is hard, this allows us
+    /// to use this value to detect when the "real" path ends.
     /// Requires `i < self.n`
     pub(crate) fn compute_merkle_tree_path_fixed_length(
         &self,

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -227,38 +227,24 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
     }
 
     #[cfg(feature = "future_snark")]
+    // TODO: remove this allow dead_code directive when function is called or future_snark is activated
     #[allow(dead_code)]
+    /// Get a path (hashes of siblings of the path to the root node)
+    /// for the `i`th value stored in the tree and pad it to reach the
+    /// given length.
+    /// Requires `i < self.n`
     pub(crate) fn compute_merkle_tree_path_fixed_length(
         &self,
         i: usize,
         path_length: u32,
     ) -> MerklePath<D> {
-        assert!(
-            i < self.n,
-            "Proof index out of bounds: asked for {} out of {}",
-            i,
-            self.n
-        );
-        let mut idx = self.get_leaf_index(i);
-        let mut proof = Vec::new();
+        let mut path = self.compute_merkle_tree_path(i);
 
-        while idx > 0 {
-            let h = if sibling(idx) < self.nodes.len() {
-                self.nodes[sibling(idx)].clone()
-            } else {
-                D::digest([0u8]).to_vec()
-            };
-            proof.push(h.clone());
-            idx = parent(idx);
+        while path.values.len() < path_length as usize {
+            path.values.push(vec![0u8; <D as Digest>::output_size()]);
         }
-        println!("base proof length{:?}", proof.len());
 
-        while proof.len() < path_length as usize {
-            proof.push(vec![0u8; 32]);
-        }
-        println!("padded proof length{:?}", proof.len());
-
-        MerklePath::new(proof, i)
+        path
     }
 }
 
@@ -617,6 +603,17 @@ mod tests {
             fn test_create_proof((t, values) in arb_tree_poseidon(30)) {
                 values.iter().enumerate().for_each(|(i, _v)| {
                     let pf = t.compute_merkle_tree_path(i);
+                    assert!(t.to_merkle_tree_commitment().verify_leaf_membership_from_path(&values[i], &pf).is_ok());
+                })
+            }
+
+            #[cfg(feature = "future_snark")]
+            #[test]
+            fn test_path_length((t, values) in arb_tree_poseidon(30)) {
+                let merkle_path_length = 13;
+                values.iter().enumerate().for_each(|(i, _v)| {
+                    let pf = t.compute_merkle_tree_path_fixed_length(i, merkle_path_length);
+                    assert_eq!(pf.values.len(), merkle_path_length as usize);
                     assert!(t.to_merkle_tree_commitment().verify_leaf_membership_from_path(&values[i], &pf).is_ok());
                 })
             }

--- a/mithril-stm/src/proof_system/halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/mod.rs
@@ -26,7 +26,7 @@ pub(crate) use unsafe_helpers::SnarkSetup;
 /// Changing this value means changing the circuit and the circuit verification key
 ///
 /// For now set to 13 to allow for 2^13 = 8192 signers
-pub const MERKLE_TREE_DEPTH_FOR_SNARK: u32 = 8;
+pub const MERKLE_TREE_DEPTH_FOR_SNARK: u32 = 13;
 
 /// Errors which can be outputted by the snark proof creation or verification.
 #[cfg(feature = "future_snark")]

--- a/mithril-stm/src/proof_system/halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/mod.rs
@@ -21,6 +21,13 @@ pub(crate) use signer::SnarkProofSigner;
 pub(crate) use single_signature::SingleSignatureForSnark;
 pub(crate) use unsafe_helpers::SnarkSetup;
 
+/// Fixed merkle tree depth used to create the merkle tree
+/// of signers for the SNARK proof
+/// Changing this value means changing the circuit and the circuit verification key
+///
+/// For now set to 13 to allow for 2^13 = 8192 signers
+pub const MERKLE_TREE_DEPTH_FOR_SNARK: u32 = 8;
+
 /// Errors which can be outputted by the snark proof creation or verification.
 #[cfg(feature = "future_snark")]
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]

--- a/mithril-stm/src/proof_system/halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/mod.rs
@@ -21,9 +21,11 @@ pub(crate) use signer::SnarkProofSigner;
 pub(crate) use single_signature::SingleSignatureForSnark;
 pub(crate) use unsafe_helpers::SnarkSetup;
 
-/// Fixed merkle tree depth used to create the merkle tree
-/// of signers for the SNARK proof
-/// Changing this value means changing the circuit and the circuit verification key
+/// Fixed merkle tree depth used of the merkle tree
+/// of signers for the SNARK proof. It is used to compute
+/// the necessary padding of the merkle path.
+///
+/// Important: Changing this value means changing the circuit and the circuit verification key
 ///
 /// For now set to 13 to allow for 2^13 = 8192 signers
 pub const MERKLE_TREE_DEPTH_FOR_SNARK: u32 = 13;

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -369,6 +369,9 @@ mod tests {
         let result = snark_proof.verify(message.as_slice(), &avk);
 
         assert!(result.is_ok());
+        snark_proof
+            .verify(message.as_slice(), &avk)
+            .expect("SNARK proof verification should succeed");
     }
 
     #[test]

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -12,8 +12,8 @@ use crate::{
     circuits::halo2::{circuit::StmCircuit, types::CircuitBase},
     codec,
     proof_system::halo2_snark::{
-        SnarkError, build_snark_message, circuit_verification_key::CircuitVerificationKey,
-        prover_input::SnarkProverInput,
+        MERKLE_TREE_DEPTH_FOR_SNARK, SnarkError, build_snark_message,
+        circuit_verification_key::CircuitVerificationKey, prover_input::SnarkProverInput,
     },
 };
 
@@ -76,7 +76,7 @@ impl<D: MembershipDigest> SnarkProof<D> {
         message: &[u8],
         aggregate_verification_key_for_snark: &AggregateVerificationKeyForSnark<D>,
     ) -> StmResult<()> {
-        let snark_setup = SnarkSetup::try_new(&self.params, self.merkle_tree_depth)?;
+        let snark_setup = SnarkSetup::try_new(&self.params, MERKLE_TREE_DEPTH_FOR_SNARK)?;
 
         let merkle_root = &aggregate_verification_key_for_snark.get_merkle_tree_commitment().root;
         let proof_message = build_snark_message(merkle_root, message)?;
@@ -244,12 +244,7 @@ impl<R: RngCore + CryptoRng> SnarkProver<R> {
 #[cfg(feature = "future_snark")]
 #[cfg(test)]
 mod tests {
-    use std::{
-        collections::{BTreeMap, btree_map::Entry},
-        marker::PhantomData,
-    };
 
-    use midnight_circuits::hash::poseidon::PoseidonState;
     use rand_chacha::ChaCha20Rng;
     use rand_core::{RngCore, SeedableRng};
 
@@ -258,7 +253,7 @@ mod tests {
         proof_system::{
             SnarkClerk,
             halo2_snark::{
-                MERKLE_TREE_DEPTH_FOR_SNARK, SnarkSetup, build_snark_message,
+                MERKLE_TREE_DEPTH_FOR_SNARK, SnarkSetup,
                 circuit_verification_key::CircuitVerificationKey, proof::SnarkProof,
                 prover_input::SnarkProverInput,
             },
@@ -307,13 +302,8 @@ mod tests {
             .collect()
     }
 
-    fn create_prover(
-        params: Parameters,
-        number_of_signers: usize,
-        seed: [u8; 32],
-    ) -> SnarkProver<ChaCha20Rng> {
-        let merkle_tree_depth = number_of_signers.next_power_of_two().trailing_zeros();
-        SnarkProver::try_new_deterministic(&params, merkle_tree_depth, seed).unwrap()
+    fn create_prover(params: Parameters, seed: [u8; 32]) -> SnarkProver<ChaCha20Rng> {
+        SnarkProver::try_new_deterministic(&params, MERKLE_TREE_DEPTH_FOR_SNARK, seed).unwrap()
     }
 
     #[test]
@@ -329,13 +319,10 @@ mod tests {
 
         let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
         let signatures = collect_signatures(&signers, &message);
-        let mut prover = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [0u8; 32],
-        );
+        let mut prover = create_prover(params, [0u8; 32]);
 
-        let result = prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
+        let result: Result<SnarkProof<MithrilMembershipDigest>, anyhow::Error> =
+            prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
         assert!(
             result.is_ok(),
             "Expected proof creation to succeed, got: {result:?}"
@@ -346,6 +333,42 @@ mod tests {
             !proof.circuit_proof.is_empty(),
             "Proof bytes should not be empty"
         );
+    }
+
+    #[test]
+    fn valid_snark_proof_with_different_path_length() {
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let params = Parameters {
+            m: 200,
+            k: 3,
+            phi_f: 0.8,
+        };
+        let nparties = 10;
+        let message = [1u8; 32];
+        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+        let signatures = collect_signatures(&signers, &message);
+        let avk = clerk.compute_aggregate_verification_key_for_snark();
+
+        let current_merkle_tree_depth = clerk
+            .closed_key_registration
+            .number_of_registered_parties()
+            .next_power_of_two()
+            .trailing_zeros();
+        let mut prover = create_prover(params, [0u8; 32]);
+
+        let prover_prep =
+            SnarkProverInput::prepare_prover_input::<D>(&clerk, &signatures, &message).unwrap();
+
+        let path_length = prover_prep.into_witness().first().unwrap().merkle_path.siblings.len();
+
+        assert!(path_length >= current_merkle_tree_depth as usize);
+
+        let snark_proof = prover
+            .aggregate_signatures::<D>(&clerk, &signatures, &message)
+            .unwrap();
+        let result = snark_proof.verify(message.as_slice(), &avk);
+
+        assert!(result.is_ok());
     }
 
     #[test]
@@ -361,11 +384,7 @@ mod tests {
 
         let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
         let signatures = collect_signatures(&signers, &message);
-        let mut prover = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [1u8; 32],
-        );
+        let mut prover = create_prover(params, [1u8; 32]);
 
         let result = prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
         assert!(
@@ -385,11 +404,7 @@ mod tests {
         let nparties = 5;
 
         let (_, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let mut prover = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [2u8; 32],
-        );
+        let mut prover = create_prover(params, [2u8; 32]);
 
         let result = prover.aggregate_signatures::<D>(&clerk, &[], &[3u8; 32]);
         assert!(result.is_err(), "Expected failure with empty signatures");
@@ -408,131 +423,11 @@ mod tests {
         let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
         let signatures = collect_signatures(&signers, &message);
         let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [0u8; 32],
-        );
+        let mut prover = create_prover(params, [0u8; 32]);
 
         let snark_proof = prover
             .aggregate_signatures::<D>(&clerk, &signatures, &message)
             .unwrap();
-        let result = snark_proof.verify(message.as_slice(), &avk);
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn incomplete_merkle_tree_generates_full_path() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 200,
-            k: 3,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
-            clerk.compute_aggregate_verification_key_for_snark();
-        let mut snark_prover = create_prover(params, [0u8; 32]);
-
-        // clerk, &signatures, &message
-        let snark_input = {
-            let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
-                clerk.compute_aggregate_verification_key_for_snark();
-            let message_to_sign =
-                build_snark_message(&avk.get_merkle_tree_commitment().root, &message).unwrap();
-
-            let valid_sigs = SnarkProverInput::collect_valid_signatures_with_indices(
-                &clerk,
-                &signatures,
-                &message_to_sign,
-            );
-            let unique_index_signature_map =
-                SnarkClerk::select_valid_signatures_for_k_indices(&clerk.parameters, &valid_sigs)
-                    .unwrap();
-
-            // Witness creation
-            // we want the tree used here to be smaller than the depth of the circuit
-            // and pad the path to generate a correct proof anyway
-
-            let merkle_tree: MerkleTree<
-                <MithrilMembershipDigest as MembershipDigest>::SnarkHash,
-                MerkleTreeSnarkLeaf,
-            > = clerk
-                .closed_key_registration
-                .to_merkle_tree_given_depth(MERKLE_TREE_DEPTH_FOR_SNARK);
-            let mut unique_signers: BTreeMap<SignerIndex, (MerkleTreeSnarkLeaf, MerklePath)> =
-                BTreeMap::new();
-
-            for sig in unique_index_signature_map.values() {
-                if let Entry::Vacant(vacant) = unique_signers.entry(sig.signer_index) {
-                    let leaf = match clerk.get_snark_registration_entry(sig.signer_index) {
-                        Ok(Some(entry)) => entry,
-                        Ok(None) => continue,
-                        Err(_) => continue,
-                    };
-                    let merkle_path = merkle_tree
-                        .compute_merkle_tree_path_fixed_length(sig.signer_index as usize, 13);
-                    let merkle_path_circuit: MerklePath =
-                        MerklePath::try_from(&merkle_path).unwrap();
-                    vacant.insert((leaf, merkle_path_circuit));
-                }
-            }
-
-            let witness = unique_index_signature_map
-                .into_iter()
-                .map(|(lottery_index, sig)| {
-                    let (leaf, merkle_path) = unique_signers
-                        .get(&sig.signer_index)
-                        .ok_or(AggregationError::MissingSnarkSignerData(sig.signer_index))
-                        .unwrap();
-                    let schnorr_sig = sig
-                        .snark_signature
-                        .as_ref()
-                        .ok_or(AggregationError::MissingSnarkSignature(lottery_index))
-                        .unwrap()
-                        .get_schnorr_signature();
-                    let circuit_leaf = CircuitMerkleTreeLeaf(leaf.0, leaf.1.into());
-                    CircuitWitnessEntry {
-                        leaf: circuit_leaf,
-                        merkle_path: merkle_path.clone(),
-                        unique_schnorr_signature: schnorr_sig,
-                        lottery_index,
-                    }
-                })
-                .collect();
-
-            let instance = (message_to_sign[0].into(), message_to_sign[1].into());
-
-            SnarkProverInput { witness, instance }
-        };
-
-        let instance = snark_input.get_instance();
-        let witness = snark_input.into_witness();
-
-        let circuit_proof = midnight_zk_stdlib::prove::<StmCircuit, PoseidonState<CircuitBase>>(
-            &snark_prover.setup.srs,
-            &snark_prover.setup.proving_key,
-            &snark_prover.setup.circuit,
-            &instance,
-            witness,
-            &mut snark_prover.rng,
-        )
-        .unwrap();
-
-        let snark_proof = SnarkProof {
-            circuit_proof,
-            circuit_verification_key: CircuitVerificationKey::new(
-                snark_prover.setup.verification_key.clone(),
-            ),
-            params: clerk.parameters,
-            merkle_tree_depth: 13,
-            phantom: PhantomData,
-        };
-
         let result = snark_proof.verify(message.as_slice(), &avk);
 
         assert!(result.is_ok());
@@ -556,11 +451,7 @@ mod tests {
         let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
             clerk.compute_aggregate_verification_key_for_snark();
 
-        let mut prover = create_prover(
-            forged_params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [0u8; 32],
-        );
+        let mut prover = create_prover(forged_params, [0u8; 32]);
 
         let forged_snark_proof = prover
             .aggregate_signatures::<D>(&clerk, &signatures, &message)
@@ -588,11 +479,7 @@ mod tests {
         let signatures = collect_signatures(&signers, &message);
         let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
             clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [0u8; 32],
-        );
+        let mut prover = create_prover(params, [0u8; 32]);
         let snark_proof = prover
             .aggregate_signatures::<D>(&clerk, &signatures, &message)
             .unwrap();
@@ -641,11 +528,7 @@ mod tests {
         let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
         let signatures = collect_signatures(&signers, &message);
         let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [0u8; 32],
-        );
+        let mut prover = create_prover(params, [0u8; 32]);
 
         let snark_proof = prover
             .aggregate_signatures::<D>(&clerk, &signatures, &message)
@@ -669,11 +552,7 @@ mod tests {
         let signatures = collect_signatures(&signers, &message);
         let avk = clerk.compute_aggregate_verification_key_for_snark();
 
-        let mut prover_1 = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [0u8; 32],
-        );
+        let mut prover_1 = create_prover(params, [0u8; 32]);
 
         let snark_proof_1 = prover_1
             .aggregate_signatures::<D>(&clerk, &signatures, &message)
@@ -703,11 +582,7 @@ mod tests {
         let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
         let signatures = collect_signatures(&signers, &message);
         let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(
-            params,
-            clerk.closed_key_registration.number_of_registered_parties(),
-            [0u8; 32],
-        );
+        let mut prover = create_prover(params, [0u8; 32]);
         let snark_proof = prover
             .aggregate_signatures::<D>(&clerk, &signatures, &message)
             .unwrap();
@@ -735,12 +610,11 @@ mod tests {
             phi_f: 0.8,
         };
         let nparties = 10;
-        let merkle_tree_depth = (nparties as u32).next_power_of_two().trailing_zeros();
         let message = [1u8; 32];
         let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
         let signatures = collect_signatures(&signers, &message);
         let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let snark_setup = SnarkSetup::try_new(&params, merkle_tree_depth).unwrap();
+        let snark_setup = SnarkSetup::try_new(&params, MERKLE_TREE_DEPTH_FOR_SNARK).unwrap();
         let mut prover = SnarkProver {
             setup: snark_setup,
             rng: ChaCha20Rng::from_seed([0u8; 32]),
@@ -811,11 +685,7 @@ mod tests {
 
             let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
             let signatures = collect_signatures(&signers, &message);
-            let mut prover = create_prover(
-                params,
-                clerk.closed_key_registration.number_of_registered_parties(),
-                [0u8; 32],
-            );
+            let mut prover = create_prover(params, [0u8; 32]);
             let avk = clerk.compute_aggregate_verification_key_for_snark();
             let snark_proof = prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
 

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -244,6 +244,12 @@ impl<R: RngCore + CryptoRng> SnarkProver<R> {
 #[cfg(feature = "future_snark")]
 #[cfg(test)]
 mod tests {
+    use std::{
+        collections::{BTreeMap, btree_map::Entry},
+        marker::PhantomData,
+    };
+
+    use midnight_circuits::hash::poseidon::PoseidonState;
     use rand_chacha::ChaCha20Rng;
     use rand_core::{RngCore, SeedableRng};
 
@@ -252,7 +258,9 @@ mod tests {
         proof_system::{
             SnarkClerk,
             halo2_snark::{
-                SnarkSetup, circuit_verification_key::CircuitVerificationKey, proof::SnarkProof,
+                MERKLE_TREE_DEPTH_FOR_SNARK, SnarkSetup, build_snark_message,
+                circuit_verification_key::CircuitVerificationKey, proof::SnarkProof,
+                prover_input::SnarkProverInput,
             },
         },
     };
@@ -409,6 +417,122 @@ mod tests {
         let snark_proof = prover
             .aggregate_signatures::<D>(&clerk, &signatures, &message)
             .unwrap();
+        let result = snark_proof.verify(message.as_slice(), &avk);
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn incomplete_merkle_tree_generates_full_path() {
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let params = Parameters {
+            m: 200,
+            k: 3,
+            phi_f: 0.8,
+        };
+        let nparties = 10;
+        let message = [1u8; 32];
+        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+        let signatures = collect_signatures(&signers, &message);
+        let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
+            clerk.compute_aggregate_verification_key_for_snark();
+        let mut snark_prover = create_prover(params, [0u8; 32]);
+
+        // clerk, &signatures, &message
+        let snark_input = {
+            let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
+                clerk.compute_aggregate_verification_key_for_snark();
+            let message_to_sign =
+                build_snark_message(&avk.get_merkle_tree_commitment().root, &message).unwrap();
+
+            let valid_sigs = SnarkProverInput::collect_valid_signatures_with_indices(
+                &clerk,
+                &signatures,
+                &message_to_sign,
+            );
+            let unique_index_signature_map =
+                SnarkClerk::select_valid_signatures_for_k_indices(&clerk.parameters, &valid_sigs)
+                    .unwrap();
+
+            // Witness creation
+            // we want the tree used here to be smaller than the depth of the circuit
+            // and pad the path to generate a correct proof anyway
+
+            let merkle_tree: MerkleTree<
+                <MithrilMembershipDigest as MembershipDigest>::SnarkHash,
+                MerkleTreeSnarkLeaf,
+            > = clerk
+                .closed_key_registration
+                .to_merkle_tree_given_depth(MERKLE_TREE_DEPTH_FOR_SNARK);
+            let mut unique_signers: BTreeMap<SignerIndex, (MerkleTreeSnarkLeaf, MerklePath)> =
+                BTreeMap::new();
+
+            for sig in unique_index_signature_map.values() {
+                if let Entry::Vacant(vacant) = unique_signers.entry(sig.signer_index) {
+                    let leaf = match clerk.get_snark_registration_entry(sig.signer_index) {
+                        Ok(Some(entry)) => entry,
+                        Ok(None) => continue,
+                        Err(_) => continue,
+                    };
+                    let merkle_path = merkle_tree
+                        .compute_merkle_tree_path_fixed_length(sig.signer_index as usize, 13);
+                    let merkle_path_circuit: MerklePath =
+                        MerklePath::try_from(&merkle_path).unwrap();
+                    vacant.insert((leaf, merkle_path_circuit));
+                }
+            }
+
+            let witness = unique_index_signature_map
+                .into_iter()
+                .map(|(lottery_index, sig)| {
+                    let (leaf, merkle_path) = unique_signers
+                        .get(&sig.signer_index)
+                        .ok_or(AggregationError::MissingSnarkSignerData(sig.signer_index))
+                        .unwrap();
+                    let schnorr_sig = sig
+                        .snark_signature
+                        .as_ref()
+                        .ok_or(AggregationError::MissingSnarkSignature(lottery_index))
+                        .unwrap()
+                        .get_schnorr_signature();
+                    let circuit_leaf = CircuitMerkleTreeLeaf(leaf.0, leaf.1.into());
+                    CircuitWitnessEntry {
+                        leaf: circuit_leaf,
+                        merkle_path: merkle_path.clone(),
+                        unique_schnorr_signature: schnorr_sig,
+                        lottery_index,
+                    }
+                })
+                .collect();
+
+            let instance = (message_to_sign[0].into(), message_to_sign[1].into());
+
+            SnarkProverInput { witness, instance }
+        };
+
+        let instance = snark_input.get_instance();
+        let witness = snark_input.into_witness();
+
+        let circuit_proof = midnight_zk_stdlib::prove::<StmCircuit, PoseidonState<CircuitBase>>(
+            &snark_prover.setup.srs,
+            &snark_prover.setup.proving_key,
+            &snark_prover.setup.circuit,
+            &instance,
+            witness,
+            &mut snark_prover.rng,
+        )
+        .unwrap();
+
+        let snark_proof = SnarkProof {
+            circuit_proof,
+            circuit_verification_key: CircuitVerificationKey::new(
+                snark_prover.setup.verification_key.clone(),
+            ),
+            params: clerk.parameters,
+            merkle_tree_depth: 13,
+            phantom: PhantomData,
+        };
+
         let result = snark_proof.verify(message.as_slice(), &avk);
 
         assert!(result.is_ok());

--- a/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
@@ -23,9 +23,9 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct SnarkProverInput {
     /// Public inputs to the SNARK circuit.
-    instance: CircuitInstance,
+    pub(crate) instance: CircuitInstance,
     /// Per-winning-lottery-index witness data.
-    witness: CircuitWitness,
+    pub(crate) witness: CircuitWitness,
 }
 
 // TODO: remove this allow dead_code directive when function is called or future_snark is activated
@@ -79,7 +79,7 @@ impl SnarkProverInput {
     /// or yield no winning indices are discarded. Since the goal is to gather as many valid
     /// signatures as possible, individual failures are not propagated, the caller decides
     /// whether the collected set is sufficient.
-    fn collect_valid_signatures_with_indices(
+    pub(crate) fn collect_valid_signatures_with_indices(
         clerk: &SnarkClerk,
         signatures: &[SingleSignature],
         message_to_sign: &[BaseFieldElement; 2],

--- a/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
@@ -26,9 +26,9 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct SnarkProverInput {
     /// Public inputs to the SNARK circuit.
-    pub(crate) instance: CircuitInstance,
+    instance: CircuitInstance,
     /// Per-winning-lottery-index witness data.
-    pub(crate) witness: CircuitWitness,
+    witness: CircuitWitness,
 }
 
 // TODO: remove this allow dead_code directive when function is called or future_snark is activated
@@ -82,7 +82,7 @@ impl SnarkProverInput {
     /// or yield no winning indices are discarded. Since the goal is to gather as many valid
     /// signatures as possible, individual failures are not propagated, the caller decides
     /// whether the collected set is sufficient.
-    pub(crate) fn collect_valid_signatures_with_indices(
+    fn collect_valid_signatures_with_indices(
         clerk: &SnarkClerk,
         signatures: &[SingleSignature],
         message_to_sign: &[BaseFieldElement; 2],

--- a/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/prover_input.rs
@@ -3,13 +3,16 @@ use std::collections::{BTreeMap, btree_map::Entry};
 use crate::{
     AggregationError, BaseFieldElement, LotteryIndex, MembershipDigest, SignerIndex,
     SingleSignature, StmResult,
-    circuits::MerklePath as Halo2MerklePath,
-    circuits::halo2::witness::CircuitWitnessEntry,
-    circuits::{CircuitInstance, CircuitMerkleTreeLeaf, CircuitWitness},
+    circuits::{
+        CircuitInstance, CircuitMerkleTreeLeaf, CircuitWitness, MerklePath as Halo2MerklePath,
+        halo2::witness::CircuitWitnessEntry,
+    },
     membership_commitment::{MerkleTree, MerkleTreeSnarkLeaf},
     proof_system::{
         AggregateVerificationKeyForSnark, SnarkClerk,
-        halo2_snark::{build_snark_message, compute_winning_lottery_indices},
+        halo2_snark::{
+            MERKLE_TREE_DEPTH_FOR_SNARK, build_snark_message, compute_winning_lottery_indices,
+        },
     },
 };
 
@@ -142,7 +145,10 @@ impl SnarkProverInput {
                     Ok(None) => continue,
                     Err(_) => continue,
                 };
-                let merkle_path = merkle_tree.compute_merkle_tree_path(sig.signer_index as usize);
+                let merkle_path = merkle_tree.compute_merkle_tree_path_fixed_length(
+                    sig.signer_index as usize,
+                    MERKLE_TREE_DEPTH_FOR_SNARK,
+                );
                 let merkle_path_circuit: Halo2MerklePath = Halo2MerklePath::try_from(&merkle_path)?;
                 vacant.insert((leaf, merkle_path_circuit));
             }

--- a/mithril-stm/src/proof_system/mod.rs
+++ b/mithril-stm/src/proof_system/mod.rs
@@ -33,6 +33,6 @@ pub use halo2_snark::SnarkProof;
 
 #[cfg(feature = "future_snark")]
 pub(crate) use halo2_snark::{
-    SingleSignatureForSnark, SnarkClerk, SnarkProofSigner, SnarkProver,
-    compute_target_value_for_snark_lottery,
+    MERKLE_TREE_DEPTH_FOR_SNARK, SingleSignatureForSnark, SnarkClerk, SnarkProofSigner,
+    SnarkProver, compute_target_value_for_snark_lottery,
 };

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -13,7 +13,7 @@ use crate::{
 #[cfg(feature = "future_snark")]
 use crate::AggregateSignatureError;
 #[cfg(feature = "future_snark")]
-use crate::proof_system::{SnarkClerk, SnarkProver};
+use crate::proof_system::{MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver};
 
 use super::{AggregateSignature, AggregateSignatureType};
 
@@ -90,20 +90,18 @@ impl<D: MembershipDigest> Clerk<D> {
                 let clerk = self
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
-                let merkle_tree_depth = clerk
-                    .closed_key_registration
-                    .number_of_registered_parties()
-                    .next_power_of_two()
-                    .trailing_zeros();
-                SnarkProver::try_new_non_deterministic(&clerk.parameters, merkle_tree_depth)?
-                    .aggregate_signatures(clerk, sigs, msg)
-                    .map(|p| AggregateSignature::Snark(Box::new(p)))
-                    .with_context(|| {
-                        format!(
-                            "Signatures failed to aggregate for type {}",
-                            AggregateSignatureType::Snark
-                        )
-                    })
+                SnarkProver::try_new_non_deterministic(
+                    &clerk.parameters,
+                    MERKLE_TREE_DEPTH_FOR_SNARK,
+                )?
+                .aggregate_signatures(clerk, sigs, msg)
+                .map(|p| AggregateSignature::Snark(Box::new(p)))
+                .with_context(|| {
+                    format!(
+                        "Signatures failed to aggregate for type {}",
+                        AggregateSignatureType::Snark
+                    )
+                })
             }
         }
     }


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes changes to the way the non-recursive circuit checks the merkle path of the elements of the witness. The length of the merkle paths given to the circuit is fixed to `13` to allow for the registration of up to `8192` signers. The merkle path computation for the witness generation pads the paths to the given length of `13` using `0` padding meaning it adds arrays `[0u8; 32]` to the path to fill it. The non-recursive circuit is changed to check of this padding (the `0` values) and ignore them when computing the root of the tree.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->
Benchmark results (in release mode):
  - Without caching:
    - regular computation (new() function): 1ms
    - depth 5: 1.8ms
    - depth 10: 62ms
    - depth 13: 412ms
  - With caching:
    - regular computation (new() function): 1ms
    - depth 5: 1ms
    - depth 10: 1.5ms
    - depth 13: 2.1ms

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Relates to #3183
