### PR TITLE
fix: anticipate Rust `1.95` clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.8.44"
+version = "0.8.45"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.8.44"
+version = "0.8.45"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -169,7 +169,7 @@ mod tests {
         signatures: &mut Vec<entities::SingleSignature>,
         quorum: usize,
     ) -> Vec<entities::SingleSignature> {
-        signatures.sort_by(|l, r| l.won_indexes.len().cmp(&r.won_indexes.len()));
+        signatures.sort_by_key(|sig| sig.won_indexes.len());
 
         let mut result = vec![];
         let mut nb_won_indexes = 0;

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.1"
+version = "0.10.2"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2/tests/golden/cases/negative.rs
+++ b/mithril-stm/src/circuits/halo2/tests/golden/cases/negative.rs
@@ -99,7 +99,7 @@ fn signature_other_message() {
     // Witness membership/path/index match (merkle_tree_commitment, message1),
     // but signature is from (merkle_tree_commitment, message0).
     let mut witness = Vec::with_capacity(witness1.len());
-    for (w1, w0) in witness1.into_iter().zip(witness0.into_iter()) {
+    for (w1, w0) in witness1.into_iter().zip(witness0) {
         witness.push(CircuitWitnessEntry {
             leaf: w1.leaf,
             merkle_path: w1.merkle_path,


### PR DESCRIPTION
## Content

This PR fix preemptively clippy lint added or updated with `rust 1.95`.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
  - [x] No new TODOs introduced