### PR TITLE
feat: dual-signature genesis certificate and wiring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ As a minor extension, we have adopted a slightly different versioning convention
 - **UNSTABLE**:
   - Support for SNARK-friendly rigid protocol message openable in recursive circuit.
   - Support for SNARK-friendly genesis certificate primitives.
+  - Support for dual-signature genesis certificate.
 
 | Crate | Version |
 | ----- | ------- |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.5"
+version = "0.9.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-client"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4141,7 +4141,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-discovery"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4232,7 +4232,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-cardano-node-internal-database"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4263,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.14.13"
+version = "0.14.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.13.14"
+version = "0.13.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.31"
+version = "0.10.32"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4063,6 +4063,7 @@ dependencies = [
  "axum-test",
  "blockfrost",
  "chrono",
+ "ciborium",
  "clap",
  "config",
  "criterion",

--- a/docs/runbook/genesis-manually/README.md
+++ b/docs/runbook/genesis-manually/README.md
@@ -1,5 +1,20 @@
 # Manual genesis of production Mithril network
 
+## Era compatibility
+
+Every `mithril-aggregator genesis` subcommand takes an optional `--mithril-era` flag.
+
+The era controls which key material the subcommand expects:
+
+| Era + key material                             | Outcome                                                     |
+| ---------------------------------------------- | ----------------------------------------------------------- |
+| `pythagoras` + legacy single-Ed25519 key       | OK (current behaviour, untouched)                           |
+| `pythagoras` + dual bundle (Ed25519 + Schnorr) | OK (only the Ed25519 half is used)                          |
+| `lagrange` + dual bundle                       | OK (dual ceremony: both signatures are produced / verified) |
+| `lagrange` + legacy single-Ed25519 key         | Error: convert it with `genesis upgrade-key-to-dual`        |
+
+The signing-key file (`genesis.sk`) and the verification-key file (`genesis.vk`) layouts are auto-detected.
+
 ## Configure environment variables
 
 Export the environment variables:
@@ -50,10 +65,10 @@ docker exec -it mithril-aggregator bash
 Once connected to the aggregator container, export the genesis payload to sign:
 
 ```bash
-/app/bin/mithril-aggregator -vvv genesis export --target-path /mithril-aggregator/mithril/genesis/genesis-payload-to-sign.txt [--mithril-era $MITHRIL_ERA]
+/app/bin/mithril-aggregator -vvv genesis export --target-path /mithril-aggregator/mithril/genesis/genesis-payload-to-sign.txt --mithril-era $MITHRIL_ERA
 ```
 
-> The `--mithril-era` parameter is optional when only one era exists, and required when multiple eras are supported. It specifies which Mithril era to use for the genesis certificate (e.g. `pythagoras`, `lagrange`).
+> The `--mithril-era` parameter specifies which Mithril era to use for the genesis certificate (e.g. `pythagoras`, `lagrange`).
 
 Then disconnect from the aggregator container:
 
@@ -80,8 +95,12 @@ Download or build the aggregator on your local machine as explained in this [doc
 Then, sign the payload with the genesis secret key:
 
 ```bash
-./mithril-aggregator -vvv genesis sign --to-sign-payload-path genesis-payload-to-sign.txt --target-signed-payload-path genesis-payload-signed.txt --genesis-secret-key-path genesis.sk
+./mithril-aggregator -vvv genesis sign --to-sign-payload-path genesis-payload-to-sign.txt --target-signed-payload-path genesis-payload-signed.txt --genesis-secret-key-path genesis.sk --mithril-era $MITHRIL_ERA
 ```
+
+> Pythagoras writes a raw 64-byte Ed25519 signature. Lagrange writes a versioned dual-signature
+> envelope (Ed25519 + Schnorr); the signing-key file must be the dual bundle produced by
+> `genesis upgrade-key-to-dual` or `genesis generate-keypair --mithril-era lagrange`.
 
 ## Import the signed genesis payload
 
@@ -117,5 +136,5 @@ docker exec -it mithril-aggregator bash
 Once connected to the aggregator container, import the signed genesis payload:
 
 ```bash
-/app/bin/mithril-aggregator -vvv genesis import --signed-payload-path /mithril-aggregator/mithril/genesis/genesis-payload-signed.txt --genesis-verification-key $(curl -s "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/$MITHRIL_NETWORK/genesis.vkey")
+/app/bin/mithril-aggregator -vvv genesis import --signed-payload-path /mithril-aggregator/mithril/genesis/genesis-payload-signed.txt --genesis-verification-key $(curl -s "https://raw.githubusercontent.com/input-output-hk/mithril/main/mithril-infra/configuration/$MITHRIL_NETWORK/genesis.vkey") --mithril-era $MITHRIL_ERA
 ```

--- a/docs/website/root/manual/develop/nodes/mithril-aggregator.md
+++ b/docs/website/root/manual/develop/nodes/mithril-aggregator.md
@@ -582,6 +582,7 @@ Here is a list of the available parameters for the serve command:
 | -------------------------- | ---------------------------- | :------------------: | -------------------------- | ------------------------------------------------------------------ | ------------- | ---------------------------------- | :----------------: |
 | `signed_payload_path`      | `--signed-payload-path`      |          -           | -                          | Path of the payload to import.                                     | -             | -                                  | :heavy_check_mark: |
 | `genesis_verification_key` | `--genesis-verification-key` |          -           | -                          | Genesis verification key                                           | -             | -                                  | :heavy_check_mark: |
+| `mithril_era`              | `--mithril-era`              |          -           | -                          | Mithril era to use for the genesis certificate                     | -             | -                                  |         -          |
 | `data_stores_directory`    | -                            |          -           | `DATA_STORES_DIRECTORY`    | Directory to store aggregator databases                            | -             | `./mithril-aggregator/stores`      | :heavy_check_mark: |
 | `cardano_node_socket_path` | -                            |          -           | `CARDANO_NODE_SOCKET_PATH` | Path of the socket opened by the Cardano node                      | -             | `/ipc/node.socket`                 | :heavy_check_mark: |
 | `cardano_cli_path`         | -                            |          -           | `CARDANO_CLI_PATH`         | Cardano CLI tool path                                              | -             | `cardano-cli`                      |         -          |
@@ -591,11 +592,12 @@ Here is a list of the available parameters for the serve command:
 
 `genesis sign` command:
 
-| Parameter                    | Command line (long)            | Command line (short) | Environment variable | Description                           | Default value | Example | Mandatory |
-| ---------------------------- | ------------------------------ | :------------------: | -------------------- | ------------------------------------- | ------------- | ------- | :-------: |
-| `to_sign_payload_path`       | `--to-sign-payload-path`       |          -           | -                    | Path of the payload to sign.          | -             | -       |     -     |
-| `target_signed_payload_path` | `--target-signed-payload-path` |          -           | -                    | Path of the signed payload to export. | -             | -       |     -     |
-| `genesis_secret_key_path`    | `--genesis-secret-key-path`    |          -           | -                    | Path of the genesis secret key.       | -             | -       |     -     |
+| Parameter                    | Command line (long)            | Command line (short) | Environment variable | Description                                    | Default value | Example | Mandatory |
+| ---------------------------- | ------------------------------ | :------------------: | -------------------- | ---------------------------------------------- | ------------- | ------- | :-------: |
+| `to_sign_payload_path`       | `--to-sign-payload-path`       |          -           | -                    | Path of the payload to sign.                   | -             | -       |     -     |
+| `target_signed_payload_path` | `--target-signed-payload-path` |          -           | -                    | Path of the signed payload to export.          | -             | -       |     -     |
+| `genesis_secret_key_path`    | `--genesis-secret-key-path`    |          -           | -                    | Path of the genesis secret key.                | -             | -       |     -     |
+| `mithril_era`                | `--mithril-era`                |          -           | -                    | Mithril era to use for the genesis certificate | -             | -       |     -     |
 
 `genesis generate-keypair` command:
 

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-cardano-node-internal-database"
-version = "0.2.2"
+version = "0.2.3"
 description = "Mechanisms that allow Mithril nodes to read the files of a Cardano node internal database and compute digests from them"
 authors.workspace = true
 documentation.workspace = true
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.3" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.4" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator-client"
-version = "0.2.1"
+version = "0.2.2"
 description = "Client to request data from a Mithril Aggregator"
 authors.workspace = true
 documentation.workspace = true
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.3" }
+mithril-common = { path = "../../mithril-common", version = "0.7.4" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mithril-aggregator-discovery"
 description = "Mechanisms to discover aggregators available in a Mithril network."
-version = "0.1.7"
+version = "0.1.8"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true
@@ -13,8 +13,8 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.1" }
-mithril-common = { path = "../../mithril-common", version = "0.7.3" }
+mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.2" }
+mithril-common = { path = "../../mithril-common", version = "0.7.4" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.5"
+version = "0.9.6"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -13,13 +13,14 @@ repository = { workspace = true }
 default = ["rustls"]
 rustls = ["reqwest/rustls"]
 
-future_snark = ["mithril-common/future_snark"]
+future_snark = ["mithril-common/future_snark", "dep:ciborium"]
 
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 blockfrost = { version = "1.2.4", default-features = false, features = ["rustls"] }
 chrono = { workspace = true }
+ciborium = { version = "0.2.2", optional = true }
 clap = { workspace = true, features = ["cargo"] }
 config = { workspace = true }
 flate2 = "1.1.9"

--- a/mithril-aggregator/src/commands/database_command.rs
+++ b/mithril-aggregator/src/commands/database_command.rs
@@ -106,7 +106,7 @@ impl MigrateCommand {
         debug!(root_logger, "DATABASE MIGRATE command"; "config" => format!("{config:?}"));
         println!(
             "Migrating databases from stores directory: {}",
-            self.stores_directory.to_string_lossy()
+            self.stores_directory.display()
         );
         let mut dependencies_builder =
             DependenciesBuilder::new(root_logger.clone(), Arc::new(config));
@@ -160,7 +160,7 @@ impl VacuumCommand {
         debug!(root_logger, "DATABASE VACUUM command"; "config" => format!("{config:?}"));
         println!(
             "Vacuuming database from stores directory: {}",
-            self.stores_directory.to_string_lossy()
+            self.stores_directory.display()
         );
         let mut dependencies_builder =
             DependenciesBuilder::new(root_logger.clone(), Arc::new(config.clone()));

--- a/mithril-aggregator/src/commands/era_command.rs
+++ b/mithril-aggregator/src/commands/era_command.rs
@@ -145,10 +145,7 @@ pub struct GenerateKeypairEraSubCommand {
 impl GenerateKeypairEraSubCommand {
     pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
         debug!(root_logger, "GENERATE KEYPAIR ERA command");
-        println!(
-            "Era generate keypair to {}",
-            self.target_path.to_string_lossy()
-        );
+        println!("Era generate keypair to {}", self.target_path.display());
 
         EraTools::create_and_save_era_keypair(&self.target_path)
             .with_context(|| "era-tools: keypair generation error")?;

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -7,9 +7,13 @@ use serde::Deserialize;
 use slog::{Logger, debug};
 
 use mithril_cardano_node_chain::chain_observer::ChainObserverType;
+#[cfg(not(feature = "future_snark"))]
+use mithril_common::crypto_helper::GenesisEd25519VerificationKey;
+#[cfg(feature = "future_snark")]
+use mithril_common::crypto_helper::GenesisVerifier;
 use mithril_common::{
     StdResult,
-    crypto_helper::{GenesisEd25519VerificationKey, GenesisSigner},
+    crypto_helper::GenesisSigner,
     entities::{HexEncodedGenesisSecretKey, HexEncodedGenesisVerificationKey, SupportedEra},
 };
 use mithril_doc::{Documenter, StructDoc};
@@ -239,6 +243,12 @@ pub struct ImportGenesisSubCommand {
     /// Genesis Verification Key
     #[clap(long)]
     genesis_verification_key: HexEncodedGenesisVerificationKey,
+
+    /// Mithril era to use for the genesis certificate
+    ///
+    /// Optional when only one era exists, required when multiple eras are supported.
+    #[clap(long)]
+    mithril_era: Option<SupportedEra>,
 }
 
 impl ImportGenesisSubCommand {
@@ -257,7 +267,7 @@ impl ImportGenesisSubCommand {
             "Genesis import signed payload from {}",
             self.signed_payload_path.to_string_lossy()
         );
-        let mithril_era = resolve_mithril_era(None)?;
+        let mithril_era = resolve_mithril_era(self.mithril_era)?;
         let mut dependencies_builder =
             DependenciesBuilder::new(root_logger.clone(), Arc::new(config.clone()));
         let dependencies = dependencies_builder
@@ -270,14 +280,45 @@ impl ImportGenesisSubCommand {
         let genesis_tools = GenesisTools::from_dependencies(dependencies)
             .await
             .with_context(|| "genesis-tools: initialization error")?;
+
+        self.run_import(&genesis_tools, mithril_era).await
+    }
+
+    #[cfg(not(feature = "future_snark"))]
+    async fn run_import(
+        &self,
+        genesis_tools: &GenesisTools,
+        _mithril_era: SupportedEra,
+    ) -> StdResult<()> {
+        let verification_key =
+            GenesisEd25519VerificationKey::from_json_hex(&self.genesis_verification_key)?;
         genesis_tools
-            .import_payload_signature(
-                &self.signed_payload_path,
-                &GenesisEd25519VerificationKey::from_json_hex(&self.genesis_verification_key)?,
-            )
+            .import_payload_signature(&self.signed_payload_path, &verification_key)
             .await
-            .with_context(|| "genesis-tools: import error")?;
-        Ok(())
+            .with_context(|| "genesis-tools: import error")
+    }
+
+    #[cfg(feature = "future_snark")]
+    async fn run_import(
+        &self,
+        genesis_tools: &GenesisTools,
+        mithril_era: SupportedEra,
+    ) -> StdResult<()> {
+        let verifier = GenesisVerifier::try_from_hex(&self.genesis_verification_key)?;
+        verifier.ensure_supports_era(mithril_era)?;
+        match mithril_era {
+            SupportedEra::Lagrange => genesis_tools
+                .import_dual_payload_signature(&self.signed_payload_path, &verifier)
+                .await
+                .with_context(|| "genesis-tools: import error"),
+            _ => genesis_tools
+                .import_payload_signature(
+                    &self.signed_payload_path,
+                    &verifier.ed25519.to_verification_key(),
+                )
+                .await
+                .with_context(|| "genesis-tools: import error"),
+        }
     }
 
     pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
@@ -438,6 +479,21 @@ mod tests {
                 "Should error when multiple eras exist and none is provided"
             );
         }
+    }
+
+    #[test]
+    fn import_subcommand_parses_era_flag() {
+        let cmd = ImportGenesisSubCommand::try_parse_from([
+            "import",
+            "--signed-payload-path",
+            "/tmp/signed",
+            "--genesis-verification-key",
+            "deadbeef",
+            "--mithril-era",
+            &SupportedEra::Lagrange.to_string(),
+        ])
+        .expect("CLI parse should succeed");
+        assert_eq!(cmd.mithril_era, Some(SupportedEra::Lagrange));
     }
 
     #[test]

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -395,7 +395,7 @@ impl GenerateKeypairGenesisSubCommand {
             self.target_path.to_string_lossy()
         );
 
-        GenesisTools::create_and_save_genesis_keypair(&self.target_path)
+        GenesisTools::create_and_save_genesis_keypair(&self.target_path, SupportedEra::Pythagoras)
             .with_context(|| "genesis-tools: keypair generation error")?;
 
         Ok(())

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -298,6 +298,12 @@ pub struct SignGenesisSubCommand {
     /// Genesis Secret Key Path
     #[clap(long)]
     genesis_secret_key_path: PathBuf,
+
+    /// Mithril era to use for the genesis certificate
+    ///
+    /// Optional when only one era exists, required when multiple eras are supported.
+    #[clap(long)]
+    mithril_era: Option<SupportedEra>,
 }
 
 impl SignGenesisSubCommand {
@@ -308,11 +314,13 @@ impl SignGenesisSubCommand {
             self.to_sign_payload_path.to_string_lossy(),
             self.target_signed_payload_path.to_string_lossy()
         );
+        let mithril_era = resolve_mithril_era(self.mithril_era)?;
 
         GenesisTools::sign_genesis_certificate(
             &self.to_sign_payload_path,
             &self.target_signed_payload_path,
             &self.genesis_secret_key_path,
+            mithril_era,
         )
         .await
         .with_context(|| "genesis-tools: sign error")?;
@@ -432,6 +440,23 @@ mod tests {
                 "Should error when multiple eras exist and none is provided"
             );
         }
+    }
+
+    #[test]
+    fn sign_subcommand_parses_era_flag() {
+        let cmd = SignGenesisSubCommand::try_parse_from([
+            "sign",
+            "--to-sign-payload-path",
+            "/tmp/to-sign",
+            "--target-signed-payload-path",
+            "/tmp/signed",
+            "--genesis-secret-key-path",
+            "/tmp/genesis.sk",
+            "--mithril-era",
+            &SupportedEra::Lagrange.to_string(),
+        ])
+        .expect("CLI parse should succeed");
+        assert_eq!(cmd.mithril_era, Some(SupportedEra::Lagrange));
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -592,18 +592,27 @@ mod tests {
         assert_eq!(cmd.mithril_era, Some(SupportedEra::Lagrange));
     }
 
-    #[tokio::test]
-    async fn generate_keypair_subcommand_parses_era_flag() {
-        let target = temp_dir!().join("keys");
-        std::fs::create_dir_all(&target).unwrap();
+    #[test]
+    fn generate_keypair_subcommand_parses_era_flag() {
         let cmd = GenerateKeypairGenesisSubCommand::try_parse_from([
             "generate-keypair",
             "--target-path",
-            target.to_str().unwrap(),
+            "/tmp/keys",
             "--mithril-era",
             &SupportedEra::Pythagoras.to_string(),
         ])
-        .unwrap();
+        .expect("CLI parse should succeed");
+        assert_eq!(cmd.mithril_era, Some(SupportedEra::Pythagoras));
+    }
+
+    #[tokio::test]
+    async fn generate_keypair_subcommand_writes_key_files() {
+        let target = temp_dir!().join("keys");
+        std::fs::create_dir_all(&target).unwrap();
+        let cmd = GenerateKeypairGenesisSubCommand {
+            target_path: target.clone(),
+            mithril_era: Some(SupportedEra::Pythagoras),
+        };
 
         cmd.execute(TestLogger::stdout())
             .await
@@ -622,14 +631,10 @@ mod tests {
         let target = temp.join("out");
         std::fs::create_dir_all(&target).unwrap();
 
-        let cmd = UpgradeKeyToDualGenesisSubCommand::try_parse_from([
-            "upgrade-key-to-dual",
-            "--legacy-secret-key-path",
-            legacy_path.to_str().unwrap(),
-            "--target-path",
-            target.to_str().unwrap(),
-        ])
-        .unwrap();
+        let cmd = UpgradeKeyToDualGenesisSubCommand {
+            legacy_secret_key_path: legacy_path,
+            target_path: target.clone(),
+        };
 
         cmd.execute(TestLogger::stdout())
             .await

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -327,7 +327,6 @@ impl ImportGenesisSubCommand {
         mithril_era: SupportedEra,
     ) -> StdResult<()> {
         let verifier = GenesisVerifier::try_from_hex(&self.genesis_verification_key)?;
-        verifier.ensure_supports_era(mithril_era)?;
         match mithril_era {
             SupportedEra::Lagrange => genesis_tools
                 .import_dual_payload_signature(&self.signed_payload_path, &verifier)

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -287,7 +287,7 @@ impl ImportGenesisSubCommand {
         debug!(root_logger, "IMPORT GENESIS command"; "config" => format!("{config:?}"));
         println!(
             "Genesis import signed payload from {}",
-            self.signed_payload_path.to_string_lossy()
+            self.signed_payload_path.display()
         );
         let mithril_era = resolve_mithril_era(self.mithril_era)?;
         let mut dependencies_builder =
@@ -373,8 +373,8 @@ impl SignGenesisSubCommand {
         debug!(root_logger, "SIGN GENESIS command");
         println!(
             "Genesis sign payload from {} to {}",
-            self.to_sign_payload_path.to_string_lossy(),
-            self.target_signed_payload_path.to_string_lossy()
+            self.to_sign_payload_path.display(),
+            self.target_signed_payload_path.display()
         );
         let mithril_era = resolve_mithril_era(self.mithril_era)?;
 
@@ -464,10 +464,7 @@ pub struct GenerateKeypairGenesisSubCommand {
 impl GenerateKeypairGenesisSubCommand {
     pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
         debug!(root_logger, "GENERATE KEYPAIR GENESIS command");
-        println!(
-            "Genesis generate keypair to {}",
-            self.target_path.to_string_lossy()
-        );
+        println!("Genesis generate keypair to {}", self.target_path.display());
         let mithril_era = resolve_mithril_era(self.mithril_era)?;
 
         GenesisTools::create_and_save_genesis_keypair(&self.target_path, mithril_era)
@@ -500,8 +497,8 @@ impl UpgradeKeyToDualGenesisSubCommand {
         debug!(root_logger, "UPGRADE-KEY-TO-DUAL GENESIS command");
         println!(
             "Upgrade legacy genesis keypair from {} to dual bundle at {}",
-            self.legacy_secret_key_path.to_string_lossy(),
-            self.target_path.to_string_lossy()
+            self.legacy_secret_key_path.display(),
+            self.target_path.display()
         );
 
         GenesisTools::upgrade_legacy_keypair_to_dual(

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -9,7 +9,7 @@ use slog::{Logger, debug};
 use mithril_cardano_node_chain::chain_observer::ChainObserverType;
 use mithril_common::{
     StdResult,
-    crypto_helper::{GenesisEd25519SecretKey, GenesisEd25519Signer, GenesisEd25519VerificationKey},
+    crypto_helper::{GenesisEd25519VerificationKey, GenesisSigner},
     entities::{HexEncodedGenesisSecretKey, HexEncodedGenesisVerificationKey, SupportedEra},
 };
 use mithril_doc::{Documenter, StructDoc};
@@ -371,10 +371,8 @@ impl BootstrapGenesisSubCommand {
         let genesis_tools = GenesisTools::from_dependencies(dependencies)
             .await
             .with_context(|| "genesis-tools: initialization error")?;
-        let genesis_secret_key =
-            GenesisEd25519SecretKey::from_json_hex(&self.genesis_secret_key)
-                .with_context(|| "json hex decode of genesis secret key failure")?;
-        let genesis_signer = GenesisEd25519Signer::from_secret_key(genesis_secret_key);
+        let genesis_signer = GenesisSigner::try_from_hex(&self.genesis_secret_key)
+            .with_context(|| "hex decode of genesis secret key failure")?;
         genesis_tools
             .bootstrap_test_genesis_certificate(genesis_signer)
             .await
@@ -440,6 +438,19 @@ mod tests {
                 "Should error when multiple eras exist and none is provided"
             );
         }
+    }
+
+    #[test]
+    fn bootstrap_subcommand_parses_era_flag() {
+        let cmd = BootstrapGenesisSubCommand::try_parse_from([
+            "bootstrap",
+            "--genesis-secret-key",
+            "deadbeef",
+            "--mithril-era",
+            &SupportedEra::Lagrange.to_string(),
+        ])
+        .expect("CLI parse should succeed");
+        assert_eq!(cmd.mithril_era, Some(SupportedEra::Lagrange));
     }
 
     #[test]

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -432,6 +432,12 @@ pub struct GenerateKeypairGenesisSubCommand {
     /// Target path for the generated keypair
     #[clap(long)]
     target_path: PathBuf,
+
+    /// Mithril era to use for the generated keypair
+    ///
+    /// Optional when only one era exists, required when multiple eras are supported.
+    #[clap(long)]
+    mithril_era: Option<SupportedEra>,
 }
 
 impl GenerateKeypairGenesisSubCommand {
@@ -441,8 +447,9 @@ impl GenerateKeypairGenesisSubCommand {
             "Genesis generate keypair to {}",
             self.target_path.to_string_lossy()
         );
+        let mithril_era = resolve_mithril_era(self.mithril_era)?;
 
-        GenesisTools::create_and_save_genesis_keypair(&self.target_path, SupportedEra::Pythagoras)
+        GenesisTools::create_and_save_genesis_keypair(&self.target_path, mithril_era)
             .with_context(|| "genesis-tools: keypair generation error")?;
 
         Ok(())
@@ -524,6 +531,26 @@ mod tests {
         ])
         .expect("CLI parse should succeed");
         assert_eq!(cmd.mithril_era, Some(SupportedEra::Lagrange));
+    }
+
+    #[tokio::test]
+    async fn generate_keypair_subcommand_parses_era_flag() {
+        let target = temp_dir!().join("keys");
+        std::fs::create_dir_all(&target).unwrap();
+        let cmd = GenerateKeypairGenesisSubCommand::try_parse_from([
+            "generate-keypair",
+            "--target-path",
+            target.to_str().unwrap(),
+            "--mithril-era",
+            &SupportedEra::Pythagoras.to_string(),
+        ])
+        .unwrap();
+
+        cmd.execute(TestLogger::stdout())
+            .await
+            .expect("generate-keypair should succeed with explicit era");
+        assert!(target.join("genesis.sk").exists());
+        assert!(target.join("genesis.vk").exists());
     }
 
     #[tokio::test]

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -133,15 +133,31 @@ impl GenesisCommand {
     }
 
     pub fn extract_config(command_path: String) -> HashMap<String, StructDoc> {
-        extract_all!(
-            command_path,
-            GenesisSubCommand,
-            Export = { ExportGenesisSubCommand },
-            Import = { ImportGenesisSubCommand },
-            Sign = { SignGenesisSubCommand },
-            Bootstrap = { BootstrapGenesisSubCommand },
-            GenerateKeypair = { GenerateKeypairGenesisSubCommand },
-        )
+        #[cfg(feature = "future_snark")]
+        {
+            extract_all!(
+                command_path,
+                GenesisSubCommand,
+                Export = { ExportGenesisSubCommand },
+                Import = { ImportGenesisSubCommand },
+                Sign = { SignGenesisSubCommand },
+                Bootstrap = { BootstrapGenesisSubCommand },
+                GenerateKeypair = { GenerateKeypairGenesisSubCommand },
+                UpgradeKeyToDual = { UpgradeKeyToDualGenesisSubCommand },
+            )
+        }
+        #[cfg(not(feature = "future_snark"))]
+        {
+            extract_all!(
+                command_path,
+                GenesisSubCommand,
+                Export = { ExportGenesisSubCommand },
+                Import = { ImportGenesisSubCommand },
+                Sign = { SignGenesisSubCommand },
+                Bootstrap = { BootstrapGenesisSubCommand },
+                GenerateKeypair = { GenerateKeypairGenesisSubCommand },
+            )
+        }
     }
 }
 
@@ -162,6 +178,10 @@ pub enum GenesisSubCommand {
 
     /// Genesis keypair generation command.
     GenerateKeypair(GenerateKeypairGenesisSubCommand),
+
+    /// Upgrade a legacy single-Ed25519 genesis keypair into a dual signing/verification bundle.
+    #[cfg(feature = "future_snark")]
+    UpgradeKeyToDual(UpgradeKeyToDualGenesisSubCommand),
 }
 
 impl GenesisSubCommand {
@@ -176,6 +196,8 @@ impl GenesisSubCommand {
             Self::Import(cmd) => cmd.execute(root_logger, config_builder).await,
             Self::Sign(cmd) => cmd.execute(root_logger).await,
             Self::GenerateKeypair(cmd) => cmd.execute(root_logger).await,
+            #[cfg(feature = "future_snark")]
+            Self::UpgradeKeyToDual(cmd) => cmd.execute(root_logger).await,
         }
     }
 }
@@ -460,11 +482,52 @@ impl GenerateKeypairGenesisSubCommand {
     }
 }
 
+/// Upgrade a legacy single-Ed25519 genesis keypair into a dual signing/verification bundle.
+#[cfg(feature = "future_snark")]
+#[derive(Parser, Debug, Clone)]
+pub struct UpgradeKeyToDualGenesisSubCommand {
+    /// Legacy single-Ed25519 secret key file (genesis.sk).
+    #[clap(long)]
+    legacy_secret_key_path: PathBuf,
+
+    /// Target path for the dual signing/verification bundle files.
+    #[clap(long)]
+    target_path: PathBuf,
+}
+
+#[cfg(feature = "future_snark")]
+impl UpgradeKeyToDualGenesisSubCommand {
+    pub async fn execute(&self, root_logger: Logger) -> StdResult<()> {
+        debug!(root_logger, "UPGRADE-KEY-TO-DUAL GENESIS command");
+        println!(
+            "Upgrade legacy genesis keypair from {} to dual bundle at {}",
+            self.legacy_secret_key_path.to_string_lossy(),
+            self.target_path.to_string_lossy()
+        );
+
+        GenesisTools::upgrade_legacy_keypair_to_dual(
+            &self.legacy_secret_key_path,
+            &self.target_path,
+        )
+        .with_context(|| "genesis-tools: upgrade-key-to-dual error")?;
+
+        Ok(())
+    }
+
+    pub fn extract_config(_parent: String) -> HashMap<String, StructDoc> {
+        HashMap::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
+    #[cfg(feature = "future_snark")]
+    use mithril_common::crypto_helper::GenesisEd25519Signer;
     use mithril_common::temp_dir;
+    #[cfg(feature = "future_snark")]
+    use mithril_common::temp_dir_create;
 
     use crate::test::TestLogger;
 
@@ -549,6 +612,32 @@ mod tests {
         cmd.execute(TestLogger::stdout())
             .await
             .expect("generate-keypair should succeed with explicit era");
+        assert!(target.join("genesis.sk").exists());
+        assert!(target.join("genesis.vk").exists());
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[tokio::test]
+    async fn upgrade_key_to_dual_subcommand_writes_bundle_files() {
+        let temp = temp_dir_create!();
+        let legacy_path = temp.join("genesis.sk");
+        let signer = GenesisEd25519Signer::create_deterministic_signer();
+        signer.secret_key().write_json_hex_to_file(&legacy_path).unwrap();
+        let target = temp.join("out");
+        std::fs::create_dir_all(&target).unwrap();
+
+        let cmd = UpgradeKeyToDualGenesisSubCommand::try_parse_from([
+            "upgrade-key-to-dual",
+            "--legacy-secret-key-path",
+            legacy_path.to_str().unwrap(),
+            "--target-path",
+            target.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        cmd.execute(TestLogger::stdout())
+            .await
+            .expect("upgrade should succeed");
         assert!(target.join("genesis.sk").exists());
         assert!(target.join("genesis.vk").exists());
     }

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -592,7 +592,7 @@ mod tests {
                 .expect("Chain should have at least one certificate")
                 .clone();
             certificate.aggregate_verification_key_snark = None;
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
 
             let record: CertificateRecord = certificate.clone().try_into().unwrap();
             assert!(record.aggregate_verification_key_snark.is_none());
@@ -646,7 +646,7 @@ mod tests {
                 .expect("Schnorr sign should not fail");
             certificate.signature =
                 CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature);
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
             certificate
         }
 

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 
 use mithril_common::StdError;
+#[cfg(feature = "future_snark")]
+use mithril_common::crypto_helper::{schnorr_signature_from_hex, schnorr_signature_to_hex};
 use mithril_common::entities::{
     Certificate, CertificateMetadata, CertificateSignature, Epoch,
     HexEncodedAggregateVerificationKey, HexEncodedKey, HexEncodedVerificationKeyForSnark,
@@ -19,6 +21,70 @@ use mithril_persistence::{
     database::Hydrator,
     sqlite::{HydrationError, Projection, SqLiteEntity},
 };
+#[cfg(feature = "future_snark")]
+use serde::{Deserialize, Serialize};
+
+/// JSON-serialised wrapper holding both signatures of a Lagrange-era dual genesis signature.
+///
+/// Stored in the `signature` column so the SQLite round-trip preserves the SNARK half. Legacy
+/// Pythagoras records keep the raw Ed25519 hex string in the same column; deserialisation
+/// attempts this JSON wrapper first and falls back to the raw hex when the input is not JSON.
+#[cfg(feature = "future_snark")]
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PersistedDualGenesisSignature {
+    /// Hex-encoded Ed25519 (ed25519) genesis signature.
+    ed25519: HexEncodedKey,
+
+    /// Hex-encoded SNARK-friendly Schnorr genesis signature.
+    schnorr: HexEncodedKey,
+}
+
+/// Wire-format signature of a [CertificateMessage] reconstructed from a stored [CertificateRecord].
+///
+/// A stored certificate carries exactly one of these signature shapes, so the variants are
+/// mutually exclusive by construction.
+#[cfg(feature = "future_snark")]
+enum PersistedRecordSignatures {
+    /// Multi-signature carried by a standard (non-genesis) certificate.
+    MultiSignature(HexEncodedKey),
+
+    /// Legacy Pythagoras-era genesis signature (Ed25519 only).
+    Genesis(HexEncodedKey),
+
+    /// Lagrange-era dual genesis signature pairing the Ed25519 and Schnorr halves.
+    GenesisDual(PersistedDualGenesisSignature),
+}
+
+#[cfg(feature = "future_snark")]
+impl PersistedDualGenesisSignature {
+    /// Parse a persisted genesis signature column value.
+    ///
+    /// Attempts to decode the JSON wrapper (Lagrange dual signature) and falls back to the raw
+    /// Ed25519 hex string used by Pythagoras-era records.
+    fn parse_genesis_signature(raw: &str) -> Result<CertificateSignature, StdError> {
+        if let Ok(payload) = serde_json::from_str::<Self>(raw) {
+            let ed25519 = payload.ed25519.as_str().try_into()?;
+            let schnorr = schnorr_signature_from_hex(&payload.schnorr)?;
+            return Ok(CertificateSignature::GenesisDualSignature(ed25519, schnorr));
+        }
+        Ok(CertificateSignature::GenesisSignature(raw.try_into()?))
+    }
+
+    /// Split a stored certificate record into its wire-format signature.
+    ///
+    /// Recovers the SNARK half from the JSON wrapper when present; otherwise treats the value as
+    /// a legacy Ed25519-only genesis signature or a multi-signature, depending on the record.
+    fn split_message_signatures(record: &CertificateRecord) -> PersistedRecordSignatures {
+        if record.parent_certificate_id.is_some() {
+            return PersistedRecordSignatures::MultiSignature(record.signature.clone());
+        }
+        if let Ok(payload) = serde_json::from_str::<Self>(&record.signature) {
+            return PersistedRecordSignatures::GenesisDual(payload);
+        }
+        PersistedRecordSignatures::Genesis(record.signature.clone())
+    }
+}
 
 /// Certificate record is the representation of a stored certificate.
 #[derive(Debug, PartialEq, Clone)]
@@ -138,6 +204,14 @@ impl TryFrom<Certificate> for CertificateRecord {
         let signed_entity_type = other.signed_entity_type();
         let (signature, parent_certificate_id) = match other.signature {
             CertificateSignature::GenesisSignature(signature) => (signature.to_bytes_hex()?, None),
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature) => {
+                let payload = PersistedDualGenesisSignature {
+                    ed25519: ed_signature.to_bytes_hex()?,
+                    schnorr: schnorr_signature_to_hex(&schnorr_signature),
+                };
+                (serde_json::to_string(&payload)?, None)
+            }
             CertificateSignature::MultiSignature(_, signature) => {
                 (signature.to_json_hex()?, Some(other.previous_hash))
             }
@@ -187,10 +261,15 @@ impl TryFrom<CertificateRecord> for Certificate {
             other.signers,
         );
         let (previous_hash, signature) = match other.parent_certificate_id {
-            None => (
-                String::new(),
-                CertificateSignature::GenesisSignature(other.signature.try_into()?),
-            ),
+            None => {
+                #[cfg(feature = "future_snark")]
+                let signature =
+                    PersistedDualGenesisSignature::parse_genesis_signature(&other.signature)?;
+                #[cfg(not(feature = "future_snark"))]
+                let signature =
+                    CertificateSignature::GenesisSignature(other.signature.as_str().try_into()?);
+                (String::new(), signature)
+            }
             Some(parent_certificate_id) => (
                 parent_certificate_id,
                 CertificateSignature::MultiSignature(
@@ -225,6 +304,25 @@ impl TryFrom<CertificateRecord> for Certificate {
 
 impl From<CertificateRecord> for CertificateMessage {
     fn from(value: CertificateRecord) -> Self {
+        #[cfg(feature = "future_snark")]
+        let (multi_signature, genesis_signature, genesis_schnorr_signature) =
+            match PersistedDualGenesisSignature::split_message_signatures(&value) {
+                PersistedRecordSignatures::MultiSignature(signature) => {
+                    (signature, String::new(), String::new())
+                }
+                PersistedRecordSignatures::Genesis(signature) => {
+                    (String::new(), signature, String::new())
+                }
+                PersistedRecordSignatures::GenesisDual(payload) => {
+                    (String::new(), payload.ed25519, payload.schnorr)
+                }
+            };
+        #[cfg(not(feature = "future_snark"))]
+        let (multi_signature, genesis_signature) = if value.parent_certificate_id.is_none() {
+            (String::new(), value.signature.clone())
+        } else {
+            (value.signature.clone(), String::new())
+        };
         let metadata = CertificateMetadataMessagePart {
             network: value.network,
             protocol_version: value.protocol_version,
@@ -232,11 +330,6 @@ impl From<CertificateRecord> for CertificateMessage {
             initiated_at: value.initiated_at,
             sealed_at: value.sealed_at,
             signers: value.signers,
-        };
-        let (multi_signature, genesis_signature) = if value.parent_certificate_id.is_none() {
-            (String::new(), value.signature)
-        } else {
-            (value.signature, String::new())
         };
 
         CertificateMessage {
@@ -252,6 +345,8 @@ impl From<CertificateRecord> for CertificateMessage {
             aggregate_verification_key_snark: value.aggregate_verification_key_snark,
             multi_signature,
             genesis_signature,
+            #[cfg(feature = "future_snark")]
+            genesis_schnorr_signature,
         }
     }
 }
@@ -524,6 +619,112 @@ mod tests {
             let message: CertificateMessage = record.into();
 
             assert_eq!(expected_snark_avk, message.aggregate_verification_key_snark,);
+        }
+    }
+
+    #[cfg(feature = "future_snark")]
+    mod dual_genesis_signature {
+        use mithril_common::crypto_helper::{GenesisEd25519Signer, GenesisSchnorrSigner};
+        use mithril_common::entities::CertificateSignature;
+
+        use super::*;
+
+        fn build_dual_genesis_certificate() -> Certificate {
+            let chain = setup_certificate_chain(5, 2);
+            let mut certificate = chain
+                .certificates_chained
+                .iter()
+                .rev()
+                .find(|c| matches!(c.signature, CertificateSignature::GenesisSignature(_)))
+                .expect("chain should contain a genesis certificate")
+                .clone();
+            let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
+            let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+            let ed_signature = ed25519_signer.sign(certificate.signed_message.as_bytes());
+            let schnorr_signature = schnorr_signer
+                .sign_non_deterministic(&[0x42u8; 32])
+                .expect("Schnorr sign should not fail");
+            certificate.signature =
+                CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature);
+            certificate.hash = certificate.compute_hash();
+            certificate
+        }
+
+        #[test]
+        fn certificate_to_record_to_certificate_preserves_dual_signature() {
+            let certificate = build_dual_genesis_certificate();
+            let (expected_ed25519, expected_schnorr) = match &certificate.signature {
+                CertificateSignature::GenesisDualSignature(ed, schnorr) => (
+                    ed.to_bytes_hex().unwrap(),
+                    schnorr_signature_to_hex(schnorr),
+                ),
+                other => panic!("expected GenesisDualSignature, got {other:?}"),
+            };
+
+            let record: CertificateRecord = certificate.clone().try_into().unwrap();
+            let restored: Certificate = record.try_into().unwrap();
+
+            match &restored.signature {
+                CertificateSignature::GenesisDualSignature(ed, schnorr) => {
+                    assert_eq!(ed.to_bytes_hex().unwrap(), expected_ed25519);
+                    assert_eq!(schnorr_signature_to_hex(schnorr), expected_schnorr);
+                }
+                other => {
+                    panic!(
+                        "expected the restored signature to be a GenesisDualSignature, got {other:?}"
+                    )
+                }
+            }
+            assert_eq!(certificate, restored);
+        }
+
+        #[test]
+        fn certificate_record_serialises_dual_signature_as_json_wrapper() {
+            let certificate = build_dual_genesis_certificate();
+
+            let record: CertificateRecord = certificate.try_into().unwrap();
+
+            assert!(
+                record.signature.starts_with('{'),
+                "dual genesis record signature column must hold the JSON wrapper, got: {}",
+                record.signature
+            );
+        }
+
+        #[test]
+        fn certificate_message_carries_both_genesis_signatures_for_dual_record() {
+            let certificate = build_dual_genesis_certificate();
+            let (expected_ed25519, expected_schnorr) = match &certificate.signature {
+                CertificateSignature::GenesisDualSignature(ed, schnorr) => (
+                    ed.to_bytes_hex().unwrap(),
+                    schnorr_signature_to_hex(schnorr),
+                ),
+                other => panic!("expected GenesisDualSignature, got {other:?}"),
+            };
+
+            let record: CertificateRecord = certificate.try_into().unwrap();
+            let message: CertificateMessage = record.into();
+
+            assert_eq!(message.genesis_signature, expected_ed25519);
+            assert_eq!(message.genesis_schnorr_signature, expected_schnorr);
+            assert!(message.multi_signature.is_empty());
+        }
+
+        #[test]
+        fn legacy_pythagoras_record_still_round_trips_without_wrapper() {
+            let chain = setup_certificate_chain(5, 2);
+            let pythagoras_genesis = chain
+                .certificates_chained
+                .iter()
+                .find(|c| matches!(c.signature, CertificateSignature::GenesisSignature(_)))
+                .expect("chain should contain a genesis certificate")
+                .clone();
+
+            let record: CertificateRecord = pythagoras_genesis.clone().try_into().unwrap();
+            assert!(!record.signature.starts_with('{'));
+            let restored: Certificate = record.try_into().unwrap();
+
+            assert_eq!(pythagoras_genesis, restored);
         }
     }
 }

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -71,18 +71,22 @@ impl PersistedDualGenesisSignature {
         Ok(CertificateSignature::GenesisSignature(raw.try_into()?))
     }
 
-    /// Split a stored certificate record into its wire-format signature.
+    /// Classify a stored signature column value into its wire-format shape.
     ///
     /// Recovers the SNARK half from the JSON wrapper when present; otherwise treats the value as
-    /// a legacy Ed25519-only genesis signature or a multi-signature, depending on the record.
-    fn split_message_signatures(record: &CertificateRecord) -> PersistedRecordSignatures {
-        if record.parent_certificate_id.is_some() {
-            return PersistedRecordSignatures::MultiSignature(record.signature.clone());
+    /// a legacy Ed25519-only genesis signature, or a multi-signature when the record has a parent.
+    /// Takes the signature by value so the caller can move it in, avoiding a clone per certificate.
+    fn split_message_signatures(
+        have_parent: bool,
+        signature: HexEncodedKey,
+    ) -> PersistedRecordSignatures {
+        if have_parent {
+            PersistedRecordSignatures::MultiSignature(signature)
+        } else if let Ok(payload) = serde_json::from_str::<Self>(&signature) {
+            PersistedRecordSignatures::GenesisDual(payload)
+        } else {
+            PersistedRecordSignatures::Genesis(signature)
         }
-        if let Ok(payload) = serde_json::from_str::<Self>(&record.signature) {
-            return PersistedRecordSignatures::GenesisDual(payload);
-        }
-        PersistedRecordSignatures::Genesis(record.signature.clone())
     }
 }
 
@@ -306,7 +310,10 @@ impl From<CertificateRecord> for CertificateMessage {
     fn from(value: CertificateRecord) -> Self {
         #[cfg(feature = "future_snark")]
         let (multi_signature, genesis_signature, genesis_schnorr_signature) =
-            match PersistedDualGenesisSignature::split_message_signatures(&value) {
+            match PersistedDualGenesisSignature::split_message_signatures(
+                value.parent_certificate_id.is_some(),
+                value.signature,
+            ) {
                 PersistedRecordSignatures::MultiSignature(signature) => {
                     (signature, String::new(), String::new())
                 }
@@ -319,9 +326,9 @@ impl From<CertificateRecord> for CertificateMessage {
             };
         #[cfg(not(feature = "future_snark"))]
         let (multi_signature, genesis_signature) = if value.parent_certificate_id.is_none() {
-            (String::new(), value.signature.clone())
+            (String::new(), value.signature)
         } else {
-            (value.signature.clone(), String::new())
+            (value.signature, String::new())
         };
         let metadata = CertificateMetadataMessagePart {
             network: value.network,

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -25,6 +25,8 @@ use mithril_cardano_node_internal_database::{
     ImmutableFileObserver,
     digesters::{ImmutableDigester, cache::ImmutableFileDigestCacheProvider},
 };
+#[cfg(feature = "future_snark")]
+use mithril_common::crypto_helper::GenesisSchnorrVerifier;
 use mithril_common::{
     api_version::APIVersionProvider,
     certificate_chain::CertificateVerifier,
@@ -191,6 +193,13 @@ pub struct DependenciesBuilder {
     /// Genesis signature verifier service.
     pub genesis_verifier: Option<Arc<GenesisEd25519Verifier>>,
 
+    /// SNARK-friendly genesis signature verifier service.
+    ///
+    /// `None` when the configured verification key is the legacy single-Ed25519 file; `Some`
+    /// when the configured verification key is a dual signing bundle.
+    #[cfg(feature = "future_snark")]
+    pub genesis_schnorr_verifier: Option<Option<Arc<GenesisSchnorrVerifier>>>,
+
     /// Certificate chain synchronizer service
     pub certificate_chain_synchronizer: Option<Arc<dyn CertificateChainSynchronizer>>,
 
@@ -327,6 +336,8 @@ impl DependenciesBuilder {
             snapshotter: None,
             certificate_verifier: None,
             genesis_verifier: None,
+            #[cfg(feature = "future_snark")]
+            genesis_schnorr_verifier: None,
             certificate_chain_synchronizer: None,
             mithril_signer_registration_leader: None,
             mithril_signer_registration_follower: None,

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -25,12 +25,10 @@ use mithril_cardano_node_internal_database::{
     ImmutableFileObserver,
     digesters::{ImmutableDigester, cache::ImmutableFileDigestCacheProvider},
 };
-#[cfg(feature = "future_snark")]
-use mithril_common::crypto_helper::GenesisSchnorrVerifier;
 use mithril_common::{
     api_version::APIVersionProvider,
     certificate_chain::CertificateVerifier,
-    crypto_helper::GenesisEd25519Verifier,
+    crypto_helper::GenesisVerifier,
     entities::SupportedEra,
     signable_builder::{SignableBuilderService, SignableSeedBuilder},
 };
@@ -191,14 +189,7 @@ pub struct DependenciesBuilder {
     pub certificate_verifier: Option<Arc<dyn CertificateVerifier>>,
 
     /// Genesis signature verifier service.
-    pub genesis_verifier: Option<Arc<GenesisEd25519Verifier>>,
-
-    /// SNARK-friendly genesis signature verifier service.
-    ///
-    /// `None` when the configured verification key is the legacy single-Ed25519 file; `Some`
-    /// when the configured verification key is a dual signing bundle.
-    #[cfg(feature = "future_snark")]
-    pub genesis_schnorr_verifier: Option<Option<Arc<GenesisSchnorrVerifier>>>,
+    pub genesis_verifier: Option<Arc<GenesisVerifier>>,
 
     /// Certificate chain synchronizer service
     pub certificate_chain_synchronizer: Option<Arc<dyn CertificateChainSynchronizer>>,
@@ -336,8 +327,6 @@ impl DependenciesBuilder {
             snapshotter: None,
             certificate_verifier: None,
             genesis_verifier: None,
-            #[cfg(feature = "future_snark")]
-            genesis_schnorr_verifier: None,
             certificate_chain_synchronizer: None,
             mithril_signer_registration_leader: None,
             mithril_signer_registration_follower: None,

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
@@ -5,6 +5,10 @@ use mithril_common::certificate_chain::{CertificateVerifier, MithrilCertificateV
 use mithril_common::crypto_helper::{
     GenesisEd25519Signer, GenesisEd25519VerificationKey, GenesisEd25519Verifier,
 };
+#[cfg(feature = "future_snark")]
+use mithril_common::crypto_helper::{
+    GenesisSchnorrSigner, GenesisSchnorrVerifier, GenesisVerificationKeyBundle,
+};
 
 use crate::database::repository::{BufferedSingleSignatureRepository, SingleSignatureRepository};
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
@@ -138,27 +142,91 @@ impl DependenciesBuilder {
 
     async fn build_genesis_verifier(&mut self) -> Result<Arc<GenesisEd25519Verifier>> {
         let genesis_verifier: GenesisEd25519Verifier = match self.configuration.environment() {
-            ExecutionEnvironment::Production => GenesisEd25519Verifier::from_verification_key(
-                GenesisEd25519VerificationKey::from_json_hex(
-                    &self.configuration.genesis_verification_key(),
-                )
-                .map_err(|e| DependenciesBuilderError::Initialization {
-                    message: format!(
-                        "Could not decode hex key to build genesis verifier: '{}'",
-                        self.configuration.genesis_verification_key()
-                    ),
-                    error: Some(e),
-                })?,
-            ),
+            ExecutionEnvironment::Production => {
+                let concatenation_verification_key =
+                    self.parse_concatenation_genesis_verification_key()?;
+                GenesisEd25519Verifier::from_verification_key(concatenation_verification_key)
+            }
             _ => GenesisEd25519Signer::create_deterministic_signer().create_verifier(),
         };
 
         Ok(Arc::new(genesis_verifier))
     }
 
+    fn parse_concatenation_genesis_verification_key(
+        &self,
+    ) -> Result<GenesisEd25519VerificationKey> {
+        let raw_verification_key = self.configuration.genesis_verification_key();
+        #[cfg(feature = "future_snark")]
+        {
+            let bundle = GenesisVerificationKeyBundle::try_from_hex_or_legacy(
+                &raw_verification_key,
+            )
+            .map_err(|e| DependenciesBuilderError::Initialization {
+                message: format!(
+                    "Could not decode genesis verification key bundle: '{raw_verification_key}'"
+                ),
+                error: Some(e),
+            })?;
+            Ok(bundle.ed25519)
+        }
+        #[cfg(not(feature = "future_snark"))]
+        {
+            GenesisEd25519VerificationKey::from_json_hex(&raw_verification_key)
+                .map_err(|e| DependenciesBuilderError::Initialization {
+                    message: format!(
+                        "Could not decode hex key to build genesis verifier: '{raw_verification_key}'"
+                    ),
+                    error: Some(e),
+                })
+        }
+    }
+
     /// Return a [GenesisEd25519Verifier]
     pub async fn get_genesis_verifier(&mut self) -> Result<Arc<GenesisEd25519Verifier>> {
         get_dependency!(self.genesis_verifier)
+    }
+
+    /// Build the optional SNARK-friendly genesis verifier.
+    ///
+    /// Returns `Some` when the configured verification key is a dual signing bundle, `None` when
+    /// it is the legacy single-Ed25519 file. In non-production environments a fresh SNARK
+    /// verifier is generated on demand to keep dev/test parity with production.
+    #[cfg(feature = "future_snark")]
+    async fn build_genesis_schnorr_verifier(
+        &mut self,
+    ) -> Result<Option<Arc<GenesisSchnorrVerifier>>> {
+        let snark_verifier = match self.configuration.environment() {
+            ExecutionEnvironment::Production => {
+                let raw_verification_key = self.configuration.genesis_verification_key();
+                let bundle = GenesisVerificationKeyBundle::try_from_hex_or_legacy(
+                    &raw_verification_key,
+                )
+                .map_err(|e| DependenciesBuilderError::Initialization {
+                    message: format!(
+                        "Could not decode genesis verification key bundle: '{raw_verification_key}'"
+                    ),
+                    error: Some(e),
+                })?;
+                bundle
+                    .schnorr
+                    .map(|key| Arc::new(GenesisSchnorrVerifier::from_verification_key(key)))
+            }
+            _ => Some(Arc::new(
+                GenesisSchnorrSigner::create_non_deterministic_signer().create_verifier(),
+            )),
+        };
+
+        Ok(snark_verifier)
+    }
+
+    /// Return the optional [GenesisSchnorrVerifier], `None` when only the legacy
+    /// single-Ed25519 verification key is configured.
+    #[cfg(feature = "future_snark")]
+    pub async fn get_genesis_schnorr_verifier(
+        &mut self,
+    ) -> Result<Option<Arc<GenesisSchnorrVerifier>>> {
+        get_dependency!(self.genesis_schnorr_verifier)
     }
 
     /// Return a [MithrilSignerRegistrationLeader] service
@@ -252,5 +320,117 @@ impl DependenciesBuilder {
         &mut self,
     ) -> Result<Arc<SingleSignatureAuthenticator>> {
         get_dependency!(self.single_signature_authenticator)
+    }
+}
+
+#[cfg(all(test, feature = "future_snark"))]
+mod tests {
+    use mithril_common::crypto_helper::{GenesisSchnorrSigner, ProtocolKey};
+    use mithril_common::temp_dir;
+
+    use crate::configuration::ServeCommandConfiguration;
+
+    use super::*;
+
+    fn dual_bundle_hex() -> (String, GenesisSchnorrVerifier) {
+        let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
+        let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+        let verification_key_bundle = GenesisVerificationKeyBundle::new(
+            ed25519_signer.verification_key(),
+            schnorr_signer.verification_key(),
+        );
+        let hex_string = ProtocolKey::new(verification_key_bundle).to_bytes_hex().unwrap();
+        (hex_string, schnorr_signer.create_verifier())
+    }
+
+    fn production_config_with_genesis_key(
+        genesis_verification_key: String,
+    ) -> ServeCommandConfiguration {
+        ServeCommandConfiguration {
+            environment: ExecutionEnvironment::Production,
+            genesis_verification_key,
+            ..ServeCommandConfiguration::new_sample(temp_dir!())
+        }
+    }
+
+    #[tokio::test]
+    async fn build_genesis_verifier_accepts_a_legacy_single_ed25519_key_in_production() {
+        let mut dep_builder = {
+            let config = ServeCommandConfiguration {
+                environment: ExecutionEnvironment::Production,
+                ..ServeCommandConfiguration::new_sample(temp_dir!())
+            };
+            DependenciesBuilder::new_with_stdout_logger(Arc::new(config))
+        };
+
+        dep_builder
+            .build_genesis_verifier()
+            .await
+            .expect("legacy single-Ed25519 verification key must be accepted in production");
+    }
+
+    #[tokio::test]
+    async fn build_genesis_verifier_accepts_a_dual_bundle_key_in_production() {
+        let (bundle_hex, _) = dual_bundle_hex();
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(
+            production_config_with_genesis_key(bundle_hex),
+        ));
+
+        dep_builder
+            .build_genesis_verifier()
+            .await
+            .expect("dual verification key bundle must be accepted in production");
+    }
+
+    #[tokio::test]
+    async fn build_genesis_schnorr_verifier_returns_none_for_a_legacy_key_in_production() {
+        let mut dep_builder = {
+            let config = ServeCommandConfiguration {
+                environment: ExecutionEnvironment::Production,
+                ..ServeCommandConfiguration::new_sample(temp_dir!())
+            };
+            DependenciesBuilder::new_with_stdout_logger(Arc::new(config))
+        };
+
+        let snark_verifier = dep_builder.build_genesis_schnorr_verifier().await.unwrap();
+
+        assert!(
+            snark_verifier.is_none(),
+            "legacy single-Ed25519 verification key must yield no SNARK verifier"
+        );
+    }
+
+    #[tokio::test]
+    async fn build_genesis_schnorr_verifier_returns_some_for_a_dual_bundle_in_production() {
+        let (bundle_hex, expected_snark_verifier) = dual_bundle_hex();
+        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(
+            production_config_with_genesis_key(bundle_hex),
+        ));
+
+        let snark_verifier = dep_builder
+            .build_genesis_schnorr_verifier()
+            .await
+            .unwrap()
+            .expect("dual bundle must yield a SNARK verifier");
+
+        assert_eq!(
+            snark_verifier.to_verification_key().to_bytes(),
+            expected_snark_verifier.to_verification_key().to_bytes(),
+        );
+    }
+
+    #[tokio::test]
+    async fn build_genesis_schnorr_verifier_returns_some_in_non_production_environment() {
+        let mut dep_builder = {
+            let config = ServeCommandConfiguration::new_sample(temp_dir!());
+            DependenciesBuilder::new_with_stdout_logger(Arc::new(config))
+        };
+
+        let snark_verifier = dep_builder.build_genesis_schnorr_verifier().await.unwrap();
+
+        assert!(
+            snark_verifier.is_some(),
+            "non-production environment must auto-generate a SNARK verifier"
+        );
     }
 }

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
@@ -2,13 +2,7 @@ use anyhow::Context;
 use std::sync::Arc;
 
 use mithril_common::certificate_chain::{CertificateVerifier, MithrilCertificateVerifier};
-use mithril_common::crypto_helper::{
-    GenesisEd25519Signer, GenesisEd25519VerificationKey, GenesisEd25519Verifier,
-};
-#[cfg(feature = "future_snark")]
-use mithril_common::crypto_helper::{
-    GenesisSchnorrSigner, GenesisSchnorrVerifier, GenesisVerificationKeyBundle,
-};
+use mithril_common::crypto_helper::GenesisVerifier;
 
 use crate::database::repository::{BufferedSingleSignatureRepository, SingleSignatureRepository};
 use crate::dependency_injection::{DependenciesBuilder, DependenciesBuilderError, Result};
@@ -140,93 +134,28 @@ impl DependenciesBuilder {
         get_dependency!(self.certificate_verifier)
     }
 
-    async fn build_genesis_verifier(&mut self) -> Result<Arc<GenesisEd25519Verifier>> {
-        let genesis_verifier: GenesisEd25519Verifier = match self.configuration.environment() {
+    async fn build_genesis_verifier(&mut self) -> Result<Arc<GenesisVerifier>> {
+        let genesis_verifier = match self.configuration.environment() {
             ExecutionEnvironment::Production => {
-                let concatenation_verification_key =
-                    self.parse_concatenation_genesis_verification_key()?;
-                GenesisEd25519Verifier::from_verification_key(concatenation_verification_key)
+                let raw_verification_key = self.configuration.genesis_verification_key();
+                GenesisVerifier::try_from_hex(&raw_verification_key).map_err(|e| {
+                    DependenciesBuilderError::Initialization {
+                        message: format!(
+                            "Could not decode genesis verification key bundle: '{raw_verification_key}'"
+                        ),
+                        error: Some(e),
+                    }
+                })?
             }
-            _ => GenesisEd25519Signer::create_deterministic_signer().create_verifier(),
+            _ => GenesisVerifier::create_deterministic_verifier(),
         };
 
         Ok(Arc::new(genesis_verifier))
     }
 
-    fn parse_concatenation_genesis_verification_key(
-        &self,
-    ) -> Result<GenesisEd25519VerificationKey> {
-        let raw_verification_key = self.configuration.genesis_verification_key();
-        #[cfg(feature = "future_snark")]
-        {
-            let bundle = GenesisVerificationKeyBundle::try_from_hex_or_legacy(
-                &raw_verification_key,
-            )
-            .map_err(|e| DependenciesBuilderError::Initialization {
-                message: format!(
-                    "Could not decode genesis verification key bundle: '{raw_verification_key}'"
-                ),
-                error: Some(e),
-            })?;
-            Ok(bundle.ed25519)
-        }
-        #[cfg(not(feature = "future_snark"))]
-        {
-            GenesisEd25519VerificationKey::from_json_hex(&raw_verification_key)
-                .map_err(|e| DependenciesBuilderError::Initialization {
-                    message: format!(
-                        "Could not decode hex key to build genesis verifier: '{raw_verification_key}'"
-                    ),
-                    error: Some(e),
-                })
-        }
-    }
-
-    /// Return a [GenesisEd25519Verifier]
-    pub async fn get_genesis_verifier(&mut self) -> Result<Arc<GenesisEd25519Verifier>> {
+    /// Return the [GenesisVerifier]
+    pub async fn get_genesis_verifier(&mut self) -> Result<Arc<GenesisVerifier>> {
         get_dependency!(self.genesis_verifier)
-    }
-
-    /// Build the optional SNARK-friendly genesis verifier.
-    ///
-    /// Returns `Some` when the configured verification key is a dual signing bundle, `None` when
-    /// it is the legacy single-Ed25519 file. In non-production environments a fresh SNARK
-    /// verifier is generated on demand to keep dev/test parity with production.
-    #[cfg(feature = "future_snark")]
-    async fn build_genesis_schnorr_verifier(
-        &mut self,
-    ) -> Result<Option<Arc<GenesisSchnorrVerifier>>> {
-        let snark_verifier = match self.configuration.environment() {
-            ExecutionEnvironment::Production => {
-                let raw_verification_key = self.configuration.genesis_verification_key();
-                let bundle = GenesisVerificationKeyBundle::try_from_hex_or_legacy(
-                    &raw_verification_key,
-                )
-                .map_err(|e| DependenciesBuilderError::Initialization {
-                    message: format!(
-                        "Could not decode genesis verification key bundle: '{raw_verification_key}'"
-                    ),
-                    error: Some(e),
-                })?;
-                bundle
-                    .schnorr
-                    .map(|key| Arc::new(GenesisSchnorrVerifier::from_verification_key(key)))
-            }
-            _ => Some(Arc::new(
-                GenesisSchnorrSigner::create_non_deterministic_signer().create_verifier(),
-            )),
-        };
-
-        Ok(snark_verifier)
-    }
-
-    /// Return the optional [GenesisSchnorrVerifier], `None` when only the legacy
-    /// single-Ed25519 verification key is configured.
-    #[cfg(feature = "future_snark")]
-    pub async fn get_genesis_schnorr_verifier(
-        &mut self,
-    ) -> Result<Option<Arc<GenesisSchnorrVerifier>>> {
-        get_dependency!(self.genesis_schnorr_verifier)
     }
 
     /// Return a [MithrilSignerRegistrationLeader] service
@@ -320,117 +249,5 @@ impl DependenciesBuilder {
         &mut self,
     ) -> Result<Arc<SingleSignatureAuthenticator>> {
         get_dependency!(self.single_signature_authenticator)
-    }
-}
-
-#[cfg(all(test, feature = "future_snark"))]
-mod tests {
-    use mithril_common::crypto_helper::{GenesisSchnorrSigner, ProtocolKey};
-    use mithril_common::temp_dir;
-
-    use crate::configuration::ServeCommandConfiguration;
-
-    use super::*;
-
-    fn dual_bundle_hex() -> (String, GenesisSchnorrVerifier) {
-        let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
-        let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
-        let verification_key_bundle = GenesisVerificationKeyBundle::new(
-            ed25519_signer.verification_key(),
-            schnorr_signer.verification_key(),
-        );
-        let hex_string = ProtocolKey::new(verification_key_bundle).to_bytes_hex().unwrap();
-        (hex_string, schnorr_signer.create_verifier())
-    }
-
-    fn production_config_with_genesis_key(
-        genesis_verification_key: String,
-    ) -> ServeCommandConfiguration {
-        ServeCommandConfiguration {
-            environment: ExecutionEnvironment::Production,
-            genesis_verification_key,
-            ..ServeCommandConfiguration::new_sample(temp_dir!())
-        }
-    }
-
-    #[tokio::test]
-    async fn build_genesis_verifier_accepts_a_legacy_single_ed25519_key_in_production() {
-        let mut dep_builder = {
-            let config = ServeCommandConfiguration {
-                environment: ExecutionEnvironment::Production,
-                ..ServeCommandConfiguration::new_sample(temp_dir!())
-            };
-            DependenciesBuilder::new_with_stdout_logger(Arc::new(config))
-        };
-
-        dep_builder
-            .build_genesis_verifier()
-            .await
-            .expect("legacy single-Ed25519 verification key must be accepted in production");
-    }
-
-    #[tokio::test]
-    async fn build_genesis_verifier_accepts_a_dual_bundle_key_in_production() {
-        let (bundle_hex, _) = dual_bundle_hex();
-        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(
-            production_config_with_genesis_key(bundle_hex),
-        ));
-
-        dep_builder
-            .build_genesis_verifier()
-            .await
-            .expect("dual verification key bundle must be accepted in production");
-    }
-
-    #[tokio::test]
-    async fn build_genesis_schnorr_verifier_returns_none_for_a_legacy_key_in_production() {
-        let mut dep_builder = {
-            let config = ServeCommandConfiguration {
-                environment: ExecutionEnvironment::Production,
-                ..ServeCommandConfiguration::new_sample(temp_dir!())
-            };
-            DependenciesBuilder::new_with_stdout_logger(Arc::new(config))
-        };
-
-        let snark_verifier = dep_builder.build_genesis_schnorr_verifier().await.unwrap();
-
-        assert!(
-            snark_verifier.is_none(),
-            "legacy single-Ed25519 verification key must yield no SNARK verifier"
-        );
-    }
-
-    #[tokio::test]
-    async fn build_genesis_schnorr_verifier_returns_some_for_a_dual_bundle_in_production() {
-        let (bundle_hex, expected_snark_verifier) = dual_bundle_hex();
-        let mut dep_builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(
-            production_config_with_genesis_key(bundle_hex),
-        ));
-
-        let snark_verifier = dep_builder
-            .build_genesis_schnorr_verifier()
-            .await
-            .unwrap()
-            .expect("dual bundle must yield a SNARK verifier");
-
-        assert_eq!(
-            snark_verifier.to_verification_key().to_bytes(),
-            expected_snark_verifier.to_verification_key().to_bytes(),
-        );
-    }
-
-    #[tokio::test]
-    async fn build_genesis_schnorr_verifier_returns_some_in_non_production_environment() {
-        let mut dep_builder = {
-            let config = ServeCommandConfiguration::new_sample(temp_dir!());
-            DependenciesBuilder::new_with_stdout_logger(Arc::new(config))
-        };
-
-        let snark_verifier = dep_builder.build_genesis_schnorr_verifier().await.unwrap();
-
-        assert!(
-            snark_verifier.is_some(),
-            "non-production environment must auto-generate a SNARK verifier"
-        );
     }
 }

--- a/mithril-aggregator/src/services/certificate_chain_synchronizer/synchronizer_service.rs
+++ b/mithril-aggregator/src/services/certificate_chain_synchronizer/synchronizer_service.rs
@@ -29,7 +29,7 @@ use std::sync::Arc;
 
 use mithril_common::StdResult;
 use mithril_common::certificate_chain::CertificateVerifier;
-use mithril_common::crypto_helper::GenesisEd25519Verifier;
+use mithril_common::crypto_helper::GenesisVerifier;
 use mithril_common::entities::{Certificate, SignedEntityType};
 use mithril_common::logging::LoggerExtensions;
 
@@ -46,7 +46,7 @@ pub struct MithrilCertificateChainSynchronizer {
     remote_certificate_retriever: Arc<dyn RemoteCertificateRetriever>,
     certificate_storer: Arc<dyn SynchronizedCertificateStorer>,
     certificate_verifier: Arc<dyn CertificateVerifier>,
-    genesis_verifier: Arc<GenesisEd25519Verifier>,
+    genesis_verifier: Arc<GenesisVerifier>,
     open_message_storer: Arc<dyn OpenMessageStorer>,
     epoch_settings_storer: Arc<dyn EpochSettingsStorer>,
     logger: Logger,
@@ -77,7 +77,7 @@ impl MithrilCertificateChainSynchronizer {
         remote_certificate_retriever: Arc<dyn RemoteCertificateRetriever>,
         certificate_storer: Arc<dyn SynchronizedCertificateStorer>,
         certificate_verifier: Arc<dyn CertificateVerifier>,
-        genesis_verifier: Arc<GenesisEd25519Verifier>,
+        genesis_verifier: Arc<GenesisVerifier>,
         open_message_storer: Arc<dyn OpenMessageStorer>,
         epoch_settings_storer: Arc<dyn EpochSettingsStorer>,
         logger: Logger,
@@ -129,7 +129,10 @@ impl MithrilCertificateChainSynchronizer {
         loop {
             let parent_certificate = self
                 .certificate_verifier
-                .verify_certificate(&certificate, &self.genesis_verifier.to_verification_key())
+                .verify_certificate(
+                    &certificate,
+                    &self.genesis_verifier.to_ed25519_verification_key(),
+                )
                 .await
                 .with_context(
                     || format!("Failed to verify certificate: `{}`", certificate.hash,),
@@ -280,9 +283,7 @@ mod tests {
                 Arc::new(MockRemoteCertificateRetriever::new()),
                 Arc::new(MockSynchronizedCertificateStorer::new()),
                 Arc::new(MockCertificateVerifier::new()),
-                Arc::new(GenesisEd25519Verifier::from_verification_key(
-                    genesis_verification_key,
-                )),
+                Arc::new(GenesisVerifier::from_ed25519(genesis_verification_key)),
                 Arc::new(MockOpenMessageStorer::new()),
                 Arc::new(FakeEpochSettingsStorer::new(epoch_settings)),
                 TestLogger::stdout(),

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -5,7 +5,7 @@ use slog::{Logger, debug, info, trace, warn};
 use std::sync::Arc;
 
 use mithril_common::certificate_chain::CertificateVerifier;
-use mithril_common::crypto_helper::{GenesisEd25519Verifier, PROTOCOL_VERSION};
+use mithril_common::crypto_helper::{GenesisVerifier, PROTOCOL_VERSION};
 use mithril_common::entities::{
     Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessage,
     SignedEntityType, SingleSignature, StakeDistributionParty,
@@ -30,7 +30,7 @@ pub struct MithrilCertifierService {
     single_signature_repository: Arc<SingleSignatureRepository>,
     certificate_repository: Arc<CertificateRepository>,
     certificate_verifier: Arc<dyn CertificateVerifier>,
-    genesis_verifier: Arc<GenesisEd25519Verifier>,
+    genesis_verifier: Arc<GenesisVerifier>,
     multi_signer: Arc<dyn MultiSigner>,
     epoch_service: EpochServiceWrapper,
     logger: Logger,
@@ -45,7 +45,7 @@ impl MithrilCertifierService {
         single_signature_repository: Arc<SingleSignatureRepository>,
         certificate_repository: Arc<CertificateRepository>,
         certificate_verifier: Arc<dyn CertificateVerifier>,
-        genesis_verifier: Arc<GenesisEd25519Verifier>,
+        genesis_verifier: Arc<GenesisVerifier>,
         multi_signer: Arc<dyn MultiSigner>,
         epoch_service: EpochServiceWrapper,
         logger: Logger,
@@ -349,7 +349,10 @@ impl CertifierService for MithrilCertifierService {
         );
 
         self.certificate_verifier
-            .verify_certificate(&certificate, &self.genesis_verifier.to_verification_key())
+            .verify_certificate(
+                &certificate,
+                &self.genesis_verifier.to_ed25519_verification_key(),
+            )
             .await
             .with_context(|| {
                 format!(
@@ -406,7 +409,7 @@ impl CertifierService for MithrilCertifierService {
             self.certificate_verifier
                 .verify_certificate_chain(
                     certificate.to_owned(),
-                    &self.genesis_verifier.to_verification_key(),
+                    &self.genesis_verifier.to_ed25519_verification_key(),
                 )
                 .await
                 .with_context(|| "CertificateVerifier can not verify certificate chain")?;
@@ -774,7 +777,7 @@ mod tests {
             .certificate_verifier
             .verify_certificate(
                 &certificate_created,
-                &certifier_service.genesis_verifier.to_verification_key(),
+                &certifier_service.genesis_verifier.to_ed25519_verification_key(),
             )
             .await
             .unwrap();

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -339,14 +339,14 @@ impl CertifierService for MithrilCertifierService {
             .map(|cert| cert.hash)
             .ok_or_else(|| Box::new(CertifierServiceError::NoParentCertificateFound))?;
 
-        let certificate = Certificate::new(
+        let certificate = Certificate::try_new(
             parent_certificate_hash,
             open_message.epoch,
             metadata,
             open_message.protocol_message.clone(),
             epoch_service.current_aggregate_verification_key()?.clone(),
             CertificateSignature::MultiSignature(signed_entity_type.clone(), multi_signature),
-        );
+        )?;
 
         self.certificate_verifier
             .verify_certificate(

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -84,7 +84,7 @@ impl CertificatesHashMigrator {
             };
 
             if let Some(new_hash) = {
-                let computed_hash = certificate.compute_hash();
+                let computed_hash = certificate.try_compute_hash()?;
                 // return none if the hash did not change
                 (computed_hash != certificate.hash).then_some(computed_hash)
             } {

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -367,7 +367,7 @@ mod test {
                 certificate.previous_hash.clone_from(hash);
             }
 
-            let new_hash = certificate.compute_hash();
+            let new_hash = certificate.try_compute_hash().unwrap();
             old_and_new_hashes.insert(certificate.hash.clone(), new_hash.clone());
             certificate.hash = new_hash;
 
@@ -631,7 +631,7 @@ mod test {
         let connection = Arc::new(connection_without_foreign_key_support());
         let certificate = {
             let mut cert = dummy_genesis("whatever", time_at(1, 2));
-            cert.hash = cert.compute_hash();
+            cert.hash = cert.try_compute_hash().unwrap();
             cert
         };
         fill_certificates_and_signed_entities_in_db(connection.clone(), &[certificate])

--- a/mithril-aggregator/src/tools/genesis.rs
+++ b/mithril-aggregator/src/tools/genesis.rs
@@ -23,6 +23,10 @@ use crate::{
     database::repository::CertificateRepository,
     dependency_injection::GenesisCommandDependenciesContainer,
 };
+#[cfg(feature = "future_snark")]
+use mithril_common::crypto_helper::{
+    GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle, ProtocolKey,
+};
 
 /// Configuration for the genesis tools.
 pub struct GenesisToolsConfiguration {
@@ -214,18 +218,52 @@ impl GenesisTools {
         Ok(())
     }
 
-    /// Export the genesis keypair to a folder and returns the paths to the files (secret key, verification_key)
-    pub fn create_and_save_genesis_keypair(keypair_path: &Path) -> StdResult<(PathBuf, PathBuf)> {
-        let genesis_signer = GenesisEd25519Signer::create_non_deterministic_signer();
+    /// Export the genesis keypair to a folder and return the paths to the files (secret key, verification key).
+    ///
+    /// Pythagoras writes the legacy single-Ed25519 JSON-hex layout; Lagrange writes a dual signing
+    /// bundle plus its matching verification bundle as bytes-hex.
+    pub fn create_and_save_genesis_keypair(
+        keypair_path: &Path,
+        mithril_era: SupportedEra,
+    ) -> StdResult<(PathBuf, PathBuf)> {
         let genesis_secret_key_path = keypair_path.join("genesis.sk");
-        genesis_signer
-            .secret_key()
-            .write_json_hex_to_file(&genesis_secret_key_path)?;
         let genesis_verification_key_path = keypair_path.join("genesis.vk");
-        genesis_signer
-            .verification_key()
-            .write_json_hex_to_file(&genesis_verification_key_path)?;
+        match mithril_era {
+            SupportedEra::Pythagoras => {
+                let signer = GenesisEd25519Signer::create_non_deterministic_signer();
+                signer.secret_key().write_json_hex_to_file(&genesis_secret_key_path)?;
+                signer
+                    .verification_key()
+                    .write_json_hex_to_file(&genesis_verification_key_path)?;
+            }
+            #[cfg(feature = "future_snark")]
+            SupportedEra::Lagrange => {
+                let concatenation = GenesisEd25519Signer::create_non_deterministic_signer();
+                let snark = GenesisSchnorrSigner::create_non_deterministic_signer();
 
+                let signing_bundle =
+                    GenesisSigningKeyBundle::new(concatenation.secret_key(), snark.secret_key());
+                let verification_bundle = GenesisVerificationKeyBundle::new(
+                    concatenation.verification_key(),
+                    snark.verification_key(),
+                );
+
+                std::fs::write(
+                    &genesis_secret_key_path,
+                    ProtocolKey::new(signing_bundle).to_bytes_hex()?,
+                )?;
+                std::fs::write(
+                    &genesis_verification_key_path,
+                    ProtocolKey::new(verification_bundle).to_bytes_hex()?,
+                )?;
+            }
+            #[cfg(not(feature = "future_snark"))]
+            SupportedEra::Lagrange => {
+                return Err(anyhow::anyhow!(
+                    "Lagrange genesis keypair generation requires the 'future_snark' build feature"
+                ));
+            }
+        }
         Ok((genesis_secret_key_path, genesis_verification_key_path))
     }
 }
@@ -234,6 +272,11 @@ impl GenesisTools {
 mod tests {
     use std::{fs::read_to_string, path::PathBuf};
 
+    #[cfg(feature = "future_snark")]
+    use mithril_common::crypto_helper::{
+        BUNDLE_FIRST_HEX_CHAR, GenesisSchnorrSigner, GenesisSigningKeyBundle,
+        GenesisVerificationKeyBundle,
+    };
     use mithril_common::{
         certificate_chain::MithrilCertificateVerifier,
         crypto_helper::{
@@ -301,8 +344,9 @@ mod tests {
         let test_dir = get_temp_dir("export_payload_to_sign");
         let payload_path = test_dir.join("payload.txt");
         let signed_payload_path = test_dir.join("payload-signed.txt");
-        let (genesis_secret_key_path, _) = GenesisTools::create_and_save_genesis_keypair(&test_dir)
-            .expect("exporting the keypair should not fail");
+        let (genesis_secret_key_path, _) =
+            GenesisTools::create_and_save_genesis_keypair(&test_dir, SupportedEra::Pythagoras)
+                .expect("exporting the keypair should not fail");
         let genesis_secret_key = GenesisEd25519SecretKey::from_json_hex(
             &read_to_string(&genesis_secret_key_path)
                 .expect("reading genesis secret key file should not fail"),
@@ -370,10 +414,10 @@ mod tests {
     }
 
     #[test]
-    fn test_create_and_save_genesis_keypair() {
-        let temp_dir = get_temp_dir("test_create_and_save_genesis_keypair");
+    fn create_and_save_genesis_keypair_pythagoras() {
+        let temp_dir = get_temp_dir("create_and_save_genesis_keypair_pythagoras");
         let (genesis_secret_key_path, genesis_verification_key_path) =
-            GenesisTools::create_and_save_genesis_keypair(&temp_dir)
+            GenesisTools::create_and_save_genesis_keypair(&temp_dir, SupportedEra::Pythagoras)
                 .expect("Failed to create and save genesis keypair");
         let genesis_secret_key = GenesisEd25519SecretKey::from_json_hex(
             &read_to_string(&genesis_secret_key_path)
@@ -390,5 +434,33 @@ mod tests {
 
         let expected_genesis_verification_key = genesis_verifier.to_verification_key();
         assert_eq!(expected_genesis_verification_key, genesis_verification_key);
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn create_and_save_genesis_keypair_lagrange() {
+        let temp_dir = get_temp_dir("create_and_save_genesis_keypair_lagrange");
+        let (genesis_secret_key_path, genesis_verification_key_path) =
+            GenesisTools::create_and_save_genesis_keypair(&temp_dir, SupportedEra::Lagrange)
+                .expect("Failed to create and save genesis keypair");
+
+        let signing_hex = read_to_string(&genesis_secret_key_path).unwrap();
+        let verification_hex = read_to_string(&genesis_verification_key_path).unwrap();
+
+        assert_eq!(signing_hex.as_bytes()[0], BUNDLE_FIRST_HEX_CHAR);
+        assert_eq!(verification_hex.as_bytes()[0], BUNDLE_FIRST_HEX_CHAR);
+
+        let signing_bundle = GenesisSigningKeyBundle::try_from_hex(&signing_hex)
+            .expect("signing bundle hex must round-trip");
+        let verification_bundle =
+            GenesisVerificationKeyBundle::try_from_hex_or_legacy(&verification_hex)
+                .expect("verification bundle hex must round-trip");
+        let expected_snark_verification_key =
+            GenesisSchnorrSigner::from_secret_key(signing_bundle.schnorr).verification_key();
+
+        assert_eq!(
+            verification_bundle.schnorr.unwrap().to_bytes(),
+            expected_snark_verification_key.to_bytes()
+        );
     }
 }

--- a/mithril-aggregator/src/tools/genesis/mod.rs
+++ b/mithril-aggregator/src/tools/genesis/mod.rs
@@ -1,0 +1,13 @@
+//! Genesis-certificate aggregator tooling.
+//!
+//! Groups the [`GenesisTools`] (export / sign / import / bootstrap / generate-keypair /
+//! upgrade-key-to-dual operations) and the dual signed-payload envelope produced by the
+//! Lagrange-era offline sign ceremony.
+
+mod operations;
+#[cfg(feature = "future_snark")]
+mod signed_payload;
+
+pub use operations::GenesisTools;
+#[cfg(feature = "future_snark")]
+pub use signed_payload::GenesisSignedPayload;

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -161,14 +161,37 @@ impl GenesisTools {
             .await
     }
 
-    /// Automatic bootstrap of the genesis certificate (test only)
+    /// Automatic bootstrap of the genesis certificate (test only).
+    ///
+    /// Pythagoras runs a single Ed25519 ceremony; Lagrange runs the dual ceremony with the SNARK
+    /// signer attached to the producer.
     pub async fn bootstrap_test_genesis_certificate(
         &self,
-        genesis_signer: GenesisEd25519Signer,
+        genesis_signer: GenesisSigner,
     ) -> StdResult<()> {
-        let genesis_verification_key = &genesis_signer.verification_key();
-        let genesis_producer = CertificateGenesisProducer::new(Some(Arc::new(genesis_signer)))
-            .with_logger(self.logger.clone());
+        #[cfg(feature = "future_snark")]
+        let genesis_signer = if matches!(self.configuration.mithril_era, SupportedEra::Lagrange)
+            && genesis_signer.schnorr.is_none()
+        {
+            GenesisSigner {
+                ed25519: genesis_signer.ed25519,
+                schnorr: Some(GenesisSchnorrSigner::create_non_deterministic_signer()),
+            }
+        } else {
+            genesis_signer
+        };
+        genesis_signer.ensure_supports_era(self.configuration.mithril_era)?;
+        let ed25519_verification_key = genesis_signer.ed25519.verification_key();
+        let genesis_producer =
+            CertificateGenesisProducer::new(Some(Arc::new(genesis_signer.ed25519)))
+                .with_logger(self.logger.clone());
+        #[cfg(feature = "future_snark")]
+        let genesis_producer = match genesis_signer.schnorr {
+            Some(schnorr_signer) => {
+                genesis_producer.with_schnorr_genesis_signer(Arc::new(schnorr_signer))
+            }
+            None => genesis_producer,
+        };
         let genesis_protocol_message = genesis_producer.create_genesis_protocol_message(
             &self.configuration.genesis_protocol_parameters,
             &self.configuration.genesis_avk,
@@ -177,8 +200,22 @@ impl GenesisTools {
         )?;
         let genesis_signature =
             genesis_producer.sign_genesis_protocol_message(genesis_protocol_message)?;
-        self.create_and_save_genesis_certificate(genesis_signature, genesis_verification_key)
+        let genesis_certificate = genesis_producer.create_genesis_certificate(
+            self.configuration.genesis_protocol_parameters.clone(),
+            self.configuration.network,
+            self.configuration.epoch,
+            self.configuration.genesis_avk.clone(),
+            genesis_signature,
+            self.configuration.mithril_era,
+        )?;
+        self.certificate_verifier
+            .verify_genesis_certificate(&genesis_certificate, &ed25519_verification_key)
+            .await?;
+        self.certificate_repository
+            .create_certificate(genesis_certificate)
             .await
+            .with_context(|| "Genesis tool can not save bootstrap genesis certificate")?;
+        Ok(())
     }
 
     /// Sign the genesis certificate offline.
@@ -323,6 +360,7 @@ mod tests {
             GenesisEd25519SecretKey, GenesisEd25519Signer, GenesisEd25519VerificationKey,
             GenesisEd25519Verifier,
         },
+        entities::Certificate,
         test::{TempDir, builder::MithrilFixtureBuilder, double::fake_data},
     };
 
@@ -349,6 +387,18 @@ mod tests {
         Arc<GenesisEd25519Verifier>,
         Arc<dyn CertificateVerifier>,
     ) {
+        build_tools_for_era(genesis_signer, SupportedEra::Pythagoras)
+    }
+
+    fn build_tools_for_era(
+        genesis_signer: &GenesisEd25519Signer,
+        mithril_era: SupportedEra,
+    ) -> (
+        GenesisTools,
+        Arc<CertificateRepository>,
+        Arc<GenesisEd25519Verifier>,
+        Arc<dyn CertificateVerifier>,
+    ) {
         let connection = main_db_connection().unwrap();
         let certificate_store = Arc::new(CertificateRepository::new(Arc::new(connection)));
         let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(
@@ -362,7 +412,7 @@ mod tests {
             epoch: Epoch(10),
             genesis_avk,
             genesis_protocol_parameters: fake_data::protocol_parameters(),
-            mithril_era: SupportedEra::Pythagoras,
+            mithril_era,
         };
         let genesis_tools = GenesisTools::new(
             configuration,
@@ -431,12 +481,12 @@ mod tests {
 
     #[tokio::test]
     async fn bootstrap_test_genesis_certificate_works() {
-        let genesis_signer = GenesisEd25519Signer::create_deterministic_signer();
+        let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
         let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
-            build_tools(&genesis_signer);
+            build_tools(&ed25519_signer);
 
         genesis_tools
-            .bootstrap_test_genesis_certificate(genesis_signer)
+            .bootstrap_test_genesis_certificate(GenesisSigner::from_ed25519(ed25519_signer))
             .await
             .expect("bootstrap test genesis certificate should not fail");
 
@@ -503,6 +553,76 @@ mod tests {
             verification_bundle.schnorr.unwrap().to_bytes(),
             expected_schnorr_verification_key.to_bytes()
         );
+    }
+
+    #[cfg(feature = "future_snark")]
+    mod bootstrap {
+        use mithril_common::crypto_helper::{GenesisSchnorrSigner, GenesisSigningKeyBundle};
+
+        use super::*;
+
+        fn build_dual_signer() -> (GenesisEd25519Signer, GenesisSigner) {
+            let ed25519 = GenesisEd25519Signer::create_deterministic_signer();
+            let schnorr = GenesisSchnorrSigner::create_non_deterministic_signer();
+            let bundle = GenesisSigningKeyBundle::new(ed25519.secret_key(), schnorr.secret_key());
+            (ed25519.clone(), GenesisSigner::from_bundle(bundle))
+        }
+
+        #[tokio::test]
+        async fn pythagoras_accepts_dual_signing_bundle() {
+            let (ed25519_signer, signer) = build_dual_signer();
+            let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
+                build_tools_for_era(&ed25519_signer, SupportedEra::Pythagoras);
+
+            genesis_tools
+                .bootstrap_test_genesis_certificate(signer)
+                .await
+                .expect("Pythagoras must accept a dual bundle");
+
+            let last = certificate_store.get_latest_certificates(10).await.unwrap();
+            assert_eq!(1, last.len());
+            certificate_verifier
+                .verify_genesis_certificate(&last[0], &genesis_verifier.to_verification_key())
+                .await
+                .expect("Ed25519 verification must pass");
+        }
+
+        #[tokio::test]
+        async fn lagrange_runs_dual_ceremony() {
+            let (ed25519_signer, signer) = build_dual_signer();
+            let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
+                build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
+
+            genesis_tools
+                .bootstrap_test_genesis_certificate(signer)
+                .await
+                .expect("Lagrange dual bootstrap must succeed");
+
+            let last = certificate_store.get_latest_certificates(10).await.unwrap();
+            assert_eq!(1, last.len());
+            certificate_verifier
+                .verify_genesis_certificate(&last[0], &genesis_verifier.to_verification_key())
+                .await
+                .expect("Ed25519 verification must pass on the dual variant");
+        }
+
+        #[tokio::test]
+        async fn lagrange_auto_augments_a_legacy_signer_with_a_fresh_schnorr_signer() {
+            let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
+            let (genesis_tools, certificate_store, _, _) =
+                build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
+
+            genesis_tools
+                .bootstrap_test_genesis_certificate(GenesisSigner::from_ed25519(ed25519_signer))
+                .await
+                .expect(
+                    "Lagrange bootstrap must auto-augment a legacy signer for test convenience",
+                );
+
+            let last: Vec<Certificate> =
+                certificate_store.get_latest_certificates(10).await.unwrap();
+            assert_eq!(1, last.len());
+        }
     }
 
     #[cfg(feature = "future_snark")]

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -12,13 +12,15 @@ use mithril_common::{
     CardanoNetwork, StdResult,
     certificate_chain::{CertificateGenesisProducer, CertificateVerifier},
     crypto_helper::{
-        GenesisEd25519SecretKey, GenesisEd25519Signature, GenesisEd25519Signer,
-        GenesisEd25519VerificationKey, ProtocolAggregateVerificationKey,
+        GenesisEd25519Signature, GenesisEd25519Signer, GenesisEd25519VerificationKey,
+        GenesisSigner, ProtocolAggregateVerificationKey,
     },
     entities::{Epoch, ProtocolParameters, SupportedEra},
     protocol::SignerBuilder,
 };
 
+#[cfg(feature = "future_snark")]
+use crate::tools::GenesisSignedPayload;
 use crate::{
     database::repository::CertificateRepository,
     dependency_injection::GenesisCommandDependenciesContainer,
@@ -26,6 +28,7 @@ use crate::{
 #[cfg(feature = "future_snark")]
 use mithril_common::crypto_helper::{
     GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle, ProtocolKey,
+    sha256_digest, signed_message_from_digest,
 };
 
 /// Configuration for the genesis tools.
@@ -116,7 +119,11 @@ impl GenesisTools {
         ))
     }
 
-    /// Export AVK of the genesis stake distribution to a payload file
+    /// Export AVK of the genesis stake distribution to a payload file.
+    ///
+    /// Pythagoras writes the canonical protocol-message hash bytes (hex string); Lagrange writes
+    /// the rigid protocol-message preimage so the offline sign tool can produce both the legacy
+    /// Ed25519 signature and the SNARK-friendly Schnorr signature.
     pub fn export_payload_to_sign(&self, target_path: &Path) -> StdResult<()> {
         let mut target_file = File::create(target_path)?;
         let genesis_producer =
@@ -127,7 +134,15 @@ impl GenesisTools {
             &self.configuration.epoch,
             self.configuration.mithril_era,
         )?;
-        target_file.write_all(protocol_message.compute_hash().as_bytes())?;
+        match self.configuration.mithril_era {
+            #[cfg(feature = "future_snark")]
+            SupportedEra::Lagrange => {
+                target_file.write_all(&protocol_message.rigid_preimage())?;
+            }
+            _ => {
+                target_file.write_all(protocol_message.compute_hash().as_bytes())?;
+            }
+        }
         Ok(())
     }
 
@@ -166,22 +181,47 @@ impl GenesisTools {
             .await
     }
 
-    /// Sign the genesis certificate
+    /// Sign the genesis certificate offline.
+    ///
+    /// Pythagoras signs the payload bytes with the ed25519 signer and writes the raw
+    /// Ed25519 signature. Lagrange hashes the rigid preimage with SHA-256, signs the
+    /// hex-encoded digest with the ed25519 signer (matching the `signed_message` bytes),
+    /// signs the raw digest with the SNARK signer, and writes a versioned dual-signature
+    /// envelope ([`crate::tools::GenesisSignedPayload`]).
     pub async fn sign_genesis_certificate(
         to_sign_payload_path: &Path,
         target_signed_payload_path: &Path,
         genesis_secret_key_path: &Path,
+        mithril_era: SupportedEra,
     ) -> StdResult<()> {
-        let genesis_secret_key =
-            GenesisEd25519SecretKey::read_json_hex_from_file(genesis_secret_key_path)?;
-        let genesis_signer = GenesisEd25519Signer::from_secret_key(genesis_secret_key);
+        let genesis_signer = GenesisSigner::read_from_file(genesis_secret_key_path)?;
+        genesis_signer.ensure_supports_era(mithril_era)?;
 
-        let mut to_sign_payload_file = File::open(to_sign_payload_path).unwrap();
+        let mut to_sign_payload_file = File::open(to_sign_payload_path)?;
         let mut to_sign_payload_buffer = Vec::new();
         to_sign_payload_file.read_to_end(&mut to_sign_payload_buffer)?;
 
-        let genesis_signature = genesis_signer.sign(&to_sign_payload_buffer);
-        let signed_payload = genesis_signature.to_bytes();
+        let signed_payload = match mithril_era {
+            #[cfg(feature = "future_snark")]
+            SupportedEra::Lagrange => {
+                let digest = sha256_digest(&to_sign_payload_buffer);
+                let signed_message = signed_message_from_digest(&digest);
+                let ed25519 = genesis_signer.ed25519.sign(signed_message.as_bytes());
+                let schnorr = genesis_signer
+                    .schnorr
+                    .as_ref()
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Lagrange genesis sign requires a SNARK signer")
+                    })?
+                    .sign_non_deterministic(&digest)?;
+                GenesisSignedPayload::new(ed25519, schnorr).to_bytes()
+            }
+            _ => genesis_signer
+                .ed25519
+                .sign(&to_sign_payload_buffer)
+                .to_bytes()
+                .to_vec(),
+        };
 
         let mut target_signed_payload_file = File::create(target_signed_payload_path)?;
         target_signed_payload_file.write_all(&signed_payload)?;
@@ -238,14 +278,14 @@ impl GenesisTools {
             }
             #[cfg(feature = "future_snark")]
             SupportedEra::Lagrange => {
-                let concatenation = GenesisEd25519Signer::create_non_deterministic_signer();
-                let snark = GenesisSchnorrSigner::create_non_deterministic_signer();
+                let ed25519 = GenesisEd25519Signer::create_non_deterministic_signer();
+                let schnorr = GenesisSchnorrSigner::create_non_deterministic_signer();
 
                 let signing_bundle =
-                    GenesisSigningKeyBundle::new(concatenation.secret_key(), snark.secret_key());
+                    GenesisSigningKeyBundle::new(ed25519.secret_key(), schnorr.secret_key());
                 let verification_bundle = GenesisVerificationKeyBundle::new(
-                    concatenation.verification_key(),
-                    snark.verification_key(),
+                    ed25519.verification_key(),
+                    schnorr.verification_key(),
                 );
 
                 std::fs::write(
@@ -363,6 +403,7 @@ mod tests {
             &payload_path,
             &signed_payload_path,
             &genesis_secret_key_path,
+            SupportedEra::Pythagoras,
         )
         .await
         .expect("sign_genesis_certificate should not fail");
@@ -455,12 +496,126 @@ mod tests {
         let verification_bundle =
             GenesisVerificationKeyBundle::try_from_hex_or_legacy(&verification_hex)
                 .expect("verification bundle hex must round-trip");
-        let expected_snark_verification_key =
+        let expected_schnorr_verification_key =
             GenesisSchnorrSigner::from_secret_key(signing_bundle.schnorr).verification_key();
 
         assert_eq!(
             verification_bundle.schnorr.unwrap().to_bytes(),
-            expected_snark_verification_key.to_bytes()
+            expected_schnorr_verification_key.to_bytes()
         );
+    }
+
+    #[cfg(feature = "future_snark")]
+    mod sign {
+        use std::fs;
+
+        use mithril_common::crypto_helper::{
+            GenesisSchnorrVerifier, GenesisSigner, sha256_digest, signed_message_from_digest,
+        };
+
+        use crate::tools::GenesisSignedPayload;
+
+        use super::*;
+
+        fn write_signing_key(target_dir: &Path, era: SupportedEra) -> PathBuf {
+            let (signing_key_path, _) =
+                GenesisTools::create_and_save_genesis_keypair(target_dir, era)
+                    .expect("keypair generation should not fail");
+            signing_key_path
+        }
+
+        #[tokio::test]
+        async fn lagrange_writes_dual_envelope_that_verifies_both_signatures() {
+            let temp = get_temp_dir("lagrange_sign_writes_envelope");
+            let preimage_path = temp.join("preimage.bin");
+            let signed_path = temp.join("signed.bin");
+            let signing_key_path = write_signing_key(&temp, SupportedEra::Lagrange);
+
+            let preimage = vec![0x42u8; 190];
+            fs::write(&preimage_path, &preimage).unwrap();
+
+            GenesisTools::sign_genesis_certificate(
+                &preimage_path,
+                &signed_path,
+                &signing_key_path,
+                SupportedEra::Lagrange,
+            )
+            .await
+            .expect("Lagrange sign should not fail");
+
+            let envelope_bytes = fs::read(&signed_path).unwrap();
+            let envelope = GenesisSignedPayload::try_from_bytes(&envelope_bytes)
+                .expect("envelope must round-trip");
+
+            let signer = GenesisSigner::read_from_file(&signing_key_path).unwrap();
+            let digest = sha256_digest(&preimage);
+            signer
+                .ed25519
+                .create_verifier()
+                .verify(
+                    signed_message_from_digest(&digest).as_bytes(),
+                    &envelope.ed25519,
+                )
+                .expect("Ed25519 signature must verify");
+            GenesisSchnorrVerifier::from_verification_key(
+                signer.schnorr.as_ref().unwrap().verification_key(),
+            )
+            .verify(&digest, &envelope.schnorr)
+            .expect("Schnorr signature must verify");
+        }
+
+        #[tokio::test]
+        async fn lagrange_rejects_legacy_signing_key() {
+            let temp = get_temp_dir("lagrange_sign_rejects_legacy_key");
+            let preimage_path = temp.join("preimage.bin");
+            let signed_path = temp.join("signed.bin");
+            let signing_key_path = write_signing_key(&temp, SupportedEra::Pythagoras);
+            fs::write(&preimage_path, vec![0xAAu8; 190]).unwrap();
+
+            let error = GenesisTools::sign_genesis_certificate(
+                &preimage_path,
+                &signed_path,
+                &signing_key_path,
+                SupportedEra::Lagrange,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(matches!(
+                error.downcast_ref::<mithril_common::crypto_helper::GenesisBundleError>(),
+                Some(mithril_common::crypto_helper::GenesisBundleError::LegacySigningKey)
+            ));
+        }
+
+        #[tokio::test]
+        async fn pythagoras_accepts_dual_signing_bundle() {
+            let temp = get_temp_dir("pythagoras_sign_accepts_dual_bundle");
+            let payload_path = temp.join("payload.txt");
+            let signed_path = temp.join("signed.bin");
+            let signing_key_path = write_signing_key(&temp, SupportedEra::Lagrange);
+
+            let payload = b"protocol-message-hash";
+            fs::write(&payload_path, payload).unwrap();
+
+            GenesisTools::sign_genesis_certificate(
+                &payload_path,
+                &signed_path,
+                &signing_key_path,
+                SupportedEra::Pythagoras,
+            )
+            .await
+            .expect("Pythagoras sign with a dual bundle should succeed");
+
+            let signature_bytes = fs::read(&signed_path).unwrap();
+            assert_eq!(signature_bytes.len(), 64);
+
+            let signer = GenesisSigner::read_from_file(&signing_key_path).unwrap();
+            let signature = GenesisEd25519Signature::from_bytes(&signature_bytes).unwrap();
+            signer
+                .ed25519
+                .create_verifier()
+                .verify(payload, &signature)
+                .expect("Ed25519 signature must verify");
+        }
     }
 }

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -15,7 +15,7 @@ use mithril_common::{
         GenesisEd25519Signature, GenesisEd25519Signer, GenesisEd25519VerificationKey,
         GenesisSigner, GenesisVerifier, ProtocolAggregateVerificationKey,
     },
-    entities::{Epoch, ProtocolParameters, SupportedEra},
+    entities::{CertificateSignature, Epoch, ProtocolParameters, SupportedEra},
     protocol::SignerBuilder,
 };
 
@@ -27,8 +27,8 @@ use crate::{
 };
 #[cfg(feature = "future_snark")]
 use mithril_common::crypto_helper::{
-    GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle, ProtocolKey,
-    sha256_digest, signed_message_from_digest,
+    GenesisEd25519SecretKey, GenesisSchnorrSigner, GenesisSigningKeyBundle,
+    GenesisVerificationKeyBundle, ProtocolKey, sha256_digest, signed_message_from_digest,
 };
 
 /// Configuration for the genesis tools.
@@ -126,8 +126,7 @@ impl GenesisTools {
     /// Ed25519 signature and the SNARK-friendly Schnorr signature.
     pub fn export_payload_to_sign(&self, target_path: &Path) -> StdResult<()> {
         let mut target_file = File::create(target_path)?;
-        let genesis_producer =
-            CertificateGenesisProducer::new(None).with_logger(self.logger.clone());
+        let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
         let protocol_message = genesis_producer.create_genesis_protocol_message(
             &self.configuration.genesis_protocol_parameters,
             &self.configuration.genesis_avk,
@@ -161,8 +160,8 @@ impl GenesisTools {
     /// Import a Lagrange-era dual signed-payload envelope and persist the dual genesis certificate.
     ///
     /// Decodes the [`crate::tools::GenesisSignedPayload`] envelope, reconstructs the certificate
-    /// from the pre-computed Ed25519 + Schnorr signatures, then runs both the legacy and the
-    /// SNARK verifiers against it before saving.
+    /// from the pre-computed Ed25519 + Schnorr signatures, then verifies both the Ed25519
+    /// (ed25519) and the Schnorr (SNARK) signatures against it before saving.
     #[cfg(feature = "future_snark")]
     pub async fn import_dual_payload_signature(
         &self,
@@ -172,16 +171,16 @@ impl GenesisTools {
         genesis_verifier.ensure_supports_era(self.configuration.mithril_era)?;
         let signed_payload_buffer = std::fs::read(signed_payload_path)?;
         let envelope = GenesisSignedPayload::try_from_bytes(&signed_payload_buffer)?;
-        genesis_verifier.verification_key_bundle().schnorr_or_err()?;
-        let genesis_producer =
-            CertificateGenesisProducer::new(None).with_logger(self.logger.clone());
-        let certificate = genesis_producer.create_genesis_certificate_from_dual_signature(
+        let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
+        let signature =
+            CertificateSignature::GenesisDualSignature(envelope.ed25519, envelope.schnorr);
+        let certificate = genesis_producer.create_genesis_certificate(
             self.configuration.genesis_protocol_parameters.clone(),
             self.configuration.network,
             self.configuration.epoch,
             self.configuration.genesis_avk.clone(),
-            envelope.ed25519,
-            envelope.schnorr,
+            signature,
+            SupportedEra::Lagrange,
         )?;
         self.certificate_verifier
             .verify_genesis_certificate(
@@ -189,6 +188,8 @@ impl GenesisTools {
                 &genesis_verifier.to_ed25519_verification_key(),
             )
             .await?;
+        let digest = sha256_digest(&certificate.protocol_message.rigid_preimage());
+        genesis_verifier.verify_schnorr(&digest, &envelope.schnorr)?;
         self.certificate_repository
             .create_certificate(certificate)
             .await
@@ -220,30 +221,21 @@ impl GenesisTools {
         #[cfg(feature = "future_snark")]
         let schnorr_verification_key =
             genesis_signer.schnorr.as_ref().map(|s| s.verification_key());
-        let genesis_producer =
-            CertificateGenesisProducer::new(Some(Arc::new(genesis_signer.ed25519)))
-                .with_logger(self.logger.clone());
-        #[cfg(feature = "future_snark")]
-        let genesis_producer = match genesis_signer.schnorr {
-            Some(schnorr_signer) => {
-                genesis_producer.with_schnorr_genesis_signer(Arc::new(schnorr_signer))
-            }
-            None => genesis_producer,
-        };
+        let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
         let genesis_protocol_message = genesis_producer.create_genesis_protocol_message(
             &self.configuration.genesis_protocol_parameters,
             &self.configuration.genesis_avk,
             &self.configuration.epoch,
             self.configuration.mithril_era,
         )?;
-        let genesis_signature =
-            genesis_producer.sign_genesis_protocol_message(genesis_protocol_message)?;
+        let signature = genesis_signer
+            .sign_non_deterministic(&genesis_protocol_message, self.configuration.mithril_era)?;
         let genesis_certificate = genesis_producer.create_genesis_certificate(
             self.configuration.genesis_protocol_parameters.clone(),
             self.configuration.network,
             self.configuration.epoch,
             self.configuration.genesis_avk.clone(),
-            genesis_signature,
+            signature,
             self.configuration.mithril_era,
         )?;
         #[cfg(not(feature = "future_snark"))]
@@ -322,14 +314,13 @@ impl GenesisTools {
         genesis_signature: GenesisEd25519Signature,
         genesis_verification_key: &GenesisEd25519VerificationKey,
     ) -> StdResult<()> {
-        let genesis_producer =
-            CertificateGenesisProducer::new(None).with_logger(self.logger.clone());
+        let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
         let genesis_certificate = genesis_producer.create_genesis_certificate(
             self.configuration.genesis_protocol_parameters.clone(),
             self.configuration.network,
             self.configuration.epoch,
             self.configuration.genesis_avk.clone(),
-            genesis_signature,
+            CertificateSignature::GenesisSignature(genesis_signature),
             self.configuration.mithril_era,
         )?;
         self.certificate_verifier
@@ -394,6 +385,53 @@ impl GenesisTools {
         }
         Ok((genesis_secret_key_path, genesis_verification_key_path))
     }
+
+    /// Upgrade a legacy single-Ed25519 genesis keypair into a dual signing/verification bundle.
+    ///
+    /// Reads the legacy secret key, generates a fresh Schnorr keypair from the OS CSPRNG, and
+    /// writes the two bundles to `<target-path>/genesis.sk` and `<target-path>/genesis.vk`. The
+    /// existing legacy secret bytes are preserved as the ed25519 half of the dual bundle.
+    ///
+    /// Refuses to run if either target file already exists, to prevent accidentally overwriting
+    /// an in-use genesis key.
+    #[cfg(feature = "future_snark")]
+    pub fn upgrade_legacy_keypair_to_dual(
+        legacy_secret_key_path: &Path,
+        target_path: &Path,
+    ) -> StdResult<(PathBuf, PathBuf)> {
+        let target_secret_key_path = target_path.join("genesis.sk");
+        let target_verification_key_path = target_path.join("genesis.vk");
+        for path in [&target_secret_key_path, &target_verification_key_path] {
+            if path.exists() {
+                return Err(anyhow::anyhow!(
+                    "refusing to overwrite existing genesis key file at {}; choose an empty target directory",
+                    path.display()
+                ));
+            }
+        }
+
+        let legacy_secret_key =
+            GenesisEd25519SecretKey::read_json_hex_from_file(legacy_secret_key_path)?;
+        let legacy_signer = GenesisEd25519Signer::from_secret_key(legacy_secret_key);
+        let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+        let signing_bundle =
+            GenesisSigningKeyBundle::new(legacy_signer.secret_key(), schnorr_signer.secret_key());
+        let verification_bundle = GenesisVerificationKeyBundle::new(
+            legacy_signer.verification_key(),
+            schnorr_signer.verification_key(),
+        );
+
+        std::fs::write(
+            &target_secret_key_path,
+            ProtocolKey::new(signing_bundle).to_bytes_hex()?,
+        )?;
+        std::fs::write(
+            &target_verification_key_path,
+            ProtocolKey::new(verification_bundle).to_bytes_hex()?,
+        )?;
+
+        Ok((target_secret_key_path, target_verification_key_path))
+    }
 }
 
 #[cfg(test)]
@@ -405,13 +443,14 @@ mod tests {
         BUNDLE_FIRST_HEX_CHAR, GenesisSchnorrSigner, GenesisSigningKeyBundle,
         GenesisVerificationKeyBundle,
     };
+    #[cfg(feature = "future_snark")]
+    use mithril_common::entities::Certificate;
     use mithril_common::{
         certificate_chain::MithrilCertificateVerifier,
         crypto_helper::{
             GenesisEd25519SecretKey, GenesisEd25519Signer, GenesisEd25519VerificationKey,
             GenesisEd25519Verifier,
         },
-        entities::Certificate,
         test::{TempDir, builder::MithrilFixtureBuilder, double::fake_data},
     };
 
@@ -873,6 +912,222 @@ mod tests {
                 error.downcast_ref::<mithril_common::crypto_helper::GenesisBundleError>(),
                 Some(mithril_common::crypto_helper::GenesisBundleError::SchnorrVerificationKeyRequired)
             ));
+        }
+
+        #[tokio::test]
+        async fn lagrange_rejects_tampered_schnorr_signature() {
+            let temp = get_temp_dir("import_lagrange_rejects_tampered_schnorr");
+            let preimage_path = temp.join("preimage.bin");
+            let signed_path = temp.join("signed.bin");
+
+            let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
+            let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+            let signer = GenesisSigner::from_bundle(GenesisSigningKeyBundle::new(
+                ed25519_signer.secret_key(),
+                schnorr_signer.secret_key(),
+            ));
+            let signing_key_path = temp.join("genesis.sk");
+            signer.write_to_file(&signing_key_path).unwrap();
+
+            let (genesis_tools, certificate_store, _, _) =
+                build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
+
+            genesis_tools
+                .export_payload_to_sign(&preimage_path)
+                .expect("export should not fail");
+            GenesisTools::sign_genesis_certificate(
+                &preimage_path,
+                &signed_path,
+                &signing_key_path,
+                SupportedEra::Lagrange,
+            )
+            .await
+            .expect("sign should not fail");
+
+            let mismatched_schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+            let tampered_bundle = GenesisVerificationKeyBundle::new(
+                ed25519_signer.verification_key(),
+                mismatched_schnorr_signer.verification_key(),
+            );
+
+            let error = genesis_tools
+                .import_dual_payload_signature(
+                    &signed_path,
+                    &GenesisVerifier::from_bundle(tampered_bundle),
+                )
+                .await
+                .unwrap_err();
+
+            assert!(
+                format!("{error:?}").contains("SNARK genesis verifier failed"),
+                "expected a SNARK verification failure, got: {error:?}"
+            );
+            let saved: Vec<Certificate> =
+                certificate_store.get_latest_certificates(10).await.unwrap();
+            assert!(
+                saved.is_empty(),
+                "no certificate must be saved when the SNARK signature is invalid"
+            );
+        }
+    }
+
+    #[cfg(feature = "future_snark")]
+    mod upgrade_key_to_dual {
+        use std::fs;
+
+        use mithril_common::crypto_helper::{
+            BUNDLE_FIRST_HEX_CHAR, GenesisSchnorrSigner, GenesisSigningKeyBundle,
+            GenesisVerificationKeyBundle, LEGACY_FIRST_HEX_CHAR,
+        };
+
+        use super::*;
+
+        fn write_legacy_secret_key(target_dir: &Path) -> (PathBuf, GenesisEd25519Signer) {
+            let signer = GenesisEd25519Signer::create_non_deterministic_signer();
+            let path = target_dir.join("genesis.sk");
+            signer.secret_key().write_json_hex_to_file(&path).unwrap();
+            (path, signer)
+        }
+
+        #[test]
+        fn upgrade_preserves_ed25519_half() {
+            let temp = get_temp_dir("upgrade_preserves_ed25519_half");
+            let target = temp.join("out");
+            fs::create_dir_all(&target).unwrap();
+            let (legacy_path, legacy_signer) = write_legacy_secret_key(&temp);
+
+            let (signing_key_path, verification_key_path) =
+                GenesisTools::upgrade_legacy_keypair_to_dual(&legacy_path, &target)
+                    .expect("upgrade should not fail");
+
+            let signing_hex = fs::read_to_string(&signing_key_path).unwrap();
+            let verification_hex = fs::read_to_string(&verification_key_path).unwrap();
+            assert_eq!(signing_hex.as_bytes()[0], BUNDLE_FIRST_HEX_CHAR);
+            assert_eq!(verification_hex.as_bytes()[0], BUNDLE_FIRST_HEX_CHAR);
+
+            let signing_bundle = GenesisSigningKeyBundle::try_from_hex(&signing_hex).unwrap();
+            let verification_bundle =
+                GenesisVerificationKeyBundle::try_from_hex_or_legacy(&verification_hex).unwrap();
+
+            assert_eq!(
+                signing_bundle.ed25519.to_bytes(),
+                legacy_signer.secret_key().to_bytes()
+            );
+            assert_eq!(
+                verification_bundle.ed25519.as_bytes(),
+                legacy_signer.verification_key().as_bytes()
+            );
+            let derived_schnorr_vk =
+                GenesisSchnorrSigner::from_secret_key(signing_bundle.schnorr).verification_key();
+            assert_eq!(
+                verification_bundle.schnorr.unwrap().to_bytes(),
+                derived_schnorr_vk.to_bytes()
+            );
+        }
+
+        #[test]
+        fn two_consecutive_upgrades_produce_distinct_schnorr_secrets() {
+            let temp = get_temp_dir("upgrade_schnorr_rng_distinct_outputs");
+            let target_a = temp.join("a");
+            let target_b = temp.join("b");
+            fs::create_dir_all(&target_a).unwrap();
+            fs::create_dir_all(&target_b).unwrap();
+            let (legacy_path, _) = write_legacy_secret_key(&temp);
+
+            let (sk_a, _) =
+                GenesisTools::upgrade_legacy_keypair_to_dual(&legacy_path, &target_a).unwrap();
+            let (sk_b, _) =
+                GenesisTools::upgrade_legacy_keypair_to_dual(&legacy_path, &target_b).unwrap();
+
+            let bundle_a =
+                GenesisSigningKeyBundle::try_from_hex(&fs::read_to_string(&sk_a).unwrap()).unwrap();
+            let bundle_b =
+                GenesisSigningKeyBundle::try_from_hex(&fs::read_to_string(&sk_b).unwrap()).unwrap();
+            assert_ne!(bundle_a.schnorr.to_bytes(), bundle_b.schnorr.to_bytes());
+        }
+
+        #[test]
+        fn upgrade_does_not_create_any_certificate() {
+            let temp = get_temp_dir("upgrade_writes_only_two_files");
+            let target = temp.join("out");
+            fs::create_dir_all(&target).unwrap();
+            let (legacy_path, _) = write_legacy_secret_key(&temp);
+
+            GenesisTools::upgrade_legacy_keypair_to_dual(&legacy_path, &target).unwrap();
+
+            let entries: Vec<_> = fs::read_dir(&target).unwrap().collect();
+            assert_eq!(entries.len(), 2);
+        }
+
+        #[test]
+        fn legacy_input_is_recognised_as_legacy_format() {
+            let temp = get_temp_dir("upgrade_legacy_input_first_char");
+            let (legacy_path, _) = write_legacy_secret_key(&temp);
+
+            let legacy_hex = fs::read_to_string(&legacy_path).unwrap();
+            assert_eq!(legacy_hex.as_bytes()[0], LEGACY_FIRST_HEX_CHAR);
+        }
+
+        #[test]
+        fn upgrade_refuses_to_overwrite_existing_target_files() {
+            let temp = get_temp_dir("upgrade_refuses_overwrite");
+            let target = temp.join("out");
+            fs::create_dir_all(&target).unwrap();
+            let (legacy_path, _) = write_legacy_secret_key(&temp);
+
+            GenesisTools::upgrade_legacy_keypair_to_dual(&legacy_path, &target)
+                .expect("first upgrade should succeed");
+
+            let error = GenesisTools::upgrade_legacy_keypair_to_dual(&legacy_path, &target)
+                .expect_err("second upgrade must refuse to overwrite");
+            assert!(
+                error.to_string().contains("refusing to overwrite"),
+                "unexpected error: {error}"
+            );
+        }
+
+        #[test]
+        fn upgrade_preserves_signature_compatibility_with_original_legacy_key() {
+            use mithril_common::crypto_helper::GenesisEd25519Verifier;
+
+            let temp = get_temp_dir("upgrade_signature_compatibility");
+            let target = temp.join("out");
+            fs::create_dir_all(&target).unwrap();
+            let (legacy_path, legacy_signer) = write_legacy_secret_key(&temp);
+
+            let (signing_key_path, verification_key_path) =
+                GenesisTools::upgrade_legacy_keypair_to_dual(&legacy_path, &target)
+                    .expect("upgrade should not fail");
+
+            let payload = b"upgrade-key-drift-canary";
+            let legacy_signature = legacy_signer.sign(payload);
+
+            let upgraded_verification_bundle =
+                GenesisVerificationKeyBundle::try_from_hex_or_legacy(
+                    &fs::read_to_string(&verification_key_path).unwrap(),
+                )
+                .unwrap();
+            GenesisEd25519Verifier::from_verification_key(
+                upgraded_verification_bundle.ed25519,
+            )
+            .verify(payload, &legacy_signature)
+            .expect(
+                "upgraded verification key must verify a signature produced by the original legacy signing key",
+            );
+
+            let upgraded_signing_bundle = GenesisSigningKeyBundle::try_from_hex(
+                &fs::read_to_string(&signing_key_path).unwrap(),
+            )
+            .unwrap();
+            let upgraded_signer =
+                GenesisEd25519Signer::from_secret_key(upgraded_signing_bundle.ed25519);
+            let upgraded_signature = upgraded_signer.sign(payload);
+            legacy_signer
+                .create_verifier()
+                .verify(payload, &upgraded_signature)
+                .expect(
+                    "original verification key must verify a signature produced by the upgraded signing key",
+                );
         }
     }
 }

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -13,7 +13,7 @@ use mithril_common::{
     certificate_chain::{CertificateGenesisProducer, CertificateVerifier},
     crypto_helper::{
         GenesisEd25519Signature, GenesisEd25519Signer, GenesisEd25519VerificationKey,
-        GenesisSigner, ProtocolAggregateVerificationKey,
+        GenesisSigner, GenesisVerifier, ProtocolAggregateVerificationKey,
     },
     entities::{Epoch, ProtocolParameters, SupportedEra},
     protocol::SignerBuilder,
@@ -27,8 +27,8 @@ use crate::{
 };
 #[cfg(feature = "future_snark")]
 use mithril_common::crypto_helper::{
-    GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle, GenesisVerifier,
-    ProtocolKey, sha256_digest, signed_message_from_digest,
+    GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle, ProtocolKey,
+    sha256_digest, signed_message_from_digest,
 };
 
 /// Configuration for the genesis tools.
@@ -146,19 +146,54 @@ impl GenesisTools {
         Ok(())
     }
 
-    /// Import signature of the AVK of the genesis stake distribution from a file
+    /// Import a Pythagoras-era Ed25519 signed payload and persist the genesis certificate.
     pub async fn import_payload_signature(
         &self,
         signed_payload_path: &Path,
         genesis_verification_key: &GenesisEd25519VerificationKey,
     ) -> StdResult<()> {
-        let mut signed_payload_file = File::open(signed_payload_path).unwrap();
-        let mut signed_payload_buffer = Vec::new();
-        signed_payload_file.read_to_end(&mut signed_payload_buffer)?;
+        let signed_payload_buffer = std::fs::read(signed_payload_path)?;
         let genesis_signature = GenesisEd25519Signature::from_bytes(&signed_payload_buffer)?;
-
         self.create_and_save_genesis_certificate(genesis_signature, genesis_verification_key)
             .await
+    }
+
+    /// Import a Lagrange-era dual signed-payload envelope and persist the dual genesis certificate.
+    ///
+    /// Decodes the [`crate::tools::GenesisSignedPayload`] envelope, reconstructs the certificate
+    /// from the pre-computed Ed25519 + Schnorr signatures, then runs both the legacy and the
+    /// SNARK verifiers against it before saving.
+    #[cfg(feature = "future_snark")]
+    pub async fn import_dual_payload_signature(
+        &self,
+        signed_payload_path: &Path,
+        genesis_verifier: &GenesisVerifier,
+    ) -> StdResult<()> {
+        genesis_verifier.ensure_supports_era(self.configuration.mithril_era)?;
+        let signed_payload_buffer = std::fs::read(signed_payload_path)?;
+        let envelope = GenesisSignedPayload::try_from_bytes(&signed_payload_buffer)?;
+        genesis_verifier.verification_key_bundle().schnorr_or_err()?;
+        let genesis_producer =
+            CertificateGenesisProducer::new(None).with_logger(self.logger.clone());
+        let certificate = genesis_producer.create_genesis_certificate_from_dual_signature(
+            self.configuration.genesis_protocol_parameters.clone(),
+            self.configuration.network,
+            self.configuration.epoch,
+            self.configuration.genesis_avk.clone(),
+            envelope.ed25519,
+            envelope.schnorr,
+        )?;
+        self.certificate_verifier
+            .verify_genesis_certificate(
+                &certificate,
+                &genesis_verifier.to_ed25519_verification_key(),
+            )
+            .await?;
+        self.certificate_repository
+            .create_certificate(certificate)
+            .await
+            .with_context(|| "Genesis tool can not save imported dual genesis certificate")?;
+        Ok(())
     }
 
     /// Automatic bootstrap of the genesis certificate (test only).
@@ -182,6 +217,9 @@ impl GenesisTools {
         };
         genesis_signer.ensure_supports_era(self.configuration.mithril_era)?;
         let ed25519_verification_key = genesis_signer.ed25519.verification_key();
+        #[cfg(feature = "future_snark")]
+        let schnorr_verification_key =
+            genesis_signer.schnorr.as_ref().map(|s| s.verification_key());
         let genesis_producer =
             CertificateGenesisProducer::new(Some(Arc::new(genesis_signer.ed25519)))
                 .with_logger(self.logger.clone());
@@ -208,10 +246,20 @@ impl GenesisTools {
             genesis_signature,
             self.configuration.mithril_era,
         )?;
+        #[cfg(not(feature = "future_snark"))]
+        let genesis_verifier = GenesisVerifier::from_ed25519(ed25519_verification_key);
+        #[cfg(feature = "future_snark")]
+        let genesis_verifier = match schnorr_verification_key {
+            Some(schnorr) => GenesisVerifier::from_bundle(GenesisVerificationKeyBundle::new(
+                ed25519_verification_key,
+                schnorr,
+            )),
+            None => GenesisVerifier::from_ed25519(ed25519_verification_key),
+        };
         self.certificate_verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &GenesisVerifier::from_ed25519(ed25519_verification_key),
+                &genesis_verifier.to_ed25519_verification_key(),
             )
             .await?;
         self.certificate_repository
@@ -254,7 +302,7 @@ impl GenesisTools {
                         anyhow::anyhow!("Lagrange genesis sign requires a SNARK signer")
                     })?
                     .sign_non_deterministic(&digest)?;
-                GenesisSignedPayload::new(ed25519, schnorr).to_bytes()
+                GenesisSignedPayload::new(ed25519, schnorr).to_bytes()?
             }
             _ => genesis_signer
                 .ed25519
@@ -285,10 +333,7 @@ impl GenesisTools {
             self.configuration.mithril_era,
         )?;
         self.certificate_verifier
-            .verify_genesis_certificate(
-                &genesis_certificate,
-                &GenesisVerifier::from_ed25519(*genesis_verification_key),
-            )
+            .verify_genesis_certificate(&genesis_certificate, genesis_verification_key)
             .await?;
         self.certificate_repository
             .create_certificate(genesis_certificate.clone())
@@ -742,6 +787,92 @@ mod tests {
                 .create_verifier()
                 .verify(payload, &signature)
                 .expect("Ed25519 signature must verify");
+        }
+    }
+
+    #[cfg(feature = "future_snark")]
+    mod import {
+        use std::fs;
+
+        use mithril_common::crypto_helper::{
+            GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle,
+        };
+
+        use super::*;
+
+        #[tokio::test]
+        async fn lagrange_round_trip_through_dual_envelope() {
+            let temp = get_temp_dir("import_lagrange_round_trip");
+            let preimage_path = temp.join("preimage.bin");
+            let signed_path = temp.join("signed.bin");
+
+            let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
+            let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+            let bundle = GenesisVerificationKeyBundle::new(
+                ed25519_signer.verification_key(),
+                schnorr_signer.verification_key(),
+            );
+            let signer = GenesisSigner::from_bundle(GenesisSigningKeyBundle::new(
+                ed25519_signer.secret_key(),
+                schnorr_signer.secret_key(),
+            ));
+            let signing_key_path = temp.join("genesis.sk");
+            signer.write_to_file(&signing_key_path).unwrap();
+
+            let (genesis_tools, certificate_store, _, _) =
+                build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
+
+            genesis_tools
+                .export_payload_to_sign(&preimage_path)
+                .expect("export should not fail");
+            let preimage_bytes = fs::read(&preimage_path).unwrap();
+            assert_eq!(preimage_bytes.len(), 190);
+
+            GenesisTools::sign_genesis_certificate(
+                &preimage_path,
+                &signed_path,
+                &signing_key_path,
+                SupportedEra::Lagrange,
+            )
+            .await
+            .expect("sign should not fail");
+
+            genesis_tools
+                .import_dual_payload_signature(&signed_path, &GenesisVerifier::from_bundle(bundle))
+                .await
+                .expect("import should not fail");
+
+            let last: Vec<Certificate> =
+                certificate_store.get_latest_certificates(10).await.unwrap();
+            assert_eq!(1, last.len());
+        }
+
+        #[tokio::test]
+        async fn lagrange_rejects_legacy_verification_key_bundle() {
+            let temp = get_temp_dir("import_lagrange_rejects_legacy_vk");
+            let signed_path = temp.join("signed.bin");
+            fs::write(&signed_path, vec![0u8; 8]).unwrap();
+
+            let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
+            let legacy_bundle = GenesisVerificationKeyBundle {
+                ed25519: ed25519_signer.verification_key(),
+                schnorr: None,
+            };
+            let (genesis_tools, _, _, _) =
+                build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
+
+            let error = genesis_tools
+                .import_dual_payload_signature(
+                    &signed_path,
+                    &GenesisVerifier::from_bundle(legacy_bundle),
+                )
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                error.downcast_ref::<mithril_common::crypto_helper::GenesisBundleError>(),
+                Some(mithril_common::crypto_helper::GenesisBundleError::SchnorrVerificationKeyRequired)
+            ));
         }
     }
 }

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -171,14 +171,13 @@ impl GenesisTools {
         let signed_payload_buffer = std::fs::read(signed_payload_path)?;
         let envelope = GenesisSignedPayload::try_from_bytes(&signed_payload_buffer)?;
         let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
-        let signature =
-            CertificateSignature::GenesisDualSignature(envelope.ed25519, envelope.schnorr);
         let certificate = genesis_producer.create_genesis_certificate(
             self.configuration.genesis_protocol_parameters.clone(),
             self.configuration.network,
             self.configuration.epoch,
             self.configuration.genesis_avk.clone(),
-            signature,
+            envelope.ed25519,
+            envelope.schnorr,
             SupportedEra::Lagrange,
         )?;
         self.certificate_verifier
@@ -228,14 +227,33 @@ impl GenesisTools {
         )?;
         let signature = genesis_signer
             .sign_non_deterministic(&genesis_protocol_message, self.configuration.mithril_era)?;
-        let genesis_certificate = genesis_producer.create_genesis_certificate(
-            self.configuration.genesis_protocol_parameters.clone(),
-            self.configuration.network,
-            self.configuration.epoch,
-            self.configuration.genesis_avk.clone(),
-            signature,
-            self.configuration.mithril_era,
-        )?;
+        let genesis_certificate = match signature {
+            CertificateSignature::GenesisSignature(genesis_signature) => genesis_producer
+                .create_legacy_genesis_certificate(
+                    self.configuration.genesis_protocol_parameters.clone(),
+                    self.configuration.network,
+                    self.configuration.epoch,
+                    self.configuration.genesis_avk.clone(),
+                    genesis_signature,
+                    self.configuration.mithril_era,
+                )?,
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(
+                genesis_signature,
+                genesis_signature_snark,
+            ) => genesis_producer.create_genesis_certificate(
+                self.configuration.genesis_protocol_parameters.clone(),
+                self.configuration.network,
+                self.configuration.epoch,
+                self.configuration.genesis_avk.clone(),
+                genesis_signature,
+                genesis_signature_snark,
+                self.configuration.mithril_era,
+            )?,
+            CertificateSignature::MultiSignature(..) => {
+                unreachable!("the genesis signer never produces a multi-signature")
+            }
+        };
         #[cfg(not(feature = "future_snark"))]
         let genesis_verifier = GenesisVerifier::from_ed25519(ed25519_verification_key);
         #[cfg(feature = "future_snark")]
@@ -310,12 +328,12 @@ impl GenesisTools {
         genesis_verification_key: &GenesisEd25519VerificationKey,
     ) -> StdResult<()> {
         let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
-        let genesis_certificate = genesis_producer.create_genesis_certificate(
+        let genesis_certificate = genesis_producer.create_legacy_genesis_certificate(
             self.configuration.genesis_protocol_parameters.clone(),
             self.configuration.network,
             self.configuration.epoch,
             self.configuration.genesis_avk.clone(),
-            CertificateSignature::GenesisSignature(genesis_signature),
+            genesis_signature,
             self.configuration.mithril_era,
         )?;
         self.certificate_verifier

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -27,8 +27,8 @@ use crate::{
 };
 #[cfg(feature = "future_snark")]
 use mithril_common::crypto_helper::{
-    GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle, ProtocolKey,
-    sha256_digest, signed_message_from_digest,
+    GenesisSchnorrSigner, GenesisSigningKeyBundle, GenesisVerificationKeyBundle, GenesisVerifier,
+    ProtocolKey, sha256_digest, signed_message_from_digest,
 };
 
 /// Configuration for the genesis tools.
@@ -209,7 +209,10 @@ impl GenesisTools {
             self.configuration.mithril_era,
         )?;
         self.certificate_verifier
-            .verify_genesis_certificate(&genesis_certificate, &ed25519_verification_key)
+            .verify_genesis_certificate(
+                &genesis_certificate,
+                &GenesisVerifier::from_ed25519(ed25519_verification_key),
+            )
             .await?;
         self.certificate_repository
             .create_certificate(genesis_certificate)
@@ -282,7 +285,10 @@ impl GenesisTools {
             self.configuration.mithril_era,
         )?;
         self.certificate_verifier
-            .verify_genesis_certificate(&genesis_certificate, genesis_verification_key)
+            .verify_genesis_certificate(
+                &genesis_certificate,
+                &GenesisVerifier::from_ed25519(*genesis_verification_key),
+            )
             .await?;
         self.certificate_repository
             .create_certificate(genesis_certificate.clone())

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 #[cfg(feature = "future_snark")]
 use mithril_common::crypto_helper::{
-    GenesisEd25519SecretKey, GenesisSchnorrSigner, GenesisSigningKeyBundle,
+    GenesisBundleError, GenesisEd25519SecretKey, GenesisSchnorrSigner, GenesisSigningKeyBundle,
     GenesisVerificationKeyBundle, ProtocolKey, sha256_digest, signed_message_from_digest,
 };
 
@@ -168,7 +168,6 @@ impl GenesisTools {
         signed_payload_path: &Path,
         genesis_verifier: &GenesisVerifier,
     ) -> StdResult<()> {
-        genesis_verifier.ensure_supports_era(self.configuration.mithril_era)?;
         let signed_payload_buffer = std::fs::read(signed_payload_path)?;
         let envelope = GenesisSignedPayload::try_from_bytes(&signed_payload_buffer)?;
         let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
@@ -216,7 +215,6 @@ impl GenesisTools {
         } else {
             genesis_signer
         };
-        genesis_signer.ensure_supports_era(self.configuration.mithril_era)?;
         let ed25519_verification_key = genesis_signer.ed25519.verification_key();
         #[cfg(feature = "future_snark")]
         let schnorr_verification_key =
@@ -275,7 +273,6 @@ impl GenesisTools {
         mithril_era: SupportedEra,
     ) -> StdResult<()> {
         let genesis_signer = GenesisSigner::read_from_file(genesis_secret_key_path)?;
-        genesis_signer.ensure_supports_era(mithril_era)?;
 
         let mut to_sign_payload_file = File::open(to_sign_payload_path)?;
         let mut to_sign_payload_buffer = Vec::new();
@@ -290,9 +287,7 @@ impl GenesisTools {
                 let schnorr = genesis_signer
                     .schnorr
                     .as_ref()
-                    .ok_or_else(|| {
-                        anyhow::anyhow!("Lagrange genesis sign requires a SNARK signer")
-                    })?
+                    .ok_or(GenesisBundleError::LegacySigningKey)?
                     .sign_non_deterministic(&digest)?;
                 GenesisSignedPayload::new(ed25519, schnorr).to_bytes()?
             }
@@ -633,14 +628,13 @@ mod tests {
 
         let signing_bundle = GenesisSigningKeyBundle::try_from_hex(&signing_hex)
             .expect("signing bundle hex must round-trip");
-        let verification_bundle =
-            GenesisVerificationKeyBundle::try_from_hex_or_legacy(&verification_hex)
-                .expect("verification bundle hex must round-trip");
+        let verification_bundle = GenesisVerificationKeyBundle::try_from_hex(&verification_hex)
+            .expect("verification bundle hex must round-trip");
         let expected_schnorr_verification_key =
             GenesisSchnorrSigner::from_secret_key(signing_bundle.schnorr).verification_key();
 
         assert_eq!(
-            verification_bundle.schnorr.unwrap().to_bytes(),
+            verification_bundle.schnorr.to_bytes(),
             expected_schnorr_verification_key.to_bytes()
         );
     }
@@ -887,34 +881,6 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn lagrange_rejects_legacy_verification_key_bundle() {
-            let temp = get_temp_dir("import_lagrange_rejects_legacy_vk");
-            let signed_path = temp.join("signed.bin");
-            fs::write(&signed_path, vec![0u8; 8]).unwrap();
-
-            let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
-            let legacy_bundle = GenesisVerificationKeyBundle {
-                ed25519: ed25519_signer.verification_key(),
-                schnorr: None,
-            };
-            let (genesis_tools, _, _, _) =
-                build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
-
-            let error = genesis_tools
-                .import_dual_payload_signature(
-                    &signed_path,
-                    &GenesisVerifier::from_bundle(legacy_bundle),
-                )
-                .await
-                .unwrap_err();
-
-            assert!(matches!(
-                error.downcast_ref::<mithril_common::crypto_helper::GenesisBundleError>(),
-                Some(mithril_common::crypto_helper::GenesisBundleError::SchnorrVerificationKeyRequired)
-            ));
-        }
-
-        #[tokio::test]
         async fn lagrange_rejects_tampered_schnorr_signature() {
             let temp = get_temp_dir("import_lagrange_rejects_tampered_schnorr");
             let preimage_path = temp.join("preimage.bin");
@@ -1007,7 +973,7 @@ mod tests {
 
             let signing_bundle = GenesisSigningKeyBundle::try_from_hex(&signing_hex).unwrap();
             let verification_bundle =
-                GenesisVerificationKeyBundle::try_from_hex_or_legacy(&verification_hex).unwrap();
+                GenesisVerificationKeyBundle::try_from_hex(&verification_hex).unwrap();
 
             assert_eq!(
                 signing_bundle.ed25519.to_bytes(),
@@ -1020,7 +986,7 @@ mod tests {
             let derived_schnorr_vk =
                 GenesisSchnorrSigner::from_secret_key(signing_bundle.schnorr).verification_key();
             assert_eq!(
-                verification_bundle.schnorr.unwrap().to_bytes(),
+                verification_bundle.schnorr.to_bytes(),
                 derived_schnorr_vk.to_bytes()
             );
         }
@@ -1102,11 +1068,10 @@ mod tests {
             let payload = b"upgrade-key-drift-canary";
             let legacy_signature = legacy_signer.sign(payload);
 
-            let upgraded_verification_bundle =
-                GenesisVerificationKeyBundle::try_from_hex_or_legacy(
-                    &fs::read_to_string(&verification_key_path).unwrap(),
-                )
-                .unwrap();
+            let upgraded_verification_bundle = GenesisVerificationKeyBundle::try_from_hex(
+                &fs::read_to_string(&verification_key_path).unwrap(),
+            )
+            .unwrap();
             GenesisEd25519Verifier::from_verification_key(
                 upgraded_verification_bundle.ed25519,
             )

--- a/mithril-aggregator/src/tools/genesis/signed_payload.rs
+++ b/mithril-aggregator/src/tools/genesis/signed_payload.rs
@@ -1,60 +1,37 @@
 //! Versioned envelope carrying the dual genesis signature (Ed25519 + Schnorr) produced by the
 //! offline sign ceremony under the Lagrange era.
 
-#![allow(dead_code)]
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 use mithril_common::StdResult;
 use mithril_common::crypto_helper::{GenesisEd25519Signature, GenesisSchnorrSignature};
-use thiserror::Error;
 
 /// Current envelope version.
 pub const GENESIS_SIGNED_PAYLOAD_VERSION: u8 = 1;
 
-/// Expected raw Ed25519 signature byte length.
-pub const ED25519_SIGNATURE_BYTES: u8 = 64;
-
-/// Expected raw Schnorr signature byte length.
-pub const SCHNORR_SIGNATURE_BYTES: u8 = 64;
-
-/// Errors raised when parsing or serialising a dual genesis signed payload.
+/// Errors raised when parsing a dual genesis signed payload.
 #[derive(Error, Debug)]
 pub enum GenesisSignedPayloadError {
+    /// The envelope is empty and carries no version byte.
+    #[error("empty genesis signed payload")]
+    Empty,
+
     /// The envelope declares a version other than [GENESIS_SIGNED_PAYLOAD_VERSION].
     #[error("unsupported genesis signed payload version: {version} (only version 1 is supported)")]
     UnsupportedVersion {
         /// Version byte read from the envelope.
         version: u8,
     },
-
-    /// A length-prefix field in the envelope does not match its expected fixed value.
-    #[error("{field_kind} length prefix mismatch: expected {expected} bytes, got {actual}")]
-    LengthPrefixMismatch {
-        /// Field name (`Ed25519` or `Schnorr`) prefixed with signature kind.
-        field_kind: &'static str,
-        /// Expected byte length pinned by [GENESIS_SIGNED_PAYLOAD_VERSION].
-        expected: u8,
-        /// Length actually declared by the envelope.
-        actual: u8,
-    },
-
-    /// The envelope decoded to fewer bytes than the layout requires.
-    #[error("genesis signed payload truncated: missing {field}")]
-    Truncated {
-        /// Layout segment that ran short.
-        field: &'static str,
-    },
-
-    /// The envelope decoded to more bytes than the layout consumes.
-    #[error("trailing bytes in genesis signed payload ({extra} extra bytes)")]
-    TrailingBytes {
-        /// Number of unconsumed bytes after the envelope layout.
-        extra: usize,
-    },
 }
 
 /// Dual genesis signed payload: a legacy Ed25519 signature paired with a SNARK-friendly Schnorr
 /// signature.
-#[derive(Debug, Clone)]
+///
+/// Serialised as a single version byte followed by the CBOR encoding of the two signatures, so the
+/// envelope can evolve without a hand-written byte parser.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GenesisSignedPayload {
     /// Ed25519 signature produced by the ed25519 signer.
     pub ed25519: GenesisEd25519Signature,
@@ -69,79 +46,24 @@ impl GenesisSignedPayload {
         Self { ed25519, schnorr }
     }
 
-    /// Encode the envelope as raw bytes.
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::with_capacity(3 + 64 + 64);
-        bytes.push(GENESIS_SIGNED_PAYLOAD_VERSION);
-        bytes.push(ED25519_SIGNATURE_BYTES);
-        bytes.extend_from_slice(&self.ed25519.to_bytes());
-        bytes.push(SCHNORR_SIGNATURE_BYTES);
-        bytes.extend_from_slice(&self.schnorr.to_bytes());
-        bytes
+    /// Encode the envelope as a version-prefixed CBOR payload.
+    pub fn to_bytes(&self) -> StdResult<Vec<u8>> {
+        let mut bytes = vec![GENESIS_SIGNED_PAYLOAD_VERSION];
+        ciborium::ser::into_writer(self, &mut bytes)
+            .with_context(|| "Failed to encode genesis signed payload to CBOR")?;
+        Ok(bytes)
     }
 
-    /// Decode an envelope from raw bytes.
+    /// Decode a version-prefixed CBOR envelope.
     pub fn try_from_bytes(bytes: &[u8]) -> StdResult<Self> {
-        let mut cursor = bytes;
-        let version = read_u8(&mut cursor, "version")?;
-        if version != GENESIS_SIGNED_PAYLOAD_VERSION {
-            return Err(GenesisSignedPayloadError::UnsupportedVersion { version }.into());
+        let (version, payload) = bytes.split_first().ok_or(GenesisSignedPayloadError::Empty)?;
+        if *version != GENESIS_SIGNED_PAYLOAD_VERSION {
+            return Err(GenesisSignedPayloadError::UnsupportedVersion { version: *version }.into());
         }
-        let ed25519_bytes = read_length_prefixed(
-            &mut cursor,
-            "Ed25519 signature",
-            ED25519_SIGNATURE_BYTES,
-            "ed25519 signature body",
-        )?;
-        let schnorr_bytes = read_length_prefixed(
-            &mut cursor,
-            "Schnorr signature",
-            SCHNORR_SIGNATURE_BYTES,
-            "schnorr signature body",
-        )?;
-        if !cursor.is_empty() {
-            return Err(GenesisSignedPayloadError::TrailingBytes {
-                extra: cursor.len(),
-            }
-            .into());
-        }
-        let ed25519 = GenesisEd25519Signature::from_bytes(ed25519_bytes)?;
-        let schnorr = GenesisSchnorrSignature::from_bytes(schnorr_bytes)?;
-        Ok(Self { ed25519, schnorr })
-    }
-}
 
-fn read_u8(cursor: &mut &[u8], field: &'static str) -> StdResult<u8> {
-    match cursor.split_first() {
-        Some((byte, rest)) => {
-            *cursor = rest;
-            Ok(*byte)
-        }
-        None => Err(GenesisSignedPayloadError::Truncated { field }.into()),
+        ciborium::de::from_reader(payload)
+            .with_context(|| "Failed to decode genesis signed payload from CBOR")
     }
-}
-
-fn read_length_prefixed<'a>(
-    cursor: &mut &'a [u8],
-    field_kind: &'static str,
-    expected: u8,
-    body_field: &'static str,
-) -> StdResult<&'a [u8]> {
-    let actual = read_u8(cursor, "length prefix")?;
-    if actual != expected {
-        return Err(GenesisSignedPayloadError::LengthPrefixMismatch {
-            field_kind,
-            expected,
-            actual,
-        }
-        .into());
-    }
-    if cursor.len() < expected as usize {
-        return Err(GenesisSignedPayloadError::Truncated { field: body_field }.into());
-    }
-    let (head, tail) = cursor.split_at(expected as usize);
-    *cursor = tail;
-    Ok(head)
 }
 
 #[cfg(test)]
@@ -163,7 +85,9 @@ mod tests {
     #[test]
     fn round_trips_through_bytes() {
         let payload = deterministic_payload();
-        let bytes = payload.to_bytes();
+        let bytes = payload.to_bytes().unwrap();
+
+        assert_eq!(bytes[0], GENESIS_SIGNED_PAYLOAD_VERSION);
 
         let restored = GenesisSignedPayload::try_from_bytes(&bytes).unwrap();
 
@@ -172,8 +96,18 @@ mod tests {
     }
 
     #[test]
+    fn rejects_empty_payload() {
+        let error = GenesisSignedPayload::try_from_bytes(&[]).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<GenesisSignedPayloadError>(),
+            Some(GenesisSignedPayloadError::Empty)
+        ));
+    }
+
+    #[test]
     fn rejects_unsupported_version() {
-        let mut bytes = deterministic_payload().to_bytes();
+        let mut bytes = deterministic_payload().to_bytes().unwrap();
         bytes[0] = 2;
 
         let error = GenesisSignedPayload::try_from_bytes(&bytes).unwrap_err();
@@ -185,46 +119,11 @@ mod tests {
     }
 
     #[test]
-    fn rejects_length_prefix_mismatch() {
-        let mut bytes = deterministic_payload().to_bytes();
-        bytes[1] = 32;
+    fn rejects_corrupted_cbor_body() {
+        let bytes = deterministic_payload().to_bytes().unwrap();
+        let truncated = &bytes[..bytes.len() - 1];
 
-        let error = GenesisSignedPayload::try_from_bytes(&bytes).unwrap_err();
-
-        assert!(matches!(
-            error.downcast_ref::<GenesisSignedPayloadError>(),
-            Some(GenesisSignedPayloadError::LengthPrefixMismatch {
-                field_kind: "Ed25519 signature",
-                expected: 64,
-                actual: 32
-            })
-        ));
-    }
-
-    #[test]
-    fn rejects_trailing_bytes() {
-        let mut bytes = deterministic_payload().to_bytes();
-        bytes.push(0xAA);
-
-        let error = GenesisSignedPayload::try_from_bytes(&bytes).unwrap_err();
-
-        assert!(matches!(
-            error.downcast_ref::<GenesisSignedPayloadError>(),
-            Some(GenesisSignedPayloadError::TrailingBytes { extra: 1 })
-        ));
-    }
-
-    #[test]
-    fn rejects_truncated_envelope() {
-        let bytes = deterministic_payload().to_bytes();
-        let truncated = &bytes[..2];
-
-        let error = GenesisSignedPayload::try_from_bytes(truncated).unwrap_err();
-
-        assert!(matches!(
-            error.downcast_ref::<GenesisSignedPayloadError>(),
-            Some(GenesisSignedPayloadError::Truncated { .. })
-        ));
+        GenesisSignedPayload::try_from_bytes(truncated).unwrap_err();
     }
 
     mod golden {

--- a/mithril-aggregator/src/tools/genesis/signed_payload.rs
+++ b/mithril-aggregator/src/tools/genesis/signed_payload.rs
@@ -1,0 +1,282 @@
+//! Versioned envelope carrying the dual genesis signature (Ed25519 + Schnorr) produced by the
+//! offline sign ceremony under the Lagrange era.
+
+#![allow(dead_code)]
+
+use mithril_common::StdResult;
+use mithril_common::crypto_helper::{GenesisEd25519Signature, GenesisSchnorrSignature};
+use thiserror::Error;
+
+/// Current envelope version.
+pub const GENESIS_SIGNED_PAYLOAD_VERSION: u8 = 1;
+
+/// Expected raw Ed25519 signature byte length.
+pub const ED25519_SIGNATURE_BYTES: u8 = 64;
+
+/// Expected raw Schnorr signature byte length.
+pub const SCHNORR_SIGNATURE_BYTES: u8 = 64;
+
+/// Errors raised when parsing or serialising a dual genesis signed payload.
+#[derive(Error, Debug)]
+pub enum GenesisSignedPayloadError {
+    /// The envelope declares a version other than [GENESIS_SIGNED_PAYLOAD_VERSION].
+    #[error("unsupported genesis signed payload version: {version} (only version 1 is supported)")]
+    UnsupportedVersion {
+        /// Version byte read from the envelope.
+        version: u8,
+    },
+
+    /// A length-prefix field in the envelope does not match its expected fixed value.
+    #[error("{field_kind} length prefix mismatch: expected {expected} bytes, got {actual}")]
+    LengthPrefixMismatch {
+        /// Field name (`Ed25519` or `Schnorr`) prefixed with signature kind.
+        field_kind: &'static str,
+        /// Expected byte length pinned by [GENESIS_SIGNED_PAYLOAD_VERSION].
+        expected: u8,
+        /// Length actually declared by the envelope.
+        actual: u8,
+    },
+
+    /// The envelope decoded to fewer bytes than the layout requires.
+    #[error("genesis signed payload truncated: missing {field}")]
+    Truncated {
+        /// Layout segment that ran short.
+        field: &'static str,
+    },
+
+    /// The envelope decoded to more bytes than the layout consumes.
+    #[error("trailing bytes in genesis signed payload ({extra} extra bytes)")]
+    TrailingBytes {
+        /// Number of unconsumed bytes after the envelope layout.
+        extra: usize,
+    },
+}
+
+/// Dual genesis signed payload: a legacy Ed25519 signature paired with a SNARK-friendly Schnorr
+/// signature.
+#[derive(Debug, Clone)]
+pub struct GenesisSignedPayload {
+    /// Ed25519 signature produced by the ed25519 signer.
+    pub ed25519: GenesisEd25519Signature,
+
+    /// Schnorr signature produced by the SNARK signer.
+    pub schnorr: GenesisSchnorrSignature,
+}
+
+impl GenesisSignedPayload {
+    /// Build a fresh envelope from the two signatures.
+    pub fn new(ed25519: GenesisEd25519Signature, schnorr: GenesisSchnorrSignature) -> Self {
+        Self { ed25519, schnorr }
+    }
+
+    /// Encode the envelope as raw bytes.
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::with_capacity(3 + 64 + 64);
+        bytes.push(GENESIS_SIGNED_PAYLOAD_VERSION);
+        bytes.push(ED25519_SIGNATURE_BYTES);
+        bytes.extend_from_slice(&self.ed25519.to_bytes());
+        bytes.push(SCHNORR_SIGNATURE_BYTES);
+        bytes.extend_from_slice(&self.schnorr.to_bytes());
+        bytes
+    }
+
+    /// Decode an envelope from raw bytes.
+    pub fn try_from_bytes(bytes: &[u8]) -> StdResult<Self> {
+        let mut cursor = bytes;
+        let version = read_u8(&mut cursor, "version")?;
+        if version != GENESIS_SIGNED_PAYLOAD_VERSION {
+            return Err(GenesisSignedPayloadError::UnsupportedVersion { version }.into());
+        }
+        let ed25519_bytes = read_length_prefixed(
+            &mut cursor,
+            "Ed25519 signature",
+            ED25519_SIGNATURE_BYTES,
+            "ed25519 signature body",
+        )?;
+        let schnorr_bytes = read_length_prefixed(
+            &mut cursor,
+            "Schnorr signature",
+            SCHNORR_SIGNATURE_BYTES,
+            "schnorr signature body",
+        )?;
+        if !cursor.is_empty() {
+            return Err(GenesisSignedPayloadError::TrailingBytes {
+                extra: cursor.len(),
+            }
+            .into());
+        }
+        let ed25519 = GenesisEd25519Signature::from_bytes(ed25519_bytes)?;
+        let schnorr = GenesisSchnorrSignature::from_bytes(schnorr_bytes)?;
+        Ok(Self { ed25519, schnorr })
+    }
+}
+
+fn read_u8(cursor: &mut &[u8], field: &'static str) -> StdResult<u8> {
+    match cursor.split_first() {
+        Some((byte, rest)) => {
+            *cursor = rest;
+            Ok(*byte)
+        }
+        None => Err(GenesisSignedPayloadError::Truncated { field }.into()),
+    }
+}
+
+fn read_length_prefixed<'a>(
+    cursor: &mut &'a [u8],
+    field_kind: &'static str,
+    expected: u8,
+    body_field: &'static str,
+) -> StdResult<&'a [u8]> {
+    let actual = read_u8(cursor, "length prefix")?;
+    if actual != expected {
+        return Err(GenesisSignedPayloadError::LengthPrefixMismatch {
+            field_kind,
+            expected,
+            actual,
+        }
+        .into());
+    }
+    if cursor.len() < expected as usize {
+        return Err(GenesisSignedPayloadError::Truncated { field: body_field }.into());
+    }
+    let (head, tail) = cursor.split_at(expected as usize);
+    *cursor = tail;
+    Ok(head)
+}
+
+#[cfg(test)]
+mod tests {
+    use mithril_common::crypto_helper::{GenesisEd25519Signer, GenesisSchnorrSigner};
+
+    use super::*;
+
+    fn deterministic_payload() -> GenesisSignedPayload {
+        let ed_signer = GenesisEd25519Signer::create_deterministic_signer();
+        let ed25519 = ed_signer.sign(b"genesis-signed-message");
+
+        let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+        let schnorr = schnorr_signer.sign_non_deterministic(&[0x42u8; 32]).unwrap();
+
+        GenesisSignedPayload::new(ed25519, schnorr)
+    }
+
+    #[test]
+    fn round_trips_through_bytes() {
+        let payload = deterministic_payload();
+        let bytes = payload.to_bytes();
+
+        let restored = GenesisSignedPayload::try_from_bytes(&bytes).unwrap();
+
+        assert_eq!(restored.ed25519.to_bytes(), payload.ed25519.to_bytes());
+        assert_eq!(restored.schnorr.to_bytes(), payload.schnorr.to_bytes());
+    }
+
+    #[test]
+    fn rejects_unsupported_version() {
+        let mut bytes = deterministic_payload().to_bytes();
+        bytes[0] = 2;
+
+        let error = GenesisSignedPayload::try_from_bytes(&bytes).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<GenesisSignedPayloadError>(),
+            Some(GenesisSignedPayloadError::UnsupportedVersion { version: 2 })
+        ));
+    }
+
+    #[test]
+    fn rejects_length_prefix_mismatch() {
+        let mut bytes = deterministic_payload().to_bytes();
+        bytes[1] = 32;
+
+        let error = GenesisSignedPayload::try_from_bytes(&bytes).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<GenesisSignedPayloadError>(),
+            Some(GenesisSignedPayloadError::LengthPrefixMismatch {
+                field_kind: "Ed25519 signature",
+                expected: 64,
+                actual: 32
+            })
+        ));
+    }
+
+    #[test]
+    fn rejects_trailing_bytes() {
+        let mut bytes = deterministic_payload().to_bytes();
+        bytes.push(0xAA);
+
+        let error = GenesisSignedPayload::try_from_bytes(&bytes).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<GenesisSignedPayloadError>(),
+            Some(GenesisSignedPayloadError::TrailingBytes { extra: 1 })
+        ));
+    }
+
+    #[test]
+    fn rejects_truncated_envelope() {
+        let bytes = deterministic_payload().to_bytes();
+        let truncated = &bytes[..2];
+
+        let error = GenesisSignedPayload::try_from_bytes(truncated).unwrap_err();
+
+        assert!(matches!(
+            error.downcast_ref::<GenesisSignedPayloadError>(),
+            Some(GenesisSignedPayloadError::Truncated { .. })
+        ));
+    }
+
+    mod golden {
+        use super::*;
+
+        const GOLDEN_MESSAGE: &[u8] = b"genesis-signed-message";
+
+        const GOLDEN_ED25519_HEX: &str = "1191eb0dcad9ad33b5f7b4af635090caa35413d24ff714c828d91d616665541d108b104a594a04c59b8b097aba6a74b900eb082f527d656681fca4e708cc2d08";
+
+        const GOLDEN_SCHNORR_HEX: &str = "35b28d59bd557a7a2d8ae3c72683d4b6e77aa1d5d978c515b3fe3bb42466a20cc4837e0dd0861abae347b0aa7b56477cd9368b3a351c3f60623698d2f4ab5e68";
+
+        const GOLDEN_BYTES: &[u8; 297] = &[
+            1, 162, 103, 101, 100, 50, 53, 53, 49, 57, 120, 128, 49, 49, 57, 49, 101, 98, 48, 100,
+            99, 97, 100, 57, 97, 100, 51, 51, 98, 53, 102, 55, 98, 52, 97, 102, 54, 51, 53, 48, 57,
+            48, 99, 97, 97, 51, 53, 52, 49, 51, 100, 50, 52, 102, 102, 55, 49, 52, 99, 56, 50, 56,
+            100, 57, 49, 100, 54, 49, 54, 54, 54, 53, 53, 52, 49, 100, 49, 48, 56, 98, 49, 48, 52,
+            97, 53, 57, 52, 97, 48, 52, 99, 53, 57, 98, 56, 98, 48, 57, 55, 97, 98, 97, 54, 97, 55,
+            52, 98, 57, 48, 48, 101, 98, 48, 56, 50, 102, 53, 50, 55, 100, 54, 53, 54, 54, 56, 49,
+            102, 99, 97, 52, 101, 55, 48, 56, 99, 99, 50, 100, 48, 56, 103, 115, 99, 104, 110, 111,
+            114, 114, 162, 104, 114, 101, 115, 112, 111, 110, 115, 101, 152, 32, 24, 53, 24, 178,
+            24, 141, 24, 89, 24, 189, 24, 85, 24, 122, 24, 122, 24, 45, 24, 138, 24, 227, 24, 199,
+            24, 38, 24, 131, 24, 212, 24, 182, 24, 231, 24, 122, 24, 161, 24, 213, 24, 217, 24,
+            120, 24, 197, 21, 24, 179, 24, 254, 24, 59, 24, 180, 24, 36, 24, 102, 24, 162, 12, 105,
+            99, 104, 97, 108, 108, 101, 110, 103, 101, 152, 32, 24, 196, 24, 131, 24, 126, 13, 24,
+            208, 24, 134, 24, 26, 24, 186, 24, 227, 24, 71, 24, 176, 24, 170, 24, 123, 24, 86, 24,
+            71, 24, 124, 24, 217, 24, 54, 24, 139, 24, 58, 24, 53, 24, 28, 24, 63, 24, 96, 24, 98,
+            24, 54, 24, 152, 24, 210, 24, 244, 24, 171, 24, 94, 24, 104,
+        ];
+
+        #[test]
+        fn golden_bytes_decode_to_expected_signatures() {
+            let payload = GenesisSignedPayload::try_from_bytes(GOLDEN_BYTES)
+                .expect("Golden genesis signed payload should decode");
+
+            assert_eq!(GOLDEN_ED25519_HEX, hex::encode(payload.ed25519.to_bytes()));
+            assert_eq!(GOLDEN_SCHNORR_HEX, hex::encode(payload.schnorr.to_bytes()));
+        }
+
+        #[test]
+        fn golden_encoding_is_stable() {
+            let payload = GenesisSignedPayload::try_from_bytes(GOLDEN_BYTES)
+                .expect("Golden genesis signed payload should decode");
+            let reencoded = payload.to_bytes().expect("Golden payload should re-encode");
+
+            assert_eq!(GOLDEN_BYTES.as_slice(), reencoded.as_slice());
+        }
+
+        #[test]
+        fn golden_ed25519_signature_is_reproducible() {
+            let ed25519 = GenesisEd25519Signer::create_deterministic_signer().sign(GOLDEN_MESSAGE);
+
+            assert_eq!(GOLDEN_ED25519_HEX, hex::encode(ed25519.to_bytes()));
+        }
+    }
+}

--- a/mithril-aggregator/src/tools/mod.rs
+++ b/mithril-aggregator/src/tools/mod.rs
@@ -10,6 +10,8 @@ mod vacuum_tracker;
 
 pub use certificates_hash_migrator::CertificatesHashMigrator;
 pub use era::EraTools;
+#[cfg(feature = "future_snark")]
+pub use genesis::GenesisSignedPayload;
 pub use genesis::GenesisTools;
 pub use single_signature_authenticator::*;
 pub use vacuum_tracker::VacuumTracker;

--- a/mithril-aggregator/tests/test_extensions/runtime_tester.rs
+++ b/mithril-aggregator/tests/test_extensions/runtime_tester.rs
@@ -22,7 +22,7 @@ use mithril_cardano_node_internal_database::test::double::{
 };
 use mithril_common::{
     StdResult,
-    crypto_helper::GenesisEd25519Signer,
+    crypto_helper::GenesisSigner,
     entities::{
         BlockNumber, Certificate, CertificateSignature, ChainPoint, Epoch, ImmutableFileNumber,
         SignedEntityType, SignedEntityTypeDiscriminants, SingleSignatureAuthenticationStatus,
@@ -130,7 +130,7 @@ pub struct RuntimeTester {
     pub chain_observer: Arc<FakeChainObserver>,
     pub immutable_file_observer: Arc<DumbImmutableFileObserver>,
     pub digester: Arc<DumbImmutableDigester>,
-    pub genesis_signer: Arc<GenesisEd25519Signer>,
+    pub genesis_signer: Arc<GenesisSigner>,
     pub dependencies: ServeCommandDependenciesContainer,
     pub runtime: AggregatorRuntime,
     pub era_reader_adapter: Arc<EraReaderDummyAdapter>,
@@ -167,7 +167,7 @@ impl RuntimeTester {
         let snapshotter = Arc::new(FakeSnapshotter::new(
             configuration.get_snapshot_dir().unwrap().join("fake_snapshots"),
         ));
-        let genesis_signer = Arc::new(GenesisEd25519Signer::create_deterministic_signer());
+        let genesis_signer = Arc::new(GenesisSigner::create_deterministic_signer());
         let era_reader_adapter =
             Arc::new(EraReaderDummyAdapter::from_markers(vec![EraMarker::new(
                 &SupportedEra::dummy().to_string(),
@@ -583,6 +583,8 @@ impl RuntimeTester {
     ) -> StdResult<Option<SignedEntityRecord>> {
         let signed_entity = match &certificate.signature {
             CertificateSignature::GenesisSignature(..) => None,
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(..) => None,
             CertificateSignature::MultiSignature(..) => {
                 let record = self
                     .dependencies

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.13.14"
+version = "0.13.15"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/shared_steps.rs
+++ b/mithril-client-cli/src/commands/cardano_db/shared_steps.rs
@@ -304,6 +304,8 @@ mod tests {
             aggregate_verification_key_snark: None,
             multi_signature: String::new(),
             genesis_signature: String::new(),
+            #[cfg(feature = "future_snark")]
+            genesis_schnorr_signature: String::new(),
         }
     }
 

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.14.13"
+version = "0.14.14"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -63,8 +63,8 @@ chrono = { workspace = true }
 flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
-mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.1" }
-mithril-common = { path = "../mithril-common", version = "0.7.3", default-features = false }
+mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.2" }
+mithril-common = { path = "../mithril-common", version = "0.7.4", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -77,8 +77,8 @@ uuid = { version = "1.23.2", features = ["v4"] }
 zstd = { version = "0.13.3", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-mithril-aggregator-discovery = { path = "../internal/mithril-aggregator-discovery", version = "0.1.7" }
-mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.2.2" }
+mithril-aggregator-discovery = { path = "../internal/mithril-aggregator-discovery", version = "0.1.8" }
+mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.2.3" }
 rand = { version = "0.10.1" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/mithril-client/src/certificate_client/mod.rs
+++ b/mithril-client/src/certificate_client/mod.rs
@@ -68,7 +68,6 @@ pub use verify_cache::MemoryCertificateVerifierCache;
 
 #[cfg(test)]
 pub(crate) mod tests_utils {
-    use mithril_common::crypto_helper::GenesisEd25519VerificationKey;
     use mithril_common::entities::Certificate;
     use mithril_common::messages::CertificateMessage;
     use mockall::predicate::eq;
@@ -97,11 +96,8 @@ pub(crate) mod tests_utils {
             self
         }
 
-        pub fn with_genesis_verification_key(
-            mut self,
-            genesis_verification_key: GenesisEd25519VerificationKey,
-        ) -> Self {
-            self.genesis_verification_key = Some(genesis_verification_key.try_into().unwrap());
+        pub fn with_genesis_verification_key(mut self, genesis_verification_key: String) -> Self {
+            self.genesis_verification_key = Some(genesis_verification_key);
             self
         }
 

--- a/mithril-client/src/certificate_client/verify.rs
+++ b/mithril-client/src/certificate_client/verify.rs
@@ -3,14 +3,14 @@ use async_trait::async_trait;
 use slog::{Logger, trace};
 use std::sync::Arc;
 
-#[cfg(feature = "future_snark")]
-use mithril_common::crypto_helper::{GenesisSchnorrVerificationKey, GenesisVerificationKeyBundle};
+#[cfg(all(test, feature = "unstable"))]
+use mithril_common::crypto_helper::GenesisEd25519VerificationKey;
 use mithril_common::{
     certificate_chain::{
         CertificateRetriever, CertificateVerifier as CommonCertificateVerifier,
         MithrilCertificateVerifier as CommonMithrilCertificateVerifier,
     },
-    crypto_helper::GenesisEd25519VerificationKey,
+    crypto_helper::GenesisVerifier,
     entities::Certificate,
     logging::LoggerExtensions,
 };
@@ -47,15 +47,7 @@ pub(super) async fn verify_chain(
 pub struct MithrilCertificateVerifier {
     retriever: Arc<InternalCertificateRetriever>,
     internal_verifier: Arc<dyn CommonCertificateVerifier>,
-    genesis_verification_key: GenesisEd25519VerificationKey,
-    /// SNARK-friendly genesis verification key.
-    ///
-    /// `None` when the operator configured the legacy single-Ed25519 file: chain verification then
-    /// validates only the Ed25519 half of dual genesis certificates and silently skips the Schnorr
-    /// check. `Some` when the operator configured a dual signing bundle: chain verification then
-    /// also runs the SNARK verifier against the dual genesis certificate.
-    #[cfg(feature = "future_snark")]
-    snark_genesis_verification_key: Option<GenesisSchnorrVerificationKey>,
+    genesis_verifier: GenesisVerifier,
     feedback_sender: FeedbackSender,
     #[cfg(feature = "unstable")]
     verifier_cache: Option<Arc<dyn CertificateVerifierCache>>,
@@ -77,24 +69,13 @@ impl MithrilCertificateVerifier {
             logger.clone(),
             retriever.clone(),
         ));
-        #[cfg(feature = "future_snark")]
-        let (genesis_verification_key, snark_genesis_verification_key) = {
-            let bundle =
-                GenesisVerificationKeyBundle::try_from_hex_or_legacy(genesis_verification_key)
-                    .with_context(|| "Invalid genesis verification key")?;
-            (bundle.ed25519, bundle.schnorr)
-        };
-        #[cfg(not(feature = "future_snark"))]
-        let genesis_verification_key =
-            GenesisEd25519VerificationKey::try_from(genesis_verification_key)
-                .with_context(|| "Invalid genesis verification key")?;
+        let genesis_verifier = GenesisVerifier::try_from_hex(genesis_verification_key)
+            .with_context(|| "Invalid genesis verification key")?;
 
         Ok(Self {
             retriever,
             internal_verifier,
-            genesis_verification_key,
-            #[cfg(feature = "future_snark")]
-            snark_genesis_verification_key,
+            genesis_verifier,
             feedback_sender,
             #[cfg(feature = "unstable")]
             verifier_cache,
@@ -109,34 +90,6 @@ impl MithrilCertificateVerifier {
         } else {
             Ok(None)
         }
-    }
-
-    /// Validate the SNARK-friendly Schnorr genesis signature when the certificate carries one
-    /// AND the client was constructed with a dual verification-key bundle.
-    ///
-    /// Skipped silently when the certificate is not a genesis, when the genesis certificate is
-    /// the legacy Pythagoras single-signature variant, or when the operator configured the
-    /// legacy single-Ed25519 verification key.
-    #[cfg(feature = "future_snark")]
-    async fn verify_genesis_schnorr_signature_if_dual(
-        &self,
-        certificate: &Certificate,
-    ) -> MithrilResult<()> {
-        let Some(snark_verification_key) = self.snark_genesis_verification_key.as_ref() else {
-            return Ok(());
-        };
-        let Some(_) = certificate.signature.schnorr_signature() else {
-            return Ok(());
-        };
-        self.internal_verifier
-            .verify_genesis_certificate_snark_signature(certificate, snark_verification_key)
-            .await
-            .with_context(|| {
-                format!(
-                    "SNARK genesis verification failed for certificate '{}'",
-                    certificate.hash
-                )
-            })
     }
 
     #[cfg(not(feature = "unstable"))]
@@ -184,11 +137,11 @@ impl MithrilCertificateVerifier {
     ) -> MithrilResult<Option<Certificate>> {
         let previous_certificate = self
             .internal_verifier
-            .verify_certificate(&certificate, &self.genesis_verification_key)
+            .verify_certificate(
+                &certificate,
+                &self.genesis_verifier.to_ed25519_verification_key(),
+            )
             .await?;
-
-        #[cfg(feature = "future_snark")]
-        self.verify_genesis_schnorr_signature_if_dual(&certificate).await?;
 
         #[cfg(feature = "unstable")]
         if let Some(cache) = self.verifier_cache.as_ref()
@@ -306,6 +259,10 @@ mod tests {
 
     use super::*;
 
+    fn ed25519_verification_key_hex(genesis_verifier: &GenesisVerifier) -> String {
+        genesis_verifier.to_ed25519_verification_key().try_into().unwrap()
+    }
+
     #[tokio::test]
     async fn validating_chain_send_feedbacks() {
         let chain = CertificateChainBuilder::new()
@@ -319,7 +276,7 @@ mod tests {
             .config_aggregator_requester_mock(|mock| {
                 mock.expect_certificate_chain(chain.certificates_chained.clone())
             })
-            .with_genesis_verification_key(chain.genesis_verifier.to_verification_key())
+            .with_genesis_verification_key(ed25519_verification_key_hex(&chain.genesis_verifier))
             .add_feedback_receiver(feedback_receiver.clone())
             .build();
 
@@ -362,7 +319,7 @@ mod tests {
             .config_aggregator_requester_mock(|mock| {
                 mock.expect_certificate_chain(chain.certificates_chained.clone())
             })
-            .with_genesis_verification_key(chain.genesis_verifier.to_verification_key())
+            .with_genesis_verification_key(ed25519_verification_key_hex(&chain.genesis_verifier))
             .build();
 
         let certificate = certificate_client
@@ -393,7 +350,7 @@ mod tests {
             .with_total_certificates(1)
             .with_certificates_per_epoch(1)
             .build();
-        let legacy_hex: String = chain.genesis_verifier.to_verification_key().try_into().unwrap();
+        let legacy_hex = ed25519_verification_key_hex(&chain.genesis_verifier);
 
         build_verifier_from_genesis_key_string(&legacy_hex)
             .expect("legacy single-Ed25519 verification key must be accepted");
@@ -451,7 +408,7 @@ mod tests {
                 .config_aggregator_requester_mock(|mock| {
                     mock.expect_certificate_chain(chain.certificates_chained.clone())
                 })
-                .with_genesis_verification_key_string(dual_hex)
+                .with_genesis_verification_key(dual_hex)
                 .build();
 
             certificate_client
@@ -459,6 +416,33 @@ mod tests {
                 .await
                 .expect(
                     "dual verification key bundle must validate a chain whose genesis is the legacy single-signature variant",
+                );
+        }
+
+        #[tokio::test]
+        async fn verify_chain_succeeds_with_legacy_verification_key_on_lagrange_chain() {
+            use mithril_common::entities::SupportedEra;
+
+            let chain = CertificateChainBuilder::new()
+                .with_total_certificates(3)
+                .with_certificates_per_epoch(1)
+                .with_mithril_era(SupportedEra::Lagrange)
+                .build();
+            let last_certificate_hash = chain.first().unwrap().hash.clone();
+            let legacy_hex = ed25519_verification_key_hex(&chain.genesis_verifier);
+
+            let certificate_client = CertificateClientTestBuilder::default()
+                .config_aggregator_requester_mock(|mock| {
+                    mock.expect_certificate_chain(chain.certificates_chained.clone())
+                })
+                .with_genesis_verification_key(legacy_hex)
+                .build();
+
+            certificate_client
+                .verify_chain(&last_certificate_hash)
+                .await
+                .expect(
+                    "legacy single-Ed25519 verification key must validate a Lagrange-era chain (SNARK half silently skipped per the dual-bundle policy)",
                 );
         }
     }
@@ -508,7 +492,7 @@ mod tests {
             let cache = Arc::new(MemoryCertificateVerifierCache::new(TimeDelta::hours(1)));
             let verifier = build_verifier_with_cache(
                 |_mock| {},
-                chain.genesis_verifier.to_verification_key(),
+                chain.genesis_verifier.to_ed25519_verification_key(),
                 cache.clone(),
             );
 
@@ -541,7 +525,7 @@ mod tests {
             let cache = Arc::new(MemoryCertificateVerifierCache::new(TimeDelta::hours(1)));
             let verifier = build_verifier_with_cache(
                 |mock| mock.expect_certificate_chain(vec![genesis_certificate.clone()]),
-                chain.genesis_verifier.to_verification_key(),
+                chain.genesis_verifier.to_ed25519_verification_key(),
                 cache.clone(),
             );
 
@@ -579,7 +563,9 @@ mod tests {
                     // Expect to fetch the first certificate from the network
                     mock.expect_certificate_chain(chain.certificates_chained.clone());
                 })
-                .with_genesis_verification_key(chain.genesis_verifier.to_verification_key())
+                .with_genesis_verification_key(ed25519_verification_key_hex(
+                    &chain.genesis_verifier,
+                ))
                 .with_verifier_cache(cache.clone())
                 .build();
 
@@ -638,7 +624,9 @@ mod tests {
                 .config_aggregator_requester_mock(|mock| {
                     mock.expect_certificate_chain(certificates_that_must_be_fully_verified);
                 })
-                .with_genesis_verification_key(chain.genesis_verifier.to_verification_key())
+                .with_genesis_verification_key(ed25519_verification_key_hex(
+                    &chain.genesis_verifier,
+                ))
                 .with_verifier_cache(cache)
                 .build();
 
@@ -666,7 +654,9 @@ mod tests {
                         [chain[0..3].to_vec(), vec![chain.last().unwrap().clone()]].concat(),
                     )
                 })
-                .with_genesis_verification_key(chain.genesis_verifier.to_verification_key())
+                .with_genesis_verification_key(ed25519_verification_key_hex(
+                    &chain.genesis_verifier,
+                ))
                 .with_verifier_cache(Arc::new(cache))
                 .build();
 

--- a/mithril-client/src/certificate_client/verify.rs
+++ b/mithril-client/src/certificate_client/verify.rs
@@ -3,6 +3,8 @@ use async_trait::async_trait;
 use slog::{Logger, trace};
 use std::sync::Arc;
 
+#[cfg(feature = "future_snark")]
+use mithril_common::crypto_helper::{GenesisSchnorrVerificationKey, GenesisVerificationKeyBundle};
 use mithril_common::{
     certificate_chain::{
         CertificateRetriever, CertificateVerifier as CommonCertificateVerifier,
@@ -46,6 +48,14 @@ pub struct MithrilCertificateVerifier {
     retriever: Arc<InternalCertificateRetriever>,
     internal_verifier: Arc<dyn CommonCertificateVerifier>,
     genesis_verification_key: GenesisEd25519VerificationKey,
+    /// SNARK-friendly genesis verification key.
+    ///
+    /// `None` when the operator configured the legacy single-Ed25519 file: chain verification then
+    /// validates only the Ed25519 half of dual genesis certificates and silently skips the Schnorr
+    /// check. `Some` when the operator configured a dual signing bundle: chain verification then
+    /// also runs the SNARK verifier against the dual genesis certificate.
+    #[cfg(feature = "future_snark")]
+    snark_genesis_verification_key: Option<GenesisSchnorrVerificationKey>,
     feedback_sender: FeedbackSender,
     #[cfg(feature = "unstable")]
     verifier_cache: Option<Arc<dyn CertificateVerifierCache>>,
@@ -67,6 +77,14 @@ impl MithrilCertificateVerifier {
             logger.clone(),
             retriever.clone(),
         ));
+        #[cfg(feature = "future_snark")]
+        let (genesis_verification_key, snark_genesis_verification_key) = {
+            let bundle =
+                GenesisVerificationKeyBundle::try_from_hex_or_legacy(genesis_verification_key)
+                    .with_context(|| "Invalid genesis verification key")?;
+            (bundle.ed25519, bundle.schnorr)
+        };
+        #[cfg(not(feature = "future_snark"))]
         let genesis_verification_key =
             GenesisEd25519VerificationKey::try_from(genesis_verification_key)
                 .with_context(|| "Invalid genesis verification key")?;
@@ -75,6 +93,8 @@ impl MithrilCertificateVerifier {
             retriever,
             internal_verifier,
             genesis_verification_key,
+            #[cfg(feature = "future_snark")]
+            snark_genesis_verification_key,
             feedback_sender,
             #[cfg(feature = "unstable")]
             verifier_cache,
@@ -89,6 +109,34 @@ impl MithrilCertificateVerifier {
         } else {
             Ok(None)
         }
+    }
+
+    /// Validate the SNARK-friendly Schnorr genesis signature when the certificate carries one
+    /// AND the client was constructed with a dual verification-key bundle.
+    ///
+    /// Skipped silently when the certificate is not a genesis, when the genesis certificate is
+    /// the legacy Pythagoras single-signature variant, or when the operator configured the
+    /// legacy single-Ed25519 verification key.
+    #[cfg(feature = "future_snark")]
+    async fn verify_genesis_schnorr_signature_if_dual(
+        &self,
+        certificate: &Certificate,
+    ) -> MithrilResult<()> {
+        let Some(snark_verification_key) = self.snark_genesis_verification_key.as_ref() else {
+            return Ok(());
+        };
+        let Some(_) = certificate.signature.schnorr_signature() else {
+            return Ok(());
+        };
+        self.internal_verifier
+            .verify_genesis_certificate_snark_signature(certificate, snark_verification_key)
+            .await
+            .with_context(|| {
+                format!(
+                    "SNARK genesis verification failed for certificate '{}'",
+                    certificate.hash
+                )
+            })
     }
 
     #[cfg(not(feature = "unstable"))]
@@ -138,6 +186,9 @@ impl MithrilCertificateVerifier {
             .internal_verifier
             .verify_certificate(&certificate, &self.genesis_verification_key)
             .await?;
+
+        #[cfg(feature = "future_snark")]
+        self.verify_genesis_schnorr_signature_if_dual(&certificate).await?;
 
         #[cfg(feature = "unstable")]
         if let Some(cache) = self.verifier_cache.as_ref()
@@ -247,7 +298,11 @@ mod tests {
     use mithril_common::test::builder::CertificateChainBuilder;
 
     use crate::certificate_client::tests_utils::CertificateClientTestBuilder;
+    use crate::certificate_client::{
+        CertificateAggregatorRequest, MockCertificateAggregatorRequest,
+    };
     use crate::feedback::StackFeedbackReceiver;
+    use crate::test_utils::TestLogger;
 
     use super::*;
 
@@ -316,6 +371,96 @@ mod tests {
             .expect("Chain validation should succeed");
 
         assert_eq!(certificate.hash, last_certificate_hash);
+    }
+
+    fn build_verifier_from_genesis_key_string(genesis_verification_key: &str) -> MithrilResult<()> {
+        let aggregator_client: Arc<dyn CertificateAggregatorRequest> =
+            Arc::new(MockCertificateAggregatorRequest::new());
+        MithrilCertificateVerifier::new(
+            aggregator_client,
+            genesis_verification_key,
+            FeedbackSender::new(&[]),
+            #[cfg(feature = "unstable")]
+            None,
+            TestLogger::stdout(),
+        )
+        .map(|_| ())
+    }
+
+    #[test]
+    fn constructor_accepts_legacy_single_ed25519_verification_key() {
+        let chain = CertificateChainBuilder::new()
+            .with_total_certificates(1)
+            .with_certificates_per_epoch(1)
+            .build();
+        let legacy_hex: String = chain.genesis_verifier.to_verification_key().try_into().unwrap();
+
+        build_verifier_from_genesis_key_string(&legacy_hex)
+            .expect("legacy single-Ed25519 verification key must be accepted");
+    }
+
+    #[test]
+    fn constructor_rejects_empty_verification_key() {
+        build_verifier_from_genesis_key_string("")
+            .expect_err("empty verification key must be rejected");
+    }
+
+    #[cfg(feature = "future_snark")]
+    mod verification_key_formats {
+        use mithril_common::crypto_helper::{
+            GenesisSchnorrSigner, GenesisVerificationKeyBundle, ProtocolKey,
+        };
+
+        use super::*;
+
+        fn dual_verification_key_hex(
+            genesis_verifier: &GenesisVerifier,
+            schnorr_signer: &GenesisSchnorrSigner,
+        ) -> String {
+            let bundle = GenesisVerificationKeyBundle::new(
+                genesis_verifier.to_ed25519_verification_key(),
+                schnorr_signer.verification_key(),
+            );
+            ProtocolKey::new(bundle).to_bytes_hex().unwrap()
+        }
+
+        #[test]
+        fn constructor_accepts_dual_verification_key_bundle() {
+            let chain = CertificateChainBuilder::new()
+                .with_total_certificates(1)
+                .with_certificates_per_epoch(1)
+                .build();
+            let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+            let dual_hex = dual_verification_key_hex(&chain.genesis_verifier, &schnorr_signer);
+
+            build_verifier_from_genesis_key_string(&dual_hex)
+                .expect("dual verification key bundle must be accepted");
+        }
+
+        #[tokio::test]
+        async fn verify_chain_succeeds_with_dual_bundle_on_pythagoras_chain() {
+            let chain = CertificateChainBuilder::new()
+                .with_total_certificates(3)
+                .with_certificates_per_epoch(1)
+                .build();
+            let last_certificate_hash = chain.first().unwrap().hash.clone();
+            let schnorr_signer = GenesisSchnorrSigner::create_non_deterministic_signer();
+            let dual_hex = dual_verification_key_hex(&chain.genesis_verifier, &schnorr_signer);
+
+            let certificate_client = CertificateClientTestBuilder::default()
+                .config_aggregator_requester_mock(|mock| {
+                    mock.expect_certificate_chain(chain.certificates_chained.clone())
+                })
+                .with_genesis_verification_key_string(dual_hex)
+                .build();
+
+            certificate_client
+                .verify_chain(&last_certificate_hash)
+                .await
+                .expect(
+                    "dual verification key bundle must validate a chain whose genesis is the legacy single-signature variant",
+                );
+        }
     }
 
     #[cfg(feature = "unstable")]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.3"
+version = "0.7.4"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.31", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.32", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -1,16 +1,17 @@
 //! A module used to create a Genesis Certificate
 //!
-use anyhow::anyhow;
 use chrono::prelude::*;
 #[cfg(feature = "future_snark")]
 use slog::warn;
 use slog::{Logger, o};
 
 #[cfg(feature = "future_snark")]
-use crate::crypto_helper::ProtocolAggregateVerificationKeyForSnark;
+use crate::crypto_helper::{GenesisSchnorrSignature, ProtocolAggregateVerificationKeyForSnark};
 use crate::{
     StdResult,
-    crypto_helper::{PROTOCOL_VERSION, ProtocolAggregateVerificationKey, ProtocolKey},
+    crypto_helper::{
+        GenesisEd25519Signature, PROTOCOL_VERSION, ProtocolAggregateVerificationKey, ProtocolKey,
+    },
     entities::{
         Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessage,
         ProtocolMessagePartKey, ProtocolParameters, SupportedEra,
@@ -102,13 +103,62 @@ impl CertificateGenesisProducer {
         Ok(protocol_message)
     }
 
-    /// Assemble a Genesis Certificate from an already-produced [CertificateSignature].
+    /// Assemble a legacy (Pythagoras) Genesis Certificate from an Ed25519 genesis signature.
     ///
     /// Signing is performed upstream by [`GenesisSigner`][crate::crypto_helper::GenesisSigner];
-    /// this only builds the certificate body. Accepts both the single Ed25519 and the dual
-    /// (Ed25519 + Schnorr) genesis signatures, and rejects a multi-signature to preserve the
-    /// genesis-certificate invariant relied upon by chain verification.
+    /// this only builds the certificate body.
+    pub fn create_legacy_genesis_certificate<T: Into<String>>(
+        &self,
+        protocol_parameters: ProtocolParameters,
+        network: T,
+        epoch: Epoch,
+        genesis_avk: ProtocolAggregateVerificationKey,
+        genesis_signature: GenesisEd25519Signature,
+        mithril_era: SupportedEra,
+    ) -> StdResult<Certificate> {
+        self.create_genesis_certificate_internal(
+            protocol_parameters,
+            network,
+            epoch,
+            genesis_avk,
+            CertificateSignature::GenesisSignature(genesis_signature),
+            mithril_era,
+        )
+    }
+
+    /// Assemble a dual (Lagrange) Genesis Certificate from the Ed25519 and Schnorr genesis
+    /// signatures.
+    ///
+    /// Signing is performed upstream by [`GenesisSigner`][crate::crypto_helper::GenesisSigner];
+    /// this only builds the certificate body.
+    #[cfg(feature = "future_snark")]
+    #[allow(clippy::too_many_arguments)]
     pub fn create_genesis_certificate<T: Into<String>>(
+        &self,
+        protocol_parameters: ProtocolParameters,
+        network: T,
+        epoch: Epoch,
+        genesis_avk: ProtocolAggregateVerificationKey,
+        genesis_signature: GenesisEd25519Signature,
+        genesis_signature_snark: GenesisSchnorrSignature,
+        mithril_era: SupportedEra,
+    ) -> StdResult<Certificate> {
+        self.create_genesis_certificate_internal(
+            protocol_parameters,
+            network,
+            epoch,
+            genesis_avk,
+            CertificateSignature::GenesisDualSignature(genesis_signature, genesis_signature_snark),
+            mithril_era,
+        )
+    }
+
+    /// Assemble a Genesis Certificate body around an already-produced genesis signature.
+    ///
+    /// Private so the public entry points ([Self::create_legacy_genesis_certificate],
+    /// [Self::create_genesis_certificate]) own the signature shape, making a multi-signature
+    /// genesis certificate unrepresentable.
+    fn create_genesis_certificate_internal<T: Into<String>>(
         &self,
         protocol_parameters: ProtocolParameters,
         network: T,
@@ -117,11 +167,6 @@ impl CertificateGenesisProducer {
         signature: CertificateSignature,
         mithril_era: SupportedEra,
     ) -> StdResult<Certificate> {
-        if matches!(signature, CertificateSignature::MultiSignature(..)) {
-            return Err(anyhow!(
-                "Can not create a genesis certificate from a multi-signature"
-            ));
-        }
         let metadata = CertificateMetadata::new(
             network,
             PROTOCOL_VERSION.to_string(),
@@ -151,31 +196,11 @@ impl CertificateGenesisProducer {
 mod tests {
     use super::*;
 
-    use crate::entities::{ProtocolMessagePartKey, SignedEntityType};
+    use crate::entities::ProtocolMessagePartKey;
     use crate::test::TestLogger;
     use crate::test::builder::MithrilFixtureBuilder;
+    #[cfg(feature = "future_snark")]
     use crate::test::double::fake_keys;
-
-    #[test]
-    fn create_genesis_certificate_rejects_a_multi_signature() {
-        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-        let producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
-        let multi_signature = CertificateSignature::MultiSignature(
-            SignedEntityType::MithrilStakeDistribution(Epoch(1)),
-            fake_keys::multi_signature()[0].try_into().unwrap(),
-        );
-
-        producer
-            .create_genesis_certificate(
-                fixture.protocol_parameters(),
-                "testnet",
-                Epoch(1),
-                fixture.compute_aggregate_verification_key(),
-                multi_signature,
-                SupportedEra::Pythagoras,
-            )
-            .expect_err("a multi-signature must be rejected as a genesis signature");
-    }
 
     #[test]
     fn genesis_protocol_message_has_expected_keys_and_values() {
@@ -269,7 +294,7 @@ mod tests {
                 .unwrap();
 
             let certificate = producer
-                .create_genesis_certificate(
+                .create_genesis_certificate_internal(
                     fixture.protocol_parameters(),
                     "testnet",
                     Epoch(1),
@@ -333,7 +358,7 @@ mod tests {
                 .unwrap();
 
             let certificate = producer
-                .create_genesis_certificate(
+                .create_genesis_certificate_internal(
                     fixture.protocol_parameters(),
                     "testnet",
                     Epoch(1),

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 
 #[cfg(feature = "future_snark")]
 use crate::crypto_helper::ProtocolAggregateVerificationKeyForSnark;
+#[cfg(feature = "future_snark")]
+use crate::crypto_helper::{GenesisSchnorrSignature, GenesisSchnorrSigner, sha256_digest};
 use crate::{
     StdResult,
     crypto_helper::{
@@ -23,18 +25,54 @@ use crate::{
     protocol::ToMessage,
 };
 
+/// The exact byte size of the rigid protocol-message preimage signed under Lagrange.
+///
+/// Mirrors the in-circuit `PREIMAGE_SIZE` constant pinned by the IVC witness layout
+/// in `mithril-stm/src/circuits/halo2_ivc/mod.rs`. The producer enforces this invariant
+/// before signing so layout drift surfaces at signing time, not deep inside the SNARK gadget.
+#[cfg(feature = "future_snark")]
+pub const PREIMAGE_SIZE: usize = 190;
+
 /// [CertificateGenesisProducer] related errors.
 #[derive(Error, Debug)]
 pub enum CertificateGenesisProducerError {
     /// Error raised when there is no genesis signer available
     #[error("missing genesis signer error")]
     MissingGenesisSigner(),
+
+    /// Error raised when a Lagrange genesis certificate is requested without a SNARK signer.
+    #[cfg(feature = "future_snark")]
+    #[error(
+        "missing SNARK genesis signer error: Lagrange-era genesis certificates require both signers"
+    )]
+    MissingSnarkGenesisSigner,
+
+    /// Error raised when the rigid protocol-message preimage does not match the pinned
+    /// [PREIMAGE_SIZE] expected by the IVC gadget.
+    #[cfg(feature = "future_snark")]
+    #[error(
+        "rigid protocol-message preimage must be exactly {expected} bytes (got {actual}); \
+        check the rigid-segment values built into ProtocolMessage"
+    )]
+    InvalidPreimageSize {
+        /// Expected pinned size ([PREIMAGE_SIZE]).
+        expected: usize,
+        /// Actual size produced by [ProtocolMessage::rigid_preimage].
+        actual: usize,
+    },
+
+    /// Error surfaced when the SNARK signer fails to produce a signature.
+    #[cfg(feature = "future_snark")]
+    #[error("SNARK genesis signing failed: {0}")]
+    SnarkSigningFailure(String),
 }
 
 /// CertificateGenesisProducer is in charge of producing a Genesis Certificate
 #[derive(Debug)]
 pub struct CertificateGenesisProducer {
     genesis_signer: Option<Arc<GenesisEd25519Signer>>,
+    #[cfg(feature = "future_snark")]
+    snark_genesis_signer: Option<Arc<GenesisSchnorrSigner>>,
     logger: Logger,
 }
 
@@ -43,8 +81,20 @@ impl CertificateGenesisProducer {
     pub fn new(genesis_signer: Option<Arc<GenesisEd25519Signer>>) -> Self {
         Self {
             genesis_signer,
+            #[cfg(feature = "future_snark")]
+            snark_genesis_signer: None,
             logger: Logger::root(slog::Discard, o!()),
         }
+    }
+
+    /// Attach a SNARK genesis signer. Required when producing Lagrange-era genesis certificates.
+    #[cfg(feature = "future_snark")]
+    pub fn with_snark_genesis_signer(
+        mut self,
+        snark_genesis_signer: Arc<GenesisSchnorrSigner>,
+    ) -> Self {
+        self.snark_genesis_signer = Some(snark_genesis_signer);
+        self
     }
 
     /// Set the [Logger] to use.
@@ -65,7 +115,13 @@ impl CertificateGenesisProducer {
             ProtocolKey::new(genesis_avk.to_concatenation_aggregate_verification_key().to_owned());
         let genesis_concatenation_avk =
             genesis_aggregate_verification_key_for_concatenation.to_json_hex()?;
-        let mut protocol_message = ProtocolMessage::new();
+        let mut protocol_message = match mithril_era {
+            SupportedEra::Pythagoras => ProtocolMessage::new(),
+            #[cfg(feature = "future_snark")]
+            SupportedEra::Lagrange => ProtocolMessage::new_rigid(),
+            #[cfg(not(feature = "future_snark"))]
+            SupportedEra::Lagrange => ProtocolMessage::new(),
+        };
         protocol_message.set_message_part(
             ProtocolMessagePartKey::NextAggregateVerificationKey,
             genesis_concatenation_avk,
@@ -114,6 +170,33 @@ impl CertificateGenesisProducer {
             .sign(genesis_message.to_message().as_bytes()))
     }
 
+    /// Sign the rigid protocol-message preimage with the SNARK genesis signer.
+    ///
+    /// The function asserts the preimage is exactly [PREIMAGE_SIZE] bytes, hashes it once with
+    /// SHA-256 to obtain the 32-byte digest the IVC gadget expects, and feeds the digest to the
+    /// underlying `sign_standard` Schnorr routine via the wrapper.
+    #[cfg(feature = "future_snark")]
+    pub fn sign_genesis_protocol_message_snark(
+        &self,
+        protocol_message: &ProtocolMessage,
+    ) -> Result<GenesisSchnorrSignature, CertificateGenesisProducerError> {
+        let signer = self
+            .snark_genesis_signer
+            .as_ref()
+            .ok_or(CertificateGenesisProducerError::MissingSnarkGenesisSigner)?;
+        let preimage = protocol_message.rigid_preimage();
+        if preimage.len() != PREIMAGE_SIZE {
+            return Err(CertificateGenesisProducerError::InvalidPreimageSize {
+                expected: PREIMAGE_SIZE,
+                actual: preimage.len(),
+            });
+        }
+        let digest = sha256_digest(&preimage);
+        signer
+            .sign_non_deterministic(&digest)
+            .map_err(|e| CertificateGenesisProducerError::SnarkSigningFailure(e.to_string()))
+    }
+
     /// Create a Genesis Certificate
     pub fn create_genesis_certificate<T: Into<String>>(
         &self,
@@ -121,7 +204,7 @@ impl CertificateGenesisProducer {
         network: T,
         epoch: Epoch,
         genesis_avk: ProtocolAggregateVerificationKey,
-        genesis_signature: GenesisEd25519Signature,
+        genesis_ed25519_signature: GenesisEd25519Signature,
         mithril_era: SupportedEra,
     ) -> StdResult<Certificate> {
         let protocol_version = PROTOCOL_VERSION.to_string();
@@ -143,13 +226,31 @@ impl CertificateGenesisProducer {
             &epoch,
             mithril_era,
         )?;
+        let signature = match mithril_era {
+            SupportedEra::Pythagoras => {
+                CertificateSignature::GenesisSignature(genesis_ed25519_signature)
+            }
+            #[cfg(feature = "future_snark")]
+            SupportedEra::Lagrange => {
+                let genesis_schnorr_signature =
+                    self.sign_genesis_protocol_message_snark(&genesis_protocol_message)?;
+                CertificateSignature::GenesisDualSignature(
+                    genesis_ed25519_signature,
+                    genesis_schnorr_signature,
+                )
+            }
+            #[cfg(not(feature = "future_snark"))]
+            SupportedEra::Lagrange => {
+                CertificateSignature::GenesisSignature(genesis_ed25519_signature)
+            }
+        };
         Ok(Certificate::new(
             previous_hash,
             epoch,
             metadata,
             genesis_protocol_message,
             genesis_avk,
-            CertificateSignature::GenesisSignature(genesis_signature),
+            signature,
         ))
     }
 }
@@ -226,5 +327,171 @@ mod tests {
                 .get_message_part(&ProtocolMessagePartKey::NextSnarkAggregateVerificationKey),
             Some(&expected_snark_avk_value)
         );
+    }
+
+    #[cfg(feature = "future_snark")]
+    mod era_dispatched_genesis_certificate {
+        use rand_chacha::ChaCha20Rng;
+        use rand_core::SeedableRng;
+
+        use crate::crypto_helper::{
+            GenesisEd25519Signer, GenesisSchnorrSigner, GenesisSchnorrVerifier,
+        };
+
+        use super::*;
+
+        fn build_ed25519_signer() -> Arc<GenesisEd25519Signer> {
+            Arc::new(GenesisEd25519Signer::create_deterministic_signer())
+        }
+
+        fn build_schnorr_signer() -> Arc<GenesisSchnorrSigner> {
+            let mut rng = ChaCha20Rng::from_seed([13u8; 32]);
+            Arc::new(GenesisSchnorrSigner::generate(&mut rng))
+        }
+
+        fn build_genesis_signature(
+            signer: &GenesisEd25519Signer,
+            protocol_message: &ProtocolMessage,
+        ) -> GenesisEd25519Signature {
+            signer.sign(protocol_message.compute_hash().as_bytes())
+        }
+
+        #[test]
+        fn pythagoras_creates_a_single_signature_variant() {
+            let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+            let ed25519_signer = build_ed25519_signer();
+            let producer = CertificateGenesisProducer::new(Some(ed25519_signer.clone()))
+                .with_logger(TestLogger::stdout());
+            let protocol_message = producer
+                .create_genesis_protocol_message(
+                    &fixture.protocol_parameters(),
+                    &fixture.compute_aggregate_verification_key(),
+                    &Epoch(1),
+                    SupportedEra::Pythagoras,
+                )
+                .unwrap();
+            let genesis_signature = build_genesis_signature(&ed25519_signer, &protocol_message);
+
+            let certificate = producer
+                .create_genesis_certificate(
+                    fixture.protocol_parameters(),
+                    "testnet",
+                    Epoch(1),
+                    fixture.compute_aggregate_verification_key(),
+                    genesis_signature,
+                    SupportedEra::Pythagoras,
+                )
+                .unwrap();
+
+            assert!(matches!(
+                certificate.signature,
+                CertificateSignature::GenesisSignature(_)
+            ));
+        }
+
+        #[test]
+        fn lagrange_creates_a_dual_signature_variant() {
+            let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+            let ed25519_signer = build_ed25519_signer();
+            let schnorr_signer = build_schnorr_signer();
+            let producer = CertificateGenesisProducer::new(Some(ed25519_signer.clone()))
+                .with_snark_genesis_signer(schnorr_signer.clone())
+                .with_logger(TestLogger::stdout());
+            let protocol_message = producer
+                .create_genesis_protocol_message(
+                    &fixture.protocol_parameters(),
+                    &fixture.compute_aggregate_verification_key(),
+                    &Epoch(1),
+                    SupportedEra::Lagrange,
+                )
+                .unwrap();
+            let genesis_signature = build_genesis_signature(&ed25519_signer, &protocol_message);
+
+            let certificate = producer
+                .create_genesis_certificate(
+                    fixture.protocol_parameters(),
+                    "testnet",
+                    Epoch(1),
+                    fixture.compute_aggregate_verification_key(),
+                    genesis_signature,
+                    SupportedEra::Lagrange,
+                )
+                .unwrap();
+
+            let (genesis_ed25519_signature, genesis_schnorr_signature) = match certificate.signature
+            {
+                CertificateSignature::GenesisDualSignature(ed25519, schnorr) => (ed25519, schnorr),
+                other => panic!("expected GenesisDualSignature, got {other:?}"),
+            };
+
+            // Cross-check the Schnorr signature verifies under the SNARK signer's verifier with
+            // the rigid preimage SHA-256 digest, matching the in-circuit encoding.
+            let verifier =
+                GenesisSchnorrVerifier::from_verification_key(schnorr_signer.verification_key());
+            let preimage = certificate.protocol_message.rigid_preimage();
+            assert_eq!(preimage.len(), PREIMAGE_SIZE);
+            let digest = sha256_digest(&preimage);
+            verifier.verify(&digest, &genesis_schnorr_signature).expect(
+                "Schnorr signature produced by the dual-genesis path must verify against the same digest",
+            );
+            // Sanity: the Ed25519 signature still verifies against the legacy signed_message.
+            ed25519_signer
+                .create_verifier()
+                .verify(
+                    certificate.signed_message.as_bytes(),
+                    &genesis_ed25519_signature,
+                )
+                .expect("Ed25519 signature must verify against the legacy signed_message bytes");
+        }
+
+        #[test]
+        fn preimage_size_constant_matches_rigid_protocol_message_preimage_length() {
+            let mut rigid = ProtocolMessage::new_rigid();
+            rigid.set_message_part(ProtocolMessagePartKey::CurrentEpoch, "1".to_string());
+
+            assert_eq!(
+                rigid.rigid_preimage().len(),
+                PREIMAGE_SIZE,
+                "Rigid protocol-message preimage length must match the PREIMAGE_SIZE constant \
+                 pinned by the IVC gadget; any drift here is the regression the runtime \
+                 InvalidPreimageSize guard exists to catch"
+            );
+        }
+
+        #[test]
+        fn lagrange_fails_without_a_schnorr_signer() {
+            let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+            let ed25519_signer = build_ed25519_signer();
+            let producer = CertificateGenesisProducer::new(Some(ed25519_signer.clone()))
+                .with_logger(TestLogger::stdout());
+            let protocol_message = producer
+                .create_genesis_protocol_message(
+                    &fixture.protocol_parameters(),
+                    &fixture.compute_aggregate_verification_key(),
+                    &Epoch(1),
+                    SupportedEra::Lagrange,
+                )
+                .unwrap();
+            let genesis_signature = build_genesis_signature(&ed25519_signer, &protocol_message);
+
+            let error = producer
+                .create_genesis_certificate(
+                    fixture.protocol_parameters(),
+                    "testnet",
+                    Epoch(1),
+                    fixture.compute_aggregate_verification_key(),
+                    genesis_signature,
+                    SupportedEra::Lagrange,
+                )
+                .unwrap_err();
+
+            let downcast = error
+                .downcast_ref::<CertificateGenesisProducerError>()
+                .expect("Producer must surface CertificateGenesisProducerError");
+            assert!(matches!(
+                downcast,
+                CertificateGenesisProducerError::MissingSnarkGenesisSigner
+            ));
+        }
     }
 }

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -1,100 +1,40 @@
 //! A module used to create a Genesis Certificate
 //!
-use std::sync::Arc;
-
+use anyhow::anyhow;
 use chrono::prelude::*;
 #[cfg(feature = "future_snark")]
 use slog::warn;
 use slog::{Logger, o};
-use thiserror::Error;
 
 #[cfg(feature = "future_snark")]
 use crate::crypto_helper::ProtocolAggregateVerificationKeyForSnark;
-#[cfg(feature = "future_snark")]
-use crate::crypto_helper::{GenesisSchnorrSignature, GenesisSchnorrSigner, sha256_digest};
 use crate::{
     StdResult,
-    crypto_helper::{
-        GenesisEd25519Signature, GenesisEd25519Signer, PROTOCOL_VERSION,
-        ProtocolAggregateVerificationKey, ProtocolKey,
-    },
+    crypto_helper::{PROTOCOL_VERSION, ProtocolAggregateVerificationKey, ProtocolKey},
     entities::{
         Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessage,
         ProtocolMessagePartKey, ProtocolParameters, SupportedEra,
     },
-    protocol::ToMessage,
 };
-
-/// The exact byte size of the rigid protocol-message preimage signed under Lagrange.
-///
-/// Mirrors the in-circuit `PREIMAGE_SIZE` constant pinned by the IVC witness layout
-/// in `mithril-stm/src/circuits/halo2_ivc/mod.rs`. The producer enforces this invariant
-/// before signing so layout drift surfaces at signing time, not deep inside the SNARK gadget.
-#[cfg(feature = "future_snark")]
-pub const PREIMAGE_SIZE: usize = 190;
-
-/// [CertificateGenesisProducer] related errors.
-#[derive(Error, Debug)]
-pub enum CertificateGenesisProducerError {
-    /// Error raised when there is no genesis signer available
-    #[error("missing genesis signer error")]
-    MissingGenesisSigner(),
-
-    /// Error raised when a Lagrange genesis certificate is requested without a SNARK signer.
-    #[cfg(feature = "future_snark")]
-    #[error(
-        "missing SNARK genesis signer error: Lagrange-era genesis certificates require both signers"
-    )]
-    MissingSnarkGenesisSigner,
-
-    /// Error raised when the rigid protocol-message preimage does not match the pinned
-    /// [PREIMAGE_SIZE] expected by the IVC gadget.
-    #[cfg(feature = "future_snark")]
-    #[error(
-        "rigid protocol-message preimage must be exactly {expected} bytes (got {actual}); \
-        check the rigid-segment values built into ProtocolMessage"
-    )]
-    InvalidPreimageSize {
-        /// Expected pinned size ([PREIMAGE_SIZE]).
-        expected: usize,
-        /// Actual size produced by [ProtocolMessage::rigid_preimage].
-        actual: usize,
-    },
-
-    /// Error surfaced when the SNARK signer fails to produce a signature.
-    #[cfg(feature = "future_snark")]
-    #[error("SNARK genesis signing failed: {0}")]
-    SnarkSigningFailure(String),
-}
 
 /// CertificateGenesisProducer is in charge of producing a Genesis Certificate
 #[derive(Debug)]
 pub struct CertificateGenesisProducer {
-    genesis_signer: Option<Arc<GenesisEd25519Signer>>,
-    #[cfg(feature = "future_snark")]
-    snark_genesis_signer: Option<Arc<GenesisSchnorrSigner>>,
     logger: Logger,
+}
+
+impl Default for CertificateGenesisProducer {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl CertificateGenesisProducer {
     /// CertificateGenesisProducer factory
-    pub fn new(genesis_signer: Option<Arc<GenesisEd25519Signer>>) -> Self {
+    pub fn new() -> Self {
         Self {
-            genesis_signer,
-            #[cfg(feature = "future_snark")]
-            snark_genesis_signer: None,
             logger: Logger::root(slog::Discard, o!()),
         }
-    }
-
-    /// Attach a SNARK genesis signer. Required when producing Lagrange-era genesis certificates.
-    #[cfg(feature = "future_snark")]
-    pub fn with_snark_genesis_signer(
-        mut self,
-        snark_genesis_signer: Arc<GenesisSchnorrSigner>,
-    ) -> Self {
-        self.snark_genesis_signer = Some(snark_genesis_signer);
-        self
     }
 
     /// Set the [Logger] to use.
@@ -158,94 +98,42 @@ impl CertificateGenesisProducer {
         Ok(protocol_message)
     }
 
-    /// Sign the Genesis protocol message (test only)
-    pub fn sign_genesis_protocol_message<T: ToMessage>(
-        &self,
-        genesis_message: T,
-    ) -> Result<GenesisEd25519Signature, CertificateGenesisProducerError> {
-        Ok(self
-            .genesis_signer
-            .as_ref()
-            .ok_or_else(CertificateGenesisProducerError::MissingGenesisSigner)?
-            .sign(genesis_message.to_message().as_bytes()))
-    }
-
-    /// Sign the rigid protocol-message preimage with the SNARK genesis signer.
+    /// Assemble a Genesis Certificate from an already-produced [CertificateSignature].
     ///
-    /// The function asserts the preimage is exactly [PREIMAGE_SIZE] bytes, hashes it once with
-    /// SHA-256 to obtain the 32-byte digest the IVC gadget expects, and feeds the digest to the
-    /// underlying `sign_standard` Schnorr routine via the wrapper.
-    #[cfg(feature = "future_snark")]
-    pub fn sign_genesis_protocol_message_snark(
-        &self,
-        protocol_message: &ProtocolMessage,
-    ) -> Result<GenesisSchnorrSignature, CertificateGenesisProducerError> {
-        let signer = self
-            .snark_genesis_signer
-            .as_ref()
-            .ok_or(CertificateGenesisProducerError::MissingSnarkGenesisSigner)?;
-        let preimage = protocol_message.rigid_preimage();
-        if preimage.len() != PREIMAGE_SIZE {
-            return Err(CertificateGenesisProducerError::InvalidPreimageSize {
-                expected: PREIMAGE_SIZE,
-                actual: preimage.len(),
-            });
-        }
-        let digest = sha256_digest(&preimage);
-        signer
-            .sign_non_deterministic(&digest)
-            .map_err(|e| CertificateGenesisProducerError::SnarkSigningFailure(e.to_string()))
-    }
-
-    /// Create a Genesis Certificate
+    /// Signing is performed upstream by [`GenesisSigner`][crate::crypto_helper::GenesisSigner];
+    /// this only builds the certificate body. Accepts both the single Ed25519 and the dual
+    /// (Ed25519 + Schnorr) genesis signatures, and rejects a multi-signature to preserve the
+    /// genesis-certificate invariant relied upon by chain verification.
     pub fn create_genesis_certificate<T: Into<String>>(
         &self,
         protocol_parameters: ProtocolParameters,
         network: T,
         epoch: Epoch,
         genesis_avk: ProtocolAggregateVerificationKey,
-        genesis_ed25519_signature: GenesisEd25519Signature,
+        signature: CertificateSignature,
         mithril_era: SupportedEra,
     ) -> StdResult<Certificate> {
-        let protocol_version = PROTOCOL_VERSION.to_string();
-        let initiated_at = Utc::now();
-        let sealed_at = Utc::now();
-        let signers = vec![];
+        if matches!(signature, CertificateSignature::MultiSignature(..)) {
+            return Err(anyhow!(
+                "Can not create a genesis certificate from a multi-signature"
+            ));
+        }
         let metadata = CertificateMetadata::new(
             network,
-            protocol_version,
+            PROTOCOL_VERSION.to_string(),
             protocol_parameters.clone(),
-            initiated_at,
-            sealed_at,
-            signers,
+            Utc::now(),
+            Utc::now(),
+            vec![],
         );
-        let previous_hash = "".to_string();
         let genesis_protocol_message = self.create_genesis_protocol_message(
             &protocol_parameters,
             &genesis_avk,
             &epoch,
             mithril_era,
         )?;
-        let signature = match mithril_era {
-            SupportedEra::Pythagoras => {
-                CertificateSignature::GenesisSignature(genesis_ed25519_signature)
-            }
-            #[cfg(feature = "future_snark")]
-            SupportedEra::Lagrange => {
-                let genesis_schnorr_signature =
-                    self.sign_genesis_protocol_message_snark(&genesis_protocol_message)?;
-                CertificateSignature::GenesisDualSignature(
-                    genesis_ed25519_signature,
-                    genesis_schnorr_signature,
-                )
-            }
-            #[cfg(not(feature = "future_snark"))]
-            SupportedEra::Lagrange => {
-                CertificateSignature::GenesisSignature(genesis_ed25519_signature)
-            }
-        };
         Ok(Certificate::new(
-            previous_hash,
+            "".to_string(),
             epoch,
             metadata,
             genesis_protocol_message,
@@ -259,9 +147,31 @@ impl CertificateGenesisProducer {
 mod tests {
     use super::*;
 
-    use crate::entities::ProtocolMessagePartKey;
+    use crate::entities::{ProtocolMessagePartKey, SignedEntityType};
     use crate::test::TestLogger;
     use crate::test::builder::MithrilFixtureBuilder;
+    use crate::test::double::fake_keys;
+
+    #[test]
+    fn create_genesis_certificate_rejects_a_multi_signature() {
+        let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+        let producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
+        let multi_signature = CertificateSignature::MultiSignature(
+            SignedEntityType::MithrilStakeDistribution(Epoch(1)),
+            fake_keys::multi_signature()[0].try_into().unwrap(),
+        );
+
+        producer
+            .create_genesis_certificate(
+                fixture.protocol_parameters(),
+                "testnet",
+                Epoch(1),
+                fixture.compute_aggregate_verification_key(),
+                multi_signature,
+                SupportedEra::Pythagoras,
+            )
+            .expect_err("a multi-signature must be rejected as a genesis signature");
+    }
 
     #[test]
     fn genesis_protocol_message_has_expected_keys_and_values() {
@@ -269,8 +179,7 @@ mod tests {
         let genesis_protocol_parameters = fixture.protocol_parameters();
         let genesis_avk = fixture.compute_aggregate_verification_key();
         let genesis_epoch = Epoch(123);
-        let genesis_producer =
-            CertificateGenesisProducer::new(None).with_logger(TestLogger::stdout());
+        let genesis_producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
         let protocol_message = genesis_producer
             .create_genesis_protocol_message(
                 &genesis_protocol_parameters,
@@ -308,8 +217,7 @@ mod tests {
         let genesis_protocol_parameters = fixture.protocol_parameters();
         let genesis_avk = fixture.compute_aggregate_verification_key();
         let genesis_epoch = Epoch(123);
-        let genesis_producer =
-            CertificateGenesisProducer::new(None).with_logger(TestLogger::stdout());
+        let genesis_producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
         let protocol_message = genesis_producer
             .create_genesis_protocol_message(
                 &genesis_protocol_parameters,
@@ -331,37 +239,18 @@ mod tests {
 
     #[cfg(feature = "future_snark")]
     mod era_dispatched_genesis_certificate {
-        use rand_chacha::ChaCha20Rng;
-        use rand_core::SeedableRng;
-
         use crate::crypto_helper::{
-            GenesisEd25519Signer, GenesisSchnorrSigner, GenesisSchnorrVerifier,
+            GenesisBundleError, GenesisEd25519Signer, GenesisSchnorrVerifier, GenesisSigner,
+            PREIMAGE_SIZE, sha256_digest,
         };
 
         use super::*;
 
-        fn build_ed25519_signer() -> Arc<GenesisEd25519Signer> {
-            Arc::new(GenesisEd25519Signer::create_deterministic_signer())
-        }
-
-        fn build_schnorr_signer() -> Arc<GenesisSchnorrSigner> {
-            let mut rng = ChaCha20Rng::from_seed([13u8; 32]);
-            Arc::new(GenesisSchnorrSigner::generate(&mut rng))
-        }
-
-        fn build_genesis_signature(
-            signer: &GenesisEd25519Signer,
-            protocol_message: &ProtocolMessage,
-        ) -> GenesisEd25519Signature {
-            signer.sign(protocol_message.compute_hash().as_bytes())
-        }
-
         #[test]
         fn pythagoras_creates_a_single_signature_variant() {
             let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-            let ed25519_signer = build_ed25519_signer();
-            let producer = CertificateGenesisProducer::new(Some(ed25519_signer.clone()))
-                .with_logger(TestLogger::stdout());
+            let genesis_signer = GenesisSigner::create_deterministic_signer();
+            let producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
             let protocol_message = producer
                 .create_genesis_protocol_message(
                     &fixture.protocol_parameters(),
@@ -370,7 +259,9 @@ mod tests {
                     SupportedEra::Pythagoras,
                 )
                 .unwrap();
-            let genesis_signature = build_genesis_signature(&ed25519_signer, &protocol_message);
+            let signature = genesis_signer
+                .sign_deterministic(&protocol_message, SupportedEra::Pythagoras)
+                .unwrap();
 
             let certificate = producer
                 .create_genesis_certificate(
@@ -378,7 +269,7 @@ mod tests {
                     "testnet",
                     Epoch(1),
                     fixture.compute_aggregate_verification_key(),
-                    genesis_signature,
+                    signature,
                     SupportedEra::Pythagoras,
                 )
                 .unwrap();
@@ -392,11 +283,8 @@ mod tests {
         #[test]
         fn lagrange_creates_a_dual_signature_variant() {
             let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-            let ed25519_signer = build_ed25519_signer();
-            let schnorr_signer = build_schnorr_signer();
-            let producer = CertificateGenesisProducer::new(Some(ed25519_signer.clone()))
-                .with_snark_genesis_signer(schnorr_signer.clone())
-                .with_logger(TestLogger::stdout());
+            let genesis_signer = GenesisSigner::create_deterministic_signer();
+            let producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
             let protocol_message = producer
                 .create_genesis_protocol_message(
                     &fixture.protocol_parameters(),
@@ -405,7 +293,9 @@ mod tests {
                     SupportedEra::Lagrange,
                 )
                 .unwrap();
-            let genesis_signature = build_genesis_signature(&ed25519_signer, &protocol_message);
+            let signature = genesis_signer
+                .sign_deterministic(&protocol_message, SupportedEra::Lagrange)
+                .unwrap();
 
             let certificate = producer
                 .create_genesis_certificate(
@@ -413,7 +303,7 @@ mod tests {
                     "testnet",
                     Epoch(1),
                     fixture.compute_aggregate_verification_key(),
-                    genesis_signature,
+                    signature,
                     SupportedEra::Lagrange,
                 )
                 .unwrap();
@@ -424,18 +314,17 @@ mod tests {
                 other => panic!("expected GenesisDualSignature, got {other:?}"),
             };
 
-            // Cross-check the Schnorr signature verifies under the SNARK signer's verifier with
-            // the rigid preimage SHA-256 digest, matching the in-circuit encoding.
-            let verifier =
-                GenesisSchnorrVerifier::from_verification_key(schnorr_signer.verification_key());
+            let verifier = GenesisSchnorrVerifier::from_verification_key(
+                genesis_signer.schnorr.as_ref().unwrap().verification_key(),
+            );
             let preimage = certificate.protocol_message.rigid_preimage();
             assert_eq!(preimage.len(), PREIMAGE_SIZE);
             let digest = sha256_digest(&preimage);
             verifier.verify(&digest, &genesis_schnorr_signature).expect(
                 "Schnorr signature produced by the dual-genesis path must verify against the same digest",
             );
-            // Sanity: the Ed25519 signature still verifies against the legacy signed_message.
-            ed25519_signer
+            genesis_signer
+                .ed25519
                 .create_verifier()
                 .verify(
                     certificate.signed_message.as_bytes(),
@@ -453,17 +342,17 @@ mod tests {
                 rigid.rigid_preimage().len(),
                 PREIMAGE_SIZE,
                 "Rigid protocol-message preimage length must match the PREIMAGE_SIZE constant \
-                 pinned by the IVC gadget; any drift here is the regression the runtime \
-                 InvalidPreimageSize guard exists to catch"
+                 pinned by the IVC gadget; any drift here is the regression the signer's \
+                 preimage-size guard exists to catch"
             );
         }
 
         #[test]
         fn lagrange_fails_without_a_schnorr_signer() {
             let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
-            let ed25519_signer = build_ed25519_signer();
-            let producer = CertificateGenesisProducer::new(Some(ed25519_signer.clone()))
-                .with_logger(TestLogger::stdout());
+            let genesis_signer =
+                GenesisSigner::from_ed25519(GenesisEd25519Signer::create_deterministic_signer());
+            let producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
             let protocol_message = producer
                 .create_genesis_protocol_message(
                     &fixture.protocol_parameters(),
@@ -472,25 +361,14 @@ mod tests {
                     SupportedEra::Lagrange,
                 )
                 .unwrap();
-            let genesis_signature = build_genesis_signature(&ed25519_signer, &protocol_message);
 
-            let error = producer
-                .create_genesis_certificate(
-                    fixture.protocol_parameters(),
-                    "testnet",
-                    Epoch(1),
-                    fixture.compute_aggregate_verification_key(),
-                    genesis_signature,
-                    SupportedEra::Lagrange,
-                )
+            let error = genesis_signer
+                .sign_deterministic(&protocol_message, SupportedEra::Lagrange)
                 .unwrap_err();
 
-            let downcast = error
-                .downcast_ref::<CertificateGenesisProducerError>()
-                .expect("Producer must surface CertificateGenesisProducerError");
             assert!(matches!(
-                downcast,
-                CertificateGenesisProducerError::MissingSnarkGenesisSigner
+                error.downcast_ref::<GenesisBundleError>(),
+                Some(GenesisBundleError::LegacySigningKey)
             ));
         }
     }

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -132,14 +132,14 @@ impl CertificateGenesisProducer {
             &epoch,
             mithril_era,
         )?;
-        Ok(Certificate::new(
+        Certificate::try_new(
             "".to_string(),
             epoch,
             metadata,
             genesis_protocol_message,
             genesis_avk,
             signature,
-        ))
+        )
     }
 }
 

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -95,6 +95,10 @@ impl CertificateGenesisProducer {
             ProtocolMessagePartKey::CurrentEpoch,
             genesis_epoch.to_string(),
         );
+
+        #[cfg(feature = "future_snark")]
+        protocol_message.check_rigid_integrity()?;
+
         Ok(protocol_message)
     }
 
@@ -241,8 +245,9 @@ mod tests {
     mod era_dispatched_genesis_certificate {
         use crate::crypto_helper::{
             GenesisBundleError, GenesisEd25519Signer, GenesisSchnorrVerifier, GenesisSigner,
-            PREIMAGE_SIZE, sha256_digest,
+            PREIMAGE_SIZE, ProtocolAggregateVerificationKeyForConcatenation, sha256_digest,
         };
+        use crate::entities::RigidProtocolMessageIntegrityError;
 
         use super::*;
 
@@ -277,6 +282,36 @@ mod tests {
             assert!(matches!(
                 certificate.signature,
                 CertificateSignature::GenesisSignature(_)
+            ));
+        }
+
+        #[test]
+        fn lagrange_genesis_rejects_an_aggregate_verification_key_without_its_snark_half() {
+            let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
+            let producer = CertificateGenesisProducer::new().with_logger(TestLogger::stdout());
+            let aggregate_verification_key_without_snark = ProtocolAggregateVerificationKey::new(
+                ProtocolAggregateVerificationKeyForConcatenation::try_from(
+                    fake_keys::aggregate_verification_key_for_concatenation()[0],
+                )
+                .unwrap()
+                .into(),
+                None,
+            );
+
+            let error = producer
+                .create_genesis_protocol_message(
+                    &fixture.protocol_parameters(),
+                    &aggregate_verification_key_without_snark,
+                    &Epoch(1),
+                    SupportedEra::Lagrange,
+                )
+                .expect_err(
+                    "Lagrange genesis must reject an aggregate verification key without its SNARK half",
+                );
+
+            assert!(matches!(
+                error.downcast_ref::<RigidProtocolMessageIntegrityError>(),
+                Some(RigidProtocolMessageIntegrityError::MissingNextSnarkAggregateVerificationKey)
             ));
         }
 

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -194,7 +194,7 @@ impl MithrilCertificateVerifier {
     }
 
     fn verify_hash_matches_content(&self, certificate: &Certificate) -> StdResult<()> {
-        if certificate.compute_hash() != certificate.hash {
+        if certificate.try_compute_hash()? != certificate.hash {
             return Err(anyhow!(CertificateVerifierError::CertificateHashUnmatch));
         }
 

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -404,7 +404,12 @@ impl CertificateVerifier for MithrilCertificateVerifier {
     ) -> StdResult<()> {
         let genesis_signature = match &genesis_certificate.signature {
             CertificateSignature::GenesisSignature(signature) => Ok(signature),
-            _ => Err(CertificateVerifierError::InvalidGenesisCertificateProvided),
+            // The Schnorr half is intentionally not verified here as it is needed for IVC SNARK only
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(signature, _) => Ok(signature),
+            CertificateSignature::MultiSignature(_, _) => {
+                Err(CertificateVerifierError::InvalidGenesisCertificateProvided)
+            }
         }?;
         self.verify_hash_matches_content(genesis_certificate)?;
         self.verify_signed_message_matches_hashed_protocol_message(genesis_certificate)?;
@@ -470,6 +475,13 @@ impl CertificateVerifier for MithrilCertificateVerifier {
 
                 Ok(None)
             }
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(_, _) => {
+                self.verify_genesis_certificate(certificate, genesis_verification_key)
+                    .await?;
+
+                Ok(None)
+            }
             CertificateSignature::MultiSignature(_, _) => {
                 let previous_certificate = self.fetch_previous_certificate(certificate).await?;
                 self.verify_standard_certificate(certificate, &previous_certificate)
@@ -502,6 +514,13 @@ mod tests {
     };
 
     use super::*;
+
+    #[cfg(feature = "future_snark")]
+    use crate::crypto_helper::GenesisSchnorrSigner;
+    #[cfg(feature = "future_snark")]
+    use rand_chacha::ChaCha20Rng;
+    #[cfg(feature = "future_snark")]
+    use rand_core::SeedableRng;
 
     macro_rules! assert_error_matches {
         ( $expected_error:path, $error:expr ) => {{
@@ -604,6 +623,35 @@ mod tests {
             .await;
 
         verify.expect("verify_genesis_certificate should not fail");
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[tokio::test]
+    async fn verify_genesis_certificate_ignores_the_schnorr_half_of_a_dual_signature() {
+        let (total_certificates, certificates_per_epoch) = (5, 1);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let bundle = fake_certificates.genesis_verifier.verification_key_bundle();
+        let ed_signature = match &fake_certificates.genesis_certificate().signature {
+            CertificateSignature::GenesisSignature(signature) => *signature,
+            other => panic!("expected a legacy genesis signature, got {other:?}"),
+        };
+
+        let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+        let schnorr_signer = GenesisSchnorrSigner::generate(&mut rng);
+
+        for digest in [[1u8; 32], [2u8; 32]] {
+            let schnorr_signature = schnorr_signer.sign(&digest, &mut rng).unwrap();
+            let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
+            genesis_certificate.signature =
+                CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature);
+            genesis_certificate.hash = genesis_certificate.compute_hash();
+
+            verifier
+                .verify_genesis_certificate(&genesis_certificate, &bundle)
+                .await
+                .expect("the Schnorr half is intentionally not verified, so this must succeed");
+        }
     }
 
     #[tokio::test]

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -468,28 +468,18 @@ impl CertificateVerifier for MithrilCertificateVerifier {
             "certificate_signed_entity_type" => ?certificate.signed_entity_type(),
         );
 
-        match &certificate.signature {
-            CertificateSignature::GenesisSignature(_) => {
-                self.verify_genesis_certificate(certificate, genesis_verification_key)
-                    .await?;
+        if certificate.is_genesis() {
+            self.verify_genesis_certificate(certificate, genesis_verification_key)
+                .await?;
 
-                Ok(None)
-            }
-            #[cfg(feature = "future_snark")]
-            CertificateSignature::GenesisDualSignature(_, _) => {
-                self.verify_genesis_certificate(certificate, genesis_verification_key)
-                    .await?;
-
-                Ok(None)
-            }
-            CertificateSignature::MultiSignature(_, _) => {
-                let previous_certificate = self.fetch_previous_certificate(certificate).await?;
-                self.verify_standard_certificate(certificate, &previous_certificate)
-                    .await?;
-
-                Ok(Some(previous_certificate))
-            }
+            return Ok(None);
         }
+
+        let previous_certificate = self.fetch_previous_certificate(certificate).await?;
+        self.verify_standard_certificate(certificate, &previous_certificate)
+            .await?;
+
+        Ok(Some(previous_certificate))
     }
 }
 
@@ -618,7 +608,7 @@ mod tests {
         let verify = verifier
             .verify_genesis_certificate(
                 genesis_certificate,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await;
 
@@ -631,7 +621,8 @@ mod tests {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
-        let bundle = fake_certificates.genesis_verifier.verification_key_bundle();
+        let genesis_verification_key =
+            fake_certificates.genesis_verifier.to_ed25519_verification_key();
         let ed_signature = match &fake_certificates.genesis_certificate().signature {
             CertificateSignature::GenesisSignature(signature) => *signature,
             other => panic!("expected a legacy genesis signature, got {other:?}"),
@@ -648,7 +639,7 @@ mod tests {
             genesis_certificate.hash = genesis_certificate.compute_hash();
 
             verifier
-                .verify_genesis_certificate(&genesis_certificate, &bundle)
+                .verify_genesis_certificate(&genesis_certificate, &genesis_verification_key)
                 .await
                 .expect("the Schnorr half is intentionally not verified, so this must succeed");
         }
@@ -667,7 +658,7 @@ mod tests {
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -689,7 +680,7 @@ mod tests {
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -712,7 +703,7 @@ mod tests {
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -735,7 +726,7 @@ mod tests {
         let error = verifier
             .verify_genesis_certificate(
                 &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await
             .expect_err("verify_genesis_certificate should fail");
@@ -1022,7 +1013,7 @@ mod tests {
         let verify = verifier
             .verify_certificate(
                 genesis_certificate,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await;
 
@@ -1046,7 +1037,7 @@ mod tests {
         let verify = verifier
             .verify_certificate(
                 &certificate,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await;
 
@@ -1114,7 +1105,7 @@ mod tests {
         let verify = verifier
             .verify_certificate_chain(
                 fake_certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await;
 
@@ -1135,7 +1126,7 @@ mod tests {
         let verify = verifier
             .verify_certificate_chain(
                 certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await;
         verify.expect("verify_certificate_chain should not fail");
@@ -1157,7 +1148,7 @@ mod tests {
         let error = verifier
             .verify_certificate_chain(
                 certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await
             .expect_err("verify_certificate_chain should fail");
@@ -1245,7 +1236,7 @@ mod tests {
         let error = verifier
             .verify_certificate(
                 &certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_verification_key(),
+                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
             )
             .await
             .expect_err("verify_certificate_chain should fail");

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -636,7 +636,7 @@ mod tests {
             let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
             genesis_certificate.signature =
                 CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature);
-            genesis_certificate.hash = genesis_certificate.compute_hash();
+            genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
             verifier
                 .verify_genesis_certificate(&genesis_certificate, &genesis_verification_key)
@@ -653,7 +653,7 @@ mod tests {
         let standard_certificate = fake_certificates[0].clone();
         let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.signature = standard_certificate.signature.clone();
-        genesis_certificate.hash = genesis_certificate.compute_hash();
+        genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
         let error = verifier
             .verify_genesis_certificate(
@@ -698,7 +698,7 @@ mod tests {
             ProtocolMessagePartKey::CurrentEpoch,
             "another-value".to_string(),
         );
-        genesis_certificate.hash = genesis_certificate.compute_hash();
+        genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
         let error = verifier
             .verify_genesis_certificate(
@@ -721,7 +721,7 @@ mod tests {
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.epoch -= 1;
-        genesis_certificate.hash = genesis_certificate.compute_hash();
+        genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
         let error = verifier
             .verify_genesis_certificate(
@@ -772,7 +772,7 @@ mod tests {
         let genesis_certificate = fake_certificates.genesis_certificate();
         let mut standard_certificate = fake_certificates[0].clone();
         standard_certificate.signature = genesis_certificate.signature.clone();
-        standard_certificate.hash = standard_certificate.compute_hash();
+        standard_certificate.hash = standard_certificate.try_compute_hash().unwrap();
         let standard_previous_certificate = fake_certificates[1].clone();
 
         let error = verifier
@@ -833,7 +833,7 @@ mod tests {
             ProtocolMessagePartKey::CurrentEpoch,
             "another-value".to_string(),
         );
-        certificate.hash = certificate.compute_hash();
+        certificate.hash = certificate.try_compute_hash().unwrap();
         let previous_certificate = fake_certificates[1].clone();
 
         let error = verifier
@@ -854,7 +854,7 @@ mod tests {
         let verifier = MockDependencyInjector::new().build_certificate_verifier();
         let mut certificate = fake_certificates[0].clone();
         certificate.epoch -= 1;
-        certificate.hash = certificate.compute_hash();
+        certificate.hash = certificate.try_compute_hash().unwrap();
         let previous_certificate = fake_certificates[1].clone();
 
         let error = verifier
@@ -940,7 +940,7 @@ mod tests {
         let certificate = fake_certificates[0].clone();
         let mut previous_certificate = fake_certificates[1].clone();
         previous_certificate.previous_hash = "another-hash".to_string();
-        previous_certificate.hash = previous_certificate.compute_hash();
+        previous_certificate.hash = previous_certificate.try_compute_hash().unwrap();
 
         let error = verifier
             .verify_standard_certificate(&certificate, &previous_certificate)
@@ -964,9 +964,9 @@ mod tests {
             ProtocolMessagePartKey::NextAggregateVerificationKey,
             "another-avk".to_string(),
         );
-        previous_certificate.hash = previous_certificate.compute_hash();
+        previous_certificate.hash = previous_certificate.try_compute_hash().unwrap();
         certificate.previous_hash.clone_from(&previous_certificate.hash);
-        certificate.hash = certificate.compute_hash();
+        certificate.hash = certificate.try_compute_hash().unwrap();
 
         let error = verifier
             .verify_standard_certificate(&certificate, &previous_certificate)
@@ -987,9 +987,9 @@ mod tests {
             ProtocolMessagePartKey::NextProtocolParameters,
             "protocol-params-hash-123".to_string(),
         );
-        previous_certificate.hash = previous_certificate.compute_hash();
+        previous_certificate.hash = previous_certificate.try_compute_hash().unwrap();
         certificate.previous_hash.clone_from(&previous_certificate.hash);
-        certificate.hash = certificate.compute_hash();
+        certificate.hash = certificate.try_compute_hash().unwrap();
 
         let error = verifier
             .verify_standard_certificate(&certificate, &previous_certificate)
@@ -1274,7 +1274,7 @@ mod tests {
                 let snark_signature = snark_aggregate_signature();
                 certificate.signature =
                     CertificateSignature::MultiSignature(entity_type, snark_signature);
-                certificate.hash = certificate.compute_hash();
+                certificate.hash = certificate.try_compute_hash().unwrap();
             } else {
                 panic!("Certificate signature should be a multi signature");
             }
@@ -1292,7 +1292,7 @@ mod tests {
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             let previous_certificate = fake_certificates[1].clone();
             certificate.previous_hash.clone_from(&previous_certificate.hash);
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
 
             verifier
                 .verify_snark_aggregate_verification_key_chaining(
@@ -1355,7 +1355,7 @@ mod tests {
             let verifier = MockDependencyInjector::new().build_certificate_verifier();
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             certificate.aggregate_verification_key_snark = None;
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
             let previous_certificate = fake_certificates[1].clone();
 
             let error = verifier
@@ -1378,7 +1378,7 @@ mod tests {
             let verifier = MockDependencyInjector::new().build_certificate_verifier();
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             certificate.aggregate_verification_key_snark = None;
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
             let mut previous_certificate = fake_certificates[1].clone();
             previous_certificate.aggregate_verification_key_snark = None;
 
@@ -1453,7 +1453,7 @@ mod tests {
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             let previous_certificate = fake_certificates[1].clone();
             certificate.previous_hash.clone_from(&previous_certificate.hash);
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
 
             verifier
                 .verify_aggregate_verification_key_chaining(&certificate, &previous_certificate)
@@ -1473,7 +1473,7 @@ mod tests {
             let genesis_certificate = fake_certificates.genesis_certificate().clone();
             let mut certificate = with_snark_proof_type(fake_certificates[3].clone());
             certificate.previous_hash.clone_from(&genesis_certificate.hash);
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
 
             verifier
                 .verify_snark_aggregate_verification_key_chaining(
@@ -1496,7 +1496,7 @@ mod tests {
             certificate.epoch = epoch;
             certificate.protocol_message = rigid;
             certificate.signed_message = certificate.protocol_message.compute_hash();
-            certificate.hash = certificate.compute_hash();
+            certificate.hash = certificate.try_compute_hash().unwrap();
             certificate
         }
 
@@ -1611,7 +1611,7 @@ mod tests {
             successor.protocol_message.hash_scheme = ProtocolMessageHashScheme::Rigid;
             successor.signed_message = successor.protocol_message.compute_hash();
             successor.previous_hash.clone_from(&predecessor.hash);
-            successor.hash = successor.compute_hash();
+            successor.hash = successor.try_compute_hash().unwrap();
 
             (predecessor, successor)
         }
@@ -1712,7 +1712,7 @@ mod tests {
                 };
                 certificate.signature =
                     CertificateSignature::MultiSignature(entity_type, snark_aggregate_signature());
-                certificate.hash = certificate.compute_hash();
+                certificate.hash = certificate.try_compute_hash().unwrap();
                 certificate
             }
 

--- a/mithril-common/src/crypto_helper/genesis/signer.rs
+++ b/mithril-common/src/crypto_helper/genesis/signer.rs
@@ -4,6 +4,8 @@
 use std::path::Path;
 
 use anyhow::anyhow;
+use rand_chacha::ChaCha20Rng;
+use rand_core::{CryptoRng, RngCore, SeedableRng};
 
 use crate::StdResult;
 use crate::crypto_helper::GenesisEd25519SecretKey;
@@ -11,9 +13,11 @@ use crate::crypto_helper::GenesisEd25519Signer;
 use crate::crypto_helper::GenesisVerifier;
 #[cfg(feature = "future_snark")]
 use crate::crypto_helper::{
-    BUNDLE_FIRST_HEX_CHAR, GenesisSchnorrSigner, GenesisSigningKeyBundle,
-    GenesisVerificationKeyBundle, LEGACY_FIRST_HEX_CHAR, ProtocolKey,
+    BUNDLE_FIRST_HEX_CHAR, GenesisBundleError, GenesisSchnorrSigner, GenesisSigningKeyBundle,
+    GenesisVerificationKeyBundle, LEGACY_FIRST_HEX_CHAR, PREIMAGE_SIZE, ProtocolKey, sha256_digest,
 };
+use crate::entities::{CertificateSignature, ProtocolMessage, SupportedEra};
+use crate::protocol::ToMessage;
 
 /// Wraps the two genesis signers and the bundle plumbing required by the offline ceremony.
 #[derive(Debug, Clone)]
@@ -58,6 +62,15 @@ impl GenesisSigner {
         }
     }
 
+    /// Build the matching [GenesisVerifier] for this signer, pairing each present half.
+    pub fn create_verifier(&self) -> GenesisVerifier {
+        GenesisVerifier {
+            ed25519: self.ed25519.create_verifier(),
+            #[cfg(feature = "future_snark")]
+            schnorr: self.schnorr.as_ref().map(|schnorr| schnorr.create_verifier()),
+        }
+    }
+
     /// Parse a hex blob, preferring the dual signing-key bundle and falling back to the legacy
     /// single-Ed25519 JSON-hex format.
     pub fn try_from_hex(raw: &str) -> StdResult<Self> {
@@ -92,19 +105,70 @@ impl GenesisSigner {
         }
     }
 
-    /// Build the matching [GenesisVerifier] for this signer, pairing each present half.
-    pub fn create_verifier(&self) -> GenesisVerifier {
-        GenesisVerifier {
-            ed25519: self.ed25519.create_verifier(),
-            #[cfg(feature = "future_snark")]
-            schnorr: self.schnorr.as_ref().map(|schnorr| schnorr.create_verifier()),
-        }
-    }
-
     /// Read [Self::try_from_hex] from disk.
     pub fn read_from_file(path: &Path) -> StdResult<Self> {
         let raw = std::fs::read_to_string(path)?;
         Self::try_from_hex(&raw)
+    }
+
+    /// Sign a genesis protocol message, producing the era-appropriate [CertificateSignature].
+    ///
+    /// Pythagoras yields a single Ed25519 signature; Lagrange yields a dual signature pairing the
+    /// Ed25519 half with a SNARK-friendly Schnorr signature over the rigid preimage digest. The
+    /// `rng` seeds the Schnorr per-signature nonce (unused under Pythagoras).
+    pub fn sign<R: CryptoRng + RngCore>(
+        &self,
+        protocol_message: &ProtocolMessage,
+        mithril_era: SupportedEra,
+        #[cfg_attr(not(feature = "future_snark"), allow(unused_variables))] rng: &mut R,
+    ) -> StdResult<CertificateSignature> {
+        let ed25519_signature = self.ed25519.sign(protocol_message.to_message().as_bytes());
+        match mithril_era {
+            SupportedEra::Pythagoras => {
+                Ok(CertificateSignature::GenesisSignature(ed25519_signature))
+            }
+            #[cfg(feature = "future_snark")]
+            SupportedEra::Lagrange => {
+                let schnorr_signer =
+                    self.schnorr.as_ref().ok_or(GenesisBundleError::LegacySigningKey)?;
+                let preimage = protocol_message.rigid_preimage();
+                if preimage.len() != PREIMAGE_SIZE {
+                    return Err(anyhow!(
+                        "rigid protocol-message preimage must be exactly {PREIMAGE_SIZE} bytes (got {})",
+                        preimage.len()
+                    ));
+                }
+                let schnorr_signature = schnorr_signer.sign(&sha256_digest(&preimage), rng)?;
+                Ok(CertificateSignature::GenesisDualSignature(
+                    ed25519_signature,
+                    schnorr_signature,
+                ))
+            }
+            #[cfg(not(feature = "future_snark"))]
+            SupportedEra::Lagrange => Ok(CertificateSignature::GenesisSignature(ed25519_signature)),
+        }
+    }
+
+    /// Sign with a fixed-seed deterministic RNG, for non-production use (devnet, tests).
+    pub(crate) fn sign_deterministic(
+        &self,
+        protocol_message: &ProtocolMessage,
+        mithril_era: SupportedEra,
+    ) -> StdResult<CertificateSignature> {
+        self.sign(
+            protocol_message,
+            mithril_era,
+            &mut ChaCha20Rng::from_seed([0u8; 32]),
+        )
+    }
+
+    /// Sign with the OS-backed CSPRNG ([rand_core::OsRng]).
+    pub fn sign_non_deterministic(
+        &self,
+        protocol_message: &ProtocolMessage,
+        mithril_era: SupportedEra,
+    ) -> StdResult<CertificateSignature> {
+        self.sign(protocol_message, mithril_era, &mut rand_core::OsRng)
     }
 
     /// Derive the matching dual verification-key bundle. Returns `None` for a legacy single-Ed25519

--- a/mithril-common/src/crypto_helper/genesis/signer.rs
+++ b/mithril-common/src/crypto_helper/genesis/signer.rs
@@ -131,6 +131,11 @@ impl GenesisSigner {
             SupportedEra::Lagrange => {
                 let schnorr_signer =
                     self.schnorr.as_ref().ok_or(GenesisBundleError::LegacySigningKey)?;
+                if !protocol_message.is_rigid() {
+                    return Err(anyhow!(
+                        "Lagrange genesis signing requires a rigid protocol message"
+                    ));
+                }
                 protocol_message.check_rigid_integrity()?;
                 let preimage = protocol_message.rigid_preimage();
                 if preimage.len() != PREIMAGE_SIZE {
@@ -274,6 +279,18 @@ mod tests {
             let mut rng = ChaCha20Rng::from_seed([7u8; 32]);
             let schnorr = GenesisSchnorrSigner::generate(&mut rng);
             GenesisSigningKeyBundle::new(ed25519.secret_key(), schnorr.secret_key())
+        }
+
+        #[test]
+        fn sign_lagrange_rejects_a_non_rigid_protocol_message() {
+            let signer = GenesisSigner::from_bundle(build_bundle());
+            let mut rng = ChaCha20Rng::from_seed([3u8; 32]);
+
+            let error = signer
+                .sign(&ProtocolMessage::new(), SupportedEra::Lagrange, &mut rng)
+                .expect_err("Lagrange signing must reject a non-rigid protocol message");
+
+            assert!(error.to_string().contains("rigid protocol message"));
         }
 
         #[test]

--- a/mithril-common/src/crypto_helper/genesis/signer.rs
+++ b/mithril-common/src/crypto_helper/genesis/signer.rs
@@ -131,6 +131,7 @@ impl GenesisSigner {
             SupportedEra::Lagrange => {
                 let schnorr_signer =
                     self.schnorr.as_ref().ok_or(GenesisBundleError::LegacySigningKey)?;
+                protocol_message.check_rigid_integrity()?;
                 let preimage = protocol_message.rigid_preimage();
                 if preimage.len() != PREIMAGE_SIZE {
                     return Err(anyhow!(

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -5,6 +5,8 @@ use sha2::{Digest, Sha256};
 use mithril_stm::AggregateSignatureType;
 
 #[cfg(feature = "future_snark")]
+use crate::crypto_helper::GenesisSchnorrSignature;
+#[cfg(feature = "future_snark")]
 use crate::crypto_helper::ProtocolAggregateVerificationKeyForSnark;
 use crate::crypto_helper::{
     GenesisEd25519Signature, ProtocolAggregateVerificationKey,
@@ -15,9 +17,19 @@ use crate::entities::{CertificateMetadata, Epoch, ProtocolMessage, SignedEntityT
 /// The signature of a [Certificate]
 #[derive(Clone, Debug)]
 pub enum CertificateSignature {
-    /// Genesis signature created from the original stake distribution
+    /// Ed25519 genesis signature created from the original stake distribution
     /// aka GENESIS_SIG(AVK(-1))
     GenesisSignature(GenesisEd25519Signature),
+
+    /// Dual genesis signature carrying both the legacy Ed25519 signature (covered by the
+    /// certificate hash to preserve chain-walking compatibility) and the SNARK-friendly
+    /// Schnorr signature (used for the in-circuit attestation under the Lagrange era).
+    ///
+    /// The Schnorr part is deliberately excluded from
+    /// [CertificateSignature::to_bytes_hex_for_certificate_hash] so a Lagrange genesis cert
+    /// hashes byte-identically to a legacy `GenesisSignature(ed)` cert with the same `ed`.
+    #[cfg(feature = "future_snark")]
+    GenesisDualSignature(GenesisEd25519Signature, GenesisSchnorrSignature),
 
     /// STM multi signature created from a quorum of single signatures from the signers
     /// aka (BEACON(p,n), MULTI_SIG(H(MSG(p,n) || AVK(n-1))))
@@ -31,9 +43,40 @@ impl CertificateSignature {
     pub fn aggregate_signature_type(&self) -> Option<AggregateSignatureType> {
         match self {
             CertificateSignature::GenesisSignature(_) => None,
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(_, _) => None,
             CertificateSignature::MultiSignature(_, multi_signature) => {
                 Some((&multi_signature.key).into())
             }
+        }
+    }
+
+    /// Return the bytes-hex of the signature payload that is included in
+    /// [Certificate::compute_hash]. For the dual-genesis variant this is the Ed25519 bytes only,
+    /// keeping the certificate hash byte-identical to today's so legacy clients can keep walking
+    /// the chain backwards across the Lagrange boundary.
+    pub fn to_bytes_hex_for_certificate_hash(&self) -> crate::StdResult<String> {
+        match self {
+            CertificateSignature::GenesisSignature(signature) => signature.to_bytes_hex(),
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(ed_signature, _schnorr_signature) => {
+                ed_signature.to_bytes_hex()
+            }
+            CertificateSignature::MultiSignature(_, signature) => signature.to_json_hex(),
+        }
+    }
+
+    /// Return the Schnorr genesis signature carried by a [CertificateSignature::GenesisDualSignature]
+    /// variant, or `None` for any other variant.
+    ///
+    /// SNARK clients fetch the Schnorr signature through this accessor when running the in-circuit
+    /// genesis attestation; the bytes are intentionally excluded from
+    /// [CertificateSignature::to_bytes_hex_for_certificate_hash].
+    #[cfg(feature = "future_snark")]
+    pub fn schnorr_signature(&self) -> Option<&GenesisSchnorrSignature> {
+        match self {
+            CertificateSignature::GenesisDualSignature(_, schnorr) => Some(schnorr),
+            _ => None,
         }
     }
 }
@@ -118,7 +161,16 @@ impl Certificate {
         certificate
     }
 
-    /// Computes the hash of a Certificate
+    /// Computes the hash of a Certificate.
+    ///
+    /// The signature is fed into the hash via
+    /// [CertificateSignature::to_bytes_hex_for_certificate_hash], which deliberately excludes
+    /// the Schnorr genesis bytes so the chain hash stays byte-identical for legacy clients.
+    ///
+    /// Design note (hash invariance between `GenesisSignature` and `GenesisDualSignature`): a
+    /// dual-signature Lagrange genesis certificate hashes byte-identically to a legacy
+    /// `GenesisSignature(ed)` certificate carrying the same Ed25519 signature. This is
+    /// intentional, so legacy clients keep walking the chain across the Lagrange boundary.
     pub fn compute_hash(&self) -> String {
         let mut hasher = Sha256::new();
         hasher.update(self.previous_hash.as_bytes());
@@ -127,21 +179,22 @@ impl Certificate {
         hasher.update(self.protocol_message.compute_hash().as_bytes());
         hasher.update(self.signed_message.as_bytes());
         hasher.update(self.aggregate_verification_key.to_json_hex().unwrap().as_bytes());
-        match &self.signature {
-            CertificateSignature::GenesisSignature(signature) => {
-                hasher.update(signature.to_bytes_hex().unwrap());
-            }
-            CertificateSignature::MultiSignature(signed_entity_type, signature) => {
-                signed_entity_type.feed_hash(&mut hasher);
-                hasher.update(signature.to_json_hex().unwrap());
-            }
-        };
+        if let CertificateSignature::MultiSignature(signed_entity_type, _) = &self.signature {
+            signed_entity_type.feed_hash(&mut hasher);
+        }
+        hasher.update(self.signature.to_bytes_hex_for_certificate_hash().unwrap());
         hex::encode(hasher.finalize())
     }
 
-    /// Tell if the certificate is a genesis certificate
+    /// Tell if the certificate is a genesis certificate (covers both the legacy and the
+    /// dual-signature variants).
     pub fn is_genesis(&self) -> bool {
-        matches!(self.signature, CertificateSignature::GenesisSignature(_))
+        match self.signature {
+            CertificateSignature::GenesisSignature(_) => true,
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(_, _) => true,
+            CertificateSignature::MultiSignature(_, _) => false,
+        }
     }
 
     /// Return true if the certificate is chaining into itself (meaning that its hash and previous
@@ -159,6 +212,10 @@ impl Certificate {
     pub fn signed_entity_type(&self) -> SignedEntityType {
         match &self.signature {
             CertificateSignature::GenesisSignature(_) => SignedEntityType::genesis(self.epoch),
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(_, _) => {
+                SignedEntityType::genesis(self.epoch)
+            }
             CertificateSignature::MultiSignature(entity_type, _) => entity_type.clone(),
         }
     }
@@ -228,7 +285,13 @@ impl Debug for Certificate {
 #[cfg(test)]
 mod tests {
     use chrono::{DateTime, Duration, Utc};
+    #[cfg(feature = "future_snark")]
+    use rand_chacha::ChaCha20Rng;
+    #[cfg(feature = "future_snark")]
+    use rand_core::SeedableRng;
 
+    #[cfg(feature = "future_snark")]
+    use crate::crypto_helper::GenesisSchnorrSigner;
     use crate::entities::SignedEntityType::CardanoStakeDistribution;
     use crate::{
         entities::{
@@ -462,6 +525,191 @@ mod tests {
                 ..genesis_certificate.clone()
             }
             .compute_hash(),
+        );
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn dual_signature_does_not_change_the_certificate_hash() {
+        let initiated_at = DateTime::parse_from_rfc3339("2024-02-12T13:11:47.0123043Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let sealed_at = initiated_at + Duration::try_seconds(100).unwrap();
+        let ed_signature: GenesisEd25519Signature =
+            fake_keys::genesis_signature()[0].try_into().unwrap();
+
+        let legacy = Certificate::new(
+            "previous_hash",
+            Epoch(10),
+            CertificateMetadata::new(
+                "testnet",
+                "0.1.0".to_string(),
+                ProtocolParameters::new(1000, 100, 0.123),
+                initiated_at,
+                sealed_at,
+                get_parties(),
+            ),
+            get_protocol_message(),
+            ProtocolAggregateVerificationKey::new(
+                ProtocolAggregateVerificationKeyForConcatenation::try_from(
+                    fake_keys::aggregate_verification_key_for_concatenation()[1],
+                )
+                .unwrap()
+                .into(),
+                None,
+            ),
+            CertificateSignature::GenesisSignature(ed_signature),
+        );
+
+        let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+        let schnorr_signer = GenesisSchnorrSigner::generate(&mut rng);
+        let schnorr_signature = schnorr_signer.sign(&[0u8; 32], &mut rng).unwrap();
+
+        let dual = Certificate::new(
+            "previous_hash",
+            Epoch(10),
+            CertificateMetadata::new(
+                "testnet",
+                "0.1.0".to_string(),
+                ProtocolParameters::new(1000, 100, 0.123),
+                initiated_at,
+                sealed_at,
+                get_parties(),
+            ),
+            get_protocol_message(),
+            ProtocolAggregateVerificationKey::new(
+                ProtocolAggregateVerificationKeyForConcatenation::try_from(
+                    fake_keys::aggregate_verification_key_for_concatenation()[1],
+                )
+                .unwrap()
+                .into(),
+                None,
+            ),
+            CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
+        );
+
+        assert_eq!(
+            legacy.compute_hash(),
+            dual.compute_hash(),
+            "dual-signature variant must hash identically to the legacy single-Ed25519 variant"
+        );
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn certificate_hash_is_independent_of_schnorr_signature_bytes() {
+        let initiated_at = DateTime::parse_from_rfc3339("2024-02-12T13:11:47.0123043Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let sealed_at = initiated_at + Duration::try_seconds(100).unwrap();
+        let ed_signature: GenesisEd25519Signature =
+            fake_keys::genesis_signature()[0].try_into().unwrap();
+
+        let metadata = CertificateMetadata::new(
+            "testnet",
+            "0.1.0".to_string(),
+            ProtocolParameters::new(1000, 100, 0.123),
+            initiated_at,
+            sealed_at,
+            get_parties(),
+        );
+
+        let mut rng = ChaCha20Rng::from_seed([1u8; 32]);
+        let schnorr_signer = GenesisSchnorrSigner::generate(&mut rng);
+        let mut hashes = std::collections::HashSet::new();
+        for seed in 0u8..6 {
+            let digest = [seed; 32];
+            let schnorr_signature = schnorr_signer.sign(&digest, &mut rng).unwrap();
+            let certificate = Certificate::new(
+                "previous_hash",
+                Epoch(10),
+                metadata.clone(),
+                get_protocol_message(),
+                ProtocolAggregateVerificationKey::new(
+                    ProtocolAggregateVerificationKeyForConcatenation::try_from(
+                        fake_keys::aggregate_verification_key_for_concatenation()[1],
+                    )
+                    .unwrap()
+                    .into(),
+                    None,
+                ),
+                CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
+            );
+            hashes.insert(certificate.compute_hash());
+        }
+        assert_eq!(
+            hashes.len(),
+            1,
+            "the certificate hash must be invariant when varying only the Schnorr signature",
+        );
+    }
+
+    #[cfg(feature = "future_snark")]
+    fn build_genesis_certificate_for_test(signature: CertificateSignature) -> Certificate {
+        let initiated_at = DateTime::parse_from_rfc3339("2024-02-12T13:11:47.0123043Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let sealed_at = initiated_at + Duration::try_seconds(100).unwrap();
+        Certificate::new(
+            "previous_hash",
+            Epoch(10),
+            CertificateMetadata::new(
+                "testnet",
+                "0.1.0".to_string(),
+                ProtocolParameters::new(1000, 100, 0.123),
+                initiated_at,
+                sealed_at,
+                get_parties(),
+            ),
+            get_protocol_message(),
+            ProtocolAggregateVerificationKey::new(
+                ProtocolAggregateVerificationKeyForConcatenation::try_from(
+                    fake_keys::aggregate_verification_key_for_concatenation()[1],
+                )
+                .unwrap()
+                .into(),
+                None,
+            ),
+            signature,
+        )
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn is_genesis_returns_true_for_both_genesis_variants() {
+        let ed_signature: GenesisEd25519Signature =
+            fake_keys::genesis_signature()[0].try_into().unwrap();
+        let mut rng = ChaCha20Rng::from_seed([2u8; 32]);
+        let schnorr_signer = GenesisSchnorrSigner::generate(&mut rng);
+        let schnorr_signature = schnorr_signer.sign(&[0u8; 32], &mut rng).unwrap();
+
+        let multi = build_genesis_certificate_for_test(CertificateSignature::MultiSignature(
+            CardanoStakeDistribution(Epoch(10)),
+            fake_keys::multi_signature()[0].try_into().unwrap(),
+        ));
+        let legacy = build_genesis_certificate_for_test(CertificateSignature::GenesisSignature(
+            ed_signature,
+        ));
+        let dual = build_genesis_certificate_for_test(CertificateSignature::GenesisDualSignature(
+            ed_signature,
+            schnorr_signature,
+        ));
+
+        assert!(legacy.is_genesis());
+        assert!(dual.is_genesis());
+        assert!(!multi.is_genesis());
+
+        assert_eq!(
+            legacy.signed_entity_type(),
+            SignedEntityType::genesis(legacy.epoch)
+        );
+        assert_eq!(
+            dual.signed_entity_type(),
+            SignedEntityType::genesis(dual.epoch)
+        );
+        assert_ne!(
+            multi.signed_entity_type(),
+            SignedEntityType::genesis(multi.epoch)
         );
     }
 }

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -52,7 +52,7 @@ impl CertificateSignature {
     }
 
     /// Return the bytes-hex of the signature payload that is included in
-    /// [Certificate::compute_hash]. For the dual-genesis variant this is the Ed25519 bytes only,
+    /// [Certificate::try_compute_hash]. For the dual-genesis variant this is the Ed25519 bytes only,
     /// keeping the certificate hash byte-identical to today's so legacy clients can keep walking
     /// the chain backwards across the Lagrange boundary.
     pub fn to_bytes_hex_for_certificate_hash(&self) -> crate::StdResult<String> {
@@ -170,14 +170,6 @@ impl Certificate {
         }
         hasher.update(self.signature.to_bytes_hex_for_certificate_hash()?);
         Ok(hex::encode(hasher.finalize()))
-    }
-
-    /// Infallible [Self::try_compute_hash] for construction-time hashing, where the inputs were
-    /// just built and validated. Panics only on a genuinely impossible serialization bug; the
-    /// verification path uses [Self::try_compute_hash] so it cannot crash the process.
-    pub fn compute_hash(&self) -> String {
-        self.try_compute_hash()
-            .expect("certificate hashing is infallible for a well-formed certificate")
     }
 
     /// Tell if the certificate is a genesis certificate (covers both the legacy and the
@@ -363,7 +355,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(HASH_EXPECTED, certificate.compute_hash());
+        assert_eq!(HASH_EXPECTED, certificate.try_compute_hash().unwrap());
 
         assert_ne!(
             HASH_EXPECTED,
@@ -371,7 +363,8 @@ mod tests {
                 previous_hash: "previous_hash-modified".to_string(),
                 ..certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
 
         assert_ne!(
@@ -380,7 +373,8 @@ mod tests {
                 epoch: certificate.epoch + 10,
                 ..certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
 
         assert_ne!(
@@ -392,7 +386,8 @@ mod tests {
                 },
                 ..certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
 
         assert_ne!(
@@ -409,7 +404,8 @@ mod tests {
                 },
                 ..certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
 
         assert_ne!(
@@ -421,7 +417,8 @@ mod tests {
                         .unwrap(),
                 ..certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
 
         assert_ne!(
@@ -433,7 +430,8 @@ mod tests {
                 ),
                 ..certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
 
         assert_ne!(
@@ -445,7 +443,8 @@ mod tests {
                 ),
                 ..certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
     }
 
@@ -456,7 +455,7 @@ mod tests {
 
         let fixture = MithrilFixtureBuilder::default().with_signers(3).build();
         let certificate = fixture.create_genesis_certificate("testnet", Epoch(1));
-        let original_hash = certificate.compute_hash();
+        let original_hash = certificate.try_compute_hash().unwrap();
 
         assert!(
             certificate.aggregate_verification_key_snark.is_some(),
@@ -468,7 +467,7 @@ mod tests {
 
         assert_eq!(
             original_hash,
-            certificate_without_snark_avk.compute_hash(),
+            certificate_without_snark_avk.try_compute_hash().unwrap(),
             "SNARK AVK should not affect the certificate hash for backward compatibility"
         );
     }
@@ -510,7 +509,10 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(HASH_EXPECTED, genesis_certificate.compute_hash());
+        assert_eq!(
+            HASH_EXPECTED,
+            genesis_certificate.try_compute_hash().unwrap()
+        );
 
         assert_ne!(
             HASH_EXPECTED,
@@ -520,7 +522,8 @@ mod tests {
                 ),
                 ..genesis_certificate.clone()
             }
-            .compute_hash(),
+            .try_compute_hash()
+            .unwrap(),
         );
     }
 
@@ -587,8 +590,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            legacy.compute_hash(),
-            dual.compute_hash(),
+            legacy.try_compute_hash().unwrap(),
+            dual.try_compute_hash().unwrap(),
             "dual-signature variant must hash identically to the legacy single-Ed25519 variant"
         );
     }
@@ -634,7 +637,7 @@ mod tests {
                 CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
             )
             .unwrap();
-            hashes.insert(certificate.compute_hash());
+            hashes.insert(certificate.try_compute_hash().unwrap());
         }
         assert_eq!(
             hashes.len(),

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -65,20 +65,6 @@ impl CertificateSignature {
             CertificateSignature::MultiSignature(_, signature) => signature.to_json_hex(),
         }
     }
-
-    /// Return the Schnorr genesis signature carried by a [CertificateSignature::GenesisDualSignature]
-    /// variant, or `None` for any other variant.
-    ///
-    /// SNARK clients fetch the Schnorr signature through this accessor when running the in-circuit
-    /// genesis attestation; the bytes are intentionally excluded from
-    /// [CertificateSignature::to_bytes_hex_for_certificate_hash].
-    #[cfg(feature = "future_snark")]
-    pub fn schnorr_signature(&self) -> Option<&GenesisSchnorrSignature> {
-        match self {
-            CertificateSignature::GenesisDualSignature(_, schnorr) => Some(schnorr),
-            _ => None,
-        }
-    }
 }
 
 /// Certificate represents a Mithril certificate embedding a Mithril STM multisignature

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -147,7 +147,7 @@ impl Certificate {
         certificate
     }
 
-    /// Computes the hash of a Certificate.
+    /// Computes the hash of a Certificate, propagating any serialization failure.
     ///
     /// The signature is fed into the hash via
     /// [CertificateSignature::to_bytes_hex_for_certificate_hash], which deliberately excludes
@@ -157,19 +157,27 @@ impl Certificate {
     /// dual-signature Lagrange genesis certificate hashes byte-identically to a legacy
     /// `GenesisSignature(ed)` certificate carrying the same Ed25519 signature. This is
     /// intentional, so legacy clients keep walking the chain across the Lagrange boundary.
-    pub fn compute_hash(&self) -> String {
+    pub fn try_compute_hash(&self) -> crate::StdResult<String> {
         let mut hasher = Sha256::new();
         hasher.update(self.previous_hash.as_bytes());
         hasher.update(self.epoch.to_be_bytes());
         hasher.update(self.metadata.compute_hash().as_bytes());
         hasher.update(self.protocol_message.compute_hash().as_bytes());
         hasher.update(self.signed_message.as_bytes());
-        hasher.update(self.aggregate_verification_key.to_json_hex().unwrap().as_bytes());
+        hasher.update(self.aggregate_verification_key.to_json_hex()?.as_bytes());
         if let CertificateSignature::MultiSignature(signed_entity_type, _) = &self.signature {
             signed_entity_type.feed_hash(&mut hasher);
         }
-        hasher.update(self.signature.to_bytes_hex_for_certificate_hash().unwrap());
-        hex::encode(hasher.finalize())
+        hasher.update(self.signature.to_bytes_hex_for_certificate_hash()?);
+        Ok(hex::encode(hasher.finalize()))
+    }
+
+    /// Infallible [Self::try_compute_hash] for construction-time hashing, where the inputs were
+    /// just built and validated. Panics only on a genuinely impossible serialization bug; the
+    /// verification path uses [Self::try_compute_hash] so it cannot crash the process.
+    pub fn compute_hash(&self) -> String {
+        self.try_compute_hash()
+            .expect("certificate hashing is infallible for a well-formed certificate")
     }
 
     /// Tell if the certificate is a genesis certificate (covers both the legacy and the

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -112,15 +112,15 @@ pub struct Certificate {
 }
 
 impl Certificate {
-    /// Certificate factory
-    pub fn new<T: Into<String>>(
+    /// Builds a certificate and computes its hash, returning an error if hashing fails.
+    pub fn try_new<T: Into<String>>(
         previous_hash: T,
         epoch: Epoch,
         metadata: CertificateMetadata,
         protocol_message: ProtocolMessage,
         aggregate_verification_key: ProtocolAggregateVerificationKey,
         signature: CertificateSignature,
-    ) -> Certificate {
+    ) -> crate::StdResult<Certificate> {
         let signed_message = protocol_message.compute_hash();
 
         #[cfg(feature = "future_snark")]
@@ -143,8 +143,8 @@ impl Certificate {
             aggregate_verification_key_snark,
             signature,
         };
-        certificate.hash = certificate.compute_hash();
-        certificate
+        certificate.hash = certificate.try_compute_hash()?;
+        Ok(certificate)
     }
 
     /// Computes the hash of a Certificate, propagating any serialization failure.
@@ -335,7 +335,7 @@ mod tests {
         let sealed_at = initiated_at + Duration::try_seconds(100).unwrap();
         let signed_entity_type = SignedEntityType::MithrilStakeDistribution(Epoch(10));
 
-        let certificate = Certificate::new(
+        let certificate = Certificate::try_new(
             "previous_hash".to_string(),
             Epoch(10),
             CertificateMetadata::new(
@@ -360,7 +360,8 @@ mod tests {
                 signed_entity_type.clone(),
                 fake_keys::multi_signature()[0].try_into().unwrap(),
             ),
-        );
+        )
+        .unwrap();
 
         assert_eq!(HASH_EXPECTED, certificate.compute_hash());
 
@@ -482,7 +483,7 @@ mod tests {
             .with_timezone(&Utc);
         let sealed_at = initiated_at + Duration::try_seconds(100).unwrap();
 
-        let genesis_certificate = Certificate::new(
+        let genesis_certificate = Certificate::try_new(
             "previous_hash",
             Epoch(10),
             CertificateMetadata::new(
@@ -506,7 +507,8 @@ mod tests {
             CertificateSignature::GenesisSignature(
                 fake_keys::genesis_signature()[0].try_into().unwrap(),
             ),
-        );
+        )
+        .unwrap();
 
         assert_eq!(HASH_EXPECTED, genesis_certificate.compute_hash());
 
@@ -532,7 +534,7 @@ mod tests {
         let ed_signature: GenesisEd25519Signature =
             fake_keys::genesis_signature()[0].try_into().unwrap();
 
-        let legacy = Certificate::new(
+        let legacy = Certificate::try_new(
             "previous_hash",
             Epoch(10),
             CertificateMetadata::new(
@@ -553,13 +555,14 @@ mod tests {
                 None,
             ),
             CertificateSignature::GenesisSignature(ed_signature),
-        );
+        )
+        .unwrap();
 
         let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
         let schnorr_signer = GenesisSchnorrSigner::generate(&mut rng);
         let schnorr_signature = schnorr_signer.sign(&[0u8; 32], &mut rng).unwrap();
 
-        let dual = Certificate::new(
+        let dual = Certificate::try_new(
             "previous_hash",
             Epoch(10),
             CertificateMetadata::new(
@@ -580,7 +583,8 @@ mod tests {
                 None,
             ),
             CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
-        );
+        )
+        .unwrap();
 
         assert_eq!(
             legacy.compute_hash(),
@@ -614,7 +618,7 @@ mod tests {
         for seed in 0u8..6 {
             let digest = [seed; 32];
             let schnorr_signature = schnorr_signer.sign(&digest, &mut rng).unwrap();
-            let certificate = Certificate::new(
+            let certificate = Certificate::try_new(
                 "previous_hash",
                 Epoch(10),
                 metadata.clone(),
@@ -628,7 +632,8 @@ mod tests {
                     None,
                 ),
                 CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
-            );
+            )
+            .unwrap();
             hashes.insert(certificate.compute_hash());
         }
         assert_eq!(
@@ -644,7 +649,7 @@ mod tests {
             .unwrap()
             .with_timezone(&Utc);
         let sealed_at = initiated_at + Duration::try_seconds(100).unwrap();
-        Certificate::new(
+        Certificate::try_new(
             "previous_hash",
             Epoch(10),
             CertificateMetadata::new(
@@ -666,6 +671,7 @@ mod tests {
             ),
             signature,
         )
+        .unwrap()
     }
 
     #[cfg(feature = "future_snark")]

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -4,6 +4,8 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use crate::StdError;
+#[cfg(feature = "future_snark")]
+use crate::crypto_helper::GenesisSchnorrSignature;
 use crate::entities::{
     Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessage,
 };
@@ -61,12 +63,73 @@ pub struct CertificateMessage {
     /// Genesis signature created from the original stake distribution
     /// aka GENESIS_SIG(AVK(-1))
     pub genesis_signature: String,
+
+    /// SNARK-friendly Schnorr genesis signature carried alongside [Self::genesis_signature]
+    /// on Lagrange-era genesis certificates.
+    ///
+    /// Empty string for Pythagoras and non-genesis certificates. Legacy clients deserialising
+    /// this message ignore the field entirely (default to empty), so the wire format remains a
+    /// strict superset of the pre-Lagrange one.
+    #[cfg(feature = "future_snark")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub genesis_schnorr_signature: String,
 }
 
 impl CertificateMessage {
     /// Check that the certificate signed message match the given protocol message.
     pub fn match_message(&self, message: &ProtocolMessage) -> bool {
         message.compute_hash() == self.signed_message
+    }
+
+    /// Build a standard certificate's multi-signature from its wire-format parts.
+    fn multi_signature_from_message(
+        signed_entity_type: SignedEntityTypeMessage,
+        multi_signature: String,
+    ) -> Result<CertificateSignature, StdError> {
+        Ok(CertificateSignature::MultiSignature(
+            signed_entity_type.try_into()?,
+            multi_signature.try_into().with_context(
+                || "Can not convert message to certificate: can not decode the multi-signature",
+            )?,
+        ))
+    }
+
+    /// Build a genesis certificate's signature from its wire-format parts.
+    ///
+    /// Yields a dual signature when the SNARK half is present, a single Ed25519 signature otherwise.
+    fn genesis_signature_from_message(
+        genesis_signature: String,
+        #[cfg(feature = "future_snark")] genesis_schnorr_signature: String,
+    ) -> Result<CertificateSignature, StdError> {
+        let concatenation_signature = genesis_signature.try_into().with_context(
+            || "Can not convert message to certificate: can not decode the genesis signature",
+        )?;
+        #[cfg(feature = "future_snark")]
+        {
+            if genesis_schnorr_signature.is_empty() {
+                Ok(CertificateSignature::GenesisSignature(
+                    concatenation_signature,
+                ))
+            } else {
+                let snark_bytes = hex::decode(&genesis_schnorr_signature).with_context(|| {
+                    "Can not convert message to certificate: SNARK genesis signature is not valid hex"
+                })?;
+                let snark_signature =
+                    GenesisSchnorrSignature::from_bytes(&snark_bytes).with_context(|| {
+                        "Can not convert message to certificate: can not decode the SNARK genesis signature"
+                    })?;
+                Ok(CertificateSignature::GenesisDualSignature(
+                    concatenation_signature,
+                    snark_signature,
+                ))
+            }
+        }
+        #[cfg(not(feature = "future_snark"))]
+        {
+            Ok(CertificateSignature::GenesisSignature(
+                concatenation_signature,
+            ))
+        }
     }
 }
 
@@ -102,8 +165,10 @@ impl Debug for CertificateMessage {
                 );
                 debug
                     .field("multi_signature", &self.multi_signature)
-                    .field("genesis_signature", &self.genesis_signature)
-                    .finish()
+                    .field("genesis_signature", &self.genesis_signature);
+                #[cfg(feature = "future_snark")]
+                debug.field("genesis_schnorr_signature", &self.genesis_schnorr_signature);
+                debug.finish()
             }
             false => debug.finish_non_exhaustive(),
         }
@@ -145,24 +210,16 @@ impl TryFrom<CertificateMessage> for Certificate {
                 "Can not convert message to certificate: can not decode the aggregate verification key for SNARK"
             })?,
             signature: if certificate_message.genesis_signature.is_empty() {
-                CertificateSignature::MultiSignature(
-                    certificate_message.signed_entity_type.try_into()?,
-                    certificate_message
-                        .multi_signature
-                        .try_into()
-                        .with_context(|| {
-                            "Can not convert message to certificate: can not decode the multi-signature"
-                        })?,
-                )
+                CertificateMessage::multi_signature_from_message(
+                    certificate_message.signed_entity_type,
+                    certificate_message.multi_signature,
+                )?
             } else {
-                CertificateSignature::GenesisSignature(
-                    certificate_message
-                        .genesis_signature
-                        .try_into()
-                        .with_context(|| {
-                            "Can not convert message to certificate: can not decode the genesis signature"
-                        })?,
-                )
+                CertificateMessage::genesis_signature_from_message(
+                    certificate_message.genesis_signature,
+                    #[cfg(feature = "future_snark")]
+                    certificate_message.genesis_schnorr_signature,
+                )?
             },
         };
 
@@ -184,6 +241,8 @@ impl TryFrom<Certificate> for CertificateMessage {
             signers: certificate.metadata.signers,
         };
 
+        #[cfg(feature = "future_snark")]
+        let mut genesis_schnorr_signature = String::new();
         let (multi_signature, genesis_signature) = match certificate.signature {
             CertificateSignature::GenesisSignature(signature) => (
                 String::new(),
@@ -191,6 +250,16 @@ impl TryFrom<Certificate> for CertificateMessage {
                     "Can not convert certificate to message: can not encode the genesis signature"
                 })?,
             ),
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature) => {
+                genesis_schnorr_signature = hex::encode(schnorr_signature.to_bytes());
+                (
+                    String::new(),
+                    ed_signature.to_bytes_hex().with_context(|| {
+                        "Can not convert certificate to message: can not encode the genesis signature"
+                    })?,
+                )
+            }
             CertificateSignature::MultiSignature(_, signature) => (
                 signature.to_json_hex().with_context(|| {
                     "Can not convert certificate to message: can not encode the multi-signature"
@@ -223,6 +292,8 @@ impl TryFrom<Certificate> for CertificateMessage {
                 })?,
             multi_signature,
             genesis_signature,
+            #[cfg(feature = "future_snark")]
+            genesis_schnorr_signature,
         };
 
         Ok(message)
@@ -288,6 +359,8 @@ mod tests {
             aggregate_verification_key_snark: None,
             multi_signature: "multi_signature".to_string(),
             genesis_signature: "genesis_signature".to_string(),
+            #[cfg(feature = "future_snark")]
+            genesis_schnorr_signature: String::new(),
         }
     }
 
@@ -448,6 +521,134 @@ mod tests {
                 let deserialized: CertificateMessage = serde_json::from_str(&json).unwrap();
 
                 assert_eq!(deserialized.aggregate_verification_key_snark, None);
+            }
+        }
+
+        #[cfg(feature = "future_snark")]
+        mod dual_genesis_certificate {
+            use rand_chacha::ChaCha20Rng;
+            use rand_core::SeedableRng;
+
+            use crate::crypto_helper::GenesisSchnorrSigner;
+
+            use super::*;
+
+            fn golden_dual_genesis_message() -> CertificateMessage {
+                let mut rng = ChaCha20Rng::from_seed([99u8; 32]);
+                let schnorr_signer = GenesisSchnorrSigner::generate(&mut rng);
+                let snark_signature = schnorr_signer.sign(&[0u8; 32], &mut rng).unwrap();
+
+                CertificateMessage {
+                    aggregate_verification_key: "00000000000000000404036cb79141a645faca33405ae82d67388a663fd1f55116781006608cccd2370000000000000006".to_string(),
+                    multi_signature: "".to_string(),
+                    genesis_signature: "c21f77fb812a8111b547c2145d765f854ca224b17e883d6483b668a8c4d095fd893efd2a2ba1d41da9f49d82bf02d8ee603791998b64436000e49184c000170b".to_string(),
+                    genesis_schnorr_signature: hex::encode(snark_signature.to_bytes()),
+                    ..golden_certificate_message()
+                }
+            }
+
+            #[test]
+            fn dual_signature_message_decodes_into_dual_certificate_variant() {
+                let message = golden_dual_genesis_message();
+                let certificate: Certificate = message.try_into().unwrap();
+
+                assert!(matches!(
+                    certificate.signature,
+                    CertificateSignature::GenesisDualSignature(_, _)
+                ));
+            }
+
+            #[test]
+            fn empty_genesis_schnorr_signature_yields_legacy_genesis_variant() {
+                let mut message = golden_dual_genesis_message();
+                message.genesis_schnorr_signature.clear();
+                let certificate: Certificate = message.try_into().unwrap();
+
+                assert!(matches!(
+                    certificate.signature,
+                    CertificateSignature::GenesisSignature(_)
+                ));
+            }
+
+            #[test]
+            fn round_trip_preserves_dual_signature_variant() {
+                let original = golden_dual_genesis_message();
+                let certificate: Certificate = original.clone().try_into().unwrap();
+                let restored: CertificateMessage = certificate.try_into().unwrap();
+
+                assert_eq!(original.genesis_signature, restored.genesis_signature);
+                assert_eq!(
+                    original.genesis_schnorr_signature,
+                    restored.genesis_schnorr_signature,
+                );
+            }
+
+            #[test]
+            fn archived_pre_lagrange_json_without_snark_field_still_deserialises() {
+                let archived_json = serde_json::json!({
+                    "hash": "hash",
+                    "previous_hash": "previous_hash",
+                    "epoch": 10,
+                    "signed_entity_type": {
+                        "MithrilStakeDistribution": 10,
+                    },
+                    "metadata": {
+                        "network": "testnet",
+                        "version": "0.1.0",
+                        "parameters": {"k": 1000, "m": 100, "phi_f": 0.123},
+                        "initiated_at": "2024-02-12T13:11:47Z",
+                        "sealed_at": "2024-02-12T13:12:57Z",
+                        "signers": []
+                    },
+                    "protocol_message": { "message_parts": {} },
+                    "signed_message": "signed_message",
+                    "aggregate_verification_key": "agg",
+                    "multi_signature": "ms",
+                    "genesis_signature": "gs",
+                });
+
+                let message: CertificateMessage =
+                    serde_json::from_value(archived_json).expect("archived JSON must deserialise");
+
+                assert_eq!(message.genesis_schnorr_signature, "");
+            }
+
+            mod golden_json_serialization {
+                use super::*;
+
+                const GOLDEN_DUAL_JSON: &str = r#"{"hash":"hash","previous_hash":"previous_hash","epoch":10,"signed_entity_type":{"CardanoDatabase":{"epoch":10,"immutable_file_number":1728}},"metadata":{"network":"testnet","version":"0.1.0","parameters":{"k":1000,"m":100,"phi_f":0.123},"initiated_at":"2024-02-12T13:11:47Z","sealed_at":"2024-02-12T13:12:57Z","signers":[{"party_id":"1","stake":10},{"party_id":"2","stake":20}]},"protocol_message":{"message_parts":{"snapshot_digest":"snapshot-digest-123","next_aggregate_verification_key":"next-avk-123"}},"signed_message":"signed_message","aggregate_verification_key":"aggregate_verification_key","multi_signature":"","genesis_signature":"c21f77fb812a8111b547c2145d765f854ca224b17e883d6483b668a8c4d095fd893efd2a2ba1d41da9f49d82bf02d8ee603791998b64436000e49184c000170b","genesis_schnorr_signature":"4e62a6e0432f63da06d9c2b7e3aeed4f0e1cd0f6b06e5dabb7d96fe33b3cdc1e1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}"#;
+
+                fn golden_dual_message_with_fixed_snark() -> CertificateMessage {
+                    CertificateMessage {
+                        multi_signature: "".to_string(),
+                        genesis_signature: "c21f77fb812a8111b547c2145d765f854ca224b17e883d6483b668a8c4d095fd893efd2a2ba1d41da9f49d82bf02d8ee603791998b64436000e49184c000170b".to_string(),
+                        genesis_schnorr_signature: "4e62a6e0432f63da06d9c2b7e3aeed4f0e1cd0f6b06e5dabb7d96fe33b3cdc1e1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef".to_string(),
+                        ..golden_certificate_message()
+                    }
+                }
+
+                #[test]
+                fn pinned_dual_signature_json_round_trips_into_message_and_back() {
+                    let json = GOLDEN_DUAL_JSON;
+                    let deserialized: CertificateMessage = serde_json::from_str(json).unwrap();
+
+                    assert_eq!(golden_dual_message_with_fixed_snark(), deserialized);
+                    let reserialized = serde_json::to_string(&deserialized).unwrap();
+                    assert_eq!(reserialized, json);
+                }
+
+                #[test]
+                fn dual_signature_field_is_present_in_serialised_wire_form() {
+                    let message = golden_dual_message_with_fixed_snark();
+
+                    let json_value: serde_json::Value = serde_json::to_value(&message).unwrap();
+
+                    assert_eq!(
+                        json_value.get("genesis_schnorr_signature").and_then(|v| v.as_str()),
+                        Some(message.genesis_schnorr_signature.as_str()),
+                        "genesis_schnorr_signature field must appear in the wire form when set",
+                    );
+                }
             }
         }
     }

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -5,7 +5,13 @@ use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
 use mithril_stm::AggregateSignatureType;
+#[cfg(feature = "future_snark")]
+use rand_chacha::ChaCha20Rng;
+#[cfg(feature = "future_snark")]
+use rand_core::SeedableRng;
 
+#[cfg(feature = "future_snark")]
+use crate::crypto_helper::GenesisSchnorrSigner;
 use crate::{
     certificate_chain::CertificateGenesisProducer,
     crypto_helper::{
@@ -513,8 +519,17 @@ impl<'a> CertificateChainBuilder<'a> {
         let certificate = self.build_base_certificate(context);
         let next_avk = Self::compute_avk_for_signers(&context.next_fixture.signers_fixture());
         let next_protocol_parameters = &context.next_fixture.protocol_parameters();
-        let genesis_producer =
+        let genesis_producer_builder =
             CertificateGenesisProducer::new(Some(Arc::new(genesis_signer.to_owned())));
+        #[cfg(feature = "future_snark")]
+        let genesis_producer = {
+            let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+            let schnorr_signer = Arc::new(GenesisSchnorrSigner::generate(&mut rng));
+            genesis_producer_builder.with_snark_genesis_signer(schnorr_signer)
+        };
+        #[cfg(not(feature = "future_snark"))]
+        let genesis_producer = genesis_producer_builder;
+
         let genesis_protocol_message = genesis_producer
             .create_genesis_protocol_message(
                 next_protocol_parameters,
@@ -889,8 +904,7 @@ mod test {
             fixture: &fixture,
             next_fixture: &next_fixture,
         };
-        let expected_protocol_message = context.compute_protocol_message_seed();
-        let expected_signed_message = expected_protocol_message.compute_hash();
+        let expected_protocol_message_legacy = context.compute_protocol_message_seed();
         let (protocol_genesis_signer, _) = CertificateChainBuilder::setup_genesis();
 
         let mithril_era = if cfg!(feature = "future_snark") {
@@ -901,6 +915,21 @@ mod test {
         let genesis_certificate = CertificateChainBuilder::default()
             .with_protocol_parameters(expected_protocol_parameters)
             .build_genesis_certificate(&context, &protocol_genesis_signer, mithril_era);
+
+        let expected_protocol_message = match mithril_era {
+            SupportedEra::Pythagoras => expected_protocol_message_legacy,
+            #[cfg(feature = "future_snark")]
+            SupportedEra::Lagrange => {
+                let mut message = ProtocolMessage::new_rigid();
+                for (key, value) in &expected_protocol_message_legacy.message_parts {
+                    message.set_message_part(*key, value.clone());
+                }
+                message
+            }
+            #[cfg(not(feature = "future_snark"))]
+            SupportedEra::Lagrange => expected_protocol_message_legacy,
+        };
+        let expected_signed_message = expected_protocol_message.compute_hash();
 
         assert!(genesis_certificate.is_genesis());
         assert_eq!(

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -406,8 +406,7 @@ impl<'a> CertificateChainBuilder<'a> {
 
     fn setup_genesis() -> (GenesisSigner, GenesisVerifier) {
         let genesis_signer = GenesisSigner::create_deterministic_signer();
-        let genesis_verifier =
-            GenesisVerifier::from_bundle(genesis_signer.verification_key_bundle());
+        let genesis_verifier = genesis_signer.create_verifier();
 
         (genesis_signer, genesis_verifier)
     }

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -581,7 +581,7 @@ impl<'a> CertificateChainBuilder<'a> {
         let mut certificate = certificate;
         certificate.previous_hash =
             previous_certificate.map(|c| c.hash.to_string()).unwrap_or_default();
-        certificate.hash = certificate.compute_hash();
+        certificate.hash = certificate.try_compute_hash().unwrap();
 
         certificate
     }

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -526,16 +526,34 @@ impl<'a> CertificateChainBuilder<'a> {
             .sign_deterministic(&genesis_protocol_message, mithril_era)
             .unwrap();
 
-        genesis_producer
-            .create_genesis_certificate(
+        match signature {
+            CertificateSignature::GenesisSignature(genesis_signature) => genesis_producer
+                .create_legacy_genesis_certificate(
+                    certificate.metadata.protocol_parameters,
+                    certificate.metadata.network,
+                    certificate.epoch,
+                    next_avk,
+                    genesis_signature,
+                    mithril_era,
+                ),
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(
+                genesis_signature,
+                genesis_signature_snark,
+            ) => genesis_producer.create_genesis_certificate(
                 certificate.metadata.protocol_parameters,
                 certificate.metadata.network,
                 certificate.epoch,
                 next_avk,
-                signature,
+                genesis_signature,
+                genesis_signature_snark,
                 mithril_era,
-            )
-            .unwrap()
+            ),
+            CertificateSignature::MultiSignature(..) => {
+                unreachable!("the genesis signer never produces a multi-signature")
+            }
+        }
+        .unwrap()
     }
 
     fn build_standard_certificate(&self, context: &CertificateChainBuilderContext) -> Certificate {

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -2,21 +2,14 @@ use std::cmp::min;
 use std::collections::{BTreeSet, HashMap};
 use std::iter::repeat_n;
 use std::ops::{Deref, DerefMut};
-use std::sync::Arc;
 
 use mithril_stm::AggregateSignatureType;
-#[cfg(feature = "future_snark")]
-use rand_chacha::ChaCha20Rng;
-#[cfg(feature = "future_snark")]
-use rand_core::SeedableRng;
 
-#[cfg(feature = "future_snark")]
-use crate::crypto_helper::GenesisSchnorrSigner;
 use crate::{
     certificate_chain::CertificateGenesisProducer,
     crypto_helper::{
-        GenesisEd25519Signer, GenesisEd25519Verifier, ProtocolAggregateVerificationKey,
-        ProtocolClerk, ProtocolParameters,
+        GenesisSigner, GenesisVerifier, ProtocolAggregateVerificationKey, ProtocolClerk,
+        ProtocolParameters,
     },
     entities::{
         CardanoDbBeacon, Certificate, CertificateMetadata, CertificateSignature, Epoch,
@@ -30,7 +23,7 @@ use crate::{
 
 /// Genesis certificate processor function type. For tests only.
 type GenesisCertificateProcessorFunc =
-    dyn Fn(Certificate, &CertificateChainBuilderContext, &GenesisEd25519Signer) -> Certificate;
+    dyn Fn(Certificate, &CertificateChainBuilderContext, &GenesisSigner) -> Certificate;
 
 /// Standard certificate processor function type. For tests only.
 type StandardCertificateProcessorFunc =
@@ -127,7 +120,7 @@ pub struct CertificateChainFixture {
     /// The full certificates list, ordered from latest to genesis
     pub certificates_chained: Vec<Certificate>,
     /// The genesis verifier associated with this chain genesis certificate
-    pub genesis_verifier: GenesisEd25519Verifier,
+    pub genesis_verifier: GenesisVerifier,
 }
 
 impl Deref for CertificateChainFixture {
@@ -411,9 +404,10 @@ impl<'a> CertificateChainBuilder<'a> {
         clerk.compute_aggregate_verification_key()
     }
 
-    fn setup_genesis() -> (GenesisEd25519Signer, GenesisEd25519Verifier) {
-        let genesis_signer = GenesisEd25519Signer::create_deterministic_signer();
-        let genesis_verifier = genesis_signer.create_verifier();
+    fn setup_genesis() -> (GenesisSigner, GenesisVerifier) {
+        let genesis_signer = GenesisSigner::create_deterministic_signer();
+        let genesis_verifier =
+            GenesisVerifier::from_bundle(genesis_signer.verification_key_bundle());
 
         (genesis_signer, genesis_verifier)
     }
@@ -512,23 +506,14 @@ impl<'a> CertificateChainBuilder<'a> {
     fn build_genesis_certificate(
         &self,
         context: &CertificateChainBuilderContext,
-        genesis_signer: &GenesisEd25519Signer,
+        genesis_signer: &GenesisSigner,
         mithril_era: SupportedEra,
     ) -> Certificate {
         let epoch = context.epoch;
         let certificate = self.build_base_certificate(context);
         let next_avk = Self::compute_avk_for_signers(&context.next_fixture.signers_fixture());
         let next_protocol_parameters = &context.next_fixture.protocol_parameters();
-        let genesis_producer_builder =
-            CertificateGenesisProducer::new(Some(Arc::new(genesis_signer.to_owned())));
-        #[cfg(feature = "future_snark")]
-        let genesis_producer = {
-            let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
-            let schnorr_signer = Arc::new(GenesisSchnorrSigner::generate(&mut rng));
-            genesis_producer_builder.with_snark_genesis_signer(schnorr_signer)
-        };
-        #[cfg(not(feature = "future_snark"))]
-        let genesis_producer = genesis_producer_builder;
+        let genesis_producer = CertificateGenesisProducer::new();
 
         let genesis_protocol_message = genesis_producer
             .create_genesis_protocol_message(
@@ -538,8 +523,8 @@ impl<'a> CertificateChainBuilder<'a> {
                 mithril_era,
             )
             .unwrap();
-        let genesis_signature = genesis_producer
-            .sign_genesis_protocol_message(genesis_protocol_message)
+        let signature = genesis_signer
+            .sign_deterministic(&genesis_protocol_message, mithril_era)
             .unwrap();
 
         genesis_producer
@@ -548,7 +533,7 @@ impl<'a> CertificateChainBuilder<'a> {
                 certificate.metadata.network,
                 certificate.epoch,
                 next_avk,
-                genesis_signature,
+                signature,
                 mithril_era,
             )
             .unwrap()

--- a/mithril-common/src/test/builder/mithril_fixture.rs
+++ b/mithril-common/src/test/builder/mithril_fixture.rs
@@ -21,9 +21,9 @@ use crate::{
         ProtocolSignerVerificationKeySignatureForConcatenation, ProtocolStakeDistribution,
     },
     entities::{
-        Certificate, Epoch, HexEncodedAggregateVerificationKey, PartyId, ProtocolParameters,
-        Signer, SignerWithStake, SingleSignature, Stake, StakeDistribution, StakeDistributionParty,
-        SupportedEra,
+        Certificate, CertificateSignature, Epoch, HexEncodedAggregateVerificationKey, PartyId,
+        ProtocolParameters, Signer, SignerWithStake, SingleSignature, Stake, StakeDistribution,
+        StakeDistributionParty, SupportedEra,
     },
     protocol::{SignerBuilder, ToMessage},
     test::crypto_helper::ProtocolInitializerTestExtension,
@@ -246,16 +246,34 @@ impl MithrilFixture {
             .sign_deterministic(&genesis_protocol_message, mithril_era)
             .unwrap();
 
-        genesis_producer
-            .create_genesis_certificate(
+        match signature {
+            CertificateSignature::GenesisSignature(genesis_signature) => genesis_producer
+                .create_legacy_genesis_certificate(
+                    self.protocol_parameters.clone(),
+                    network,
+                    epoch,
+                    genesis_avk,
+                    genesis_signature,
+                    mithril_era,
+                ),
+            #[cfg(feature = "future_snark")]
+            CertificateSignature::GenesisDualSignature(
+                genesis_signature,
+                genesis_signature_snark,
+            ) => genesis_producer.create_genesis_certificate(
                 self.protocol_parameters.clone(),
                 network,
                 epoch,
                 genesis_avk,
-                signature,
+                genesis_signature,
+                genesis_signature_snark,
                 mithril_era,
-            )
-            .unwrap()
+            ),
+            CertificateSignature::MultiSignature(..) => {
+                unreachable!("the genesis signer never produces a multi-signature")
+            }
+        }
+        .unwrap()
     }
 
     /// Make all underlying signers sign the given message, filter the resulting list to remove

--- a/mithril-common/src/test/builder/mithril_fixture.rs
+++ b/mithril-common/src/test/builder/mithril_fixture.rs
@@ -3,7 +3,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::Arc,
 };
 
 #[cfg(feature = "future_snark")]
@@ -15,7 +14,7 @@ use crate::{
     StdResult,
     certificate_chain::CertificateGenesisProducer,
     crypto_helper::{
-        GenesisEd25519Signer, ProtocolAggregateVerificationKey,
+        GenesisSigner, ProtocolAggregateVerificationKey,
         ProtocolAggregateVerificationKeyForConcatenation, ProtocolClosedKeyRegistration,
         ProtocolInitializer, ProtocolOpCert, ProtocolSigner,
         ProtocolSignerVerificationKeyForConcatenation,
@@ -232,8 +231,8 @@ impl MithrilFixture {
         epoch: Epoch,
     ) -> Certificate {
         let genesis_avk = self.compute_aggregate_verification_key();
-        let genesis_signer = GenesisEd25519Signer::create_deterministic_signer();
-        let genesis_producer = CertificateGenesisProducer::new(Some(Arc::new(genesis_signer)));
+        let genesis_signer = GenesisSigner::create_deterministic_signer();
+        let genesis_producer = CertificateGenesisProducer::new();
         let mithril_era = SupportedEra::Pythagoras;
         let genesis_protocol_message = genesis_producer
             .create_genesis_protocol_message(
@@ -243,8 +242,8 @@ impl MithrilFixture {
                 mithril_era,
             )
             .unwrap();
-        let genesis_signature = genesis_producer
-            .sign_genesis_protocol_message(genesis_protocol_message)
+        let signature = genesis_signer
+            .sign_deterministic(&genesis_protocol_message, mithril_era)
             .unwrap();
 
         genesis_producer
@@ -253,7 +252,7 @@ impl MithrilFixture {
                 network,
                 epoch,
                 genesis_avk,
-                genesis_signature,
+                signature,
                 mithril_era,
             )
             .unwrap()

--- a/mithril-common/src/test/double/dummies.rs
+++ b/mithril-common/src/test/double/dummies.rs
@@ -541,6 +541,8 @@ mod messages {
                 aggregate_verification_key_snark: None,
                 multi_signature: fake_keys::multi_signature()[0].to_owned(),
                 genesis_signature: String::new(),
+                #[cfg(feature = "future_snark")]
+                genesis_schnorr_signature: String::new(),
             }
         }
     }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.31"
+version = "0.10.32"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1753,12 +1753,28 @@ components:
           description: Aggregate verification key used to verify the multi signature
           type: string
           format: bytes
+        aggregate_verification_key_snark:
+          description: |
+            Hex-encoded SNARK-friendly aggregate verification key, emitted alongside
+            `aggregate_verification_key` on Lagrange-era certificates. Omitted on
+            Pythagoras and pre-Lagrange certificates: clients that ignore this field
+            remain compatible with the pre-Lagrange wire format.
+          type: string
+          format: bytes
         multi_signature:
           description: STM multi signature created from a quorum of single signatures from the signers
           type: string
           format: bytes
         genesis_signature:
           description: Genesis signature created to bootstrap the certificate chain with the Cardano Genesis Keys
+          type: string
+          format: bytes
+        genesis_schnorr_signature:
+          description: |
+            Hex-encoded SNARK-friendly Schnorr genesis signature, emitted alongside
+            `genesis_signature` on Lagrange-era genesis certificates. Omitted or empty
+            on Pythagoras and non-genesis certificates: clients that ignore this field
+            remain compatible with the pre-Lagrange wire format.
           type: string
           format: bytes
       examples:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.64
+  version: 0.1.65
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content

This PR includes **the dual-signature genesis certificate for the Lagrange era and wires it through the nodes, while staying fully backward compatible with the legacy Ed25519 genesis under Pythagoras**:

- Introduce a `GenesisDualSignature` certificate variant carrying both the legacy Ed25519 signature and the Schnorr signature, and add era-aware signing on `GenesisSigner` to produce it. The certificate hash feeds only the Ed25519 bytes, so a Lagrange genesis certificate hashes byte-identically to a legacy one and existing clients keep walking the
chain across the era boundary.
- Make the genesis certificate producer and verifier era-aware (Pythagoras accepts an Ed25519-only key, Lagrange requires the Schnorr half), and accept the new `GenesisVerifier` in the certificate verifier.
- Extend the certificate message wire format with optional `aggregate_verification_key_snark` and `genesis_schnorr_signature` fields (omitted or empty outside Lagrange genesis, so the format stays a strict superset of the previous one), and document them in `openapi.yaml`.
- Adapt the aggregator genesis subcommands (`generate-keypair`, `export`, `sign`, `import`, `bootstrap`) to the dual signature, and add an `upgrade-key-to-dual` subcommand to migrate an existing Ed25519 key to a dual bundle.
- Adapt the client certificate verifier to the new `GenesisVerifier`.
- Update the genesis runbook for the dual ceremony.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

This PR is the second part following https://github.com/input-output-hk/mithril/pull/3304

## Issue(s)
Closes #3145 
