### PR TITLE
feat(mithril-stm): add reproducible benchmarks for StmCertificateCircuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.20"
+version = "0.10.21"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.2" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.20", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.21", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.21 (05-21-2026)
+
+### Added
+
+- Added Criterion benchmarks for `StmCertificateCircuit` covering VK/PK setup, proof generation, and verification across small, medium, large, and production parameter tiers.
+- Added CI parameter benchmarks comparing `MockProver` and real prover across a range of `k` values, with E2E extrapolation formula and reference results table documented in the README.
+
+### Changed
+
+- Corrected production tier `k` from `2093` to `1944` in benchmarks and README.
+- Unified `setup`, `prove`, and `verify` benchmarks into a single Criterion group with consistent flat sampling configuration.
+
 ## 0.10.20 (05-19-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -104,6 +104,11 @@ harness = false
 required-features = ["future_snark", "benchmark-internals"]
 
 [[bench]]
+name = "halo2_snark"
+harness = false
+required-features = ["future_snark", "benchmark-internals"]
+
+[[bench]]
 name = "stm"
 harness = false
 

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -109,6 +109,11 @@ harness = false
 required-features = ["future_snark", "benchmark-internals"]
 
 [[bench]]
+name = "halo2_prover_modes"
+harness = false
+required-features = ["future_snark", "benchmark-internals"]
+
+[[bench]]
 name = "stm"
 harness = false
 

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.20"
+version = "0.10.21"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -255,3 +255,42 @@ Large and production tiers run a single timed measurement (Criterion's 10-sample
 cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/large
 cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/production
 ```
+
+## CI Parameter Benchmarks
+
+Single-run benchmarks for the `StmCertificateCircuit` across small `k` values, covering both the real prover and the mock prover (`MockProver` from `midnight_proofs`). Used to determine the optimal circuit parameters for CI and end-to-end tests.
+
+Gated behind the `future_snark` and `benchmark-internals` features.
+
+### E2E extrapolation formula
+
+The E2E columns are derived from individual timings using the following formula:
+
+```text
+E2E (mock prover) ≈ mock_circuit_gen + 80 × mock_prove
+E2E (real prover) ≈ 80 × proof_gen
+```
+
+The constant 80 is the number of certificates generated in a standard Mithril end-to-end test run (with k = 70 or k = 140).
+
+### Hardware requirements
+
+All tiers complete in under 15 minutes on any developer machine with at least 4 GB RAM.
+
+### Reference results (Apple M4 Max, 48 GB, macOS, 3 000 signers, depth = 12)
+
+| k   | K   | mock_circuit_gen | mock_prove | mock_verify | e2e_mock | proof_gen | proof_verify | e2e_real |
+| --- | --- | ---------------- | ---------- | ----------- | -------- | --------- | ------------ | -------- |
+| 1   | 12  | ~25 ms           | ~62 ms     | ~11 ms      | ~5.0 s   | ~178 ms   | ~4 ms        | ~14.2 s  |
+| 2   | 13  | ~51 ms           | ~121 ms    | ~16 ms      | ~9.7 s   | ~300 ms   | ~4 ms        | ~23.9 s  |
+| 5   | 14  | ~133 ms          | ~300 ms    | ~33 ms      | ~24.1 s  | ~606 ms   | ~4 ms        | ~48.5 s  |
+| 10  | 15  | ~285 ms          | ~592 ms    | ~60 ms      | ~47.6 s  | ~1.2 s    | ~4 ms        | ~94.2 s  |
+| 20  | 16  | ~631 ms          | ~1.2 s     | ~115 ms     | ~94.8 s  | ~2.3 s    | ~4 ms        | ~184.9 s |
+| 50  | 17  | ~1.8 s           | ~3.0 s     | ~268 ms     | ~238.7 s | ~5.3 s    | ~4 ms        | ~422.1 s |
+| 100 | 18  | ~3.9 s           | ~5.9 s     | ~528 ms     | ~477.3 s | ~10.1 s   | ~4 ms        | ~811.4 s |
+
+### Running the benchmarks
+
+```bash
+cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_prover_modes
+```

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -222,21 +222,21 @@ Three metrics are measured per tier: VK/PK setup time, proof generation time, an
 
 ### Hardware requirements
 
-| Tier | Min RAM | Typical machine |
-|---|---|---|
-| small | < 1 GB | Any |
-| medium | ~1 GB | Any |
-| large | ~38 GB | Apple M1 Pro 48 GB or equivalent |
-| production | ~70 GB | AWS r7i.12xlarge (384 GB) or equivalent |
+| Tier       | Min RAM | Typical machine                         |
+| ---------- | ------- | --------------------------------------- |
+| small      | < 1 GB  | Any                                     |
+| medium     | ~1 GB   | Any                                     |
+| large      | ~38 GB  | Apple M4 Max 48 GB or equivalent        |
+| production | ~70 GB  | AWS r7i.12xlarge (384 GB) or equivalent |
 
-### Reference results (Apple M1 Pro, macOS, 3 000 signers, depth = 12)
+### Reference results (Apple M4 Max, 48 GB, macOS, 3 000 signers, depth = 12)
 
-| Tier | Degree | k | Setup | Prove | Verify | Proof size |
-|---|---|---|---|---|---|---|
-| small | 13 | 3 | ~196 ms | ~365 ms | ~4.1 ms | 3,600 B |
-| medium | 16 | 32 | ~1.99 s | ~3.08 s | ~4.1 ms | 3,600 B |
-| large | 21 | 1,024 | ~89 s | ~111 s | ~6.3 ms | 3,600 B |
-| production† | 22 | 2,093 | ~136 s | ~362 s | ~7 ms | 3,824 B |
+| Tier        | Degree | k     | Setup   | Prove   | Verify  | Proof size |
+| ----------- | ------ | ----- | ------- | ------- | ------- | ---------- |
+| small       | 13     | 3     | ~196 ms | ~365 ms | ~4.1 ms | 3,600 B    |
+| medium      | 16     | 32    | ~1.99 s | ~3.08 s | ~4.1 ms | 3,600 B    |
+| large       | 21     | 1,024 | ~89 s   | ~111 s  | ~6.3 ms | 3,600 B    |
+| production† | 22     | 2,093 | ~136 s  | ~362 s  | ~7 ms   | 3,824 B    |
 
 †Production numbers from the SNARK Book (AWS r7i.12xlarge, 48 vCPU, 384 GB RAM). Requires ≥ 70 GB RAM.
 

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -213,3 +213,45 @@ STM/Blake2b/Aggregation/k: 250, m: 1523, nr_parties: 2000
 STM/Blake2b/Verification/k: 250, m: 1523, nr_parties: 2000
                         time:   [13.944 ms 14.010 ms 14.077 ms]
 ```
+
+## Certificate Circuit Benchmarks
+
+Criterion benchmarks for the non-recursive `StmCertificateCircuit` (Halo2/KZG), gated behind the `future_snark` and `benchmark-internals` features.
+
+Three metrics are measured per tier: VK/PK setup time, proof generation time, and proof verification time. Circuit cost and proof size are printed at startup.
+
+### Hardware requirements
+
+| Tier | Min RAM | Typical machine |
+|---|---|---|
+| small | < 1 GB | Any |
+| medium | ~1 GB | Any |
+| large | ~38 GB | Apple M1 Pro 48 GB or equivalent |
+| production | ~70 GB | AWS r7i.12xlarge (384 GB) or equivalent |
+
+### Reference results (Apple M1 Pro, macOS, 3 000 signers, depth = 12)
+
+| Tier | Degree | k | Setup | Prove | Verify | Proof size |
+|---|---|---|---|---|---|---|
+| small | 13 | 3 | ~196 ms | ~365 ms | ~4.1 ms | 3,600 B |
+| medium | 16 | 32 | ~1.99 s | ~3.08 s | ~4.1 ms | 3,600 B |
+| large | 21 | 1,024 | ~89 s | ~111 s | ~6.3 ms | 3,600 B |
+| production† | 22 | 2,093 | ~136 s | ~362 s | ~7 ms | 3,824 B |
+
+†Production numbers from the SNARK Book (AWS r7i.12xlarge, 48 vCPU, 384 GB RAM). Requires ≥ 70 GB RAM.
+
+### Running the benchmarks
+
+Small and medium tiers use Criterion (10 samples, flat sampling — one iteration per sample):
+
+```bash
+cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/small
+cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/medium
+```
+
+Large and production tiers run a single timed measurement (Criterion's 10-sample minimum is impractical at this scale):
+
+```bash
+cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/large
+cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/production
+```

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -236,7 +236,7 @@ Three metrics are measured per tier: VK/PK setup time, proof generation time, an
 | small       | 13     | 3     | ~196 ms | ~365 ms | ~4.1 ms | 3,600 B    |
 | medium      | 16     | 32    | ~1.99 s | ~3.08 s | ~4.1 ms | 3,600 B    |
 | large       | 21     | 1,024 | ~89 s   | ~111 s  | ~6.3 ms | 3,600 B    |
-| production† | 22     | 2,093 | ~136 s  | ~362 s  | ~7 ms   | 3,824 B    |
+| production† | 22     | 1,944 | ~136 s  | ~362 s  | ~7 ms   | 3,824 B    |
 
 †Production numbers from the SNARK Book (AWS r7i.12xlarge, 48 vCPU, 384 GB RAM). Requires ≥ 70 GB RAM.
 

--- a/mithril-stm/benches/halo2_prover_modes.rs
+++ b/mithril-stm/benches/halo2_prover_modes.rs
@@ -1,0 +1,132 @@
+use std::time::Instant;
+
+use mithril_stm::circuits::halo2::bench_helpers::{BenchEnv, compute_circuit_degree};
+
+fn fmt_ms(ms: u128) -> String {
+    if ms >= 1000 {
+        format!("~{:.1}s", ms as f64 / 1000.0)
+    } else {
+        format!("~{}ms", ms)
+    }
+}
+
+/// E2E constant: number of certificates generated in a standard Mithril e2e test run.
+/// Derived from the protocol using k=70 or k=140, which produces ~80 certificates.
+const E2E_CERT_COUNT: u128 = 80;
+
+struct Tier {
+    k: u32,
+    m: u32,
+}
+
+const TIERS: &[Tier] = &[
+    Tier { k: 1, m: 10 },
+    Tier { k: 2, m: 20 },
+    Tier { k: 5, m: 50 },
+    Tier { k: 10, m: 100 },
+    Tier { k: 20, m: 200 },
+    Tier { k: 50, m: 500 },
+    Tier { k: 100, m: 1000 },
+];
+
+fn main() {
+    println!("mithril-stm halo2_prover_modes — release mode, num_signers = 3000");
+    println!();
+    println!("E2E formula:");
+    println!(
+        "  E2E (mock prover) ≈ mock_circuit_gen + {} × mock_prove",
+        E2E_CERT_COUNT
+    );
+    println!("  E2E (real prover) ≈ {} × proof_gen", E2E_CERT_COUNT);
+    println!();
+
+    println!(
+        "{:<12} {:<4} {:<4} {:<22} {:<22} {:<22} {:<22} {:<22} {:<22} {:<20}",
+        "params",
+        "k",
+        "K",
+        "mock_circuit_gen",
+        "mock_prove",
+        "mock_verify",
+        "e2e_mock",
+        "proof_gen",
+        "proof_verify",
+        "e2e_real"
+    );
+    println!("{}", "-".repeat(180));
+
+    for tier in TIERS {
+        let circuit_degree = match compute_circuit_degree(tier.k, tier.m) {
+            Ok(d) => d,
+            Err(e) => {
+                eprintln!(
+                    "k={} m={}: failed to compute circuit degree: {e}",
+                    tier.k, tier.m
+                );
+                continue;
+            }
+        };
+
+        let env = match BenchEnv::new(circuit_degree, tier.k, tier.m) {
+            Ok(e) => e,
+            Err(e) => {
+                eprintln!("k={} m={}: BenchEnv::new failed: {e}", tier.k, tier.m);
+                continue;
+            }
+        };
+
+        let witness = match env.build_witness() {
+            Ok(w) => w,
+            Err(e) => {
+                eprintln!("k={} m={}: build_witness failed: {e}", tier.k, tier.m);
+                continue;
+            }
+        };
+
+        // --- Mock prover ---
+        let mock = match env.mock_run(&witness) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("k={} m={}: mock_run failed: {e}", tier.k, tier.m);
+                continue;
+            }
+        };
+
+        let e2e_mock_ms =
+            mock.circuit_gen.as_millis() + E2E_CERT_COUNT * mock.mock_prove.as_millis();
+
+        // --- Real prover ---
+        let t = Instant::now();
+        let proof = match env.prove(&witness) {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("k={} m={}: prove failed: {e}", tier.k, tier.m);
+                continue;
+            }
+        };
+        let proof_gen = t.elapsed();
+
+        let t = Instant::now();
+        if let Err(e) = env.verify(&proof, &witness) {
+            eprintln!("k={} m={}: verify failed: {e}", tier.k, tier.m);
+            continue;
+        }
+        let proof_verify = t.elapsed();
+
+        let e2e_real_ms = E2E_CERT_COUNT * proof_gen.as_millis();
+
+        println!(
+            "{:<12} {:<4} {:<4} {:<22} {:<22} {:<22} {:<22} {:<22} {:<22} {:<20}",
+            format!("k={} m={}", tier.k, tier.m),
+            tier.k,
+            circuit_degree,
+            format!("{:.3?}", mock.circuit_gen),
+            format!("{:.3?}", mock.mock_prove),
+            format!("{:.3?}", mock.mock_verify),
+            fmt_ms(e2e_mock_ms),
+            format!("{:.3?}", proof_gen),
+            format!("{:.3?}", proof_verify),
+            fmt_ms(e2e_real_ms),
+        );
+    }
+}

--- a/mithril-stm/benches/halo2_snark.rs
+++ b/mithril-stm/benches/halo2_snark.rs
@@ -30,7 +30,7 @@ const TIERS: &[Tier] = &[
     Tier {
         name: "production",
         circuit_degree: 22,
-        k: 2093,
+        k: 1944,
     },
 ];
 
@@ -70,13 +70,10 @@ fn bench_tier_criterion(c: &mut Criterion, tier: &Tier, measurement_time_secs: u
     slow_group.bench_function("prove", |b| {
         b.iter(|| env.prove(&witness).expect("prove should not fail"));
     });
-    slow_group.finish();
-
-    let mut verify_group = c.benchmark_group(&group_name);
-    verify_group.bench_function("verify", |b| {
+    slow_group.bench_function("verify", |b| {
         b.iter(|| env.verify(&proof, &witness).expect("verify should not fail"));
     });
-    verify_group.finish();
+    slow_group.finish();
 }
 
 /// Single timed run for large/production tiers where 10 Criterion samples would be too costly.

--- a/mithril-stm/benches/halo2_snark.rs
+++ b/mithril-stm/benches/halo2_snark.rs
@@ -12,10 +12,26 @@ struct Tier {
 }
 
 const TIERS: &[Tier] = &[
-    Tier { name: "small",      circuit_degree: 13, k: 3    },
-    Tier { name: "medium",     circuit_degree: 16, k: 32   },
-    Tier { name: "large",      circuit_degree: 21, k: 1024 },
-    Tier { name: "production", circuit_degree: 22, k: 2093 },
+    Tier {
+        name: "small",
+        circuit_degree: 13,
+        k: 3,
+    },
+    Tier {
+        name: "medium",
+        circuit_degree: 16,
+        k: 32,
+    },
+    Tier {
+        name: "large",
+        circuit_degree: 21,
+        k: 1024,
+    },
+    Tier {
+        name: "production",
+        circuit_degree: 22,
+        k: 2093,
+    },
 ];
 
 /// Returns true if no filter was passed, or if the filter matches `tier`.
@@ -87,22 +103,30 @@ fn bench_tier_single_run(tier: &Tier) {
 }
 
 fn bench_small(c: &mut Criterion) {
-    if !tier_is_selected("small") { return; }
+    if !tier_is_selected("small") {
+        return;
+    }
     bench_tier_criterion(c, &TIERS[0], 10);
 }
 
 fn bench_medium(c: &mut Criterion) {
-    if !tier_is_selected("medium") { return; }
+    if !tier_is_selected("medium") {
+        return;
+    }
     bench_tier_criterion(c, &TIERS[1], 60);
 }
 
 fn bench_large(_c: &mut Criterion) {
-    if !tier_is_selected("large") { return; }
+    if !tier_is_selected("large") {
+        return;
+    }
     bench_tier_single_run(&TIERS[2]);
 }
 
 fn bench_production(_c: &mut Criterion) {
-    if !tier_is_selected("production") { return; }
+    if !tier_is_selected("production") {
+        return;
+    }
     bench_tier_single_run(&TIERS[3]);
 }
 

--- a/mithril-stm/benches/halo2_snark.rs
+++ b/mithril-stm/benches/halo2_snark.rs
@@ -1,0 +1,112 @@
+use std::time::Instant;
+
+use criterion::{Criterion, SamplingMode, criterion_group, criterion_main};
+use std::time::Duration;
+
+use mithril_stm::circuits::halo2::bench_helpers::BenchEnv;
+
+struct Tier {
+    name: &'static str,
+    circuit_degree: u32,
+    k: u32,
+}
+
+const TIERS: &[Tier] = &[
+    Tier { name: "small",      circuit_degree: 13, k: 3    },
+    Tier { name: "medium",     circuit_degree: 16, k: 32   },
+    Tier { name: "large",      circuit_degree: 21, k: 1024 },
+    Tier { name: "production", circuit_degree: 22, k: 2093 },
+];
+
+/// Returns true if no filter was passed, or if the filter matches `tier`.
+///
+/// Criterion skips `b.iter()` for non-matching benchmarks but still calls all
+/// benchmark functions and their setup code. This guard skips expensive
+/// `BenchEnv::new` for tiers that would not be benchmarked anyway.
+fn tier_is_selected(tier: &str) -> bool {
+    std::env::args()
+        .skip(1)
+        .find(|a| !a.starts_with('-'))
+        .map(|filter| filter.contains(tier))
+        .unwrap_or(true)
+}
+
+/// Criterion-based benchmark for small/medium tiers (10 samples, flat sampling).
+fn bench_tier_criterion(c: &mut Criterion, tier: &Tier, measurement_time_secs: u64) {
+    let m = tier.k * 10;
+    let env = BenchEnv::new(tier.circuit_degree, tier.k, m).expect("BenchEnv::new should not fail");
+    env.print_circuit_cost();
+
+    let witness = env.build_witness().expect("build_witness should not fail");
+    let proof = env.prove(&witness).expect("prove should not fail");
+    println!("VK size: {} bytes", env.vk_size_bytes());
+    println!("Proof size: {} bytes", proof.len());
+
+    let group_name = format!("certificate/{}", tier.name);
+
+    let mut slow_group = c.benchmark_group(&group_name);
+    slow_group.sampling_mode(SamplingMode::Flat);
+    slow_group.sample_size(10);
+    slow_group.measurement_time(Duration::from_secs(measurement_time_secs));
+    slow_group.bench_function("setup", |b| {
+        b.iter(|| env.setup_keys_for_bench());
+    });
+    slow_group.bench_function("prove", |b| {
+        b.iter(|| env.prove(&witness).expect("prove should not fail"));
+    });
+    slow_group.finish();
+
+    let mut verify_group = c.benchmark_group(&group_name);
+    verify_group.bench_function("verify", |b| {
+        b.iter(|| env.verify(&proof, &witness).expect("verify should not fail"));
+    });
+    verify_group.finish();
+}
+
+/// Single timed run for large/production tiers where 10 Criterion samples would be too costly.
+fn bench_tier_single_run(tier: &Tier) {
+    let m = tier.k * 10;
+    let env = BenchEnv::new(tier.circuit_degree, tier.k, m).expect("BenchEnv::new should not fail");
+    env.print_circuit_cost();
+    println!("VK size: {} bytes", env.vk_size_bytes());
+
+    let t = Instant::now();
+    let _keys = env.setup_keys_for_bench();
+    println!("certificate/{}/setup  time: {:?}", tier.name, t.elapsed());
+
+    let witness = env.build_witness().expect("build_witness should not fail");
+
+    let t = Instant::now();
+    let proof = env.prove(&witness).expect("prove should not fail");
+    println!("certificate/{}/prove  time: {:?}", tier.name, t.elapsed());
+    println!("Proof size: {} bytes", proof.len());
+
+    let t = Instant::now();
+    env.verify(&proof, &witness).expect("verify should not fail");
+    println!("certificate/{}/verify time: {:?}", tier.name, t.elapsed());
+}
+
+fn bench_small(c: &mut Criterion) {
+    if !tier_is_selected("small") { return; }
+    bench_tier_criterion(c, &TIERS[0], 10);
+}
+
+fn bench_medium(c: &mut Criterion) {
+    if !tier_is_selected("medium") { return; }
+    bench_tier_criterion(c, &TIERS[1], 60);
+}
+
+fn bench_large(_c: &mut Criterion) {
+    if !tier_is_selected("large") { return; }
+    bench_tier_single_run(&TIERS[2]);
+}
+
+fn bench_production(_c: &mut Criterion) {
+    if !tier_is_selected("production") { return; }
+    bench_tier_single_run(&TIERS[3]);
+}
+
+criterion_group!(name = benches;
+                 config = Criterion::default();
+                 targets = bench_small, bench_medium, bench_large, bench_production);
+criterion_main!(benches);

--- a/mithril-stm/src/circuits/halo2/bench_helpers.rs
+++ b/mithril-stm/src/circuits/halo2/bench_helpers.rs
@@ -10,13 +10,16 @@ use std::fs::{self, File};
 use std::io::{BufReader, BufWriter};
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, RwLock};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, anyhow};
 use midnight_circuits::hash::poseidon::PoseidonState;
 use midnight_curves::Bls12;
+use midnight_proofs::circuit::Value;
+use midnight_proofs::dev::MockProver;
 use midnight_proofs::poly::kzg::params::ParamsKZG;
 use midnight_proofs::utils::SerdeFormat;
-use midnight_zk_stdlib::{self as zk, MidnightPK, MidnightVK};
+use midnight_zk_stdlib::{self as zk, MidnightCircuit, MidnightPK, MidnightVK, Relation};
 use rand_chacha::ChaCha20Rng;
 use rand_core::SeedableRng;
 
@@ -61,6 +64,7 @@ pub struct BenchEnv {
     pk: MidnightPK<StmCertificateCircuit>,
     num_signers: usize,
     k: u32,
+    circuit_degree: u32,
 }
 
 /// Pre-built witness ready for repeated `BenchEnv::prove` calls.
@@ -101,6 +105,7 @@ impl BenchEnv {
             pk: key_pair.1.clone(),
             num_signers,
             k,
+            circuit_degree,
         })
     }
 
@@ -168,10 +173,79 @@ impl BenchEnv {
         buf.len()
     }
 
+    /// Return the circuit degree (log₂ of the number of rows) used by this environment.
+    pub fn circuit_degree(&self) -> u32 {
+        self.circuit_degree
+    }
+
     /// Print the circuit cost model (rows, columns, gates) to stdout.
     pub fn print_circuit_cost(&self) {
         println!("{:?}", zk::cost_model(&self.circuit));
     }
+
+    /// Run the mock prover on `witness` and return timing for each phase.
+    ///
+    /// Three phases are timed separately to match Daniel's benchmark tables:
+    /// 1. Circuit construction (`MidnightCircuit::new`) — fills the witness into the circuit.
+    /// 2. Mock proving (`MockProver::run`) — synthesizes the circuit and evaluates constraints.
+    /// 3. Mock verification (`MockProver::verify`) — checks all constraints passed.
+    pub fn mock_run(&self, witness: &BenchWitness) -> StmResult<MockRunTimings> {
+        let instance = (witness.merkle_tree_commitment, witness.message);
+        let entries = witness.entries.clone();
+
+        let pi = StmCertificateCircuit::format_instance(&instance)
+            .map_err(|e| anyhow!("mock_run: failed to format instance: {e:?}"))?;
+
+        let t = Instant::now();
+        let mc = MidnightCircuit::new(
+            &self.circuit,
+            Value::known(instance),
+            Value::known(entries),
+            None,
+        );
+        let circuit_gen = t.elapsed();
+
+        let t = Instant::now();
+        let prover = MockProver::run(self.circuit_degree, &mc, vec![vec![], pi])
+            .map_err(|e| anyhow!("mock_run: MockProver::run failed: {e:?}"))?;
+        let mock_prove = t.elapsed();
+
+        let t = Instant::now();
+        prover
+            .verify()
+            .map_err(|e| anyhow!("mock_run: MockProver::verify failed: {e:?}"))?;
+        let mock_verify = t.elapsed();
+
+        Ok(MockRunTimings {
+            circuit_gen,
+            mock_prove,
+            mock_verify,
+        })
+    }
+}
+
+/// Timing breakdown from a single `BenchEnv::mock_run` call.
+pub struct MockRunTimings {
+    pub circuit_gen: Duration,
+    pub mock_prove: Duration,
+    pub mock_verify: Duration,
+}
+
+/// Compute the minimum circuit degree (K) required for the given parameters.
+///
+/// Uses `MidnightCircuit::from_relation().min_k()` with `DEFAULT_NUM_SIGNERS` and
+/// `phi_f = 0.2`. Call this once per tier to determine the `circuit_degree` argument
+/// for `BenchEnv::new`.
+pub fn compute_circuit_degree(k: u32, m: u32) -> StmResult<u32> {
+    let depth = DEFAULT_NUM_SIGNERS.next_power_of_two().trailing_zeros();
+    let params = Parameters {
+        k: k as u64,
+        m: m as u64,
+        phi_f: 0.2,
+    };
+    let circuit = StmCertificateCircuit::try_new(&params, depth)
+        .context("compute_circuit_degree: failed to create StmCertificateCircuit")?;
+    Ok(MidnightCircuit::from_relation(&circuit).min_k())
 }
 
 struct SignerEntry {

--- a/mithril-stm/src/circuits/halo2/bench_helpers.rs
+++ b/mithril-stm/src/circuits/halo2/bench_helpers.rs
@@ -1,0 +1,302 @@
+//! Benchmark helpers for the `StmCertificateCircuit`.
+//!
+//! Exposes `BenchEnv` and `BenchWitness` for Criterion benchmarks that measure
+//! VK/PK setup, proof generation, and proof verification across parameter tiers.
+//!
+//! Gated behind `benchmark-internals` so this module is never compiled into release
+//! builds unless explicitly requested.
+use std::collections::HashMap;
+use std::fs::{self, File};
+use std::io::{BufReader, BufWriter};
+use std::path::PathBuf;
+use std::sync::{Arc, LazyLock, RwLock};
+
+use anyhow::{Context, anyhow};
+use midnight_circuits::hash::poseidon::PoseidonState;
+use midnight_curves::Bls12;
+use midnight_proofs::poly::kzg::params::ParamsKZG;
+use midnight_proofs::utils::SerdeFormat;
+use midnight_zk_stdlib::{self as zk, MidnightPK, MidnightVK};
+use rand_chacha::ChaCha20Rng;
+use rand_core::SeedableRng;
+
+use crate::circuits::halo2::circuit::StmCertificateCircuit;
+use crate::circuits::halo2::types::CircuitBase;
+use crate::circuits::halo2::witness::{
+    CircuitMerkleTreeLeaf, CircuitWitnessEntry, LotteryTargetValue as CircuitLotteryTargetValue,
+    MerkleRoot, SignedMessageWithoutPrefix,
+};
+use crate::hash::poseidon::MidnightPoseidonDigest;
+use crate::membership_commitment::{
+    MerkleTree as StmMerkleTree, MerkleTreeSnarkLeaf as StmMerkleTreeSnarkLeaf,
+};
+use crate::signature_scheme::{BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey};
+use crate::{LotteryIndex, Parameters, StmResult};
+
+const DEFAULT_NUM_SIGNERS: usize = 3000;
+const DEFAULT_BENCH_MSG: u64 = 42;
+
+type BenchKeyPair = Arc<(MidnightVK, MidnightPK<StmCertificateCircuit>)>;
+type BenchKeysCache = HashMap<BenchCircuitConfig, BenchKeyPair>;
+
+static BENCH_KEYS_CACHE: LazyLock<RwLock<BenchKeysCache>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct BenchCircuitConfig {
+    circuit_degree: u32,
+    k: u32,
+    m: u32,
+    merkle_tree_depth: u32,
+}
+
+/// Full benchmark environment: SRS, compiled circuit, and derived VK/PK.
+///
+/// Construct with `BenchEnv::new`, then call `build_witness` + `prove` / `verify`
+/// inside Criterion benchmark closures.
+pub struct BenchEnv {
+    srs: ParamsKZG<Bls12>,
+    circuit: StmCertificateCircuit,
+    vk: MidnightVK,
+    pk: MidnightPK<StmCertificateCircuit>,
+    num_signers: usize,
+    k: u32,
+}
+
+/// Pre-built witness ready for repeated `BenchEnv::prove` calls.
+pub struct BenchWitness {
+    merkle_tree_commitment: MerkleRoot,
+    message: SignedMessageWithoutPrefix,
+    entries: Vec<CircuitWitnessEntry>,
+}
+
+impl BenchEnv {
+    /// Construct a full benchmark environment for the given parameters.
+    ///
+    /// Loads or generates the SRS deterministically (seed 42, same as golden tests).
+    /// VK/PK derivation is cached per `(circuit_degree, k, m, depth)`.
+    pub fn new(circuit_degree: u32, k: u32, m: u32) -> StmResult<Self> {
+        let srs = load_or_generate_srs(circuit_degree)?;
+        let num_signers = DEFAULT_NUM_SIGNERS;
+        let depth = num_signers.next_power_of_two().trailing_zeros();
+        let params = Parameters {
+            k: k as u64,
+            m: m as u64,
+            phi_f: 0.2,
+        };
+        let circuit = StmCertificateCircuit::try_new(&params, depth)
+            .context("BenchEnv: failed to create StmCertificateCircuit")?;
+        let config = BenchCircuitConfig { circuit_degree, k, m, merkle_tree_depth: depth };
+        let key_pair = get_or_build_bench_keys(config, &circuit, &srs)?;
+
+        Ok(Self {
+            srs,
+            circuit,
+            vk: key_pair.0.clone(),
+            pk: key_pair.1.clone(),
+            num_signers,
+            k,
+        })
+    }
+
+    /// Derive a fresh VK/PK pair from the stored SRS and circuit.
+    ///
+    /// Call this inside a Criterion `iter` closure to benchmark key-derivation time.
+    pub fn setup_keys_for_bench(&self) -> (MidnightVK, MidnightPK<StmCertificateCircuit>) {
+        let vk = zk::setup_vk(&self.srs, &self.circuit);
+        let pk = zk::setup_pk(&self.circuit, &vk);
+        (vk, pk)
+    }
+
+    /// Build the default witness for `self.k` lottery indices.
+    ///
+    /// Uses 3 000 deterministic signers (depth = 12, seed = `[0u8; 32]`).
+    pub fn build_witness(&self) -> StmResult<BenchWitness> {
+        let message = SignedMessageWithoutPrefix::from(DEFAULT_BENCH_MSG);
+        let (tree, signer_fixtures) = build_bench_merkle_tree(self.num_signers)?;
+        let commitment = bench_merkle_root(&tree)?;
+        let entries = build_bench_witness(&tree, &signer_fixtures, commitment, message, self.k)?;
+        Ok(BenchWitness { merkle_tree_commitment: commitment, message, entries })
+    }
+
+    /// Generate a SNARK proof for `witness`.
+    ///
+    /// `witness.entries` is cloned internally so `witness` can be reused across iterations.
+    pub fn prove(&self, witness: &BenchWitness) -> StmResult<Vec<u8>> {
+        let instance = (witness.merkle_tree_commitment, witness.message);
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let entries = witness.entries.clone();
+        zk::prove::<StmCertificateCircuit, PoseidonState<CircuitBase>>(
+            &self.srs,
+            &self.pk,
+            &self.circuit,
+            &instance,
+            entries,
+            &mut rng,
+        )
+        .map_err(|e| anyhow::Error::new(e).context("BenchEnv: proof generation failed"))
+    }
+
+    /// Verify a SNARK proof against `witness`'s public inputs.
+    pub fn verify(&self, proof: &[u8], witness: &BenchWitness) -> StmResult<()> {
+        let instance = (witness.merkle_tree_commitment, witness.message);
+        zk::verify::<StmCertificateCircuit, PoseidonState<CircuitBase>>(
+            &self.srs.verifier_params(),
+            &self.vk,
+            &instance,
+            None,
+            proof,
+        )
+        .map_err(|e| anyhow::Error::new(e).context("BenchEnv: proof verification failed"))
+    }
+
+    /// Return the serialized byte length of the verification key.
+    pub fn vk_size_bytes(&self) -> usize {
+        let mut buf = vec![];
+        self.vk
+            .write(&mut buf, SerdeFormat::RawBytes)
+            .expect("VK serialization should not fail");
+        buf.len()
+    }
+
+    /// Print the circuit cost model (rows, columns, gates) to stdout.
+    pub fn print_circuit_cost(&self) {
+        println!("{:?}", zk::cost_model(&self.circuit));
+    }
+}
+
+struct SignerEntry {
+    sk: SchnorrSigningKey,
+    vk: SchnorrVerificationKey,
+    circuit_target: CircuitLotteryTargetValue,
+}
+
+fn build_bench_merkle_tree(
+    num_signers: usize,
+) -> StmResult<(StmMerkleTree<MidnightPoseidonDigest, StmMerkleTreeSnarkLeaf>, Vec<SignerEntry>)> {
+    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+    let circuit_target = -CircuitLotteryTargetValue::ONE;
+    let stm_target = circuit_target.into();
+
+    let mut signer_entries = Vec::with_capacity(num_signers);
+    let mut stm_leaves = Vec::with_capacity(num_signers);
+
+    for _ in 0..num_signers {
+        let sk = SchnorrSigningKey::generate(&mut rng);
+        let vk = SchnorrVerificationKey::new_from_signing_key(sk.clone());
+        stm_leaves.push(StmMerkleTreeSnarkLeaf(vk, stm_target));
+        signer_entries.push(SignerEntry { sk, vk, circuit_target });
+    }
+
+    let tree = StmMerkleTree::<MidnightPoseidonDigest, StmMerkleTreeSnarkLeaf>::new(&stm_leaves);
+    Ok((tree, signer_entries))
+}
+
+fn bench_merkle_root(
+    tree: &StmMerkleTree<MidnightPoseidonDigest, StmMerkleTreeSnarkLeaf>,
+) -> StmResult<MerkleRoot> {
+    let root_bytes = tree.to_merkle_tree_commitment().root;
+    let root_array: [u8; 32] = root_bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("bench: merkle root digest has unexpected length"))?;
+    BaseFieldElement::from_bytes(&root_array)
+        .ok()
+        .map(Into::into)
+        .ok_or_else(|| anyhow!("bench: merkle root digest is not a canonical field element"))
+}
+
+fn build_bench_witness(
+    tree: &StmMerkleTree<MidnightPoseidonDigest, StmMerkleTreeSnarkLeaf>,
+    signer_entries: &[SignerEntry],
+    commitment: MerkleRoot,
+    message: SignedMessageWithoutPrefix,
+    k: u32,
+) -> StmResult<Vec<CircuitWitnessEntry>> {
+    let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+    let num_signers = signer_entries.len();
+    let mut witness = Vec::with_capacity(k as usize);
+
+    for i in 0..k as usize {
+        let signer_index = i % num_signers;
+        let entry = &signer_entries[signer_index];
+
+        let stm_path = tree.compute_merkle_tree_path(signer_index);
+        let merkle_path = crate::circuits::halo2::witness::MerklePath::try_from(&stm_path)
+            .map_err(|e| anyhow!("bench: merkle path conversion failed: {e}"))?;
+
+        let transcript: [BaseFieldElement; 2] = [commitment.into(), message.into()];
+        let signature = entry
+            .sk
+            .sign_unique(&transcript, &mut rng)
+            .map_err(|_| anyhow!("bench: signature generation failed"))?;
+
+        let leaf = CircuitMerkleTreeLeaf(entry.vk, entry.circuit_target);
+
+        witness.push(CircuitWitnessEntry {
+            leaf,
+            merkle_path,
+            unique_schnorr_signature: signature,
+            lottery_index: i as LotteryIndex,
+        });
+    }
+
+    Ok(witness)
+}
+
+fn get_or_build_bench_keys(
+    config: BenchCircuitConfig,
+    circuit: &StmCertificateCircuit,
+    srs: &ParamsKZG<Bls12>,
+) -> StmResult<BenchKeyPair> {
+    if let Some(pair) = BENCH_KEYS_CACHE
+        .read()
+        .map_err(|_| anyhow!("bench keys cache lock poisoned on read"))?
+        .get(&config)
+        .cloned()
+    {
+        return Ok(pair);
+    }
+
+    let vk = zk::setup_vk(srs, circuit);
+    let pk = zk::setup_pk(circuit, &vk);
+    let pair = Arc::new((vk, pk));
+
+    BENCH_KEYS_CACHE
+        .write()
+        .map_err(|_| anyhow!("bench keys cache lock poisoned on write"))?
+        .insert(config, pair.clone());
+
+    Ok(pair)
+}
+
+fn load_or_generate_srs(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let assets_dir = manifest_dir
+        .join("src")
+        .join("circuits")
+        .join("halo2")
+        .join("assets");
+    let path = assets_dir.join(format!("params_kzg_unsafe_{circuit_degree}"));
+
+    if path.exists() {
+        let file = File::open(&path)
+            .with_context(|| format!("bench: failed to open SRS at '{}'", path.display()))?;
+        let mut reader = BufReader::new(file);
+        return ParamsKZG::read_custom(&mut reader, SerdeFormat::RawBytesUnchecked)
+            .with_context(|| format!("bench: failed to parse SRS at '{}'", path.display()));
+    }
+
+    fs::create_dir_all(&assets_dir).with_context(|| {
+        format!("bench: failed to create SRS directory at '{}'", assets_dir.display())
+    })?;
+
+    let srs = ParamsKZG::unsafe_setup(circuit_degree, ChaCha20Rng::seed_from_u64(42));
+    let file = File::create(&path)
+        .with_context(|| format!("bench: failed to create SRS file at '{}'", path.display()))?;
+    let mut writer = BufWriter::new(file);
+    srs.write_custom(&mut writer, SerdeFormat::RawBytesUnchecked)
+        .with_context(|| format!("bench: failed to write SRS to '{}'", path.display()))?;
+
+    Ok(srs)
+}

--- a/mithril-stm/src/circuits/halo2/bench_helpers.rs
+++ b/mithril-stm/src/circuits/halo2/bench_helpers.rs
@@ -86,7 +86,12 @@ impl BenchEnv {
         };
         let circuit = StmCertificateCircuit::try_new(&params, depth)
             .context("BenchEnv: failed to create StmCertificateCircuit")?;
-        let config = BenchCircuitConfig { circuit_degree, k, m, merkle_tree_depth: depth };
+        let config = BenchCircuitConfig {
+            circuit_degree,
+            k,
+            m,
+            merkle_tree_depth: depth,
+        };
         let key_pair = get_or_build_bench_keys(config, &circuit, &srs)?;
 
         Ok(Self {
@@ -116,7 +121,11 @@ impl BenchEnv {
         let (tree, signer_fixtures) = build_bench_merkle_tree(self.num_signers)?;
         let commitment = bench_merkle_root(&tree)?;
         let entries = build_bench_witness(&tree, &signer_fixtures, commitment, message, self.k)?;
-        Ok(BenchWitness { merkle_tree_commitment: commitment, message, entries })
+        Ok(BenchWitness {
+            merkle_tree_commitment: commitment,
+            message,
+            entries,
+        })
     }
 
     /// Generate a SNARK proof for `witness`.
@@ -173,7 +182,10 @@ struct SignerEntry {
 
 fn build_bench_merkle_tree(
     num_signers: usize,
-) -> StmResult<(StmMerkleTree<MidnightPoseidonDigest, StmMerkleTreeSnarkLeaf>, Vec<SignerEntry>)> {
+) -> StmResult<(
+    StmMerkleTree<MidnightPoseidonDigest, StmMerkleTreeSnarkLeaf>,
+    Vec<SignerEntry>,
+)> {
     let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
     let circuit_target = -CircuitLotteryTargetValue::ONE;
     let stm_target = circuit_target.into();
@@ -185,7 +197,11 @@ fn build_bench_merkle_tree(
         let sk = SchnorrSigningKey::generate(&mut rng);
         let vk = SchnorrVerificationKey::new_from_signing_key(sk.clone());
         stm_leaves.push(StmMerkleTreeSnarkLeaf(vk, stm_target));
-        signer_entries.push(SignerEntry { sk, vk, circuit_target });
+        signer_entries.push(SignerEntry {
+            sk,
+            vk,
+            circuit_target,
+        });
     }
 
     let tree = StmMerkleTree::<MidnightPoseidonDigest, StmMerkleTreeSnarkLeaf>::new(&stm_leaves);
@@ -272,11 +288,7 @@ fn get_or_build_bench_keys(
 
 fn load_or_generate_srs(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let assets_dir = manifest_dir
-        .join("src")
-        .join("circuits")
-        .join("halo2")
-        .join("assets");
+    let assets_dir = manifest_dir.join("src").join("circuits").join("halo2").join("assets");
     let path = assets_dir.join(format!("params_kzg_unsafe_{circuit_degree}"));
 
     if path.exists() {
@@ -288,7 +300,10 @@ fn load_or_generate_srs(circuit_degree: u32) -> StmResult<ParamsKZG<Bls12>> {
     }
 
     fs::create_dir_all(&assets_dir).with_context(|| {
-        format!("bench: failed to create SRS directory at '{}'", assets_dir.display())
+        format!(
+            "bench: failed to create SRS directory at '{}'",
+            assets_dir.display()
+        )
     })?;
 
     let srs = ParamsKZG::unsafe_setup(circuit_degree, ChaCha20Rng::seed_from_u64(42));

--- a/mithril-stm/src/circuits/halo2/bench_helpers.rs
+++ b/mithril-stm/src/circuits/halo2/bench_helpers.rs
@@ -165,8 +165,12 @@ impl BenchEnv {
     }
 
     /// Return the serialized byte length of the verification key.
+    ///
+    /// Infallible: the `Write` impl for `Vec<u8>` never returns an error.
     pub fn vk_size_bytes(&self) -> usize {
         let mut buf = vec![];
+        // Safety: writing to Vec<u8> is infallible; the only failure mode
+        // (allocation) would already have panicked before reaching this point.
         self.vk
             .write(&mut buf, SerdeFormat::RawBytes)
             .expect("VK serialization should not fail");

--- a/mithril-stm/src/circuits/halo2/mod.rs
+++ b/mithril-stm/src/circuits/halo2/mod.rs
@@ -25,6 +25,9 @@ pub(crate) mod types;
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) mod witness;
 
+#[cfg(any(test, feature = "benchmark-internals"))]
+pub mod bench_helpers;
+
 #[cfg(test)]
 pub(crate) mod tests;
 


### PR DESCRIPTION
## Content

This PR adds a Criterion benchmark suite for the non-recursive `StmCertificateCircuit` (Halo2/KZG), making ZK circuit performance numbers reproducible from the public repo.

### Changes
- **Add `src/circuits/halo2/bench_helpers.rs`**: exposes `BenchEnv` and `BenchWitness` as a clean public API for the bench binary, gated behind `benchmark-internals`
- **Add `benches/halo2_snark.rs`**: four-tier benchmark (small/medium/large/production) covering VK/PK setup, proof generation, and proof verification; small and medium use Criterion (10 samples, flat sampling), large and production use a single `Instant::now()` timed run (Criterion enforces a hard minimum of 10 samples, impractical at this scale)
- **Update `Cargo.toml`**: wire `halo2_snark` bench entry with `required-features = ["future_snark", "benchmark-internals"]`
- **Update `README.md`**: add ZK Certificate Circuit Benchmarks section with hardware requirements table, reference results, and auditor commands

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] Update README file (if relevant)
  - [x] No new TODOs introduced

## Issue(s)
Closes https://github.com/input-output-hk/mithril/issues/3274
