### PR TITLE
drop support for x86_64-darwin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
 
   outputs = inputs:
     inputs.flake-parts.lib.mkFlake {inherit inputs;} {
-      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin"];
+      systems = ["x86_64-linux" "aarch64-linux" "aarch64-darwin"];
 
       imports = [inputs.treefmt-nix.flakeModule];
 


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

- Nixpkgs expects to drop support for intel macs in 26.11 as per Nixpkgs 25.11 [release notes](https://nixos.org/manual/nixpkgs/stable/release-notes#sec-nixpkgs-release-25.11-highlights).                          
- It was [decided](https://input-output-rnd.slack.com/archives/CG1FBSDMM/p1776704401411139?thread_ts=1776677872.325309&cid=CG1FBSDMM) to no longer build x86_64-darwin on [ci.iog.io](https://ci.iog.io) to reduce strain on the struggling mac builders.

This PR includes...

## Pre-submit checklist

- Branch
  - [x] ~~Tests are provided (if possible)~~
  - [x] ~~Crates versions are updated (if relevant)~~
  - [x] ~~CHANGELOG file is updated (if relevant)~~
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] ~~Update README file (if relevant)~~
  - [x] ~~Update documentation website (if relevant)~~
  - [x] ~~Add dev blog post (if relevant)~~
  - [x] ~~Add ADR blog post or Dev ADR entry (if relevant)~~
  - [x] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)