### PR TITLE
fix(halo2_ivc): split slow MockProver tests into mod slow and registe…

### DIFF
--- a/.github/workflows/scripts/filter-slow-tests.sh
+++ b/.github/workflows/scripts/filter-slow-tests.sh
@@ -89,7 +89,8 @@ readonly COMMIT_REF=${COMMIT_REF:-"origin/main"} ALLOW_ALL
 
 readonly -a SLOW_MITHRIL_STM_TESTS=(
   "mithril-stm/src/#protocol::aggregate_signature::"
-  "mithril-stm/src/circuits/halo2#circuits::halo2::"
+  "mithril-stm/src/circuits/halo2/#circuits::halo2::"
+  "mithril-stm/src/circuits/halo2_ivc#circuits::halo2_ivc::"
   "mithril-stm/src/membership_commitment/merkle_tree#membership_commitment::merkle_tree::"
   "mithril-stm/src/proof_system/halo2_snark#proof_system::halo2_snark::"
   "mithril-stm/src/signature_scheme/bls_multi_signature#signature_scheme::bls_multi_signature::"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.8"
+version = "0.10.9"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.7", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.9", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.9 (04-28-2026)
+
+### Changed
+
+- Split slow `MockProver` tests into `mod slow` submodules in the `halo2_ivc` test suite and registered `circuits::halo2_ivc` in the CI slow-test filter, preventing slow tests from triggering on unrelated file changes.
+
 ## 0.10.8 (04-28-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.8"
+version = "0.10.9"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -1,5 +1,5 @@
 //! Negative encoding tests: tampered public inputs (fast CI) and MockProver
-//! constraint checks (slow, `#[ignore]`).
+//! constraint checks (in `mod slow`).
 
 use ff::Field;
 use midnight_circuits::types::Instantiable;
@@ -120,70 +120,68 @@ fn current_epoch_tampered_public_input_is_rejected() {
     );
 }
 
-/// Builds a genesis circuit with a tampered witness and asserts the MockProver rejects it.
-///
-/// `tamper` receives the genesis witness before it is passed to the circuit,
-/// allowing each test to corrupt exactly the byte range it wants to verify.
-fn assert_genesis_circuit_rejects_tampered_witness(tamper: impl FnOnce(&mut Witness)) {
-    let setup = build_asset_generation_setup();
-    let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
+mod slow {
+    use super::*;
 
-    let mut witness = build_genesis_base_case_witness(&setup);
-    tamper(&mut witness);
+    /// Builds a genesis circuit with a tampered witness and asserts the MockProver rejects it.
+    ///
+    /// `tamper` receives the genesis witness before it is passed to the circuit,
+    /// allowing each test to corrupt exactly the byte range it wants to verify.
+    fn assert_genesis_circuit_rejects_tampered_witness(tamper: impl FnOnce(&mut Witness)) {
+        let setup = build_asset_generation_setup();
+        let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
 
-    let circuit = IvcCircuit::new(
-        mock_prover_setup.global.clone(),
-        State::genesis(),
-        witness,
-        vec![],
-        vec![],
-        mock_prover_setup.trivial_accumulator.clone(),
-        mock_prover_setup.certificate_verifying_key.vk(),
-        &mock_prover_setup.recursive_verifying_key,
-    );
+        let mut witness = build_genesis_base_case_witness(&setup);
+        tamper(&mut witness);
 
-    let public_inputs = [
-        mock_prover_setup.global.as_public_input(),
-        build_genesis_base_case_next_state(&setup, GENESIS_EPOCH).as_public_input(),
-        AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
-    ]
-    .concat();
+        let circuit = IvcCircuit::new(
+            mock_prover_setup.global.clone(),
+            State::genesis(),
+            witness,
+            vec![],
+            vec![],
+            mock_prover_setup.trivial_accumulator.clone(),
+            mock_prover_setup.certificate_verifying_key.vk(),
+            &mock_prover_setup.recursive_verifying_key,
+        );
 
-    assert_recursive_mock_prover_rejects(circuit, public_inputs);
-}
+        let public_inputs = [
+            mock_prover_setup.global.as_public_input(),
+            build_genesis_base_case_next_state(&setup, GENESIS_EPOCH).as_public_input(),
+            AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
+        ]
+        .concat();
 
-// TODO: Move this slow encoding test into a dedicated slow/extended CI mode once
-// the recursive test suite is split into fast and slow lanes.
-#[test]
-fn slow_circuit_rejects_wrong_bytes_at_next_merkle_root_range() {
-    // MockProver check that the circuit rejects a genesis witness where
-    // msg_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES] contains wrong bytes,
-    // confirming the byte extraction constraint for PREIMAGE_NEXT_MERKLE_ROOT_BYTES is enforced.
-    assert_genesis_circuit_rejects_tampered_witness(|w| {
-        w.msg_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].fill(0xff)
-    });
-}
+        assert_recursive_mock_prover_rejects(circuit, public_inputs);
+    }
 
-// TODO: Move this slow encoding test into a dedicated slow/extended CI mode once
-// the recursive test suite is split into fast and slow lanes.
-#[test]
-fn slow_circuit_rejects_wrong_bytes_at_next_protocol_params_range() {
-    // MockProver check that the circuit rejects a genesis witness where
-    // msg_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES] contains wrong bytes,
-    // confirming the byte extraction constraint for PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES is enforced.
-    assert_genesis_circuit_rejects_tampered_witness(|w| {
-        w.msg_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].fill(0xff)
-    });
-}
+    #[test]
+    fn circuit_rejects_wrong_bytes_at_next_merkle_root_range() {
+        // MockProver check that the circuit rejects a genesis witness where
+        // msg_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES] contains wrong bytes,
+        // confirming the byte extraction constraint for PREIMAGE_NEXT_MERKLE_ROOT_BYTES is enforced.
+        assert_genesis_circuit_rejects_tampered_witness(|w| {
+            w.msg_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].fill(0xff)
+        });
+    }
 
-// TODO: Move this slow encoding test into a dedicated slow/extended CI mode once
-// the recursive test suite is split into fast and slow lanes.
-#[test]
-fn slow_circuit_rejects_wrong_bytes_at_current_epoch_range() {
-    // MockProver check that the circuit rejects a genesis witness where
-    // msg_preimage[PREIMAGE_CURRENT_EPOCH_BYTES] contains wrong bytes,
-    // confirming the byte extraction constraint for PREIMAGE_CURRENT_EPOCH_BYTES is enforced.
-    assert_genesis_circuit_rejects_tampered_witness(|w| {
-        w.msg_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].fill(0xff)
-    });
+    #[test]
+    fn circuit_rejects_wrong_bytes_at_next_protocol_params_range() {
+        // MockProver check that the circuit rejects a genesis witness where
+        // msg_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES] contains wrong bytes,
+        // confirming the byte extraction constraint for PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES is enforced.
+        assert_genesis_circuit_rejects_tampered_witness(|w| {
+            w.msg_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].fill(0xff)
+        });
+    }
+
+    #[test]
+    fn circuit_rejects_wrong_bytes_at_current_epoch_range() {
+        // MockProver check that the circuit rejects a genesis witness where
+        // msg_preimage[PREIMAGE_CURRENT_EPOCH_BYTES] contains wrong bytes,
+        // confirming the byte extraction constraint for PREIMAGE_CURRENT_EPOCH_BYTES is enforced.
+        assert_genesis_circuit_rejects_tampered_witness(|w| {
+            w.msg_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].fill(0xff)
+        });
+    }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/golden/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/golden/positive.rs
@@ -32,121 +32,154 @@ use crate::circuits::halo2_ivc::{
     state::{State, Witness},
 };
 
-// TODO: Move this slow golden test into a dedicated slow/extended CI mode once
-// the recursive test suite is split into fast and slow lanes.
-#[test]
-fn slow_genesis_base_case_accepts_valid_public_inputs() {
-    // MockProver check for the explicit genesis/base-case branch where no
-    // previous recursive proof exists yet and the circuit must accept the
-    // first valid transition.
-    let setup = build_asset_generation_setup();
-    let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
+mod slow {
+    use super::*;
 
-    let circuit = IvcCircuit::new(
-        mock_prover_setup.global.clone(),
-        State::genesis(),
-        build_genesis_base_case_witness(&setup),
-        vec![],
-        vec![],
-        mock_prover_setup.trivial_accumulator.clone(),
-        mock_prover_setup.certificate_verifying_key.vk(),
-        &mock_prover_setup.recursive_verifying_key,
-    );
+    /// Builds a non-genesis recursive circuit from fresh certificate data and asserts the MockProver
+    /// accepts it.
+    ///
+    /// `build_cert_data` receives the deterministic setup, the shared mock-prover context, and the
+    /// stored chain-state asset, and returns the certificate proof, accumulator, next state, and IVC
+    /// witness for that step — allowing each test to choose the transition variant it covers.
+    fn assert_recursive_step_circuit_accepts(
+        build_cert_data: impl FnOnce(
+            &AssetGenerationSetup,
+            &RecursiveMockProverSetup,
+            &RecursiveChainStateAsset,
+        ) -> (Vec<u8>, Accumulator<S>, State, Witness),
+    ) {
+        let setup = build_asset_generation_setup();
+        let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
+        let recursive_chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
 
-    let public_inputs = [
-        mock_prover_setup.global.as_public_input(),
-        build_genesis_base_case_next_state(&setup, 5u64).as_public_input(),
-        AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
-    ]
-    .concat();
+        let (certificate_proof, certificate_accumulator, next_state, recursive_witness) =
+            build_cert_data(&setup, &mock_prover_setup, &recursive_chain_state);
 
-    assert_recursive_mock_prover_accepts(circuit, public_inputs);
-}
+        let next_accumulator = compute_expected_next_accumulator(
+            &mock_prover_setup,
+            &recursive_chain_state,
+            certificate_accumulator,
+        );
 
-/// Builds a non-genesis recursive circuit from fresh certificate data and asserts the MockProver
-/// accepts it.
-///
-/// `build_cert_data` receives the deterministic setup, the shared mock-prover context, and the
-/// stored chain-state asset, and returns the certificate proof, accumulator, next state, and IVC
-/// witness for that step — allowing each test to choose the transition variant it covers.
-fn assert_recursive_step_circuit_accepts(
-    build_cert_data: impl FnOnce(
-        &AssetGenerationSetup,
-        &RecursiveMockProverSetup,
-        &RecursiveChainStateAsset,
-    ) -> (Vec<u8>, Accumulator<S>, State, Witness),
-) {
-    let setup = build_asset_generation_setup();
-    let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
-    let recursive_chain_state = load_embedded_recursive_chain_state_asset()
-        .expect("recursive chain state asset should load");
+        let circuit = IvcCircuit::new(
+            mock_prover_setup.global.clone(),
+            recursive_chain_state.state.clone(),
+            recursive_witness,
+            certificate_proof,
+            recursive_chain_state.proof.clone(),
+            recursive_chain_state.accumulator.clone(),
+            mock_prover_setup.certificate_verifying_key.vk(),
+            &mock_prover_setup.recursive_verifying_key,
+        );
 
-    let (certificate_proof, certificate_accumulator, next_state, recursive_witness) =
-        build_cert_data(&setup, &mock_prover_setup, &recursive_chain_state);
+        let public_inputs = [
+            mock_prover_setup.global.as_public_input(),
+            next_state.as_public_input(),
+            AssignedAccumulator::as_public_input(&next_accumulator),
+        ]
+        .concat();
 
-    let next_accumulator = compute_expected_next_accumulator(
-        &mock_prover_setup,
-        &recursive_chain_state,
-        certificate_accumulator,
-    );
+        assert_recursive_mock_prover_accepts(circuit, public_inputs);
+    }
 
-    let circuit = IvcCircuit::new(
-        mock_prover_setup.global.clone(),
-        recursive_chain_state.state.clone(),
-        recursive_witness,
-        certificate_proof,
-        recursive_chain_state.proof.clone(),
-        recursive_chain_state.accumulator.clone(),
-        mock_prover_setup.certificate_verifying_key.vk(),
-        &mock_prover_setup.recursive_verifying_key,
-    );
+    #[test]
+    fn genesis_base_case_accepts_valid_public_inputs() {
+        // MockProver check for the explicit genesis/base-case branch where no
+        // previous recursive proof exists yet and the circuit must accept the
+        // first valid transition.
+        let setup = build_asset_generation_setup();
+        let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
 
-    let public_inputs = [
-        mock_prover_setup.global.as_public_input(),
-        next_state.as_public_input(),
-        AssignedAccumulator::as_public_input(&next_accumulator),
-    ]
-    .concat();
+        let circuit = IvcCircuit::new(
+            mock_prover_setup.global.clone(),
+            State::genesis(),
+            build_genesis_base_case_witness(&setup),
+            vec![],
+            vec![],
+            mock_prover_setup.trivial_accumulator.clone(),
+            mock_prover_setup.certificate_verifying_key.vk(),
+            &mock_prover_setup.recursive_verifying_key,
+        );
 
-    assert_recursive_mock_prover_accepts(circuit, public_inputs);
-}
+        let public_inputs = [
+            mock_prover_setup.global.as_public_input(),
+            build_genesis_base_case_next_state(&setup, 5u64).as_public_input(),
+            AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
+        ]
+        .concat();
 
-// TODO: Move this slow golden test into a dedicated slow/extended CI mode once
-// the recursive test suite is split into fast and slow lanes.
-#[test]
-fn slow_recursive_step_next_epoch_accepts_valid_public_inputs() {
-    // MockProver check for one non-genesis next-epoch recursive step using
-    // stored previous recursive artifacts plus fresh certificate-side data
-    // generated in-test.
-    assert_recursive_step_circuit_accepts(|setup, mock, chain_state| {
-        build_next_certificate_asset_data(
-            setup,
-            &mock.certificate_commitment_parameters,
-            &setup.certificate_relation,
-            &mock.certificate_verifying_key,
-            &chain_state.state,
-            &mut rand_core::OsRng,
-        )
-    });
-}
+        assert_recursive_mock_prover_accepts(circuit, public_inputs);
+    }
 
-// TODO: Move this slow golden test into a dedicated slow/extended CI mode once
-// the recursive test suite is split into fast and slow lanes.
-#[test]
-fn slow_recursive_step_same_epoch_accepts_valid_public_inputs() {
-    // MockProver check for one non-genesis same-epoch recursive step using
-    // stored previous recursive artifacts plus fresh certificate-side data
-    // generated in-test.
-    assert_recursive_step_circuit_accepts(|setup, mock, chain_state| {
-        build_same_epoch_certificate_asset_data(
-            setup,
-            &mock.certificate_commitment_parameters,
-            &setup.certificate_relation,
-            &mock.certificate_verifying_key,
-            &chain_state.state,
-            &mut rand_core::OsRng,
-        )
-    });
+    #[test]
+    fn recursive_step_next_epoch_accepts_valid_public_inputs() {
+        // MockProver check for one non-genesis next-epoch recursive step using
+        // stored previous recursive artifacts plus fresh certificate-side data
+        // generated in-test.
+        assert_recursive_step_circuit_accepts(|setup, mock, chain_state| {
+            build_next_certificate_asset_data(
+                setup,
+                &mock.certificate_commitment_parameters,
+                &setup.certificate_relation,
+                &mock.certificate_verifying_key,
+                &chain_state.state,
+                &mut rand_core::OsRng,
+            )
+        });
+    }
+
+    #[test]
+    fn recursive_step_same_epoch_accepts_valid_public_inputs() {
+        // MockProver check for one non-genesis same-epoch recursive step using
+        // stored previous recursive artifacts plus fresh certificate-side data
+        // generated in-test.
+        assert_recursive_step_circuit_accepts(|setup, mock, chain_state| {
+            build_same_epoch_certificate_asset_data(
+                setup,
+                &mock.certificate_commitment_parameters,
+                &setup.certificate_relation,
+                &mock.certificate_verifying_key,
+                &chain_state.state,
+                &mut rand_core::OsRng,
+            )
+        });
+    }
+
+    #[test]
+    fn recursive_step_output_asset_matches_replayed_chain_flow() {
+        // Asset-based replay check that recomputes the expected next step from the
+        // stored previous checkpoint and verifies that the stored next-step
+        // artifact is truly its continuation.
+        let setup = build_asset_generation_setup();
+        let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
+        let recursive_chain_state = load_embedded_recursive_chain_state_asset()
+            .expect("recursive chain state asset should load");
+        let recursive_step_output = load_embedded_recursive_step_output_asset()
+            .expect("recursive step output asset should load");
+        let (expected_message, _) =
+            next_message_and_preimage_for_step(&setup, &recursive_chain_state.state);
+        let expected_next_state =
+            next_state_for_step(&recursive_chain_state.state, expected_message);
+
+        let expected_next_accumulator = compute_exact_next_accumulator_from_assets(
+            &mock_prover_setup,
+            &recursive_chain_state,
+            &expected_next_state,
+            &recursive_step_output.certificate_proof,
+        );
+
+        assert_eq!(
+            expected_next_state.as_public_input(),
+            recursive_step_output.next_state.as_public_input(),
+            "stored recursive step output should match the expected chained-flow next state"
+        );
+        assert_eq!(
+            AssignedAccumulator::as_public_input(&expected_next_accumulator),
+            AssignedAccumulator::as_public_input(&recursive_step_output.next_accumulator),
+            "replayed next accumulator should match the stored recursive step output"
+        );
+    }
 }
 
 #[test]
@@ -215,41 +248,5 @@ fn recursive_step_output_asset_proof_and_accumulator_are_valid() {
             &verification_context.combined_fixed_bases,
         ),
         "stored recursive step output accumulator should verify"
-    );
-}
-
-// TODO: Move this slow golden test into a dedicated slow/extended CI mode once
-// the recursive test suite is split into fast and slow lanes.
-#[test]
-fn slow_recursive_step_output_asset_matches_replayed_chain_flow() {
-    // Asset-based replay check that recomputes the expected next step from the
-    // stored previous checkpoint and verifies that the stored next-step
-    // artifact is truly its continuation.
-    let setup = build_asset_generation_setup();
-    let mock_prover_setup = build_recursive_mock_prover_setup(&setup);
-    let recursive_chain_state = load_embedded_recursive_chain_state_asset()
-        .expect("recursive chain state asset should load");
-    let recursive_step_output = load_embedded_recursive_step_output_asset()
-        .expect("recursive step output asset should load");
-    let (expected_message, _) =
-        next_message_and_preimage_for_step(&setup, &recursive_chain_state.state);
-    let expected_next_state = next_state_for_step(&recursive_chain_state.state, expected_message);
-
-    let expected_next_accumulator = compute_exact_next_accumulator_from_assets(
-        &mock_prover_setup,
-        &recursive_chain_state,
-        &expected_next_state,
-        &recursive_step_output.certificate_proof,
-    );
-
-    assert_eq!(
-        expected_next_state.as_public_input(),
-        recursive_step_output.next_state.as_public_input(),
-        "stored recursive step output should match the expected chained-flow next state"
-    );
-    assert_eq!(
-        AssignedAccumulator::as_public_input(&expected_next_accumulator),
-        AssignedAccumulator::as_public_input(&recursive_step_output.next_accumulator),
-        "replayed next accumulator should match the stored recursive step output"
     );
 }


### PR DESCRIPTION
## Content
This PR splits slow `MockProver` tests into `mod slow { use super::*; }` for the `halo2_ivc `encoding and golden layers, and wires them into the CI slow-test filter infrastructure.

It includes:
- `encoding/negative.rs`: slow MockProver constraint checks moved into `mod slow`, `slow_ prefix` dropped
- `golden/positive.rs`: slow MockProver circuit acceptance checks moved into `mod slow`, `slow_ prefix` dropped
- `filter-slow-tests.sh`: registers `circuits::halo2_ivc` so slow tests gate on module file changes

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Relates to https://github.com/input-output-hk/mithril/issues/3191
Relates to https://github.com/input-output-hk/mithril/issues/3206