### PR TITLE
chore: add `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# Mithril code owners
+
+# Default owners (repository maintainers)
+*                              @jpraynaud @Alenar @turmelclem
+
+# Cryptography: Stake-based Threshold Multisignatures
+/mithril-stm/                  @jpraynaud @curiecrypt @hjeljeli32 @damrobi
+


### PR DESCRIPTION
## Content

This PR includes **the `.github/CODEOWNERS` file to assign ownership for the Mithril codebase**. 

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
