### PR TITLE
ci: publish crates all at once

### DIFF
--- a/.github/workflows/actions/publish-rust-crates/action.yml
+++ b/.github/workflows/actions/publish-rust-crates/action.yml
@@ -1,12 +1,12 @@
-name: publish-crate-package
+name: publish-rust-crates
 description: |
-  Deploy the crate package to crates.io
+  Deploy a list of rust crates to crates.io
 inputs:
   dry_run:
     description: Dry run will not publish to crates.io, just test it.
     required: true
-  package:
-    description: crate package name.
+  packages:
+    description: comma separated list of rust crates to publish.
     required: true
   api_token:
     description: crates.io API token.
@@ -22,9 +22,9 @@ runs:
       id: check_version
       shell: bash
       run: |
-        echo "Check crate latest published version for '${{ inputs.package }}' package"
-        LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/${{ inputs.package }}  --user-agent "iog/mithril (https://github.com/input-output-hk/mithril)" | jq -r '.crate.newest_version')
-        LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="${{ inputs.package }}") | .version')
+        echo "Check crate latest published version for '${{ inputs.packages }}' package"
+        LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/${{ inputs.packages }}  --user-agent "iog/mithril (https://github.com/input-output-hk/mithril)" | jq -r '.crate.newest_version')
+        LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="${{ inputs.packages }}") | .version')
         echo "Latest crate.io version: $LATEST_REMOTE_VERSION"
         echo "Local version: $LOCAL_VERSION"
 
@@ -37,27 +37,27 @@ runs:
         fi
 
     - name: Copy OpenAPI specs files
-      if: inputs.package == 'mithril-common'
+      if: inputs.packages == 'mithril-common'
       shell: bash
       run: |
         echo "Copy OpenAPI specs files"
-        cp openapi*.yaml ./${{ inputs.package }}
+        cp openapi*.yaml ./${{ inputs.packages }}
 
     - name: Cargo publish dry run
       shell: bash
       run: |
-        echo "Cargo publish '${{ inputs.package }}' package (dry run)"
-        cargo publish -p ${{ inputs.package }} --dry-run --no-verify --allow-dirty ${{ inputs.publish_args }}
+        echo "Cargo publish '${{ inputs.packages }}' package (dry run)"
+        cargo publish -p ${{ inputs.packages }} --dry-run --no-verify --allow-dirty ${{ inputs.publish_args }}
 
     - name: Cargo package list
       shell: bash
       run: |
-        echo "Cargo package list '${{ inputs.package }}' package"
-        cargo package -p ${{ inputs.package }} --list --allow-dirty
+        echo "Cargo package list '${{ inputs.packages }}' package"
+        cargo package -p ${{ inputs.packages }} --list --allow-dirty
 
     - name: Cargo publish
       if: inputs.dry_run == 'false' && steps.check_version.outputs.should_deploy == 'true'
       shell: bash
       run: |
-        echo "Cargo publish '${{ inputs.package }}' package"
-        cargo publish -p ${{ inputs.package }} --token ${{ inputs.api_token }} --no-verify --allow-dirty ${{ inputs.publish_args }}
+        echo "Cargo publish '${{ inputs.packages }}' package"
+        cargo publish -p ${{ inputs.packages }} --token ${{ inputs.api_token }} --no-verify --allow-dirty ${{ inputs.publish_args }}

--- a/.github/workflows/actions/publish-rust-crates/action.yml
+++ b/.github/workflows/actions/publish-rust-crates/action.yml
@@ -18,46 +18,71 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Check crate latest version
-      id: check_version
+    - name: Check crates latest version
+      id: check_versions
       shell: bash
       run: |
-        echo "Check crate latest published version for '${{ inputs.packages }}' package"
-        LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/${{ inputs.packages }}  --user-agent "iog/mithril (https://github.com/input-output-hk/mithril)" | jq -r '.crate.newest_version')
-        LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r '.packages[] | select(.name=="${{ inputs.packages }}") | .version')
-        echo "Latest crate.io version: $LATEST_REMOTE_VERSION"
-        echo "Local version: $LOCAL_VERSION"
+        set -euo pipefail
 
-        if [ "$LOCAL_VERSION" != "$LATEST_REMOTE_VERSION" ]; then 
-          echo "Local version is newer than remote version: we will publish to crates.io"
+        PACKAGES_TO_DEPLOY=""
+        CARGO_PACKAGE_ARGS=""
+        IFS=',' read -r -a PACKAGES <<< "${{ inputs.packages }}"
+
+        for PACKAGE in "${PACKAGES[@]}"; do
+          PACKAGE="$(echo "$PACKAGE" | xargs)" # trim
+
+          echo "Check crate latest published version for '$PACKAGE' package"
+          LATEST_REMOTE_VERSION=$(curl -sL https://crates.io/api/v1/crates/$PACKAGE  --user-agent "iog/mithril (https://github.com/input-output-hk/mithril)" | jq -r '.crate.newest_version')
+          LOCAL_VERSION=$(cargo metadata --quiet --no-deps | jq -r --arg package "$PACKAGE" '.packages[] | select(.name== $package) | .version')
+          echo "Latest crate.io version: $LATEST_REMOTE_VERSION"
+          echo "Local version: $LOCAL_VERSION"
+
+          if [ -z "$LOCAL_VERSION" ]; then
+            echo "Could not find local package '$PACKAGE' in cargo metadata. Does it exist?"
+            exit 1
+          fi
+
+          PACKAGES_TO_DEPLOY="$PACKAGES_TO_DEPLOY $PACKAGE" 
+          if [ "$LOCAL_VERSION" != "$LATEST_REMOTE_VERSION" ]; then 
+            echo "$PACKAGE local version is newer than remote version: we will publish it to crates.io"
+            CARGO_PACKAGE_ARGS="$CARGO_PACKAGE_ARGS --package $PACKAGE"
+          else
+            echo "$PACKAGE local version and remote version are the same: no need to publish it to crates.io"
+          fi
+        done
+
+        echo "packages_to_deploy=$PACKAGES_TO_DEPLOY" >> $GITHUB_OUTPUT
+        if [ -n "$CARGO_PACKAGE_ARGS" ]; then
+          echo "cargo_package_args=$CARGO_PACKAGE_ARGS" >> $GITHUB_OUTPUT
           echo "should_deploy=true" >> $GITHUB_OUTPUT
-        else
-          echo "Local version and remote version are the same: no need to publish to crates.io"
+        else 
           echo "should_deploy=false" >> $GITHUB_OUTPUT
         fi
 
     - name: Copy OpenAPI specs files
-      if: inputs.packages == 'mithril-common'
+      if: contains(inputs.packages, 'mithril-common')
       shell: bash
       run: |
         echo "Copy OpenAPI specs files"
-        cp openapi*.yaml ./${{ inputs.packages }}
+        cp openapi*.yaml ./mithril-common/
 
     - name: Cargo publish dry run
+      if: steps.check_versions.outputs.should_deploy == 'true'
       shell: bash
       run: |
-        echo "Cargo publish '${{ inputs.packages }}' package (dry run)"
-        cargo publish -p ${{ inputs.packages }} --dry-run --no-verify --allow-dirty ${{ inputs.publish_args }}
+        echo "Cargo publish '${{ steps.check_versions.outputs.packages_to_deploy }}' packages (dry run)"
+        cargo publish ${{ steps.check_versions.outputs.cargo_package_args }} --dry-run --no-verify --allow-dirty ${{ inputs.publish_args }}
 
     - name: Cargo package list
+      if: steps.check_versions.outputs.should_deploy == 'true'
       shell: bash
       run: |
-        echo "Cargo package list '${{ inputs.packages }}' package"
-        cargo package -p ${{ inputs.packages }} --list --allow-dirty
+        echo "Cargo package list '${{ steps.check_versions.outputs.packages_to_deploy }}' packages"
+        cargo package ${{ steps.check_versions.outputs.cargo_package_args }} --list --allow-dirty
 
     - name: Cargo publish
-      if: inputs.dry_run == 'false' && steps.check_version.outputs.should_deploy == 'true'
+      if: inputs.dry_run == 'false' && steps.check_versions.outputs.should_deploy == 'true'
       shell: bash
       run: |
-        echo "Cargo publish '${{ inputs.packages }}' package"
-        cargo publish -p ${{ inputs.packages }} --token ${{ inputs.api_token }} --no-verify --allow-dirty ${{ inputs.publish_args }}
+        echo "Cargo publish '${{ steps.check_versions.outputs.packages_to_deploy }}' packages"
+        cargo publish ${{ steps.check_versions.outputs.cargo_package_args }} --token ${{ inputs.api_token }} --no-verify --allow-dirty ${{ inputs.publish_args }}

--- a/.github/workflows/actions/publish-rust-crates/action.yml
+++ b/.github/workflows/actions/publish-rust-crates/action.yml
@@ -23,6 +23,7 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        echo "::group::Check crates latest version"
 
         PACKAGES_TO_DEPLOY=""
         CARGO_PACKAGE_ARGS=""
@@ -58,6 +59,7 @@ runs:
         else 
           echo "should_deploy=false" >> $GITHUB_OUTPUT
         fi
+        echo "::endgroup::"
 
     - name: Copy OpenAPI specs files
       if: contains(inputs.packages, 'mithril-common')
@@ -70,19 +72,25 @@ runs:
       if: steps.check_versions.outputs.should_deploy == 'true'
       shell: bash
       run: |
-        echo "Cargo publish '${{ steps.check_versions.outputs.packages_to_deploy }}' packages (dry run)"
+        echo "::group::Cargo publish packages (dry run)"
+        echo "Packages to publish (dry-run): '${{ steps.check_versions.outputs.packages_to_deploy }}'"
         cargo publish ${{ steps.check_versions.outputs.cargo_package_args }} --dry-run --no-verify --allow-dirty ${{ inputs.publish_args }}
+        echo "::endgroup::"
 
     - name: Cargo package list
       if: steps.check_versions.outputs.should_deploy == 'true'
       shell: bash
       run: |
-        echo "Cargo package list '${{ steps.check_versions.outputs.packages_to_deploy }}' packages"
+        echo "::group::Cargo packages list"
+        echo "Packages to list: '${{ steps.check_versions.outputs.packages_to_deploy }}'"
         cargo package ${{ steps.check_versions.outputs.cargo_package_args }} --list --allow-dirty
+        echo "::endgroup::"
 
     - name: Cargo publish
       if: inputs.dry_run == 'false' && steps.check_versions.outputs.should_deploy == 'true'
       shell: bash
       run: |
-        echo "Cargo publish '${{ steps.check_versions.outputs.packages_to_deploy }}' packages"
+        echo "::group::Cargo publish packages"
+        echo "Packages to publish: '${{ steps.check_versions.outputs.packages_to_deploy }}'"
         cargo publish ${{ steps.check_versions.outputs.cargo_package_args }} --token ${{ inputs.api_token }} --no-verify --allow-dirty ${{ inputs.publish_args }}
+        echo "::endgroup::"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -553,12 +553,6 @@ jobs:
 
   publish-crate-test:
     runs-on: ubuntu-24.04
-    needs:
-      - build
-      - test-rust
-      - e2e
-      - check
-      - licenses
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -574,12 +568,11 @@ jobs:
           dry_run: "true"
           packages: mithril-stm, mithril-build-script, mithril-common, mithril-aggregator-client, mithril-aggregator-discovery, mithril-cardano-node-internal-database, mithril-client
 
-  publish-wasm-test:
+  publish-npm-test:
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
-        package: [mithril-client-wasm]
         include:
           - package: mithril-client-wasm
             tag: latest
@@ -587,8 +580,6 @@ jobs:
             api_token_secret_name: NPM_API_TOKEN_MITHRIL_CLIENT_WASM
 
     runs-on: ubuntu-24.04
-    needs:
-      - build-test-wasm
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
@@ -619,6 +610,8 @@ jobs:
       - e2e
       - check
       - licenses
+      - publish-crate-test
+      - publish-npm-test
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -584,10 +584,10 @@ jobs:
           toolchain: stable
 
       - name: Publish package to crates.io
-        uses: ./.github/workflows/actions/publish-crate-package
+        uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: "true"
-          package: ${{ matrix.package }}
+          packages: ${{ matrix.package }}
 
   publish-wasm-test:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -552,21 +552,6 @@ jobs:
           provenance: false
 
   publish-crate-test:
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        package:
-          [
-            mithril-stm,
-            mithril-build-script,
-            mithril-common,
-            mithril-aggregator-client,
-            mithril-aggregator-discovery,
-            mithril-cardano-node-internal-database,
-            mithril-client,
-          ]
-
     runs-on: ubuntu-24.04
     needs:
       - build
@@ -587,7 +572,7 @@ jobs:
         uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: "true"
-          packages: ${{ matrix.package }}
+          packages: mithril-stm, mithril-build-script, mithril-common, mithril-aggregator-client, mithril-aggregator-discovery, mithril-cardano-node-internal-database, mithril-client
 
   publish-wasm-test:
     strategy:

--- a/.github/workflows/manual-publish-crates.yml
+++ b/.github/workflows/manual-publish-crates.yml
@@ -18,6 +18,8 @@ on:
           - mithril-stm
           - mithril-common
           - mithril-client
+          - mithril-aggregator-client
+          - mithril-aggregator-discovery
           - mithril-build-script
           - mithril-cardano-node-internal-database
       dry_run:
@@ -30,22 +32,28 @@ jobs:
   publish-crate:
     runs-on: ubuntu-24.04
     steps:
+      - name: Prepare
+        id: prepare
+        run: |
+          if [[ ${{ inputs.package }} == 'all' ]]; then
+            echo "packages=mithril-stm, mithril-build-script, mithril-common, mithril-aggregator-client, mithril-aggregator-discovery, mithril-cardano-node-internal-database, mithril-client" >> $GITHUB_OUTPUT
+          else
+            echo "packages=${{ inputs.package }}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Checkout sources
-        if: inputs.package == matrix.package || inputs.package == 'all'
         uses: actions/checkout@v5
         with:
           ref: ${{ inputs.commit_sha }}
 
       - name: Install stable toolchain
-        if: inputs.package == matrix.package || inputs.package == 'all'
         uses: dtolnay/rust-toolchain@master
         with:
           toolchain: stable
 
       - name: ${{ inputs.dry_run && 'Test publish' || 'Publish' }} package to crates.io
-        if: inputs.package == matrix.package || inputs.package == 'all'
         uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: ${{ inputs.dry_run }}
-          packages: mithril-stm, mithril-build-script, mithril-common, mithril-aggregator-client, mithril-aggregator-discovery, mithril-cardano-node-internal-database, mithril-client
+          packages: ${{ steps.prepare.outputs.packages }}
           api_token: ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/manual-publish-crates.yml
+++ b/.github/workflows/manual-publish-crates.yml
@@ -64,8 +64,8 @@ jobs:
 
       - name: ${{ inputs.dry_run && 'Test publish' || 'Publish' }} package to crates.io
         if: inputs.package == matrix.package || inputs.package == 'all'
-        uses: ./.github/workflows/actions/publish-crate-package
+        uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: ${{ inputs.dry_run }}
-          package: ${{ matrix.package }}
+          packages: ${{ matrix.package }}
           api_token: ${{ secrets[matrix.api_token_secret_name] }}

--- a/.github/workflows/manual-publish-crates.yml
+++ b/.github/workflows/manual-publish-crates.yml
@@ -28,26 +28,6 @@ on:
 
 jobs:
   publish-crate:
-    strategy:
-      fail-fast: true
-      max-parallel: 1
-      matrix:
-        include:
-          - package: mithril-stm
-            api_token_secret_name: CRATES_IO_API_TOKEN
-          - package: mithril-build-script
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_BUILD_SCRIPT
-          - package: mithril-common
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_COMMON
-          - package: mithril-aggregator-client,
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_AGGREGATOR_CLIENT
-          - package: mithril-aggregator-discovery,
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_AGGREGATOR_DISCOVERY
-          - package: mithril-cardano-node-internal-database
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_CARDANO_NODE_INTERNAL_DATABASE
-          - package: mithril-client
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_CLIENT
-
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
@@ -67,5 +47,5 @@ jobs:
         uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: ${{ inputs.dry_run }}
-          packages: ${{ matrix.package }}
-          api_token: ${{ secrets[matrix.api_token_secret_name] }}
+          packages: mithril-stm, mithril-build-script, mithril-common, mithril-aggregator-client, mithril-aggregator-discovery, mithril-cardano-node-internal-database, mithril-client
+          api_token: ${{ secrets.CRATES_IO_API_TOKEN }}

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -324,21 +324,6 @@ jobs:
 
   publish-crate-test:
     if: github.event_name == 'push'
-    strategy:
-      fail-fast: false
-      max-parallel: 1
-      matrix:
-        package:
-          [
-            mithril-stm,
-            mithril-build-script,
-            mithril-common,
-            mithril-aggregator-client,
-            mithril-aggregator-discovery,
-            mithril-cardano-node-internal-database,
-            mithril-client,
-          ]
-
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
@@ -353,7 +338,7 @@ jobs:
         uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: "true"
-          packages: ${{ matrix.package }}
+          packages: mithril-stm, mithril-build-script, mithril-common, mithril-aggregator-client, mithril-aggregator-discovery, mithril-cardano-node-internal-database, mithril-client
 
   publish-next-wasm-package:
     if: github.event_name == 'push'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -350,10 +350,10 @@ jobs:
           toolchain: stable
 
       - name: Publish package to crates.io
-        uses: ./.github/workflows/actions/publish-crate-package
+        uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: "true"
-          package: ${{ matrix.package }}
+          packages: ${{ matrix.package }}
 
   publish-next-wasm-package:
     if: github.event_name == 'push'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,26 +234,6 @@ jobs:
 
   publish-crate:
     if: github.event_name == 'release'
-    strategy:
-      fail-fast: true
-      max-parallel: 1
-      matrix:
-        include:
-          - package: mithril-stm
-            api_token_secret_name: CRATES_IO_API_TOKEN
-          - package: mithril-build-script
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_BUILD_SCRIPT
-          - package: mithril-common
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_COMMON
-          - package: mithril-aggregator-client,
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_AGGREGATOR_CLIENT
-          - package: mithril-aggregator-discovery,
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_AGGREGATOR_DISCOVERY
-          - package: mithril-cardano-node-internal-database
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_CARDANO_NODE_INTERNAL_DATABASE
-          - package: mithril-client
-            api_token_secret_name: CRATES_IO_API_TOKEN_MITHRIL_CLIENT
-
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
@@ -268,8 +248,8 @@ jobs:
         uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: "false"
-          packages: ${{ matrix.package }}
-          api_token: ${{ secrets[matrix.api_token_secret_name] }}
+          packages: mithril-stm, mithril-build-script, mithril-common, mithril-aggregator-client, mithril-aggregator-discovery, mithril-cardano-node-internal-database, mithril-client
+          api_token: ${{ secrets.CRATES_IO_API_TOKEN }}
 
   promote-wasm-package-to-latest:
     if: github.event_name == 'release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,10 +265,10 @@ jobs:
           toolchain: stable
 
       - name: Publish package to crates.io
-        uses: ./.github/workflows/actions/publish-crate-package
+        uses: ./.github/workflows/actions/publish-rust-crates
         with:
           dry_run: "false"
-          package: ${{ matrix.package }}
+          packages: ${{ matrix.package }}
           api_token: ${{ secrets[matrix.api_token_secret_name] }}
 
   promote-wasm-package-to-latest:

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = ">=0.6" }
+mithril-common = { path = "../../../mithril-common", version = "0.6.68" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = ">=0.6" }
+mithril-common = { path = "../../mithril-common", version = "0.6.68" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.1" }
-mithril-common = { path = "../../mithril-common", version = ">=0.6" }
+mithril-common = { path = "../../mithril-common", version = "0.6.68" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -68,8 +68,8 @@ chrono = { workspace = true }
 flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
-mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = ">=0.1.4" }
-mithril-common = { path = "../mithril-common", version = ">=0.6", default-features = false }
+mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.1.10" }
+mithril-common = { path = "../mithril-common", version = "0.6.68", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ ed25519-dalek = { version = "2.2.0", features = ["rand_core", "serde"] }
 fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
-mithril-stm = { path = "../mithril-stm", version = ">=0.9", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.7", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes reworks the publication of rust crates to leverage the new ability of cargo to works on multiple crates at once.

Currently our publish have huge limitations which hurt our ability to deliver crates with correct dependencies to crates.io :
- we can't use exact versions for published crates depending on another published crates. We set those versions using `>=x.y.z` as a stopgap, but this means that a published `mithril-client` can be seen as compatible with an older `mithril-common` even if they are not.
- we are forced to do a first manual publication when we want to publish a new package

Those limitations are mostly due to the fact that we are publishing the crates one at a time, meaning that if crates `B` depends on a updated version of `A`, versions which is not yet published (likely because running publish in dry-run for the CI), the

The idea behind the introduction of the publish test in the CI was to protect ourselves against unpublished dependency graphs when releasing a new version. E.G., if crates `A` was already published but we want to publish a new version which introduce a dependency against a crate `B` we want this CI job to fail if `B` was not taken into account for the publication.

This PR removes those limitations by running `cargo publish`, dry run or not, on all crates that needs it at once. This means that now `cargo publish` is able to verify that the whole sets of crates to publish is coherent, solving our issues.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #3230
