### PR TITLE
refactor(mithril-stm): type consistency for halo2 IVC

### DIFF
--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -31,7 +31,7 @@ use crate::{
 /// on a clone gives cheap early abort; the original `DualMSM` is returned on
 /// success for downstream reuse (e.g. wrapping into a certificate accumulator
 /// for recursive aggregation).
-// TODO: remove this allow dead_code directive when the IVC prover consumes this helper
+// Kept until the IVC prover prepares certificate proof accumulators.
 #[allow(dead_code)]
 pub(crate) fn verify_and_prepare_accumulator(
     proof_bytes: &[u8],

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -11,6 +11,7 @@ use super::{
     gadget::IvcGadget,
     nb_foreign_ecc_chip_columns,
     state::{Global, State, Witness},
+    types::CertificateProofBytes,
 };
 
 #[derive(Clone, Debug)]
@@ -35,6 +36,8 @@ pub struct IvcCircuit {
 
 impl IvcCircuit {
     /// Validates that the self VK degree matches the IVC circuit degree constant K.
+    // TODO: remove this allow dead_code directive when the IVC prover consumes this circuit
+    #[allow(dead_code)]
     pub(crate) fn validate_self_vk_degree(
         self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
     ) -> StmResult<()> {
@@ -88,12 +91,14 @@ impl IvcCircuit {
     /// `configure_ivc_circuit` is sufficient for all chips. Returns an error containing
     /// [`IvcCircuitError::SelfVkDegreeMismatch`] or [`IvcCircuitError::InsufficientAdviceColumns`]
     /// / [`IvcCircuitError::InsufficientFixedColumns`] if either check fails.
+    // TODO: remove this allow dead_code directive when the IVC prover consumes this circuit
+    #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
-    pub fn try_new(
+    pub(crate) fn try_new(
         global: Global,
         state: State,
         witness: Witness,
-        cert_proof: Vec<u8>,
+        cert_proof: CertificateProofBytes,
         self_proof: Vec<u8>,
         acc: Accumulator<S>,
         cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
@@ -105,7 +110,7 @@ impl IvcCircuit {
             global: Value::known(global),
             state: Value::known(state),
             witness: Value::known(witness),
-            cert_proof: Value::known(cert_proof),
+            cert_proof: Value::known(cert_proof.into_vec()),
             self_proof: Value::known(self_proof),
             acc: Value::known(acc),
             cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -11,7 +11,7 @@ use super::{
     gadget::IvcGadget,
     nb_foreign_ecc_chip_columns,
     state::{Global, State, Witness},
-    types::CertificateProofBytes,
+    types::{CertificateProofBytes, IvcProofBytes},
 };
 
 #[derive(Clone, Debug)]
@@ -99,7 +99,7 @@ impl IvcCircuit {
         state: State,
         witness: Witness,
         cert_proof: CertificateProofBytes,
-        self_proof: Vec<u8>,
+        self_proof: IvcProofBytes,
         acc: Accumulator<S>,
         cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
         self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
@@ -111,7 +111,7 @@ impl IvcCircuit {
             state: Value::known(state),
             witness: Value::known(witness),
             cert_proof: Value::known(cert_proof.into_vec()),
-            self_proof: Value::known(self_proof),
+            self_proof: Value::known(self_proof.into_vec()),
             acc: Value::known(acc),
             cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),
             self_domain_cs: (self_vk.get_domain().clone(), self_vk.cs().clone()),

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -17,21 +17,21 @@ use super::{
 #[derive(Clone, Debug)]
 pub struct IvcCircuit {
     // Persistent values throughout an ivc stream. This is the root of trust for an ivc stream.
-    pub global: Value<Global>,
+    global: Value<Global>,
     // State values from the last aggregated certificate
-    pub state: Value<State>,
+    state: Value<State>,
     // Witness (mainly the next certificate to be aggregated) for deriving the next state
-    pub witness: Value<Witness>,
+    witness: Value<Witness>,
     // Snark proof of the next certificate
-    pub cert_proof: Value<Vec<u8>>,
+    cert_proof: Value<Vec<u8>>,
     // Latest IVC proof
-    pub self_proof: Value<Vec<u8>>,
+    self_proof: Value<Vec<u8>>,
     // Latest Accumulator
-    pub acc: Value<Accumulator<S>>,
+    acc: Value<Accumulator<S>>,
     // Domain and ConstraintSystem associated with certificate circuit VerifyingKey
-    pub cert_domain_cs: (EvaluationDomain<F>, ConstraintSystem<F>),
+    cert_domain_cs: (EvaluationDomain<F>, ConstraintSystem<F>),
     // Domain and ConstraintSystem associated with ivc circuit VerifyingKey
-    pub self_domain_cs: (EvaluationDomain<F>, ConstraintSystem<F>),
+    self_domain_cs: (EvaluationDomain<F>, ConstraintSystem<F>),
 }
 
 impl IvcCircuit {

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -36,7 +36,7 @@ pub struct IvcCircuit {
 
 impl IvcCircuit {
     /// Validates that the self VK degree matches the IVC circuit degree constant K.
-    // TODO: remove this allow dead_code directive when the IVC prover consumes this circuit
+    // Kept until the IVC prover validates recursive circuit keys.
     #[allow(dead_code)]
     pub(crate) fn validate_self_vk_degree(
         self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
@@ -91,7 +91,7 @@ impl IvcCircuit {
     /// `configure_ivc_circuit` is sufficient for all chips. Returns an error containing
     /// [`IvcCircuitError::SelfVkDegreeMismatch`] or [`IvcCircuitError::InsufficientAdviceColumns`]
     /// / [`IvcCircuitError::InsufficientFixedColumns`] if either check fails.
-    // TODO: remove this allow dead_code directive when the IVC prover consumes this circuit
+    // Kept until the IVC prover constructs recursive circuit instances.
     #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn try_new(

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -68,7 +68,7 @@ impl IvcGadget {
     ) -> Result<AssignedGlobal, Error> {
         let genesis_msg: AssignedNative<_> = self
             .native_gadget
-            .assign_as_public_input(layouter, global.clone().map(|gl| gl.genesis_msg))?;
+            .assign_as_public_input(layouter, global.clone().map(|gl| gl.genesis_msg.as_field()))?;
         let genesis_vk: AssignedNativePoint<_> = self.jubjub_chip.assign_as_public_input(
             layouter,
             global.clone().map(|gl| *gl.genesis_vk.as_jubjub_subgroup()),
@@ -80,7 +80,7 @@ impl IvcGadget {
             CERT_VK_NAME,
             cert_domain,
             cert_cs,
-            global.clone().map(|gl| gl.cert_vk_repr),
+            global.clone().map(|gl| gl.cert_vk_repr.as_field()),
         )?;
 
         // Assign for self-proof verification
@@ -90,7 +90,7 @@ impl IvcGadget {
             IVC_ONE_NAME,
             self_domain,
             self_cs,
-            global.clone().map(|gl| gl.self_vk_repr),
+            global.clone().map(|gl| gl.self_vk_repr.as_field()),
         )?;
 
         let fixed_base_names = {
@@ -120,13 +120,13 @@ impl IvcGadget {
             .clone()
             .map(|s| {
                 vec![
-                    s.counter,
-                    s.msg,
-                    s.merkle_root,
-                    s.next_merkle_root,
-                    s.protocol_params,
-                    s.next_protocol_params,
-                    s.current_epoch,
+                    s.counter.as_field(),
+                    s.msg.as_field(),
+                    s.merkle_root.as_field(),
+                    s.next_merkle_root.as_field(),
+                    s.protocol_params.as_field(),
+                    s.next_protocol_params.as_field(),
+                    s.current_epoch.as_field(),
                 ]
             })
             .transpose_vec(7);
@@ -200,7 +200,7 @@ impl IvcGadget {
         let [cert_msg, cert_merkle_root]: [AssignedNative<F>; 2] = {
             let values = witness
                 .clone()
-                .map(|w| vec![w.cert_msg, w.cert_merkle_root])
+                .map(|w| vec![w.cert_msg.as_field(), w.cert_merkle_root.as_field()])
                 .transpose_vec(2);
             self.native_gadget
                 .assign_many(layouter, &values)?
@@ -214,7 +214,7 @@ impl IvcGadget {
         };
 
         let msg_preimage = {
-            let preimage = witness.clone().map(|w| w.msg_preimage).transpose_array();
+            let preimage = witness.clone().map(|w| w.msg_preimage.into_inner()).transpose_array();
             self.native_gadget.assign_many(layouter, &preimage)?
         };
 

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -61,7 +61,7 @@ pub(crate) mod state;
 pub(crate) mod types;
 
 #[cfg(test)]
-pub mod tests;
+pub(crate) mod tests;
 
 type S = BlstrsEmulation;
 type F = <S as SelfEmulation>::F;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -49,14 +49,15 @@ pub(crate) use midnight_proofs::{
 };
 
 pub(crate) mod certificate_proof;
-pub mod circuit;
-pub mod config;
-pub mod errors;
-pub mod gadget;
-pub mod io;
+pub(crate) mod circuit;
+pub(crate) mod config;
+pub(crate) mod errors;
+pub(crate) mod gadget;
+#[cfg(test)]
+pub(crate) mod io;
 #[cfg(test)]
 pub(crate) mod protocol_message;
-pub mod state;
+pub(crate) mod state;
 pub(crate) mod types;
 
 #[cfg(test)]

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -57,6 +57,7 @@ pub mod io;
 #[cfg(test)]
 pub(crate) mod protocol_message;
 pub mod state;
+pub(crate) mod types;
 
 #[cfg(test)]
 pub mod tests;

--- a/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
@@ -42,6 +42,17 @@ pub(crate) struct ProtocolMessage {
     message_parts: BTreeMap<ProtocolMessagePartKey, String>,
 }
 
+/// Formats the SNARK AVK protocol-message value like `mithril-common` does through
+/// `ProtocolAggregateVerificationKeyForSnark::to_bytes_hex()`.
+pub(crate) fn aggregate_verification_key_message_part<D: MembershipDigest>(
+    aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
+) -> StmResult<String> {
+    let bytes = aggregate_verification_key
+        .to_bytes()
+        .context("aggregate verification key serialization failed")?;
+    Ok(hex::encode(bytes))
+}
+
 impl ProtocolMessage {
     pub(crate) fn new() -> Self {
         Self {

--- a/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
@@ -2,9 +2,10 @@
 
 use std::collections::BTreeMap;
 
-use anyhow::{Context, anyhow};
+use anyhow::anyhow;
 use sha2::{Digest as Sha2Digest, Sha256};
 
+use crate::proof_system::SNARK_AGGREGATE_VERIFICATION_KEY_RIGID_SLOT_BYTES;
 use crate::{AggregateVerificationKeyForSnark, MembershipDigest, StmResult};
 
 use super::PREIMAGE_SIZE;
@@ -18,61 +19,59 @@ const RIGID_NEXT_PROTOCOL_PARAMETERS_LABEL: &[u8] = b"next_protocol_parameters";
 const RIGID_CURRENT_EPOCH_LABEL: &[u8] = b"current_epoch";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub(crate) enum ProtocolMessagePartKey {
+pub(crate) enum DynamicProtocolMessagePartKey {
     SnapshotDigest,
-    NextSnarkAggregateVerificationKey,
-    NextProtocolParameters,
-    CurrentEpoch,
 }
 
-impl std::fmt::Display for ProtocolMessagePartKey {
+impl std::fmt::Display for DynamicProtocolMessagePartKey {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::SnapshotDigest => write!(f, "snapshot_digest"),
-            Self::NextSnarkAggregateVerificationKey => {
-                write!(f, "next_aggregate_verification_key_snark")
-            }
-            Self::NextProtocolParameters => write!(f, "next_protocol_parameters"),
-            Self::CurrentEpoch => write!(f, "current_epoch"),
         }
     }
 }
 
 pub(crate) struct ProtocolMessage {
-    message_parts: BTreeMap<ProtocolMessagePartKey, String>,
-}
-
-/// Formats the SNARK AVK protocol-message value like `mithril-common` does through
-/// `ProtocolAggregateVerificationKeyForSnark::to_bytes_hex()`.
-pub(crate) fn aggregate_verification_key_message_part<D: MembershipDigest>(
-    aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
-) -> StmResult<String> {
-    let bytes = aggregate_verification_key
-        .to_bytes()
-        .context("aggregate verification key serialization failed")?;
-    Ok(hex::encode(bytes))
+    dynamic_message_parts: BTreeMap<DynamicProtocolMessagePartKey, String>,
+    next_snark_aggregate_verification_key:
+        Option<[u8; SNARK_AGGREGATE_VERIFICATION_KEY_RIGID_SLOT_BYTES]>,
+    next_protocol_parameters: Option<[u8; 32]>,
+    current_epoch: Option<u64>,
 }
 
 impl ProtocolMessage {
     pub(crate) fn new() -> Self {
         Self {
-            message_parts: BTreeMap::new(),
+            dynamic_message_parts: BTreeMap::new(),
+            next_snark_aggregate_verification_key: None,
+            next_protocol_parameters: None,
+            current_epoch: None,
         }
     }
 
-    pub(crate) fn set_message_part(&mut self, key: ProtocolMessagePartKey, value: String) {
-        self.message_parts.insert(key, value);
+    pub(crate) fn set_dynamic_message_part(
+        &mut self,
+        key: DynamicProtocolMessagePartKey,
+        value: String,
+    ) {
+        self.dynamic_message_parts.insert(key, value);
     }
 
-    fn required_message_part(
-        &self,
-        key: ProtocolMessagePartKey,
-        name: &'static str,
-    ) -> StmResult<&str> {
-        self.message_parts
-            .get(&key)
-            .map(String::as_str)
-            .ok_or_else(|| anyhow!("{name} slot is required"))
+    pub(crate) fn set_next_snark_aggregate_verification_key<D: MembershipDigest>(
+        &mut self,
+        aggregate_verification_key: &AggregateVerificationKeyForSnark<D>,
+    ) -> StmResult<()> {
+        self.next_snark_aggregate_verification_key =
+            Some(aggregate_verification_key.to_rigid_slot_bytes()?);
+        Ok(())
+    }
+
+    pub(crate) fn set_next_protocol_parameters(&mut self, protocol_parameters: [u8; 32]) {
+        self.next_protocol_parameters = Some(protocol_parameters);
+    }
+
+    pub(crate) fn set_current_epoch(&mut self, current_epoch: u64) {
+        self.current_epoch = Some(current_epoch);
     }
 
     /// Assembles the 190-byte rigid preimage that matches `mithril-common::ProtocolMessage::rigid_preimage()`.
@@ -89,11 +88,18 @@ impl ProtocolMessage {
     /// || epoch_slot                      (8 bytes)
     /// = 190 bytes
     /// ```
-    pub(crate) fn try_rigid_preimage<D: MembershipDigest>(&self) -> StmResult<[u8; PREIMAGE_SIZE]> {
+    pub(crate) fn try_rigid_preimage(&self) -> StmResult<[u8; PREIMAGE_SIZE]> {
         let dynamic_hash = self.compute_dynamic_parts_hash();
-        let avk_slot = self.avk_slot_from_key::<D>()?;
-        let params_slot = self.params_slot_from_key()?;
-        let epoch_slot = self.epoch_slot_from_key()?;
+        let avk_slot = self
+            .next_snark_aggregate_verification_key
+            .ok_or_else(|| anyhow!("next SNARK aggregate verification key slot is required"))?;
+        let params_slot = self
+            .next_protocol_parameters
+            .ok_or_else(|| anyhow!("next protocol parameters slot is required"))?;
+        let epoch_slot = self
+            .current_epoch
+            .ok_or_else(|| anyhow!("current epoch slot is required"))?
+            .to_le_bytes();
 
         let mut preimage = [0u8; PREIMAGE_SIZE];
         let mut cursor = 0;
@@ -135,53 +141,14 @@ impl ProtocolMessage {
         Ok(preimage)
     }
 
-    /// SHA256 of the dynamic parts: all keys except the three rigid fixed-slot keys,
-    /// in BTreeMap order: `SHA256(key.to_string() || value)` for each remaining entry.
+    /// SHA256 of the dynamic parts in BTreeMap order:
+    /// `SHA256(key.to_string() || value)` for each entry.
     fn compute_dynamic_parts_hash(&self) -> [u8; 32] {
         let mut hasher = Sha256::new();
-        for (key, value) in &self.message_parts {
-            if matches!(
-                key,
-                ProtocolMessagePartKey::NextSnarkAggregateVerificationKey
-                    | ProtocolMessagePartKey::NextProtocolParameters
-                    | ProtocolMessagePartKey::CurrentEpoch
-            ) {
-                continue;
-            }
+        for (key, value) in &self.dynamic_message_parts {
             hasher.update(key.to_string().as_bytes());
             hasher.update(value.as_bytes());
         }
         hasher.finalize().into()
-    }
-
-    fn avk_slot_from_key<D: MembershipDigest>(&self) -> StmResult<[u8; 44]> {
-        let value = self.required_message_part(
-            ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-            "next SNARK aggregate verification key",
-        )?;
-        let bytes =
-            hex::decode(value).context("invalid next SNARK aggregate verification key hex")?;
-        let avk = AggregateVerificationKeyForSnark::<D>::from_bytes(&bytes)
-            .context("invalid next SNARK aggregate verification key bytes")?;
-        avk.to_rigid_slot_bytes()
-    }
-
-    fn params_slot_from_key(&self) -> StmResult<[u8; 32]> {
-        let value = self.required_message_part(
-            ProtocolMessagePartKey::NextProtocolParameters,
-            "next protocol parameters",
-        )?;
-        let bytes = hex::decode(value).context("invalid next protocol parameters hex")?;
-        let actual = bytes.len();
-        bytes.try_into().map_err(|_| {
-            anyhow!("next protocol parameters slot must be exactly 32 bytes, got {actual}")
-        })
-    }
-
-    fn epoch_slot_from_key(&self) -> StmResult<[u8; 8]> {
-        let value =
-            self.required_message_part(ProtocolMessagePartKey::CurrentEpoch, "current epoch")?;
-        let epoch: u64 = value.parse().context("invalid current epoch slot")?;
-        Ok(epoch.to_le_bytes())
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -18,7 +18,7 @@ use super::{
 };
 
 #[derive(Clone, Debug)]
-pub struct State {
+pub(crate) struct State {
     pub(crate) counter: StepCounter,
     pub(crate) msg: MessageHash,
     pub(crate) merkle_root: MerkleTreeCommitment,
@@ -81,7 +81,7 @@ impl State {
 
 /// In-circuit counterpart of [`State`].
 #[derive(Clone, Debug)]
-pub struct AssignedState {
+pub(crate) struct AssignedState {
     pub(crate) counter: AssignedNative<F>,
     pub(crate) msg: AssignedNative<F>,
     pub(crate) merkle_root: AssignedNative<F>,
@@ -92,7 +92,7 @@ pub struct AssignedState {
 }
 
 impl AssignedState {
-    pub fn as_public_input(&self) -> Vec<AssignedNative<F>> {
+    pub(crate) fn as_public_input(&self) -> Vec<AssignedNative<F>> {
         let state = self.clone();
         vec![
             state.counter,
@@ -107,7 +107,7 @@ impl AssignedState {
 }
 
 #[derive(Clone, Debug)]
-pub struct Global {
+pub(crate) struct Global {
     // Persistent values that do not change through an ivc stream
     pub(crate) genesis_msg: MessageHash,
     pub(crate) genesis_vk: SchnorrVerificationKey,
@@ -149,7 +149,7 @@ impl Global {
 }
 
 #[derive(Clone, Debug)]
-pub struct AssignedGlobal {
+pub(crate) struct AssignedGlobal {
     //Persistent values that do not change through an ivc stream
     pub(crate) genesis_msg: AssignedNative<F>,
     pub(crate) genesis_vk: AssignedNativePoint<Jubjub>,
@@ -160,7 +160,7 @@ pub struct AssignedGlobal {
 }
 
 #[derive(Clone, Debug)]
-pub struct Witness {
+pub(crate) struct Witness {
     pub(crate) genesis_sig: StandardSchnorrSignature,
     pub(crate) cert_msg: MessageHash,
     pub(crate) cert_merkle_root: MerkleTreeCommitment,
@@ -186,7 +186,7 @@ impl Witness {
 }
 
 #[derive(Clone, Debug)]
-pub struct AssignedWitness {
+pub(crate) struct AssignedWitness {
     pub(crate) genesis_sig: (AssignedScalarOfNativeCurve<Jubjub>, AssignedNative<F>),
     pub(crate) cert_merkle_root: AssignedNative<F>,
     pub(crate) cert_msg: AssignedNative<F>,
@@ -194,7 +194,7 @@ pub struct AssignedWitness {
     pub(crate) msg_preimage: Vec<AssignedByte<F>>,
 }
 
-pub fn trivial_acc(fixed_base_names: &[String]) -> Accumulator<S> {
+pub(crate) fn trivial_acc(fixed_base_names: &[String]) -> Accumulator<S> {
     Accumulator::<S>::new(
         Msm::new(&[C::default()], &[F::ONE], &BTreeMap::new()),
         Msm::new(
@@ -205,7 +205,7 @@ pub fn trivial_acc(fixed_base_names: &[String]) -> Accumulator<S> {
     )
 }
 
-pub fn fixed_bases_and_names(
+pub(crate) fn fixed_bases_and_names(
     vk_name: &str,
     vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
 ) -> (BTreeMap<String, C>, Vec<String>) {
@@ -216,7 +216,7 @@ pub fn fixed_bases_and_names(
     (fixed_bases, fixed_base_names)
 }
 
-pub fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<F>) -> Vec<String> {
+pub(crate) fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<F>) -> Vec<String> {
     let mut fixed_base_names = vec![String::from("com_instance")];
     fixed_base_names.extend(verifier::fixed_base_names::<S>(
         vk_name,

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -7,30 +7,37 @@ use crate::signature_scheme::{SchnorrVerificationKey, StandardSchnorrSignature};
 
 use super::{
     Accumulator, AssignedByte, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignedVk, C, ConstraintSystem, E, F, Instantiable, Jubjub, KZGCommitmentScheme, Msm,
-    PREIMAGE_SIZE, S, VerifyingKey, verifier,
+    AssignedVk, C, ConstraintSystem, E, F, Instantiable, Jubjub, KZGCommitmentScheme, Msm, S,
+    VerifyingKey,
+    types::{
+        CertificateCircuitVerificationKeyRepresentation, EpochNumber,
+        IvcCircuitVerificationKeyRepresentation, MerkleTreeCommitment, MessageHash,
+        ProtocolMessagePreimage, ProtocolParametersHash, StepCounter,
+    },
+    verifier,
 };
 
 #[derive(Clone, Debug)]
 pub struct State {
-    pub(crate) counter: F,
-    pub(crate) msg: F,
-    pub(crate) merkle_root: F,
-    pub(crate) next_merkle_root: F,
-    pub(crate) protocol_params: F,
-    pub(crate) next_protocol_params: F,
-    pub(crate) current_epoch: F,
+    pub(crate) counter: StepCounter,
+    pub(crate) msg: MessageHash,
+    pub(crate) merkle_root: MerkleTreeCommitment,
+    pub(crate) next_merkle_root: MerkleTreeCommitment,
+    pub(crate) protocol_params: ProtocolParametersHash,
+    pub(crate) next_protocol_params: ProtocolParametersHash,
+    pub(crate) current_epoch: EpochNumber,
 }
 
 impl State {
-    pub fn new(
-        counter: F,
-        msg: F,
-        merkle_root: F,
-        next_merkle_root: F,
-        protocol_params: F,
-        next_protocol_params: F,
-        current_epoch: F,
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        counter: StepCounter,
+        msg: MessageHash,
+        merkle_root: MerkleTreeCommitment,
+        next_merkle_root: MerkleTreeCommitment,
+        protocol_params: ProtocolParametersHash,
+        next_protocol_params: ProtocolParametersHash,
+        current_epoch: EpochNumber,
     ) -> Self {
         State {
             counter,
@@ -43,28 +50,31 @@ impl State {
         }
     }
 
-    pub fn genesis() -> Self {
+    pub(crate) fn genesis() -> Self {
         State {
-            counter: F::ZERO,
-            msg: F::ZERO,
-            merkle_root: F::ZERO,
-            next_merkle_root: F::ZERO,
-            protocol_params: F::ZERO,
-            next_protocol_params: F::ZERO,
-            current_epoch: F::ZERO,
+            counter: StepCounter::ZERO,
+            msg: MessageHash::ZERO,
+            merkle_root: MerkleTreeCommitment::ZERO,
+            next_merkle_root: MerkleTreeCommitment::ZERO,
+            protocol_params: ProtocolParametersHash::ZERO,
+            next_protocol_params: ProtocolParametersHash::ZERO,
+            current_epoch: EpochNumber::ZERO,
         }
     }
 
-    pub fn as_public_input(&self) -> Vec<F> {
+    #[allow(dead_code)]
+    pub(crate) fn as_public_input(&self) -> Vec<F> {
         let state = self.clone();
+        // Public-input order is part of the recursive circuit statement contract:
+        // [counter, msg, merkle_root, next_merkle_root, protocol_params, next_protocol_params, current_epoch].
         vec![
-            state.counter,
-            state.msg,
-            state.merkle_root,
-            state.next_merkle_root,
-            state.protocol_params,
-            state.next_protocol_params,
-            state.current_epoch,
+            state.counter.as_field(),
+            state.msg.as_field(),
+            state.merkle_root.as_field(),
+            state.next_merkle_root.as_field(),
+            state.protocol_params.as_field(),
+            state.next_protocol_params.as_field(),
+            state.current_epoch.as_field(),
         ]
     }
 }
@@ -99,17 +109,18 @@ impl AssignedState {
 #[derive(Clone, Debug)]
 pub struct Global {
     // Persistent values that do not change through an ivc stream
-    pub(crate) genesis_msg: F,
+    pub(crate) genesis_msg: MessageHash,
     pub(crate) genesis_vk: SchnorrVerificationKey,
     // cert_vk hash
-    pub(crate) cert_vk_repr: F,
+    pub(crate) cert_vk_repr: CertificateCircuitVerificationKeyRepresentation,
     // ivc_vk hash
-    pub(crate) self_vk_repr: F,
+    pub(crate) self_vk_repr: IvcCircuitVerificationKeyRepresentation,
 }
 
 impl Global {
-    pub fn new(
-        genesis_msg: F,
+    #[allow(dead_code)]
+    pub(crate) fn new(
+        genesis_msg: MessageHash,
         genesis_vk: SchnorrVerificationKey,
         cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
         self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
@@ -117,16 +128,21 @@ impl Global {
         Global {
             genesis_msg,
             genesis_vk,
-            cert_vk_repr: cert_vk.transcript_repr(),
-            self_vk_repr: self_vk.transcript_repr(),
+            cert_vk_repr: CertificateCircuitVerificationKeyRepresentation::from_field(
+                cert_vk.transcript_repr(),
+            ),
+            self_vk_repr: IvcCircuitVerificationKeyRepresentation::from_field(
+                self_vk.transcript_repr(),
+            ),
         }
     }
 
-    pub fn as_public_input(&self) -> Vec<F> {
+    #[allow(dead_code)]
+    pub(crate) fn as_public_input(&self) -> Vec<F> {
         [
-            vec![self.genesis_msg],
+            vec![self.genesis_msg.as_field()],
             AssignedNativePoint::<Jubjub>::as_public_input(self.genesis_vk.as_jubjub_subgroup()),
-            vec![self.cert_vk_repr, self.self_vk_repr],
+            vec![self.cert_vk_repr.as_field(), self.self_vk_repr.as_field()],
         ]
         .concat()
     }
@@ -146,18 +162,19 @@ pub struct AssignedGlobal {
 #[derive(Clone, Debug)]
 pub struct Witness {
     pub(crate) genesis_sig: StandardSchnorrSignature,
-    pub(crate) cert_msg: F,
-    pub(crate) cert_merkle_root: F,
+    pub(crate) cert_msg: MessageHash,
+    pub(crate) cert_merkle_root: MerkleTreeCommitment,
     // Protocol msg preimage bytes
-    pub(crate) msg_preimage: [u8; PREIMAGE_SIZE],
+    pub(crate) msg_preimage: ProtocolMessagePreimage,
 }
 
 impl Witness {
-    pub fn new(
+    #[allow(dead_code)]
+    pub(crate) fn new(
         genesis_sig: StandardSchnorrSignature,
-        cert_merkle_root: F,
-        cert_msg: F,
-        msg_preimage: [u8; PREIMAGE_SIZE],
+        cert_merkle_root: MerkleTreeCommitment,
+        cert_msg: MessageHash,
+        msg_preimage: ProtocolMessagePreimage,
     ) -> Self {
         Witness {
             genesis_sig,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
@@ -19,7 +19,10 @@ use crate::circuits::halo2_ivc::{
     circuit::IvcCircuit,
     io::{Read as IvcRead, Write as IvcWrite},
     state::State,
-    types::{EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolParametersHash, StepCounter},
+    types::{
+        CertificateProofBytes, EpochNumber, IvcProofBytes, MerkleTreeCommitment, MessageHash,
+        ProtocolParametersHash, StepCounter,
+    },
 };
 
 use super::field_encoding::jubjub_base_from_raw_le_bytes;
@@ -32,7 +35,7 @@ pub(crate) struct RecursiveChainStateAsset {
     /// Stored recursive state checkpoint.
     pub(crate) state: State,
     /// Stored previous recursive proof bytes.
-    pub(crate) proof: Vec<u8>,
+    pub(crate) proof: IvcProofBytes,
     /// Stored folded accumulator for the checkpoint.
     pub(crate) accumulator: Accumulator<S>,
 }
@@ -58,13 +61,13 @@ pub(crate) struct VerificationContextAsset {
 #[derive(Debug)]
 pub(crate) struct RecursiveStepOutputAsset {
     /// Stored final recursive proof bytes for the next step.
-    pub(crate) proof: Vec<u8>,
+    pub(crate) proof: IvcProofBytes,
     /// Stored folded accumulator after extending the chain by one step.
     pub(crate) next_accumulator: Accumulator<S>,
     /// Stored next recursive state.
     pub(crate) next_state: State,
     /// Stored certificate proof consumed by the recursive step.
-    pub(crate) certificate_proof: Vec<u8>,
+    pub(crate) certificate_proof: CertificateProofBytes,
 }
 
 const RECURSIVE_CHAIN_STATE_ASSET_BYTES: &[u8] =
@@ -190,7 +193,7 @@ fn load_recursive_chain_state_asset_from_reader<R: Read>(
         .map(|_| read_field_element(reader))
         .collect::<Result<Vec<_>, _>>()?;
     let state = read_state_public_input(reader)?;
-    let proof = read_length_prefixed_proof(reader)?;
+    let proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
     let accumulator = Accumulator::<S>::read(reader, SerdeFormat::RawBytesUnchecked)?;
 
     Ok(RecursiveChainStateAsset {
@@ -240,7 +243,7 @@ pub(crate) fn store_recursive_chain_state_asset(
         write_field_element(&mut writer, value)?;
     }
     write_state_public_input(&mut writer, &asset.state)?;
-    write_length_prefixed_proof(&mut writer, &asset.proof)?;
+    write_length_prefixed_proof(&mut writer, asset.proof.as_bytes())?;
     asset.accumulator.write(&mut writer, SerdeFormat::RawBytesUnchecked)?;
     writer.flush().with_context(|| {
         format!(
@@ -353,10 +356,12 @@ pub(crate) fn store_verification_context_asset(
 fn load_recursive_step_output_asset_from_reader<R: Read>(
     reader: &mut R,
 ) -> StmResult<RecursiveStepOutputAsset> {
-    let proof = read_length_prefixed_proof(reader)?;
+    let proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
     let next_accumulator = Accumulator::<S>::read(reader, SerdeFormat::RawBytesUnchecked)?;
     let next_state = read_state_public_input(reader)?;
-    let certificate_proof = read_length_prefixed_proof(reader)?;
+    let certificate_proof = CertificateProofBytes::from_certificate_circuit_proof_bytes(
+        read_length_prefixed_proof(reader)?,
+    );
 
     Ok(RecursiveStepOutputAsset {
         proof,
@@ -399,12 +404,12 @@ pub(crate) fn store_recursive_step_output_asset(
         )
     })?;
 
-    write_length_prefixed_proof(&mut writer, &asset.proof)?;
+    write_length_prefixed_proof(&mut writer, asset.proof.as_bytes())?;
     asset
         .next_accumulator
         .write(&mut writer, SerdeFormat::RawBytesUnchecked)?;
     write_state_public_input(&mut writer, &asset.next_state)?;
-    write_length_prefixed_proof(&mut writer, &asset.certificate_proof)?;
+    write_length_prefixed_proof(&mut writer, asset.certificate_proof.as_bytes())?;
     writer.flush().with_context(|| {
         format!(
             "failed to flush recursive step output asset: {}",

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
@@ -19,6 +19,7 @@ use crate::circuits::halo2_ivc::{
     circuit::IvcCircuit,
     io::{Read as IvcRead, Write as IvcWrite},
     state::State,
+    types::{EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolParametersHash, StepCounter},
 };
 
 use super::field_encoding::jubjub_base_from_raw_le_bytes;
@@ -105,13 +106,13 @@ fn write_field_element<W: Write>(writer: &mut W, value: &F) -> StmResult<()> {
 /// Reads the seven public-input field elements that define a recursive state.
 fn read_state_public_input<R: Read>(reader: &mut R) -> StmResult<State> {
     Ok(State::new(
-        read_field_element(reader)?,
-        read_field_element(reader)?,
-        read_field_element(reader)?,
-        read_field_element(reader)?,
-        read_field_element(reader)?,
-        read_field_element(reader)?,
-        read_field_element(reader)?,
+        StepCounter::from_field(read_field_element(reader)?),
+        MessageHash::from_field(read_field_element(reader)?),
+        MerkleTreeCommitment::from_field(read_field_element(reader)?),
+        MerkleTreeCommitment::from_field(read_field_element(reader)?),
+        ProtocolParametersHash::from_field(read_field_element(reader)?),
+        ProtocolParametersHash::from_field(read_field_element(reader)?),
+        EpochNumber::from_field(read_field_element(reader)?),
     ))
 }
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -25,7 +25,7 @@ use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, C, E, F, S,
     circuit::IvcCircuit,
     state::{Global, State, trivial_acc},
-    types::CertificateProofBytes,
+    types::{CertificateProofBytes, IvcProofBytes},
 };
 
 struct CertificateChainArtifacts {
@@ -37,7 +37,7 @@ struct CertificateChainArtifacts {
 
 struct RecursiveChainSnapshot {
     state: State,
-    proof: Vec<u8>,
+    proof: IvcProofBytes,
     accumulator: Accumulator<S>,
 }
 
@@ -109,7 +109,7 @@ fn build_recursive_chain_snapshot(
 ) -> RecursiveChainSnapshot {
     let combined_fixed_base_names = combined_fixed_bases.keys().cloned().collect::<Vec<_>>();
     let mut current_state = State::genesis();
-    let mut recursive_proof = vec![];
+    let mut recursive_proof = IvcProofBytes::empty();
     let mut current_accumulator = trivial_acc(&combined_fixed_base_names);
     let mut next_accumulator = current_accumulator.clone();
     let mut recursive_random_generator = OsRng;
@@ -164,7 +164,7 @@ fn build_recursive_chain_snapshot(
 
         current_state = artifacts.recursive_next_states[i].clone();
         current_accumulator = next_accumulator.clone();
-        recursive_proof = proof;
+        recursive_proof = IvcProofBytes::new(proof);
 
         if i < INITIAL_CHAIN_LENGTH {
             let mut accumulated_accumulator = Accumulator::accumulate(&[
@@ -258,7 +258,7 @@ fn build_next_recursive_step_inputs(
     .concat();
     let previous_dual_msm = verify_prepare_poseidon_ivc(
         &context.recursive_verifying_key,
-        &recursive_chain_state.proof,
+        recursive_chain_state.proof.as_bytes(),
         &previous_public_inputs,
     );
     assert!(previous_dual_msm.clone().check(&context.universal_verifier_params));
@@ -347,10 +347,10 @@ fn store_recursive_step_output(
         paths.recursive_step_output.display()
     );
     let asset = RecursiveStepOutputAsset {
-        proof,
+        proof: IvcProofBytes::new(proof),
         next_accumulator: next_step_inputs.next_accumulator,
         next_state: next_step_inputs.next_state,
-        certificate_proof: next_step_inputs.certificate_proof.into_vec(),
+        certificate_proof: next_step_inputs.certificate_proof,
     };
     store_recursive_step_output_asset(&paths.recursive_step_output, &asset)
         .expect("failed to write recursive_step_output asset");
@@ -522,7 +522,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
         State::genesis(),
         genesis_witness,
         CertificateProofBytes::empty(),
-        vec![],
+        IvcProofBytes::empty(),
         current_accumulator,
         context.certificate_verifying_key.vk(),
         &context.recursive_verifying_key,
@@ -562,10 +562,10 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
         paths.genesis_step_output.display()
     );
     let asset = RecursiveStepOutputAsset {
-        proof,
+        proof: IvcProofBytes::new(proof),
         next_accumulator,
         next_state: genesis_next_state,
-        certificate_proof: CertificateProofBytes::empty().into_vec(),
+        certificate_proof: CertificateProofBytes::empty(),
     };
     store_recursive_step_output_asset(&paths.genesis_step_output, &asset)
         .expect("failed to write genesis_step_output asset");
@@ -631,7 +631,7 @@ pub(crate) fn generate_same_epoch_step_output_asset(
     .concat();
     let previous_dual_msm = verify_prepare_poseidon_ivc(
         &context.recursive_verifying_key,
-        &chain_state.proof,
+        chain_state.proof.as_bytes(),
         &previous_public_inputs,
     );
     assert!(
@@ -700,10 +700,10 @@ pub(crate) fn generate_same_epoch_step_output_asset(
         paths.same_epoch_step_output.display()
     );
     let asset = RecursiveStepOutputAsset {
-        proof,
+        proof: IvcProofBytes::new(proof),
         next_accumulator,
         next_state,
-        certificate_proof: certificate_proof.into_vec(),
+        certificate_proof,
     };
     store_recursive_step_output_asset(&paths.same_epoch_step_output, &asset)
         .expect("failed to write same_epoch_step_output asset");

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -184,7 +184,8 @@ fn build_recursive_chain_snapshot(
     }
 
     assert_eq!(
-        current_state.next_merkle_root, setup.genesis_next_merkle_root,
+        current_state.next_merkle_root.as_field(),
+        setup.genesis_next_merkle_root,
         "recursive_chain_state writer is about to persist a next_merkle_root that does not match setup"
     );
 
@@ -217,7 +218,8 @@ fn store_recursive_chain_snapshot(
     let reloaded = load_recursive_chain_state_asset(&paths.recursive_chain_state)
         .expect("failed to reload recursive_chain_state asset after writing");
     assert_eq!(
-        reloaded.state.next_merkle_root, setup.genesis_next_merkle_root,
+        reloaded.state.next_merkle_root.as_field(),
+        setup.genesis_next_merkle_root,
         "reloaded recursive_chain_state next_merkle_root does not match setup"
     );
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -25,10 +25,11 @@ use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, C, E, F, S,
     circuit::IvcCircuit,
     state::{Global, State, trivial_acc},
+    types::CertificateProofBytes,
 };
 
 struct CertificateChainArtifacts {
-    certificate_proofs: Vec<Vec<u8>>,
+    certificate_proofs: Vec<CertificateProofBytes>,
     certificate_accumulators: Vec<Accumulator<S>>,
     recursive_next_states: Vec<State>,
     recursive_witnesses: Vec<crate::circuits::halo2_ivc::state::Witness>,
@@ -41,7 +42,7 @@ struct RecursiveChainSnapshot {
 }
 
 struct NextRecursiveStepInputs {
-    certificate_proof: Vec<u8>,
+    certificate_proof: CertificateProofBytes,
     next_state: State,
     recursive_witness: crate::circuits::halo2_ivc::state::Witness,
     next_accumulator: Accumulator<S>,
@@ -52,7 +53,7 @@ fn build_certificate_chain_artifacts(
     context: &super::setup::SharedRecursiveContext,
     recursive_fixed_base_names: &[String],
 ) -> CertificateChainArtifacts {
-    let mut certificate_proofs = vec![vec![]];
+    let mut certificate_proofs = vec![CertificateProofBytes::empty()];
     let mut certificate_accumulators = vec![trivial_acc(recursive_fixed_base_names)];
     let mut recursive_next_states = vec![build_genesis_base_case_next_state(setup, GENESIS_EPOCH)];
     let mut recursive_witnesses = vec![build_genesis_base_case_witness(setup)];
@@ -349,7 +350,7 @@ fn store_recursive_step_output(
         proof,
         next_accumulator: next_step_inputs.next_accumulator,
         next_state: next_step_inputs.next_state,
-        certificate_proof: next_step_inputs.certificate_proof,
+        certificate_proof: next_step_inputs.certificate_proof.into_vec(),
     };
     store_recursive_step_output_asset(&paths.recursive_step_output, &asset)
         .expect("failed to write recursive_step_output asset");
@@ -520,7 +521,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
         global.clone(),
         State::genesis(),
         genesis_witness,
-        vec![],
+        CertificateProofBytes::empty(),
         vec![],
         current_accumulator,
         context.certificate_verifying_key.vk(),
@@ -564,7 +565,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
         proof,
         next_accumulator,
         next_state: genesis_next_state,
-        certificate_proof: vec![],
+        certificate_proof: CertificateProofBytes::empty().into_vec(),
     };
     store_recursive_step_output_asset(&paths.genesis_step_output, &asset)
         .expect("failed to write genesis_step_output asset");
@@ -702,7 +703,7 @@ pub(crate) fn generate_same_epoch_step_output_asset(
         proof,
         next_accumulator,
         next_state,
-        certificate_proof,
+        certificate_proof: certificate_proof.into_vec(),
     };
     store_recursive_step_output_asset(&paths.same_epoch_step_output, &asset)
         .expect("failed to write same_epoch_step_output asset");

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -309,11 +309,13 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
     let genesis_next_protocol_params = F::from(7u64);
 
     let genesis_message = {
-        let params_hex = hex::encode(genesis_next_protocol_params.to_bytes_le());
-        let protocol_message =
-            build_genesis_protocol_message(&aggregate_verification_key, &params_hex, genesis_epoch);
+        let protocol_message = build_genesis_protocol_message(
+            &aggregate_verification_key,
+            genesis_next_protocol_params.to_bytes_le(),
+            genesis_epoch,
+        );
         let preimage = protocol_message
-            .try_rigid_preimage::<MithrilMembershipDigest>()
+            .try_rigid_preimage()
             .expect("genesis protocol message preimage should succeed");
         let message_hash = Sha256::digest(preimage);
         jubjub_base_from_raw_le_bytes(message_hash.as_ref())

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -87,7 +87,7 @@ pub(crate) struct AssetGenerationSetup {
     /// Verification key for the trusted genesis signature.
     pub(crate) genesis_verification_key: SchnorrVerificationKey,
     /// Hash of the deterministic genesis protocol message.
-    pub(crate) genesis_message: F,
+    pub(crate) genesis_message: MessageHash,
     /// Deterministic trusted genesis signature.
     pub(crate) genesis_signature: StandardSchnorrSignature,
     /// Deterministic signer-membership Merkle tree.
@@ -262,7 +262,7 @@ pub(crate) fn build_recursive_global(
     recursive_verifying_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
 ) -> Global {
     Global::new(
-        MessageHash::from_field(setup.genesis_message),
+        setup.genesis_message,
         setup.genesis_verification_key,
         certificate_verifying_key.vk(),
         recursive_verifying_key,
@@ -330,7 +330,7 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
     AssetGenerationSetup {
         certificate_relation,
         genesis_verification_key,
-        genesis_message,
+        genesis_message: MessageHash::from_field(genesis_message),
         genesis_signature,
         merkle_tree,
         merkle_tree_leaves,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -17,6 +17,7 @@ use sha2::{Digest as Sha2Digest, Sha256};
 
 use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2_ivc::state::fixed_bases_and_names;
+use crate::circuits::halo2_ivc::types::MessageHash;
 use crate::circuits::halo2_ivc::{
     C, CERT_VK_NAME, E, F, IVC_ONE_NAME, circuit::IvcCircuit, state::Global,
 };
@@ -262,7 +263,7 @@ pub(crate) fn build_recursive_global(
     recursive_verifying_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
 ) -> Global {
     Global::new(
-        setup.genesis_message,
+        MessageHash::from_field(setup.genesis_message),
         setup.genesis_verification_key,
         certificate_verifying_key.vk(),
         recursive_verifying_key,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -15,6 +15,7 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::{CryptoRng, RngCore, SeedableRng};
 use sha2::{Digest as Sha2Digest, Sha256};
 
+use crate::AggregateVerificationKeyForSnark;
 use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2_ivc::state::fixed_bases_and_names;
 use crate::circuits::halo2_ivc::types::MessageHash;
@@ -95,11 +96,9 @@ pub(crate) struct AssetGenerationSetup {
     pub(crate) merkle_tree_leaves: Vec<MerkleTreeSnarkLeaf>,
     /// Deterministic signing keys used to build certificate witnesses.
     pub(crate) signing_keys: Vec<SchnorrSigningKey>,
-    /// Protocol-message string value for the legacy AVK bytes (`root_LE_32 || stake_BE_8`).
-    ///
-    /// `ProtocolMessage` stores parts as strings, then decodes this hex value before calling
-    /// `AggregateVerificationKeyForSnark::from_bytes`.
-    pub(crate) avk_hex: String,
+    /// Deterministic aggregate verification key committed by generated protocol messages.
+    pub(crate) aggregate_verification_key:
+        AggregateVerificationKeyForSnark<MithrilMembershipDigest>,
     /// Deterministic next Merkle root committed by the genesis message.
     pub(crate) genesis_next_merkle_root: F,
     /// Deterministic next protocol parameters committed by the genesis message.
@@ -290,14 +289,17 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
     let (signing_keys, merkle_tree_leaves, merkle_tree) = build_merkle_tree(&mut rng, SIGNER_COUNT);
     let genesis_next_merkle_root = merkle_root_from_stm_tree(&merkle_tree);
 
-    // Build the protocol-message value for the legacy AVK bytes: root_LE(32) || stake_BE(8).
-    // The serializer decodes the hex string before calling AggregateVerificationKeyForSnark::from_bytes.
-    let avk_hex = {
+    let aggregate_verification_key = {
         let commitment = merkle_tree.to_merkle_tree_commitment();
+        // `AggregateVerificationKeyForSnark` has no public constructor from
+        // commitment plus stake. Decode the deterministic components once, and
+        // let protocol-message builders serialize this STM type in the
+        // production-compatible message-part format.
         let mut avk_input = [0u8; 40];
         avk_input[0..32].copy_from_slice(&commitment.root);
         avk_input[32..40].copy_from_slice(&total_stake.to_be_bytes());
-        hex::encode(avk_input)
+        AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&avk_input)
+            .expect("deterministic aggregate verification key should decode")
     };
 
     let genesis_signing_key = SchnorrSigningKey::generate(&mut rng);
@@ -308,7 +310,8 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
 
     let genesis_message = {
         let params_hex = hex::encode(genesis_next_protocol_params.to_bytes_le());
-        let protocol_message = build_genesis_protocol_message(&avk_hex, &params_hex, genesis_epoch);
+        let protocol_message =
+            build_genesis_protocol_message(&aggregate_verification_key, &params_hex, genesis_epoch);
         let preimage = protocol_message
             .try_rigid_preimage::<MithrilMembershipDigest>()
             .expect("genesis protocol message preimage should succeed");
@@ -332,7 +335,7 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
         merkle_tree,
         merkle_tree_leaves,
         signing_keys,
-        avk_hex,
+        aggregate_verification_key,
         genesis_next_merkle_root,
         genesis_next_protocol_params,
     }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -214,7 +214,7 @@ fn build_certificate_asset_data_inner(
 
     let certificate_instance = certificate_public_inputs(merkle_root, next_state.msg.as_field());
 
-    let certificate_proof = CertificateProofBytes::from_snark_proof_bytes(
+    let certificate_proof = CertificateProofBytes::from_certificate_circuit_proof_bytes(
         zk_lib::prove::<StmCertificateCircuit, PoseidonState<F>>(
             certificate_commitment_parameters,
             &certificate_proving_key,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -92,7 +92,7 @@ pub(crate) fn build_genesis_base_case_next_state(
 ) -> State {
     State::new(
         StepCounter::new(1),
-        MessageHash::from_field(setup.genesis_message),
+        setup.genesis_message,
         MerkleTreeCommitment::ZERO,
         MerkleTreeCommitment::from_field(setup.genesis_next_merkle_root),
         ProtocolParametersHash::ZERO,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -6,12 +6,13 @@ use midnight_zk_stdlib::{MidnightVK, Relation};
 use rand_core::{CryptoRng, RngCore};
 use sha2::{Digest as Sha2Digest, Sha256};
 
-use crate::MithrilMembershipDigest;
 use crate::circuits::common::merkle::MerklePath;
 use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2::types::CircuitBaseField;
 use crate::circuits::halo2::witness::{CircuitMerkleTreeLeaf, CircuitWitnessEntry};
-use crate::circuits::halo2_ivc::protocol_message::{ProtocolMessage, ProtocolMessagePartKey};
+use crate::circuits::halo2_ivc::protocol_message::{
+    ProtocolMessage, ProtocolMessagePartKey, aggregate_verification_key_message_part,
+};
 use crate::circuits::halo2_ivc::state::{State, Witness, fixed_bases_and_names};
 use crate::circuits::halo2_ivc::types::{
     CertificateProofBytes, EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
@@ -21,6 +22,7 @@ use crate::circuits::halo2_ivc::{Accumulator, CERT_VK_NAME, F, PREIMAGE_SIZE, S}
 use crate::signature_scheme::{
     BaseFieldElement, SchnorrVerificationKey as StmSchnorrVerificationKey,
 };
+use crate::{AggregateVerificationKeyForSnark, MithrilMembershipDigest};
 
 use super::super::field_encoding::jubjub_base_from_raw_le_bytes;
 use super::proofs::verify_prepare_poseidon_ivc;
@@ -32,7 +34,7 @@ use super::setup::{AssetGenerationSetup, GENESIS_EPOCH, QUORUM_SIZE};
 /// recursive base-case path, so future tests can reuse it without re-encoding
 /// the protocol-message layout by hand.
 pub(super) fn build_genesis_protocol_message(
-    avk_hex: &str,
+    aggregate_verification_key: &AggregateVerificationKeyForSnark<MithrilMembershipDigest>,
     params_hex: &str,
     genesis_epoch: u64,
 ) -> ProtocolMessage {
@@ -43,7 +45,8 @@ pub(super) fn build_genesis_protocol_message(
     );
     protocol_message.set_message_part(
         ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        avk_hex.to_owned(),
+        aggregate_verification_key_message_part(aggregate_verification_key)
+            .expect("aggregate verification key message part should be produced"),
     );
     protocol_message.set_message_part(
         ProtocolMessagePartKey::NextProtocolParameters,
@@ -59,10 +62,14 @@ pub(super) fn build_genesis_protocol_message(
 /// Returns the raw genesis protocol-message preimage bytes produced by the serializer.
 pub(crate) fn build_genesis_protocol_message_preimage(setup: &AssetGenerationSetup) -> Vec<u8> {
     let params_hex = hex::encode(setup.genesis_next_protocol_params.to_bytes_le());
-    build_genesis_protocol_message(&setup.avk_hex, &params_hex, GENESIS_EPOCH)
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("genesis protocol message preimage should succeed")
-        .to_vec()
+    build_genesis_protocol_message(
+        &setup.aggregate_verification_key,
+        &params_hex,
+        GENESIS_EPOCH,
+    )
+    .try_rigid_preimage::<MithrilMembershipDigest>()
+    .expect("genesis protocol message preimage should succeed")
+    .to_vec()
 }
 
 /// Builds the witness used by the recursive genesis/base-case branch.
@@ -295,7 +302,8 @@ pub(crate) fn next_message_and_preimage_for_step(
     );
     protocol_message.set_message_part(
         ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        setup.avk_hex.clone(),
+        aggregate_verification_key_message_part(&setup.aggregate_verification_key)
+            .expect("aggregate verification key message part should be produced"),
     );
     protocol_message.set_message_part(ProtocolMessagePartKey::NextProtocolParameters, params_hex);
     protocol_message.set_message_part(
@@ -330,7 +338,8 @@ pub(crate) fn same_epoch_message_and_preimage_for_step(
     );
     protocol_message.set_message_part(
         ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        setup.avk_hex.clone(),
+        aggregate_verification_key_message_part(&setup.aggregate_verification_key)
+            .expect("aggregate verification key message part should be produced"),
     );
     protocol_message.set_message_part(ProtocolMessagePartKey::NextProtocolParameters, params_hex);
     protocol_message.set_message_part(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -14,7 +14,7 @@ use crate::circuits::halo2::witness::{CircuitMerkleTreeLeaf, CircuitWitnessEntry
 use crate::circuits::halo2_ivc::protocol_message::{ProtocolMessage, ProtocolMessagePartKey};
 use crate::circuits::halo2_ivc::state::{State, Witness, fixed_bases_and_names};
 use crate::circuits::halo2_ivc::types::{
-    EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
+    CertificateProofBytes, EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
     ProtocolParametersHash, StepCounter,
 };
 use crate::circuits::halo2_ivc::{Accumulator, CERT_VK_NAME, F, PREIMAGE_SIZE, S};
@@ -102,7 +102,7 @@ pub(crate) fn build_next_certificate_asset_data(
     certificate_verifying_key: &MidnightVK,
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
-) -> (Vec<u8>, Accumulator<S>, State, Witness) {
+) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
     let merkle_root = recursive_chain_state.next_merkle_root.as_field();
     let (message, message_preimage) =
         next_message_and_preimage_for_step(setup, recursive_chain_state);
@@ -128,7 +128,7 @@ pub(crate) fn build_same_epoch_certificate_asset_data(
     certificate_verifying_key: &MidnightVK,
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
-) -> (Vec<u8>, Accumulator<S>, State, Witness) {
+) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
     let merkle_root = recursive_chain_state.merkle_root.as_field();
     let (message, message_preimage) =
         same_epoch_message_and_preimage_for_step(setup, recursive_chain_state);
@@ -162,7 +162,7 @@ fn build_certificate_asset_data_inner(
     message_preimage: Vec<u8>,
     next_state: State,
     random_generator: &mut (impl RngCore + CryptoRng),
-) -> (Vec<u8>, Accumulator<S>, State, Witness) {
+) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
     let certificate_proving_key = zk_lib::setup_pk(certificate_relation, certificate_verifying_key);
     let (certificate_fixed_bases, _) =
         fixed_bases_and_names(CERT_VK_NAME, certificate_verifying_key.vk());
@@ -214,22 +214,24 @@ fn build_certificate_asset_data_inner(
 
     let certificate_instance = certificate_public_inputs(merkle_root, next_state.msg.as_field());
 
-    let certificate_proof = zk_lib::prove::<StmCertificateCircuit, PoseidonState<F>>(
-        certificate_commitment_parameters,
-        &certificate_proving_key,
-        certificate_relation,
-        &(
-            CircuitBaseField::from(certificate_instance[0]),
-            CircuitBaseField::from(certificate_instance[1]),
-        ),
-        certificate_witness_entries,
-        random_generator,
-    )
-    .expect("Certificate proof generation should not fail");
+    let certificate_proof = CertificateProofBytes::from_snark_proof_bytes(
+        zk_lib::prove::<StmCertificateCircuit, PoseidonState<F>>(
+            certificate_commitment_parameters,
+            &certificate_proving_key,
+            certificate_relation,
+            &(
+                CircuitBaseField::from(certificate_instance[0]),
+                CircuitBaseField::from(certificate_instance[1]),
+            ),
+            certificate_witness_entries,
+            random_generator,
+        )
+        .expect("Certificate proof generation should not fail"),
+    );
 
     let certificate_dual_msm = verify_prepare_poseidon_ivc(
         certificate_verifying_key.vk(),
-        &certificate_proof,
+        certificate_proof.as_bytes(),
         &certificate_instance,
     );
     assert!(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -11,7 +11,7 @@ use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2::types::CircuitBaseField;
 use crate::circuits::halo2::witness::{CircuitMerkleTreeLeaf, CircuitWitnessEntry};
 use crate::circuits::halo2_ivc::protocol_message::{
-    ProtocolMessage, ProtocolMessagePartKey, aggregate_verification_key_message_part,
+    DynamicProtocolMessagePartKey, ProtocolMessage,
 };
 use crate::circuits::halo2_ivc::state::{State, Witness, fixed_bases_and_names};
 use crate::circuits::halo2_ivc::types::{
@@ -35,39 +35,30 @@ use super::setup::{AssetGenerationSetup, GENESIS_EPOCH, QUORUM_SIZE};
 /// the protocol-message layout by hand.
 pub(super) fn build_genesis_protocol_message(
     aggregate_verification_key: &AggregateVerificationKeyForSnark<MithrilMembershipDigest>,
-    params_hex: &str,
+    protocol_parameters: [u8; 32],
     genesis_epoch: u64,
 ) -> ProtocolMessage {
     let mut protocol_message = ProtocolMessage::new();
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
+    protocol_message.set_dynamic_message_part(
+        DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode([2u8; 32]),
     );
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        aggregate_verification_key_message_part(aggregate_verification_key)
-            .expect("aggregate verification key message part should be produced"),
-    );
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::NextProtocolParameters,
-        params_hex.to_owned(),
-    );
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::CurrentEpoch,
-        genesis_epoch.to_string(),
-    );
+    protocol_message
+        .set_next_snark_aggregate_verification_key(aggregate_verification_key)
+        .expect("aggregate verification key rigid slot should be produced");
+    protocol_message.set_next_protocol_parameters(protocol_parameters);
+    protocol_message.set_current_epoch(genesis_epoch);
     protocol_message
 }
 
 /// Returns the raw genesis protocol-message preimage bytes produced by the serializer.
 pub(crate) fn build_genesis_protocol_message_preimage(setup: &AssetGenerationSetup) -> Vec<u8> {
-    let params_hex = hex::encode(setup.genesis_next_protocol_params.to_bytes_le());
     build_genesis_protocol_message(
         &setup.aggregate_verification_key,
-        &params_hex,
+        setup.genesis_next_protocol_params.to_bytes_le(),
         GENESIS_EPOCH,
     )
-    .try_rigid_preimage::<MithrilMembershipDigest>()
+    .try_rigid_preimage()
     .expect("genesis protocol message preimage should succeed")
     .to_vec()
 }
@@ -293,26 +284,20 @@ pub(crate) fn next_message_and_preimage_for_step(
 ) -> (F, Vec<u8>) {
     let current_epoch = current_epoch_from_state(previous_state);
     let step = step_index_from_state(previous_state);
-    let params_hex = hex::encode(setup.genesis_next_protocol_params.to_bytes_le());
 
     let mut protocol_message = ProtocolMessage::new();
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
+    protocol_message.set_dynamic_message_part(
+        DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode(vec![(step as u8) + 2; 32]),
     );
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        aggregate_verification_key_message_part(&setup.aggregate_verification_key)
-            .expect("aggregate verification key message part should be produced"),
-    );
-    protocol_message.set_message_part(ProtocolMessagePartKey::NextProtocolParameters, params_hex);
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::CurrentEpoch,
-        (current_epoch + 1).to_string(),
-    );
+    protocol_message
+        .set_next_snark_aggregate_verification_key(&setup.aggregate_verification_key)
+        .expect("aggregate verification key rigid slot should be produced");
+    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_params.to_bytes_le());
+    protocol_message.set_current_epoch(current_epoch + 1);
 
     let preimage = protocol_message
-        .try_rigid_preimage::<MithrilMembershipDigest>()
+        .try_rigid_preimage()
         .expect("protocol message preimage should succeed");
     let message_hash = Sha256::digest(preimage);
     (
@@ -329,26 +314,20 @@ pub(crate) fn same_epoch_message_and_preimage_for_step(
 ) -> (F, Vec<u8>) {
     let current_epoch = current_epoch_from_state(previous_state);
     let step = step_index_from_state(previous_state);
-    let params_hex = hex::encode(setup.genesis_next_protocol_params.to_bytes_le());
 
     let mut protocol_message = ProtocolMessage::new();
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
+    protocol_message.set_dynamic_message_part(
+        DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode(vec![(step as u8) + 2; 32]),
     );
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        aggregate_verification_key_message_part(&setup.aggregate_verification_key)
-            .expect("aggregate verification key message part should be produced"),
-    );
-    protocol_message.set_message_part(ProtocolMessagePartKey::NextProtocolParameters, params_hex);
-    protocol_message.set_message_part(
-        ProtocolMessagePartKey::CurrentEpoch,
-        current_epoch.to_string(),
-    );
+    protocol_message
+        .set_next_snark_aggregate_verification_key(&setup.aggregate_verification_key)
+        .expect("aggregate verification key rigid slot should be produced");
+    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_params.to_bytes_le());
+    protocol_message.set_current_epoch(current_epoch);
 
     let preimage = protocol_message
-        .try_rigid_preimage::<MithrilMembershipDigest>()
+        .try_rigid_preimage()
         .expect("protocol message preimage should succeed");
     let message_hash = Sha256::digest(preimage);
     (

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -1,4 +1,3 @@
-use ff::Field;
 use midnight_circuits::hash::poseidon::PoseidonState;
 use midnight_curves::Bls12;
 use midnight_proofs::poly::kzg::params::ParamsKZG;
@@ -14,6 +13,10 @@ use crate::circuits::halo2::types::CircuitBaseField;
 use crate::circuits::halo2::witness::{CircuitMerkleTreeLeaf, CircuitWitnessEntry};
 use crate::circuits::halo2_ivc::protocol_message::{ProtocolMessage, ProtocolMessagePartKey};
 use crate::circuits::halo2_ivc::state::{State, Witness, fixed_bases_and_names};
+use crate::circuits::halo2_ivc::types::{
+    EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
+    ProtocolParametersHash, StepCounter,
+};
 use crate::circuits::halo2_ivc::{Accumulator, CERT_VK_NAME, F, PREIMAGE_SIZE, S};
 use crate::signature_scheme::{
     BaseFieldElement, SchnorrVerificationKey as StmSchnorrVerificationKey,
@@ -67,7 +70,12 @@ pub(crate) fn build_genesis_base_case_witness(setup: &AssetGenerationSetup) -> W
     let preimage: [u8; PREIMAGE_SIZE] = build_genesis_protocol_message_preimage(setup)
         .try_into()
         .expect("genesis protocol message preimage should be PREIMAGE_SIZE bytes");
-    Witness::new(setup.genesis_signature, F::ZERO, F::ZERO, preimage)
+    Witness::new(
+        setup.genesis_signature,
+        MerkleTreeCommitment::ZERO,
+        MessageHash::ZERO,
+        ProtocolMessagePreimage::new(preimage),
+    )
 }
 
 /// Builds the first next-state public output produced by the recursive base case.
@@ -76,13 +84,13 @@ pub(crate) fn build_genesis_base_case_next_state(
     genesis_epoch: u64,
 ) -> State {
     State::new(
-        F::ONE,
-        setup.genesis_message,
-        F::ZERO,
-        setup.genesis_next_merkle_root,
-        F::ZERO,
-        setup.genesis_next_protocol_params,
-        F::from(genesis_epoch),
+        StepCounter::new(1),
+        MessageHash::from_field(setup.genesis_message),
+        MerkleTreeCommitment::ZERO,
+        MerkleTreeCommitment::from_field(setup.genesis_next_merkle_root),
+        ProtocolParametersHash::ZERO,
+        ProtocolParametersHash::from_field(setup.genesis_next_protocol_params),
+        EpochNumber::new(genesis_epoch),
     )
 }
 
@@ -95,7 +103,7 @@ pub(crate) fn build_next_certificate_asset_data(
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> (Vec<u8>, Accumulator<S>, State, Witness) {
-    let merkle_root = recursive_chain_state.next_merkle_root;
+    let merkle_root = recursive_chain_state.next_merkle_root.as_field();
     let (message, message_preimage) =
         next_message_and_preimage_for_step(setup, recursive_chain_state);
     let next_state = next_state_for_step(recursive_chain_state, message);
@@ -121,7 +129,7 @@ pub(crate) fn build_same_epoch_certificate_asset_data(
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> (Vec<u8>, Accumulator<S>, State, Witness) {
-    let merkle_root = recursive_chain_state.merkle_root;
+    let merkle_root = recursive_chain_state.merkle_root.as_field();
     let (message, message_preimage) =
         same_epoch_message_and_preimage_for_step(setup, recursive_chain_state);
     let next_state = same_epoch_next_state_for_step(recursive_chain_state, message);
@@ -204,7 +212,7 @@ fn build_certificate_asset_data_inner(
         });
     }
 
-    let certificate_instance = certificate_public_inputs(merkle_root, next_state.msg);
+    let certificate_instance = certificate_public_inputs(merkle_root, next_state.msg.as_field());
 
     let certificate_proof = zk_lib::prove::<StmCertificateCircuit, PoseidonState<F>>(
         certificate_commitment_parameters,
@@ -235,9 +243,9 @@ fn build_certificate_asset_data_inner(
 
     let ivc_witness = Witness::new(
         setup.genesis_signature,
-        merkle_root,
-        message,
-        message_preimage.try_into().unwrap(),
+        MerkleTreeCommitment::from_field(merkle_root),
+        MessageHash::from_field(message),
+        ProtocolMessagePreimage::new(message_preimage.try_into().unwrap()),
     );
 
     (
@@ -262,7 +270,10 @@ pub(crate) fn certificate_public_inputs_for_step(
     previous_state: &State,
     next_state: &State,
 ) -> Vec<F> {
-    certificate_public_inputs(previous_state.next_merkle_root, next_state.msg)
+    certificate_public_inputs(
+        previous_state.next_merkle_root.as_field(),
+        next_state.msg.as_field(),
+    )
 }
 
 /// Returns the deterministic next certificate message and preimage for one
@@ -342,13 +353,13 @@ pub(crate) fn next_state_for_step(previous_state: &State, message: F) -> State {
     let step = step_index_from_state(previous_state);
 
     State::new(
-        F::from((step + 1) as u64),
-        message,
+        StepCounter::new((step + 1) as u64),
+        MessageHash::from_field(message),
         previous_state.next_merkle_root,
         previous_state.next_merkle_root,
         previous_state.next_protocol_params,
         previous_state.next_protocol_params,
-        F::from(current_epoch + 1),
+        EpochNumber::new(current_epoch + 1),
     )
 }
 
@@ -358,22 +369,20 @@ pub(crate) fn same_epoch_next_state_for_step(previous_state: &State, message: F)
     let step = step_index_from_state(previous_state);
 
     State::new(
-        F::from((step + 1) as u64),
-        message,
+        StepCounter::new((step + 1) as u64),
+        MessageHash::from_field(message),
         previous_state.merkle_root,
         previous_state.next_merkle_root,
         previous_state.protocol_params,
         previous_state.next_protocol_params,
-        F::from(current_epoch),
+        EpochNumber::new(current_epoch),
     )
 }
 
 fn current_epoch_from_state(previous_state: &State) -> u64 {
-    let bytes = previous_state.current_epoch.to_bytes_le();
-    u64::from_le_bytes(bytes[0..8].try_into().unwrap())
+    previous_state.current_epoch.as_u64()
 }
 
 fn step_index_from_state(previous_state: &State) -> usize {
-    let bytes = previous_state.counter.to_bytes_le();
-    u64::from_le_bytes(bytes[0..8].try_into().unwrap()) as usize
+    previous_state.counter.as_u64() as usize
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
@@ -16,6 +16,7 @@ use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, C, E, F, K, S, VerifyingKey,
     circuit::IvcCircuit,
     state::{Global, State, Witness, trivial_acc},
+    types::CertificateProofBytes,
 };
 
 pub(crate) use super::generators::{
@@ -276,7 +277,7 @@ pub(crate) fn build_trivial_mock_prover_circuit(
         setup.global.clone(),
         prev_state,
         witness,
-        vec![],
+        CertificateProofBytes::empty(),
         vec![],
         setup.trivial_accumulator.clone(),
         setup.certificate_verifying_key.vk(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
@@ -16,7 +16,7 @@ use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, C, E, F, K, S, VerifyingKey,
     circuit::IvcCircuit,
     state::{Global, State, Witness, trivial_acc},
-    types::CertificateProofBytes,
+    types::{CertificateProofBytes, IvcProofBytes},
 };
 
 pub(crate) use super::generators::{
@@ -190,7 +190,7 @@ pub(crate) fn prepare_previous_recursive_proof_accumulator(
 
     let previous_dual_msm = verify_prepare_poseidon_recursive_proof(
         &setup.recursive_verifying_key,
-        &recursive_chain_state.proof,
+        recursive_chain_state.proof.as_bytes(),
         &previous_public_inputs,
     );
     assert!(
@@ -278,7 +278,7 @@ pub(crate) fn build_trivial_mock_prover_circuit(
         prev_state,
         witness,
         CertificateProofBytes::empty(),
-        vec![],
+        IvcProofBytes::empty(),
         setup.trivial_accumulator.clone(),
         setup.certificate_verifying_key.vk(),
         &setup.recursive_verifying_key,
@@ -326,7 +326,7 @@ pub(crate) fn build_unextracted_certificate_accumulator_from_assets()
 
     let accumulator: Accumulator<S> = verify_prepare_poseidon_recursive_proof(
         verification_context.certificate_verifying_key.vk(),
-        &recursive_step_output.certificate_proof,
+        recursive_step_output.certificate_proof.as_bytes(),
         &certificate_public_inputs,
     )
     .into();
@@ -364,7 +364,7 @@ pub(crate) fn build_unextracted_recursive_proof_accumulator_from_assets()
 
     let accumulator: Accumulator<S> = verify_prepare_poseidon_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &recursive_chain_state.proof,
+        recursive_chain_state.proof.as_bytes(),
         &public_inputs,
     )
     .into();

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -24,6 +24,7 @@ use crate::circuits::halo2_ivc::{
             verify_prepare_blake2b_recursive_proof,
         },
     },
+    types::{EpochNumber, MerkleTreeCommitment, ProtocolParametersHash},
 };
 
 fn valid_rigid_protocol_message() -> ProtocolMessage {
@@ -193,7 +194,7 @@ fn next_merkle_root_tampered_public_input_is_rejected() {
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.next_merkle_root = F::ONE;
+    tampered_state.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),
@@ -225,7 +226,7 @@ fn next_protocol_params_tampered_public_input_is_rejected() {
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.next_protocol_params = F::ONE;
+    tampered_state.next_protocol_params = ProtocolParametersHash::from_field(F::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),
@@ -257,7 +258,7 @@ fn current_epoch_tampered_public_input_is_rejected() {
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.current_epoch = F::ONE;
+    tampered_state.current_epoch = EpochNumber::from_field(F::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),
@@ -291,7 +292,7 @@ mod slow {
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
 
         let mut witness = build_genesis_base_case_witness(&setup);
-        witness.msg_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].fill(0xff);
+        witness.msg_preimage.as_mut_bytes()[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].fill(0xff);
         let circuit =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
@@ -311,7 +312,7 @@ mod slow {
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
 
         let mut witness = build_genesis_base_case_witness(&setup);
-        witness.msg_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].fill(0xff);
+        witness.msg_preimage.as_mut_bytes()[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].fill(0xff);
         let circuit =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
@@ -331,7 +332,7 @@ mod slow {
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
 
         let mut witness = build_genesis_base_case_witness(&setup);
-        witness.msg_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].fill(0xff);
+        witness.msg_preimage.as_mut_bytes()[PREIMAGE_CURRENT_EPOCH_BYTES].fill(0xff);
         let circuit =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -7,9 +7,7 @@ use midnight_circuits::types::Instantiable;
 use crate::circuits::halo2_ivc::{
     AssignedAccumulator, F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES,
-    protocol_message::{
-        ProtocolMessage, ProtocolMessagePartKey, aggregate_verification_key_message_part,
-    },
+    protocol_message::{DynamicProtocolMessagePartKey, ProtocolMessage},
     state::State,
     tests::common::{
         asset_readers::{
@@ -29,36 +27,17 @@ use crate::circuits::halo2_ivc::{
 };
 use crate::{AggregateVerificationKeyForSnark, MithrilMembershipDigest};
 
-fn valid_snark_aggregate_verification_key_hex() -> String {
+fn valid_snark_aggregate_verification_key()
+-> AggregateVerificationKeyForSnark<MithrilMembershipDigest> {
     let mut avk_input = [0u8; 40];
     avk_input[39] = 1;
-    let avk = AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&avk_input)
-        .expect("valid test aggregate verification key should decode");
-    aggregate_verification_key_message_part(&avk)
-        .expect("test aggregate verification key should serialize")
-}
-
-fn valid_rigid_protocol_message() -> ProtocolMessage {
-    let mut message = ProtocolMessage::new();
-    message.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
-        hex::encode([2u8; 32]),
-    );
-    message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        valid_snark_aggregate_verification_key_hex(),
-    );
-    message.set_message_part(
-        ProtocolMessagePartKey::NextProtocolParameters,
-        hex::encode([7u8; 32]),
-    );
-    message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "42".to_string());
-    message
+    AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&avk_input)
+        .expect("valid test aggregate verification key should decode")
 }
 
 fn assert_rigid_preimage_rejects_with_message(message: ProtocolMessage, expected: &str) {
     let error = message
-        .try_rigid_preimage::<MithrilMembershipDigest>()
+        .try_rigid_preimage()
         .expect_err("rigid preimage should reject invalid message");
 
     assert!(
@@ -70,15 +49,12 @@ fn assert_rigid_preimage_rejects_with_message(message: ProtocolMessage, expected
 #[test]
 fn rigid_preimage_rejects_missing_next_snark_aggregate_verification_key() {
     let mut message = ProtocolMessage::new();
-    message.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
+    message.set_dynamic_message_part(
+        DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode([2u8; 32]),
     );
-    message.set_message_part(
-        ProtocolMessagePartKey::NextProtocolParameters,
-        hex::encode([7u8; 32]),
-    );
-    message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "42".to_string());
+    message.set_next_protocol_parameters([7u8; 32]);
+    message.set_current_epoch(42);
 
     assert_rigid_preimage_rejects_with_message(
         message,
@@ -87,45 +63,16 @@ fn rigid_preimage_rejects_missing_next_snark_aggregate_verification_key() {
 }
 
 #[test]
-fn rigid_preimage_rejects_invalid_next_snark_aggregate_verification_key_hex() {
-    let mut message = valid_rigid_protocol_message();
-    message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        "not-hex".to_string(),
-    );
-
-    assert_rigid_preimage_rejects_with_message(
-        message,
-        "invalid next SNARK aggregate verification key hex",
-    );
-}
-
-#[test]
-fn rigid_preimage_rejects_invalid_next_snark_aggregate_verification_key_bytes() {
-    let mut message = valid_rigid_protocol_message();
-    message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        hex::encode([0u8; 7]),
-    );
-
-    assert_rigid_preimage_rejects_with_message(
-        message,
-        "invalid next SNARK aggregate verification key bytes",
-    );
-}
-
-#[test]
 fn rigid_preimage_rejects_missing_next_protocol_parameters() {
     let mut message = ProtocolMessage::new();
-    message.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
+    message.set_dynamic_message_part(
+        DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode([2u8; 32]),
     );
-    message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        valid_snark_aggregate_verification_key_hex(),
-    );
-    message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "42".to_string());
+    message
+        .set_next_snark_aggregate_verification_key(&valid_snark_aggregate_verification_key())
+        .expect("test aggregate verification key should project to rigid slot");
+    message.set_current_epoch(42);
 
     assert_rigid_preimage_rejects_with_message(
         message,
@@ -134,55 +81,18 @@ fn rigid_preimage_rejects_missing_next_protocol_parameters() {
 }
 
 #[test]
-fn rigid_preimage_rejects_invalid_next_protocol_parameters_hex() {
-    let mut message = valid_rigid_protocol_message();
-    message.set_message_part(
-        ProtocolMessagePartKey::NextProtocolParameters,
-        "not-hex".to_string(),
-    );
-
-    assert_rigid_preimage_rejects_with_message(message, "invalid next protocol parameters hex");
-}
-
-#[test]
-fn rigid_preimage_rejects_wrong_next_protocol_parameters_width() {
-    let mut message = valid_rigid_protocol_message();
-    message.set_message_part(
-        ProtocolMessagePartKey::NextProtocolParameters,
-        hex::encode([7u8; 31]),
-    );
-
-    assert_rigid_preimage_rejects_with_message(
-        message,
-        "next protocol parameters slot must be exactly 32 bytes, got 31",
-    );
-}
-
-#[test]
 fn rigid_preimage_rejects_missing_current_epoch() {
     let mut message = ProtocolMessage::new();
-    message.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
+    message.set_dynamic_message_part(
+        DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode([2u8; 32]),
     );
-    message.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        valid_snark_aggregate_verification_key_hex(),
-    );
-    message.set_message_part(
-        ProtocolMessagePartKey::NextProtocolParameters,
-        hex::encode([7u8; 32]),
-    );
+    message
+        .set_next_snark_aggregate_verification_key(&valid_snark_aggregate_verification_key())
+        .expect("test aggregate verification key should project to rigid slot");
+    message.set_next_protocol_parameters([7u8; 32]);
 
     assert_rigid_preimage_rejects_with_message(message, "current epoch slot is required");
-}
-
-#[test]
-fn rigid_preimage_rejects_invalid_current_epoch() {
-    let mut message = valid_rigid_protocol_message();
-    message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "oops".to_string());
-
-    assert_rigid_preimage_rejects_with_message(message, "invalid current epoch slot");
 }
 
 #[test]

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -4,11 +4,12 @@
 use ff::Field;
 use midnight_circuits::types::Instantiable;
 
-use crate::MithrilMembershipDigest;
 use crate::circuits::halo2_ivc::{
     AssignedAccumulator, F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES,
-    protocol_message::{ProtocolMessage, ProtocolMessagePartKey},
+    protocol_message::{
+        ProtocolMessage, ProtocolMessagePartKey, aggregate_verification_key_message_part,
+    },
     state::State,
     tests::common::{
         asset_readers::{
@@ -26,11 +27,18 @@ use crate::circuits::halo2_ivc::{
     },
     types::{EpochNumber, MerkleTreeCommitment, ProtocolParametersHash},
 };
+use crate::{AggregateVerificationKeyForSnark, MithrilMembershipDigest};
 
-fn valid_rigid_protocol_message() -> ProtocolMessage {
+fn valid_snark_aggregate_verification_key_hex() -> String {
     let mut avk_input = [0u8; 40];
     avk_input[39] = 1;
+    let avk = AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&avk_input)
+        .expect("valid test aggregate verification key should decode");
+    aggregate_verification_key_message_part(&avk)
+        .expect("test aggregate verification key should serialize")
+}
 
+fn valid_rigid_protocol_message() -> ProtocolMessage {
     let mut message = ProtocolMessage::new();
     message.set_message_part(
         ProtocolMessagePartKey::SnapshotDigest,
@@ -38,7 +46,7 @@ fn valid_rigid_protocol_message() -> ProtocolMessage {
     );
     message.set_message_part(
         ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        hex::encode(avk_input),
+        valid_snark_aggregate_verification_key_hex(),
     );
     message.set_message_part(
         ProtocolMessagePartKey::NextProtocolParameters,
@@ -108,9 +116,6 @@ fn rigid_preimage_rejects_invalid_next_snark_aggregate_verification_key_bytes() 
 
 #[test]
 fn rigid_preimage_rejects_missing_next_protocol_parameters() {
-    let mut avk_input = [0u8; 40];
-    avk_input[39] = 1;
-
     let mut message = ProtocolMessage::new();
     message.set_message_part(
         ProtocolMessagePartKey::SnapshotDigest,
@@ -118,7 +123,7 @@ fn rigid_preimage_rejects_missing_next_protocol_parameters() {
     );
     message.set_message_part(
         ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        hex::encode(avk_input),
+        valid_snark_aggregate_verification_key_hex(),
     );
     message.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "42".to_string());
 
@@ -155,9 +160,6 @@ fn rigid_preimage_rejects_wrong_next_protocol_parameters_width() {
 
 #[test]
 fn rigid_preimage_rejects_missing_current_epoch() {
-    let mut avk_input = [0u8; 40];
-    avk_input[39] = 1;
-
     let mut message = ProtocolMessage::new();
     message.set_message_part(
         ProtocolMessagePartKey::SnapshotDigest,
@@ -165,7 +167,7 @@ fn rigid_preimage_rejects_missing_current_epoch() {
     );
     message.set_message_part(
         ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        hex::encode(avk_input),
+        valid_snark_aggregate_verification_key_hex(),
     );
     message.set_message_part(
         ProtocolMessagePartKey::NextProtocolParameters,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -205,7 +205,7 @@ fn next_merkle_root_tampered_public_input_is_rejected() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &recursive_step_output.proof,
+        recursive_step_output.proof.as_bytes(),
         &public_inputs,
     );
 
@@ -237,7 +237,7 @@ fn next_protocol_params_tampered_public_input_is_rejected() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &recursive_step_output.proof,
+        recursive_step_output.proof.as_bytes(),
         &public_inputs,
     );
 
@@ -269,7 +269,7 @@ fn current_epoch_tampered_public_input_is_rejected() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &recursive_step_output.proof,
+        recursive_step_output.proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
@@ -5,14 +5,15 @@ use ff::Field;
 use midnight_proofs::utils::SerdeFormat;
 use sha2::{Digest as Sha2Digest, Sha256};
 
-use crate::MithrilMembershipDigest;
 use crate::circuits::halo2_ivc::{
     Accumulator, E, F, KZGCommitmentScheme, PREIMAGE_CURRENT_EPOCH_BYTES,
     PREIMAGE_NEXT_MERKLE_ROOT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PREIMAGE_SIZE, S,
     VerifyingKey,
     circuit::IvcCircuit,
     io::{Read as IvcRead, Write as IvcWrite},
-    protocol_message::{ProtocolMessage, ProtocolMessagePartKey},
+    protocol_message::{
+        ProtocolMessage, ProtocolMessagePartKey, aggregate_verification_key_message_part,
+    },
     state::State,
     tests::common::{
         asset_readers::{
@@ -23,18 +24,28 @@ use crate::circuits::halo2_ivc::{
     },
     types::{EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolParametersHash, StepCounter},
 };
+use crate::{AggregateVerificationKeyForSnark, MithrilMembershipDigest};
 
-/// Minimal fixture for rigid preimage layout pinning tests.
-/// Input: 40-byte legacy AVK (root_LE_32 || stake_BE_8); output: expected 44-byte slot.
-fn build_test_message() -> (ProtocolMessage, [u8; 44]) {
-    // Legacy AVK input: root(32) || total_stake_BE(8) — no leaf-count field.
-    // from_bytes_legacy: root = bytes[0..32], stake = be_u64(bytes[32..40]).
+type TestAggregateVerificationKey = AggregateVerificationKeyForSnark<MithrilMembershipDigest>;
+
+fn build_test_aggregate_verification_key() -> TestAggregateVerificationKey {
     let mut avk_input = [0u8; 40];
     avk_input[39] = 1; // total_stake = 1, big-endian u64
+    AggregateVerificationKeyForSnark::<MithrilMembershipDigest>::from_bytes(&avk_input)
+        .expect("valid test aggregate verification key should decode")
+}
 
-    // to_rigid_slot_bytes output: root(32) || zeros(4) || stake_LE(8).
-    let mut avk_slot = [0u8; 44];
-    avk_slot[36] = 1; // total_stake = 1, little-endian u64
+/// Minimal fixture for rigid preimage layout pinning tests.
+///
+/// The input message part uses the same bytes-hex representation as the production
+/// `ProtocolAggregateVerificationKeyForSnark::to_bytes_hex()` path.
+fn build_test_message() -> (ProtocolMessage, [u8; 44]) {
+    let avk = build_test_aggregate_verification_key();
+    let avk_hex = aggregate_verification_key_message_part(&avk)
+        .expect("test aggregate verification key should serialize");
+    let avk_slot = avk
+        .to_rigid_slot_bytes()
+        .expect("test aggregate verification key should project to rigid slot");
 
     let mut msg = ProtocolMessage::new();
     msg.set_message_part(
@@ -43,13 +54,14 @@ fn build_test_message() -> (ProtocolMessage, [u8; 44]) {
     );
     msg.set_message_part(
         ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        hex::encode(avk_input),
+        avk_hex,
     );
     msg.set_message_part(
         ProtocolMessagePartKey::NextProtocolParameters,
         hex::encode([7u8; 32]),
     );
     msg.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "42".to_string());
+
     (msg, avk_slot)
 }
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
@@ -11,9 +11,7 @@ use crate::circuits::halo2_ivc::{
     VerifyingKey,
     circuit::IvcCircuit,
     io::{Read as IvcRead, Write as IvcWrite},
-    protocol_message::{
-        ProtocolMessage, ProtocolMessagePartKey, aggregate_verification_key_message_part,
-    },
+    protocol_message::{DynamicProtocolMessagePartKey, ProtocolMessage},
     state::State,
     tests::common::{
         asset_readers::{
@@ -36,31 +34,21 @@ fn build_test_aggregate_verification_key() -> TestAggregateVerificationKey {
 }
 
 /// Minimal fixture for rigid preimage layout pinning tests.
-///
-/// The input message part uses the same bytes-hex representation as the production
-/// `ProtocolAggregateVerificationKeyForSnark::to_bytes_hex()` path.
 fn build_test_message() -> (ProtocolMessage, [u8; 44]) {
     let avk = build_test_aggregate_verification_key();
-    let avk_hex = aggregate_verification_key_message_part(&avk)
-        .expect("test aggregate verification key should serialize");
     let avk_slot = avk
         .to_rigid_slot_bytes()
         .expect("test aggregate verification key should project to rigid slot");
 
     let mut msg = ProtocolMessage::new();
-    msg.set_message_part(
-        ProtocolMessagePartKey::SnapshotDigest,
+    msg.set_dynamic_message_part(
+        DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode([2u8; 32]),
     );
-    msg.set_message_part(
-        ProtocolMessagePartKey::NextSnarkAggregateVerificationKey,
-        avk_hex,
-    );
-    msg.set_message_part(
-        ProtocolMessagePartKey::NextProtocolParameters,
-        hex::encode([7u8; 32]),
-    );
-    msg.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "42".to_string());
+    msg.set_next_snark_aggregate_verification_key(&avk)
+        .expect("test aggregate verification key should project to rigid slot");
+    msg.set_next_protocol_parameters([7u8; 32]);
+    msg.set_current_epoch(42);
 
     (msg, avk_slot)
 }
@@ -221,7 +209,7 @@ fn vk_serialization_round_trip() {
 fn rigid_preimage_length_is_190_bytes() {
     let (msg, _) = build_test_message();
     let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
+        .try_rigid_preimage()
         .expect("try_rigid_preimage should succeed for a valid message");
     assert_eq!(preimage.len(), PREIMAGE_SIZE);
 }
@@ -229,18 +217,14 @@ fn rigid_preimage_length_is_190_bytes() {
 #[test]
 fn rigid_preimage_digest_label_is_at_offset_0() {
     let (msg, _) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[0..6], b"digest");
 }
 
 #[test]
 fn rigid_preimage_dynamic_hash_is_at_offset_6() {
     let (msg, _) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     // Dynamic parts: only SnapshotDigest is non-fixed; SHA256("snapshot_digest" || hex([2u8;32]))
     let mut hasher = Sha256::new();
     hasher.update(b"snapshot_digest");
@@ -252,18 +236,14 @@ fn rigid_preimage_dynamic_hash_is_at_offset_6() {
 #[test]
 fn rigid_preimage_avk_label_is_at_offset_38() {
     let (msg, _) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[38..69], b"next_aggregate_verification_key");
 }
 
 #[test]
 fn rigid_preimage_avk_slot_matches_expected_output() {
     let (msg, avk_slot) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(PREIMAGE_NEXT_MERKLE_ROOT_BYTES, 69..101);
     // AVK slot occupies 69..113: root(32) || zeros(4) || stake_LE(8).
     assert_eq!(&preimage[69..113], &avk_slot);
@@ -272,18 +252,14 @@ fn rigid_preimage_avk_slot_matches_expected_output() {
 #[test]
 fn rigid_preimage_params_label_is_at_offset_113() {
     let (msg, _) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[113..137], b"next_protocol_parameters");
 }
 
 #[test]
 fn rigid_preimage_params_slot_matches_input() {
     let (msg, _) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, 137..169);
     assert_eq!(&preimage[137..169], &[7u8; 32]);
 }
@@ -291,18 +267,14 @@ fn rigid_preimage_params_slot_matches_input() {
 #[test]
 fn rigid_preimage_epoch_label_is_at_offset_169() {
     let (msg, _) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[169..182], b"current_epoch");
 }
 
 #[test]
 fn rigid_preimage_epoch_slot_is_42_le() {
     let (msg, _) = build_test_message();
-    let preimage = msg
-        .try_rigid_preimage::<MithrilMembershipDigest>()
-        .expect("try_rigid_preimage should succeed");
+    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(PREIMAGE_CURRENT_EPOCH_BYTES, 182..190);
     assert_eq!(&preimage[182..190], &42u64.to_le_bytes());
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
@@ -21,6 +21,7 @@ use crate::circuits::halo2_ivc::{
         },
         generators::{build_asset_generation_setup, build_genesis_protocol_message_preimage},
     },
+    types::{EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolParametersHash, StepCounter},
 };
 
 /// Minimal fixture for rigid preimage layout pinning tests.
@@ -102,13 +103,13 @@ fn state_public_input_has_7_elements_in_correct_order() {
     let current_epoch = F::from(7u64);
 
     let state = State::new(
-        counter,
-        msg,
-        merkle_root,
-        next_merkle_root,
-        protocol_params,
-        next_protocol_params,
-        current_epoch,
+        StepCounter::from_field(counter),
+        MessageHash::from_field(msg),
+        MerkleTreeCommitment::from_field(merkle_root),
+        MerkleTreeCommitment::from_field(next_merkle_root),
+        ProtocolParametersHash::from_field(protocol_params),
+        ProtocolParametersHash::from_field(next_protocol_params),
+        EpochNumber::from_field(current_epoch),
     );
     let public_input = state.as_public_input();
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/golden/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/golden/positive.rs
@@ -49,7 +49,7 @@ fn recursive_chain_state_asset_proof_and_accumulator_are_valid() {
 
     let dual_msm = verify_prepare_poseidon_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &recursive_chain_state.proof,
+        recursive_chain_state.proof.as_bytes(),
         &public_inputs,
     );
 
@@ -78,7 +78,7 @@ fn recursive_step_output_asset_proof_and_accumulator_are_valid() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &recursive_step_output.proof,
+        recursive_step_output.proof.as_bytes(),
         &public_inputs,
     );
 
@@ -142,7 +142,7 @@ mod slow {
             &mock_prover_setup,
             &recursive_chain_state,
             &expected_next_state,
-            &recursive_step_output.certificate_proof,
+            recursive_step_output.certificate_proof.as_bytes(),
         );
         assert_eq!(
             expected_next_state.as_public_input(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
@@ -43,7 +43,7 @@ fn assert_step_output_rejects_tampered_next_accumulator(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &step_output.proof,
+        step_output.proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/certificate_proof.rs
@@ -38,7 +38,7 @@ fn assert_valid_certificate_proof_is_accepted(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &step_output.proof,
+        step_output.proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
@@ -20,7 +20,7 @@ use crate::circuits::halo2_ivc::{
             assert_recursive_mock_prover_accepts_with_label, build_mock_prover_setup_from_assets,
         },
     },
-    types::CertificateProofBytes,
+    types::{CertificateProofBytes, IvcProofBytes},
 };
 
 mod slow {
@@ -44,7 +44,7 @@ mod slow {
             State::genesis(),
             build_genesis_base_case_witness(&setup),
             CertificateProofBytes::garbage(vec![0u8; 64]),
-            vec![],
+            IvcProofBytes::empty(),
             mock_prover_setup.trivial_accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,
@@ -75,7 +75,7 @@ mod slow {
             State::genesis(),
             build_genesis_base_case_witness(&setup),
             CertificateProofBytes::empty(),
-            vec![0u8; 64],
+            IvcProofBytes::new(vec![0u8; 64]),
             mock_prover_setup.trivial_accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
@@ -20,6 +20,7 @@ use crate::circuits::halo2_ivc::{
             assert_recursive_mock_prover_accepts_with_label, build_mock_prover_setup_from_assets,
         },
     },
+    types::CertificateProofBytes,
 };
 
 mod slow {
@@ -42,7 +43,7 @@ mod slow {
             mock_prover_setup.global.clone(),
             State::genesis(),
             build_genesis_base_case_witness(&setup),
-            vec![0u8; 64],
+            CertificateProofBytes::garbage(vec![0u8; 64]),
             vec![],
             mock_prover_setup.trivial_accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),
@@ -73,7 +74,7 @@ mod slow {
             mock_prover_setup.global.clone(),
             State::genesis(),
             build_genesis_base_case_witness(&setup),
-            vec![],
+            CertificateProofBytes::empty(),
             vec![0u8; 64],
             mock_prover_setup.trivial_accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/previous_ivc_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/previous_ivc_proof.rs
@@ -43,7 +43,7 @@ fn assert_valid_previous_ivc_proof_is_accepted(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &step_output.proof,
+        step_output.proof.as_bytes(),
         &public_inputs,
     );
 
@@ -93,7 +93,7 @@ fn tampered_previous_ivc_proof_produces_invalid_accumulator() {
     ]
     .concat();
 
-    let mut tampered_ivc_proof = recursive_chain_state.proof.clone();
+    let mut tampered_ivc_proof = recursive_chain_state.proof.clone().into_vec();
     tampered_ivc_proof[0] ^= 0xFF;
 
     // Try to parse the tampered IVC proof off-circuit. Returns None if the bytes

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
@@ -47,7 +47,7 @@ fn assert_genesis_step_output_rejects_tampered_public_inputs(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &genesis_step_output.proof,
+        genesis_step_output.proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
@@ -28,6 +28,9 @@ mod slow {
                 build_mock_prover_setup_from_assets, build_trivial_mock_prover_circuit,
             },
         },
+        types::{
+            MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage, ProtocolParametersHash,
+        },
     };
 
     #[test]
@@ -44,13 +47,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.merkle_root,
-            same_epoch_message,
-            same_epoch_message_preimage_bytes
-                .try_into()
-                .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(same_epoch_message),
+            ProtocolMessagePreimage::new(
+                same_epoch_message_preimage_bytes
+                    .try_into()
+                    .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.next_merkle_root = F::ONE;
+        tampered_state.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
@@ -73,13 +78,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.merkle_root,
-            same_epoch_message,
-            same_epoch_message_preimage_bytes
-                .try_into()
-                .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(same_epoch_message),
+            ProtocolMessagePreimage::new(
+                same_epoch_message_preimage_bytes
+                    .try_into()
+                    .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.next_protocol_params = F::ONE;
+        tampered_state.next_protocol_params = ProtocolParametersHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
@@ -103,13 +110,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.merkle_root,
-            same_epoch_message,
-            same_epoch_message_preimage_bytes
-                .try_into()
-                .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(same_epoch_message),
+            ProtocolMessagePreimage::new(
+                same_epoch_message_preimage_bytes
+                    .try_into()
+                    .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.msg = F::ONE;
+        tampered_state.msg = MessageHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
@@ -48,7 +48,7 @@ fn verify_and_prepare_accumulator_rejects_valid_proof_with_wrong_public_inputs()
     let wrong_inputs = vec![CircuitBase::ZERO, CircuitBase::ZERO];
 
     let result = verify_and_prepare_accumulator(
-        &step_output.certificate_proof,
+        step_output.certificate_proof.as_bytes(),
         &wrong_inputs,
         &ctx.certificate_verifying_key,
         &ctx.verifier_params,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/proof_verification.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/proof_verification.rs
@@ -42,7 +42,7 @@ fn same_epoch_proof_passes_dual_msm_check_and_accumulator_check() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &same_epoch_step_output.proof,
+        same_epoch_step_output.proof.as_bytes(),
         &public_inputs,
     );
 
@@ -78,7 +78,7 @@ fn chain_state_proof_passes_dual_msm_check_and_accumulator_check() {
 
     let dual_msm = verify_prepare_poseidon_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &recursive_chain_state.proof,
+        recursive_chain_state.proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
@@ -13,6 +13,7 @@ use crate::circuits::halo2_ivc::{
             build_mock_prover_setup_from_assets, build_trivial_mock_prover_circuit,
         },
     },
+    types::{EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolParametersHash, StepCounter},
 };
 
 #[test]
@@ -21,7 +22,7 @@ fn merkle_root_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.merkle_root = F::ONE,
+        |s| s.merkle_root = MerkleTreeCommitment::from_field(F::ONE),
         "proof with tampered merkle_root should be rejected by the verifier",
     );
 }
@@ -32,7 +33,7 @@ fn protocol_params_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.protocol_params = F::ONE,
+        |s| s.protocol_params = ProtocolParametersHash::from_field(F::ONE),
         "proof with tampered protocol_params should be rejected by the verifier",
     );
 }
@@ -43,7 +44,7 @@ fn next_merkle_root_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.next_merkle_root = F::ONE,
+        |s| s.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE),
         "proof with tampered next_merkle_root should be rejected by the verifier",
     );
 }
@@ -54,7 +55,7 @@ fn next_protocol_params_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.next_protocol_params = F::ONE,
+        |s| s.next_protocol_params = ProtocolParametersHash::from_field(F::ONE),
         "proof with tampered next_protocol_params should be rejected by the verifier",
     );
 }
@@ -65,7 +66,7 @@ fn counter_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.counter = F::from(2u64),
+        |s| s.counter = StepCounter::new(2),
         "proof with tampered counter should be rejected by the verifier",
     );
 }
@@ -76,7 +77,7 @@ fn current_epoch_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.current_epoch = F::ONE,
+        |s| s.current_epoch = EpochNumber::from_field(F::ONE),
         "proof with tampered current_epoch should be rejected by the verifier",
     );
 }
@@ -87,7 +88,7 @@ fn msg_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.msg = F::ONE,
+        |s| s.msg = MessageHash::from_field(F::ONE),
         "proof with tampered msg should be rejected by the verifier",
     );
 }
@@ -119,6 +120,8 @@ mod slow {
     fn circuit_rejects_msg_inconsistent_with_preimage() {
         // MockProver check that the in-circuit Blake2b hash constraint between
         // msg_preimage bytes and the resulting msg field is wired correctly.
-        assert_genesis_circuit_rejects_tampered_next_state(|s| s.msg = F::ONE);
+        assert_genesis_circuit_rejects_tampered_next_state(|s| {
+            s.msg = MessageHash::from_field(F::ONE)
+        });
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/mod.rs
@@ -43,7 +43,7 @@ fn assert_step_output_rejects_tampered_state(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &step_output.proof,
+        step_output.proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
@@ -14,6 +14,10 @@ use crate::circuits::halo2_ivc::{
             build_mock_prover_setup_from_assets, build_trivial_mock_prover_circuit,
         },
     },
+    types::{
+        EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
+        ProtocolParametersHash, StepCounter,
+    },
 };
 
 #[test]
@@ -22,7 +26,7 @@ fn merkle_root_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.merkle_root = F::ONE,
+        |s| s.merkle_root = MerkleTreeCommitment::from_field(F::ONE),
         "proof with tampered merkle_root should be rejected by the verifier",
     );
 }
@@ -33,7 +37,7 @@ fn protocol_params_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.protocol_params = F::ONE,
+        |s| s.protocol_params = ProtocolParametersHash::from_field(F::ONE),
         "proof with tampered protocol_params should be rejected by the verifier",
     );
 }
@@ -44,7 +48,7 @@ fn next_merkle_root_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.next_merkle_root = F::ONE,
+        |s| s.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE),
         "proof with tampered next_merkle_root should be rejected by the verifier",
     );
 }
@@ -55,7 +59,7 @@ fn next_protocol_params_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.next_protocol_params = F::ONE,
+        |s| s.next_protocol_params = ProtocolParametersHash::from_field(F::ONE),
         "proof with tampered next_protocol_params should be rejected by the verifier",
     );
 }
@@ -66,7 +70,7 @@ fn counter_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.counter = F::ONE,
+        |s| s.counter = StepCounter::from_field(F::ONE),
         "proof with tampered counter should be rejected by the verifier",
     );
 }
@@ -77,7 +81,7 @@ fn current_epoch_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.current_epoch = F::ZERO,
+        |s| s.current_epoch = EpochNumber::ZERO,
         "proof with tampered current_epoch should be rejected by the verifier",
     );
 }
@@ -88,7 +92,7 @@ fn msg_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.msg = F::ONE,
+        |s| s.msg = MessageHash::from_field(F::ONE),
         "proof with tampered msg should be rejected by the verifier",
     );
 }
@@ -109,13 +113,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.next_merkle_root,
-            message,
-            preimage_bytes
-                .try_into()
-                .expect("next-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(message),
+            ProtocolMessagePreimage::new(
+                preimage_bytes
+                    .try_into()
+                    .expect("next-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
-        tampered_state.protocol_params = F::ONE;
+        tampered_state.protocol_params = ProtocolParametersHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
@@ -138,13 +144,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.next_merkle_root,
-            message,
-            preimage_bytes
-                .try_into()
-                .expect("next-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(message),
+            ProtocolMessagePreimage::new(
+                preimage_bytes
+                    .try_into()
+                    .expect("next-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
-        tampered_state.merkle_root = F::ONE;
+        tampered_state.merkle_root = MerkleTreeCommitment::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
@@ -167,13 +175,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.next_merkle_root,
-            message,
-            preimage_bytes
-                .try_into()
-                .expect("next-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(message),
+            ProtocolMessagePreimage::new(
+                preimage_bytes
+                    .try_into()
+                    .expect("next-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
-        tampered_state.current_epoch -= F::ONE;
+        tampered_state.current_epoch = EpochNumber::new(tampered_state.current_epoch.as_u64() - 1);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
@@ -15,6 +15,10 @@ use crate::circuits::halo2_ivc::{
             build_mock_prover_setup_from_assets, build_trivial_mock_prover_circuit,
         },
     },
+    types::{
+        EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
+        ProtocolParametersHash, StepCounter,
+    },
 };
 
 #[test]
@@ -23,7 +27,7 @@ fn merkle_root_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.merkle_root = F::ONE,
+        |s| s.merkle_root = MerkleTreeCommitment::from_field(F::ONE),
         "proof with tampered merkle_root should be rejected by the verifier",
     );
 }
@@ -34,7 +38,7 @@ fn next_merkle_root_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.next_merkle_root = F::ONE,
+        |s| s.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE),
         "proof with tampered next_merkle_root should be rejected by the verifier",
     );
 }
@@ -45,7 +49,7 @@ fn protocol_params_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.protocol_params = F::ONE,
+        |s| s.protocol_params = ProtocolParametersHash::from_field(F::ONE),
         "proof with tampered protocol_params should be rejected by the verifier",
     );
 }
@@ -56,7 +60,7 @@ fn next_protocol_params_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.next_protocol_params = F::ONE,
+        |s| s.next_protocol_params = ProtocolParametersHash::from_field(F::ONE),
         "proof with tampered next_protocol_params should be rejected by the verifier",
     );
 }
@@ -67,7 +71,7 @@ fn current_epoch_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.current_epoch = F::ONE,
+        |s| s.current_epoch = EpochNumber::from_field(F::ONE),
         "proof with tampered current_epoch should be rejected by the verifier",
     );
 }
@@ -78,7 +82,7 @@ fn counter_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.counter = F::ONE,
+        |s| s.counter = StepCounter::from_field(F::ONE),
         "proof with tampered counter should be rejected by the verifier",
     );
 }
@@ -89,7 +93,7 @@ fn msg_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.msg = F::ONE,
+        |s| s.msg = MessageHash::from_field(F::ONE),
         "proof with tampered msg should be rejected by the verifier",
     );
 }
@@ -111,13 +115,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.merkle_root,
-            message,
-            preimage_bytes
-                .try_into()
-                .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(message),
+            ProtocolMessagePreimage::new(
+                preimage_bytes
+                    .try_into()
+                    .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
-        tampered_state.merkle_root = F::ONE;
+        tampered_state.merkle_root = MerkleTreeCommitment::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
@@ -141,13 +147,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.merkle_root,
-            message,
-            preimage_bytes
-                .try_into()
-                .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(message),
+            ProtocolMessagePreimage::new(
+                preimage_bytes
+                    .try_into()
+                    .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
-        tampered_state.protocol_params = F::ONE;
+        tampered_state.protocol_params = ProtocolParametersHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
@@ -171,13 +179,15 @@ mod slow {
         let witness = Witness::new(
             setup.genesis_signature,
             prev_state.merkle_root,
-            message,
-            preimage_bytes
-                .try_into()
-                .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            MessageHash::from_field(message),
+            ProtocolMessagePreimage::new(
+                preimage_bytes
+                    .try_into()
+                    .expect("same-epoch preimage should be PREIMAGE_SIZE bytes"),
+            ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
-        tampered_state.current_epoch += F::ONE;
+        tampered_state.current_epoch = EpochNumber::new(tampered_state.current_epoch.as_u64() + 1);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/positive.rs
@@ -36,7 +36,7 @@ fn assert_step_proof_verifies(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        &step_output.proof,
+        step_output.proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -3,36 +3,33 @@
 //! This module gives domain names to values that are represented as raw field
 //! elements or bytes at lower circuit/gadget boundaries.
 
-#![allow(dead_code)]
-
 use ff::Field;
 
-use super::{
-    F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
-    PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PREIMAGE_SIZE,
-};
-
-fn field_from_le_bytes(bytes: &[u8]) -> F {
-    let bytes: &[u8; 32] = bytes
-        .try_into()
-        .expect("protocol message field slot should be 32 bytes");
-    F::from_bytes_le(bytes)
-        .into_option()
-        .expect("protocol message field slot should be canonical")
-}
+use super::{F, PREIMAGE_SIZE};
 
 macro_rules! field_wrapper {
-    ($name:ident) => {
+    ($name:ident, zero) => {
         #[derive(Clone, Copy, Debug, PartialEq, Eq)]
         pub(crate) struct $name(F);
 
         impl $name {
             pub(crate) const ZERO: Self = Self(F::ZERO);
 
-            pub(crate) fn new(value: F) -> Self {
+            #[cfg(test)]
+            pub(crate) fn from_field(value: F) -> Self {
                 Self(value)
             }
 
+            pub(crate) fn as_field(self) -> F {
+                self.0
+            }
+        }
+    };
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub(crate) struct $name(F);
+
+        impl $name {
             pub(crate) fn from_field(value: F) -> Self {
                 Self(value)
             }
@@ -44,9 +41,9 @@ macro_rules! field_wrapper {
     };
 }
 
-field_wrapper!(MessageHash);
-field_wrapper!(MerkleTreeCommitment);
-field_wrapper!(ProtocolParametersHash);
+field_wrapper!(MessageHash, zero);
+field_wrapper!(MerkleTreeCommitment, zero);
+field_wrapper!(ProtocolParametersHash, zero);
 field_wrapper!(CertificateCircuitVerificationKeyRepresentation);
 field_wrapper!(IvcCircuitVerificationKeyRepresentation);
 
@@ -58,14 +55,12 @@ macro_rules! u64_wrapper {
         impl $name {
             pub(crate) const ZERO: Self = Self(0);
 
+            #[cfg(test)]
             pub(crate) fn new(value: u64) -> Self {
                 Self(value)
             }
 
-            pub(crate) fn zero() -> Self {
-                Self(0)
-            }
-
+            #[cfg(test)]
             pub(crate) fn as_u64(self) -> u64 {
                 self.0
             }
@@ -74,6 +69,7 @@ macro_rules! u64_wrapper {
                 F::from(self.0)
             }
 
+            #[cfg(test)]
             pub(crate) fn from_field(value: F) -> Self {
                 let bytes = value.to_bytes_le();
                 let low_bytes = bytes[0..8]
@@ -104,39 +100,18 @@ u64_wrapper!(StepCounter);
 pub(crate) struct ProtocolMessagePreimage([u8; PREIMAGE_SIZE]);
 
 impl ProtocolMessagePreimage {
+    #[cfg(test)]
     pub(crate) fn new(bytes: [u8; PREIMAGE_SIZE]) -> Self {
         Self(bytes)
     }
 
-    pub(crate) fn as_bytes(&self) -> &[u8; PREIMAGE_SIZE] {
-        &self.0
-    }
-
+    #[cfg(test)]
     pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8; PREIMAGE_SIZE] {
         &mut self.0
     }
 
     pub(crate) fn into_inner(self) -> [u8; PREIMAGE_SIZE] {
         self.0
-    }
-
-    pub(crate) fn next_merkle_root(&self) -> MerkleTreeCommitment {
-        MerkleTreeCommitment::from_field(field_from_le_bytes(
-            &self.0[PREIMAGE_NEXT_MERKLE_ROOT_BYTES],
-        ))
-    }
-
-    pub(crate) fn next_protocol_params(&self) -> ProtocolParametersHash {
-        ProtocolParametersHash::from_field(field_from_le_bytes(
-            &self.0[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES],
-        ))
-    }
-
-    pub(crate) fn current_epoch(&self) -> EpochNumber {
-        let bytes = self.0[PREIMAGE_CURRENT_EPOCH_BYTES]
-            .try_into()
-            .expect("current epoch preimage slot should be 8 bytes");
-        EpochNumber::new(u64::from_le_bytes(bytes))
     }
 }
 
@@ -154,6 +129,7 @@ impl CertificateProofBytes {
         Self(bytes)
     }
 
+    #[cfg(test)]
     pub(crate) fn empty() -> Self {
         Self(Vec::new())
     }
@@ -163,6 +139,7 @@ impl CertificateProofBytes {
         Self(bytes)
     }
 
+    #[cfg(test)]
     pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.0
     }
@@ -177,6 +154,7 @@ impl CertificateProofBytes {
 pub(crate) struct IvcProofBytes(Vec<u8>);
 
 impl IvcProofBytes {
+    #[cfg(test)]
     pub(crate) fn new(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
@@ -185,10 +163,12 @@ impl IvcProofBytes {
         Self(Vec::new())
     }
 
+    #[cfg(test)]
     pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.0
     }
 
+    #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()
     }

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -1,0 +1,198 @@
+//! Circuit boundary types for the Halo2 IVC circuit.
+//!
+//! This module gives domain names to values that are represented as raw field
+//! elements or bytes at lower circuit/gadget boundaries.
+
+#![allow(dead_code)]
+
+use ff::Field;
+
+use super::{
+    F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
+    PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PREIMAGE_SIZE,
+};
+
+fn field_from_le_bytes(bytes: &[u8]) -> F {
+    let bytes: &[u8; 32] = bytes
+        .try_into()
+        .expect("protocol message field slot should be 32 bytes");
+    F::from_bytes_le(bytes)
+        .into_option()
+        .expect("protocol message field slot should be canonical")
+}
+
+macro_rules! field_wrapper {
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub(crate) struct $name(F);
+
+        impl $name {
+            pub(crate) const ZERO: Self = Self(F::ZERO);
+
+            pub(crate) fn new(value: F) -> Self {
+                Self(value)
+            }
+
+            pub(crate) fn from_field(value: F) -> Self {
+                Self(value)
+            }
+
+            pub(crate) fn as_field(self) -> F {
+                self.0
+            }
+        }
+    };
+}
+
+field_wrapper!(MessageHash);
+field_wrapper!(MerkleTreeCommitment);
+field_wrapper!(ProtocolParametersHash);
+field_wrapper!(CertificateCircuitVerificationKeyRepresentation);
+field_wrapper!(IvcCircuitVerificationKeyRepresentation);
+
+macro_rules! u64_wrapper {
+    ($name:ident) => {
+        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        pub(crate) struct $name(u64);
+
+        impl $name {
+            pub(crate) const ZERO: Self = Self(0);
+
+            pub(crate) fn new(value: u64) -> Self {
+                Self(value)
+            }
+
+            pub(crate) fn zero() -> Self {
+                Self(0)
+            }
+
+            pub(crate) fn as_u64(self) -> u64 {
+                self.0
+            }
+
+            pub(crate) fn as_field(self) -> F {
+                F::from(self.0)
+            }
+
+            pub(crate) fn from_field(value: F) -> Self {
+                let bytes = value.to_bytes_le();
+                let low_bytes = bytes[0..8]
+                    .try_into()
+                    .expect("field byte representation should contain at least 8 bytes");
+                Self(u64::from_le_bytes(low_bytes))
+            }
+        }
+
+        impl From<u64> for $name {
+            fn from(value: u64) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<$name> for u64 {
+            fn from(value: $name) -> Self {
+                value.0
+            }
+        }
+    };
+}
+
+u64_wrapper!(EpochNumber);
+u64_wrapper!(StepCounter);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct ProtocolMessagePreimage([u8; PREIMAGE_SIZE]);
+
+impl ProtocolMessagePreimage {
+    pub(crate) fn new(bytes: [u8; PREIMAGE_SIZE]) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8; PREIMAGE_SIZE] {
+        &self.0
+    }
+
+    pub(crate) fn into_inner(self) -> [u8; PREIMAGE_SIZE] {
+        self.0
+    }
+
+    pub(crate) fn next_merkle_root(&self) -> MerkleTreeCommitment {
+        MerkleTreeCommitment::from_field(field_from_le_bytes(
+            &self.0[PREIMAGE_NEXT_MERKLE_ROOT_BYTES],
+        ))
+    }
+
+    pub(crate) fn next_protocol_params(&self) -> ProtocolParametersHash {
+        ProtocolParametersHash::from_field(field_from_le_bytes(
+            &self.0[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES],
+        ))
+    }
+
+    pub(crate) fn current_epoch(&self) -> EpochNumber {
+        let bytes = self.0[PREIMAGE_CURRENT_EPOCH_BYTES]
+            .try_into()
+            .expect("current epoch preimage slot should be 8 bytes");
+        EpochNumber::new(u64::from_le_bytes(bytes))
+    }
+}
+
+impl From<[u8; PREIMAGE_SIZE]> for ProtocolMessagePreimage {
+    fn from(bytes: [u8; PREIMAGE_SIZE]) -> Self {
+        Self(bytes)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct CertificateProofBytes(Vec<u8>);
+
+impl CertificateProofBytes {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub(crate) fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl From<Vec<u8>> for CertificateProofBytes {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}
+
+/// Provisional recursive proof-byte wrapper until `IvcProof` is wired end-to-end.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct IvcProofBytes(Vec<u8>);
+
+impl IvcProofBytes {
+    pub(crate) fn new(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
+    pub(crate) fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+
+    pub(crate) fn into_vec(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl From<Vec<u8>> for IvcProofBytes {
+    fn from(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+}

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -129,6 +129,7 @@ impl CertificateProofBytes {
         Self(bytes)
     }
 
+    // Used for the genesis IVC step. This can be un-gated when the production IVC prover is wired.
     #[cfg(test)]
     pub(crate) fn empty() -> Self {
         Self(Vec::new())

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -53,10 +53,9 @@ macro_rules! u64_wrapper {
         pub(crate) struct $name(u64);
 
         impl $name {
-            pub(crate) const ZERO: Self = Self(0);
+            pub(crate) const ZERO: Self = Self::new(0);
 
-            #[cfg(test)]
-            pub(crate) fn new(value: u64) -> Self {
+            pub(crate) const fn new(value: u64) -> Self {
                 Self(value)
             }
 
@@ -76,18 +75,6 @@ macro_rules! u64_wrapper {
                     .try_into()
                     .expect("field byte representation should contain at least 8 bytes");
                 Self(u64::from_le_bytes(low_bytes))
-            }
-        }
-
-        impl From<u64> for $name {
-            fn from(value: u64) -> Self {
-                Self(value)
-            }
-        }
-
-        impl From<$name> for u64 {
-            fn from(value: $name) -> Self {
-                value.0
             }
         }
     };

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -150,12 +150,13 @@ impl From<[u8; PREIMAGE_SIZE]> for ProtocolMessagePreimage {
 pub(crate) struct CertificateProofBytes(Vec<u8>);
 
 impl CertificateProofBytes {
-    pub(crate) fn new(bytes: Vec<u8>) -> Self {
-        Self(bytes)
-    }
-
     pub(crate) fn empty() -> Self {
         Self(Vec::new())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn garbage(bytes: Vec<u8>) -> Self {
+        Self(bytes)
     }
 
     pub(crate) fn as_bytes(&self) -> &[u8] {
@@ -164,12 +165,6 @@ impl CertificateProofBytes {
 
     pub(crate) fn into_vec(self) -> Vec<u8> {
         self.0
-    }
-}
-
-impl From<Vec<u8>> for CertificateProofBytes {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
     }
 }
 

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -150,7 +150,7 @@ impl From<[u8; PREIMAGE_SIZE]> for ProtocolMessagePreimage {
 pub(crate) struct CertificateProofBytes(Vec<u8>);
 
 impl CertificateProofBytes {
-    pub(crate) fn from_snark_proof_bytes(bytes: Vec<u8>) -> Self {
+    pub(crate) fn from_certificate_circuit_proof_bytes(bytes: Vec<u8>) -> Self {
         Self(bytes)
     }
 
@@ -187,6 +187,10 @@ impl IvcProofBytes {
 
     pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.0
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.0.is_empty()
     }
 
     pub(crate) fn into_vec(self) -> Vec<u8> {

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -150,6 +150,10 @@ impl From<[u8; PREIMAGE_SIZE]> for ProtocolMessagePreimage {
 pub(crate) struct CertificateProofBytes(Vec<u8>);
 
 impl CertificateProofBytes {
+    pub(crate) fn from_snark_proof_bytes(bytes: Vec<u8>) -> Self {
+        Self(bytes)
+    }
+
     pub(crate) fn empty() -> Self {
         Self(Vec::new())
     }

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -112,6 +112,10 @@ impl ProtocolMessagePreimage {
         &self.0
     }
 
+    pub(crate) fn as_mut_bytes(&mut self) -> &mut [u8; PREIMAGE_SIZE] {
+        &mut self.0
+    }
+
     pub(crate) fn into_inner(self) -> [u8; PREIMAGE_SIZE] {
         self.0
     }

--- a/mithril-stm/src/proof_system/halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/mod.rs
@@ -10,6 +10,8 @@ mod single_signature;
 mod unsafe_helpers;
 
 pub use aggregate_key::AggregateVerificationKeyForSnark;
+#[cfg(test)]
+pub(crate) use aggregate_key::RIGID_SLOT_BYTES;
 pub(crate) use clerk::SnarkClerk;
 pub(crate) use eligibility::{
     compute_target_value_for_snark_lottery, compute_winning_lottery_indices,

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -18,7 +18,9 @@ use crate::{
     AggregateVerificationKeyForSnark, MembershipDigest, Parameters, SingleSignature, StmResult,
     circuits::{
         halo2::{circuit::StmCertificateCircuit, types::CircuitBase},
-        halo2_ivc::certificate_proof::verify_and_prepare_accumulator,
+        halo2_ivc::{
+            certificate_proof::verify_and_prepare_accumulator, types::CertificateProofBytes,
+        },
     },
     codec,
     proof_system::halo2_snark::{
@@ -85,6 +87,12 @@ impl<D: MembershipDigest> SnarkProof<D> {
             merkle_tree_depth,
             phantom: PhantomData,
         })
+    }
+
+    // Kept until certificate SNARK proofs are fed into the IVC prover.
+    #[allow(dead_code)]
+    pub(crate) fn into_circuit_proof_bytes(self) -> CertificateProofBytes {
+        CertificateProofBytes::from_certificate_circuit_proof_bytes(self.circuit_proof)
     }
 
     /// Verify a SNARK proof given a message, an aggregate verification key for snark,

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -89,7 +89,7 @@ impl<D: MembershipDigest> SnarkProof<D> {
         })
     }
 
-    // Kept until certificate SNARK proofs are fed into the IVC prover.
+    // TODO: remove this allow dead_code directive when the IVC prover consumes this method
     #[allow(dead_code)]
     pub(crate) fn into_circuit_proof_bytes(self) -> CertificateProofBytes {
         CertificateProofBytes::from_certificate_circuit_proof_bytes(self.circuit_proof)

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -5,7 +5,10 @@ use std::sync::Arc;
 use midnight_circuits::verifier::{Accumulator, BlstrsEmulation};
 use rand_core::{CryptoRng, RngCore};
 
-use crate::{circuits::halo2_ivc::state::State, proof_system::ivc_halo2_snark::setup::IvcSetup};
+use crate::{
+    circuits::halo2_ivc::{state::State, types::IvcProofBytes},
+    proof_system::ivc_halo2_snark::setup::IvcSetup,
+};
 
 /// Per-session IVC prover handle.
 // TODO: remove this allow dead_code directive when the IVC prover is wired into STM
@@ -22,7 +25,7 @@ pub(crate) struct IvcProver<R: RngCore + CryptoRng> {
 #[allow(dead_code)]
 pub(crate) struct IvcProof {
     /// Externally-verifiable proof bytes (Blake2b transcript).
-    pub(crate) proof_bytes: Vec<u8>,
+    pub(crate) proof_bytes: IvcProofBytes,
     /// Chain state the proof commits to.
     pub(crate) state: State,
     /// Folded accumulator the proof commits to.

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -3,7 +3,10 @@
 use midnight_circuits::verifier::{Accumulator, BlstrsEmulation};
 
 use crate::{
-    circuits::halo2_ivc::state::{State, trivial_acc},
+    circuits::halo2_ivc::{
+        state::{State, trivial_acc},
+        types::IvcProofBytes,
+    },
     signature_scheme::StandardSchnorrSignature,
 };
 
@@ -17,7 +20,7 @@ pub(crate) struct IvcRollingState {
     /// Last committed chain state.
     state: State,
     /// Bytes of the last IVC proof under the Poseidon transcript
-    ivc_proof: Vec<u8>,
+    ivc_proof: IvcProofBytes,
     /// Folded accumulator the new step will build on top of
     accumulator: Accumulator<BlstrsEmulation>,
     /// Chain-specific Schnorr signature over the genesis state
@@ -29,7 +32,7 @@ impl IvcRollingState {
     /// Builds a rolling state from the four fields produced by an IVC proving step.
     pub(crate) fn new(
         state: State,
-        ivc_proof: Vec<u8>,
+        ivc_proof: IvcProofBytes,
         accumulator: Accumulator<BlstrsEmulation>,
         genesis_signature: StandardSchnorrSignature,
     ) -> Self {
@@ -54,7 +57,7 @@ impl IvcRollingState {
     ) -> Self {
         Self {
             state: State::genesis(),
-            ivc_proof: Vec::new(),
+            ivc_proof: IvcProofBytes::empty(),
             accumulator: trivial_acc(fixed_base_names),
             genesis_signature,
         }
@@ -82,7 +85,7 @@ impl IvcRollingState {
     }
 
     /// Returns the bytes of the last IVC proof.
-    pub(crate) fn ivc_proof(&self) -> &[u8] {
+    pub(crate) fn ivc_proof(&self) -> &IvcProofBytes {
         &self.ivc_proof
     }
 
@@ -155,7 +158,7 @@ mod tests {
     #[test]
     fn from_previous_proof_carries_proof_bytes_and_supplied_signature() {
         let genesis_signature = build_genesis_signature();
-        let proof_bytes = vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03];
+        let proof_bytes = IvcProofBytes::new(vec![0xDE, 0xAD, 0xBE, 0xEF, 0x01, 0x02, 0x03]);
         let previous_proof = IvcProof {
             proof_bytes: proof_bytes.clone(),
             state: State::genesis(),
@@ -165,7 +168,7 @@ mod tests {
         let rolling_state =
             IvcRollingState::from_previous_proof(&previous_proof, genesis_signature);
 
-        assert_eq!(rolling_state.ivc_proof(), proof_bytes.as_slice());
+        assert_eq!(rolling_state.ivc_proof(), &proof_bytes);
         assert_eq!(rolling_state.genesis_signature(), genesis_signature);
     }
 
@@ -174,7 +177,7 @@ mod tests {
         let genesis_signature = build_genesis_signature();
         let previous_state = State::genesis();
         let previous_proof = IvcProof {
-            proof_bytes: Vec::new(),
+            proof_bytes: IvcProofBytes::empty(),
             state: previous_state,
             accumulator: trivial_acc(&["base_one".to_string()]),
         };

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -84,7 +84,7 @@ impl IvcRollingState {
         &self.state
     }
 
-    /// Returns the bytes of the last IVC proof.
+    /// Returns the last IVC proof bytes wrapper.
     pub(crate) fn ivc_proof(&self) -> &IvcProofBytes {
         &self.ivc_proof
     }

--- a/mithril-stm/src/proof_system/mod.rs
+++ b/mithril-stm/src/proof_system/mod.rs
@@ -41,3 +41,6 @@ pub(crate) use halo2_snark::{
     SingleSignatureForSnark, SnarkClerk, SnarkProofSigner, SnarkProver, SnarkVerifierSetup,
     compute_target_value_for_snark_lottery,
 };
+
+#[cfg(all(test, feature = "future_snark"))]
+pub(crate) use halo2_snark::RIGID_SLOT_BYTES as SNARK_AGGREGATE_VERIFICATION_KEY_RIGID_SLOT_BYTES;


### PR DESCRIPTION
## Content

This PR completes WS7, aligning the `halo2_ivc` public API with domain-specific types and restricting internal visibility across the module.

### Changes
- **`types.rs`** (new): introduces domain newtypes for all raw `F` and `Vec<u8>` values at  the `State`, `Witness`, `Global`, and proof-byte boundaries 
- **`state.rs`**: `State`, `Witness`, and `Global` fields replaced with domain newtypes; `AssignedState`, `AssignedWitness`, and `AssignedGlobal` kept as raw assignment-layer types;`State::as_public_input()` ordering contract documented
- **`gadget.rs`**: domain wrappers lowered to raw `F` or bytes only at the gadget assignment and public-input edges
- **`circuit.rs`**: `IvcCircuit::try_new()` accepts `CertificateProofBytes` and `IvcProofBytes`; fields changed from `pub` to private; `try_new` changed from `pub` to `pub(crate)`; internal storage stays `Value<Vec<u8>>` because `VerifierGadget::prepare()` requires raw bytes
- **`proof_system/halo2_snark/proof.rs`**: adds `SnarkProof<D>::into_circuit_proof_bytes()`, the production path for constructing `CertificateProofBytes`
- **`proof_system/ivc_halo2_snark/`**: `IvcProof::proof_bytes` and `IvcRollingState::ivc_proof` typed as `IvcProofBytes`; genesis initialises with `IvcProofBytes::empty()`
- **`protocol_message.rs`**: adds `aggregate_verification_key_message_part()`, deriving the  protocol-message hex from `AggregateVerificationKeyForSnark` in the same format as `mithril-common`
- **`tests/common/generators/setup.rs`**: generator setup stores `AggregateVerificationKeyForSnark<MithrilMembershipDigest>` and `MessageHash` directly; hex derived at protocol-message construction boundary
- **`mod.rs`**: all sub-modules changed to `pub(crate)`; `io` and `protocol_message` gated  to `#[cfg(test)]`
- **Test call sites**: all `State::new`, `Witness::new`, and `Global::new` call sites and direct field tampering assignments updated to use domain constructors

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Comments
Closes https://github.com/input-output-hk/mithril/issues/3128
