### PR TITLE
docs(website): fix doubled title on homepage

### DIFF
--- a/docs/website/docusaurus.config.js
+++ b/docs/website/docusaurus.config.js
@@ -9,7 +9,7 @@ import rehypeKatex from "rehype-katex";
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Mithril | Trustless state proofs for Cardano",
+  title: "Mithril",
   tagline:
     "Trustless, lightweight access to verified Cardano blockchain state — no full node required.",
   url: "https://mithril.network",

--- a/docs/website/src/pages/index.tsx
+++ b/docs/website/src/pages/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 import { PageContext, PageType } from "../context/PageContext";
 import HomepageHero from "../components/HomepageHero";
@@ -11,10 +12,10 @@ export default function HomePage() {
   return (
     <PageContext.Provider value={{ page: PageType.Landing }}>
       <div style={{ zIndex: 1000 }}>
-        <Layout
-          title="Mithril | Trustless Light Client Access for Cardano"
-          description="Mithril is a stake-based threshold multisignature protocol for Cardano, enabling trustless, lightweight access to verified blockchain state without requiring a full node."
-        >
+        <Layout description="Mithril is a stake-based threshold multisignature protocol for Cardano, enabling trustless, lightweight access to verified blockchain state without requiring a full node.">
+          <Head>
+            <title>Mithril | Trustless state proofs for Cardano</title>
+          </Head>
           <HomepageHero />
           <main>
             <WhyMithril />


### PR DESCRIPTION
## Summary

- Homepage title was rendering as `Mithril | Trustless Light Client Access for Cardano | Mithril | Trustless state proofs for Cardano` — the `Layout` `title` prop was concatenated with a site title that already contained both brand and descriptor.
- Shorten the site title to `Mithril`, so subpages render as `[page title] | Mithril`.
- Use `<Head>` on the homepage to set the title directly to `Mithril | Trustless state proofs for Cardano`, bypassing Docusaurus's auto-formatting and avoiding any duplication.

## Test plan

- [ ] Run `npm start` in `docs/website` and confirm the homepage tab title reads `Mithril | Trustless state proofs for Cardano`
- [ ] Click into a docs page and confirm its tab title reads `[page title] | Mithril`
- [ ] After deploy, recheck Google search results to confirm the homepage title is no longer doubled

🤖 Generated with [Claude Code](https://claude.com/claude-code)