### PR TITLE
Add a cache mecanism on immutable files synchronisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4010,7 +4010,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.1"
+version = "0.9.2"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -106,6 +106,7 @@ impl ImmutableFilesUploader for CloudUploader {
         filepaths: &[PathBuf],
         compression_algorithm: Option<CompressionAlgorithm>,
     ) -> StdResult<ImmutablesLocation> {
+        self.refresh_existing_files_path_cache().await?;
         let mut file_uris = Vec::new();
         for filepath in filepaths {
             file_uris.push(self.upload(filepath).await?.into());

--- a/mithril-aggregator/src/file_uploaders/cloud_uploader/api.rs
+++ b/mithril-aggregator/src/file_uploaders/cloud_uploader/api.rs
@@ -1,5 +1,7 @@
 use anyhow::Context;
 use async_trait::async_trait;
+use std::collections::HashSet;
+use std::sync::Mutex;
 use std::{path::Path, sync::Arc};
 
 use mithril_common::{StdResult, entities::FileUri};
@@ -23,6 +25,7 @@ pub struct CloudUploader {
     remote_folder: CloudRemotePath,
     allow_overwrite: bool,
     retry_policy: FileUploadRetryPolicy,
+    existing_files_path_cache: Mutex<HashSet<CloudRemotePath>>,
 }
 
 impl CloudUploader {
@@ -38,22 +41,56 @@ impl CloudUploader {
             remote_folder,
             allow_overwrite,
             retry_policy,
+            existing_files_path_cache: Mutex::new(HashSet::new()),
         }
     }
-}
 
+    /// Refresh the cache of files path from the cloud backend
+    pub async fn refresh_existing_files_path_cache(&self) -> StdResult<()> {
+        let files_path: Vec<CloudRemotePath> = self
+            .cloud_backend_uploader
+            .list_files(&self.remote_folder)
+            .await
+            .with_context(|| "listing files in cloud")?;
+
+        let mut cache = self
+            .existing_files_path_cache
+            .lock()
+            .expect("Failed to acquire lock on existing_files_path_cache");
+        *cache = files_path.into_iter().collect();
+        Ok(())
+    }
+
+    fn find_file_in_cache(&self, remote_file_path: &CloudRemotePath) -> Option<FileUri> {
+        let cache = self
+            .existing_files_path_cache
+            .lock()
+            .expect("Failed to acquire lock on existing_files_path_cache");
+        cache
+            .get(remote_file_path)
+            .cloned()
+            .map(|remote_path| self.cloud_backend_uploader.get_file_uri(&remote_path))
+    }
+}
 #[async_trait]
 impl FileUploader for CloudUploader {
     async fn upload_without_retry(&self, file_path: &Path) -> StdResult<FileUri> {
         let remote_file_path = self.remote_folder.join(get_file_name(file_path)?);
-        if !self.allow_overwrite
-            && let Some(file_uri) = self
+        if !self.allow_overwrite {
+            // First, check if file exists in the cache
+            if let Some(cached_file_uri) = self.find_file_in_cache(&remote_file_path) {
+                return Ok(cached_file_uri);
+            }
+
+            // If not in cache, check with the cloud backend
+            if let Some(file_uri) = self
                 .cloud_backend_uploader
                 .file_exists(&remote_file_path)
                 .await
                 .with_context(|| "checking if file exists in cloud")?
-        {
-            return Ok(file_uri);
+            {
+                return Ok(file_uri);
+            }
         }
 
         let file_uri = self
@@ -85,6 +122,95 @@ mod tests {
     use crate::file_uploaders::cloud_uploader::MockCloudBackendUploader;
 
     use super::*;
+
+    #[tokio::test]
+    async fn upload_public_file_succeeds_without_uploading_it_if_file_exists_in_cache() {
+        let allow_overwrite = false;
+        let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+        let remote_folder_path = CloudRemotePath::new("remote_folder");
+        let expected_file_uri =
+            FileUri("https://cloud-host/remote_folder/snapshot.xxx.tar.gz".to_string());
+        let files_in_cache = vec![
+            CloudRemotePath::new("remote_folder/snapshot.yyy.tar.gz"),
+            CloudRemotePath::new("remote_folder/snapshot.xxx.tar.gz"),
+            CloudRemotePath::new("remote_folder/snapshot.zzz.tar.gz"),
+        ];
+
+        let cloud_backend_uploader = {
+            let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+            mock_cloud_backend_uploader
+                .expect_list_files()
+                .with(eq(remote_folder_path.clone()))
+                .return_once(move |_| Ok(files_in_cache))
+                .once();
+            let expected_file_uri_clone = expected_file_uri.clone();
+            mock_cloud_backend_uploader
+                .expect_get_file_uri()
+                .with(eq(CloudRemotePath::new(
+                    "remote_folder/snapshot.xxx.tar.gz",
+                )))
+                .return_once(move |_| expected_file_uri_clone)
+                .once();
+            mock_cloud_backend_uploader.expect_file_exists().never();
+            mock_cloud_backend_uploader.expect_upload_file().never();
+
+            mock_cloud_backend_uploader
+        };
+
+        let file_uploader = CloudUploader::new(
+            Arc::new(cloud_backend_uploader),
+            remote_folder_path,
+            allow_overwrite,
+            FileUploadRetryPolicy::never(),
+        );
+
+        file_uploader.refresh_existing_files_path_cache().await.unwrap();
+
+        let file_uri = file_uploader.upload(&local_file_path).await.unwrap();
+        assert_eq!(expected_file_uri, file_uri);
+    }
+
+    #[tokio::test]
+    async fn upload_public_file_succeeds_if_cache_is_empty_and_fallback_checking_for_file_existence()
+     {
+        let allow_overwrite = false;
+        let local_file_path = Path::new("local_folder").join("snapshot.xxx.tar.gz");
+        let remote_folder_path = CloudRemotePath::new("remote_folder");
+        let remote_file_path = remote_folder_path.join("snapshot.xxx.tar.gz");
+        let expected_file_uri =
+            FileUri("https://cloud-host/remote_folder/snapshot.xxx.tar.gz".to_string());
+        let files_in_cache = vec![];
+
+        let cloud_backend_uploader = {
+            let mut mock_cloud_backend_uploader = MockCloudBackendUploader::new();
+            mock_cloud_backend_uploader
+                .expect_list_files()
+                .with(eq(remote_folder_path.clone()))
+                .return_once(move |_| Ok(files_in_cache))
+                .once();
+            let expected_file_uri_clone = expected_file_uri.clone();
+            mock_cloud_backend_uploader
+                .expect_file_exists()
+                .with(eq(remote_file_path.clone()))
+                .return_once(move |_| Ok(Some(expected_file_uri_clone)))
+                .once();
+            mock_cloud_backend_uploader.expect_upload_file().never();
+
+            mock_cloud_backend_uploader
+        };
+
+        let file_uploader = CloudUploader::new(
+            Arc::new(cloud_backend_uploader),
+            remote_folder_path,
+            allow_overwrite,
+            FileUploadRetryPolicy::never(),
+        );
+
+        file_uploader.refresh_existing_files_path_cache().await.unwrap();
+
+        let file_uri = file_uploader.upload(&local_file_path).await.unwrap();
+        assert_eq!(expected_file_uri, file_uri);
+    }
 
     #[tokio::test]
     async fn upload_public_file_succeeds_when_file_does_not_exist_remotely_and_without_overwriting_allowed()

--- a/mithril-aggregator/src/file_uploaders/cloud_uploader/gcloud_backend.rs
+++ b/mithril-aggregator/src/file_uploaders/cloud_uploader/gcloud_backend.rs
@@ -9,6 +9,7 @@ use gcloud_storage::http::object_access_controls::insert::{
     InsertObjectAccessControlRequest, ObjectAccessControlCreationConfig,
 };
 use gcloud_storage::http::objects::get::GetObjectRequest;
+use gcloud_storage::http::objects::list::ListObjectsRequest;
 use gcloud_storage::http::objects::upload::{Media, UploadObjectRequest, UploadType};
 use slog::{Logger, info};
 use tokio_util::codec::{BytesCodec, FramedRead};
@@ -88,6 +89,40 @@ impl CloudBackendUploader for GCloudBackendUploader {
         };
 
         Ok(file_uri)
+    }
+
+    async fn list_files(
+        &self,
+        remote_folder_path: &CloudRemotePath,
+    ) -> StdResult<Vec<CloudRemotePath>> {
+        let mut normalized_path = remote_folder_path.to_string();
+        if !normalized_path.is_empty() && !normalized_path.ends_with('/') {
+            normalized_path.push('/');
+        }
+        info!(self.logger, "Listing files with prefix {normalized_path}");
+        let request = ListObjectsRequest {
+            bucket: self.bucket.clone(),
+            prefix: Some(normalized_path),
+            ..Default::default()
+        };
+        let response = self
+            .storage_client
+            .list_objects(&request)
+            .await
+            .with_context(|| "remote listing files failure")?;
+
+        let files_path: Vec<CloudRemotePath> = response
+            .items
+            .into_iter()
+            .flatten()
+            .map(|object| CloudRemotePath::new(&object.name))
+            .collect();
+
+        Ok(files_path)
+    }
+
+    fn get_file_uri(&self, remote_file_path: &CloudRemotePath) -> FileUri {
+        remote_file_path.to_gcloud_storage_location(&self.bucket, self.use_cdn_domain)
     }
 
     async fn upload_file(

--- a/mithril-aggregator/src/file_uploaders/cloud_uploader/interface.rs
+++ b/mithril-aggregator/src/file_uploaders/cloud_uploader/interface.rs
@@ -7,7 +7,7 @@ use mithril_common::StdResult;
 use mithril_common::entities::FileUri;
 
 /// CloudRemotePath represents a cloud remote path
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Hash, Eq)]
 pub struct CloudRemotePath(PathBuf);
 
 impl CloudRemotePath {
@@ -53,6 +53,15 @@ impl From<&Path> for CloudRemotePath {
 pub trait CloudBackendUploader: Send + Sync {
     /// Check if a file exists in the cloud backend
     async fn file_exists(&self, remote_file_path: &CloudRemotePath) -> StdResult<Option<FileUri>>;
+
+    /// List files URI from remote folder of cloud backend
+    async fn list_files(
+        &self,
+        remote_folder_path: &CloudRemotePath,
+    ) -> StdResult<Vec<CloudRemotePath>>;
+
+    /// Get the file URI for a given remote file path in the cloud backend
+    fn get_file_uri(&self, remote_file_path: &CloudRemotePath) -> FileUri;
 
     /// Upload a file to the cloud backend
     async fn upload_file(


### PR DESCRIPTION

## Content

This PR add a cache mecanism in the `CloudUploader` that is used for immutable file synchronisation. 
- At each `upload_without_retry` it will look if the file we try to upload exist in the cache 
- if it does not exist, it check is `file_exists` in remote folder
- if file is neither in cache nor exist remotely, file is uploaded

to populate the cache new methods has been added to `GCloudBackendUploader` ( `list_files` to list existing file in remote_folder of the bucket) and it `CloudUploader` (`refresh_files_path_cache` to cache those file path).

Cache refresh is called a each immutables batch upload.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

this PR relates closes #3243 
