### PR TITLE
ci: upgrade GitHub actions

### DIFF
--- a/.github/workflows/actions/build-upload-mithril-artifact/action.yml
+++ b/.github/workflows/actions/build-upload-mithril-artifact/action.yml
@@ -80,7 +80,7 @@ runs:
         cp ${{ steps.build-path.outputs.path }}/mithril-relay.exe binaries/ || true
 
     - name: Publish Mithril Distribution (${{ runner.os }}-${{ runner.arch }})
-      uses: actions/upload-artifact@v5
+      uses: actions/upload-artifact@v7
       with:
         name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
         path: |

--- a/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
+++ b/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
@@ -234,10 +234,10 @@ runs:
   using: "composite"
   steps:
     - name: Checkout sources
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
 
     - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v3
+      uses: hashicorp/setup-terraform@v4
       with:
         terraform_wrapper: false
 

--- a/.github/workflows/aggregator-stress-test.yml
+++ b/.github/workflows/aggregator-stress-test.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Prepare environment variables
         id: prepare
@@ -62,7 +62,7 @@ jobs:
           toolchain: stable
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-X64
           path: ./bin
@@ -72,7 +72,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download test runners
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-tooling-Linux-X64
           path: ./bin
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload stress test artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: aggregator-stress-test-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}
           path: |

--- a/.github/workflows/backward-compatibility.yml
+++ b/.github/workflows/backward-compatibility.yml
@@ -64,7 +64,7 @@ jobs:
       tags: ${{ steps.tags-test-lab.outputs.tags }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -90,7 +90,7 @@ jobs:
           cp ./target/release/mithril-end-to-end ./mithril-binaries/e2e-${{ inputs.e2e-release }}
 
       - name: Upload Mithril binaries
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-binaries
           path: ./mithril-binaries
@@ -116,10 +116,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download binaries
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-binaries
           path: ./mithril-binaries
@@ -140,7 +140,7 @@ jobs:
           mkdir artifacts
 
       - name: Run E2E tests
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           shell: bash
           max_attempts: 3
@@ -204,14 +204,14 @@ jobs:
 
       - name: Upload test result JSON
         if: success() || failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.RESULT_FILE_NAME }}
           path: ./${{ env.RESULT_FILE_NAME }}.json
 
       - name: Upload E2E Tests Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-tag_${{ matrix.tag }}-node-${{ matrix.node }}-cardano-${{ matrix.cardano_node_version }}-run_id_${{ matrix.run_id }}
           path: |
@@ -229,7 +229,7 @@ jobs:
 
     steps:
       - name: Download all test result artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           path: ./test-results
           pattern: e2e-test-result*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -992,6 +992,13 @@ jobs:
       - build-test-explorer
       - build-open-api-ui
       - check
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Download mithril-rust-doc artifact
         uses: actions/download-artifact@v8
@@ -1029,16 +1036,22 @@ jobs:
           name: openapi-ui-build
           path: ./github-pages/openapi-ui
 
-      - name: Add CNAME & Redirect
+      - name: Add CNAME, .nojekyll & Redirect
         run: |
           echo "mithril.network" > ./github-pages/CNAME
+          touch ./github-pages/.nojekyll
           echo '<!DOCTYPE html><html><head><meta http-equiv="Refresh" content="0; URL=https://mithril.network/doc"></head></html>' > ./github-pages/index.html
           # Remove the index.html from the url to avoid a display issue that duplicates the content of the page
           sed -i '1s/^/<script type="text\/javascript"> if (window.location.href.endsWith("\/index.html")) { end_of_clean_url = window.location.href.lastIndexOf("\/"); window.location.href = window.location.href.substring(0, end_of_clean_url); } <\/script>\n/' ./github-pages/doc/index.html
 
-      - name: Mithril / Publish GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Configure GitHub Pages
+        uses: actions/configure-pages@v6
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v5
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN || github.token }}
-          publish_dir: ./github-pages
-          force_orphan: true
+          path: ./github-pages
+
+      - name: Deploy GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       eras: ${{ steps.eras-test-lab.outputs.eras }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -69,7 +69,7 @@ jobs:
           cargo deb --no-build --package mithril-relay --target=${{ matrix.musl_target }}
 
       - name: Publish Debian packages
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-deb-packages-${{ runner.os }}-${{ runner.arch }}
           path: target/debian/*.deb
@@ -77,7 +77,7 @@ jobs:
 
       - name: Publish End-to-end runner (${{ runner.os }}-${{ runner.arch }})
         if: matrix.os == 'ubuntu-22.04'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-tooling-${{ runner.os }}-${{ runner.arch }}
           path: |
@@ -111,7 +111,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -131,7 +131,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -183,7 +183,7 @@ jobs:
           wasm-pack test --node mithril-client-wasm --release --features test-node
 
       - name: Publish Mithril Distribution (WASM)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-distribution-wasm
           path: |
@@ -200,7 +200,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -318,7 +318,7 @@ jobs:
           - deny-args: ""
             manifest-path: mithril-client-wasm/Cargo.toml
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
@@ -400,16 +400,16 @@ jobs:
             extra_args: "--mithril-era-regenesis-on-switch --aggregate-signature-type=Concatenation"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download binaries
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
           path: ./bin
 
       - name: Download rust test runner
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-tooling-${{ runner.os }}-${{ runner.arch }}
           path: ./
@@ -423,7 +423,7 @@ jobs:
           mkdir artifacts
 
       - name: Test
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
           shell: bash
           max_attempts: 3
@@ -454,7 +454,7 @@ jobs:
 
       - name: Upload E2E Tests Artifacts
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-mode_${{ matrix.mode }}-era_${{ matrix.era }}-cardano-${{ matrix.cardano_node_version }}-fork-${{  matrix.hard_fork_latest_era_at_epoch }}-run_id_${{ matrix.run_id }}
           path: |
@@ -501,20 +501,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get short SHA
         id: slug
         run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -522,7 +522,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
@@ -530,19 +530,19 @@ jobs:
             type=raw,value=${{ github.base_ref || github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-X64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
 
       - name: Download built artifacts (Linux-ARM64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.CONTEXT }}
           file: ${{ env.DOCKER_FILE }}
@@ -555,7 +555,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -582,7 +582,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -614,7 +614,7 @@ jobs:
       - publish-npm-test
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Prepare packaging
         run: mkdir package
@@ -624,43 +624,43 @@ jobs:
         run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Download built artifacts (Linux-X64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-Linux-X64
           path: ./package-Linux-X64
 
       - name: Download Debian packages (Linux-X64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-deb-packages-Linux-X64
           path: ./package
 
       - name: Download built artifacts (Linux-ARM64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-Linux-ARM64
           path: ./package-Linux-ARM64
 
       - name: Download Debian packages (Linux-ARM64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-deb-packages-Linux-ARM64
           path: ./package
 
       - name: Download built artifacts (macOS-ARM64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-macOS-ARM64
           path: ./package-macOS-ARM64
 
       - name: Download built artifacts (Windows-X64)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-Windows-X64
           path: ./package-Windows-X64
 
       - name: Download built artifacts (Explorer)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: explorer-build
           path: ./package-explorer
@@ -684,7 +684,7 @@ jobs:
           fi
 
       - name: Update unstable release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: unstable
@@ -745,7 +745,7 @@ jobs:
         working-directory: mithril-infra
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get Docker image id
         run: echo "DOCKER_IMAGE_ID=${{ github.base_ref || github.ref_name }}-$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_ENV
@@ -821,7 +821,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache
@@ -865,7 +865,7 @@ jobs:
           wait-for-processing: true
 
       - name: Publish Mithril-rust-doc
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-rust-doc
           if-no-files-found: error
@@ -876,7 +876,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -895,7 +895,7 @@ jobs:
           npm run build
 
       - name: Publish Docusaurus build
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: docusaurus-build
           if-no-files-found: error
@@ -907,10 +907,10 @@ jobs:
     needs: build-test-wasm
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download built artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-distribution-wasm
           path: mithril-client-wasm
@@ -939,7 +939,7 @@ jobs:
         run: make build
 
       - name: Publish Explorer build (stable)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: explorer-build
           if-no-files-found: error
@@ -954,7 +954,7 @@ jobs:
         run: make build
 
       - name: Publish Explorer build (unstable)
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: explorer-build-unstable
           if-no-files-found: error
@@ -965,7 +965,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Build OpenAPI UI
         uses: Legion2/swagger-ui-action@v1
@@ -976,7 +976,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish OpenAPI UI build
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: openapi-ui-build
           if-no-files-found: error
@@ -994,13 +994,13 @@ jobs:
       - check
     steps:
       - name: Download mithril-rust-doc artifact
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: mithril-rust-doc
           path: ./github-pages/rust-doc
 
       - name: Download Docusaurus build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: docusaurus-build
           path: ./github-pages/doc
@@ -1018,13 +1018,13 @@ jobs:
           tar xvf mithril-explorer-${LAST_DISTRIBUTION}.tar.gz --directory=./github-pages/explorer/
 
       - name: Download Explorer build (unstable)
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: explorer-build-unstable
           path: ./github-pages/explorer/unstable
 
       - name: Download OpenAPI UI build
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: openapi-ui-build
           path: ./github-pages/openapi-ui

--- a/.github/workflows/docker-builds.yml
+++ b/.github/workflows/docker-builds.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.CONTEXT }}
           file: ${{ env.DOCKER_FILE }}

--- a/.github/workflows/manual-publish-crates.yml
+++ b/.github/workflows/manual-publish-crates.yml
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit_sha }}
 

--- a/.github/workflows/manual-publish-npm.yml
+++ b/.github/workflows/manual-publish-npm.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: Checkout sources
         if: inputs.package == matrix.package || inputs.package == 'all'
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.commit_sha }}
 

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -26,13 +26,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Prepare packaging
         run: mkdir package
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-X64
           path: ./package-Linux-X64
@@ -41,7 +41,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download Debian packages (Linux-X64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-deb-packages-Linux-X64
           path: ./package
@@ -50,7 +50,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Linux-ARM64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-ARM64
           path: ./package-Linux-ARM64
@@ -59,7 +59,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download Debian packages (Linux-ARM64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-deb-packages-Linux-ARM64
           path: ./package
@@ -68,7 +68,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (macOS-ARM64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-macOS-ARM64
           path: ./package-macOS-ARM64
@@ -77,7 +77,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Windows-x64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Windows-X64
           path: ./package-Windows-X64
@@ -86,7 +86,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Explorer)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: explorer-build
           path: ./package-explorer
@@ -107,7 +107,7 @@ jobs:
           compatibility-table: '{ "release-mainnet": "⛔", "release-preprod": "⛔", "pre-release-preview": "✔", "testing-preview": "⛔" }'
 
       - name: Create pre-release ${{ github.ref_name }}
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref_name }}
@@ -142,20 +142,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get short SHA
         id: slug
         run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
@@ -171,7 +171,7 @@ jobs:
             type=raw,value=${{ github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
@@ -180,7 +180,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Linux-arm64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64
@@ -189,7 +189,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.CONTEXT }}
           file: ${{ env.DOCKER_FILE }}
@@ -245,7 +245,7 @@ jobs:
         working-directory: mithril-infra
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get Docker image id
         run: |
@@ -327,7 +327,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -356,7 +356,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,20 +42,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get short SHA
         id: slug
         run: echo "sha8=$(echo ${{ github.sha }} | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -63,7 +63,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
@@ -71,7 +71,7 @@ jobs:
             type=raw,value=${{ github.ref_name }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
@@ -80,7 +80,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Download built artifacts (Linux-arm64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64
@@ -89,7 +89,7 @@ jobs:
           workflow_conclusion: success
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.CONTEXT }}
           file: ${{ env.DOCKER_FILE }}
@@ -163,7 +163,7 @@ jobs:
         working-directory: mithril-infra
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get Docker image id
         run: |
@@ -237,7 +237,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@master
@@ -267,7 +267,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Install stable toolchain, tools, and restore cache
         uses: ./.github/workflows/actions/toolchain-and-cache

--- a/.github/workflows/test-client.yml
+++ b/.github/workflows/test-client.yml
@@ -145,10 +145,10 @@ jobs:
       ANCILLARY_VERIFICATION_KEY: ${{ needs.prepare.outputs.ancillary_verification_key }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Checkout binary
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
           path: ./bin
@@ -304,10 +304,10 @@ jobs:
       ANCILLARY_VERIFICATION_KEY: ${{ needs.prepare.outputs.ancillary_verification_key }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Checkout binary
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-${{ runner.os }}-${{ runner.arch }}
           path: ./bin
@@ -585,10 +585,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Download built artifacts
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-wasm
           path: ./mithril-client-wasm
@@ -655,7 +655,7 @@ jobs:
 
       - name: Upload Results Artifacts
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: mithril-client-wasm-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-os_${{ matrix.os }}
           path: |

--- a/.github/workflows/test-deploy-network.yml
+++ b/.github/workflows/test-deploy-network.yml
@@ -134,7 +134,7 @@ jobs:
     steps:
       - name: Checkout sources
         if: inputs.environment == matrix.environment
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: ${{ inputs.dry_run == true && 'Plan' || 'Apply' }} terraform infrastructure
         if: inputs.environment == matrix.environment

--- a/.github/workflows/test-docker-distribution.yml
+++ b/.github/workflows/test-docker-distribution.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Get short SHA
         id: slug
@@ -74,13 +74,13 @@ jobs:
           git checkout ${{ inputs.commit_sha }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Download built artifacts (Linux-x64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-X64
           path: ${{ matrix.project }}/bin-linux-amd64
@@ -89,7 +89,7 @@ jobs:
           workflow_conclusion: completed
 
       - name: Download built artifacts (Linux-arm64)
-        uses: dawidd6/action-download-artifact@v11
+        uses: dawidd6/action-download-artifact@v21
         with:
           name: mithril-distribution-Linux-ARM64
           path: ${{ matrix.project }}/bin-linux-arm64
@@ -98,7 +98,7 @@ jobs:
           workflow_conclusion: completed
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.PACKAGE }}
           tags: |
@@ -114,7 +114,7 @@ jobs:
             type=raw,value=test-${{ inputs.distribution_code }}-${{ steps.slug.outputs.sha8 }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ env.CONTEXT }}
           file: ${{ env.DOCKER_FILE }}

--- a/.github/workflows/test-notify-on-failure.yml
+++ b/.github/workflows/test-notify-on-failure.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Write HTML body to file
         run: |
@@ -24,7 +24,7 @@ jobs:
           EOF
 
       - name: Send failure notification via Mailgun
-        uses: dawidd6/action-send-mail@v6
+        uses: dawidd6/action-send-mail@v17
         with:
           server_address: ${{ vars.CI_NOTIFICATION_SMTP_SERVER }}
           server_port: ${{ vars.CI_NOTIFICATION_SMTP_PORT }}

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 2 # Needed to get the diff of the last commit, which is used to filter out slow tests
 
@@ -94,7 +94,7 @@ jobs:
           mv target/nextest/ci/tests-result.junit.xml test-results-${{ runner.os }}-${{ runner.arch }}${{ matrix.artifact-suffix }}.xml
 
       - name: Upload Tests Results
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         if: success() || failure()
         with:
           name: test-results-${{ runner.os }}-${{ runner.arch }}${{ matrix.artifact-suffix }}
@@ -108,7 +108,7 @@ jobs:
     steps:
       - name: Download Tests Results
         if: success() || failure()
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           pattern: test-results-*
           merge-multiple: true


### PR DESCRIPTION
## Content

This PR:

- upgrades all actions used in our workflows to their latest available version
- refactor github-pages publish, moving from [`peaceiris/actions-gh-pages`](https://github.com/peaceiris/actions-gh-pages/) (which have not been updated since ~2 years) to official github actions

> [!NOTE]
> This should remove most, or all, `node20` warnings in the ci

> [!IMPORTANT]
> Moving to official github actions for pages publishing means that the `Code and automation >  Pages > Source > Build and deployment` repository setting [should be set to ](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site) `GitHub Actions`.
>
> It also means that our [`gh-pages` branch](https://github.com/input-output-hk/mithril/tree/gh-pages), automatically managed by `peaceiris/actions-gh-pages`, won't have any more uses.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #3173
