### PR TITLE
chore: make signer stable with `1.0.0` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ As a minor extension, we have adopted a slightly different versioning convention
 
 ## Mithril Distribution [XXXX] - UNRELEASED
 
+- **STABLE**: the Mithril signer has reached its first stable version `1.0.0` and is now officially production-ready on the `release-mainnet` network.
+
 - Support for `Cardano node` `10.6.2` in the signer and the aggregator.
 
 - Support for `Cardano node` `10.7.1` in the signer, aggregator and client.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4532,7 +4532,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "0.3.33"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "0.3.33"
+version = "1.0.0"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Content

This PR makes the **Mithril signer reach its first stable version `1.0.0`. It is now officially production-ready on the `release-mainnet` network**.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2967 
