### PR TITLE
fix(client): rare race condition when a file download finish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,7 +4217,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.14.7"
+version = "0.14.8"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.14.7"
+version = "0.14.8"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/src/file_downloader/http.rs
+++ b/mithril-client/src/file_downloader/http.rs
@@ -240,7 +240,7 @@ mod tests {
 
     use httpmock::MockServer;
 
-    use mithril_common::{entities::FileUri, test::TempDir};
+    use mithril_common::{entities::FileUri, temp_dir_create};
 
     use crate::{
         feedback::{
@@ -273,11 +273,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_download_http_file_send_feedback() {
-        let target_dir = TempDir::create(
-            "client-http-downloader",
-            "test_download_http_file_send_feedback",
-        );
+    async fn downloading_http_file_send_feedback() {
+        let target_dir = temp_dir_create!();
         let content = "Hello, world!";
         let size = content.len() as u64;
         let server = MockServer::start();
@@ -327,11 +324,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_download_local_file_send_feedback() {
-        let target_dir = TempDir::create(
-            "client-http-downloader",
-            "test_download_local_file_send_feedback",
-        );
+    async fn downloading_local_file_send_feedback() {
+        let target_dir = temp_dir_create!();
         let content = "Hello, world!";
         let size = content.len() as u64;
 

--- a/mithril-client/src/file_downloader/http.rs
+++ b/mithril-client/src/file_downloader/http.rs
@@ -128,9 +128,17 @@ impl HttpFileDownloader {
         while let Some(item) = remote_stream.next().await {
             let chunk = item.with_context(|| "Download: Could not read from byte stream")?;
 
-            if sender.is_disconnected() {
+            if chunk.is_empty() {
                 break;
             }
+
+            if sender.is_disconnected() {
+                anyhow::bail!(
+                    "Download: unpack finished but `{}` bytes were remaining",
+                    chunk.len()
+                );
+            }
+
             sender.send_async(chunk.to_vec()).await.with_context(|| {
                 format!("Download: could not write {} bytes to stream.", chunk.len())
             })?;
@@ -391,7 +399,7 @@ mod tests {
         // Simulate an unpack task end by dropping the receiver immediately, the download task should stop without error
         drop(rx);
 
-        let download_result = http_file_downloader
+        let error = http_file_downloader
             .download_remote_file(
                 &server.url("/snapshot.tar"),
                 &tx,
@@ -400,11 +408,13 @@ mod tests {
                 },
                 0,
             )
-            .await;
+            .await
+            .unwrap_err();
 
+        let expected_error = "Download: unpack finished but `1` bytes were remaining";
         assert!(
-            download_result.is_ok(),
-            "Remote download failed: {download_result:?}"
+            error.to_string().contains(expected_error),
+            "Expected error to contains `{expected_error}` but got: `{error:?}`"
         );
     }
 

--- a/mithril-client/src/file_downloader/http.rs
+++ b/mithril-client/src/file_downloader/http.rs
@@ -127,6 +127,10 @@ impl HttpFileDownloader {
 
         while let Some(item) = remote_stream.next().await {
             let chunk = item.with_context(|| "Download: Could not read from byte stream")?;
+
+            if sender.is_disconnected() {
+                break;
+            }
             sender.send_async(chunk.to_vec()).await.with_context(|| {
                 format!("Download: could not write {} bytes to stream.", chunk.len())
             })?;
@@ -370,5 +374,68 @@ mod tests {
             }),
         ];
         assert_eq!(expected_events, feedback_receiver.stacked_events());
+    }
+
+    #[tokio::test]
+    async fn downloading_http_file_handle_early_unpack_receiver_closure() {
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/snapshot.tar");
+            then.status(200).body("a");
+        });
+        let http_file_downloader =
+            HttpFileDownloader::new(FeedbackSender::new(&[]), TestLogger::stdout()).unwrap();
+        let download_id = "id".to_string();
+        let (tx, rx) = flume::bounded(1);
+
+        // Simulate an unpack task end by dropping the receiver immediately, the download task should stop without error
+        drop(rx);
+
+        let download_result = http_file_downloader
+            .download_remote_file(
+                &server.url("/snapshot.tar"),
+                &tx,
+                DownloadEvent::Digest {
+                    download_id: download_id.clone(),
+                },
+                0,
+            )
+            .await;
+
+        assert!(
+            download_result.is_ok(),
+            "Remote download failed: {download_result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn downloading_local_file_handle_early_unpack_receiver_closure() {
+        let target_dir = temp_dir_create!();
+        let source_file_path = target_dir.join("snapshot.txt");
+        let _file = std::fs::File::create(&source_file_path).unwrap();
+
+        let http_file_downloader =
+            HttpFileDownloader::new(FeedbackSender::new(&[]), TestLogger::stdout()).unwrap();
+        let download_id = "id".to_string();
+        let (tx, rx) = flume::bounded(1);
+
+        // Simulate an unpack task end by dropping the receiver immediately, the download task should stop without error
+        drop(rx);
+
+        let download_result = http_file_downloader
+            .download_local_file(
+                &source_file_path.to_string_lossy(),
+                &tx,
+                DownloadEvent::Digest {
+                    download_id: download_id.clone(),
+                },
+                0,
+            )
+            .await;
+
+        assert!(
+            download_result.is_ok(),
+            "Remote download failed: {download_result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Content

This PR a fix for a rare race condition that can occurs in the `mithril-client` library when it download a file.

### Issue

In our nightly test lately we often have one `test-client / bin-cdb-download` out of nine which fail with the following error:

> [!NOTE]
> The failing immutable vary 

```
src: CardanoDatabaseClient
 May 04 01:54:46.485 ERRO Failed downloading and unpacking immutable_file_22084 for location FileUri(FileUri("https://storage.googleapis.com/cdn.aggregator.testing-preview.api.mithril.network/cardano-database/immutable/22084.tar.zst")), error: Download of location FileUri(FileUri("https://storage.googleapis.com/cdn.aggregator.testing-preview.api.mithril.network/cardano-database/immutable/22084.tar.zst")) failed after 3 attempts

Caused by:
    0: Download: could not write 0 bytes to stream.
    1: sending on a closed channel
Error: Can not download and unpack cardano db snapshot for hash: 'e3bd1ae37e80af363de96a021f9f8dc9b1915b50d5f14a9e1dcabc6e24afbc8a'

Caused by:
    All locations failed for immutable_file_22084, tried locations: https://storage.googleapis.com/cdn.aggregator.testing-preview.api.mithril.network/cardano-database/immutable/22084.tar.zst
``` 

The code who throw the error is the `HttpFileDownloader::download_remote_file` method, specifically the `send_async` method of flume.
Looking at flume code, the `sending on a closed channel` is only sent when the receiver channel was drop, which can happen very rarely when the file download do a last loop, who will read 0 bytes, but the receiver was closed because the unpack task finished (probably because the archive unpacker may know just by looking at the bytes that no more bytes are needed).

### Fix

If no more bytes can be read, the file downloader now stop and don't try to send more bytes to the receiver. An error will still be send if the sender is disconnected with the receiver and there is still bytes to send.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #3210
