### PR TITLE
fix: e2e compatibility rules for Cardano `10.7`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4350,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.4.129"
+version = "0.4.130"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.4.129"
+version = "0.4.130"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/backward-compatibility.md
+++ b/mithril-test-lab/mithril-end-to-end/backward-compatibility.md
@@ -64,6 +64,7 @@ format is:
 - **below `0.7.91` (next to 2543.1) with signer `0.2.277` (next to 2543.1) and up**: new `/protocol-configuration/{epoch}`aggregator
   route to update network parameters (required by signer`0.2.277` and up)
 - **below `0.7.55` (2524.0) with cardano-node version `10.4.1` and up**: support of UTxO-HD was added only on aggregator `0.7.55` and up
+- **below `0.8.46` (next to 2543.1) with cardano-node version `10.7.0` and up**: changes in the UTxO-HD ledger state snapshot format
 
 ### Mithril signer
 

--- a/mithril-test-lab/mithril-end-to-end/src/utils/compatibility_checker.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/compatibility_checker.rs
@@ -28,6 +28,11 @@ impl Default for CompatibilityChecker {
                 "mithril-signer", min_supported_version: semver::Version::new(0, 2, 221),
                 context: "older signers raise errors when an aggregator propagate a signed entity types that they don't know (i.e. CardanoDatabase signed entity type)"
             ),
+            incompatibility_rule!(
+                "mithril-aggregator", below_version: semver::Version::new(0, 8, 46),
+                is_incompatible_with: "cardano-node", starting_version: semver::Version::new(10, 7, 0),
+                context: "older aggregator doesn't support new UTxO-HD ledger state snapshot format"
+            ),
         ])
     }
 }


### PR DESCRIPTION
## Content

This PR includes a **fix to the compatibility rules of the end to end tests for the aggregator with Cardano `10.7`**.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2894 
