### PR TITLE
ci/test: multi speed tiers for tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -6,6 +6,8 @@
 failure-output = "immediate-final"
 # Do not cancel the test run on the first failure.
 fail-fast = false
+# Report test as "slow" if they take more than 30s to run
+slow-timeout = "30s"
 
 [profile.ci.junit]
 path = "tests-result.junit.xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,9 @@ jobs:
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-slow-tests') }}" == "true" ]]; then
             FILTERSET="$(.github/workflows/scripts/filter-slow-tests.sh --all)"
           else
+            # For pull-request HEAD^1 targets the "simulated merge commit" created by GitHub Actions.
+            # For push (i.e. merging on main branch), HEAD^1 refers be an actual, not simulated, merge commit.
+            # Note: this approach does not correctly detect changes when multiple commits are pushed directly to the main branch at once.
             FILTERSET="$(.github/workflows/scripts/filter-slow-tests.sh --commit-ref "HEAD^1")"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 2 # Needed to get the diff of the last commit, which is used to filter out slow tests
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -235,11 +237,20 @@ jobs:
           cargo-tools: cargo-nextest
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - id: prepare
+        name: Prepare
+        shell: bash
+        run: |
+          FILTERSET="$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh --commit-ref "HEAD^1")"
+
+          echo "Tests filterset: $FILTERSET"
+          echo "filterset=$FILTERSET" >> $GITHUB_OUTPUT
+
       - name: Build tests
         run: cargo nextest run --cargo-profile ci-tests --no-run ${{ matrix.test-args }}
 
       - name: Run tests
-        run: cargo nextest run --profile ci --cargo-profile ci-tests ${{ matrix.test-args }}
+        run: cargo nextest run --profile ci --cargo-profile ci-tests --filterset "${{ steps.prepare.outputs.filterset }}" ${{ matrix.test-args }}
 
       - name: Run doc tests
         run: cargo test --profile ci-tests --doc ${{ matrix.test-args }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,9 +243,9 @@ jobs:
         run: |
           # Run all tests, including slow tests, if "run-slow-tests" label is in the PR labels
           if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-slow-tests') }}" == "true" ]]; then
-            FILTERSET="$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh --all)"
+            FILTERSET="$(.github/workflows/scripts/filter-slow-tests.sh --all)"
           else
-            FILTERSET="$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh --commit-ref "HEAD^1")"
+            FILTERSET="$(.github/workflows/scripts/filter-slow-tests.sh --commit-ref "HEAD^1")"
           fi
 
           echo "Tests filterset: $FILTERSET"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,12 @@ jobs:
         name: Prepare
         shell: bash
         run: |
-          FILTERSET="$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh --commit-ref "HEAD^1")"
+          # Run all tests, including slow tests, if "run-slow-tests" label is in the PR labels
+          if [[ "${{ contains(github.event.pull_request.labels.*.name, 'run-slow-tests') }}" == "true" ]]; then
+            FILTERSET="$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh --all)"
+          else
+            FILTERSET="$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh --commit-ref "HEAD^1")"
+          fi
 
           echo "Tests filterset: $FILTERSET"
           echo "filterset=$FILTERSET" >> $GITHUB_OUTPUT

--- a/.github/workflows/scripts/filter-slow-tests.sh
+++ b/.github/workflows/scripts/filter-slow-tests.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# ---------- Filter Slow tests - Cargo nextest filterset generator ----------
+#
+# See associated documentation in the `filter-slow-tests` DevBook
+#
+# ---------------------------------------------------------------------------
 set +a -eu -o pipefail
 
 if [[ "${TRACE-0}" == "1" ]]; then set -o xtrace; fi

--- a/.github/workflows/scripts/filter-slow-tests.sh
+++ b/.github/workflows/scripts/filter-slow-tests.sh
@@ -4,6 +4,7 @@
 #
 # See associated documentation in the `filter-slow-tests` DevBook
 #
+# **IMPORTANT** To run against GitHub Actions macOS runners, this script *must* be compatible with bash `3.2`
 # ---------------------------------------------------------------------------
 set +a -eu -o pipefail
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,7 +4313,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.6.67"
+version = "0.6.68"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4595,7 +4595,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/DEV-ADR.md
+++ b/DEV-ADR.md
@@ -23,6 +23,94 @@ To complete
 To complete
 -->
 
+### 8. Running slow tests on CI conditionally
+
+**Date:** 2025-04-23
+**Status:** Accepted
+
+#### Context
+
+Some tests are inherently too slow to run on every CI execution — typically because they rely on complex logic or
+cryptography that cannot be optimized further.
+This was significantly slowing down the CI pipeline, in some cases doubling the total test run time and hurting
+developer productivity.
+
+#### Decision
+
+##### 1. Identify slow tests
+
+A test **must** be categorized as "slow" if it **consistently** takes more than **30 seconds** to run on CI.
+
+Because run times can vary significantly based on environmental conditions (e.g. machine performance or load),
+developers **may** also categorize a test as "slow" at their discretion if it takes more than **15 seconds** on their local
+machine.
+
+The CI should automatically flag tests exceeding the 30-second threshold using tools such as cargo
+nextest [slow test output](https://nexte.st/docs/features/slow-tests/#slow-tests), so that slow tests can be identified
+and categorized.
+
+##### 2. Marking tests as "slow"
+
+To mark a test as "slow":
+
+1. Move it into a dedicated `slow` submodule, placed at the end of the `tests` module:
+
+```rust
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn normal_test() { }
+
+    mod slow {
+        use super::*;
+
+        #[test]
+        fn heavy_test() {
+            // heavy test logic
+        }
+    }
+}
+```
+
+2. If the slow test belongs to a package not yet listed in [`filter-slow-tests.sh`](./docs/devbook/filter-slow-tests/filter-slow-tests.sh),
+   or if its source path is not already covered by an existing entry, update the script's slow test entries accordingly.
+   See the script's [README.md](./docs/devbook/filter-slow-tests/README.md) for more details.
+
+> [!CAUTION]
+> If a test is moved to a `slow` submodule but the script is not updated, **it will never run on CI**.
+
+##### 3. Running slow tests selectively
+
+Both developers and CI should run slow tests only when a related source path has changed or when explicitly requested.
+
+Use the [`filter-slow-tests.sh`](./docs/devbook/filter-slow-tests/filter-slow-tests.sh) script to generate a
+`cargo nextest` filter expression that selectively includes slow tests based on which source paths have changed.
+
+The CI must run this script automatically to keep total test run times low.
+
+The CI must also allow developers to explicitly request a full test run, regardless of which source paths have changed,
+via the `run-slow-tests` Pull Request label.
+
+#### Consequences
+
+- Faster testing feedback loop for developers
+- Faster CI runs in the common case
+- Developers can easily skip slow tests in local runs:
+  - For `cargo test`: `cargo test -- --skip slow::`
+  - For `cargo nextest`: `cargo nextest run -E "not test(#*slow::*)"`
+- Developers can run only slow tests when needed
+
+```shell
+cargo nextest run --workspace --profile ci -E "$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh)"
+```
+
+- [`filter-slow-tests.sh`](./docs/devbook/filter-slow-tests/filter-slow-tests.sh) becomes a maintenance dependency.
+  Stale or missing entries will silently cause slow tests to be excluded from CI runs. Entries should be reviewed
+  whenever a slow test is added, renamed, or moved.
+- Marking a test as "slow" and keeping the script in sync introduces a small but ongoing maintenance overhead.
+
+---
+
 ### 7. Do not expose arithmetic wrapper types to WebAssembly
 
 **Date:** 2025-04-15

--- a/DEV-ADR.md
+++ b/DEV-ADR.md
@@ -72,7 +72,7 @@ mod tests {
 }
 ```
 
-2. If the slow test belongs to a package not yet listed in [`filter-slow-tests.sh`](./docs/devbook/filter-slow-tests/filter-slow-tests.sh),
+2. If the slow test belongs to a package not yet listed in [`filter-slow-tests.sh`](.github/workflows/scripts/filter-slow-tests.sh),
    or if its source path is not already covered by an existing entry, update the script's slow test entries accordingly.
    See the script's [README.md](./docs/devbook/filter-slow-tests/README.md) for more details.
 
@@ -83,7 +83,7 @@ mod tests {
 
 Both developers and CI should run slow tests only when a related source path has changed or when explicitly requested.
 
-Use the [`filter-slow-tests.sh`](./docs/devbook/filter-slow-tests/filter-slow-tests.sh) script to generate a
+Use the [`filter-slow-tests.sh`](.github/workflows/scripts/filter-slow-tests.sh) script to generate a
 `cargo nextest` filter expression that selectively includes slow tests based on which source paths have changed.
 
 The CI must run this script automatically to keep total test run times low.
@@ -101,10 +101,10 @@ via the `run-slow-tests` Pull Request label.
 - Developers can run only slow tests when needed
 
 ```shell
-cargo nextest run --workspace --profile ci -E "$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh)"
+cargo nextest run --workspace --profile ci -E "$(.github/workflows/scripts/filter-slow-tests.sh)"
 ```
 
-- [`filter-slow-tests.sh`](./docs/devbook/filter-slow-tests/filter-slow-tests.sh) becomes a maintenance dependency.
+- [`filter-slow-tests.sh`](.github/workflows/scripts/filter-slow-tests.sh) becomes a maintenance dependency.
   Stale or missing entries will silently cause slow tests to be excluded from CI runs. Entries should be reviewed
   whenever a slow test is added, renamed, or moved.
 - Marking a test as "slow" and keeping the script in sync introduces a small but ongoing maintenance overhead.

--- a/docs/devbook/README.md
+++ b/docs/devbook/README.md
@@ -4,8 +4,8 @@ This page gathers the available guides and tools for Mithril nodes developers.
 
 # Guides
 
-| Operation                               | Location                                                                       | Description                                                                                            |
-| --------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
-| **Bump versions**                       | [bump-versions](bump-versions/README.md)                                       | Script to easily bump crates, js packages, and openapi versions before merging a pull request          |
-| **Filter slow tests**                   | [filter-slow-tests](filter-slow-tests/README.md)                               | Script that generates a `cargo nextest` filterset that excludes slow tests with unchanged dependencies |
-| **Upgrade the repository dependencies** | [upgrade-repository-dependencies](./upgrade-repository-dependencies/README.md) | Upgrade the project's dependencies in the repository                                                   |
+| Operation                               | Location                                                                       | Description                                                                                         |
+| --------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
+| **Bump versions**                       | [bump-versions](bump-versions/README.md)                                       | Script to easily bump crates, js packages, and openapi versions before merging a pull request       |
+| **Filter slow tests**                   | [filter-slow-tests](filter-slow-tests/README.md)                               | Script to generate a `cargo nextest` filterset that excludes slow tests with unchanged dependencies |
+| **Upgrade the repository dependencies** | [upgrade-repository-dependencies](./upgrade-repository-dependencies/README.md) | Upgrade the project's dependencies in the repository                                                |

--- a/docs/devbook/README.md
+++ b/docs/devbook/README.md
@@ -4,7 +4,8 @@ This page gathers the available guides and tools for Mithril nodes developers.
 
 # Guides
 
-| Operation                               | Location                                                                       | Description                                                                                   |
-| --------------------------------------- | ------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| **Bump versions**                       | [bump-versions](bump-versions/README.md)                                       | Script to easily bump crates, js packages, and openapi versions before merging a pull request |
-| **Upgrade the repository dependencies** | [upgrade-repository-dependencies](./upgrade-repository-dependencies/README.md) | Upgrade the project's dependencies in the repository                                          |
+| Operation                               | Location                                                                       | Description                                                                                            |
+| --------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------ |
+| **Bump versions**                       | [bump-versions](bump-versions/README.md)                                       | Script to easily bump crates, js packages, and openapi versions before merging a pull request          |
+| **Filter slow tests**                   | [filter-slow-tests](filter-slow-tests/README.md)                               | Script that generates a `cargo nextest` filterset that excludes slow tests with unchanged dependencies |
+| **Upgrade the repository dependencies** | [upgrade-repository-dependencies](./upgrade-repository-dependencies/README.md) | Upgrade the project's dependencies in the repository                                                   |

--- a/docs/devbook/filter-slow-tests/README.md
+++ b/docs/devbook/filter-slow-tests/README.md
@@ -1,0 +1,84 @@
+# Generate a `cargo nextest` filterset that excludes slow tests with unchanged dependencies
+
+> [!IMPORTANT]
+> This script must be compatible with bash `3.2` as it will run on GitHub Actions macOS runners.
+
+## Introduction
+
+This devbook provides a script that generates a `cargo nextest` filterset that excludes all slow tests unless
+a related source path has been changed compared to a base branch or commit (`origin/main` by default).
+
+## Usage
+
+Just run the script without argument.
+
+For example, if there's no change in the source code compared to the base branch or commit:
+
+```shell
+$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh
+not test(#*slow::*)
+```
+
+For example, if there are some changes in the source code compared to the base branch or commit:
+
+```shell
+$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh
+not test(#*slow::*) or (package(mithril-stm) and (test(#protocol::aggregate_signature::*slow::*) or test(#circuits::halo2::*slow::*)))
+```
+
+If you want to change the base branch or commit, use the `-c` or `--commit-ref` option:
+
+```shell
+$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh -c HEAD~2
+not test(#*slow::*) or (package(mithril-stm) and (test(#protocol::aggregate_signature::*slow::*)))
+```
+
+If you want to include all tests, regardless of the source code changes, use the `-a` or `--all` option:
+
+> [!NOTE]
+> This is useful if there's an external flag available that forces to run all tests (e.g., a PR label)
+
+```shell
+$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh --all
+all()
+```
+
+Full usage, together with cargo nextest:
+
+```shell
+$ cargo nextest list --workspace --profile ci -E "$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh)"
+```
+
+## Updating the filterset
+
+First, find the `SLOW_{RUST_PACKAGE}_TESTS` variable in the `filter-slow-tests.sh` script.
+
+If it exists for your Rust package, update the list of slow tests with the new ones, following the format:
+
+`path/that/trigger/tests/inclusion#rust::module::path::`
+
+> [!NOTE]
+> A file path can be used multiple times.
+
+If it doesn't exist, first define in the `Slow tests entries`, following this template:
+
+```shell
+readonly -a SLOW_MY_PACKAGE_TESTS=(
+"my-package/src/code/path#rust::module::path::"
+)
+```
+
+Then integrate it in the `main` function (around other filtersets usage):
+
+```shell
+FILTERSET_MY_PACKAGE="$(generate_nextest_allowed_slow_filterset "$CHANGED_FILES" "${SLOW_MY_PACKAGE_TESTS[@]}")"
+OUTPUT="$(append_output "$OUTPUT" "my-package" "$FILTERSET_MY_PACKAGE")"
+```
+
+> [!IMPORTANT]
+> Make sure to test the filterset with `cargo nextest list -E "$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh)"` before committing the changes.
+
+> [!TIP]
+> For your filterset to be triggered, you may have to introduce a change in the source code, such as a temporary line break.
+>
+> You don't even need to commit the change.

--- a/docs/devbook/filter-slow-tests/README.md
+++ b/docs/devbook/filter-slow-tests/README.md
@@ -3,10 +3,16 @@
 > [!IMPORTANT]
 > This script must be compatible with bash `3.2` as it will run on GitHub Actions macOS runners.
 
+> [!NOTE]
+> All paths are relative to the root of the repository.
+
 ## Introduction
 
-This devbook provides a script that generates a `cargo nextest` filterset that excludes all slow tests unless
-a related source path has been changed compared to a base branch or commit (`origin/main` by default).
+This is a devbook about the [`.github/workflows/scripts/filter-slow-tests.sh`](../../../.github/workflows/scripts/filter-slow-tests.sh)
+script.
+
+This script allows generating a `cargo nextest` filterset that excludes all known slow tests unless a related source
+path has been changed compared to a base branch or commit (`origin/main` by default).
 
 ## Usage
 
@@ -15,21 +21,21 @@ Just run the script without argument.
 For example, if there's no change in the source code compared to the base branch or commit:
 
 ```shell
-$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh
+$ .github/workflows/scripts/filter-slow-tests.sh
 not test(#*slow::*)
 ```
 
 For example, if there are some changes in the source code compared to the base branch or commit:
 
 ```shell
-$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh
+$ .github/workflows/scripts/filter-slow-tests.sh
 not test(#*slow::*) or (package(mithril-stm) and (test(#protocol::aggregate_signature::*slow::*) or test(#circuits::halo2::*slow::*)))
 ```
 
 If you want to change the base branch or commit, use the `-c` or `--commit-ref` option:
 
 ```shell
-$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh -c HEAD~2
+$ .github/workflows/scripts/filter-slow-tests.sh -c HEAD~2
 not test(#*slow::*) or (package(mithril-stm) and (test(#protocol::aggregate_signature::*slow::*)))
 ```
 
@@ -39,19 +45,19 @@ If you want to include all tests, regardless of the source code changes, use the
 > This is useful if there's an external flag available that forces to run all tests (e.g., a PR label)
 
 ```shell
-$ ./docs/devbook/filter-slow-tests/filter-slow-tests.sh --all
+$ .github/workflows/scripts/filter-slow-tests.sh --all
 all()
 ```
 
 Full usage, together with cargo nextest:
 
 ```shell
-$ cargo nextest list --workspace --profile ci -E "$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh)"
+$ cargo nextest list --workspace --profile ci -E "$(.github/workflows/scripts/filter-slow-tests.sh)"
 ```
 
 ## Updating the filterset
 
-First, find the `SLOW_{RUST_PACKAGE}_TESTS` variable in the `filter-slow-tests.sh` script.
+First, find the `SLOW_{RUST_PACKAGE}_TESTS` variable in the [`filter-slow-tests.sh`](../../../.github/workflows/scripts/filter-slow-tests.sh) script.
 
 If it exists for your Rust package, update the list of slow tests with the new ones, following the format:
 
@@ -76,7 +82,8 @@ OUTPUT="$(append_output "$OUTPUT" "my-package" "$FILTERSET_MY_PACKAGE")"
 ```
 
 > [!IMPORTANT]
-> Make sure to test the filterset with `cargo nextest list -E "$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh)"` before committing the changes.
+> Make sure to test the filterset with `cargo nextest list -E "$(.github/workflows/scripts/filter-slow-tests.sh)"`
+> before committing the changes.
 
 > [!TIP]
 > For your filterset to be triggered, you may have to introduce a change in the source code, such as a temporary line break.

--- a/docs/devbook/filter-slow-tests/README.md
+++ b/docs/devbook/filter-slow-tests/README.md
@@ -1,8 +1,5 @@
 # Generate a `cargo nextest` filterset that excludes slow tests with unchanged dependencies
 
-> [!IMPORTANT]
-> This script must be compatible with bash `3.2` as it will run on GitHub Actions macOS runners.
-
 > [!NOTE]
 > All paths are relative to the root of the repository.
 

--- a/docs/devbook/filter-slow-tests/filter-slow-tests.sh
+++ b/docs/devbook/filter-slow-tests/filter-slow-tests.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set +a -eu -o pipefail
+
+if [[ "${TRACE-0}" == "1" ]]; then set -o xtrace; fi
+
+display_help() {
+    echo "Generate a cargo-nextest filterset that excludes slow tests unless a related source path"
+    echo "has been changed compared to a base branch."
+    echo
+    echo "Usage: $0 [OPTIONS]"
+    echo
+    echo "Options:"
+    echo "  -a, --all                  allow all tests regardless of changes from the base branch"
+    echo "  -c, --commit-ref <commit>  commit from which changes will be identified (default: origin/main)"
+    echo "  -h, --help                 Print this help"
+    echo
+    exit 0
+}
+
+# Build the nextest 'or'-joined filter fragment for slow tests whose source
+# paths appear in the list of changed files.
+#
+# Arguments:
+#   $1 - newline-separated list of changed file paths (plain string)
+#   $2..N - slow-test entries of the form "path/from/repo/root#full::rust::module::path::"
+generate_nextest_allowed_slow_filterset() {
+  local -r changed_files="$1"
+  shift
+
+  local filterset=""
+
+  for entry in "$@"; do
+      local watch_path="${entry%%#*}"
+      local module_prefix="${entry##*#}"
+
+      if echo "$changed_files" | grep -q "${watch_path}"; then
+          # Uses glob notation from the nextest filterset DSL
+          local fragment="test(#${module_prefix}*slow::*)"
+
+          if [[ -z "$filterset" ]]; then
+            filterset="$fragment"
+          else
+            filterset="$filterset or $fragment"
+          fi
+      fi
+  done
+
+  echo "$filterset"
+}
+
+append_output() {
+  local string_to_append="$1"
+  local -r rust_package="$2"
+  local -r generated_filterset="$3"
+
+  if [[ -n "$generated_filterset" ]]; then
+    string_to_append="$string_to_append or (package($rust_package) and ($generated_filterset))"
+  fi
+
+  echo "$string_to_append"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+declare COMMIT_REF="" ALLOW_ALL=false
+while [[ "${1:-}" == -* && ! "${1:-}" == "--" ]]; do case "$1" in
+      -h | --help ) display_help ;;
+      -a | --all ) ALLOW_ALL=true ;;
+      -c | --commit-ref ) shift; COMMIT_REF=${1:-} ;;
+    esac
+    shift
+done
+readonly COMMIT_REF=${COMMIT_REF:-"origin/main"} ALLOW_ALL
+
+# ---------------------------------------------------------------------------
+# Slow tests entries
+#
+# Format: "path/from/repo/root#rust::module::path::" (A path can be referenced multiple times)
+# ---------------------------------------------------------------------------
+
+readonly -a SLOW_MITHRIL_STM_TESTS=(
+  "mithril-stm/src/#protocol::aggregate_signature::"
+  "mithril-stm/src/circuits/halo2#circuits::halo2::"
+  "mithril-stm/src/membership_commitment/merkle_tree#membership_commitment::merkle_tree::"
+  "mithril-stm/src/proof_system/halo2_snark#proof_system::halo2_snark::"
+  "mithril-stm/src/signature_scheme/bls_multi_signature#signature_scheme::bls_multi_signature::"
+)
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+if $ALLOW_ALL; then
+  echo "all()"
+else
+  OUTPUT="not test(#*slow::*)"
+
+  # Newline-separated list of files changed since the base commit
+  readonly CHANGED_FILES="$(git diff --name-only "$COMMIT_REF")"
+
+  FILTERSET_STM="$(generate_nextest_allowed_slow_filterset "$CHANGED_FILES" "${SLOW_MITHRIL_STM_TESTS[@]}")"
+  OUTPUT="$(append_output "$OUTPUT" "mithril-stm" "$FILTERSET_STM")"
+
+  echo "$OUTPUT"
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -196,6 +196,7 @@
             // lib.optionalAttrs (cargoToml != null) rec {
               inherit (craneLib.crateNameFromCargoToml {inherit cargoToml;}) pname version;
               cargoExtraArgs = "-p ${pname}";
+              cargoTestExtraArgs = "-- --skip slow::";
             }
             // {
               cargoArtifacts = buildDeps craneLib commonsArgs cargoToml baseCargoArtifacts;
@@ -210,6 +211,7 @@
             // lib.optionalAttrs (cargoToml != null) rec {
               inherit (craneLibMusl.crateNameFromCargoToml {inherit cargoToml;}) pname version;
               cargoExtraArgs = "-p ${pname}";
+              cargoTestExtraArgs = "-- --skip slow::";
             }
             // {
               cargoArtifacts = buildDeps craneLibMusl commonsArgsMusl cargoToml baseCargoArtifacts;
@@ -222,6 +224,7 @@
             // lib.optionalAttrs (cargoToml != null) rec {
               inherit (craneLibWindows.crateNameFromCargoToml {inherit cargoToml;}) pname version;
               cargoExtraArgs = "-p ${pname}";
+              cargoTestExtraArgs = "-- --skip slow::";
             }
             // {
               cargoArtifacts = buildDeps craneLibWindows commonsArgsWindows cargoToml baseCargoArtifacts;

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.6.67"
+version = "0.6.68"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -270,8 +270,8 @@ impl<'a> CertificateChainBuilder<'a> {
             total_signers_per_epoch_processor: &|epoch| min(2 + *epoch as usize, 5),
             genesis_certificate_processor: &|certificate, _, _| certificate,
             standard_certificate_processor: &|certificate, _| certificate,
-            certificate_chaining_method: Default::default(),
-            aggregate_signature_type: Default::default(),
+            certificate_chaining_method: CertificateChainingMethod::default(),
+            aggregate_signature_type: AggregateSignatureType::default(),
             mithril_era: *SupportedEra::eras().first().unwrap(),
         }
     }
@@ -657,7 +657,7 @@ mod test {
             .with_certificates_per_epoch(certificates_per_epoch)
             .build_epochs_sequence()
             .map(|epoch| *epoch)
-            .collect::<Vec<_>>()
+            .collect()
     }
 
     fn build_certificate_index_and_epoch_numbers_sequence(
@@ -669,7 +669,7 @@ mod test {
             .with_certificates_per_epoch(certificates_per_epoch)
             .build_certificate_index_and_epoch_sequence()
             .map(|(certificate_index, epoch)| (certificate_index, *epoch))
-            .collect::<Vec<_>>()
+            .collect()
     }
 
     fn build_epoch_numbers_sequence_in_certificate_chain(
@@ -682,19 +682,7 @@ mod test {
         )
         .iter()
         .map(|(_certificate_index, epoch)| *epoch)
-        .collect::<Vec<_>>()
-    }
-
-    fn build_certificate_chain(
-        total_certificates: u64,
-        certificates_per_epoch: u64,
-    ) -> Vec<Certificate> {
-        let certificate_chain_fixture = CertificateChainBuilder::default()
-            .with_total_certificates(total_certificates)
-            .with_certificates_per_epoch(certificates_per_epoch)
-            .build();
-
-        certificate_chain_fixture.certificates_chained
+        .collect()
     }
 
     #[test]
@@ -773,20 +761,48 @@ mod test {
     }
 
     #[test]
-    fn builds_certificate_chain_with_correct_length() {
-        assert_eq!(4, build_certificate_chain(4, 1).len());
-        assert_eq!(4, build_certificate_chain(4, 2).len());
-        assert_eq!(4, build_certificate_chain(4, 3).len());
-        assert_eq!(4, build_certificate_chain(4, 4).len());
-        assert_eq!(5, build_certificate_chain(5, 1).len());
-        assert_eq!(5, build_certificate_chain(5, 2).len());
-        assert_eq!(5, build_certificate_chain(5, 3).len());
-        assert_eq!(7, build_certificate_chain(7, 3).len());
-        assert_eq!(15, build_certificate_chain(15, 3).len());
+    fn built_chain_sequence_always_contains_exactly_the_requested_number_of_certificates() {
+        assert_eq!(
+            4,
+            build_certificate_index_and_epoch_numbers_sequence(4, 1).len()
+        );
+        assert_eq!(
+            4,
+            build_certificate_index_and_epoch_numbers_sequence(4, 2).len()
+        );
+        assert_eq!(
+            4,
+            build_certificate_index_and_epoch_numbers_sequence(4, 3).len()
+        );
+        assert_eq!(
+            4,
+            build_certificate_index_and_epoch_numbers_sequence(4, 4).len()
+        );
+        assert_eq!(
+            5,
+            build_certificate_index_and_epoch_numbers_sequence(5, 1).len()
+        );
+        assert_eq!(
+            5,
+            build_certificate_index_and_epoch_numbers_sequence(5, 2).len()
+        );
+        assert_eq!(
+            5,
+            build_certificate_index_and_epoch_numbers_sequence(5, 3).len()
+        );
+        assert_eq!(
+            7,
+            build_certificate_index_and_epoch_numbers_sequence(7, 3).len()
+        );
+        assert_eq!(
+            15,
+            build_certificate_index_and_epoch_numbers_sequence(15, 3).len()
+        );
     }
 
     #[test]
-    fn builds_valid_epochs_sequence() {
+    fn epoch_sequence_includes_two_extra_epochs_one_for_the_genesis_certificate_and_one_for_last_next_avk_computation()
+     {
         assert_eq!(vec![1, 2, 3, 4], build_epoch_numbers_sequence(3, 1));
         assert_eq!(vec![1, 2, 3, 4], build_epoch_numbers_sequence(4, 2));
         assert_eq!(vec![1, 2, 3, 4], build_epoch_numbers_sequence(5, 2));
@@ -798,7 +814,7 @@ mod test {
     }
 
     #[test]
-    fn builds_valid_certificate_index_and_epoch_numbers_sequence() {
+    fn certificates_in_chain_are_grouped_under_the_right_epoch() {
         assert_eq!(
             vec![1, 2, 3],
             build_epoch_numbers_sequence_in_certificate_chain(3, 1)
@@ -823,14 +839,13 @@ mod test {
 
     #[test]
     #[should_panic]
-    fn panics_building_invalid_epochs_sequence_no_certificates_per_epoch() {
+    fn epoch_sequence_panics_when_certificates_per_epoch_is_zero() {
         build_epoch_numbers_sequence(3, 0);
     }
 
     #[test]
     #[should_panic]
-    fn panics_building_invalid_epochs_sequence_less_total_certificates_than_certificates_per_epoch()
-    {
+    fn epoch_sequence_panics_when_certificates_per_epoch_exceeds_total_certificates() {
         build_epoch_numbers_sequence(3, 5);
     }
 
@@ -962,7 +977,7 @@ mod test {
     }
 
     #[test]
-    fn builds_certificate_chain_chained_by_default_to_master_certificates() {
+    fn master_chaining_links_each_certificate_to_the_first_certificate_of_its_epoch() {
         fn create_fake_certificate(epoch: Epoch, index_in_epoch: u64) -> Certificate {
             Certificate {
                 epoch,
@@ -1020,7 +1035,7 @@ mod test {
     }
 
     #[test]
-    fn builds_certificate_chain_chained_sequentially() {
+    fn sequential_chaining_links_each_certificate_to_its_immediate_predecessor() {
         fn create_fake_certificate(epoch: Epoch, index_in_epoch: u64) -> Certificate {
             Certificate {
                 epoch,
@@ -1127,24 +1142,24 @@ mod test {
         use super::*;
 
         #[test]
-        fn get_genesis_certificate() {
+        fn genesis_certificate_is_always_the_last_element_of_the_chain() {
             let chain_with_only_a_genesis =
                 CertificateChainBuilder::new().with_total_certificates(1).build();
             assert!(chain_with_only_a_genesis.genesis_certificate().is_genesis());
 
             let chain_with_multiple_certificates =
-                CertificateChainBuilder::new().with_total_certificates(10).build();
+                CertificateChainBuilder::new().with_total_certificates(3).build();
             assert!(chain_with_multiple_certificates.genesis_certificate().is_genesis());
         }
 
         #[test]
-        fn get_latest_certificate() {
+        fn latest_certificate_is_the_first_element_of_the_chain() {
             let chain_with_only_a_genesis =
                 CertificateChainBuilder::new().with_total_certificates(1).build();
             assert!(chain_with_only_a_genesis.latest_certificate().is_genesis());
 
             let chain_with_multiple_certificates =
-                CertificateChainBuilder::new().with_total_certificates(10).build();
+                CertificateChainBuilder::new().with_total_certificates(3).build();
             assert_eq!(
                 chain_with_multiple_certificates.latest_certificate(),
                 chain_with_multiple_certificates.first().unwrap()
@@ -1152,7 +1167,7 @@ mod test {
         }
 
         #[test]
-        fn path_to_genesis_from_a_chain_with_one_certificate_per_epoch() {
+        fn path_to_genesis_traverses_the_full_chain_when_one_certificate_per_epoch() {
             let chain = CertificateChainBuilder::new()
                 .with_total_certificates(5)
                 .with_certificates_per_epoch(1)
@@ -1165,7 +1180,7 @@ mod test {
         }
 
         #[test]
-        fn path_to_genesis_from_a_chain_with_multiple_certificates_per_epoch() {
+        fn path_to_genesis_skips_sibling_certificates_of_the_same_epoch() {
             let chain = CertificateChainBuilder::new()
                 .with_total_certificates(9)
                 .with_certificates_per_epoch(3)
@@ -1180,7 +1195,7 @@ mod test {
         }
 
         #[test]
-        fn reversed_chain() {
+        fn reversed_chain_returns_certificates_from_genesis_to_latest() {
             let chain = CertificateChainBuilder::new()
                 .with_total_certificates(5)
                 .with_certificates_per_epoch(2)
@@ -1189,6 +1204,7 @@ mod test {
             let expected: Vec<Certificate> =
                 chain.certificates_chained.clone().into_iter().rev().collect();
             assert_eq!(chain.reversed_chain(), expected);
+            assert!(chain.reversed_chain()[0].is_genesis());
         }
     }
 }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.6"
+version = "0.10.7"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/Makefile
+++ b/mithril-stm/Makefile
@@ -16,6 +16,9 @@ debug:
 	@${CARGO} run -- -vvv $(call args,defaultstring)
 
 test:
+	${CARGO} test -- --skip slow::
+
+test-with-slow:
 	${CARGO} test
 
 check:

--- a/mithril-stm/src/circuits/halo2/tests/golden/cases/negative.rs
+++ b/mithril-stm/src/circuits/halo2/tests/golden/cases/negative.rs
@@ -39,557 +39,582 @@ fn m_exceeds_lottery_bit_bound() {
     ));
 }
 
-#[test]
-fn message_mismatch() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message0 = SignedMessageWithoutPrefix::from(42);
-    let message1 = SignedMessageWithoutPrefix::from(43);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("message_mismatch env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("message_mismatch tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let witness = build_witness(&merkle_tree, merkle_tree_commitment, message0, K)
-        .expect("message_mismatch witness build should succeed");
+mod slow {
+    use super::*;
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message1, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+    #[test]
+    fn message_mismatch() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message0 = SignedMessageWithoutPrefix::from(42);
+        let message1 = SignedMessageWithoutPrefix::from(43);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("message_mismatch env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("message_mismatch tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let witness = build_witness(&merkle_tree, merkle_tree_commitment, message0, K)
+            .expect("message_mismatch witness build should succeed");
 
-#[test]
-fn merkle_tree_commitment_mismatch() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("merkle_tree_commitment_mismatch env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("merkle_tree_commitment_mismatch tree creation should succeed");
-    let merkle_tree_commitment_0 = merkle_tree.merkle_tree_commitment();
-    let merkle_tree_commitment_1 = merkle_tree_commitment_0 + SignedMessageWithoutPrefix::ONE;
-    let witness = build_witness(&merkle_tree, merkle_tree_commitment_0, message, K)
-        .expect("merkle_tree_commitment_mismatch witness build should succeed");
-
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment_1, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
-
-#[test]
-fn signature_other_message() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message0 = SignedMessageWithoutPrefix::from(42);
-    let message1 = SignedMessageWithoutPrefix::from(43);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("signature_other_message env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("signature_other_message tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let witness0 =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message0, &indices)
-            .expect("signature_other_message witness0 build should succeed");
-    let witness1 =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message1, &indices)
-            .expect("signature_other_message witness1 build should succeed");
-
-    // Witness membership/path/index match (merkle_tree_commitment, message1),
-    // but signature is from (merkle_tree_commitment, message0).
-    let mut witness = Vec::with_capacity(witness1.len());
-    for (w1, w0) in witness1.into_iter().zip(witness0) {
-        witness.push(CircuitWitnessEntry {
-            leaf: w1.leaf,
-            merkle_path: w1.merkle_path,
-            unique_schnorr_signature: w0.unique_schnorr_signature,
-            lottery_index: w1.lottery_index,
-        });
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message1, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
     }
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message1, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+    #[test]
+    fn merkle_tree_commitment_mismatch() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("merkle_tree_commitment_mismatch env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("merkle_tree_commitment_mismatch tree creation should succeed");
+        let merkle_tree_commitment_0 = merkle_tree.merkle_tree_commitment();
+        let merkle_tree_commitment_1 = merkle_tree_commitment_0 + SignedMessageWithoutPrefix::ONE;
+        let witness = build_witness(&merkle_tree, merkle_tree_commitment_0, message, K)
+            .expect("merkle_tree_commitment_mismatch witness build should succeed");
 
-#[test]
-fn signature_verification_key_mismatch() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("signature_verification_key_mismatch env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("signature_verification_key_mismatch tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("signature_verification_key_mismatch witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment_1, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let (i, j) = find_two_distinct_witness_entries(&witness)
-        .expect("signature_verification_key_mismatch distinct entries should exist");
-    // Keep leaf/path/index from i, but replace signature with j's signature.
-    let sig_j = witness[j].unique_schnorr_signature;
-    witness[i].unique_schnorr_signature = sig_j;
+    #[test]
+    fn signature_other_message() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message0 = SignedMessageWithoutPrefix::from(42);
+        let message1 = SignedMessageWithoutPrefix::from(43);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("signature_other_message env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("signature_other_message tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let witness0 =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message0, &indices)
+                .expect("signature_other_message witness0 build should succeed");
+        let witness1 =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message1, &indices)
+                .expect("signature_other_message witness1 build should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        // Witness membership/path/index match (merkle_tree_commitment, message1),
+        // but signature is from (merkle_tree_commitment, message0).
+        let mut witness = Vec::with_capacity(witness1.len());
+        for (w1, w0) in witness1.into_iter().zip(witness0) {
+            witness.push(CircuitWitnessEntry {
+                leaf: w1.leaf,
+                merkle_path: w1.merkle_path,
+                unique_schnorr_signature: w0.unique_schnorr_signature,
+                lottery_index: w1.lottery_index,
+            });
+        }
 
-#[test]
-fn signature_bad_challenge() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("signature_bad_challenge env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("signature_bad_challenge tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("signature_bad_challenge witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message1, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    witness[0].unique_schnorr_signature.challenge =
-        witness[0].unique_schnorr_signature.challenge + BaseFieldElement::get_one();
+    #[test]
+    fn signature_verification_key_mismatch() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("signature_verification_key_mismatch env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("signature_verification_key_mismatch tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("signature_verification_key_mismatch witness build should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        let (i, j) = find_two_distinct_witness_entries(&witness)
+            .expect("signature_verification_key_mismatch distinct entries should exist");
+        // Keep leaf/path/index from i, but replace signature with j's signature.
+        let sig_j = witness[j].unique_schnorr_signature;
+        witness[i].unique_schnorr_signature = sig_j;
 
-#[test]
-fn signature_bad_response() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("signature_bad_response env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("signature_bad_response tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("signature_bad_response witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    witness[0].unique_schnorr_signature.response = witness[0].unique_schnorr_signature.response
-        - ScalarFieldElement::from_base_field(&BaseFieldElement::get_one())
-            .expect("signature_bad_response response scalar conversion should succeed");
+    #[test]
+    fn signature_bad_challenge() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("signature_bad_challenge env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("signature_bad_challenge tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("signature_bad_challenge witness build should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        witness[0].unique_schnorr_signature.challenge =
+            witness[0].unique_schnorr_signature.challenge + BaseFieldElement::get_one();
 
-#[test]
-fn signature_bad_commitment() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("signature_bad_commitment env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("signature_bad_commitment tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("signature_bad_commitment witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    witness[0].unique_schnorr_signature.commitment_point =
-        witness[1].unique_schnorr_signature.commitment_point;
+    #[test]
+    fn signature_bad_response() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("signature_bad_response env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("signature_bad_response tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("signature_bad_response witness build should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        witness[0].unique_schnorr_signature.response = witness[0].unique_schnorr_signature.response
+            - ScalarFieldElement::from_base_field(&BaseFieldElement::get_one())
+                .expect("signature_bad_response response scalar conversion should succeed");
 
-#[test]
-fn indices_not_increasing() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("indices_not_increasing env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("indices_not_increasing tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 14];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("indices_not_increasing witness build should succeed");
+    #[test]
+    fn signature_bad_commitment() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("signature_bad_commitment env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("signature_bad_commitment tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("signature_bad_commitment witness build should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        witness[0].unique_schnorr_signature.commitment_point =
+            witness[1].unique_schnorr_signature.commitment_point;
 
-#[test]
-fn index_out_of_bounds() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("index_out_of_bounds env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("index_out_of_bounds tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices = vec![6, 14, m as LotteryIndex];
-    let witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("index_out_of_bounds witness build should succeed");
+    #[test]
+    fn indices_not_increasing() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("indices_not_increasing env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("indices_not_increasing tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proving_backend_message_contains(
-        prove_and_verify_result(&env, scenario),
-        &format!(
-            "Circuit::validate_lottery_index failed: index ({}) must be lower than m ({m})",
-            m as LotteryIndex
-        ),
-    );
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 14];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("indices_not_increasing witness build should succeed");
 
-#[test]
-fn index_too_large_for_circuit_range() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("index_too_large_for_circuit_range env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("index_too_large_for_circuit_range tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let max_supported = ((1u64 << LOTTERY_BIT_BOUND) - 1) as LotteryIndex;
-    let too_large = max_supported + 1;
-    let indices = vec![6, 14, too_large];
-    let witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("index_too_large_for_circuit_range witness build should succeed");
+    #[test]
+    fn index_out_of_bounds() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("index_out_of_bounds env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("index_out_of_bounds tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proving_backend_message_contains(
-        prove_and_verify_result(&env, scenario),
-        &format!(
-            "Circuit::validate_lottery_index failed: index ({too_large}) exceeds max supported ({max_supported})",
-        ),
-    );
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices = vec![6, 14, m as LotteryIndex];
+        let witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("index_out_of_bounds witness build should succeed");
 
-#[test]
-fn merkle_path_corrupt_sibling() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("merkle_path_corrupt_sibling env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("merkle_path_corrupt_sibling tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proving_backend_message_contains(
+            prove_and_verify_result(&env, scenario),
+            &format!(
+                "Circuit::validate_lottery_index failed: index ({}) must be lower than m ({m})",
+                m as LotteryIndex
+            ),
+        );
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("merkle_path_corrupt_sibling witness build should succeed");
-    let d = 0usize;
-    assert!(!witness[0].merkle_path.siblings.is_empty());
-    assert!(d < witness[0].merkle_path.siblings.len());
-    witness[0].merkle_path.siblings[d].1 += SignedMessageWithoutPrefix::ONE;
+    #[test]
+    fn index_too_large_for_circuit_range() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("index_too_large_for_circuit_range env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("index_too_large_for_circuit_range tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let max_supported = ((1u64 << LOTTERY_BIT_BOUND) - 1) as LotteryIndex;
+        let too_large = max_supported + 1;
+        let indices = vec![6, 14, too_large];
+        let witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("index_too_large_for_circuit_range witness build should succeed");
 
-#[test]
-fn merkle_path_flip_position() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("merkle_path_flip_position env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("merkle_path_flip_position tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proving_backend_message_contains(
+            prove_and_verify_result(&env, scenario),
+            &format!(
+                "Circuit::validate_lottery_index failed: index ({too_large}) exceeds max supported ({max_supported})",
+            ),
+        );
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("merkle_path_flip_position witness build should succeed");
-    let d = 1usize;
-    assert!(d < witness[0].merkle_path.siblings.len());
-    witness[0].merkle_path.siblings[d].0 = match witness[0].merkle_path.siblings[d].0 {
-        Position::Left => Position::Right,
-        Position::Right => Position::Left,
-    };
+    #[test]
+    fn merkle_path_corrupt_sibling() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("merkle_path_corrupt_sibling env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("merkle_path_corrupt_sibling tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("merkle_path_corrupt_sibling witness build should succeed");
+        let d = 0usize;
+        assert!(!witness[0].merkle_path.siblings.is_empty());
+        assert!(d < witness[0].merkle_path.siblings.len());
+        witness[0].merkle_path.siblings[d].1 += SignedMessageWithoutPrefix::ONE;
 
-#[test]
-fn merkle_path_length_short() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("merkle_path_length_short env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("merkle_path_length_short tree creation should succeed");
-    let expected_depth = env.num_signers().next_power_of_two().trailing_zeros();
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("merkle_path_length_short witness build should succeed");
-    assert!(!witness[0].merkle_path.siblings.is_empty());
-    witness[0].merkle_path.siblings.pop();
+    #[test]
+    fn merkle_path_flip_position() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("merkle_path_flip_position env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("merkle_path_flip_position tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
-    assert_proving_backend_message_contains(
-        prove_and_verify_result(&env, scenario),
-        &format!(
-            "Circuit::validate_merkle_sibling_length failed: expected depth {expected_depth}, got {}",
-            expected_depth - 1
-        ),
-    );
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("merkle_path_flip_position witness build should succeed");
+        let d = 1usize;
+        assert!(d < witness[0].merkle_path.siblings.len());
+        witness[0].merkle_path.siblings[d].0 = match witness[0].merkle_path.siblings[d].0 {
+            Position::Left => Position::Right,
+            Position::Right => Position::Left,
+        };
 
-#[test]
-fn merkle_path_length_long() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("merkle_path_length_long env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("merkle_path_length_long tree creation should succeed");
-    let expected_depth = env.num_signers().next_power_of_two().trailing_zeros();
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("merkle_path_length_long witness build should succeed");
-    witness[0]
-        .merkle_path
-        .siblings
-        .push((Position::Left, SignedMessageWithoutPrefix::ZERO));
+    #[test]
+    fn merkle_path_length_short() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("merkle_path_length_short env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("merkle_path_length_short tree creation should succeed");
+        let expected_depth = env.num_signers().next_power_of_two().trailing_zeros();
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
-    assert_proving_backend_message_contains(
-        prove_and_verify_result(&env, scenario),
-        &format!(
-            "Circuit::validate_merkle_sibling_length failed: expected depth {expected_depth}, got {}",
-            expected_depth + 1
-        ),
-    );
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("merkle_path_length_short witness build should succeed");
+        assert!(!witness[0].merkle_path.siblings.is_empty());
+        witness[0].merkle_path.siblings.pop();
 
-#[test]
-fn leaf_swap_keep_merkle_path() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("leaf_swap_keep_merkle_path env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("leaf_swap_keep_merkle_path tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
+        assert_proving_backend_message_contains(
+            prove_and_verify_result(&env, scenario),
+            &format!(
+                "Circuit::validate_merkle_sibling_length failed: expected depth {expected_depth}, got {}",
+                expected_depth - 1
+            ),
+        );
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("leaf_swap_keep_merkle_path witness build should succeed");
-    let (i, j) = find_two_distinct_witness_entries(&witness)
-        .expect("leaf_swap_keep_merkle_path distinct entries should exist");
-    // Keep path/signature/index from i, but swap leaf with j.
-    witness[i].leaf = witness[j].leaf;
+    #[test]
+    fn merkle_path_length_long() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("merkle_path_length_long env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("merkle_path_length_long tree creation should succeed");
+        let expected_depth = env.num_signers().next_power_of_two().trailing_zeros();
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("merkle_path_length_long witness build should succeed");
+        witness[0]
+            .merkle_path
+            .siblings
+            .push((Position::Left, SignedMessageWithoutPrefix::ZERO));
 
-#[test]
-fn leaf_merkle_path_mismatch() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("leaf_merkle_path_mismatch env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("leaf_merkle_path_mismatch tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
+        assert_proving_backend_message_contains(
+            prove_and_verify_result(&env, scenario),
+            &format!(
+                "Circuit::validate_merkle_sibling_length failed: expected depth {expected_depth}, got {}",
+                expected_depth + 1
+            ),
+        );
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("leaf_merkle_path_mismatch witness build should succeed");
-    let (i, j) = find_two_distinct_witness_entries(&witness)
-        .expect("leaf_merkle_path_mismatch distinct entries should exist");
-    // Keep leaf/signature/index from i, but swap in j's Merkle path.
-    witness[i].merkle_path = witness[j].merkle_path.clone();
+    #[test]
+    fn leaf_swap_keep_merkle_path() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("leaf_swap_keep_merkle_path env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("leaf_swap_keep_merkle_path tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("leaf_swap_keep_merkle_path witness build should succeed");
+        let (i, j) = find_two_distinct_witness_entries(&witness)
+            .expect("leaf_swap_keep_merkle_path distinct entries should exist");
+        // Keep path/signature/index from i, but swap leaf with j.
+        witness[i].leaf = witness[j].leaf;
 
-#[test]
-fn leaf_wrong_verification_key() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("leaf_wrong_verification_key env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("leaf_wrong_verification_key tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("leaf_wrong_verification_key witness build should succeed");
-    let (i, j) = find_two_distinct_witness_entries(&witness)
-        .expect("leaf_wrong_verification_key distinct entries should exist");
-    // Keep lottery_target_value/path/signature/index from i, but swap in j's verification key.
-    let lottery_target_value = witness[i].leaf.lottery_target_value();
-    let verification_key = witness[j].leaf.verification_key();
-    witness[i].leaf = CircuitMerkleTreeLeaf(verification_key, lottery_target_value);
+    #[test]
+    fn leaf_merkle_path_mismatch() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("leaf_merkle_path_mismatch env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("leaf_merkle_path_mismatch tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("leaf_merkle_path_mismatch witness build should succeed");
+        let (i, j) = find_two_distinct_witness_entries(&witness)
+            .expect("leaf_merkle_path_mismatch distinct entries should exist");
+        // Keep leaf/signature/index from i, but swap in j's Merkle path.
+        witness[i].merkle_path = witness[j].merkle_path.clone();
 
-#[test]
-fn target_less_than_evaluation() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("target_less_than_evaluation env setup should succeed");
-    let depth = env.num_signers().next_power_of_two().trailing_zeros();
-    let signer_index = 0usize;
-    let (merkle_tree, _) = create_merkle_tree_with_leaf_selector(
-        depth,
-        LeafSelector::Index(signer_index),
-        SignedMessageWithoutPrefix::ZERO,
-    )
-    .expect("target_less_than_evaluation tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![5, 17, 25];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let witness = build_witness_with_fixed_signer(
-        &merkle_tree,
-        signer_index,
-        merkle_tree_commitment,
-        message,
-        &indices,
-    )
-    .expect("target_less_than_evaluation witness build should succeed");
+    #[test]
+    fn leaf_wrong_verification_key() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("leaf_wrong_verification_key env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("leaf_wrong_verification_key tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("leaf_wrong_verification_key witness build should succeed");
+        let (i, j) = find_two_distinct_witness_entries(&witness)
+            .expect("leaf_wrong_verification_key distinct entries should exist");
+        // Keep lottery_target_value/path/signature/index from i, but swap in j's verification key.
+        let lottery_target_value = witness[i].leaf.lottery_target_value();
+        let verification_key = witness[j].leaf.verification_key();
+        witness[i].leaf = CircuitMerkleTreeLeaf(verification_key, lottery_target_value);
 
-#[test]
-fn witness_length_short() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("witness_length_short env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("witness_length_short tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let mut witness = build_witness(&merkle_tree, merkle_tree_commitment, message, K)
-        .expect("witness_length_short witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    witness.pop();
+    #[test]
+    fn target_less_than_evaluation() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("target_less_than_evaluation env setup should succeed");
+        let depth = env.num_signers().next_power_of_two().trailing_zeros();
+        let signer_index = 0usize;
+        let (merkle_tree, _) = create_merkle_tree_with_leaf_selector(
+            depth,
+            LeafSelector::Index(signer_index),
+            SignedMessageWithoutPrefix::ZERO,
+        )
+        .expect("target_less_than_evaluation tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
-    assert_proving_backend_message_contains(
-        prove_and_verify_result(&env, scenario),
-        &format!("Circuit::validate_witness_length failed: expected k {K}, got 2"),
-    );
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![5, 17, 25];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let witness = build_witness_with_fixed_signer(
+            &merkle_tree,
+            signer_index,
+            merkle_tree_commitment,
+            message,
+            &indices,
+        )
+        .expect("target_less_than_evaluation witness build should succeed");
 
-#[test]
-fn witness_length_long() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("witness_length_long env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("witness_length_long tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let mut witness = build_witness(&merkle_tree, merkle_tree_commitment, message, K)
-        .expect("witness_length_long witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 
-    let extra = witness
-        .last()
-        .cloned()
-        .expect("witness should not be empty in witness_length_long");
-    witness.push(extra);
+    #[test]
+    fn witness_length_short() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("witness_length_short env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("witness_length_short tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let mut witness = build_witness(&merkle_tree, merkle_tree_commitment, message, K)
+            .expect("witness_length_short witness build should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
-    assert_proving_backend_message_contains(
-        prove_and_verify_result(&env, scenario),
-        &format!("Circuit::validate_witness_length failed: expected k {K}, got 4"),
-    );
-}
+        witness.pop();
 
-#[test]
-fn witness_duplicate_entry() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("witness_duplicate_entry env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("witness_duplicate_entry tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![6, 14, 22];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let mut witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("witness_duplicate_entry witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
+        assert_proving_backend_message_contains(
+            prove_and_verify_result(&env, scenario),
+            &format!("Circuit::validate_witness_length failed: expected k {K}, got 2"),
+        );
+    }
 
-    witness[1] = witness[0].clone();
+    #[test]
+    fn witness_length_long() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("witness_length_long env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("witness_length_long tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let mut witness = build_witness(&merkle_tree, merkle_tree_commitment, message, K)
+            .expect("witness_length_long witness build should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+        let extra = witness
+            .last()
+            .cloned()
+            .expect("witness should not be empty in witness_length_long");
+        witness.push(extra);
+
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        // Relation boundary flattens this typed guard error into `PlonkError::Synthesis(String)`.
+        assert_proving_backend_message_contains(
+            prove_and_verify_result(&env, scenario),
+            &format!("Circuit::validate_witness_length failed: expected k {K}, got 4"),
+        );
+    }
+
+    #[test]
+    fn witness_duplicate_entry() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("witness_duplicate_entry env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("witness_duplicate_entry tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![6, 14, 22];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let mut witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("witness_duplicate_entry witness build should succeed");
+
+        witness[1] = witness[0].clone();
+
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        assert_proof_rejected_by_verifier(prove_and_verify_result(&env, scenario));
+    }
 }

--- a/mithril-stm/src/circuits/halo2/tests/golden/cases/positive.rs
+++ b/mithril-stm/src/circuits/halo2/tests/golden/cases/positive.rs
@@ -9,156 +9,172 @@ use crate::circuits::halo2::witness::{
     LotteryTargetValue as CircuitLotteryTargetValue, SignedMessageWithoutPrefix,
 };
 
-#[test]
-fn baseline_valid() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    run_stm_circuit_case_default(current_function!(), CIRCUIT_DEGREE, K)
-        .expect("baseline_valid setup should succeed");
-}
+mod slow {
+    use super::*;
 
-// Expensive; excluded from CI and intended for manual runs.
-#[ignore]
-#[test]
-fn medium_valid() {
-    const CIRCUIT_DEGREE: u32 = 16;
-    const K: u32 = 32;
-    run_stm_circuit_case_default(current_function!(), CIRCUIT_DEGREE, K)
-        .expect("medium_valid setup should succeed");
-}
+    #[test]
+    fn baseline_valid() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        run_stm_circuit_case_default(current_function!(), CIRCUIT_DEGREE, K)
+            .expect("baseline_valid setup should succeed");
+    }
 
-// Extremely expensive; excluded from CI and intended for manual runs.
-#[ignore]
-#[test]
-fn large_valid() {
-    const CIRCUIT_DEGREE: u32 = 21;
-    const K: u32 = 1024;
-    run_stm_circuit_case_default(current_function!(), CIRCUIT_DEGREE, K)
-        .expect("large_valid setup should succeed");
-}
+    // Expensive; excluded from CI and intended for manual runs.
+    #[ignore]
+    #[test]
+    fn medium_valid() {
+        const CIRCUIT_DEGREE: u32 = 16;
+        const K: u32 = 32;
+        run_stm_circuit_case_default(current_function!(), CIRCUIT_DEGREE, K)
+            .expect("medium_valid setup should succeed");
+    }
 
-#[test]
-fn message_zero() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    run_stm_circuit_case(
-        current_function!(),
-        CIRCUIT_DEGREE,
-        K,
-        SignedMessageWithoutPrefix::ZERO,
-    )
-    .expect("message_zero setup should succeed");
-}
+    // Extremely expensive; excluded from CI and intended for manual runs.
+    #[ignore]
+    #[test]
+    fn large_valid() {
+        const CIRCUIT_DEGREE: u32 = 21;
+        const K: u32 = 1024;
+        run_stm_circuit_case_default(current_function!(), CIRCUIT_DEGREE, K)
+            .expect("large_valid setup should succeed");
+    }
 
-#[test]
-fn message_max() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let msg_max = -SignedMessageWithoutPrefix::ONE; // p - 1
-    run_stm_circuit_case(current_function!(), CIRCUIT_DEGREE, K, msg_max)
-        .expect("message_max setup should succeed");
-}
+    #[test]
+    fn message_zero() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        run_stm_circuit_case(
+            current_function!(),
+            CIRCUIT_DEGREE,
+            K,
+            SignedMessageWithoutPrefix::ZERO,
+        )
+        .expect("message_zero setup should succeed");
+    }
 
-#[test]
-fn indices_from_zero() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("indices_from_zero env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("indices_from_zero tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let indices: Vec<LotteryIndex> = vec![0, 1, 2];
-    let witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("indices_from_zero witness build should succeed");
+    #[test]
+    fn message_max() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let msg_max = -SignedMessageWithoutPrefix::ONE; // p - 1
+        run_stm_circuit_case(current_function!(), CIRCUIT_DEGREE, K, msg_max)
+            .expect("message_max setup should succeed");
+    }
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    prove_and_verify_result(&env, scenario).expect("indices_from_zero prove/verify should succeed");
-}
+    #[test]
+    fn indices_from_zero() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("indices_from_zero env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("indices_from_zero tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let indices: Vec<LotteryIndex> = vec![0, 1, 2];
+        let witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("indices_from_zero witness build should succeed");
 
-#[test]
-fn indices_to_max() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("indices_to_max env setup should succeed");
-    let merkle_tree = create_default_merkle_tree(env.num_signers())
-        .expect("indices_to_max tree creation should succeed");
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    assert!(m >= K, "m must be >= k");
-    let start = m - K;
-    let indices = (start as LotteryIndex..m as LotteryIndex).collect::<Vec<LotteryIndex>>();
-    let witness =
-        build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
-            .expect("indices_to_max witness build should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        prove_and_verify_result(&env, scenario)
+            .expect("indices_from_zero prove/verify should succeed");
+    }
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    prove_and_verify_result(&env, scenario).expect("indices_to_max prove/verify should succeed");
-}
+    #[test]
+    fn indices_to_max() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("indices_to_max env setup should succeed");
+        let merkle_tree = create_default_merkle_tree(env.num_signers())
+            .expect("indices_to_max tree creation should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        assert!(m >= K, "m must be >= k");
+        let start = m - K;
+        let indices = (start as LotteryIndex..m as LotteryIndex).collect::<Vec<LotteryIndex>>();
+        let witness =
+            build_witness_with_indices(&merkle_tree, merkle_tree_commitment, message, &indices)
+                .expect("indices_to_max witness build should succeed");
 
-#[test]
-fn merkle_path_all_right() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("merkle_path_all_right env setup should succeed");
-    let depth = env.num_signers().next_power_of_two().trailing_zeros();
-    let lottery_target_value = -CircuitLotteryTargetValue::ONE;
-    let (merkle_tree, rightmost_index) =
-        create_merkle_tree_with_leaf_selector(depth, LeafSelector::RightMost, lottery_target_value)
-            .expect("merkle_path_all_right tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        prove_and_verify_result(&env, scenario)
+            .expect("indices_to_max prove/verify should succeed");
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![4, 12, 25];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let witness = build_witness_with_fixed_signer(
-        &merkle_tree,
-        rightmost_index,
-        merkle_tree_commitment,
-        message,
-        &indices,
-    )
-    .expect("merkle_path_all_right witness build should succeed");
+    #[test]
+    fn merkle_path_all_right() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("merkle_path_all_right env setup should succeed");
+        let depth = env.num_signers().next_power_of_two().trailing_zeros();
+        let lottery_target_value = -CircuitLotteryTargetValue::ONE;
+        let (merkle_tree, rightmost_index) = create_merkle_tree_with_leaf_selector(
+            depth,
+            LeafSelector::RightMost,
+            lottery_target_value,
+        )
+        .expect("merkle_path_all_right tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    prove_and_verify_result(&env, scenario)
-        .expect("merkle_path_all_right prove/verify should succeed");
-}
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![4, 12, 25];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let witness = build_witness_with_fixed_signer(
+            &merkle_tree,
+            rightmost_index,
+            merkle_tree_commitment,
+            message,
+            &indices,
+        )
+        .expect("merkle_path_all_right witness build should succeed");
 
-// Requires power-of-two signers; otherwise padding prevents an all-left path.
-#[test]
-fn merkle_path_all_left() {
-    const CIRCUIT_DEGREE: u32 = 13;
-    const K: u32 = 3;
-    let message = SignedMessageWithoutPrefix::from(42);
-    let env = setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
-        .expect("merkle_path_all_left env setup should succeed");
-    let depth = env.num_signers().next_power_of_two().trailing_zeros();
-    let lottery_target_value = -CircuitLotteryTargetValue::ONE;
-    let (merkle_tree, leftmost_index) =
-        create_merkle_tree_with_leaf_selector(depth, LeafSelector::LeftMost, lottery_target_value)
-            .expect("merkle_path_all_left tree creation should succeed");
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        prove_and_verify_result(&env, scenario)
+            .expect("merkle_path_all_right prove/verify should succeed");
+    }
 
-    let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
-    let m = env.m();
-    let indices: Vec<LotteryIndex> = vec![5, 13, 21];
-    assert!(indices.iter().all(|i| *i < m as LotteryIndex));
-    let witness = build_witness_with_fixed_signer(
-        &merkle_tree,
-        leftmost_index,
-        merkle_tree_commitment,
-        message,
-        &indices,
-    )
-    .expect("merkle_path_all_left witness build should succeed");
+    // Requires power-of-two signers; otherwise padding prevents an all-left path.
+    #[test]
+    fn merkle_path_all_left() {
+        const CIRCUIT_DEGREE: u32 = 13;
+        const K: u32 = 3;
+        let message = SignedMessageWithoutPrefix::from(42);
+        let env =
+            setup_stm_circuit_env(current_function!(), CIRCUIT_DEGREE, K, K * LOTTERIES_PER_K)
+                .expect("merkle_path_all_left env setup should succeed");
+        let depth = env.num_signers().next_power_of_two().trailing_zeros();
+        let lottery_target_value = -CircuitLotteryTargetValue::ONE;
+        let (merkle_tree, leftmost_index) = create_merkle_tree_with_leaf_selector(
+            depth,
+            LeafSelector::LeftMost,
+            lottery_target_value,
+        )
+        .expect("merkle_path_all_left tree creation should succeed");
 
-    let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
-    prove_and_verify_result(&env, scenario)
-        .expect("merkle_path_all_left prove/verify should succeed");
+        let merkle_tree_commitment = merkle_tree.merkle_tree_commitment();
+        let m = env.m();
+        let indices: Vec<LotteryIndex> = vec![5, 13, 21];
+        assert!(indices.iter().all(|i| *i < m as LotteryIndex));
+        let witness = build_witness_with_fixed_signer(
+            &merkle_tree,
+            leftmost_index,
+            merkle_tree_commitment,
+            message,
+            &indices,
+        )
+        .expect("merkle_path_all_left witness build should succeed");
+
+        let scenario = StmCircuitScenario::new(merkle_tree_commitment, message, witness);
+        prove_and_verify_result(&env, scenario)
+            .expect("merkle_path_all_left prove/verify should succeed");
+    }
 }

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -706,18 +706,22 @@ mod tests {
             }
         }
 
-        proptest! {
-            #[cfg(feature = "future_snark")]
-            #[test]
-            fn test_create_invalid_proof(
-                i in any::<usize>(),
-                (values, proof) in values_with_invalid_proof(10)
-            ) {
-                let t = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&values[1..]);
-                let index = i % (values.len() - 1);
-                let path_values = proof.iter().map(|x| SnarkHash::digest(x).to_vec()).collect();
-                let path = MerklePath::new(path_values, index);
-                assert!(t.to_merkle_tree_commitment().verify_leaf_membership_from_path(&values[0], &path).is_err());
+        mod slow {
+            use super::*;
+
+            proptest! {
+                #[cfg(feature = "future_snark")]
+                #[test]
+                fn test_create_invalid_proof(
+                    i in any::<usize>(),
+                    (values, proof) in values_with_invalid_proof(10)
+                ) {
+                    let t = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&values[1..]);
+                    let index = i % (values.len() - 1);
+                    let path_values = proof.iter().map(|x| SnarkHash::digest(x).to_vec()).collect();
+                    let path = MerklePath::new(path_values, index);
+                    assert!(t.to_merkle_tree_commitment().verify_leaf_membership_from_path(&values[0], &path).is_err());
+                }
             }
         }
 

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -244,7 +244,6 @@ impl<R: RngCore + CryptoRng> SnarkProver<R> {
 #[cfg(feature = "future_snark")]
 #[cfg(test)]
 mod tests {
-
     use rand_chacha::ChaCha20Rng;
     use rand_core::{RngCore, SeedableRng};
 
@@ -307,74 +306,6 @@ mod tests {
     }
 
     #[test]
-    fn produces_valid_snark_proof() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 200,
-            k: 5,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let mut prover = create_prover(params, [0u8; 32]);
-
-        let result: Result<SnarkProof<MithrilMembershipDigest>, anyhow::Error> =
-            prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
-        assert!(
-            result.is_ok(),
-            "Expected proof creation to succeed, got: {result:?}"
-        );
-
-        let proof = result.unwrap();
-        assert!(
-            !proof.circuit_proof.is_empty(),
-            "Proof bytes should not be empty"
-        );
-    }
-
-    #[test]
-    fn valid_snark_proof_with_different_path_length() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 200,
-            k: 3,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk = clerk.compute_aggregate_verification_key_for_snark();
-
-        let current_merkle_tree_depth = clerk
-            .closed_key_registration
-            .number_of_registered_parties()
-            .next_power_of_two()
-            .trailing_zeros();
-        let mut prover = create_prover(params, [0u8; 32]);
-
-        let prover_prep =
-            SnarkProverInput::prepare_prover_input::<D>(&clerk, &signatures, &message).unwrap();
-
-        let path_length = prover_prep.into_witness().first().unwrap().merkle_path.siblings.len();
-
-        assert!(path_length >= current_merkle_tree_depth as usize);
-
-        let snark_proof = prover
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-        let result = snark_proof.verify(message.as_slice(), &avk);
-
-        assert!(result.is_ok());
-        snark_proof
-            .verify(message.as_slice(), &avk)
-            .expect("SNARK proof verification should succeed");
-    }
-
-    #[test]
     fn fails_with_insufficient_signatures() {
         let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
         let params = Parameters {
@@ -413,244 +344,318 @@ mod tests {
         assert!(result.is_err(), "Expected failure with empty signatures");
     }
 
-    #[test]
-    fn valid_proof_verifies() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 200,
-            k: 3,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(params, [0u8; 32]);
-
-        let snark_proof = prover
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-        let result = snark_proof.verify(message.as_slice(), &avk);
-
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn different_parameters_prove_and_verify_fails() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 100,
-            k: 5,
-            phi_f: 0.8,
-        };
-        let forged_params = Parameters { m: 3000, ..params };
-        assert_ne!(params, forged_params);
-        let nparties = 10;
-        let merkle_tree_depth = (nparties as u32).next_power_of_two().trailing_zeros();
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
-            clerk.compute_aggregate_verification_key_for_snark();
-
-        let mut prover = create_prover(forged_params, [0u8; 32]);
-
-        let forged_snark_proof = prover
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-
-        let snark_proof =
-            SnarkProof::try_new(forged_snark_proof.circuit_proof, params, merkle_tree_depth)
-                .unwrap();
-        let result = snark_proof.verify(message.as_slice(), &avk);
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn verify_fails_with_random_bytes_or_wrong_number_bytes() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 200,
-            k: 3,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk: crate::AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
-            clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(params, [0u8; 32]);
-        let snark_proof = prover
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-
-        let mut random_bytes = vec![0u8; snark_proof.circuit_proof.len()];
-        rng.fill_bytes(&mut random_bytes);
-        let random_proof =
-            SnarkProof::try_new(random_bytes, params, compute_circuit_degree(params.k)).unwrap();
-        let result = random_proof.verify(message.as_slice(), &avk);
-
-        assert!(result.is_err(), "Verification of random proof should fail");
-
-        let not_enough_bytes = &snark_proof.circuit_proof[0..snark_proof.circuit_proof.len() - 1];
-        let small_proof = SnarkProof::try_new(
-            not_enough_bytes.to_vec(),
-            params,
-            compute_circuit_degree(params.k),
-        )
-        .unwrap();
-        assert!(
-            small_proof.verify(message.as_slice(), &avk).is_err(),
-            "Verification of small proof should fail"
-        );
-
-        let mut too_many_bytes = snark_proof.circuit_proof.to_vec();
-        too_many_bytes.push(0u8);
-        let large_proof =
-            SnarkProof::try_new(too_many_bytes, params, compute_circuit_degree(params.k)).unwrap();
-        assert!(
-            large_proof.verify(message.as_slice(), &avk).is_err(),
-            "Verification of large proof should fail"
-        );
-    }
-
-    #[test]
-    fn verify_fails_with_wrong_message() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 100,
-            k: 5,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let wrong_message = [2u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(params, [0u8; 32]);
-
-        let snark_proof = prover
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-        let result = snark_proof.verify(wrong_message.as_slice(), &avk);
-
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn non_deterministic_proofs_verify() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 100,
-            k: 5,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk = clerk.compute_aggregate_verification_key_for_snark();
-
-        let mut prover_1 = create_prover(params, [0u8; 32]);
-
-        let snark_proof_1 = prover_1
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-        let snark_proof_2 = prover_1
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-
-        assert!(snark_proof_1.verify(&message, &avk).is_ok());
-        assert!(snark_proof_2.verify(&message, &avk).is_ok());
-        assert_ne!(
-            snark_proof_1.circuit_proof, snark_proof_2.circuit_proof,
-            "The two proofs are different but both verify."
-        );
-    }
-
-    #[test]
-    fn snark_proof_to_from_bytes() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 100,
-            k: 5,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let mut prover = create_prover(params, [0u8; 32]);
-        let snark_proof = prover
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-        assert!(snark_proof.verify(&message, &avk).is_ok());
-
-        let proof_bytes = snark_proof.to_bytes().unwrap();
-        let reconstructed_proof: SnarkProof<MithrilMembershipDigest> =
-            SnarkProof::from_bytes(&proof_bytes).unwrap();
-
-        assert_eq!(
-            proof_bytes,
-            reconstructed_proof.to_bytes().unwrap(),
-            "The original bytes should match the ones of the reconstructed proof."
-        );
-
-        assert!(reconstructed_proof.verify(&message, &avk).is_ok());
-    }
-
-    #[test]
-    fn midnight_vk_wrapper_to_from_bytes() {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let params = Parameters {
-            m: 100,
-            k: 5,
-            phi_f: 0.8,
-        };
-        let nparties = 10;
-        let message = [1u8; 32];
-        let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-        let signatures = collect_signatures(&signers, &message);
-        let avk = clerk.compute_aggregate_verification_key_for_snark();
-        let snark_setup = SnarkSetup::try_new(&params, MERKLE_TREE_DEPTH_FOR_SNARK).unwrap();
-        let mut prover = SnarkProver {
-            setup: snark_setup,
-            rng: ChaCha20Rng::from_seed([0u8; 32]),
-        };
-        let mut snark_proof = prover
-            .aggregate_signatures::<D>(&clerk, &signatures, &message)
-            .unwrap();
-        snark_proof.verify(&message, &avk).unwrap();
-
-        let cvk_bytes = snark_proof.circuit_verification_key.to_bytes().unwrap();
-        let cvk_recovered = CircuitVerificationKey::from_bytes(&cvk_bytes).unwrap();
-
-        assert_eq!(
-            cvk_bytes,
-            cvk_recovered.to_bytes().unwrap(),
-            "The original bytes should match the ones of the reconstructed value."
-        );
-
-        snark_proof.circuit_verification_key = cvk_recovered;
-
-        assert!(
-            snark_proof.verify(&message, &avk).is_ok(),
-            "The verification should work when using the reconstructed circuit verification key"
-        );
-    }
-
-    mod golden {
-
+    mod slow {
         use crate::AggregateVerificationKeyForSnark;
 
         use super::*;
 
-        const GOLDEN_JSON: &str = r#"
+        #[test]
+        fn produces_valid_snark_proof() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 200,
+                k: 5,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let mut prover = create_prover(params, [0u8; 32]);
+
+            let result: Result<SnarkProof<MithrilMembershipDigest>, anyhow::Error> =
+                prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
+            assert!(
+                result.is_ok(),
+                "Expected proof creation to succeed, got: {result:?}"
+            );
+
+            let proof = result.unwrap();
+            assert!(
+                !proof.circuit_proof.is_empty(),
+                "Proof bytes should not be empty"
+            );
+        }
+
+        #[test]
+        fn valid_snark_proof_with_different_path_length() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 200,
+                k: 3,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk = clerk.compute_aggregate_verification_key_for_snark();
+
+            let current_merkle_tree_depth = clerk
+                .closed_key_registration
+                .number_of_registered_parties()
+                .next_power_of_two()
+                .trailing_zeros();
+            let mut prover = create_prover(params, [0u8; 32]);
+
+            let prover_prep =
+                SnarkProverInput::prepare_prover_input::<D>(&clerk, &signatures, &message).unwrap();
+
+            let path_length =
+                prover_prep.into_witness().first().unwrap().merkle_path.siblings.len();
+
+            assert!(path_length >= current_merkle_tree_depth as usize);
+
+            let snark_proof = prover
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+            let result = snark_proof.verify(message.as_slice(), &avk);
+
+            assert!(result.is_ok());
+            snark_proof
+                .verify(message.as_slice(), &avk)
+                .expect("SNARK proof verification should succeed");
+        }
+
+        #[test]
+        fn valid_proof_verifies() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 200,
+                k: 3,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk = clerk.compute_aggregate_verification_key_for_snark();
+            let mut prover = create_prover(params, [0u8; 32]);
+
+            let snark_proof = prover
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+            let result = snark_proof.verify(message.as_slice(), &avk);
+
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn different_parameters_prove_and_verify_fails() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 100,
+                k: 5,
+                phi_f: 0.8,
+            };
+            let forged_params = Parameters { m: 3000, ..params };
+            assert_ne!(params, forged_params);
+            let nparties = 10;
+            let merkle_tree_depth = (nparties as u32).next_power_of_two().trailing_zeros();
+            let message = [1u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk: AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
+                clerk.compute_aggregate_verification_key_for_snark();
+
+            let mut prover = create_prover(forged_params, [0u8; 32]);
+
+            let forged_snark_proof = prover
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+
+            let snark_proof =
+                SnarkProof::try_new(forged_snark_proof.circuit_proof, params, merkle_tree_depth)
+                    .unwrap();
+            let result = snark_proof.verify(message.as_slice(), &avk);
+
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn verify_fails_with_random_bytes_or_wrong_number_bytes() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 200,
+                k: 3,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk: AggregateVerificationKeyForSnark<MithrilMembershipDigest> =
+                clerk.compute_aggregate_verification_key_for_snark();
+            let mut prover = create_prover(params, [0u8; 32]);
+            let snark_proof = prover
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+
+            let mut random_bytes = vec![0u8; snark_proof.circuit_proof.len()];
+            rng.fill_bytes(&mut random_bytes);
+            let random_proof =
+                SnarkProof::try_new(random_bytes, params, compute_circuit_degree(params.k))
+                    .unwrap();
+            let result = random_proof.verify(message.as_slice(), &avk);
+
+            assert!(result.is_err(), "Verification of random proof should fail");
+
+            let not_enough_bytes =
+                &snark_proof.circuit_proof[0..snark_proof.circuit_proof.len() - 1];
+            let small_proof = SnarkProof::try_new(
+                not_enough_bytes.to_vec(),
+                params,
+                compute_circuit_degree(params.k),
+            )
+            .unwrap();
+            assert!(
+                small_proof.verify(message.as_slice(), &avk).is_err(),
+                "Verification of small proof should fail"
+            );
+
+            let mut too_many_bytes = snark_proof.circuit_proof.to_vec();
+            too_many_bytes.push(0u8);
+            let large_proof =
+                SnarkProof::try_new(too_many_bytes, params, compute_circuit_degree(params.k))
+                    .unwrap();
+            assert!(
+                large_proof.verify(message.as_slice(), &avk).is_err(),
+                "Verification of large proof should fail"
+            );
+        }
+
+        #[test]
+        fn verify_fails_with_wrong_message() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 100,
+                k: 5,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+            let wrong_message = [2u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk = clerk.compute_aggregate_verification_key_for_snark();
+            let mut prover = create_prover(params, [0u8; 32]);
+
+            let snark_proof = prover
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+            let result = snark_proof.verify(wrong_message.as_slice(), &avk);
+
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn non_deterministic_proofs_verify() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 100,
+                k: 5,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk = clerk.compute_aggregate_verification_key_for_snark();
+
+            let mut prover_1 = create_prover(params, [0u8; 32]);
+
+            let snark_proof_1 = prover_1
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+            let snark_proof_2 = prover_1
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+
+            assert!(snark_proof_1.verify(&message, &avk).is_ok());
+            assert!(snark_proof_2.verify(&message, &avk).is_ok());
+            assert_ne!(
+                snark_proof_1.circuit_proof, snark_proof_2.circuit_proof,
+                "The two proofs are different but both verify."
+            );
+        }
+
+        #[test]
+        fn snark_proof_to_from_bytes() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 100,
+                k: 5,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk = clerk.compute_aggregate_verification_key_for_snark();
+            let mut prover = create_prover(params, [0u8; 32]);
+            let snark_proof = prover
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+            assert!(snark_proof.verify(&message, &avk).is_ok());
+
+            let proof_bytes = snark_proof.to_bytes().unwrap();
+            let reconstructed_proof: SnarkProof<MithrilMembershipDigest> =
+                SnarkProof::from_bytes(&proof_bytes).unwrap();
+
+            assert_eq!(
+                proof_bytes,
+                reconstructed_proof.to_bytes().unwrap(),
+                "The original bytes should match the ones of the reconstructed proof."
+            );
+
+            assert!(reconstructed_proof.verify(&message, &avk).is_ok());
+        }
+
+        #[test]
+        fn midnight_vk_wrapper_to_from_bytes() {
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let params = Parameters {
+                m: 100,
+                k: 5,
+                phi_f: 0.8,
+            };
+            let nparties = 10;
+            let message = [1u8; 32];
+            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+            let signatures = collect_signatures(&signers, &message);
+            let avk = clerk.compute_aggregate_verification_key_for_snark();
+            let snark_setup = SnarkSetup::try_new(&params, MERKLE_TREE_DEPTH_FOR_SNARK).unwrap();
+            let mut prover = SnarkProver {
+                setup: snark_setup,
+                rng: ChaCha20Rng::from_seed([0u8; 32]),
+            };
+            let mut snark_proof = prover
+                .aggregate_signatures::<D>(&clerk, &signatures, &message)
+                .unwrap();
+            snark_proof.verify(&message, &avk).unwrap();
+
+            let cvk_bytes = snark_proof.circuit_verification_key.to_bytes().unwrap();
+            let cvk_recovered = CircuitVerificationKey::from_bytes(&cvk_bytes).unwrap();
+
+            assert_eq!(
+                cvk_bytes,
+                cvk_recovered.to_bytes().unwrap(),
+                "The original bytes should match the ones of the reconstructed value."
+            );
+
+            snark_proof.circuit_verification_key = cvk_recovered;
+
+            assert!(
+                snark_proof.verify(&message, &avk).is_ok(),
+                "The verification should work when using the reconstructed circuit verification key"
+            );
+        }
+
+        mod golden {
+            use super::*;
+
+            const GOLDEN_JSON: &str = r#"
         {
             "circuit_proof": [
                 179,176,81,240,155,194,225,72,19,100,136,87,186,87,160,172,222,222,118,153,238,236,19,53,19,170,136,7,145,18,240,112,103,207,150,240,161,139,199,179,16,200,226,18,251,212,83,137,169,141,94,231,228,137,127,221,126,19,41,32,12,5,49,115,81,82,127,5,101,136,144,20,71,61,73,96,47,70,84,122,59,112,226,62,116,96,95,249,196,107,136,92,91,33,74,217,180,148,22,138,212,112,89,235,218,31,145,66,33,8,27,211,170,151,91,179,160,195,180,209,59,4,98,155,6,174,184,69,188,15,174,56,164,244,177,106,8,172,205,56,205,217,243,183,165,152,61,62,214,56,149,239,228,119,49,184,108,254,147,14,37,4,239,112,198,192,164,132,165,242,113,98,234,9,235,34,212,177,139,161,181,91,117,245,125,95,8,42,222,175,46,180,183,105,113,209,22,252,171,57,112,215,136,40,98,121,110,45,190,11,80,101,91,163,128,67,117,182,54,66,5,142,103,249,70,66,187,120,115,227,33,197,227,221,56,214,252,191,224,41,181,40,5,144,24,49,46,233,131,144,1,34,85,133,50,5,126,202,78,93,26,240,102,50,228,247,221,121,107,98,187,168,174,23,195,56,74,246,216,95,139,115,17,221,57,54,150,32,132,127,177,65,252,82,162,137,149,245,211,140,120,54,234,255,76,36,168,247,148,195,35,116,135,61,12,82,152,237,190,195,251,233,116,118,36,94,91,133,35,170,178,102,75,187,132,8,136,171,94,128,156,153,102,156,76,68,112,57,67,32,3,99,64,253,159,132,249,135,166,92,73,181,29,61,200,7,140,147,61,0,46,96,25,77,169,50,50,126,88,105,94,221,120,93,184,241,62,2,218,126,32,119,253,14,15,132,33,4,132,126,111,130,55,213,218,175,57,144,189,145,165,134,84,253,164,18,154,19,113,144,186,137,74,88,107,79,203,150,99,249,232,84,138,164,172,119,155,170,233,235,170,116,23,3,230,43,54,52,80,252,44,121,35,139,44,13,235,16,142,145,83,170,228,56,210,237,12,221,169,200,225,20,93,130,214,26,39,51,239,202,142,214,32,45,159,74,88,74,143,232,125,214,130,41,105,225,138,218,58,99,18,240,59,104,34,40,19,113,38,154,52,85,13,82,237,54,227,97,147,22,217,156,140,66,251,153,208,136,134,202,78,216,213,2,34,39,230,145,29,170,9,175,107,71,48,27,188,219,201,225,136,168,113,71,53,57,27,242,43,178,196,189,174,93,221,138,175,186,170,9,5,126,179,19,210,241,179,74,162,98,107,47,6,6,76,138,253,30,225,154,2,69,142,232,174,139,122,212,234,172,176,2,28,32,138,70,137,61,56,89,178,64,106,198,71,59,194,97,160,24,81,131,31,19,147,83,229,9,203,210,30,210,117,77,50,193,77,115,155,148,216,105,160,157,51,42,158,253,225,136,161,194,44,222,247,235,125,215,180,247,189,44,73,130,84,236,209,10,65,211,183,95,164,26,130,38,147,250,157,115,40,123,51,85,148,193,146,61,21,241,9,128,7,255,160,56,125,105,35,15,185,24,143,243,27,129,86,6,174,196,171,77,11,27,141,88,249,127,206,19,160,220,7,253,30,9,57,151,8,35,10,11,37,143,172,228,57,146,29,227,107,42,68,201,75,177,19,129,100,194,145,114,149,212,158,210,126,155,23,217,81,101,51,234,218,68,240,157,142,233,33,84,20,139,165,144,44,169,64,96,11,156,194,35,114,48,92,54,33,40,51,224,237,19,20,126,144,24,242,173,183,240,246,66,17,173,106,155,245,36,104,89,248,152,115,155,132,90,234,186,223,134,231,251,96,31,75,184,89,158,82,206,170,115,150,162,72,34,65,16,188,105,134,95,7,26,23,211,105,58,113,216,3,209,80,255,109,232,153,182,76,159,155,145,166,5,53,160,108,87,58,250,73,163,70,166,76,179,231,34,28,152,225,35,27,55,135,254,4,60,108,77,155,14,24,205,74,190,162,172,23,245,197,0,183,240,226,140,48,247,250,246,148,243,198,172,169,155,244,205,49,13,20,38,24,123,17,246,187,70,239,190,103,230,138,33,48,81,195,134,247,4,78,119,17,185,156,151,146,192,60,136,14,30,179,65,54,235,179,138,134,219,109,199,24,89,46,167,185,183,238,185,240,102,41,215,223,247,180,44,17,84,207,240,89,229,194,105,196,202,231,34,159,80,240,113,210,174,41,217,111,69,21,245,15,71,199,181,143,154,83,63,196,152,195,233,162,185,130,2,14,33,86,217,122,187,86,52,52,127,136,10,56,139,164,79,125,74,144,74,183,79,59,56,96,136,134,173,235,186,102,90,70,228,45,128,141,255,170,137,190,255,172,167,222,126,218,93,96,104,12,113,98,132,176,177,151,26,177,1,150,149,247,112,188,121,99,16,100,173,82,133,200,12,113,193,168,251,145,121,100,126,46,140,175,59,189,41,242,83,202,62,3,104,84,59,197,154,150,2,115,152,110,191,141,243,153,221,37,229,184,163,237,111,9,133,55,124,156,228,58,232,178,203,237,31,222,212,217,144,205,29,130,98,117,9,186,199,15,132,73,148,73,226,253,199,64,163,0,161,86,192,70,126,197,234,205,66,63,151,228,204,241,66,42,49,77,27,130,166,164,181,81,36,53,168,199,122,213,110,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,115,180,185,233,219,54,134,1,249,204,228,105,25,52,21,197,192,179,131,47,167,49,39,123,78,169,158,231,4,215,105,38,173,215,53,153,82,126,227,85,73,11,17,231,119,214,25,74,210,46,45,175,249,228,92,205,221,151,138,52,173,5,118,2,188,153,237,228,184,139,77,219,117,134,72,197,92,249,135,87,115,110,90,142,198,212,198,67,10,136,182,52,201,232,8,55,175,186,247,226,1,99,235,121,169,88,97,98,224,115,73,107,243,76,63,141,197,70,237,68,109,254,2,186,178,228,212,39,26,176,160,197,144,73,51,119,243,114,196,134,167,150,10,140,136,172,11,61,78,70,233,16,228,253,111,194,63,240,86,100,1,94,129,101,156,161,105,247,12,195,114,36,77,147,98,242,37,53,36,224,89,128,36,152,200,75,197,136,15,127,44,90,1,79,28,50,222,189,30,59,230,75,68,48,170,165,82,136,26,40,176,75,161,6,154,135,218,97,46,10,46,148,5,106,254,124,53,144,86,147,83,248,113,153,0,215,173,142,118,109,54,79,4,232,211,187,104,123,93,62,209,239,112,107,243,111,154,166,113,150,191,76,27,99,69,88,165,160,125,199,242,162,250,56,140,254,2,223,62,69,201,200,53,43,157,209,10,31,159,51,108,226,85,248,56,197,1,126,116,254,61,8,25,176,109,241,97,70,249,186,249,98,22,32,144,4,171,99,159,36,38,247,186,22,100,126,33,104,160,161,180,14,215,119,139,14,150,4,82,181,198,75,245,112,207,156,239,56,86,254,250,59,22,183,204,177,144,129,75,168,1,45,109,50,75,51,74,4,11,3,148,80,196,84,67,22,217,196,162,109,64,217,34,72,209,141,96,181,141,23,233,215,5,159,218,165,147,209,162,146,45,52,86,186,23,190,49,161,43,238,185,120,121,201,245,111,51,234,248,242,3,113,134,74,164,165,238,36,108,189,185,21,79,43,248,248,133,134,25,138,251,216,107,214,110,253,157,22,37,189,250,60,122,191,37,148,67,143,150,180,204,181,45,76,191,10,100,37,83,82,226,99,240,242,173,2,110,167,204,4,145,177,209,105,25,150,55,207,202,61,221,181,142,51,51,104,186,35,182,146,103,122,153,20,182,0,89,36,255,151,193,114,83,109,105,119,196,41,144,179,24,161,162,194,129,254,152,255,62,137,36,207,78,83,30,13,170,39,37,235,105,138,147,110,109,221,71,169,12,15,144,59,122,191,140,114,201,123,80,63,24,47,162,134,79,99,247,207,191,129,91,174,176,86,249,68,224,30,70,29,130,101,203,247,94,111,3,87,93,179,225,165,74,151,103,203,80,60,32,152,180,119,217,245,163,24,2,109,252,244,222,240,14,155,12,115,125,59,160,142,24,249,184,228,151,54,38,104,103,252,37,120,234,169,218,182,23,87,80,30,25,147,186,106,246,120,89,37,214,82,228,97,133,104,220,32,170,15,161,227,213,115,168,77,151,100,234,96,64,1,161,6,165,230,23,24,54,67,28,58,248,13,119,164,247,0,35,50,135,229,133,167,16,160,51,252,147,247,235,125,69,225,224,54,180,7,64,85,121,147,141,212,37,91,53,70,251,176,198,209,11,147,136,179,42,16,219,176,240,92,164,106,18,220,97,10,64,151,247,3,71,43,25,3,97,58,197,53,68,127,109,0,239,189,243,190,212,225,195,195,240,164,232,150,72,15,40,96,51,192,181,172,192,15,28,190,98,14,151,98,66,197,228,76,59,160,205,133,77,24,165,158,240,21,235,220,79,104,245,98,237,150,21,191,127,56,87,209,91,21,10,32,210,192,217,57,189,44,226,145,231,182,31,73,183,96,73,110,45,196,19,34,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,103,45,74,83,75,149,79,63,245,30,216,109,18,189,13,150,161,242,79,215,65,197,23,103,41,7,142,72,221,254,113,95,145,217,231,253,106,155,216,145,86,124,244,208,103,216,31,150,237,40,254,68,199,169,97,166,108,87,40,135,163,196,171,12,230,240,1,102,28,131,17,243,203,22,168,40,100,254,204,111,167,170,130,16,59,208,213,63,89,80,204,225,17,239,121,11,220,113,189,183,188,205,211,181,11,30,210,89,144,112,94,168,9,53,84,179,188,166,245,171,188,182,95,180,55,171,184,20,115,117,131,134,238,35,235,38,85,210,208,44,136,151,152,116,186,170,49,82,48,188,0,85,228,237,200,89,46,144,139,77,209,13,7,183,60,196,131,78,166,20,226,93,200,34,214,72,2,129,130,21,183,226,216,51,64,224,219,74,104,94,96,43,133,74,49,33,145,7,21,203,95,118,221,52,207,249,133,122,162,51,109,73,178,184,32,210,231,241,179,123,118,200,223,88,6,60,203,152,181,175,231,168,215,180,120,120,167,12,180,77,27,143,132,71,73,26,133,84,180,55,191,209,108,146,24,22,150,156,134,186,255,169,170,234,89,154,172,157,64,104,128,242,198,244,192,6,156,207,146,179,104,223,181,253,249,248,244,92,110,194,156,117,43,97,54,253,225,196,27,31,123,194,130,3,141,104,13,48,252,175,19,160,71,33,133,27,35,83,143,55,121,6,12,246,47,118,197,14,193,96,85,253,4,141,99,82,167,43,4,153,240,151,220,25,108,24,161,2,252,38,115,80,2,147,215,144,233,9,0,53,229,180,228,237,10,68,70,195,166,217,102,146,70,69,115,166,161,20,72,246,110,47,50,101,170,203,117,94,145,50,115,178,183,241,158,145,113,243,35,1,194,80,167,217,31,28,224,68,25,106,240,13,5,52,138,68,7,21,48,15,248,215,45,219,6,114,195,114,94,77,153,169,139,79,22,255,114,8,138,127,20,24,214,96,222,145,156,10,239,91,207,184,130,59,142,33,43,233,2,136,33,54,123,190,6,246,127,100,130,186,159,234,219,67,95,131,69,182,225,51,148,210,56,123,179,75,200,67,230,130,186,94,98,103,190,92,119,175,20,243,219,137,218,24,238,105,23,188,188,70,90,20,88,33,22,67,161,140,193,59,219,121,171,138,101,34,206,146,114,129,81,162,198,159,177,42,0,61,244,79,55,50,215,80,249,68,83,169,241,171,161,65,238,150,55,222,158,23,226,26,46,237,13,192,98,18,215,73,150,83,160,69,194,24,194,29,83,69,200,150,72,196,222,58,216,6,128,31,121,251,54,178,162,187,254,136,73,90,108,190,177,196,21,52,64,27,40,3,196,27,236,218,5,137,226,7,253,156,191,60,22,28,169,4,183,237,1,17,140,33,16,19,102,188,225,126,104,168,254,92,36,70,117,82,144,32,212,53,134,199,199,242,182,5,62,235,250,28,216,250,145,126,252,34,131,110,251,13,91,124,130,111,57,93,11,179,191,119,229,138,178,38,228,113,210,6,27,4,73,197,178,85,248,230,239,95,119,150,24,72,234,34,100,108,57,37,99,250,72,1,47,39,153,211,93,211,124,32,201,18,65,0,48,98,240,247,16,20,184,174,243,48,65,153,28,10,165,255,219,250,140,160,157,73,186,70,65,139,45,228,222,171,2,219,211,233,70,237,52,212,150,115,169,179,243,14,86,98,1,91,133,98,49,79,92,144,203,65,132,241,119,93,22,68,201,100,120,228,233,183,166,149,125,83,116,157,214,217,249,78,176,85,234,110,231,14,110,95,157,214,253,164,242,90,126,37,213,251,159,135,136,37,222,228,177,91,54,116,168,207,69,41,184,136,78,216,74,232,125,113,238,113,16,9,114,131,102,90,39,131,50,126,72,139,45,132,79,97,187,69,181,142,12,4,5,163,54,146,67,82,211,68,233,37,213,178,100,30,142,111,58,181,54,184,41,1,242,47,35,149,94,144,234,249,167,34,50,51,102,145,212,17,209,185,17,186,12,78,96,52,219,232,113,79,211,0,225,202,136,148,8,232,47,248,192,229,149,26,73,192,58,234,98,206,166,123,136,58,4,21,250,121,50,177,139,2,201,58,196,40,14,6,0,63,41,54,244,82,100,94,51,187,31,244,251,71,97,215,210,109,182,43,132,188,212,139,172,105,46,39,245,47,196,10,201,63,247,179,72,242,134,79,182,24,184,211,138,80,215,149,250,89,39,206,220,100,86,200,24,79,67,194,60,141,63,96,81,115,180,247,251,188,167,59,190,196,22,140,16,106,189,251,228,101,99,4,165,232,135,148,29,96,139,174,238,184,216,58,103,80,88,184,96,160,228,61,222,180,106,74,125,240,7,150,130,203,44,112,254,83,107,227,41,172,165,133,174,242,100,159,234,111,247,122,173,172,200,6,162,250,87,195,64,154,56,167,150,210,175,220,122,96,248,56,169,35,101,121,27,235,53,34,30,70,214,175,47,143,73,16,177,37,116,224,82,102,117,226,27,161,30,96,213,49,217,183,104,64,103,87,18,40,156,95,76,53,129,51,42,248,56,94,110,90,118,29,175,160,93,59,91,3,169,112,117,140,145,76,156,7,57,98,107,219,164,72,106,207,228,123,134,4,160,13,77,111,237,133,139,139,8,21,62,114,131,35,67,246,248,22,176,153,156,238,102,89,238,211,245,131,134,54,151,211,225,72,180,226,203,106,60,101,117,145,231,41,255,60,187,148,87,46,67,40,104,113,254,27,177,126,231,28,197,94,134,184,137,103,240,209,228,201,20,227,14,141,255,29,232,233,127,59,27,222,77,57,95,205,60,93,35,56,158,10,78,78,245,187,233,28,163,235,254,66,133,77,15,77,65,59,66,18,224,9,148,137,210,47,33,132,165,237,200,98,131,75,58,22,232,137,252,68,70,72,84,180,64,120,71,17,56,190,203,148,19,49,98,39,43,200,14,132,183,31,252,14,165,146,26,174,144,74,197,158,52,244,12,98,198,10,37,181,66,7,146,128,77,18,238,78,40,160,71,157,11,240,94,171,0,249,226,45,138,80,143,79,168,40,92,152,80,218,215,64,166,51,35,72,70,211,252,59,74,208,106,125,66,191,157,40,160,230,178,3,21,177,158,80,173,179,126,156,158,22,67,52,82,127,143,13,185,145,6,78,25,206,110,59,55,164,189,48,197,234,62,194,242,236,123,144,36,251,110,28,116,34,249,42,146,178,248,163,112,172,194,112,168,161,219,229,30,236,44,3,130,155,169,192,79,117,127,70,158,190,156,96,74,23,165,70,188,153,16,100,91,173,145,67,103,49,87,95,46,190,71,150,160,232,40,17,106,112,0,164
@@ -667,42 +672,43 @@ mod tests {
         }
         "#;
 
-        // The proof generated is random for now so the golden value function is only
-        // used to generate a proof that is stored and needs to be verifiable
-        // TODO: Once the deterministic proof generation is available in the released
-        // midnight-proof crate, we can update is function to output a fixed value
-        // that can be compared to the JSON constant
-        fn golden_value_setup() -> (
-            SnarkProof<MithrilMembershipDigest>,
-            AggregateVerificationKeyForSnark<MithrilMembershipDigest>,
-            [u8; 32],
-        ) {
-            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-            let params = Parameters {
-                m: 200,
-                k: 5,
-                phi_f: 0.8,
-            };
-            let nparties = 10;
-            let message = [1u8; 32];
+            // The proof generated is random for now so the golden value function is only
+            // used to generate a proof that is stored and needs to be verifiable
+            // TODO: Once the deterministic proof generation is available in the released
+            // midnight-proof crate, we can update is function to output a fixed value
+            // that can be compared to the JSON constant
+            fn golden_value_setup() -> (
+                SnarkProof<MithrilMembershipDigest>,
+                AggregateVerificationKeyForSnark<MithrilMembershipDigest>,
+                [u8; 32],
+            ) {
+                let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+                let params = Parameters {
+                    m: 200,
+                    k: 5,
+                    phi_f: 0.8,
+                };
+                let nparties = 10;
+                let message = [1u8; 32];
 
-            let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
-            let signatures = collect_signatures(&signers, &message);
-            let mut prover = create_prover(params, [0u8; 32]);
-            let avk = clerk.compute_aggregate_verification_key_for_snark();
-            let snark_proof = prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
+                let (signers, clerk) = setup_signers_and_clerk(params, nparties, &mut rng);
+                let signatures = collect_signatures(&signers, &message);
+                let mut prover = create_prover(params, [0u8; 32]);
+                let avk = clerk.compute_aggregate_verification_key_for_snark();
+                let snark_proof = prover.aggregate_signatures::<D>(&clerk, &signatures, &message);
 
-            (snark_proof.unwrap(), avk, message)
-        }
+                (snark_proof.unwrap(), avk, message)
+            }
 
-        #[test]
-        fn golden_conversion() {
-            let snark_proof: SnarkProof<MithrilMembershipDigest> =
-                serde_json::from_str(GOLDEN_JSON)
-                    .expect("This JSON deserialization should not fail");
+            #[test]
+            fn golden_conversion() {
+                let snark_proof: SnarkProof<MithrilMembershipDigest> =
+                    serde_json::from_str(GOLDEN_JSON)
+                        .expect("This JSON deserialization should not fail");
 
-            let (_, aggregate_verification_key, message) = golden_value_setup();
-            assert!(snark_proof.verify(&message, &aggregate_verification_key).is_ok());
+                let (_, aggregate_verification_key, message) = golden_value_setup();
+                assert!(snark_proof.verify(&message, &aggregate_verification_key).is_ok());
+            }
         }
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -232,90 +232,6 @@ mod tests {
                 },
             }
         }
-
-        #[test]
-        /// Test that batch verification of certificates works
-        fn batch_verify(nparties in 2_usize..15,
-                              m in 10_u64..20,
-                              k in 1_u64..4,
-                              seed in any::<[u8;32]>(),
-                              batch_size in 2..10,
-        ) {
-            let aggr_sig_type = AggregateSignatureType::Concatenation;
-            let mut rng = ChaCha20Rng::from_seed(seed);
-            let mut aggr_avks: Vec<AggregateVerificationKey<D>> = Vec::new();
-            let mut aggr_stms = Vec::new();
-            let mut batch_msgs = Vec::new();
-            let mut batch_params = Vec::new();
-            for _ in 0..batch_size {
-                let mut msg = [0u8; 32];
-                rng.fill_bytes(&mut msg);
-                let params = Parameters { m, k, phi_f: 0.95 };
-                let ps = setup_equal_parties(params, nparties);
-                let clerk = Clerk::new_clerk_from_signer(&ps[0]);
-
-                let all_ps: Vec<usize> = (0..nparties).collect();
-                let sigs = find_signatures(&msg, &ps, &all_ps);
-                let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
-
-                match msig {
-                    Ok(aggr) => {
-                        aggr_avks.push(clerk.compute_aggregate_verification_key());
-                        aggr_stms.push(aggr);
-                        batch_msgs.push(msg.to_vec());
-                        batch_params.push(params);
-                    }
-                    Err(error) => { assert!(
-                        matches!(
-                            error.downcast_ref::<AggregationError>(),
-                            Some(AggregationError::NotEnoughSignatures{..})
-                        ),
-                        "Unexpected error: {error:?}");
-                    }
-                }
-            }
-
-            assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params).is_ok());
-
-            if aggr_stms.len() >= 2 {
-                let mut swapped_msgs = batch_msgs.clone();
-                swapped_msgs.swap(0, 1);
-                assert!(
-                    AggregateSignature::batch_verify(&aggr_stms, &swapped_msgs, &aggr_avks, &batch_params).is_err(),
-                    "Batch verify should reject swapped messages"
-                );
-
-                let wrong_avk = {
-                    let wrong_params = Parameters { m, k, phi_f: 0.95 };
-                    let mut rng_wrong = ChaCha20Rng::from_seed([0xdeu8; 32]);
-                    let mut kr = KeyRegistration::initialize();
-                    let p = Initializer::new(wrong_params, 1 as Stake, &mut rng_wrong);
-                    let entry: RegistrationEntry = p.clone().try_into().unwrap();
-                    kr.register_by_entry(&entry).unwrap();
-                    let closed_reg = kr.close_registration(&wrong_params).unwrap();
-                    AggregateVerificationKey::from(&closed_reg)
-                };
-                let mut wrong_avks = aggr_avks.clone();
-                wrong_avks[0] = wrong_avk;
-                assert!(
-                    AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &wrong_avks, &batch_params).is_err(),
-                    "Batch verify should reject a wrong avk"
-                );
-            }
-
-            let mut msg = [0u8; 32];
-            rng.fill_bytes(&mut msg);
-            let params = Parameters { m, k, phi_f: 0.8 };
-            let ps = setup_equal_parties(params, nparties);
-            let clerk = Clerk::new_clerk_from_signer(&ps[0]);
-
-            let all_ps: Vec<usize> = (0..nparties).collect();
-            let sigs = find_signatures(&msg, &ps, &all_ps);
-            let fake_msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
-
-            aggr_stms[0] = fake_msig.unwrap();
-            assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params).is_err());
-        }
     }
 
     proptest! {
@@ -391,46 +307,6 @@ mod tests {
     }
 
     proptest! {
-        #![proptest_config(ProptestConfig::with_cases(5))]
-
-        #[test]
-        /// Test that when the adversaries do not hold sufficient stake, they can not form a quorum
-        fn test_adversary_quorum(
-            (adversaries, parties) in arb_parties_adversary_stake(4, 15, 16, 4),
-            msg in any::<[u8;16]>(),
-        ) {
-            // Test sanity check:
-            // Check that the adversarial party has less than 40% of the total stake.
-            let (good, bad) = parties.iter().enumerate().fold((0,0), |(acc1, acc2), (i, st)| {
-                if adversaries.contains(&i) {
-                    (acc1, acc2 + *st)
-                } else {
-                    (acc1 + *st, acc2)
-                }
-            });
-            assert!(bad as f64 / ((good + bad) as f64) < 0.4);
-
-            let params = Parameters { m: 2642, k: 357, phi_f: 0.2 }; // From Table 1
-            let ps = setup_parties(params, parties);
-
-            let sigs =  find_signatures(&msg, &ps, &adversaries.into_iter().collect::<Vec<_>>());
-
-            assert!(sigs.len() < params.k as usize);
-
-            let clerk = Clerk::new_clerk_from_signer(&ps[0]);
-            let aggr_sig_type = AggregateSignatureType::Concatenation;
-
-            let error = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type).expect_err("Not enough quorum should fail!");
-            assert!(
-                matches!(
-                    error.downcast_ref::<AggregationError>(),
-                    Some(AggregationError::NotEnoughSignatures{..})
-                ),
-                "Unexpected error: {error:?}");
-            }
-    }
-
-    proptest! {
         #![proptest_config(ProptestConfig::with_cases(20))]
 
         // Each of the tests below corresponds to falsifying a conjunct in the
@@ -482,6 +358,139 @@ mod tests {
                 concatenation_proof.batch_proof = batch_proof;
                 *aggr = AggregateSignature::Concatenation(Box::new(concatenation_proof));
             })
+        }
+    }
+
+    mod slow {
+        use super::*;
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(5))]
+
+            #[test]
+            /// Test that batch verification of certificates works
+            fn batch_verify(nparties in 2_usize..15,
+                                  m in 10_u64..20,
+                                  k in 1_u64..4,
+                                  seed in any::<[u8;32]>(),
+                                  batch_size in 2..10,
+            ) {
+                let aggr_sig_type = AggregateSignatureType::Concatenation;
+                let mut rng = ChaCha20Rng::from_seed(seed);
+                let mut aggr_avks: Vec<AggregateVerificationKey<D>> = Vec::new();
+                let mut aggr_stms = Vec::new();
+                let mut batch_msgs = Vec::new();
+                let mut batch_params = Vec::new();
+                for _ in 0..batch_size {
+                    let mut msg = [0u8; 32];
+                    rng.fill_bytes(&mut msg);
+                    let params = Parameters { m, k, phi_f: 0.95 };
+                    let ps = setup_equal_parties(params, nparties);
+                    let clerk = Clerk::new_clerk_from_signer(&ps[0]);
+
+                    let all_ps: Vec<usize> = (0..nparties).collect();
+                    let sigs = find_signatures(&msg, &ps, &all_ps);
+                    let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
+
+                    match msig {
+                        Ok(aggr) => {
+                            aggr_avks.push(clerk.compute_aggregate_verification_key());
+                            aggr_stms.push(aggr);
+                            batch_msgs.push(msg.to_vec());
+                            batch_params.push(params);
+                        }
+                        Err(error) => { assert!(
+                            matches!(
+                                error.downcast_ref::<AggregationError>(),
+                                Some(AggregationError::NotEnoughSignatures{..})
+                            ),
+                            "Unexpected error: {error:?}");
+                        }
+                    }
+                }
+
+                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params).is_ok());
+
+                if aggr_stms.len() >= 2 {
+                    let mut swapped_msgs = batch_msgs.clone();
+                    swapped_msgs.swap(0, 1);
+                    assert!(
+                        AggregateSignature::batch_verify(&aggr_stms, &swapped_msgs, &aggr_avks, &batch_params).is_err(),
+                        "Batch verify should reject swapped messages"
+                    );
+
+                    let wrong_avk = {
+                        let wrong_params = Parameters { m, k, phi_f: 0.95 };
+                        let mut rng_wrong = ChaCha20Rng::from_seed([0xdeu8; 32]);
+                        let mut kr = KeyRegistration::initialize();
+                        let p = Initializer::new(wrong_params, 1 as Stake, &mut rng_wrong);
+                        let entry: RegistrationEntry = p.clone().try_into().unwrap();
+                        kr.register_by_entry(&entry).unwrap();
+                        let closed_reg = kr.close_registration(&wrong_params).unwrap();
+                        AggregateVerificationKey::from(&closed_reg)
+                    };
+                    let mut wrong_avks = aggr_avks.clone();
+                    wrong_avks[0] = wrong_avk;
+                    assert!(
+                        AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &wrong_avks, &batch_params).is_err(),
+                        "Batch verify should reject a wrong avk"
+                    );
+                }
+
+                let mut msg = [0u8; 32];
+                rng.fill_bytes(&mut msg);
+                let params = Parameters { m, k, phi_f: 0.8 };
+                let ps = setup_equal_parties(params, nparties);
+                let clerk = Clerk::new_clerk_from_signer(&ps[0]);
+
+                let all_ps: Vec<usize> = (0..nparties).collect();
+                let sigs = find_signatures(&msg, &ps, &all_ps);
+                let fake_msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
+
+                aggr_stms[0] = fake_msig.unwrap();
+                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params).is_err());
+            }
+        }
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(5))]
+
+            #[test]
+            /// Test that when the adversaries do not hold sufficient stake, they can not form a quorum
+            fn test_adversary_quorum(
+                (adversaries, parties) in arb_parties_adversary_stake(4, 15, 16, 4),
+                msg in any::<[u8;16]>(),
+            ) {
+                // Test sanity check:
+                // Check that the adversarial party has less than 40% of the total stake.
+                let (good, bad) = parties.iter().enumerate().fold((0,0), |(acc1, acc2), (i, st)| {
+                    if adversaries.contains(&i) {
+                        (acc1, acc2 + *st)
+                    } else {
+                        (acc1 + *st, acc2)
+                    }
+                });
+                assert!(bad as f64 / ((good + bad) as f64) < 0.4);
+
+                let params = Parameters { m: 2642, k: 357, phi_f: 0.2 }; // From Table 1
+                let ps = setup_parties(params, parties);
+
+                let sigs =  find_signatures(&msg, &ps, &adversaries.into_iter().collect::<Vec<_>>());
+
+                assert!(sigs.len() < params.k as usize);
+
+                let clerk = Clerk::new_clerk_from_signer(&ps[0]);
+                let aggr_sig_type = AggregateSignatureType::Concatenation;
+
+                let error = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type).expect_err("Not enough quorum should fail!");
+                assert!(
+                    matches!(
+                        error.downcast_ref::<AggregationError>(),
+                        Some(AggregationError::NotEnoughSignatures{..})
+                    ),
+                    "Unexpected error: {error:?}"
+                );
+            }
         }
     }
 }

--- a/mithril-stm/src/signature_scheme/bls_multi_signature/mod.rs
+++ b/mithril-stm/src/signature_scheme/bls_multi_signature/mod.rs
@@ -258,50 +258,59 @@ mod tests {
             let sk2 = BlsSigningKey::from_bytes(&sk_bytes).unwrap();
             assert_eq!(sk, sk2);
         }
+    }
 
-        #[test]
-        fn batch_verify(num_batches in 2..10usize,
-                              seed in any::<[u8;32]>(),
-        ) {
-            let mut rng = ChaCha20Rng::from_seed(seed);
-            let num_sigs = 10;
-            let mut batch_msgs = Vec::new();
-            let mut batch_vk = Vec::new();
-            let mut batch_sig = Vec::new();
-            for _ in 0..num_batches {
+    mod test {
+        use super::*;
+
+        proptest! {
+            #![proptest_config(ProptestConfig::with_cases(300))]
+
+            #[test]
+            fn batch_verify(num_batches in 2..10usize,
+                            seed in any::<[u8;32]>(),
+            ) {
+                let mut rng = ChaCha20Rng::from_seed(seed);
+                let num_sigs = 10;
+                let mut batch_msgs = Vec::new();
+                let mut batch_vk = Vec::new();
+                let mut batch_sig = Vec::new();
+                for _ in 0..num_batches {
+                    let mut msg = [0u8; 32];
+                    rng.fill_bytes(&mut msg);
+                    let mut mvks = Vec::new();
+                    let mut sigs = Vec::new();
+                    for _ in 0..num_sigs {
+                        let sk = BlsSigningKey::generate(&mut rng);
+                        let vk = BlsVerificationKey::from(&sk);
+                        let sig = sk.sign(&msg);
+                        sigs.push(sig);
+                        mvks.push(vk);
+                    }
+                    assert!(BlsSignature::verify_aggregate(&msg, &mvks, &sigs).is_ok());
+                    let (agg_vk, agg_sig) = BlsSignature::aggregate(&mvks, &sigs).unwrap();
+                    batch_msgs.push(msg.to_vec());
+                    batch_vk.push(agg_vk);
+                    batch_sig.push(agg_sig);
+                }
+                assert!(BlsSignature::batch_verify_aggregates(&batch_msgs, &batch_vk, &batch_sig).is_ok());
+
+                // If we have an invalid signature, the batch verification will fail
                 let mut msg = [0u8; 32];
                 rng.fill_bytes(&mut msg);
-                let mut mvks = Vec::new();
-                let mut sigs = Vec::new();
-                for _ in 0..num_sigs {
-                    let sk = BlsSigningKey::generate(&mut rng);
-                    let vk = BlsVerificationKey::from(&sk);
-                    let sig = sk.sign(&msg);
-                    sigs.push(sig);
-                    mvks.push(vk);
-                }
-                assert!(BlsSignature::verify_aggregate(&msg, &mvks, &sigs).is_ok());
-                let (agg_vk, agg_sig) = BlsSignature::aggregate(&mvks, &sigs).unwrap();
-                batch_msgs.push(msg.to_vec());
-                batch_vk.push(agg_vk);
-                batch_sig.push(agg_sig);
+                let sk = BlsSigningKey::generate(&mut rng);
+                let fake_sig = sk.sign(&msg);
+                batch_sig[0] = fake_sig;
+
+                let error = BlsSignature::batch_verify_aggregates(&batch_msgs, &batch_vk, &batch_sig).expect_err("Batch verify should fail");
+                assert!(
+                    matches!(
+                        error.downcast_ref::<BlsSignatureError>(),
+                        Some(BlsSignatureError::BatchInvalid)
+                    ),
+                    "Unexpected error: {error:?}"
+                );
             }
-            assert!(BlsSignature::batch_verify_aggregates(&batch_msgs, &batch_vk, &batch_sig).is_ok());
-
-            // If we have an invalid signature, the batch verification will fail
-            let mut msg = [0u8; 32];
-            rng.fill_bytes(&mut msg);
-            let sk = BlsSigningKey::generate(&mut rng);
-            let fake_sig = sk.sign(&msg);
-            batch_sig[0] = fake_sig;
-
-            let error = BlsSignature::batch_verify_aggregates(&batch_msgs, &batch_vk, &batch_sig).expect_err("Batch verify should fail");
-            assert!(
-                matches!(
-                    error.downcast_ref::<BlsSignatureError>(),
-                    Some(BlsSignatureError::BatchInvalid)
-                ),
-                "Unexpected error: {error:?}");
         }
     }
 }

--- a/mithril-stm/src/signature_scheme/bls_multi_signature/mod.rs
+++ b/mithril-stm/src/signature_scheme/bls_multi_signature/mod.rs
@@ -260,7 +260,7 @@ mod tests {
         }
     }
 
-    mod test {
+    mod slow {
         use super::*;
 
         proptest! {


### PR DESCRIPTION
## Content

This PR introduce a two tiers mechanisms for tests:
- most tests have no changes, and run as before
- some tests are marked as "slow" (more on that below), by default they don't run in the CI except if their tested codes have changes

### Slow tests

The base rule is: any tests that **consistently** takes more than 30 seconds to run.

`cargo nextest` already reports by himself when a tests takes more than `60s`, the `ci-profile` have been modified to lower that threshold to the previously said `30s`.

But this is not enough:
- it depends on the running computer: tests will probably be faster on the developer computers, but sometimes its the reverse (it was for me with most `mithril_stm::circuits::halo2::tests::golden`)
- and execution time can very on a same machine depending on its load

This means that the `30s` must not considered as a strict threshold, we may want to include tests that are a little faster than that (in the 20~30s range) or exclude some that are slower (e.g. I choose to always run integration tests in `mithril-stm/tests/stm_protocol.rs`).

When choosing to mark a test as slow, the following change is made:
The tests is moved to a `slow` submodule inside the current file (most likely after all "fast" tests).

Moving it to a submodule allow to easily identify them using `cargo nextest` filter capabilities or even with `cargo test` using `-- --skip slow::` (to exclude all of them for this example).

### Mechanisms

A new devbook script is introduced, `filter-slow-tests.sh`, this script looks for the changed files on the current branch compared on `origin/main` (customizable) and compare it to a list of paths to watch, if any of those paths are in the changed files then it enable the related tests to runs.

This works by constructing a `cargo nextest` filterset ([reference](https://nexte.st/docs/filtersets/reference/)), which by default removes all tests located in a `slow` submodule but add an exception for all detected paths.

For example, if the paths lists contains only the following entries:

```shell
readonly -a SLOW_MITHRIL_STM_TESTS=(
  "mithril-stm/src/#protocol::aggregate_signature::"
  "mithril-stm/src/circuits/halo2#circuits::halo2::"
 )
```

If the files and folders container in `mithril-stm/src/circuits/halo2` does not contains any change then the produced default filterset will exclude all slow tests without exception:
```
not test(#*slow::*)
``` 

But, if there's a change to any file or folders in `mithril-stm/src/circuits/halo2`, then the an exclusion is added to the returned filterset:
```
not test(#*slow::*) or (package(mithril-stm) and (test(#protocol::aggregate_signature::*slow::*) or test(#circuits::halo2::*slow::*)))
```

Said filterset can be used directly with `cargo nextest` commands, e.g:
```shell
cargo nextest list --workspace --profile ci --filterset "$(./docs/devbook/filter-slow-tests/filter-slow-tests.sh)
```

> [!NOTE]
> - `cargo nextest` won't crash nor complain if a filterset does not apply to any tests of a targeted crate, meaning it can be applied freely on all environments even if they don't run `mithril-stm` tests.
> - The script is located in the devbook instead of the github workflows script so it can be more easily be discovered and used by Mithril developers
> - the script have two options: 
>   - `-c`/`--commit-ref` to change the comparison points for changed files discovery
>   - `-a`/`--all` to change the returned filterset to `all()`, useful if the triggering condition is not related to changed files (e.g. a PR label)

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

Relates to #3206
