### PR TITLE
fix(node-db): flush file after write to avoid race with tokio's async…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,7 +4186,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-cardano-node-internal-database"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/flake.nix
+++ b/flake.nix
@@ -290,6 +290,7 @@
             pkgsRustOverlay.libiconv
             config.treefmt.package
             pkgsRustOverlay.gnumake
+            pkgsRustOverlay.cargo-edit
           ];
 
           shellHook = ''

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-cardano-node-internal-database"
-version = "0.2.0"
+version = "0.2.1"
 description = "Mechanisms that allow Mithril nodes to read the files of a Cardano node internal database and compute digests from them"
 authors.workspace = true
 documentation.workspace = true

--- a/internal/cardano-node/mithril-cardano-node-internal-database/src/digesters/cache/json_provider.rs
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/src/digesters/cache/json_provider.rs
@@ -45,9 +45,13 @@ impl JsonImmutableFileDigestCacheProvider {
         &self,
         values: InnerStructure,
     ) -> Result<(), ImmutableDigesterCacheStoreError> {
-        let mut file = File::create(&self.filepath).await?;
+        let tmp_path = self.filepath.with_extension("tmp");
+        let mut file = File::create(&tmp_path).await?;
         file.write_all(serde_json::to_string_pretty(&values)?.as_bytes())
             .await?;
+        file.flush().await?;
+        drop(file);
+        fs::rename(&tmp_path, &self.filepath).await?;
 
         Ok(())
     }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -78,7 +78,7 @@ zstd = { version = "0.13.3", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 mithril-aggregator-discovery = { path = "../internal/mithril-aggregator-discovery", version = "0.1.6" }
-mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.2.0" }
+mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.2.1" }
 rand = { version = "0.10.1" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]


### PR DESCRIPTION
Hi, this small PR fixes a small bug that results in a flaky CI

See this run: https://github.com/input-output-hk/mithril/actions/runs/26501507482/job/78042861251

the PR of that run did not touch that test. Note that `flush()` forces any buffered bytes to be written out, ensuring the data is fully persisted before the function returns.