### PR TITLE
 refactor(mithril-stm): structured error handling for halo2_ivc circuit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4608,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.2" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.23", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.24", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.24 (05-22-2026)
+
+### Changed
+
+- Replaced infallible `IvcCircuit::new` with fallible `try_new` and `unknown` returning `StmResult` with typed `IvcCircuitError` variants.
+- Added `validate_self_vk_degree` and `validate_column_counts` pre-flight guards in the `halo2_ivc` circuit.
+- Added unit tests for `IvcCircuitError` variants in the `halo2_ivc` off-circuit test suite.
+
 ## 0.10.22 (05-21-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.23"
+version = "0.10.24"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -1,3 +1,4 @@
+use crate::StmResult;
 use anyhow::anyhow;
 
 use super::{
@@ -5,13 +6,12 @@ use super::{
     EvaluationDomain, F, K, KZGCommitmentScheme, Layouter, NB_ARITH_COLS, NB_ARITH_FIXED_COLS,
     NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_ADVICE_COLS,
     NB_SHA256_FIXED_COLS, NG, PublicInputInstructions, S, SimpleFloorPlanner, Value, VerifyingKey,
-    config::{IvcConfig, configure_ivc_circuit},
+    config::{IvcConfig, configure_ivc_circuit, ivc_column_pool_sizes},
     errors::IvcCircuitError,
     gadget::IvcGadget,
     nb_foreign_ecc_chip_columns,
     state::{Global, State, Witness},
 };
-use crate::StmResult;
 
 #[derive(Clone, Debug)]
 pub struct IvcCircuit {
@@ -53,26 +53,14 @@ impl IvcCircuit {
     /// `try_new` and `unknown`) so that the `.expect` calls inside `configure_ivc_circuit`
     /// are guaranteed not to trigger.
     fn validate_column_counts() -> StmResult<()> {
-        let nb_advice_cols = [
-            NB_EDWARDS_COLS,
-            NB_POSEIDON_ADVICE_COLS,
-            NB_SHA256_ADVICE_COLS,
-            nb_foreign_ecc_chip_columns::<F, C, C, NG>(),
-        ]
-        .into_iter()
-        .max()
-        .unwrap_or(0);
-
-        let nb_fixed_cols = [NB_ARITH_FIXED_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_FIXED_COLS]
-            .into_iter()
-            .max()
-            .unwrap_or(0);
+        let (nb_advice_cols, nb_fixed_cols) = ivc_column_pool_sizes();
 
         for needed in [
             NB_ARITH_COLS,
             NB_EDWARDS_COLS,
             NB_POSEIDON_ADVICE_COLS,
             NB_SHA256_ADVICE_COLS,
+            nb_foreign_ecc_chip_columns::<F, C, C, NG>(),
         ] {
             if needed > nb_advice_cols {
                 return Err(anyhow!(IvcCircuitError::InsufficientAdviceColumns {
@@ -94,6 +82,12 @@ impl IvcCircuit {
         Ok(())
     }
 
+    /// Creates a new `IvcCircuit` with the given witness and proof data.
+    ///
+    /// Validates that `self_vk` has degree `K` and that the column pool allocated by
+    /// `configure_ivc_circuit` is sufficient for all chips. Returns an error containing
+    /// [`IvcCircuitError::SelfVkDegreeMismatch`] or [`IvcCircuitError::InsufficientAdviceColumns`]
+    /// / [`IvcCircuitError::InsufficientFixedColumns`] if either check fails.
     #[allow(clippy::too_many_arguments)]
     pub fn try_new(
         global: Global,

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -35,7 +35,9 @@ pub struct IvcCircuit {
 
 impl IvcCircuit {
     /// Validates that the self VK degree matches the IVC circuit degree constant K.
-    pub(crate) fn validate_self_vk_degree(self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>) -> StmResult<()> {
+    pub(crate) fn validate_self_vk_degree(
+        self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    ) -> StmResult<()> {
         let actual = self_vk.get_domain().k();
         if actual != K {
             return Err(anyhow!(IvcCircuitError::SelfVkDegreeMismatch {
@@ -104,6 +106,7 @@ impl IvcCircuit {
         self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
     ) -> StmResult<Self> {
         Self::validate_self_vk_degree(self_vk)?;
+        Self::validate_column_counts()?;
         Ok(IvcCircuit {
             global: Value::known(global),
             state: Value::known(state),

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -1,11 +1,17 @@
+use anyhow::anyhow;
+
 use super::{
-    Accumulator, BinaryInstructions, Circuit, ComposableChip, ConstraintSystem, E, Error,
-    EvaluationDomain, F, K, KZGCommitmentScheme, Layouter, PublicInputInstructions, S,
-    SimpleFloorPlanner, Value, VerifyingKey,
+    Accumulator, BinaryInstructions, C, Circuit, ComposableChip, ConstraintSystem, E, Error,
+    EvaluationDomain, F, K, KZGCommitmentScheme, Layouter, NB_ARITH_COLS, NB_ARITH_FIXED_COLS,
+    NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_ADVICE_COLS,
+    NB_SHA256_FIXED_COLS, NG, PublicInputInstructions, S, SimpleFloorPlanner, Value, VerifyingKey,
     config::{IvcConfig, configure_ivc_circuit},
+    errors::IvcCircuitError,
     gadget::IvcGadget,
+    nb_foreign_ecc_chip_columns,
     state::{Global, State, Witness},
 };
+use crate::StmResult;
 
 #[derive(Clone, Debug)]
 pub struct IvcCircuit {
@@ -28,8 +34,66 @@ pub struct IvcCircuit {
 }
 
 impl IvcCircuit {
+    /// Validates that the self VK degree matches the IVC circuit degree constant K.
+    fn validate_self_vk_degree(self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>) -> StmResult<()> {
+        let actual = self_vk.get_domain().k();
+        if actual != K {
+            return Err(anyhow!(IvcCircuitError::SelfVkDegreeMismatch {
+                expected: K,
+                actual,
+            }));
+        }
+        Ok(())
+    }
+
+    /// Validates that the column pool allocated by `configure_ivc_circuit` is large enough
+    /// for every chip. Must be called before `Circuit::configure` is reached (e.g. in
+    /// `try_new` and `unknown`) so that the `.expect` calls inside `configure_ivc_circuit`
+    /// are guaranteed not to trigger.
+    fn validate_column_counts() -> StmResult<()> {
+        let nb_advice_cols = [
+            NB_EDWARDS_COLS,
+            NB_POSEIDON_ADVICE_COLS,
+            NB_SHA256_ADVICE_COLS,
+            nb_foreign_ecc_chip_columns::<F, C, C, NG>(),
+        ]
+        .into_iter()
+        .max()
+        .unwrap_or(0);
+
+        let nb_fixed_cols = [NB_ARITH_FIXED_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_FIXED_COLS]
+            .into_iter()
+            .max()
+            .unwrap_or(0);
+
+        for needed in [
+            NB_ARITH_COLS,
+            NB_EDWARDS_COLS,
+            NB_POSEIDON_ADVICE_COLS,
+            NB_SHA256_ADVICE_COLS,
+        ] {
+            if needed > nb_advice_cols {
+                return Err(anyhow!(IvcCircuitError::InsufficientAdviceColumns {
+                    needed,
+                    available: nb_advice_cols,
+                }));
+            }
+        }
+
+        for needed in [NB_ARITH_FIXED_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_FIXED_COLS] {
+            if needed > nb_fixed_cols {
+                return Err(anyhow!(IvcCircuitError::InsufficientFixedColumns {
+                    needed,
+                    available: nb_fixed_cols,
+                }));
+            }
+        }
+
+        Ok(())
+    }
+
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub fn try_new(
         global: Global,
         state: State,
         witness: Witness,
@@ -38,8 +102,9 @@ impl IvcCircuit {
         acc: Accumulator<S>,
         cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
         self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
-    ) -> Self {
-        IvcCircuit {
+    ) -> StmResult<Self> {
+        Self::validate_self_vk_degree(self_vk)?;
+        Ok(IvcCircuit {
             global: Value::known(global),
             state: Value::known(state),
             witness: Value::known(witness),
@@ -48,16 +113,17 @@ impl IvcCircuit {
             acc: Value::known(acc),
             cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),
             self_domain_cs: (self_vk.get_domain().clone(), self_vk.cs().clone()),
-        }
+        })
     }
 
-    // Create a default ivc circuit for generating ivc proving key and verifying key
-    pub fn unknown(cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>) -> Self {
+    /// Creates a default IVC circuit for generating the proving and verifying keys.
+    pub fn unknown(cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>) -> StmResult<Self> {
+        Self::validate_column_counts()?;
         let mut self_cs = ConstraintSystem::default();
         configure_ivc_circuit(&mut self_cs);
         let self_domain = EvaluationDomain::new(self_cs.degree() as u32, K);
 
-        IvcCircuit {
+        Ok(IvcCircuit {
             global: Value::unknown(),
             state: Value::unknown(),
             witness: Value::unknown(),
@@ -66,7 +132,7 @@ impl IvcCircuit {
             acc: Value::unknown(),
             cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),
             self_domain_cs: (self_domain, self_cs),
-        }
+        })
     }
 }
 
@@ -76,7 +142,16 @@ impl Circuit<F> for IvcCircuit {
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
-        unreachable!()
+        IvcCircuit {
+            global: Value::unknown(),
+            state: Value::unknown(),
+            witness: Value::unknown(),
+            cert_proof: Value::unknown(),
+            self_proof: Value::unknown(),
+            acc: Value::unknown(),
+            cert_domain_cs: self.cert_domain_cs.clone(),
+            self_domain_cs: self.self_domain_cs.clone(),
+        }
     }
 
     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -35,7 +35,7 @@ pub struct IvcCircuit {
 
 impl IvcCircuit {
     /// Validates that the self VK degree matches the IVC circuit degree constant K.
-    fn validate_self_vk_degree(self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>) -> StmResult<()> {
+    pub(crate) fn validate_self_vk_degree(self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>) -> StmResult<()> {
         let actual = self_vk.get_domain().k();
         if actual != K {
             return Err(anyhow!(IvcCircuitError::SelfVkDegreeMismatch {

--- a/mithril-stm/src/circuits/halo2_ivc/config.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/config.rs
@@ -19,10 +19,13 @@ pub struct IvcConfig {
     pub(crate) sha256_config: Sha256Config,
 }
 
-pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
+/// Returns `(nb_advice_cols, nb_fixed_cols)` — the column pool sizes allocated by
+/// `configure_ivc_circuit`. Single source of truth shared with `validate_column_counts`.
+pub(crate) fn ivc_column_pool_sizes() -> (usize, usize) {
     // unwrap_or(0) never panics: max() returns None only on an empty iterator,
     // but both arrays are non-empty so the fallback is unreachable.
     let nb_advice_cols = [
+        NB_ARITH_COLS,
         NB_EDWARDS_COLS,
         NB_POSEIDON_ADVICE_COLS,
         NB_SHA256_ADVICE_COLS,
@@ -36,6 +39,12 @@ pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
         .into_iter()
         .max()
         .unwrap_or(0);
+
+    (nb_advice_cols, nb_fixed_cols)
+}
+
+pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
+    let (nb_advice_cols, nb_fixed_cols) = ivc_column_pool_sizes();
 
     let advice_columns: Vec<_> = (0..nb_advice_cols).map(|_| meta.advice_column()).collect();
     let fixed_columns: Vec<_> = (0..nb_fixed_cols).map(|_| meta.fixed_column()).collect();

--- a/mithril-stm/src/circuits/halo2_ivc/config.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/config.rs
@@ -20,6 +20,8 @@ pub struct IvcConfig {
 }
 
 pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
+    // unwrap_or(0) never panics: max() returns None only on an empty iterator,
+    // but both arrays are non-empty so the fallback is unreachable.
     let nb_advice_cols = [
         NB_EDWARDS_COLS,
         NB_POSEIDON_ADVICE_COLS,
@@ -43,8 +45,12 @@ pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
     let native_config = NativeChip::configure(
         meta,
         &(
-            advice_columns[..NB_ARITH_COLS].try_into().unwrap(),
-            fixed_columns[..NB_ARITH_FIXED_COLS].try_into().unwrap(),
+            advice_columns[..NB_ARITH_COLS]
+                .try_into()
+                .expect("column counts pre-validated by validate_column_counts"),
+            fixed_columns[..NB_ARITH_FIXED_COLS]
+                .try_into()
+                .expect("column counts pre-validated by validate_column_counts"),
             [committed_instance_column, instance_column],
         ),
     );
@@ -53,8 +59,12 @@ pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
         P2RDecompositionChip::configure(meta, &(native_config.clone(), pow2_config))
     };
 
-    let jubjub_config =
-        EccChip::<Jubjub>::configure(meta, &advice_columns[..NB_EDWARDS_COLS].try_into().unwrap());
+    let jubjub_config = EccChip::<Jubjub>::configure(
+        meta,
+        &advice_columns[..NB_EDWARDS_COLS]
+            .try_into()
+            .expect("column counts pre-validated by validate_column_counts"),
+    );
 
     let base_config = FieldChip::<F, CBase, C, NG>::configure(meta, &advice_columns);
     let bls12_381_config =
@@ -63,16 +73,24 @@ pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
     let poseidon_config = PoseidonChip::configure(
         meta,
         &(
-            advice_columns[..NB_POSEIDON_ADVICE_COLS].try_into().unwrap(),
-            fixed_columns[..NB_POSEIDON_FIXED_COLS].try_into().unwrap(),
+            advice_columns[..NB_POSEIDON_ADVICE_COLS]
+                .try_into()
+                .expect("column counts pre-validated by validate_column_counts"),
+            fixed_columns[..NB_POSEIDON_FIXED_COLS]
+                .try_into()
+                .expect("column counts pre-validated by validate_column_counts"),
         ),
     );
 
     let sha256_config = Sha256Chip::configure(
         meta,
         &(
-            advice_columns[..NB_SHA256_ADVICE_COLS].try_into().unwrap(),
-            fixed_columns[..NB_SHA256_FIXED_COLS].try_into().unwrap(),
+            advice_columns[..NB_SHA256_ADVICE_COLS]
+                .try_into()
+                .expect("column counts pre-validated by validate_column_counts"),
+            fixed_columns[..NB_SHA256_FIXED_COLS]
+                .try_into()
+                .expect("column counts pre-validated by validate_column_counts"),
         ),
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -1,3 +1,4 @@
+use midnight_proofs::plonk::Error as PlonkError;
 use thiserror::Error;
 
 /// Circuit-scoped errors for the IVC recursive SNARK circuit and its off-circuit helpers.
@@ -7,4 +8,29 @@ pub enum IvcCircuitError {
     /// Off-circuit verifier rejected a certificate proof.
     #[error("Certificate proof verification rejected")]
     CertificateProofRejected,
+
+    /// Self VK degree does not match the IVC circuit degree constant K.
+    #[error("IvcCircuit::validate_self_vk_degree failed: expected k={expected}, got k={actual}")]
+    SelfVkDegreeMismatch { expected: u32, actual: u32 },
+
+    /// `assign_many` returned a different number of values than expected.
+    #[error("IvcGadget: expected {expected} assigned values, got {actual}")]
+    AssignedValueCountMismatch { expected: usize, actual: usize },
+
+    /// Not enough advice columns were allocated to satisfy chip requirements.
+    #[error(
+        "IvcCircuit::validate_column_counts failed: need {needed} advice columns, only {available} allocated"
+    )]
+    InsufficientAdviceColumns { needed: usize, available: usize },
+
+    /// Not enough fixed columns were allocated to satisfy chip requirements.
+    #[error(
+        "IvcCircuit::validate_column_counts failed: need {needed} fixed columns, only {available} allocated"
+    )]
+    InsufficientFixedColumns { needed: usize, available: usize },
+}
+
+/// Convert an IVC circuit error into a Plonk synthesis error at gadget boundaries.
+pub(crate) fn to_synthesis_error(error: IvcCircuitError) -> PlonkError {
+    PlonkError::Synthesis(error.to_string())
 }

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -31,6 +31,10 @@ pub enum IvcCircuitError {
 }
 
 /// Convert an IVC circuit error into a Plonk synthesis error at gadget boundaries.
+///
+/// Takes `IvcCircuitError` directly rather than `StmError` (unlike the `halo2` variant) because
+/// `halo2_ivc::synthesize` has no `anyhow` wrapping layer — call sites always hold the concrete
+/// type and no downcasting is needed.
 pub(crate) fn to_synthesis_error(error: IvcCircuitError) -> PlonkError {
     PlonkError::Synthesis(error.to_string())
 }

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -9,6 +9,7 @@ use super::{
     PREIMAGE_NEXT_MERKLE_ROOT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PoseidonChip,
     PublicInputInstructions, S, Value, VerifierGadget, ZeroInstructions,
     config::IvcConfig,
+    errors::{IvcCircuitError, to_synthesis_error},
     state::{
         AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness, fixed_base_names,
     },
@@ -137,8 +138,12 @@ impl IvcGadget {
             self.native_gadget
                 .assign_many(layouter, &values)?
                 .try_into()
-                // this won't fail
-                .unwrap()
+                .map_err(|v: Vec<_>| {
+                    to_synthesis_error(IvcCircuitError::AssignedValueCountMismatch {
+                        expected: 7,
+                        actual: v.len(),
+                    })
+                })?
         };
 
         Ok(AssignedState {
@@ -195,8 +200,12 @@ impl IvcGadget {
             self.native_gadget
                 .assign_many(layouter, &values)?
                 .try_into()
-                // this won't fail
-                .unwrap()
+                .map_err(|v: Vec<_>| {
+                    to_synthesis_error(IvcCircuitError::AssignedValueCountMismatch {
+                        expected: 2,
+                        actual: v.len(),
+                    })
+                })?
         };
 
         let msg_preimage = {

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -29,6 +29,8 @@ pub(crate) use midnight_circuits::{
     hash::poseidon::{
         NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, PoseidonChip, PoseidonConfig,
     },
+    hash::sha256::NB_SHA256_ADVICE_COLS,
+    hash::sha256::NB_SHA256_FIXED_COLS,
     instructions::{
         ArithInstructions, AssertionInstructions, AssignmentInstructions, BinaryInstructions,
         ControlFlowInstructions, ConversionInstructions, EccInstructions, EqualityInstructions,

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -29,8 +29,7 @@ pub(crate) use midnight_circuits::{
     hash::poseidon::{
         NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, PoseidonChip, PoseidonConfig,
     },
-    hash::sha256::NB_SHA256_ADVICE_COLS,
-    hash::sha256::NB_SHA256_FIXED_COLS,
+    hash::sha256::{NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS},
     instructions::{
         ArithInstructions, AssertionInstructions, AssignmentInstructions, BinaryInstructions,
         ControlFlowInstructions, ConversionInstructions, EccInstructions, EqualityInstructions,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -120,7 +120,7 @@ fn build_recursive_chain_snapshot(
             INITIAL_CHAIN_LENGTH + 1
         );
         let recursive_step_start = Instant::now();
-        let circuit = IvcCircuit::new(
+        let circuit = IvcCircuit::try_new(
             global.clone(),
             current_state.clone(),
             artifacts.recursive_witnesses[i].clone(),
@@ -129,7 +129,8 @@ fn build_recursive_chain_snapshot(
             current_accumulator.clone(),
             context.certificate_verifying_key.vk(),
             &context.recursive_verifying_key,
-        );
+        )
+        .expect("valid IvcCircuit construction");
 
         let public_inputs = [
             global.as_public_input(),
@@ -293,7 +294,7 @@ fn build_recursive_step_output_proof(
     next_step_inputs: &NextRecursiveStepInputs,
 ) -> Vec<u8> {
     let mut recursive_step_output_random_generator = OsRng;
-    let circuit = IvcCircuit::new(
+    let circuit = IvcCircuit::try_new(
         global.clone(),
         recursive_chain_state.state.clone(),
         next_step_inputs.recursive_witness.clone(),
@@ -302,7 +303,8 @@ fn build_recursive_step_output_proof(
         recursive_chain_state.accumulator.clone(),
         context.certificate_verifying_key.vk(),
         &context.recursive_verifying_key,
-    );
+    )
+    .expect("valid IvcCircuit construction");
     let public_inputs = [
         global.as_public_input(),
         next_step_inputs.next_state.as_public_input(),
@@ -512,7 +514,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
     let current_accumulator = trivial_acc(&combined_fixed_base_names);
     let next_accumulator = current_accumulator.clone();
 
-    let circuit = IvcCircuit::new(
+    let circuit = IvcCircuit::try_new(
         global.clone(),
         State::genesis(),
         genesis_witness,
@@ -521,7 +523,8 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
         current_accumulator,
         context.certificate_verifying_key.vk(),
         &context.recursive_verifying_key,
-    );
+    )
+    .expect("valid IvcCircuit construction");
 
     let public_inputs = [
         global.as_public_input(),
@@ -650,7 +653,7 @@ pub(crate) fn generate_same_epoch_step_output_asset(
         "same-epoch next accumulator check failed"
     );
 
-    let circuit = IvcCircuit::new(
+    let circuit = IvcCircuit::try_new(
         global.clone(),
         chain_state.state.clone(),
         ivc_witness,
@@ -659,7 +662,8 @@ pub(crate) fn generate_same_epoch_step_output_asset(
         chain_state.accumulator.clone(),
         context.certificate_verifying_key.vk(),
         &context.recursive_verifying_key,
-    );
+    )
+    .expect("valid IvcCircuit construction");
 
     let public_inputs = [
         global.as_public_input(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -187,7 +187,8 @@ pub(crate) fn build_shared_recursive_context(
         &certificate_commitment_parameters,
         &setup.certificate_relation,
     );
-    let default_ivc_circuit = IvcCircuit::unknown(certificate_verifying_key.vk());
+    let default_ivc_circuit =
+        IvcCircuit::unknown(certificate_verifying_key.vk()).expect("valid IvcCircuit unknown");
     let recursive_verifying_key = keygen_vk_with_k(
         &recursive_commitment_parameters,
         &default_ivc_circuit,
@@ -209,7 +210,8 @@ pub(crate) fn build_shared_recursive_context(
 pub(crate) fn build_recursive_proving_key(
     context: &SharedRecursiveContext,
 ) -> ProvingKey<F, KZGCommitmentScheme<E>> {
-    let default_ivc_circuit = IvcCircuit::unknown(context.certificate_verifying_key.vk());
+    let default_ivc_circuit = IvcCircuit::unknown(context.certificate_verifying_key.vk())
+        .expect("valid IvcCircuit unknown");
     keygen_pk(
         context.recursive_verifying_key.clone(),
         &default_ivc_circuit,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
@@ -272,7 +272,7 @@ pub(crate) fn build_trivial_mock_prover_circuit(
     prev_state: State,
     witness: Witness,
 ) -> IvcCircuit {
-    IvcCircuit::new(
+    IvcCircuit::try_new(
         setup.global.clone(),
         prev_state,
         witness,
@@ -282,6 +282,7 @@ pub(crate) fn build_trivial_mock_prover_circuit(
         setup.certificate_verifying_key.vk(),
         &setup.recursive_verifying_key,
     )
+    .expect("valid IvcCircuit construction")
 }
 
 /// Builds the public-input vector for a MockProver-based negative test.

--- a/mithril-stm/src/circuits/halo2_ivc/tests/golden/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/golden/mod.rs
@@ -56,7 +56,8 @@ mod golden_verification_key_test {
         let circuit_verification_key =
             midnight_zk_stdlib::setup_vk(&srs_for_non_recursive_circuit, &circuit);
 
-        let default_ivc_circuit = IvcCircuit::unknown(circuit_verification_key.vk());
+        let default_ivc_circuit =
+            IvcCircuit::unknown(circuit_verification_key.vk()).expect("valid IvcCircuit unknown");
         let recursive_verifying_key: VerifyingKey<
             <BlstrsEmulation as SelfEmulation>::F,
             KZGCommitmentScheme<<BlstrsEmulation as SelfEmulation>::Engine>,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
@@ -130,7 +130,7 @@ mod slow {
             cert_accumulator,
         );
 
-        let circuit = IvcCircuit::new(
+        let circuit = IvcCircuit::try_new(
             mock_prover_setup.global.clone(),
             recursive_chain_state.state.clone(),
             ivc_witness,
@@ -139,7 +139,8 @@ mod slow {
             recursive_chain_state.accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,
-        );
+        )
+        .expect("valid IvcCircuit construction");
 
         let mut accumulator_encoding = AssignedAccumulator::as_public_input(&next_accumulator);
         accumulator_encoding[0] = F::ONE;

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
@@ -38,7 +38,7 @@ mod slow {
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
         ]
         .concat();
-        let circuit = IvcCircuit::new(
+        let circuit = IvcCircuit::try_new(
             mock_prover_setup.global.clone(),
             State::genesis(),
             build_genesis_base_case_witness(&setup),
@@ -47,7 +47,8 @@ mod slow {
             mock_prover_setup.trivial_accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,
-        );
+        )
+        .expect("valid IvcCircuit construction");
         assert_recursive_mock_prover_accepts_with_label(
             circuit,
             public_inputs,
@@ -68,7 +69,7 @@ mod slow {
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
         ]
         .concat();
-        let circuit = IvcCircuit::new(
+        let circuit = IvcCircuit::try_new(
             mock_prover_setup.global.clone(),
             State::genesis(),
             build_genesis_base_case_witness(&setup),
@@ -77,7 +78,8 @@ mod slow {
             mock_prover_setup.trivial_accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,
-        );
+        )
+        .expect("valid IvcCircuit construction");
         assert_recursive_mock_prover_accepts_with_label(
             circuit,
             public_inputs,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
@@ -11,8 +11,7 @@ use crate::circuits::halo2_ivc::{
     certificate_proof::verify_and_prepare_accumulator,
     errors::IvcCircuitError,
     tests::common::asset_readers::{
-        load_embedded_same_epoch_step_output_asset,
-        load_embedded_verification_context_asset,
+        load_embedded_same_epoch_step_output_asset, load_embedded_verification_context_asset,
     },
 };
 
@@ -20,11 +19,11 @@ use crate::circuits::halo2_ivc::{
 fn verify_and_prepare_accumulator_rejects_garbage_proof_bytes() {
     // Garbage bytes cannot be parsed as a valid Poseidon transcript, so
     // `prepare` returns an error and the function returns CertificateProofRejected.
-    let ctx = load_embedded_verification_context_asset()
-        .expect("verification context asset should load");
+    let ctx =
+        load_embedded_verification_context_asset().expect("verification context asset should load");
 
     let result = verify_and_prepare_accumulator(
-        &vec![0u8; 64],
+        &[0u8; 64],
         &[],
         &ctx.certificate_verifying_key,
         &ctx.verifier_params,
@@ -41,8 +40,8 @@ fn verify_and_prepare_accumulator_rejects_garbage_proof_bytes() {
 fn verify_and_prepare_accumulator_rejects_valid_proof_with_wrong_public_inputs() {
     // A valid cert proof paired with wrong public inputs produces a DualMSM
     // that fails the pairing check, so the function returns CertificateProofRejected.
-    let ctx = load_embedded_verification_context_asset()
-        .expect("verification context asset should load");
+    let ctx =
+        load_embedded_verification_context_asset().expect("verification context asset should load");
     let step_output = load_embedded_same_epoch_step_output_asset()
         .expect("same-epoch step output asset should load");
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
@@ -1,0 +1,63 @@
+//! Negative tests for verify_and_prepare_accumulator.
+//!
+//! Confirms that CertificateProofRejected is returned for:
+//! - garbage proof bytes (transcript parse failure)
+//! - a valid proof paired with wrong public inputs (pairing check failure)
+
+use ff::Field;
+
+use crate::circuits::halo2::types::CircuitBase;
+use crate::circuits::halo2_ivc::{
+    certificate_proof::verify_and_prepare_accumulator,
+    errors::IvcCircuitError,
+    tests::common::asset_readers::{
+        load_embedded_same_epoch_step_output_asset,
+        load_embedded_verification_context_asset,
+    },
+};
+
+#[test]
+fn verify_and_prepare_accumulator_rejects_garbage_proof_bytes() {
+    // Garbage bytes cannot be parsed as a valid Poseidon transcript, so
+    // `prepare` returns an error and the function returns CertificateProofRejected.
+    let ctx = load_embedded_verification_context_asset()
+        .expect("verification context asset should load");
+
+    let result = verify_and_prepare_accumulator(
+        &vec![0u8; 64],
+        &[],
+        &ctx.certificate_verifying_key,
+        &ctx.verifier_params,
+    );
+
+    let err = result
+        .unwrap_err()
+        .downcast::<IvcCircuitError>()
+        .expect("error should downcast to IvcCircuitError");
+    assert_eq!(err, IvcCircuitError::CertificateProofRejected);
+}
+
+#[test]
+fn verify_and_prepare_accumulator_rejects_valid_proof_with_wrong_public_inputs() {
+    // A valid cert proof paired with wrong public inputs produces a DualMSM
+    // that fails the pairing check, so the function returns CertificateProofRejected.
+    let ctx = load_embedded_verification_context_asset()
+        .expect("verification context asset should load");
+    let step_output = load_embedded_same_epoch_step_output_asset()
+        .expect("same-epoch step output asset should load");
+
+    let wrong_inputs = vec![CircuitBase::ZERO, CircuitBase::ZERO];
+
+    let result = verify_and_prepare_accumulator(
+        &step_output.certificate_proof,
+        &wrong_inputs,
+        &ctx.certificate_verifying_key,
+        &ctx.verifier_params,
+    );
+
+    let err = result
+        .unwrap_err()
+        .downcast::<IvcCircuitError>()
+        .expect("error should downcast to IvcCircuitError");
+    assert_eq!(err, IvcCircuitError::CertificateProofRejected);
+}

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
@@ -6,7 +6,7 @@ use crate::circuits::halo2_ivc::{
 };
 
 #[test]
-fn try_new_rejects_self_vk_with_wrong_degree() {
+fn validate_self_vk_degree_rejects_wrong_degree_vk() {
     // The certificate VK stored in the verification context has degree
     // CERTIFICATE_CIRCUIT_DEGREE (13) != K (19), so it is a cheap wrong-degree
     // input for validate_self_vk_degree without requiring any SRS generation.

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
@@ -1,0 +1,33 @@
+//! Tests that IvcCircuit constructor validations return the expected typed errors.
+
+use crate::circuits::halo2_ivc::{
+    K,
+    circuit::IvcCircuit,
+    errors::IvcCircuitError,
+    tests::common::asset_readers::load_embedded_verification_context_asset,
+};
+
+#[test]
+fn try_new_rejects_self_vk_with_wrong_degree() {
+    // The certificate VK stored in the verification context has degree
+    // CERTIFICATE_CIRCUIT_DEGREE (13) != K (19), so it is a cheap wrong-degree
+    // input for validate_self_vk_degree without requiring any SRS generation.
+    let ctx = load_embedded_verification_context_asset()
+        .expect("verification context asset should load");
+    let wrong_degree_vk = ctx.certificate_verifying_key.vk();
+    let actual_degree = wrong_degree_vk.get_domain().k();
+
+    let result = IvcCircuit::validate_self_vk_degree(wrong_degree_vk);
+
+    let err = result
+        .unwrap_err()
+        .downcast::<IvcCircuitError>()
+        .expect("error should downcast to IvcCircuitError");
+    assert_eq!(
+        err,
+        IvcCircuitError::SelfVkDegreeMismatch {
+            expected: K,
+            actual: actual_degree,
+        }
+    );
+}

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
@@ -1,9 +1,7 @@
 //! Tests that IvcCircuit constructor validations return the expected typed errors.
 
 use crate::circuits::halo2_ivc::{
-    K,
-    circuit::IvcCircuit,
-    errors::IvcCircuitError,
+    K, circuit::IvcCircuit, errors::IvcCircuitError,
     tests::common::asset_readers::load_embedded_verification_context_asset,
 };
 
@@ -12,8 +10,8 @@ fn try_new_rejects_self_vk_with_wrong_degree() {
     // The certificate VK stored in the verification context has degree
     // CERTIFICATE_CIRCUIT_DEGREE (13) != K (19), so it is a cheap wrong-degree
     // input for validate_self_vk_degree without requiring any SRS generation.
-    let ctx = load_embedded_verification_context_asset()
-        .expect("verification context asset should load");
+    let ctx =
+        load_embedded_verification_context_asset().expect("verification context asset should load");
     let wrong_degree_vk = ctx.certificate_verifying_key.vk();
     let actual_degree = wrong_degree_vk.get_domain().k();
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/mod.rs
@@ -6,16 +6,20 @@
 //! combined proof verification — as opposed to the in-circuit constraints
 //! covered by Layer C1.
 //!
-//! `accumulator_construction`  — `trivial_acc` structure and public-input encoding.
-//! `fixed_base_extraction`     — `extract_fixed_bases` reclassification and encoding effects.
-//! `accumulator_collapse`      — `collapse` preserves the `accumulator.check` invariant.
-//! `accumulator_verification`  — `accumulator.check` accepts valid stored accumulators and rejects tampered ones.
-//! `accumulator_update`        — full folding pipeline on stored assets; soundness under wrong previous accumulator.
-//! `proof_verification`        — `dual_msm.check` + `accumulator.check` combined for same-epoch and chain-state proofs.
+//! `accumulator_collapse`        — `collapse` preserves the `accumulator.check` invariant.
+//! `accumulator_construction`    — `trivial_acc` structure and public-input encoding.
+//! `accumulator_update`          — full folding pipeline on stored assets; soundness under wrong previous accumulator.
+//! `accumulator_verification`    — `accumulator.check` accepts valid stored accumulators and rejects tampered ones.
+//! `certificate_proof_rejection` — `verify_and_prepare_accumulator` rejects garbage bytes and wrong public inputs.
+//! `circuit_validation`          — `IvcCircuit::validate_self_vk_degree` rejects a VK with degree ≠ K.
+//! `fixed_base_extraction`       — `extract_fixed_bases` reclassification and encoding effects.
+//! `proof_verification`          — `dual_msm.check` + `accumulator.check` combined for same-epoch and chain-state proofs.
 
 mod accumulator_collapse;
 mod accumulator_construction;
 mod accumulator_update;
 mod accumulator_verification;
+mod certificate_proof_rejection;
+mod circuit_validation;
 mod fixed_base_extraction;
 mod proof_verification;

--- a/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
@@ -47,7 +47,7 @@ fn compute_recursive_circuit_verification_key(srs_path: &Path) -> StmResult<Vec<
         MidnightVK::read(&mut non_recursive_verification_key, SerdeFormat::RawBytes)
             .with_context(|| "Failed to deserialize the circuit verification key.")?;
 
-    // Create the IVC circuit, it is initiliazed with empty public inputs and the verification key
+    // Create the IVC circuit, it is initialized with empty public inputs and the verification key
     // of the non-recursive circuit
     let default_ivc_circuit =
         IvcCircuit::unknown(certificate_verifying_key.vk()).expect("valid IvcCircuit unknown");

--- a/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
@@ -49,7 +49,8 @@ fn compute_recursive_circuit_verification_key(srs_path: &Path) -> StmResult<Vec<
 
     // Create the IVC circuit, it is initiliazed with empty public inputs and the verification key
     // of the non-recursive circuit
-    let default_ivc_circuit = IvcCircuit::unknown(certificate_verifying_key.vk());
+    let default_ivc_circuit =
+        IvcCircuit::unknown(certificate_verifying_key.vk()).expect("valid IvcCircuit unknown");
     let recursive_verification_key: VerifyingKey<
         <BlstrsEmulation as SelfEmulation>::F,
         KZGCommitmentScheme<<BlstrsEmulation as SelfEmulation>::Engine>,


### PR DESCRIPTION
## Content

This PR completes **Workstream 2**, replacing panics and infallible constructors with typed errors and fallible constructors.

### Changes
- **`errors.rs`**: adds 4 new `IvcCircuitError` variants and a `to_synthesis_error` converter
- **`mod.rs`**: re-exports `NB_SHA256_ADVICE_COLS` and `NB_SHA256_FIXED_COLS` so `validate_column_counts` can include SHA256 chip requirements
- **`circuit.rs`**: replaces `new() -> Self` with `try_new() -> StmResult<Self>` and `unknown() -> StmResult<Self>`; adds validation guards called from both constructors
- **`gadget.rs`**: replaces 2 `.try_into().unwrap()` sites with `map_err` + `?` propagating `AssignedValueCountMismatch`
- **`config.rs`**: replaces 7 `.try_into().unwrap()` sites with `.expect("column counts pre-validated by validate_column_counts")`; 
- **Test call sites**: updates all `IvcCircuit::new(...)` → `try_new(...).expect(...)` and `unknown(...)` → `unknown(...).expect(...)` across test files 
- **New tests**: 
   - `circuit_validation.rs`: asserts `SelfVkDegreeMismatch` on a wrong-degree VK
   - `certificate_proof_rejection.rs`: asserts `CertificateProofRejected` for garbage bytes and wrong public inputs

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Comments
Closes https://github.com/input-output-hk/mithril/issues/3127