### PR TITLE
Fix artifact retrieval by specifying signed entity type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.8.49"
+version = "0.8.50"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.8.49"
+version = "0.8.50"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/query/signed_entity/get_signed_entity.rs
+++ b/mithril-aggregator/src/database/query/signed_entity/get_signed_entity.rs
@@ -19,11 +19,18 @@ impl GetSignedEntityRecordQuery {
         }
     }
 
-    pub fn by_signed_entity_id(signed_entity_id: &str) -> Self {
+    pub fn by_signed_entity_id_and_signed_entity_type(
+        signed_entity_id: &str,
+        signed_entity_type: &SignedEntityTypeDiscriminants,
+    ) -> Self {
+        let signed_entity_type_id = signed_entity_type.index() as i64;
         Self {
             condition: WhereCondition::new(
-                "signed_entity_id = ?*",
-                vec![Value::String(signed_entity_id.to_owned())],
+                "signed_entity_id = ?* and signed_entity_type_id = ?*",
+                vec![
+                    Value::String(signed_entity_id.to_owned()),
+                    Value::Integer(signed_entity_type_id),
+                ],
             ),
         }
     }
@@ -170,7 +177,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_record_by_id() {
+    fn test_get_record_by_id_and_signed_entity_type() {
         let signed_entity_records = vec![
             SignedEntityRecord::fake_with_signed_entity(
                 SignedEntityType::CardanoStakeDistribution(Epoch(3)),
@@ -186,11 +193,42 @@ mod tests {
 
         let first_signed_entity_type = signed_entity_records[0].clone();
         let fetched_record = connection
-            .fetch_first(GetSignedEntityRecordQuery::by_signed_entity_id(
-                &first_signed_entity_type.signed_entity_id,
-            ))
+            .fetch_first(
+                GetSignedEntityRecordQuery::by_signed_entity_id_and_signed_entity_type(
+                    &first_signed_entity_type.signed_entity_id,
+                    &SignedEntityTypeDiscriminants::CardanoStakeDistribution,
+                ),
+            )
             .unwrap();
         assert_eq!(Some(first_signed_entity_type), fetched_record);
+    }
+
+    #[test]
+    fn test_get_record_by_id_and_signed_entity_type_must_return_none_if_signed_entity_type_does_not_match()
+     {
+        let signed_entity_records = vec![
+            SignedEntityRecord::fake_with_signed_entity(
+                SignedEntityType::CardanoStakeDistribution(Epoch(3)),
+            ),
+            SignedEntityRecord::fake_with_signed_entity(SignedEntityType::CardanoTransactions(
+                Epoch(4),
+                BlockNumber(5),
+            )),
+        ];
+
+        let connection = main_db_connection().unwrap();
+        insert_signed_entities(&connection, signed_entity_records.clone()).unwrap();
+
+        let first_signed_entity_type = signed_entity_records[0].clone();
+        let fetched_record = connection
+            .fetch_first(
+                GetSignedEntityRecordQuery::by_signed_entity_id_and_signed_entity_type(
+                    &first_signed_entity_type.signed_entity_id,
+                    &SignedEntityTypeDiscriminants::CardanoBlocksTransactions,
+                ),
+            )
+            .unwrap();
+        assert_eq!(None, fetched_record);
     }
 
     #[test]

--- a/mithril-aggregator/src/database/repository/signed_entity_store.rs
+++ b/mithril-aggregator/src/database/repository/signed_entity_store.rs
@@ -19,10 +19,11 @@ pub trait SignedEntityStorer: Sync + Send {
     /// Store a signed entity
     async fn store_signed_entity(&self, signed_entity: &SignedEntityRecord) -> StdResult<()>;
 
-    /// Get signed entity type
+    /// Get signed entity type by id and entity type
     async fn get_signed_entity(
         &self,
         signed_entity_id: &str,
+        signed_entity_type: &SignedEntityTypeDiscriminants,
     ) -> StdResult<Option<SignedEntityRecord>>;
 
     /// Get signed entity type by certificate id
@@ -90,11 +91,15 @@ impl SignedEntityStorer for SignedEntityStore {
     async fn get_signed_entity(
         &self,
         signed_entity_id: &str,
+        signed_entity_type: &SignedEntityTypeDiscriminants,
     ) -> StdResult<Option<SignedEntityRecord>> {
         self.connection
-            .fetch_first(GetSignedEntityRecordQuery::by_signed_entity_id(
-                signed_entity_id,
-            ))
+            .fetch_first(
+                GetSignedEntityRecordQuery::by_signed_entity_id_and_signed_entity_type(
+                    signed_entity_id,
+                    signed_entity_type,
+                ),
+            )
             .with_context(|| format!("get signed entity by id failure, id: {signed_entity_id}"))
     }
 

--- a/mithril-aggregator/src/services/message.rs
+++ b/mithril-aggregator/src/services/message.rs
@@ -279,7 +279,13 @@ impl MessageService for MithrilMessageService {
         &self,
         signed_entity_id: &str,
     ) -> StdResult<Option<SnapshotMessage>> {
-        let signed_entity = self.signed_entity_storer.get_signed_entity(signed_entity_id).await?;
+        let signed_entity = self
+            .signed_entity_storer
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            )
+            .await?;
 
         signed_entity.map(|s| s.try_into()).transpose()
     }
@@ -298,7 +304,13 @@ impl MessageService for MithrilMessageService {
         &self,
         signed_entity_id: &str,
     ) -> StdResult<Option<CardanoDatabaseSnapshotMessage>> {
-        let signed_entity = self.signed_entity_storer.get_signed_entity(signed_entity_id).await?;
+        let signed_entity = self
+            .signed_entity_storer
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::CardanoDatabase,
+            )
+            .await?;
 
         signed_entity.map(|v| v.try_into()).transpose()
     }
@@ -351,7 +363,13 @@ impl MessageService for MithrilMessageService {
         &self,
         signed_entity_id: &str,
     ) -> StdResult<Option<MithrilStakeDistributionMessage>> {
-        let signed_entity = self.signed_entity_storer.get_signed_entity(signed_entity_id).await?;
+        let signed_entity = self
+            .signed_entity_storer
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            )
+            .await?;
 
         signed_entity.map(|v| v.try_into()).transpose()
     }
@@ -373,7 +391,13 @@ impl MessageService for MithrilMessageService {
         &self,
         signed_entity_id: &str,
     ) -> StdResult<Option<CardanoTransactionSnapshotMessage>> {
-        let signed_entity = self.signed_entity_storer.get_signed_entity(signed_entity_id).await?;
+        let signed_entity = self
+            .signed_entity_storer
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::CardanoTransactions,
+            )
+            .await?;
 
         signed_entity.map(|v| v.try_into()).transpose()
     }
@@ -395,7 +419,13 @@ impl MessageService for MithrilMessageService {
         &self,
         signed_entity_id: &str,
     ) -> StdResult<Option<CardanoBlocksTransactionsSnapshotMessage>> {
-        let signed_entity = self.signed_entity_storer.get_signed_entity(signed_entity_id).await?;
+        let signed_entity = self
+            .signed_entity_storer
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::CardanoBlocksTransactions,
+            )
+            .await?;
 
         signed_entity.map(|v| v.try_into()).transpose()
     }
@@ -417,7 +447,13 @@ impl MessageService for MithrilMessageService {
         &self,
         signed_entity_id: &str,
     ) -> StdResult<Option<CardanoStakeDistributionMessage>> {
-        let signed_entity = self.signed_entity_storer.get_signed_entity(signed_entity_id).await?;
+        let signed_entity = self
+            .signed_entity_storer
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::CardanoStakeDistribution,
+            )
+            .await?;
 
         signed_entity.map(|v| v.try_into()).transpose()
     }

--- a/mithril-aggregator/src/services/signed_entity.rs
+++ b/mithril-aggregator/src/services/signed_entity.rs
@@ -412,7 +412,10 @@ impl SignedEntityService for MithrilSignedEntityService {
     ) -> StdResult<Option<SignedEntity<Snapshot>>> {
         let entity: Option<SignedEntity<Snapshot>> = match self
             .signed_entity_storer
-            .get_signed_entity(signed_entity_id)
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::CardanoImmutableFilesFull,
+            )
             .await
             .with_context(|| {
                 format!(
@@ -446,7 +449,10 @@ impl SignedEntityService for MithrilSignedEntityService {
     ) -> StdResult<Option<SignedEntity<CardanoDatabaseSnapshot>>> {
         let entity: Option<SignedEntity<CardanoDatabaseSnapshot>> = match self
             .signed_entity_storer
-            .get_signed_entity(signed_entity_id)
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::CardanoDatabase,
+            )
             .await
             .with_context(|| {
                 format!(
@@ -483,7 +489,10 @@ impl SignedEntityService for MithrilSignedEntityService {
     ) -> StdResult<Option<SignedEntity<MithrilStakeDistribution>>> {
         let entity: Option<SignedEntity<MithrilStakeDistribution>> = match self
             .signed_entity_storer
-            .get_signed_entity(signed_entity_id)
+            .get_signed_entity(
+                signed_entity_id,
+                &SignedEntityTypeDiscriminants::MithrilStakeDistribution,
+            )
             .await
             .with_context(|| {
                 format!(


### PR DESCRIPTION
## Content
Fix an aggregator error, visible through `mithril-client-cli`, that occurs when attempting to fetch an existing snapshot by ID that is not of the expected signed entity type.

Signed entity records are now retrieved using both the signed entity ID and type. If no match is found, an empty result is returned instead of a deserialization error.

Example when trying to fetch a existing **cardano-transaction snapshot** with **cardano-block** command : 
```
./mithril-client cardano-block snapshot show d4889953d2dc795db1b732b5e01c7f7112374ff29b86f5c97b73131b0f1b14bb --unstable
```
before :
```
Error: Failed to get Cardano block snapshot with hash 'd4889953d2dc795db1b732b5e01c7f7112374ff29b86f5c97b73131b0f1b14bb'

Caused by:
    0: Internal error of the Aggregator
    1: internal server error: missing field `block_number_signed` at line 1 column 216
       
       Stack backtrace:
          0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from

```
now : 
```
Error: Cardano blocks transactions snapshot not found for hash: '0909654ce0418597e9bf234f37961af207876634a3360fa259e1d770645ca94e'
```

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

this PR closes #3244 
