### PR TITLE
fix(stm): Fixing the flakiness in the circuit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4638,6 +4638,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.11"
+version = "0.10.12"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.12 (04-30-2026)
+
+### Added
+
+- Fixed the flakiness in some of the circuit tests by making the generation of the srs more stable for access by multiple threads.
+
 ## 0.10.11 (04-30-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -83,6 +83,7 @@ proptest = "1.11.0"
 rand = "0.10.1"
 rand_chacha = { workspace = true }
 serde_json = { workspace = true }
+tempfile = "3.27.0"
 
 [[bench]]
 name = "multi_sig"

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.11"
+version = "0.10.12"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2/tests/golden/helpers.rs
+++ b/mithril-stm/src/circuits/halo2/tests/golden/helpers.rs
@@ -551,7 +551,7 @@ pub(crate) fn setup_stm_circuit_env(
     k: u32,
     m: u32,
 ) -> StmResult<StmCircuitEnv> {
-    let srs = load_or_generate_params(circuit_degree, case_name)?;
+    let srs = load_or_generate_params(circuit_degree)?;
 
     let num_signers: usize = DEFAULT_NUM_SIGNERS;
     let depth = num_signers.next_power_of_two().trailing_zeros();
@@ -670,7 +670,7 @@ pub(crate) fn run_stm_circuit_case(
 }
 
 // Load cached KZG params if present; otherwise generate and persist them for reuse.
-fn load_or_generate_params(circuit_degree: u32, case_name: &str) -> StmResult<ParamsKZG<Bls12>> {
+fn load_or_generate_params(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let assets_dir = manifest_dir.join("src").join("circuits").join("halo2").join("assets");
     let path = assets_dir.join(format!("params_kzg_unsafe_{}", circuit_degree));
@@ -694,7 +694,6 @@ fn load_or_generate_params(circuit_degree: u32, case_name: &str) -> StmResult<Pa
         circuit_degree,
         path.to_string_lossy().as_ref(),
         SerdeFormat::RawBytesUnchecked,
-        case_name,
     ))
 }
 

--- a/mithril-stm/src/circuits/halo2/tests/golden/helpers.rs
+++ b/mithril-stm/src/circuits/halo2/tests/golden/helpers.rs
@@ -10,6 +10,7 @@ use midnight_circuits::hash::poseidon::PoseidonState;
 use midnight_curves::Bls12;
 use midnight_proofs::plonk::Error as PlonkError;
 use midnight_proofs::poly::kzg::params::ParamsKZG;
+use midnight_proofs::utils::SerdeFormat;
 use midnight_zk_stdlib as zk;
 use midnight_zk_stdlib::{MidnightCircuit, MidnightPK, MidnightVK};
 use rand_chacha::ChaCha20Rng;
@@ -675,7 +676,10 @@ fn load_or_generate_params(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
     let path = assets_dir.join(format!("params_kzg_unsafe_{}", circuit_degree));
 
     if path.exists() {
-        return Ok(load_params(path.to_string_lossy().as_ref()));
+        return Ok(load_params(
+            path.to_string_lossy().as_ref(),
+            SerdeFormat::RawBytesUnchecked,
+        ));
     }
 
     create_dir_all(&assets_dir)
@@ -689,6 +693,7 @@ fn load_or_generate_params(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
     Ok(generate_params(
         circuit_degree,
         path.to_string_lossy().as_ref(),
+        SerdeFormat::RawBytesUnchecked,
     ))
 }
 

--- a/mithril-stm/src/circuits/halo2/tests/golden/helpers.rs
+++ b/mithril-stm/src/circuits/halo2/tests/golden/helpers.rs
@@ -551,7 +551,7 @@ pub(crate) fn setup_stm_circuit_env(
     k: u32,
     m: u32,
 ) -> StmResult<StmCircuitEnv> {
-    let srs = load_or_generate_params(circuit_degree)?;
+    let srs = load_or_generate_params(circuit_degree, case_name)?;
 
     let num_signers: usize = DEFAULT_NUM_SIGNERS;
     let depth = num_signers.next_power_of_two().trailing_zeros();
@@ -670,7 +670,7 @@ pub(crate) fn run_stm_circuit_case(
 }
 
 // Load cached KZG params if present; otherwise generate and persist them for reuse.
-fn load_or_generate_params(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
+fn load_or_generate_params(circuit_degree: u32, case_name: &str) -> StmResult<ParamsKZG<Bls12>> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let assets_dir = manifest_dir.join("src").join("circuits").join("halo2").join("assets");
     let path = assets_dir.join(format!("params_kzg_unsafe_{}", circuit_degree));
@@ -694,6 +694,7 @@ fn load_or_generate_params(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
         circuit_degree,
         path.to_string_lossy().as_ref(),
         SerdeFormat::RawBytesUnchecked,
+        case_name,
     ))
 }
 

--- a/mithril-stm/src/circuits/test_utils/setup.rs
+++ b/mithril-stm/src/circuits/test_utils/setup.rs
@@ -7,20 +7,28 @@ use midnight_proofs::{poly::kzg::params::ParamsKZG, utils::SerdeFormat};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 
-pub(crate) fn generate_params(k: u32, path: &str, format: SerdeFormat) -> ParamsKZG<Bls12> {
+pub(crate) fn generate_params(
+    k: u32,
+    path: &str,
+    format: SerdeFormat,
+    case_name: &str,
+) -> ParamsKZG<Bls12> {
     let parent = std::path::Path::new(path).parent().expect("No parent directory.");
     let params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(k, ChaCha20Rng::seed_from_u64(42));
     fs::create_dir_all(parent).expect("Failed to create the directories.");
-    // Use a PID-unique temp file so concurrent processes don't corrupt each other's writes.
-    // The rename at the end is atomic on Linux: readers see either the complete file or nothing.
-    let tmp_path = format!("{}.tmp.{}", path, std::process::id());
+    // Uses the name of the higher level test calling the function to create a temporary file
+    // storing the srs and renames the file once it is done being written
+    // The rename at the end is atomic on most config so it should be possible to access the file
+    // during the renaming when several tests create the same file
+    let tmp_path = format!("{}.tmp.{}", path, case_name);
     {
         let file = File::create(&tmp_path).expect("Failed to create the temp SRS file.");
         let mut writer = BufWriter::new(file);
         params
             .write_custom(&mut writer, format)
             .expect("Failed to write the SRS in the temp file.");
-    } // BufWriter flushed and File closed here before the rename
+    }
+    // Rename the temporary file holding the srs to the actual file
     fs::rename(&tmp_path, path).expect("Failed to atomically rename SRS temp file.");
 
     params

--- a/mithril-stm/src/circuits/test_utils/setup.rs
+++ b/mithril-stm/src/circuits/test_utils/setup.rs
@@ -6,6 +6,7 @@ use midnight_curves::Bls12;
 use midnight_proofs::{poly::kzg::params::ParamsKZG, utils::SerdeFormat};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
+use tempfile::NamedTempFile;
 
 pub(crate) fn generate_params(
     k: u32,
@@ -20,22 +21,24 @@ pub(crate) fn generate_params(
     // storing the srs and renames the file once it is done being written
     // The rename at the end is atomic on most config so it should be possible to access the file
     // during the renaming when several tests create the same file
-    let tmp_path = format!("{}.tmp.{}", path, case_name);
+    let mut tmp_path = NamedTempFile::new_in(format!("{}.tmp.{}", path, case_name))
+        .expect("Failed to generate temporary file to store the SRS");
     {
-        let file = File::create(&tmp_path).expect("Failed to create the temp SRS file.");
-        let mut writer = BufWriter::new(file);
+        let mut writer = BufWriter::new(tmp_path.as_file_mut());
         params
             .write_custom(&mut writer, format)
-            .expect("Failed to write the SRS in the temp file.");
+            .expect("Failed to write the SRS in the temporary file.");
     }
     // Rename the temporary file holding the srs to the actual file
-    fs::rename(&tmp_path, path).expect("Failed to atomically rename SRS temp file.");
+    tmp_path
+        .persist(path)
+        .expect("Failed to atomically rename SRS temp file.");
 
     params
 }
 
 pub(crate) fn load_params(path: &str, format: SerdeFormat) -> ParamsKZG<Bls12> {
-    let file = File::open(path).unwrap();
+    let file = File::open(path).expect("Failed to open the SRS file.");
     let mut reader = BufReader::new(file);
     ParamsKZG::read_custom(&mut reader, format)
         .expect("Failure while reading the SRS file during tests!")

--- a/mithril-stm/src/circuits/test_utils/setup.rs
+++ b/mithril-stm/src/circuits/test_utils/setup.rs
@@ -1,30 +1,27 @@
 use std::fs;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
-use std::path::Path;
-use std::sync::OnceLock;
-
-use rand_chacha::ChaCha20Rng;
-use rand_core::SeedableRng;
 
 use midnight_curves::Bls12;
 use midnight_proofs::{poly::kzg::params::ParamsKZG, utils::SerdeFormat};
-
-static PARAMS_LOCK_DEGREE_13: OnceLock<()> = OnceLock::new();
-
-fn write_srs_to_file(parent: &Path, path: &str, format: SerdeFormat, params: &ParamsKZG<Bls12>) {
-    fs::create_dir_all(parent).expect("Failed to create the directories.");
-    let file = File::create(path).expect("Failed to create the file.");
-    let mut writer = BufWriter::new(file);
-    params
-        .write_custom(&mut writer, format)
-        .expect("Failed to write the SRS in the file.");
-}
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
 
 pub(crate) fn generate_params(k: u32, path: &str, format: SerdeFormat) -> ParamsKZG<Bls12> {
     let parent = std::path::Path::new(path).parent().expect("No parent directory.");
     let params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(k, ChaCha20Rng::seed_from_u64(42));
-    PARAMS_LOCK_DEGREE_13.get_or_init(|| write_srs_to_file(parent, path, format, &params));
+    fs::create_dir_all(parent).expect("Failed to create the directories.");
+    // Use a PID-unique temp file so concurrent processes don't corrupt each other's writes.
+    // The rename at the end is atomic on Linux: readers see either the complete file or nothing.
+    let tmp_path = format!("{}.tmp.{}", path, std::process::id());
+    {
+        let file = File::create(&tmp_path).expect("Failed to create the temp SRS file.");
+        let mut writer = BufWriter::new(file);
+        params
+            .write_custom(&mut writer, format)
+            .expect("Failed to write the SRS in the temp file.");
+    } // BufWriter flushed and File closed here before the rename
+    fs::rename(&tmp_path, path).expect("Failed to atomically rename SRS temp file.");
 
     params
 }

--- a/mithril-stm/src/circuits/test_utils/setup.rs
+++ b/mithril-stm/src/circuits/test_utils/setup.rs
@@ -8,12 +8,7 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 use tempfile::NamedTempFile;
 
-pub(crate) fn generate_params(
-    k: u32,
-    path: &str,
-    format: SerdeFormat,
-    case_name: &str,
-) -> ParamsKZG<Bls12> {
+pub(crate) fn generate_params(k: u32, path: &str, format: SerdeFormat) -> ParamsKZG<Bls12> {
     let parent = std::path::Path::new(path).parent().expect("No parent directory.");
     let params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(k, ChaCha20Rng::seed_from_u64(42));
     fs::create_dir_all(parent).expect("Failed to create the directories.");
@@ -21,8 +16,8 @@ pub(crate) fn generate_params(
     // storing the srs and renames the file once it is done being written
     // The rename at the end is atomic on most config so it should be possible to access the file
     // during the renaming when several tests create the same file
-    let mut tmp_path = NamedTempFile::new_in(format!("{}.tmp.{}", path, case_name))
-        .expect("Failed to generate temporary file to store the SRS");
+    let mut tmp_path =
+        NamedTempFile::new_in(parent).expect("Failed to generate temporary file to store the SRS");
     {
         let mut writer = BufWriter::new(tmp_path.as_file_mut());
         params

--- a/mithril-stm/src/circuits/test_utils/setup.rs
+++ b/mithril-stm/src/circuits/test_utils/setup.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use std::fs::File;
 use std::io::{BufReader, BufWriter};
+use std::path::Path;
+use std::sync::OnceLock;
 
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
@@ -8,24 +10,28 @@ use rand_core::SeedableRng;
 use midnight_curves::Bls12;
 use midnight_proofs::{poly::kzg::params::ParamsKZG, utils::SerdeFormat};
 
-pub(crate) fn generate_params(k: u32, path: &str) -> ParamsKZG<Bls12> {
-    let parent = std::path::Path::new(path).parent().unwrap();
-    fs::create_dir_all(parent).unwrap();
+static PARAMS_LOCK_DEGREE_13: OnceLock<()> = OnceLock::new();
 
-    let params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(k, ChaCha20Rng::seed_from_u64(42));
-
-    let file = File::create(path).unwrap();
+fn write_srs_to_file(parent: &Path, path: &str, format: SerdeFormat, params: &ParamsKZG<Bls12>) {
+    fs::create_dir_all(parent).expect("Failed to create the directories.");
+    let file = File::create(path).expect("Failed to create the file.");
     let mut writer = BufWriter::new(file);
-
     params
-        .write_custom(&mut writer, SerdeFormat::RawBytesUnchecked)
-        .unwrap();
+        .write_custom(&mut writer, format)
+        .expect("Failed to write the SRS in the file.");
+}
+
+pub(crate) fn generate_params(k: u32, path: &str, format: SerdeFormat) -> ParamsKZG<Bls12> {
+    let parent = std::path::Path::new(path).parent().expect("No parent directory.");
+    let params: ParamsKZG<Bls12> = ParamsKZG::unsafe_setup(k, ChaCha20Rng::seed_from_u64(42));
+    PARAMS_LOCK_DEGREE_13.get_or_init(|| write_srs_to_file(parent, path, format, &params));
 
     params
 }
 
-pub(crate) fn load_params(path: &str) -> ParamsKZG<Bls12> {
+pub(crate) fn load_params(path: &str, format: SerdeFormat) -> ParamsKZG<Bls12> {
     let file = File::open(path).unwrap();
     let mut reader = BufReader::new(file);
-    ParamsKZG::read_custom(&mut reader, SerdeFormat::RawBytesUnchecked).unwrap()
+    ParamsKZG::read_custom(&mut reader, format)
+        .expect("Failure while reading the SRS file during tests!")
 }


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes a fix for the flakiness in the circuit tests by using a lock in the function that generates and saves the test SRSs. This way the file should be written properly and the loadings should not fail to generate the field elements.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes to #3231 
