### PR TITLE
feat(mithril-stm): implement IVC prover input preparation (phase 4 of #3138)

### DIFF
--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -11,7 +11,7 @@ use group::Group;
 use midnight_circuits::hash::poseidon::PoseidonState;
 use midnight_curves::{Bls12, G1Projective};
 use midnight_proofs::{
-    plonk::prepare,
+    plonk::{VerifyingKey, prepare},
     poly::kzg::{KZGCommitmentScheme, msm::DualMSM, params::ParamsVerifierKZG},
     transcript::{CircuitTranscript, Transcript},
 };
@@ -21,6 +21,50 @@ use crate::{
     StmResult,
     circuits::{halo2::types::CircuitBase, halo2_ivc::errors::IvcCircuitError},
 };
+
+/// Runs the Poseidon-transcript off-circuit verifier for any PLONK proof
+/// that was produced under the same transcript and returns the verifier's
+/// intermediate `DualMSM`.
+///
+/// Used by the IVC prover's preparation step to verify both certificate
+/// SNARK proofs and previous IVC self-proofs.  Unlike
+/// [`verify_and_prepare_accumulator`], this function accepts a raw
+/// [`VerifyingKey`] directly instead of a [`MidnightVK`] wrapper, which
+/// matches the key type stored in [`IvcSetup`].
+///
+/// A pairing check on a clone gives cheap early abort; the original
+/// `DualMSM` is returned on success for downstream folding.
+pub(crate) fn verify_and_prepare_poseidon(
+    proof_bytes: &[u8],
+    public_inputs: &[CircuitBase],
+    verifying_key: &VerifyingKey<CircuitBase, KZGCommitmentScheme<Bls12>>,
+    verifier_params: &ParamsVerifierKZG<Bls12>,
+) -> StmResult<DualMSM<Bls12>> {
+    let mut transcript =
+        CircuitTranscript::<PoseidonState<CircuitBase>>::init_from_bytes(proof_bytes);
+
+    let dual_msm = prepare::<
+        CircuitBase,
+        KZGCommitmentScheme<Bls12>,
+        CircuitTranscript<PoseidonState<CircuitBase>>,
+    >(
+        verifying_key,
+        &[&[G1Projective::identity()]],
+        &[&[public_inputs]],
+        &mut transcript,
+    )
+    .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
+
+    transcript
+        .assert_empty()
+        .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
+
+    if !dual_msm.clone().check(verifier_params) {
+        return Err(IvcCircuitError::CertificateProofRejected.into());
+    }
+
+    Ok(dual_msm)
+}
 
 /// Runs the off-circuit verifier for a cert SNARK proof and returns the
 /// verifier's intermediate `DualMSM`.

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -9,6 +9,18 @@ pub enum IvcCircuitError {
     #[error("Certificate proof verification rejected")]
     CertificateProofRejected,
 
+    /// Off-circuit verifier rejected a previous IVC proof.
+    #[error("Previous IVC proof verification rejected")]
+    IvcProofRejected,
+
+    /// Step counter would overflow u64.
+    #[error("IVC step counter overflow")]
+    StepCounterOverflow,
+
+    /// Certificate epoch is neither the current epoch nor the next epoch.
+    #[error("Certificate epoch is invalid: must equal current_epoch or current_epoch + 1")]
+    InvalidEpoch,
+
     /// Self VK degree does not match the IVC circuit degree constant K.
     #[error("IvcCircuit::validate_self_vk_degree failed: expected k={expected}, got k={actual}")]
     SelfVkDegreeMismatch { expected: u32, actual: u32 },

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -15,7 +15,6 @@ macro_rules! field_wrapper {
         impl $name {
             pub(crate) const ZERO: Self = Self(F::ZERO);
 
-            #[cfg(test)]
             pub(crate) fn from_field(value: F) -> Self {
                 Self(value)
             }
@@ -81,7 +80,19 @@ macro_rules! u64_wrapper {
 }
 
 u64_wrapper!(EpochNumber);
+
+// `StepCounter::as_u64` is used in production (state transition arithmetic).
 u64_wrapper!(StepCounter);
+
+impl StepCounter {
+    // In test mode the macro already generates `#[cfg(test)] fn as_u64`; this
+    // unconditional definition is only compiled outside of tests to avoid a
+    // duplicate-definition error.
+    #[cfg(not(test))]
+    pub(crate) fn as_u64(self) -> u64 {
+        self.0
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct ProtocolMessagePreimage([u8; PREIMAGE_SIZE]);
@@ -116,8 +127,8 @@ impl CertificateProofBytes {
         Self(bytes)
     }
 
-    // Used for the genesis IVC step. This can be un-gated when the production IVC prover is wired.
-    #[cfg(test)]
+    // TODO: remove this allow dead_code directive when the IVC prover uses this for the genesis step
+    #[allow(dead_code)]
     pub(crate) fn empty() -> Self {
         Self(Vec::new())
     }
@@ -127,7 +138,6 @@ impl CertificateProofBytes {
         Self(bytes)
     }
 
-    #[cfg(test)]
     pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.0
     }
@@ -151,7 +161,6 @@ impl IvcProofBytes {
         Self(Vec::new())
     }
 
-    #[cfg(test)]
     pub(crate) fn as_bytes(&self) -> &[u8] {
         &self.0
     }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/epoch_data.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/epoch_data.rs
@@ -6,6 +6,7 @@ use crate::{
     circuits::halo2_ivc::{
         PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
         PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PREIMAGE_SIZE,
+        types::{EpochNumber, MerkleTreeCommitment, ProtocolParametersHash},
     },
 };
 
@@ -18,7 +19,7 @@ pub(crate) struct EpochData {
     /// Raw protocol-message preimage.
     message_preimage: [u8; PREIMAGE_SIZE],
     /// Certificate's epoch, decoded from `PREIMAGE_CURRENT_EPOCH_BYTES`.
-    current_epoch: BaseFieldElement,
+    current_epoch: u64,
     /// Next epoch's Merkle-tree commitment, decoded from `PREIMAGE_NEXT_MERKLE_ROOT_BYTES`.
     next_merkle_root: BaseFieldElement,
     /// Next epoch's protocol parameters, decoded from `PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES`.
@@ -35,7 +36,7 @@ impl EpochData {
     pub(crate) fn new(message_preimage: [u8; PREIMAGE_SIZE]) -> StmResult<Self> {
         let current_epoch_bytes: [u8; 8] =
             message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].try_into()?;
-        let current_epoch = BaseFieldElement::from(u64::from_le_bytes(current_epoch_bytes));
+        let current_epoch = u64::from_le_bytes(current_epoch_bytes);
 
         let next_merkle_root_bytes: [u8; 32] =
             message_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].try_into()?;
@@ -58,19 +59,34 @@ impl EpochData {
         &self.message_preimage
     }
 
-    /// Returns the certificate's epoch.
+    /// Returns the certificate's epoch as a base field element.
     pub(crate) fn current_epoch(&self) -> BaseFieldElement {
-        self.current_epoch
+        BaseFieldElement::from(self.current_epoch)
     }
 
-    /// Returns the next epoch's Merkle-tree commitment.
+    /// Returns the certificate's epoch as an `EpochNumber`.
+    pub(crate) fn epoch_number(&self) -> EpochNumber {
+        EpochNumber::new(self.current_epoch)
+    }
+
+    /// Returns the next epoch's Merkle-tree commitment as a base field element.
     pub(crate) fn next_merkle_root(&self) -> BaseFieldElement {
         self.next_merkle_root
     }
 
-    /// Returns the next epoch's protocol parameters.
+    /// Returns the next epoch's Merkle-tree commitment as a typed IVC wrapper.
+    pub(crate) fn next_merkle_tree_commitment(&self) -> MerkleTreeCommitment {
+        MerkleTreeCommitment::from_field(self.next_merkle_root.0)
+    }
+
+    /// Returns the next epoch's protocol parameters as a base field element.
     pub(crate) fn next_protocol_parameters(&self) -> BaseFieldElement {
         self.next_protocol_parameters
+    }
+
+    /// Returns the next epoch's protocol parameters as a typed IVC wrapper.
+    pub(crate) fn next_protocol_parameters_hash(&self) -> ProtocolParametersHash {
+        ProtocolParametersHash::from_field(self.next_protocol_parameters.0)
     }
 }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -1,11 +1,14 @@
 //! Pre-circuit inputs produced by the IVC prover's preparation step.
 //!
-//! Holds the witness, the advanced chain state, and the folded accumulator that
-//! the in-circuit construction and proof-generation steps consume next.
+//! Holds the witness, certificate proof, advanced chain state, and the folded
+//! accumulator that the in-circuit construction and proof-generation steps consume next.
 
 use midnight_circuits::verifier::{Accumulator, BlstrsEmulation};
 
-use crate::circuits::halo2_ivc::state::{State, Witness};
+use crate::circuits::halo2_ivc::{
+    state::{State, Witness},
+    types::CertificateProofBytes,
+};
 
 /// Pre-circuit inputs consumed by the IVC prover's circuit-construction and proof-generation steps.
 // TODO: remove this allow dead_code directive when the IVC prover consumes this input
@@ -13,6 +16,8 @@ use crate::circuits::halo2_ivc::state::{State, Witness};
 pub(crate) struct IvcProverInput {
     /// In-circuit witness for the new step.
     pub(crate) witness: Witness,
+    /// Certificate SNARK proof witnessed by this step (empty on genesis).
+    pub(crate) cert_proof: CertificateProofBytes,
     /// Chain state advanced by one step.
     pub(crate) next_state: State,
     /// Folded accumulator the new step's IVC proof commits to.

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -1,16 +1,30 @@
 //! `IvcRollingState`: caller-owned bridge between consecutive IVC proving steps.
 
-use midnight_circuits::verifier::{Accumulator, BlstrsEmulation};
+use sha2::{Digest, Sha256};
+
+use midnight_circuits::{
+    types::Instantiable,
+    verifier::{Accumulator, AssignedAccumulator, BlstrsEmulation},
+};
 
 use crate::{
+    StmResult,
+    circuits::halo2::types::CircuitBase,
     circuits::halo2_ivc::{
-        state::{State, trivial_acc},
-        types::IvcProofBytes,
+        certificate_proof::verify_and_prepare_poseidon,
+        errors::IvcCircuitError,
+        state::{Global, State, Witness, trivial_acc},
+        types::{
+            CertificateProofBytes, IvcProofBytes, MerkleTreeCommitment, MessageHash,
+            ProtocolMessagePreimage, ProtocolParametersHash, StepCounter,
+        },
     },
     signature_scheme::StandardSchnorrSignature,
 };
 
-use super::proof::IvcProof;
+use super::{
+    epoch_data::EpochData, proof::IvcProof, prover_input::IvcProverInput, setup::IvcSetup,
+};
 
 /// Caller-owned bridge between consecutive IVC proving steps.
 // TODO: remove this allow dead_code directive when the IVC prover consumes this rolling state
@@ -97,6 +111,206 @@ impl IvcRollingState {
     /// Returns the chain-specific Schnorr signature over the genesis state.
     pub(crate) fn genesis_signature(&self) -> StandardSchnorrSignature {
         self.genesis_signature
+    }
+
+    /// Executes all off-circuit IVC prover preparation steps and returns the
+    /// pre-circuit inputs for the next IVC proving step.
+    ///
+    /// # Steps
+    ///
+    /// 1. **Cert message**: SHA2-256 of the protocol-message preimage, interpreted
+    ///    as a little-endian base-field element (mirrors the circuit's `combine_bytes`
+    ///    gadget on the SHA256 output).
+    /// 2. **Epoch classification**: compares the certificate's epoch against the
+    ///    current chain state to determine genesis / same-epoch / next-epoch.
+    ///    Returns `IvcCircuitError::InvalidEpoch` if epoch is neither.
+    /// 3. **Certificate accumulator**: genesis → trivial accumulator (in-circuit the
+    ///    result is zeroed via `scale_by_bit`; off-circuit we skip verification entirely);
+    ///    non-genesis → verify the certificate SNARK proof under the Poseidon transcript,
+    ///    extract the verifier's `DualMSM`, apply `extract_fixed_bases` with the
+    ///    certificate fixed-base map, and collapse.
+    /// 4. **Genesis signature**: included in the witness; in-circuit validation of
+    ///    the Schnorr signature is enforced by the IVC circuit on the genesis step.
+    /// 5. **Witness construction**: packages genesis signature, cert merkle root, cert
+    ///    message, and raw preimage bytes for the circuit.
+    /// 6. **Chain state advancement**: applies the circuit's transition rules to
+    ///    produce `next_state`.
+    /// 7. **Self-proof accumulator**: genesis → trivial accumulator; non-genesis →
+    ///    verify previous IVC proof, extract, collapse.
+    /// 8. **Accumulator folding**: genesis → trivial accumulator (matches `scale_by_bit`
+    ///    behaviour in the circuit); non-genesis → `accumulate([chain_acc, cert_acc,
+    ///    self_acc])` then `collapse()`.
+    pub(crate) fn prepare_prover_input(
+        &self,
+        global: &Global,
+        epoch_data: &EpochData,
+        cert_proof: &CertificateProofBytes,
+        setup: &IvcSetup,
+    ) -> StmResult<IvcProverInput> {
+        let is_genesis = self.state.counter == StepCounter::ZERO;
+        let preimage = epoch_data.message_preimage();
+
+        // Shared across genesis and non-genesis steps.
+        let combined_fixed_base_names: Vec<String> =
+            setup.combined_fixed_bases.keys().cloned().collect();
+
+        // Step 1: cert_msg = SHA256(preimage) as a little-endian base-field element.
+        // Mirrors the circuit's `sha2_256_chip.hash` + `combine_bytes` on the digest.
+        // SHA256 always produces 32 bytes so the slice conversions below are infallible.
+        let hash_bytes: [u8; 32] = Sha256::digest(preimage.as_slice()).into();
+        let cert_msg = MessageHash::from_field(CircuitBase::from_raw([
+            u64::from_le_bytes(hash_bytes[0..8].try_into().unwrap()),
+            u64::from_le_bytes(hash_bytes[8..16].try_into().unwrap()),
+            u64::from_le_bytes(hash_bytes[16..24].try_into().unwrap()),
+            u64::from_le_bytes(hash_bytes[24..32].try_into().unwrap()),
+        ]));
+
+        // Step 2: classify the step.
+        // is_same_epoch: cert epoch == state epoch.
+        // is_next_epoch: cert epoch == state epoch + 1.
+        // Genesis: epoch constraints do not apply.
+        let epoch_field: CircuitBase = epoch_data.current_epoch().0;
+        let is_same_epoch = epoch_field == self.state.current_epoch.as_field();
+        let is_next_epoch =
+            epoch_field == self.state.current_epoch.as_field() + CircuitBase::from(1u64);
+
+        if !is_genesis && !is_same_epoch && !is_next_epoch {
+            return Err(IvcCircuitError::InvalidEpoch.into());
+        }
+
+        // cert_merkle_root: the Merkle root the certificate was signed under.
+        // Genesis → ZERO; same-epoch → state.merkle_root; next-epoch → state.next_merkle_root.
+        let cert_merkle_root = if is_genesis {
+            MerkleTreeCommitment::ZERO
+        } else if is_same_epoch {
+            self.state.merkle_root
+        } else {
+            self.state.next_merkle_root
+        };
+
+        // Decode next_merkle_root, next_protocol_params, and current_epoch via EpochData
+        // typed accessors (decoded once in EpochData::new using the same LE combine_bytes
+        // encoding the circuit applies).
+        let next_merkle_root = epoch_data.next_merkle_tree_commitment();
+        let next_protocol_params = epoch_data.next_protocol_parameters_hash();
+        let current_epoch = epoch_data.epoch_number();
+
+        // Steps 4 & 5: build the witness.
+        // genesis_sig is carried from the rolling state unchanged.
+        // cert_msg and cert_merkle_root are used as the certificate public inputs.
+        let witness = Witness::new(
+            self.genesis_signature,
+            cert_merkle_root,
+            cert_msg,
+            ProtocolMessagePreimage::from(*preimage),
+        );
+
+        // Step 6: advance chain state following the circuit's transition function.
+        //
+        // msg:             genesis → genesis_msg; else → SHA256(preimage)
+        // merkle_root:     genesis → ZERO; else → cert_merkle_root
+        // protocol_params: genesis → ZERO; same-epoch → state.protocol_params;
+        //                  next-epoch → state.next_protocol_params
+        let msg = if is_genesis {
+            global.genesis_msg
+        } else {
+            cert_msg
+        };
+        let protocol_params = if is_genesis {
+            ProtocolParametersHash::ZERO
+        } else if is_same_epoch {
+            self.state.protocol_params
+        } else {
+            self.state.next_protocol_params
+        };
+        let next_counter = self
+            .state
+            .counter
+            .as_u64()
+            .checked_add(1)
+            .ok_or(IvcCircuitError::StepCounterOverflow)?;
+        let next_state = State::new(
+            StepCounter::new(next_counter),
+            msg,
+            cert_merkle_root, // = ZERO for genesis by construction
+            next_merkle_root,
+            protocol_params,
+            next_protocol_params,
+            current_epoch,
+        );
+
+        let verifier_params = setup.srs.verifier_params();
+
+        // Step 3: verify certificate SNARK proof and extract accumulator.
+        // Genesis: the circuit zeros the cert accumulator contribution via
+        // `scale_by_bit(is_not_genesis)` so we use trivial_acc off-circuit.
+        // Non-genesis: public inputs match the circuit's `prepare` call: [cert_merkle_root, cert_msg].
+        let cert_public_inputs: Vec<CircuitBase> =
+            vec![cert_merkle_root.as_field(), cert_msg.as_field()];
+        let cert_accumulator = if is_genesis {
+            trivial_acc(&combined_fixed_base_names)
+        } else {
+            let dual_msm = verify_and_prepare_poseidon(
+                cert_proof.as_bytes(),
+                &cert_public_inputs,
+                &setup.certificate_verifying_key,
+                &verifier_params,
+            )?;
+            let mut acc: Accumulator<BlstrsEmulation> = dual_msm.into();
+            acc.extract_fixed_bases(&setup.certificate_fixed_bases);
+            acc.collapse();
+            acc
+        };
+
+        // Step 7: prepare the IVC self-proof accumulator.
+        // Genesis: no previous IVC proof → trivial accumulator over combined fixed bases.
+        // Non-genesis: verify previous IVC proof under Poseidon transcript.
+        let self_proof_accumulator = if is_genesis {
+            trivial_acc(&combined_fixed_base_names)
+        } else {
+            // Public inputs of the previous IVC proof: [global | state | accumulator].
+            let self_public_inputs: Vec<CircuitBase> = [
+                global.as_public_input(),
+                self.state.as_public_input(),
+                AssignedAccumulator::as_public_input(&self.accumulator),
+            ]
+            .concat();
+            let self_dual_msm = verify_and_prepare_poseidon(
+                self.ivc_proof.as_bytes(),
+                &self_public_inputs,
+                &setup.ivc_verifying_key,
+                &verifier_params,
+            )
+            .map_err(|_| IvcCircuitError::IvcProofRejected)?;
+            let mut self_acc: Accumulator<BlstrsEmulation> = self_dual_msm.into();
+            self_acc.extract_fixed_bases(&setup.ivc_fixed_bases);
+            self_acc.collapse();
+            self_acc
+        };
+
+        // Step 8: fold the three accumulators and collapse.
+        // Genesis: the circuit zeros cert and self-proof contributions via `scale_by_bit`;
+        // return trivial_acc directly to match the in-circuit output exactly.
+        // Non-genesis: order matches the in-circuit `accumulate` call:
+        // [chain_acc, cert_acc, self_acc].
+        let next_accumulator = if is_genesis {
+            trivial_acc(&combined_fixed_base_names)
+        } else {
+            let mut acc = Accumulator::accumulate(&[
+                self.accumulator.clone(),
+                cert_accumulator,
+                self_proof_accumulator,
+            ]);
+            acc.collapse();
+            acc
+        };
+
+        Ok(IvcProverInput {
+            witness,
+            cert_proof: cert_proof.clone(),
+            next_state,
+            next_accumulator,
+        })
     }
 }
 


### PR DESCRIPTION
Implements `IvcRollingState::prepare_prover_input`, the off-circuit                                                                                                                 
  bridge that transforms a certificate SNARK proof and the current chain                                                                                                              
  state into `IvcProverInput` ready for the IVC circuit.                                                                                                                              
                                                                                                                                                                                      
  ## Commit layout
                                                                                                                                                                                      
  1. **Promote circuit boundary types to production**: removes `#[cfg(test)]`                                                                                                         
     gates from accessor methods on the IVC type wrappers (`from_field`,
     `as_u64`, `as_bytes`, `is_empty`). These were test-only until now;                                                                                                               
     the prover preparation path needs them in production.                                                                                                                            
                                                                                                                                                                                      
  2. **Add Poseidon-transcript off-circuit verifier**: adds                                                                                                                           
     `verify_and_prepare_poseidon` in `certificate_proof.rs`, a variant
     of the existing `verify_and_prepare_accumulator` that accepts a raw                                                                                                              
     `VerifyingKey` instead of a `MidnightVK` wrapper, matching what                                                                                                                  
     `IvcSetup` stores.
                                                                                                                                                                                      
  3. **Implement `prepare_prover_input`**: the core of phase 4.
     Follows the eight steps from the spec:                                                                                                                                           
     - SHA256(preimage) → cert message (little-endian field encoding)                                                                                                                 
     - Epoch classification (genesis / same-epoch / next-epoch)                                                                                                                       
     - Cert-proof off-circuit verification + accumulator extraction                                                                                                                   
     - Witness and `next_state` construction per the circuit transition rules                                                                                                         
     - Self-proof accumulator (trivial on genesis, verified on non-genesis)                                                                                                           
     - Three-accumulator fold: `accumulate([chain, cert, self])` → `collapse()`                                                                                                       
                                                                                                                                                                                      
  Closes part of #3138.