### PR TITLE
Add a script to check dependency version consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,10 @@ jobs:
         shell: bash
         run: cargo machete
 
+      - name: Run crates versions consistency check
+        shell: bash
+        run: ./.github/workflows/scripts/crate-version-checker/crate-version-checker.sh
+
       - name: Dependency & Vulnerabilities Review
         if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v4

--- a/.github/workflows/scripts/crate-version-checker/README.md
+++ b/.github/workflows/scripts/crate-version-checker/README.md
@@ -1,0 +1,62 @@
+# Crate Version Checker
+
+This script verifies that all internal workspace dependencies use the expected crate version across the repository.
+
+## Purpose
+
+Internal crates often evolve together and are expected to stay version-aligned.
+
+This script helps enforce that policy by:
+
+- reading workspace crate versions using `cargo metadata`
+- inspecting all declared dependencies
+- detecting version mismatches for selected internal crates
+- failing when inconsistencies are found
+
+## What it checks
+
+For each configured crate:
+
+- retrieve the actual workspace crate version
+- inspect all workspace package dependencies
+- compare dependency version requirements against the expected version
+
+The script ignores `^` in versions, so the following versions are considered the same:
+
+- 0.5.12
+- ^0.5.12
+
+All other differences will fail the script, for example :
+
+- crate version `0.5.12` , dependency version `=0.5.12`
+- crate version `0.5.12` , dependency version `^0.5.10`
+- crate version `0.5.12` , dependency version `=0.5`
+- crate version `0.5.12` , dependency version `>=0.5.12`
+- crate version `0.5.12` , dependency version `~0.5.12`
+
+You can run it from the root directory of the workspace using :
+`bash ./.github/workflows/scripts/crate-version-checker/crate-version-checker.sh`
+
+here a example of a error output:
+
+```
+Checking that all usages of mithril-common use version 0.6.72 -> KO
+ERROR: mithril-aggregator-client depends to mithril-common with version ^0.6.70
+ERROR: mithril-cardano-node-internal-database depends to mithril-common with version =0.6.60
+
+...
+
+Dependency version mismatches detected.
+```
+
+and a example of a success output:
+
+```
+Checking that all usages of mithril-common use version 0.6.72 -> OK
+
+...
+
+Checking that all usages of mithril-end-to-end use version 0.4.133 -> OK
+
+All dependency versions are consistent.
+```

--- a/.github/workflows/scripts/crate-version-checker/crate-version-checker.sh
+++ b/.github/workflows/scripts/crate-version-checker/crate-version-checker.sh
@@ -1,0 +1,92 @@
+set +a -eu -o pipefail
+
+# -----------------------------------------------------------------------------
+# Requirements:
+#   - cargo
+#   - jq
+#
+# Exit code:
+#   0 => OK
+#   1 => At least one version mismatch
+# -----------------------------------------------------------------------------
+RESET='\033[0m'
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+
+has_warning=0
+
+metadata_json=$(cargo metadata --format-version 1 --no-deps)
+
+crates_dependencies_to_check=(
+    $(echo "${metadata_json}" | jq -r '
+        .packages[]
+        | select(.name | startswith("mithril-"))
+        | .name
+    ')
+)
+
+for crate_dependency in "${crates_dependencies_to_check[@]}"; do
+    # Retrieve actual workspace crate version
+    crate_version=$(
+        echo "${metadata_json}" \
+        | jq -r --arg crate "${crate_dependency}" '
+            .packages[]
+            | select(.name == $crate)
+            | .version
+            ' \
+        | head -n1
+    )
+
+    if [[ -z "${crate_version}" || "${crate_version}" == "null" ]]; then
+        echo "WARNING: Cannot find workspace crate version for ${crate_dependency}"
+        has_warning=1
+        continue
+    fi
+
+    echo
+    echo -n "Checking that all usages of ${crate_dependency} use version ${crate_version}"
+
+    # Inspect all packages depending on this crate
+    mismatches=$(
+    echo "${metadata_json}" \
+        | jq -r \
+        --arg crate "${crate_dependency}" \
+        --arg expected "${crate_version}" '
+            .packages[]
+            | . as $pkg
+            | .dependencies[]
+            | select(.name == $crate)
+
+            # normalize version requirement (allow minor version)
+            | (.req | sub("^\\^"; "")) as $normalized_req
+
+            | select(
+                $normalized_req != $expected
+                and .req != "*"
+            )
+
+            | "\($pkg.name)|\(.req)"
+        '
+    )
+
+    if [[ -n "${mismatches}" ]]; then
+    echo -e "${RED} -> KO${RESET}"
+    while IFS='|' read -r package_name found_version; do
+        echo -e "${RED}ERROR:${RESET} ${package_name} depends to ${crate_dependency} with version ${RED}${found_version}${RESET}"
+
+        has_warning=1
+    done <<< "${mismatches}"
+    else
+        echo -e "${GREEN} -> OK${RESET}"
+    fi
+done
+
+echo
+
+if [[ "${has_warning}" -eq 1 ]]; then
+    echo "Dependency version mismatches detected."
+    exit 1
+fi
+
+echo "All dependency versions are consistent."
+exit 0

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.1" }
+mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.1.11" }
 mithril-common = { path = "../../mithril-common", version = "0.6.72" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -82,8 +82,8 @@ uuid = { version = "1.23.1", features = ["v4"] }
 zstd = { version = "0.13.3", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-mithril-aggregator-discovery = { path = "../internal/mithril-aggregator-discovery", version = "0.1" }
-mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.1" }
+mithril-aggregator-discovery = { path = "../internal/mithril-aggregator-discovery", version = "0.1.5" }
+mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.1.12" }
 rand = { version = "0.10.1" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -45,7 +45,7 @@ ed25519-dalek = { version = "2.2.0", features = ["rand_core", "serde"] }
 fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
-mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1" }
+mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.2" }
 mithril-stm = { path = "../mithril-stm", version = "0.10.17", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
@@ -68,7 +68,7 @@ walkdir = "2.5.0"
 wasm-bindgen = "0.2.118"
 
 [build-dependencies]
-mithril-build-script = { path = "../internal/mithril-build-script", version = "=0.2" }
+mithril-build-script = { path = "../internal/mithril-build-script", version = "0.2.31" }
 
 [dev-dependencies]
 criterion = { version = "0.8.2", features = ["html_reports", "async_tokio"] }


### PR DESCRIPTION
## Content

This PR adds a script to check dependency version consistency for internal crates (`mithril-*`) across the workspace.

It then checks whether these crates are used as dependencies in other packages and compares their versions.

The script warns if version mismatches are found and fails if at least one warning is detected.

This script has been added to the `ci.yml` file in a dedicated step of the check job.

It can be run manually using:
```
bash ./.github/workflows/scripts/crate-version-checker/crate-version-checker.sh
```
## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

The issue(s) Closes #3245 
