### PR TITLE
fix(nix): add native mithril-client-cli build for darwin and aarch64-…

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -272,6 +272,13 @@
               pname = "mithril-client";
             };
 
+        } // lib.optionalAttrs (pkgsMusl == null) {
+
+          mithril-client-cli =
+            buildPackage ./mithril-client-cli/Cargo.toml mithril.cargoArtifacts {
+              pname = "mithril-client";
+            };
+
         };
 
         devShells.default = pkgsRustOverlay.mkShell {


### PR DESCRIPTION
…linux

mithril-client-cli was only defined under pkgsMusl (x86_64-linux), leaving darwin targets without the package and breaking devShell evaluation. Add a native buildPackage variant for all systems where pkgsMusl is null.

## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes...

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [ ] Commit sequence broadly makes sense
  - [ ] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [ ] Self-reviewed the diff
  - [ ] Useful pull request description
  - [ ] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [ ] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Relates to #YYY or Closes #YYY
