### PR TITLE
fix: conversion of ledger state snapshot to LSM flavour

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.13.8"
+version = "0.13.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.13.8"
+version = "0.13.9"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/tools/utxo_hd/snapshot_converter.rs
+++ b/mithril-client-cli/src/commands/tools/utxo_hd/snapshot_converter.rs
@@ -178,14 +178,6 @@ fn build_command_from_10_7(
     if cfg.utxo_hd_flavor == UTxOHDFlavor::Lsm {
         let output_database_path =
             output_path.parent().unwrap_or(output_path).join(LSM_DATABASE_DIR);
-        if !output_database_path.exists() {
-            create_dir(&output_database_path).with_context(|| {
-                format!(
-                    "Failed to create output LSM database directory: {}",
-                    output_database_path.display()
-                )
-            })?;
-        }
         command
             .arg("--output-lsm-snapshot")
             .arg(output_path)


### PR DESCRIPTION
## Content

This PR includes a **fix on the client CLI snapshot conversion for LSM UTxO-HD flavor which created an unnecessary LSM database folder**. This resulted on the command being stuck asking for user confirmation to overwrite the folder.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #2894 
