### PR TITLE
Remove mention of Open API documentation website in Open API files

### DIFF
--- a/docs/website/openapi.current.yaml
+++ b/docs/website/openapi.current.yaml
@@ -8,8 +8,6 @@ info:
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.
-
-    You can play with it [here](https://mithril.network/doc/aggregator-api/current).
   termsOfService: http://swagger.io/terms/
   contact:
     name: Mithril Team

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -8,8 +8,6 @@ info:
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.
-
-    You can play with it [here](https://mithril.network/doc/aggregator-api/current).
   termsOfService: http://swagger.io/terms/
   contact:
     name: Mithril Team

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.62
+  version: 0.1.63
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content

Remove mention of Open API documentation website in Open API files

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced