### PR TITLE
refactor(mithril-stm): align halo2 IVC naming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4653,7 +4653,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.29"
+version = "0.10.30"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.29", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.30", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.30 (06-05-2026)
+
+### Changed
+
+- Aligned `halo2_ivc` APIs with STM and domain-specific types, including typed state and witness fields, certificate and recursive proof byte wrappers, and aggregate verification key protocol-message handling.
+- Aligned `halo2_ivc` naming with STM and certificate-circuit terminology across circuit data, state, witness, protocol-message, proof-system callers, and test/generator identifiers.
+
 ## 0.10.29 (06-02-2026)
 
 ### Changed

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.29"
+version = "0.10.30"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -14,6 +14,11 @@ use super::{
     types::{CertificateProofBytes, IvcProofBytes},
 };
 
+/// Data required to run one step of the IVC (Incrementally Verifiable Computation) circuit.
+///
+/// Holds the global root-of-trust, the current state, the next certificate witness,
+/// the associated SNARK proofs, the latest accumulator, and the verification-key metadata
+/// for both the certificate circuit and the IVC circuit itself.
 #[derive(Clone, Debug)]
 pub struct IvcCircuitData {
     // Persistent values throughout an ivc stream. This is the root of trust for an ivc stream.

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -15,7 +15,7 @@ use super::{
 };
 
 #[derive(Clone, Debug)]
-pub struct IvcCircuit {
+pub struct IvcCircuitData {
     // Persistent values throughout an ivc stream. This is the root of trust for an ivc stream.
     global: Value<Global>,
     // State values from the last aggregated certificate
@@ -25,25 +25,28 @@ pub struct IvcCircuit {
     // Snark proof of the next certificate
     certificate_proof: Value<Vec<u8>>,
     // Latest IVC proof
-    self_proof: Value<Vec<u8>>,
+    ivc_proof: Value<Vec<u8>>,
     // Latest Accumulator
     acc: Value<Accumulator<S>>,
     // Domain and ConstraintSystem associated with certificate circuit VerifyingKey
-    cert_domain_cs: (EvaluationDomain<F>, ConstraintSystem<F>),
-    // Domain and ConstraintSystem associated with ivc circuit VerifyingKey
-    self_domain_cs: (EvaluationDomain<F>, ConstraintSystem<F>),
+    certificate_circuit_domain_and_constraint_system: (EvaluationDomain<F>, ConstraintSystem<F>),
+    // Domain and ConstraintSystem associated with IVC circuit VerifyingKey
+    ivc_circuit_domain_and_constraint_system: (EvaluationDomain<F>, ConstraintSystem<F>),
 }
 
-impl IvcCircuit {
-    /// Validates that the self VK degree matches the IVC circuit degree constant K.
+// Backward-compatible alias for non-circuit callers; circuit-local code uses `IvcCircuitData`.
+pub(crate) type IvcCircuit = IvcCircuitData;
+
+impl IvcCircuitData {
+    /// Validates that the IVC verification key degree matches the IVC circuit degree constant K.
     // Kept until the IVC prover validates recursive circuit keys.
     #[allow(dead_code)]
-    pub(crate) fn validate_self_vk_degree(
-        self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    pub(crate) fn validate_ivc_verification_key_degree(
+        ivc_verification_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
     ) -> StmResult<()> {
-        let actual = self_vk.get_domain().k();
+        let actual = ivc_verification_key.get_domain().k();
         if actual != K {
-            return Err(anyhow!(IvcCircuitError::SelfVkDegreeMismatch {
+            return Err(anyhow!(IvcCircuitError::IvcVerificationKeyDegreeMismatch {
                 expected: K,
                 actual,
             }));
@@ -85,12 +88,13 @@ impl IvcCircuit {
         Ok(())
     }
 
-    /// Creates a new `IvcCircuit` with the given witness and proof data.
+    /// Creates a new `IvcCircuitData` with the given witness and proof data.
     ///
-    /// Validates that `self_vk` has degree `K` and that the column pool allocated by
+    /// Validates that `ivc_verification_key` has degree `K` and that the column pool allocated by
     /// `configure_ivc_circuit` is sufficient for all chips. Returns an error containing
-    /// [`IvcCircuitError::SelfVkDegreeMismatch`] or [`IvcCircuitError::InsufficientAdviceColumns`]
-    /// / [`IvcCircuitError::InsufficientFixedColumns`] if either check fails.
+    /// [`IvcCircuitError::IvcVerificationKeyDegreeMismatch`] or
+    /// [`IvcCircuitError::InsufficientAdviceColumns`] /
+    /// [`IvcCircuitError::InsufficientFixedColumns`] if either check fails.
     // Kept until the IVC prover constructs recursive circuit instances.
     #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
@@ -99,60 +103,79 @@ impl IvcCircuit {
         state: State,
         witness: Witness,
         certificate_proof: CertificateProofBytes,
-        self_proof: IvcProofBytes,
+        ivc_proof: IvcProofBytes,
         acc: Accumulator<S>,
-        cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
-        self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+        certificate_verification_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+        ivc_verification_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
     ) -> StmResult<Self> {
-        Self::validate_self_vk_degree(self_vk)?;
+        Self::validate_ivc_verification_key_degree(ivc_verification_key)?;
         Self::validate_column_counts()?;
-        Ok(IvcCircuit {
+        Ok(IvcCircuitData {
             global: Value::known(global),
             state: Value::known(state),
             witness: Value::known(witness),
             certificate_proof: Value::known(certificate_proof.into_vec()),
-            self_proof: Value::known(self_proof.into_vec()),
+            ivc_proof: Value::known(ivc_proof.into_vec()),
             acc: Value::known(acc),
-            cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),
-            self_domain_cs: (self_vk.get_domain().clone(), self_vk.cs().clone()),
+            certificate_circuit_domain_and_constraint_system: (
+                certificate_verification_key.get_domain().clone(),
+                certificate_verification_key.cs().clone(),
+            ),
+            ivc_circuit_domain_and_constraint_system: (
+                ivc_verification_key.get_domain().clone(),
+                ivc_verification_key.cs().clone(),
+            ),
         })
     }
 
     /// Creates a default IVC circuit for generating the proving and verifying keys.
-    pub fn unknown(cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>) -> StmResult<Self> {
+    pub fn unknown(
+        certificate_verification_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    ) -> StmResult<Self> {
         Self::validate_column_counts()?;
-        let mut self_cs = ConstraintSystem::default();
-        configure_ivc_circuit(&mut self_cs);
-        let self_domain = EvaluationDomain::new(self_cs.degree() as u32, K);
+        let mut ivc_circuit_constraint_system = ConstraintSystem::default();
+        configure_ivc_circuit(&mut ivc_circuit_constraint_system);
+        let ivc_circuit_domain =
+            EvaluationDomain::new(ivc_circuit_constraint_system.degree() as u32, K);
 
-        Ok(IvcCircuit {
+        Ok(IvcCircuitData {
             global: Value::unknown(),
             state: Value::unknown(),
             witness: Value::unknown(),
             certificate_proof: Value::unknown(),
-            self_proof: Value::unknown(),
+            ivc_proof: Value::unknown(),
             acc: Value::unknown(),
-            cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),
-            self_domain_cs: (self_domain, self_cs),
+            certificate_circuit_domain_and_constraint_system: (
+                certificate_verification_key.get_domain().clone(),
+                certificate_verification_key.cs().clone(),
+            ),
+            ivc_circuit_domain_and_constraint_system: (
+                ivc_circuit_domain,
+                ivc_circuit_constraint_system,
+            ),
         })
     }
 }
 
-impl Circuit<F> for IvcCircuit {
+impl Circuit<F> for IvcCircuitData {
     type Config = IvcConfig;
     type FloorPlanner = SimpleFloorPlanner;
     type Params = ();
 
     fn without_witnesses(&self) -> Self {
-        IvcCircuit {
+        IvcCircuitData {
             global: Value::unknown(),
             state: Value::unknown(),
             witness: Value::unknown(),
             certificate_proof: Value::unknown(),
-            self_proof: Value::unknown(),
+            ivc_proof: Value::unknown(),
             acc: Value::unknown(),
-            cert_domain_cs: self.cert_domain_cs.clone(),
-            self_domain_cs: self.self_domain_cs.clone(),
+            certificate_circuit_domain_and_constraint_system: self
+                .certificate_circuit_domain_and_constraint_system
+                .clone(),
+            ivc_circuit_domain_and_constraint_system: self
+                .ivc_circuit_domain_and_constraint_system
+                .clone(),
         }
     }
 
@@ -171,8 +194,8 @@ impl Circuit<F> for IvcCircuit {
         let global = ivc_gadget.assign_global_as_public_input(
             &mut layouter,
             &self.global,
-            &self.cert_domain_cs,
-            &self.self_domain_cs,
+            &self.certificate_circuit_domain_and_constraint_system,
+            &self.ivc_circuit_domain_and_constraint_system,
         )?;
         // Assign previous state
         let state = ivc_gadget.assign_state(&mut layouter, &self.state)?;
@@ -206,7 +229,7 @@ impl Circuit<F> for IvcCircuit {
             &state,
             &witness,
             &self.certificate_proof,
-            &self.self_proof,
+            &self.ivc_proof,
             &self.acc,
         )?;
         // Constrain the next accumulator as public input

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -34,9 +34,6 @@ pub struct IvcCircuitData {
     ivc_circuit_domain_and_constraint_system: (EvaluationDomain<F>, ConstraintSystem<F>),
 }
 
-// Backward-compatible alias for non-circuit callers; circuit-local code uses `IvcCircuitData`.
-pub(crate) type IvcCircuit = IvcCircuitData;
-
 impl IvcCircuitData {
     /// Validates that the IVC verification key degree matches the IVC circuit degree constant K.
     // Kept until the IVC prover validates recursive circuit keys.

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -23,7 +23,7 @@ pub struct IvcCircuit {
     // Witness (mainly the next certificate to be aggregated) for deriving the next state
     witness: Value<Witness>,
     // Snark proof of the next certificate
-    cert_proof: Value<Vec<u8>>,
+    certificate_proof: Value<Vec<u8>>,
     // Latest IVC proof
     self_proof: Value<Vec<u8>>,
     // Latest Accumulator
@@ -98,7 +98,7 @@ impl IvcCircuit {
         global: Global,
         state: State,
         witness: Witness,
-        cert_proof: CertificateProofBytes,
+        certificate_proof: CertificateProofBytes,
         self_proof: IvcProofBytes,
         acc: Accumulator<S>,
         cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
@@ -110,7 +110,7 @@ impl IvcCircuit {
             global: Value::known(global),
             state: Value::known(state),
             witness: Value::known(witness),
-            cert_proof: Value::known(cert_proof.into_vec()),
+            certificate_proof: Value::known(certificate_proof.into_vec()),
             self_proof: Value::known(self_proof.into_vec()),
             acc: Value::known(acc),
             cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),
@@ -129,7 +129,7 @@ impl IvcCircuit {
             global: Value::unknown(),
             state: Value::unknown(),
             witness: Value::unknown(),
-            cert_proof: Value::unknown(),
+            certificate_proof: Value::unknown(),
             self_proof: Value::unknown(),
             acc: Value::unknown(),
             cert_domain_cs: (cert_vk.get_domain().clone(), cert_vk.cs().clone()),
@@ -148,7 +148,7 @@ impl Circuit<F> for IvcCircuit {
             global: Value::unknown(),
             state: Value::unknown(),
             witness: Value::unknown(),
-            cert_proof: Value::unknown(),
+            certificate_proof: Value::unknown(),
             self_proof: Value::unknown(),
             acc: Value::unknown(),
             cert_domain_cs: self.cert_domain_cs.clone(),
@@ -179,7 +179,7 @@ impl Circuit<F> for IvcCircuit {
         // Assign witness for the new certificate to be aggregated
         let witness = ivc_gadget.assign_witness(&mut layouter, &self.witness)?;
 
-        // If state.counter = 0, we are aggregating the genesis certificate
+        // If state.step_counter = 0, we are aggregating the genesis certificate
         let is_genesis = ivc_gadget.is_genesis(&mut layouter, &state)?;
         let is_not_genesis = ivc_gadget.native_gadget.not(&mut layouter, &is_genesis)?;
 
@@ -198,14 +198,14 @@ impl Circuit<F> for IvcCircuit {
         // Constrain the next state as public input
         ivc_gadget.constrain_state_as_public_input(&mut layouter, &next_state)?;
 
-        // Verify (prepare) cert_proof and previous ivc_proof and update accumulator
+        // Verify (prepare) certificate_proof and previous ivc_proof and update accumulator
         let next_acc = ivc_gadget.verify_prepare(
             &mut layouter,
             &global,
             &is_not_genesis,
             &state,
             &witness,
-            &self.cert_proof,
+            &self.certificate_proof,
             &self.self_proof,
             &self.acc,
         )?;

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -9,9 +9,11 @@ pub enum IvcCircuitError {
     #[error("Certificate proof verification rejected")]
     CertificateProofRejected,
 
-    /// Self VK degree does not match the IVC circuit degree constant K.
-    #[error("IvcCircuit::validate_self_vk_degree failed: expected k={expected}, got k={actual}")]
-    SelfVkDegreeMismatch { expected: u32, actual: u32 },
+    /// IVC verification key degree does not match the IVC circuit degree constant K.
+    #[error(
+        "IvcCircuitData::validate_ivc_verification_key_degree failed: expected k={expected}, got k={actual}"
+    )]
+    IvcVerificationKeyDegreeMismatch { expected: u32, actual: u32 },
 
     /// `assign_many` returned a different number of values than expected.
     #[error("IvcGadget: expected {expected} assigned values, got {actual}")]
@@ -19,13 +21,13 @@ pub enum IvcCircuitError {
 
     /// Not enough advice columns were allocated to satisfy chip requirements.
     #[error(
-        "IvcCircuit::validate_column_counts failed: need {needed} advice columns, only {available} allocated"
+        "IvcCircuitData::validate_column_counts failed: need {needed} advice columns, only {available} allocated"
     )]
     InsufficientAdviceColumns { needed: usize, available: usize },
 
     /// Not enough fixed columns were allocated to satisfy chip requirements.
     #[error(
-        "IvcCircuit::validate_column_counts failed: need {needed} fixed columns, only {available} allocated"
+        "IvcCircuitData::validate_column_counts failed: need {needed} fixed columns, only {available} allocated"
     )]
     InsufficientFixedColumns { needed: usize, available: usize },
 }

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -13,8 +13,8 @@ use super::{
     ComposableChip, ConstraintSystem, ControlFlowInstructions, ConversionInstructions, EccChip,
     EccInstructions, EqualityInstructions, Error, EvaluationDomain, F, ForeignEccChip,
     HashInstructions, IVC_ONE_NAME, Jubjub, K, Layouter, NG, NativeChip, NativeGadget,
-    P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
-    PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PoseidonChip, PublicInputInstructions, S, Value,
+    P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions, S, Value,
     VerifierGadget, ZeroInstructions,
     config::IvcConfig,
     errors::{IvcCircuitError, to_synthesis_error},
@@ -66,9 +66,9 @@ impl IvcGadget {
         cert_domain_cs: &(EvaluationDomain<F>, ConstraintSystem<F>),
         self_domain_cs: &(EvaluationDomain<F>, ConstraintSystem<F>),
     ) -> Result<AssignedGlobal, Error> {
-        let genesis_msg: AssignedNative<_> = self
+        let genesis_message: AssignedNative<_> = self
             .native_gadget
-            .assign_as_public_input(layouter, global.clone().map(|gl| gl.genesis_msg.as_field()))?;
+            .assign_as_public_input(layouter, global.clone().map(|gl| gl.genesis_message.as_field()))?;
         let genesis_vk: AssignedNativePoint<_> = self.jubjub_chip.assign_as_public_input(
             layouter,
             global.clone().map(|gl| *gl.genesis_vk.as_jubjub_subgroup()),
@@ -103,7 +103,7 @@ impl IvcGadget {
         };
 
         Ok(AssignedGlobal {
-            genesis_msg,
+            genesis_message,
             genesis_vk,
             cert_vk,
             self_vk,
@@ -120,24 +120,24 @@ impl IvcGadget {
             .clone()
             .map(|s| {
                 vec![
-                    s.counter.as_field(),
-                    s.msg.as_field(),
-                    s.merkle_root.as_field(),
-                    s.next_merkle_root.as_field(),
-                    s.protocol_params.as_field(),
-                    s.next_protocol_params.as_field(),
+                    s.step_counter.as_field(),
+                    s.message.as_field(),
+                    s.merkle_tree_commitment.as_field(),
+                    s.next_merkle_tree_commitment.as_field(),
+                    s.protocol_parameters.as_field(),
+                    s.next_protocol_parameters.as_field(),
                     s.current_epoch.as_field(),
                 ]
             })
             .transpose_vec(7);
 
         let [
-            counter,
-            msg,
-            merkle_root,
-            next_merkle_root,
-            protocol_params,
-            next_protocol_params,
+            step_counter,
+            message,
+            merkle_tree_commitment,
+            next_merkle_tree_commitment,
+            protocol_parameters,
+            next_protocol_parameters,
             current_epoch,
         ]: [AssignedNative<_>; 7] = {
             self.native_gadget
@@ -152,12 +152,12 @@ impl IvcGadget {
         };
 
         Ok(AssignedState {
-            counter,
-            msg,
-            merkle_root,
-            next_merkle_root,
-            protocol_params,
-            next_protocol_params,
+            step_counter,
+            message,
+            merkle_tree_commitment,
+            next_merkle_tree_commitment,
+            protocol_parameters,
+            next_protocol_parameters,
             current_epoch,
         })
     }
@@ -168,12 +168,12 @@ impl IvcGadget {
         state: &AssignedState,
     ) -> Result<(), Error> {
         for value in [
-            &state.counter,
-            &state.msg,
-            &state.merkle_root,
-            &state.next_merkle_root,
-            &state.protocol_params,
-            &state.next_protocol_params,
+            &state.step_counter,
+            &state.message,
+            &state.merkle_tree_commitment,
+            &state.next_merkle_tree_commitment,
+            &state.protocol_parameters,
+            &state.next_protocol_parameters,
             &state.current_epoch,
         ] {
             self.native_gadget.constrain_as_public_input(layouter, value)?;
@@ -197,10 +197,10 @@ impl IvcGadget {
             (s, c)
         };
 
-        let [cert_msg, cert_merkle_root]: [AssignedNative<F>; 2] = {
+        let [certificate_message, certificate_merkle_tree_commitment]: [AssignedNative<F>; 2] = {
             let values = witness
                 .clone()
-                .map(|w| vec![w.cert_msg.as_field(), w.cert_merkle_root.as_field()])
+                .map(|w| vec![w.certificate_message.as_field(), w.certificate_merkle_tree_commitment.as_field()])
                 .transpose_vec(2);
             self.native_gadget
                 .assign_many(layouter, &values)?
@@ -213,16 +213,16 @@ impl IvcGadget {
                 })?
         };
 
-        let msg_preimage = {
-            let preimage = witness.clone().map(|w| w.msg_preimage.into_inner()).transpose_array();
+        let message_preimage = {
+            let preimage = witness.clone().map(|w| w.message_preimage.into_inner()).transpose_array();
             self.native_gadget.assign_many(layouter, &preimage)?
         };
 
         Ok(AssignedWitness {
             genesis_sig,
-            cert_merkle_root,
-            cert_msg,
-            msg_preimage,
+            certificate_merkle_tree_commitment,
+            certificate_message,
+            message_preimage,
         })
     }
 
@@ -231,7 +231,7 @@ impl IvcGadget {
         layouter: &mut impl Layouter<F>,
         state: &AssignedState,
     ) -> Result<AssignedBit<F>, Error> {
-        self.native_gadget.is_zero(layouter, &state.counter)
+        self.native_gadget.is_zero(layouter, &state.step_counter)
     }
 
     pub fn is_genesis_sig_valid(
@@ -271,7 +271,7 @@ impl IvcGadget {
                 vk_y,
                 cap_r_x,
                 cap_r_y,
-                global.genesis_msg.clone(),
+                global.genesis_message.clone(),
             ],
         )?;
 
@@ -303,7 +303,7 @@ impl IvcGadget {
     ) -> Result<Vec<AssignedNative<F>>, Error> {
         let pi = [
             vec![
-                global.genesis_msg.clone(),
+                global.genesis_message.clone(),
                 self.jubjub_chip.x_coordinate(&global.genesis_vk),
                 self.jubjub_chip.y_coordinate(&global.genesis_vk),
             ],
@@ -338,18 +338,18 @@ impl IvcGadget {
         state: &AssignedState,
         witness: &AssignedWitness,
     ) -> Result<AssignedState, Error> {
-        let counter = self.native_gadget.add_constant(layouter, &state.counter, F::ONE)?;
+        let step_counter = self.native_gadget.add_constant(layouter, &state.step_counter, F::ONE)?;
 
-        let (cert_msg, cert_merkle_root) =
-            (witness.cert_msg.clone(), witness.cert_merkle_root.clone());
+        let (certificate_message, certificate_merkle_tree_commitment) =
+            (witness.certificate_message.clone(), witness.certificate_merkle_tree_commitment.clone());
 
-        // Open msg hash to check the link between certificates
-        // If it is genesis, select genesis msg as msg; otherwise, select cert msg as msg.
-        let msg =
+        // Open message hash to check the link between certificates
+        // If it is genesis, select genesis message as message; otherwise, select cert message as message.
+        let message =
             self.native_gadget
-                .select(layouter, is_genesis, &global.genesis_msg, &cert_msg)?;
+                .select(layouter, is_genesis, &global.genesis_message, &certificate_message)?;
 
-        let hash = self.sha2_256_chip.hash(layouter, &witness.msg_preimage)?;
+        let hash = self.sha2_256_chip.hash(layouter, &witness.message_preimage)?;
 
         let factor = F::from(256u64);
         let bases: Vec<_> = (0..32)
@@ -361,32 +361,32 @@ impl IvcGadget {
             .collect();
 
         {
-            // Compare msg and hash
+            // Compare message and hash
             let hash_native = self.combine_bytes(layouter, &hash, &bases)?;
-            self.native_gadget.assert_equal(layouter, &msg, &hash_native)?;
+            self.native_gadget.assert_equal(layouter, &message, &hash_native)?;
         }
 
-        // If it is genesis, merkle_root = 0; otherwise, merkle_root = cert_merkle_root.
+        // If it is genesis, merkle_tree_commitment = 0; otherwise, merkle_tree_commitment = certificate_merkle_tree_commitment.
         let zero = self.native_gadget.assign_fixed(layouter, F::ZERO)?;
-        let merkle_root =
+        let merkle_tree_commitment =
             self.native_gadget
-                .select(layouter, is_genesis, &zero, &cert_merkle_root)?;
+                .select(layouter, is_genesis, &zero, &certificate_merkle_tree_commitment)?;
 
-        // Read the value of next merkle root, next protocol parameters and current epoch from protocol message preimage
+        // Read the value of next Merkle-tree commitment, next protocol parameters and current epoch from protocol message preimage
         // digest(6) | bytes(32) | next_aggregate_verification_key(31) | bytes(44) | next_protocol_parameters(24) | bytes(32) | current_epoch(13) | bytes(8)
         // todo: check field keywords(?)
-        let next_merkle_root_bytes = witness.msg_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].to_vec();
-        let next_protocol_params_bytes =
-            witness.msg_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].to_vec();
-        let current_epoch_bytes = witness.msg_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].to_vec();
+        let next_merkle_tree_commitment_bytes = witness.message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].to_vec();
+        let next_protocol_parameters_bytes =
+            witness.message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].to_vec();
+        let current_epoch_bytes = witness.message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].to_vec();
 
         // Get the field elements by linearly combining the bytes
-        let (next_merkle_root, next_protocol_params, current_epoch) = {
-            let next_merkle_root = self.combine_bytes(layouter, next_merkle_root_bytes, &bases)?;
-            let next_protocol_params =
-                self.combine_bytes(layouter, next_protocol_params_bytes, &bases)?;
+        let (next_merkle_tree_commitment, next_protocol_parameters, current_epoch) = {
+            let next_merkle_tree_commitment = self.combine_bytes(layouter, next_merkle_tree_commitment_bytes, &bases)?;
+            let next_protocol_parameters =
+                self.combine_bytes(layouter, next_protocol_parameters_bytes, &bases)?;
             let current_epoch = self.combine_bytes(layouter, current_epoch_bytes, &bases)?;
-            (next_merkle_root, next_protocol_params, current_epoch)
+            (next_merkle_tree_commitment, next_protocol_parameters, current_epoch)
         };
 
         let (is_same_epoch, is_next_epoch) = {
@@ -405,13 +405,13 @@ impl IvcGadget {
         };
 
         {
-            // If state.counter == 1, the previous certificate is a genesis certificate and
+            // If state.step_counter == 1, the previous certificate is a genesis certificate and
             // the current certificate is the first certificate after the genesis and
             // its epoch number must be the next epoch number.
             // Assert true: is_not_first or is_next_epoch
             let is_first =
                 self.native_gadget
-                    .is_equal_to_fixed(layouter, &state.counter, F::ONE)?;
+                    .is_equal_to_fixed(layouter, &state.step_counter, F::ONE)?;
             let is_not_first = self.native_gadget.not(layouter, &is_first)?;
 
             let is_valid = self
@@ -421,18 +421,18 @@ impl IvcGadget {
         }
 
         {
-            // Check the link on the current merkle root; if it is genesis, skip the checking
-            // Assert true: is_genesis or (is_same_epoch && merkle_root == state.merkle_root) or (is_next_epoch && merkle_root == state.next_merkle_root)
+            // Check the link on the current Merkle-tree commitment; if it is genesis, skip the checking
+            // Assert true: is_genesis or (is_same_epoch && merkle_tree_commitment == state.merkle_tree_commitment) or (is_next_epoch && merkle_tree_commitment == state.next_merkle_tree_commitment)
             let mut is_equal_current =
                 self.native_gadget
-                    .is_equal(layouter, &merkle_root, &state.merkle_root)?;
+                    .is_equal(layouter, &merkle_tree_commitment, &state.merkle_tree_commitment)?;
             is_equal_current = self
                 .native_gadget
                 .and(layouter, &[is_equal_current, is_same_epoch.clone()])?;
 
             let mut is_equal_next =
                 self.native_gadget
-                    .is_equal(layouter, &merkle_root, &state.next_merkle_root)?;
+                    .is_equal(layouter, &merkle_tree_commitment, &state.next_merkle_tree_commitment)?;
             is_equal_next = self
                 .native_gadget
                 .and(layouter, &[is_equal_next, is_next_epoch.clone()])?;
@@ -445,41 +445,41 @@ impl IvcGadget {
                 .assert_equal_to_fixed(layouter, &is_link_valid, true)?;
         }
 
-        let protocol_params = {
-            // If genesis: protocol_params = 0
+        let protocol_parameters = {
+            // If genesis: protocol_parameters = 0
             // Else:
-            //     if same_epoch: protocol_params = state.protocol_params;
-            //     else: protocol_params = state.next_protocol_params
-            let mut protocol_params = self.native_gadget.select(
+            //     if same_epoch: protocol_parameters = state.protocol_parameters;
+            //     else: protocol_parameters = state.next_protocol_parameters
+            let mut protocol_parameters = self.native_gadget.select(
                 layouter,
                 is_genesis,
                 &zero,
-                &state.next_protocol_params,
+                &state.next_protocol_parameters,
             )?;
             let is_same_epoch_not_genesis = self
                 .native_gadget
                 .and(layouter, &[is_same_epoch.clone(), is_not_genesis.clone()])?;
-            protocol_params = self.native_gadget.select(
+            protocol_parameters = self.native_gadget.select(
                 layouter,
                 &is_same_epoch_not_genesis,
-                &state.protocol_params,
-                &protocol_params,
+                &state.protocol_parameters,
+                &protocol_parameters,
             )?;
-            protocol_params
+            protocol_parameters
         };
 
         {
-            // Check the consistence on next_merkle_root and next_protocol_params for certificates of the same epoch
-            // Assert true: is_genesis or (is_same_epoch && next_merkle_root == state.next_merkle_root && next_protocol_params == state.next_protocol_params) or is_next_epoch
+            // Check the consistence on next_merkle_tree_commitment and next_protocol_parameters for certificates of the same epoch
+            // Assert true: is_genesis or (is_same_epoch && next_merkle_tree_commitment == state.next_merkle_tree_commitment && next_protocol_parameters == state.next_protocol_parameters) or is_next_epoch
             let is_equal_mt = self.native_gadget.is_equal(
                 layouter,
-                &next_merkle_root,
-                &state.next_merkle_root,
+                &next_merkle_tree_commitment,
+                &state.next_merkle_tree_commitment,
             )?;
             let is_equal_pp = self.native_gadget.is_equal(
                 layouter,
-                &next_protocol_params,
-                &state.next_protocol_params,
+                &next_protocol_parameters,
+                &state.next_protocol_parameters,
             )?;
             let mut is_valid = self
                 .native_gadget
@@ -492,12 +492,12 @@ impl IvcGadget {
 
         // Return the next state
         Ok(AssignedState {
-            counter,
-            msg,
-            merkle_root,
-            next_merkle_root,
-            protocol_params,
-            next_protocol_params,
+            step_counter,
+            message,
+            merkle_tree_commitment,
+            next_merkle_tree_commitment,
+            protocol_parameters,
+            next_protocol_parameters,
             current_epoch,
         })
     }
@@ -510,19 +510,19 @@ impl IvcGadget {
         is_not_genesis: &AssignedBit<F>,
         state: &AssignedState,
         witness: &AssignedWitness,
-        cert_proof: &Value<Vec<u8>>,
+        certificate_proof: &Value<Vec<u8>>,
         self_proof: &Value<Vec<u8>>,
         acc_value: &Value<Accumulator<S>>,
     ) -> Result<AssignedAccumulator<S>, Error> {
         let id_point: AssignedForeignPoint<_, _, _> =
             self.bls12_381_chip.assign_fixed(layouter, C::identity())?;
 
-        let mut cert_proof_acc = self.verifier_gadget.prepare(
+        let mut certificate_proof_accumulator = self.verifier_gadget.prepare(
             layouter,
             &global.cert_vk,
             &[("com_instance", id_point.clone())],
-            &[&[witness.cert_merkle_root.clone(), witness.cert_msg.clone()]],
-            cert_proof.clone(),
+            &[&[witness.certificate_merkle_tree_commitment.clone(), witness.certificate_message.clone()]],
+            certificate_proof.clone(),
         )?;
 
         // If it is genesis, we allow the prover to change the (probably
@@ -531,9 +531,9 @@ impl IvcGadget {
             layouter,
             &self.native_gadget,
             is_not_genesis,
-            &mut cert_proof_acc,
+            &mut certificate_proof_accumulator,
         )?;
-        cert_proof_acc.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
+        certificate_proof_accumulator.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
 
         let acc = AssignedAccumulator::assign(
             layouter,
@@ -575,13 +575,13 @@ impl IvcGadget {
         )?;
         self_proof_acc.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
 
-        // Accumulate the cert_proof_acc
+        // Accumulate the certificate_proof_accumulator
         let mut next_acc = AssignedAccumulator::<S>::accumulate(
             layouter,
             &self.verifier_gadget,
             &self.native_gadget,
             &self.poseidon_chip,
-            &[acc, cert_proof_acc, self_proof_acc],
+            &[acc, certificate_proof_accumulator, self_proof_acc],
         )?;
         next_acc.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
 

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -250,8 +250,8 @@ impl IvcGadget {
 
         Ok(AssignedWitness {
             genesis_signature,
-            certificate_merkle_tree_commitment,
             certificate_message,
+            certificate_merkle_tree_commitment,
             message_preimage,
         })
     }

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -264,6 +264,12 @@ impl IvcGadget {
         self.native_gadget.is_zero(layouter, &state.step_counter)
     }
 
+    /// Verifies the genesis Schnorr signature in-circuit.
+    ///
+    /// Reconstructs the challenge via Poseidon hash over the genesis verification key,
+    /// the nonce commitment R, and the genesis message, then checks equality against
+    /// the committed challenge scalar from `witness.genesis_signature`.
+    /// Returns an `AssignedBit` that is `true` when the signature is valid.
     pub fn is_genesis_signature_valid(
         &self,
         layouter: &mut impl Layouter<F>,
@@ -523,7 +529,7 @@ impl IvcGadget {
         };
 
         {
-            // Check the consistence on next_merkle_tree_commitment and next_protocol_parameters for certificates of the same epoch
+            // Check the consistency on next_merkle_tree_commitment and next_protocol_parameters for certificates of the same epoch
             // Assert true: is_genesis or (is_same_epoch && next_merkle_tree_commitment == state.next_merkle_tree_commitment && next_protocol_parameters == state.next_protocol_parameters) or is_next_epoch
             let is_equal_mt = self.native_gadget.is_equal(
                 layouter,

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -9,13 +9,13 @@ use crate::signature_scheme::DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE;
 use super::{
     Accumulator, ArithInstructions, AssertionInstructions, AssignedAccumulator, AssignedBit,
     AssignedForeignPoint, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignedVk, AssignmentInstructions, BinaryInstructions, C, CERT_VK_NAME, CircuitCurve,
-    ComposableChip, ConstraintSystem, ControlFlowInstructions, ConversionInstructions, EccChip,
-    EccInstructions, EqualityInstructions, Error, EvaluationDomain, F, ForeignEccChip,
-    HashInstructions, IVC_ONE_NAME, Jubjub, K, Layouter, NG, NativeChip, NativeGadget,
-    P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
-    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions, S, Value,
-    VerifierGadget, ZeroInstructions,
+    AssignedVk, AssignmentInstructions, BinaryInstructions, C, CERTIFICATE_VERIFICATION_KEY_NAME,
+    CircuitCurve, ComposableChip, ConstraintSystem, ControlFlowInstructions,
+    ConversionInstructions, EccChip, EccInstructions, EqualityInstructions, Error,
+    EvaluationDomain, F, ForeignEccChip, HashInstructions, IVC_VERIFICATION_KEY_NAME, Jubjub, K,
+    Layouter, NG, NativeChip, NativeGadget, P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES,
+    PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
+    PoseidonChip, PublicInputInstructions, S, Value, VerifierGadget, ZeroInstructions,
     config::IvcConfig,
     errors::{IvcCircuitError, to_synthesis_error},
     state::{
@@ -63,39 +63,59 @@ impl IvcGadget {
         &self,
         layouter: &mut impl Layouter<F>,
         global: &Value<Global>,
-        cert_domain_cs: &(EvaluationDomain<F>, ConstraintSystem<F>),
-        self_domain_cs: &(EvaluationDomain<F>, ConstraintSystem<F>),
+        certificate_circuit_domain_and_constraint_system: &(
+            EvaluationDomain<F>,
+            ConstraintSystem<F>,
+        ),
+        ivc_circuit_domain_and_constraint_system: &(EvaluationDomain<F>, ConstraintSystem<F>),
     ) -> Result<AssignedGlobal, Error> {
-        let genesis_message: AssignedNative<_> = self
-            .native_gadget
-            .assign_as_public_input(layouter, global.clone().map(|gl| gl.genesis_message.as_field()))?;
-        let genesis_vk: AssignedNativePoint<_> = self.jubjub_chip.assign_as_public_input(
+        let genesis_message: AssignedNative<_> = self.native_gadget.assign_as_public_input(
             layouter,
-            global.clone().map(|gl| *gl.genesis_vk.as_jubjub_subgroup()),
+            global.clone().map(|gl| gl.genesis_message.as_field()),
         )?;
+        let genesis_verification_key: AssignedNativePoint<_> =
+            self.jubjub_chip.assign_as_public_input(
+                layouter,
+                global
+                    .clone()
+                    .map(|gl| *gl.genesis_verification_key.as_jubjub_subgroup()),
+            )?;
 
-        let (cert_domain, cert_cs) = &cert_domain_cs;
-        let cert_vk: AssignedVk<S> = self.verifier_gadget.assign_vk_as_public_input(
-            layouter,
-            CERT_VK_NAME,
-            cert_domain,
-            cert_cs,
-            global.clone().map(|gl| gl.cert_vk_repr.as_field()),
-        )?;
+        let (certificate_circuit_domain, certificate_circuit_constraint_system) =
+            &certificate_circuit_domain_and_constraint_system;
+        let certificate_verification_key: AssignedVk<S> =
+            self.verifier_gadget.assign_vk_as_public_input(
+                layouter,
+                CERTIFICATE_VERIFICATION_KEY_NAME,
+                certificate_circuit_domain,
+                certificate_circuit_constraint_system,
+                global
+                    .clone()
+                    .map(|gl| gl.certificate_circuit_verification_key_representation.as_field()),
+            )?;
 
-        // Assign for self-proof verification
-        let (self_domain, self_cs) = &self_domain_cs;
-        let self_vk: AssignedVk<S> = self.verifier_gadget.assign_vk_as_public_input(
+        // Assign for IVC proof verification
+        let (ivc_circuit_domain, ivc_circuit_constraint_system) =
+            &ivc_circuit_domain_and_constraint_system;
+        let ivc_verification_key: AssignedVk<S> = self.verifier_gadget.assign_vk_as_public_input(
             layouter,
-            IVC_ONE_NAME,
-            self_domain,
-            self_cs,
-            global.clone().map(|gl| gl.self_vk_repr.as_field()),
+            IVC_VERIFICATION_KEY_NAME,
+            ivc_circuit_domain,
+            ivc_circuit_constraint_system,
+            global
+                .clone()
+                .map(|gl| gl.ivc_circuit_verification_key_representation.as_field()),
         )?;
 
         let fixed_base_names = {
-            let mut names = fixed_base_names(CERT_VK_NAME, cert_cs);
-            names.extend(fixed_base_names(IVC_ONE_NAME, self_cs));
+            let mut names = fixed_base_names(
+                CERTIFICATE_VERIFICATION_KEY_NAME,
+                certificate_circuit_constraint_system,
+            );
+            names.extend(fixed_base_names(
+                IVC_VERIFICATION_KEY_NAME,
+                ivc_circuit_constraint_system,
+            ));
             // Remove repeated names for committed_instance and the generator
             let mut seen = HashSet::new();
             names.retain(|x| seen.insert(x.clone()));
@@ -104,9 +124,9 @@ impl IvcGadget {
 
         Ok(AssignedGlobal {
             genesis_message,
-            genesis_vk,
-            cert_vk,
-            self_vk,
+            genesis_verification_key,
+            certificate_verification_key,
+            ivc_verification_key,
             fixed_base_names,
         })
     }
@@ -187,20 +207,27 @@ impl IvcGadget {
         layouter: &mut impl Layouter<F>,
         witness: &Value<Witness>,
     ) -> Result<AssignedWitness, Error> {
-        let genesis_sig = {
-            let s: AssignedScalarOfNativeCurve<_> = self
-                .jubjub_chip
-                .assign(layouter, witness.clone().map(|w| w.genesis_sig.response.0))?;
-            let c: AssignedNative<_> = self
-                .native_gadget
-                .assign(layouter, witness.clone().map(|w| w.genesis_sig.challenge.0))?;
+        let genesis_signature = {
+            let s: AssignedScalarOfNativeCurve<_> = self.jubjub_chip.assign(
+                layouter,
+                witness.clone().map(|w| w.genesis_signature.response.0),
+            )?;
+            let c: AssignedNative<_> = self.native_gadget.assign(
+                layouter,
+                witness.clone().map(|w| w.genesis_signature.challenge.0),
+            )?;
             (s, c)
         };
 
         let [certificate_message, certificate_merkle_tree_commitment]: [AssignedNative<F>; 2] = {
             let values = witness
                 .clone()
-                .map(|w| vec![w.certificate_message.as_field(), w.certificate_merkle_tree_commitment.as_field()])
+                .map(|w| {
+                    vec![
+                        w.certificate_message.as_field(),
+                        w.certificate_merkle_tree_commitment.as_field(),
+                    ]
+                })
                 .transpose_vec(2);
             self.native_gadget
                 .assign_many(layouter, &values)?
@@ -214,12 +241,15 @@ impl IvcGadget {
         };
 
         let message_preimage = {
-            let preimage = witness.clone().map(|w| w.message_preimage.into_inner()).transpose_array();
+            let preimage = witness
+                .clone()
+                .map(|w| w.message_preimage.into_inner())
+                .transpose_array();
             self.native_gadget.assign_many(layouter, &preimage)?
         };
 
         Ok(AssignedWitness {
-            genesis_sig,
+            genesis_signature,
             certificate_merkle_tree_commitment,
             certificate_message,
             message_preimage,
@@ -234,14 +264,14 @@ impl IvcGadget {
         self.native_gadget.is_zero(layouter, &state.step_counter)
     }
 
-    pub fn is_genesis_sig_valid(
+    pub fn is_genesis_signature_valid(
         &self,
         layouter: &mut impl Layouter<F>,
         global: &AssignedGlobal,
         witness: &AssignedWitness,
     ) -> Result<AssignedBit<F>, Error> {
-        let s = witness.genesis_sig.0.clone();
-        let c_native = witness.genesis_sig.1.clone();
+        let s = witness.genesis_signature.0.clone();
+        let c_native = witness.genesis_signature.1.clone();
         let c: AssignedScalarOfNativeCurve<_> = self.jubjub_chip.convert(layouter, &c_native)?;
 
         let dst_signature: AssignedNative<_> = self
@@ -255,11 +285,11 @@ impl IvcGadget {
         let cap_r = self.jubjub_chip.msm(
             layouter,
             &[s, c.clone()],
-            &[generator.clone(), global.genesis_vk.clone()],
+            &[generator.clone(), global.genesis_verification_key.clone()],
         )?;
 
-        let vk_x = self.jubjub_chip.x_coordinate(&global.genesis_vk);
-        let vk_y = self.jubjub_chip.y_coordinate(&global.genesis_vk);
+        let vk_x = self.jubjub_chip.x_coordinate(&global.genesis_verification_key);
+        let vk_y = self.jubjub_chip.y_coordinate(&global.genesis_verification_key);
         let cap_r_x = self.jubjub_chip.x_coordinate(&cap_r);
         let cap_r_y = self.jubjub_chip.y_coordinate(&cap_r);
 
@@ -286,12 +316,14 @@ impl IvcGadget {
         witness: &AssignedWitness,
     ) -> Result<(), Error> {
         // Verify the genesis signature
-        let is_genesis_sig_valid = self.is_genesis_sig_valid(layouter, global, witness)?;
+        let is_genesis_signature_valid =
+            self.is_genesis_signature_valid(layouter, global, witness)?;
 
         // Skip the genesis signature verification if it is not genesis
-        let check_genesis = self
-            .native_gadget
-            .or(layouter, &[is_genesis_sig_valid, is_not_genesis.clone()])?;
+        let check_genesis = self.native_gadget.or(
+            layouter,
+            &[is_genesis_signature_valid, is_not_genesis.clone()],
+        )?;
         self.native_gadget
             .assert_equal_to_fixed(layouter, &check_genesis, true)
     }
@@ -304,11 +336,13 @@ impl IvcGadget {
         let pi = [
             vec![
                 global.genesis_message.clone(),
-                self.jubjub_chip.x_coordinate(&global.genesis_vk),
-                self.jubjub_chip.y_coordinate(&global.genesis_vk),
+                self.jubjub_chip.x_coordinate(&global.genesis_verification_key),
+                self.jubjub_chip.y_coordinate(&global.genesis_verification_key),
             ],
-            self.verifier_gadget.as_public_input(layouter, &global.cert_vk)?,
-            self.verifier_gadget.as_public_input(layouter, &global.self_vk)?,
+            self.verifier_gadget
+                .as_public_input(layouter, &global.certificate_verification_key)?,
+            self.verifier_gadget
+                .as_public_input(layouter, &global.ivc_verification_key)?,
         ]
         .concat();
         Ok(pi)
@@ -338,16 +372,23 @@ impl IvcGadget {
         state: &AssignedState,
         witness: &AssignedWitness,
     ) -> Result<AssignedState, Error> {
-        let step_counter = self.native_gadget.add_constant(layouter, &state.step_counter, F::ONE)?;
+        let step_counter =
+            self.native_gadget
+                .add_constant(layouter, &state.step_counter, F::ONE)?;
 
-        let (certificate_message, certificate_merkle_tree_commitment) =
-            (witness.certificate_message.clone(), witness.certificate_merkle_tree_commitment.clone());
+        let (certificate_message, certificate_merkle_tree_commitment) = (
+            witness.certificate_message.clone(),
+            witness.certificate_merkle_tree_commitment.clone(),
+        );
 
         // Open message hash to check the link between certificates
         // If it is genesis, select genesis message as message; otherwise, select cert message as message.
-        let message =
-            self.native_gadget
-                .select(layouter, is_genesis, &global.genesis_message, &certificate_message)?;
+        let message = self.native_gadget.select(
+            layouter,
+            is_genesis,
+            &global.genesis_message,
+            &certificate_message,
+        )?;
 
         let hash = self.sha2_256_chip.hash(layouter, &witness.message_preimage)?;
 
@@ -368,25 +409,34 @@ impl IvcGadget {
 
         // If it is genesis, merkle_tree_commitment = 0; otherwise, merkle_tree_commitment = certificate_merkle_tree_commitment.
         let zero = self.native_gadget.assign_fixed(layouter, F::ZERO)?;
-        let merkle_tree_commitment =
-            self.native_gadget
-                .select(layouter, is_genesis, &zero, &certificate_merkle_tree_commitment)?;
+        let merkle_tree_commitment = self.native_gadget.select(
+            layouter,
+            is_genesis,
+            &zero,
+            &certificate_merkle_tree_commitment,
+        )?;
 
-        // Read the value of next Merkle-tree commitment, next protocol parameters and current epoch from protocol message preimage
+        // Read the next Merkle-tree commitment, next protocol parameters, and current epoch from the protocol message preimage.
         // digest(6) | bytes(32) | next_aggregate_verification_key(31) | bytes(44) | next_protocol_parameters(24) | bytes(32) | current_epoch(13) | bytes(8)
         // todo: check field keywords(?)
-        let next_merkle_tree_commitment_bytes = witness.message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].to_vec();
+        let next_merkle_tree_commitment_bytes =
+            witness.message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].to_vec();
         let next_protocol_parameters_bytes =
             witness.message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].to_vec();
         let current_epoch_bytes = witness.message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].to_vec();
 
         // Get the field elements by linearly combining the bytes
         let (next_merkle_tree_commitment, next_protocol_parameters, current_epoch) = {
-            let next_merkle_tree_commitment = self.combine_bytes(layouter, next_merkle_tree_commitment_bytes, &bases)?;
+            let next_merkle_tree_commitment =
+                self.combine_bytes(layouter, next_merkle_tree_commitment_bytes, &bases)?;
             let next_protocol_parameters =
                 self.combine_bytes(layouter, next_protocol_parameters_bytes, &bases)?;
             let current_epoch = self.combine_bytes(layouter, current_epoch_bytes, &bases)?;
-            (next_merkle_tree_commitment, next_protocol_parameters, current_epoch)
+            (
+                next_merkle_tree_commitment,
+                next_protocol_parameters,
+                current_epoch,
+            )
         };
 
         let (is_same_epoch, is_next_epoch) = {
@@ -421,18 +471,22 @@ impl IvcGadget {
         }
 
         {
-            // Check the link on the current Merkle-tree commitment; if it is genesis, skip the checking
+            // Check the current Merkle-tree commitment link; if it is genesis, skip the check.
             // Assert true: is_genesis or (is_same_epoch && merkle_tree_commitment == state.merkle_tree_commitment) or (is_next_epoch && merkle_tree_commitment == state.next_merkle_tree_commitment)
-            let mut is_equal_current =
-                self.native_gadget
-                    .is_equal(layouter, &merkle_tree_commitment, &state.merkle_tree_commitment)?;
+            let mut is_equal_current = self.native_gadget.is_equal(
+                layouter,
+                &merkle_tree_commitment,
+                &state.merkle_tree_commitment,
+            )?;
             is_equal_current = self
                 .native_gadget
                 .and(layouter, &[is_equal_current, is_same_epoch.clone()])?;
 
-            let mut is_equal_next =
-                self.native_gadget
-                    .is_equal(layouter, &merkle_tree_commitment, &state.next_merkle_tree_commitment)?;
+            let mut is_equal_next = self.native_gadget.is_equal(
+                layouter,
+                &merkle_tree_commitment,
+                &state.next_merkle_tree_commitment,
+            )?;
             is_equal_next = self
                 .native_gadget
                 .and(layouter, &[is_equal_next, is_next_epoch.clone()])?;
@@ -511,7 +565,7 @@ impl IvcGadget {
         state: &AssignedState,
         witness: &AssignedWitness,
         certificate_proof: &Value<Vec<u8>>,
-        self_proof: &Value<Vec<u8>>,
+        ivc_proof: &Value<Vec<u8>>,
         acc_value: &Value<Accumulator<S>>,
     ) -> Result<AssignedAccumulator<S>, Error> {
         let id_point: AssignedForeignPoint<_, _, _> =
@@ -519,9 +573,12 @@ impl IvcGadget {
 
         let mut certificate_proof_accumulator = self.verifier_gadget.prepare(
             layouter,
-            &global.cert_vk,
+            &global.certificate_verification_key,
             &[("com_instance", id_point.clone())],
-            &[&[witness.certificate_merkle_tree_commitment.clone(), witness.certificate_message.clone()]],
+            &[&[
+                witness.certificate_merkle_tree_commitment.clone(),
+                witness.certificate_message.clone(),
+            ]],
             certificate_proof.clone(),
         )?;
 
@@ -533,7 +590,11 @@ impl IvcGadget {
             is_not_genesis,
             &mut certificate_proof_accumulator,
         )?;
-        certificate_proof_accumulator.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
+        certificate_proof_accumulator.collapse(
+            layouter,
+            &self.bls12_381_chip,
+            &self.native_gadget,
+        )?;
 
         let acc = AssignedAccumulator::assign(
             layouter,
@@ -555,14 +616,14 @@ impl IvcGadget {
         ]
         .concat();
 
-        // Verify a witnessed proof that ensures the validity of previous state.
-        // The proof is valid iff `proof_acc` satisfies the invariant.
-        let mut self_proof_acc = self.verifier_gadget.prepare(
+        // Verify a witnessed proof that ensures the validity of the previous state.
+        // The proof is valid iff `ivc_proof_accumulator` satisfies the invariant.
+        let mut ivc_proof_accumulator = self.verifier_gadget.prepare(
             layouter,
-            &global.self_vk,
+            &global.ivc_verification_key,
             &[("com_instance", id_point)],
             &[&assigned_pi],
-            self_proof.clone(),
+            ivc_proof.clone(),
         )?;
 
         // If the previous state is genesis, we allow the prover to change the (probably
@@ -571,17 +632,17 @@ impl IvcGadget {
             layouter,
             &self.native_gadget,
             is_not_genesis,
-            &mut self_proof_acc,
+            &mut ivc_proof_accumulator,
         )?;
-        self_proof_acc.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
+        ivc_proof_accumulator.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
 
-        // Accumulate the certificate_proof_accumulator
+        // Accumulate the certificate and IVC proof accumulators.
         let mut next_acc = AssignedAccumulator::<S>::accumulate(
             layouter,
             &self.verifier_gadget,
             &self.native_gadget,
             &self.poseidon_chip,
-            &[acc, certificate_proof_accumulator, self_proof_acc],
+            &[acc, certificate_proof_accumulator, ivc_proof_accumulator],
         )?;
         next_acc.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
 

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -267,8 +267,8 @@ impl IvcGadget {
     /// Verifies the genesis Schnorr signature in-circuit.
     ///
     /// Reconstructs the challenge via Poseidon hash over the genesis verification key,
-    /// the nonce commitment R, and the genesis message, then checks equality against
-    /// the committed challenge scalar from `witness.genesis_signature`.
+    /// the reconstructed nonce commitment, and the genesis message, then checks
+    /// equality against the committed challenge scalar from `witness.genesis_signature`.
     /// Returns an `AssignedBit` that is `true` when the signature is valid.
     pub fn is_genesis_signature_valid(
         &self,

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -76,12 +76,15 @@ type NG = NativeGadget<F, P2RDecompositionChip<F>, NativeChip<F>>;
 pub(crate) const K: u32 = 19;
 
 pub const PREIMAGE_SIZE: usize = 190;
-/// Byte range of the next Merkle root within the protocol message preimage.
-pub const PREIMAGE_NEXT_MERKLE_ROOT_BYTES: std::ops::Range<usize> = 69..101;
+/// Byte range of the next Merkle-tree commitment within the protocol message preimage.
+pub const PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES: std::ops::Range<usize> = 69..101;
 /// Byte range of the next protocol parameters within the protocol message preimage.
-pub const PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES: std::ops::Range<usize> = 137..169;
+pub const PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES: std::ops::Range<usize> = 137..169;
 /// Byte range of the current epoch within the protocol message preimage.
 pub const PREIMAGE_CURRENT_EPOCH_BYTES: std::ops::Range<usize> = 182..190;
+
+pub const PREIMAGE_NEXT_MERKLE_ROOT_BYTES: std::ops::Range<usize> = 69..101;
+pub const PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES: std::ops::Range<usize> = 137..169;
 
 pub(crate) const CERT_VK_NAME: &str = "cert_vk";
 pub(crate) const IVC_ONE_NAME: &str = "ivc_one_vk";

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -86,8 +86,12 @@ pub const PREIMAGE_CURRENT_EPOCH_BYTES: std::ops::Range<usize> = 182..190;
 pub const PREIMAGE_NEXT_MERKLE_ROOT_BYTES: std::ops::Range<usize> = 69..101;
 pub const PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES: std::ops::Range<usize> = 137..169;
 
-pub(crate) const CERT_VK_NAME: &str = "cert_vk";
-pub(crate) const IVC_ONE_NAME: &str = "ivc_one_vk";
+pub(crate) const CERTIFICATE_VERIFICATION_KEY_NAME: &str = "cert_vk";
+pub(crate) const IVC_VERIFICATION_KEY_NAME: &str = "ivc_one_vk";
+
+// Backward-compatible aliases for non-circuit callers; circuit-local code uses the aligned names.
+pub(crate) const CERT_VK_NAME: &str = CERTIFICATE_VERIFICATION_KEY_NAME;
+pub(crate) const IVC_ONE_NAME: &str = IVC_VERIFICATION_KEY_NAME;
 
 /// Circuit verification key of the recursive circuit used for production.
 /// It is created using the circuit verification key of the non-recursive

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -83,15 +83,8 @@ pub const PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES: std::ops::Range<usize> = 137.
 /// Byte range of the current epoch within the protocol message preimage.
 pub const PREIMAGE_CURRENT_EPOCH_BYTES: std::ops::Range<usize> = 182..190;
 
-pub const PREIMAGE_NEXT_MERKLE_ROOT_BYTES: std::ops::Range<usize> = 69..101;
-pub const PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES: std::ops::Range<usize> = 137..169;
-
 pub(crate) const CERTIFICATE_VERIFICATION_KEY_NAME: &str = "cert_vk";
 pub(crate) const IVC_VERIFICATION_KEY_NAME: &str = "ivc_one_vk";
-
-// Backward-compatible aliases for non-circuit callers; circuit-local code uses the aligned names.
-pub(crate) const CERT_VK_NAME: &str = CERTIFICATE_VERIFICATION_KEY_NAME;
-pub(crate) const IVC_ONE_NAME: &str = IVC_VERIFICATION_KEY_NAME;
 
 /// Circuit verification key of the recursive circuit used for production.
 /// It is created using the circuit verification key of the non-recursive

--- a/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
@@ -117,7 +117,7 @@ impl ProtocolMessage {
             .copy_from_slice(RIGID_NEXT_AGGREGATE_VERIFICATION_KEY_LABEL);
         cursor += RIGID_NEXT_AGGREGATE_VERIFICATION_KEY_LABEL.len();
 
-        // offset 69..113 — AVK slot; circuit reads Merkle root from PREIMAGE_NEXT_MERKLE_ROOT_BYTES (69..101)
+        // offset 69..113 — AVK slot; circuit reads Merkle-tree commitment from PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES (69..101)
         preimage[cursor..cursor + avk_slot.len()].copy_from_slice(&avk_slot);
         cursor += avk_slot.len();
 
@@ -126,7 +126,7 @@ impl ProtocolMessage {
             .copy_from_slice(RIGID_NEXT_PROTOCOL_PARAMETERS_LABEL);
         cursor += RIGID_NEXT_PROTOCOL_PARAMETERS_LABEL.len();
 
-        // offset 137..169 — params slot; circuit reads from PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES (137..169)
+        // offset 137..169 — params slot; circuit reads from PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES (137..169)
         preimage[cursor..cursor + params_slot.len()].copy_from_slice(&params_slot);
         cursor += params_slot.len();
 

--- a/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/protocol_message.rs
@@ -117,7 +117,7 @@ impl ProtocolMessage {
             .copy_from_slice(RIGID_NEXT_AGGREGATE_VERIFICATION_KEY_LABEL);
         cursor += RIGID_NEXT_AGGREGATE_VERIFICATION_KEY_LABEL.len();
 
-        // offset 69..113 — AVK slot; circuit reads Merkle-tree commitment from PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES (69..101)
+        // offset 69..113 — AVK slot; circuit reads the next Merkle-tree commitment from PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES (69..101)
         preimage[cursor..cursor + avk_slot.len()].copy_from_slice(&avk_slot);
         cursor += avk_slot.len();
 

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -110,30 +110,33 @@ impl AssignedState {
 pub(crate) struct Global {
     // Persistent values that do not change through an ivc stream
     pub(crate) genesis_message: MessageHash,
-    pub(crate) genesis_vk: SchnorrVerificationKey,
-    // cert_vk hash
-    pub(crate) cert_vk_repr: CertificateCircuitVerificationKeyRepresentation,
-    // ivc_vk hash
-    pub(crate) self_vk_repr: IvcCircuitVerificationKeyRepresentation,
+    pub(crate) genesis_verification_key: SchnorrVerificationKey,
+    // Certificate circuit verification key transcript representation.
+    pub(crate) certificate_circuit_verification_key_representation:
+        CertificateCircuitVerificationKeyRepresentation,
+    // IVC circuit verification key transcript representation.
+    pub(crate) ivc_circuit_verification_key_representation: IvcCircuitVerificationKeyRepresentation,
 }
 
 impl Global {
     #[allow(dead_code)]
     pub(crate) fn new(
         genesis_message: MessageHash,
-        genesis_vk: SchnorrVerificationKey,
-        cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
-        self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+        genesis_verification_key: SchnorrVerificationKey,
+        certificate_verification_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+        ivc_verification_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
     ) -> Self {
         Global {
             genesis_message,
-            genesis_vk,
-            cert_vk_repr: CertificateCircuitVerificationKeyRepresentation::from_field(
-                cert_vk.transcript_repr(),
-            ),
-            self_vk_repr: IvcCircuitVerificationKeyRepresentation::from_field(
-                self_vk.transcript_repr(),
-            ),
+            genesis_verification_key,
+            certificate_circuit_verification_key_representation:
+                CertificateCircuitVerificationKeyRepresentation::from_field(
+                    certificate_verification_key.transcript_repr(),
+                ),
+            ivc_circuit_verification_key_representation:
+                IvcCircuitVerificationKeyRepresentation::from_field(
+                    ivc_verification_key.transcript_repr(),
+                ),
         }
     }
 
@@ -141,8 +144,13 @@ impl Global {
     pub(crate) fn as_public_input(&self) -> Vec<F> {
         [
             vec![self.genesis_message.as_field()],
-            AssignedNativePoint::<Jubjub>::as_public_input(self.genesis_vk.as_jubjub_subgroup()),
-            vec![self.cert_vk_repr.as_field(), self.self_vk_repr.as_field()],
+            AssignedNativePoint::<Jubjub>::as_public_input(
+                self.genesis_verification_key.as_jubjub_subgroup(),
+            ),
+            vec![
+                self.certificate_circuit_verification_key_representation.as_field(),
+                self.ivc_circuit_verification_key_representation.as_field(),
+            ],
         ]
         .concat()
     }
@@ -152,16 +160,16 @@ impl Global {
 pub(crate) struct AssignedGlobal {
     //Persistent values that do not change through an ivc stream
     pub(crate) genesis_message: AssignedNative<F>,
-    pub(crate) genesis_vk: AssignedNativePoint<Jubjub>,
-    pub(crate) cert_vk: AssignedVk<S>,
-    pub(crate) self_vk: AssignedVk<S>,
-    // Combined fixed base names for cert_vk and ivc_vk
+    pub(crate) genesis_verification_key: AssignedNativePoint<Jubjub>,
+    pub(crate) certificate_verification_key: AssignedVk<S>,
+    pub(crate) ivc_verification_key: AssignedVk<S>,
+    // Combined fixed base names for certificate and IVC verification keys.
     pub(crate) fixed_base_names: Vec<String>,
 }
 
 #[derive(Clone, Debug)]
 pub(crate) struct Witness {
-    pub(crate) genesis_sig: StandardSchnorrSignature,
+    pub(crate) genesis_signature: StandardSchnorrSignature,
     pub(crate) certificate_message: MessageHash,
     pub(crate) certificate_merkle_tree_commitment: MerkleTreeCommitment,
     // Protocol message preimage bytes
@@ -171,13 +179,13 @@ pub(crate) struct Witness {
 impl Witness {
     #[allow(dead_code)]
     pub(crate) fn new(
-        genesis_sig: StandardSchnorrSignature,
+        genesis_signature: StandardSchnorrSignature,
         certificate_merkle_tree_commitment: MerkleTreeCommitment,
         certificate_message: MessageHash,
         message_preimage: ProtocolMessagePreimage,
     ) -> Self {
         Witness {
-            genesis_sig,
+            genesis_signature,
             certificate_merkle_tree_commitment,
             certificate_message,
             message_preimage,
@@ -187,7 +195,7 @@ impl Witness {
 
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedWitness {
-    pub(crate) genesis_sig: (AssignedScalarOfNativeCurve<Jubjub>, AssignedNative<F>),
+    pub(crate) genesis_signature: (AssignedScalarOfNativeCurve<Jubjub>, AssignedNative<F>),
     pub(crate) certificate_merkle_tree_commitment: AssignedNative<F>,
     pub(crate) certificate_message: AssignedNative<F>,
     // Protocol message preimage bytes

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -180,14 +180,14 @@ impl Witness {
     #[allow(dead_code)]
     pub(crate) fn new(
         genesis_signature: StandardSchnorrSignature,
-        certificate_merkle_tree_commitment: MerkleTreeCommitment,
         certificate_message: MessageHash,
+        certificate_merkle_tree_commitment: MerkleTreeCommitment,
         message_preimage: ProtocolMessagePreimage,
     ) -> Self {
         Witness {
             genesis_signature,
-            certificate_merkle_tree_commitment,
             certificate_message,
+            certificate_merkle_tree_commitment,
             message_preimage,
         }
     }
@@ -196,8 +196,8 @@ impl Witness {
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedWitness {
     pub(crate) genesis_signature: (AssignedScalarOfNativeCurve<Jubjub>, AssignedNative<F>),
-    pub(crate) certificate_merkle_tree_commitment: AssignedNative<F>,
     pub(crate) certificate_message: AssignedNative<F>,
+    pub(crate) certificate_merkle_tree_commitment: AssignedNative<F>,
     // Protocol message preimage bytes
     pub(crate) message_preimage: Vec<AssignedByte<F>>,
 }

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -19,45 +19,45 @@ use super::{
 
 #[derive(Clone, Debug)]
 pub(crate) struct State {
-    pub(crate) counter: StepCounter,
-    pub(crate) msg: MessageHash,
-    pub(crate) merkle_root: MerkleTreeCommitment,
-    pub(crate) next_merkle_root: MerkleTreeCommitment,
-    pub(crate) protocol_params: ProtocolParametersHash,
-    pub(crate) next_protocol_params: ProtocolParametersHash,
+    pub(crate) step_counter: StepCounter,
+    pub(crate) message: MessageHash,
+    pub(crate) merkle_tree_commitment: MerkleTreeCommitment,
+    pub(crate) next_merkle_tree_commitment: MerkleTreeCommitment,
+    pub(crate) protocol_parameters: ProtocolParametersHash,
+    pub(crate) next_protocol_parameters: ProtocolParametersHash,
     pub(crate) current_epoch: EpochNumber,
 }
 
 impl State {
     #[allow(dead_code)]
     pub(crate) fn new(
-        counter: StepCounter,
-        msg: MessageHash,
-        merkle_root: MerkleTreeCommitment,
-        next_merkle_root: MerkleTreeCommitment,
-        protocol_params: ProtocolParametersHash,
-        next_protocol_params: ProtocolParametersHash,
+        step_counter: StepCounter,
+        message: MessageHash,
+        merkle_tree_commitment: MerkleTreeCommitment,
+        next_merkle_tree_commitment: MerkleTreeCommitment,
+        protocol_parameters: ProtocolParametersHash,
+        next_protocol_parameters: ProtocolParametersHash,
         current_epoch: EpochNumber,
     ) -> Self {
         State {
-            counter,
-            msg,
-            merkle_root,
-            next_merkle_root,
-            protocol_params,
-            next_protocol_params,
+            step_counter,
+            message,
+            merkle_tree_commitment,
+            next_merkle_tree_commitment,
+            protocol_parameters,
+            next_protocol_parameters,
             current_epoch,
         }
     }
 
     pub(crate) fn genesis() -> Self {
         State {
-            counter: StepCounter::ZERO,
-            msg: MessageHash::ZERO,
-            merkle_root: MerkleTreeCommitment::ZERO,
-            next_merkle_root: MerkleTreeCommitment::ZERO,
-            protocol_params: ProtocolParametersHash::ZERO,
-            next_protocol_params: ProtocolParametersHash::ZERO,
+            step_counter: StepCounter::ZERO,
+            message: MessageHash::ZERO,
+            merkle_tree_commitment: MerkleTreeCommitment::ZERO,
+            next_merkle_tree_commitment: MerkleTreeCommitment::ZERO,
+            protocol_parameters: ProtocolParametersHash::ZERO,
+            next_protocol_parameters: ProtocolParametersHash::ZERO,
             current_epoch: EpochNumber::ZERO,
         }
     }
@@ -66,14 +66,14 @@ impl State {
     pub(crate) fn as_public_input(&self) -> Vec<F> {
         let state = self.clone();
         // Public-input order is part of the recursive circuit statement contract:
-        // [counter, msg, merkle_root, next_merkle_root, protocol_params, next_protocol_params, current_epoch].
+        // [step_counter, message, merkle_tree_commitment, next_merkle_tree_commitment, protocol_parameters, next_protocol_parameters, current_epoch].
         vec![
-            state.counter.as_field(),
-            state.msg.as_field(),
-            state.merkle_root.as_field(),
-            state.next_merkle_root.as_field(),
-            state.protocol_params.as_field(),
-            state.next_protocol_params.as_field(),
+            state.step_counter.as_field(),
+            state.message.as_field(),
+            state.merkle_tree_commitment.as_field(),
+            state.next_merkle_tree_commitment.as_field(),
+            state.protocol_parameters.as_field(),
+            state.next_protocol_parameters.as_field(),
             state.current_epoch.as_field(),
         ]
     }
@@ -82,12 +82,12 @@ impl State {
 /// In-circuit counterpart of [`State`].
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedState {
-    pub(crate) counter: AssignedNative<F>,
-    pub(crate) msg: AssignedNative<F>,
-    pub(crate) merkle_root: AssignedNative<F>,
-    pub(crate) next_merkle_root: AssignedNative<F>,
-    pub(crate) protocol_params: AssignedNative<F>,
-    pub(crate) next_protocol_params: AssignedNative<F>,
+    pub(crate) step_counter: AssignedNative<F>,
+    pub(crate) message: AssignedNative<F>,
+    pub(crate) merkle_tree_commitment: AssignedNative<F>,
+    pub(crate) next_merkle_tree_commitment: AssignedNative<F>,
+    pub(crate) protocol_parameters: AssignedNative<F>,
+    pub(crate) next_protocol_parameters: AssignedNative<F>,
     pub(crate) current_epoch: AssignedNative<F>,
 }
 
@@ -95,12 +95,12 @@ impl AssignedState {
     pub(crate) fn as_public_input(&self) -> Vec<AssignedNative<F>> {
         let state = self.clone();
         vec![
-            state.counter,
-            state.msg,
-            state.merkle_root,
-            state.next_merkle_root,
-            state.protocol_params,
-            state.next_protocol_params,
+            state.step_counter,
+            state.message,
+            state.merkle_tree_commitment,
+            state.next_merkle_tree_commitment,
+            state.protocol_parameters,
+            state.next_protocol_parameters,
             state.current_epoch,
         ]
     }
@@ -109,7 +109,7 @@ impl AssignedState {
 #[derive(Clone, Debug)]
 pub(crate) struct Global {
     // Persistent values that do not change through an ivc stream
-    pub(crate) genesis_msg: MessageHash,
+    pub(crate) genesis_message: MessageHash,
     pub(crate) genesis_vk: SchnorrVerificationKey,
     // cert_vk hash
     pub(crate) cert_vk_repr: CertificateCircuitVerificationKeyRepresentation,
@@ -120,13 +120,13 @@ pub(crate) struct Global {
 impl Global {
     #[allow(dead_code)]
     pub(crate) fn new(
-        genesis_msg: MessageHash,
+        genesis_message: MessageHash,
         genesis_vk: SchnorrVerificationKey,
         cert_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
         self_vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
     ) -> Self {
         Global {
-            genesis_msg,
+            genesis_message,
             genesis_vk,
             cert_vk_repr: CertificateCircuitVerificationKeyRepresentation::from_field(
                 cert_vk.transcript_repr(),
@@ -140,7 +140,7 @@ impl Global {
     #[allow(dead_code)]
     pub(crate) fn as_public_input(&self) -> Vec<F> {
         [
-            vec![self.genesis_msg.as_field()],
+            vec![self.genesis_message.as_field()],
             AssignedNativePoint::<Jubjub>::as_public_input(self.genesis_vk.as_jubjub_subgroup()),
             vec![self.cert_vk_repr.as_field(), self.self_vk_repr.as_field()],
         ]
@@ -151,7 +151,7 @@ impl Global {
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedGlobal {
     //Persistent values that do not change through an ivc stream
-    pub(crate) genesis_msg: AssignedNative<F>,
+    pub(crate) genesis_message: AssignedNative<F>,
     pub(crate) genesis_vk: AssignedNativePoint<Jubjub>,
     pub(crate) cert_vk: AssignedVk<S>,
     pub(crate) self_vk: AssignedVk<S>,
@@ -162,25 +162,25 @@ pub(crate) struct AssignedGlobal {
 #[derive(Clone, Debug)]
 pub(crate) struct Witness {
     pub(crate) genesis_sig: StandardSchnorrSignature,
-    pub(crate) cert_msg: MessageHash,
-    pub(crate) cert_merkle_root: MerkleTreeCommitment,
-    // Protocol msg preimage bytes
-    pub(crate) msg_preimage: ProtocolMessagePreimage,
+    pub(crate) certificate_message: MessageHash,
+    pub(crate) certificate_merkle_tree_commitment: MerkleTreeCommitment,
+    // Protocol message preimage bytes
+    pub(crate) message_preimage: ProtocolMessagePreimage,
 }
 
 impl Witness {
     #[allow(dead_code)]
     pub(crate) fn new(
         genesis_sig: StandardSchnorrSignature,
-        cert_merkle_root: MerkleTreeCommitment,
-        cert_msg: MessageHash,
-        msg_preimage: ProtocolMessagePreimage,
+        certificate_merkle_tree_commitment: MerkleTreeCommitment,
+        certificate_message: MessageHash,
+        message_preimage: ProtocolMessagePreimage,
     ) -> Self {
         Witness {
             genesis_sig,
-            cert_merkle_root,
-            cert_msg,
-            msg_preimage,
+            certificate_merkle_tree_commitment,
+            certificate_message,
+            message_preimage,
         }
     }
 }
@@ -188,10 +188,10 @@ impl Witness {
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedWitness {
     pub(crate) genesis_sig: (AssignedScalarOfNativeCurve<Jubjub>, AssignedNative<F>),
-    pub(crate) cert_merkle_root: AssignedNative<F>,
-    pub(crate) cert_msg: AssignedNative<F>,
-    // Protocol msg preimage bytes
-    pub(crate) msg_preimage: Vec<AssignedByte<F>>,
+    pub(crate) certificate_merkle_tree_commitment: AssignedNative<F>,
+    pub(crate) certificate_message: AssignedNative<F>,
+    // Protocol message preimage bytes
+    pub(crate) message_preimage: Vec<AssignedByte<F>>,
 }
 
 pub(crate) fn trivial_acc(fixed_base_names: &[String]) -> Accumulator<S> {

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
@@ -16,7 +16,7 @@ use midnight_zk_stdlib::MidnightVK;
 use crate::StmResult;
 use crate::circuits::halo2_ivc::{
     Accumulator, C, E, F, KZGCommitmentScheme, S, VerifyingKey,
-    circuit::IvcCircuit,
+    circuit::IvcCircuitData,
     io::{Read as IvcRead, Write as IvcWrite},
     state::State,
     types::{
@@ -35,7 +35,7 @@ pub(crate) struct RecursiveChainStateAsset {
     /// Stored recursive state checkpoint.
     pub(crate) state: State,
     /// Stored previous recursive proof bytes.
-    pub(crate) proof: IvcProofBytes,
+    pub(crate) ivc_proof: IvcProofBytes,
     /// Stored folded accumulator for the checkpoint.
     pub(crate) accumulator: Accumulator<S>,
 }
@@ -61,7 +61,7 @@ pub(crate) struct VerificationContextAsset {
 #[derive(Debug)]
 pub(crate) struct RecursiveStepOutputAsset {
     /// Stored final recursive proof bytes for the next step.
-    pub(crate) proof: IvcProofBytes,
+    pub(crate) ivc_proof: IvcProofBytes,
     /// Stored folded accumulator after extending the chain by one step.
     pub(crate) next_accumulator: Accumulator<S>,
     /// Stored next recursive state.
@@ -193,13 +193,13 @@ fn load_recursive_chain_state_asset_from_reader<R: Read>(
         .map(|_| read_field_element(reader))
         .collect::<Result<Vec<_>, _>>()?;
     let state = read_state_public_input(reader)?;
-    let proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
+    let ivc_proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
     let accumulator = Accumulator::<S>::read(reader, SerdeFormat::RawBytesUnchecked)?;
 
     Ok(RecursiveChainStateAsset {
         global_field_elements,
         state,
-        proof,
+        ivc_proof,
         accumulator,
     })
 }
@@ -243,7 +243,7 @@ pub(crate) fn store_recursive_chain_state_asset(
         write_field_element(&mut writer, value)?;
     }
     write_state_public_input(&mut writer, &asset.state)?;
-    write_length_prefixed_proof(&mut writer, asset.proof.as_bytes())?;
+    write_length_prefixed_proof(&mut writer, asset.ivc_proof.as_bytes())?;
     asset.accumulator.write(&mut writer, SerdeFormat::RawBytesUnchecked)?;
     writer.flush().with_context(|| {
         format!(
@@ -266,14 +266,13 @@ fn load_verification_context_asset_from_reader<R: Read>(
     let global_field_elements = (0..5)
         .map(|_| read_field_element(reader))
         .collect::<Result<Vec<_>, _>>()?;
-    let recursive_verifying_key = VerifyingKey::<F, KZGCommitmentScheme<E>>::read::<_, IvcCircuit>(
-        reader,
-        SerdeFormat::RawBytesUnchecked,
-        (),
-    )?;
+    let recursive_verifying_key = VerifyingKey::<F, KZGCommitmentScheme<E>>::read::<
+        _,
+        IvcCircuitData,
+    >(reader, SerdeFormat::RawBytesUnchecked, ())?;
     let combined_fixed_bases = read_named_fixed_bases(reader)?;
 
-    // verifier_params is length-prefixed so certificate_vk can follow it.
+    // verifier_params is length-prefixed so the certificate verification key can follow it.
     let verifier_param_bytes = read_length_prefixed_proof(reader)?;
 
     let mut verifier_params_reader = Cursor::new(&verifier_param_bytes);
@@ -287,9 +286,11 @@ fn load_verification_context_asset_from_reader<R: Read>(
     let verifier_tau_in_g2 =
         <E as Engine>::G2::read(&mut verifier_tau_reader, SerdeFormat::RawBytesUnchecked)?.into();
 
-    let cert_vk_bytes = read_length_prefixed_proof(reader)?;
-    let certificate_verifying_key =
-        MidnightVK::read(&mut cert_vk_bytes.as_slice(), SerdeFormat::RawBytes)?;
+    let certificate_verification_key_bytes = read_length_prefixed_proof(reader)?;
+    let certificate_verifying_key = MidnightVK::read(
+        &mut certificate_verification_key_bytes.as_slice(),
+        SerdeFormat::RawBytes,
+    )?;
 
     Ok(VerificationContextAsset {
         global_field_elements,
@@ -330,18 +331,18 @@ pub(crate) fn store_verification_context_asset(
         .write(&mut writer, SerdeFormat::RawBytesUnchecked)?;
     write_named_fixed_bases(&mut writer, &asset.combined_fixed_bases)?;
 
-    // Buffer verifier_params to write with a length prefix so certificate_vk can follow.
+    // Buffer verifier_params to write with a length prefix so the certificate verification key can follow.
     let mut verifier_params_buf = Vec::new();
     asset
         .verifier_params
         .write(&mut verifier_params_buf, SerdeFormat::RawBytesUnchecked)?;
     write_length_prefixed_proof(&mut writer, &verifier_params_buf)?;
 
-    let mut cert_vk_buf = Vec::new();
+    let mut certificate_verification_key_buf = Vec::new();
     asset
         .certificate_verifying_key
-        .write(&mut cert_vk_buf, SerdeFormat::RawBytes)?;
-    write_length_prefixed_proof(&mut writer, &cert_vk_buf)?;
+        .write(&mut certificate_verification_key_buf, SerdeFormat::RawBytes)?;
+    write_length_prefixed_proof(&mut writer, &certificate_verification_key_buf)?;
 
     writer.flush().with_context(|| {
         format!(
@@ -356,7 +357,7 @@ pub(crate) fn store_verification_context_asset(
 fn load_recursive_step_output_asset_from_reader<R: Read>(
     reader: &mut R,
 ) -> StmResult<RecursiveStepOutputAsset> {
-    let proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
+    let ivc_proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
     let next_accumulator = Accumulator::<S>::read(reader, SerdeFormat::RawBytesUnchecked)?;
     let next_state = read_state_public_input(reader)?;
     let certificate_proof = CertificateProofBytes::from_certificate_circuit_proof_bytes(
@@ -364,7 +365,7 @@ fn load_recursive_step_output_asset_from_reader<R: Read>(
     );
 
     Ok(RecursiveStepOutputAsset {
-        proof,
+        ivc_proof,
         next_accumulator,
         next_state,
         certificate_proof,
@@ -404,7 +405,7 @@ pub(crate) fn store_recursive_step_output_asset(
         )
     })?;
 
-    write_length_prefixed_proof(&mut writer, asset.proof.as_bytes())?;
+    write_length_prefixed_proof(&mut writer, asset.ivc_proof.as_bytes())?;
     asset
         .next_accumulator
         .write(&mut writer, SerdeFormat::RawBytesUnchecked)?;

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -23,7 +23,7 @@ use crate::circuits::halo2_ivc::tests::common::asset_readers::{
 };
 use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, C, E, F, S,
-    circuit::IvcCircuit,
+    circuit::IvcCircuitData,
     state::{Global, State, trivial_acc},
     types::{CertificateProofBytes, IvcProofBytes},
 };
@@ -37,7 +37,7 @@ struct CertificateChainArtifacts {
 
 struct RecursiveChainSnapshot {
     state: State,
-    proof: IvcProofBytes,
+    ivc_proof: IvcProofBytes,
     accumulator: Accumulator<S>,
 }
 
@@ -121,7 +121,7 @@ fn build_recursive_chain_snapshot(
             INITIAL_CHAIN_LENGTH + 1
         );
         let recursive_step_start = Instant::now();
-        let circuit = IvcCircuit::try_new(
+        let ivc_circuit_data = IvcCircuitData::try_new(
             global.clone(),
             current_state.clone(),
             artifacts.recursive_witnesses[i].clone(),
@@ -131,7 +131,7 @@ fn build_recursive_chain_snapshot(
             context.certificate_verifying_key.vk(),
             &context.recursive_verifying_key,
         )
-        .expect("valid IvcCircuit construction");
+        .expect("valid IvcCircuitData construction");
 
         let public_inputs = [
             global.as_public_input(),
@@ -143,7 +143,7 @@ fn build_recursive_chain_snapshot(
         let proof = prove_poseidon_ivc(
             &context.recursive_commitment_parameters,
             recursive_proving_key,
-            &circuit,
+            &ivc_circuit_data,
             &public_inputs,
             &mut recursive_random_generator,
         );
@@ -192,7 +192,7 @@ fn build_recursive_chain_snapshot(
 
     RecursiveChainSnapshot {
         state: current_state,
-        proof: recursive_proof,
+        ivc_proof: recursive_proof,
         accumulator: current_accumulator,
     }
 }
@@ -210,7 +210,7 @@ fn store_recursive_chain_snapshot(
     let asset = RecursiveChainStateAsset {
         global_field_elements: global.as_public_input(),
         state: snapshot.state.clone(),
-        proof: snapshot.proof.clone(),
+        ivc_proof: snapshot.ivc_proof.clone(),
         accumulator: snapshot.accumulator.clone(),
     };
     store_recursive_chain_state_asset(&paths.recursive_chain_state, &asset)
@@ -258,7 +258,7 @@ fn build_next_recursive_step_inputs(
     .concat();
     let previous_dual_msm = verify_prepare_poseidon_ivc(
         &context.recursive_verifying_key,
-        recursive_chain_state.proof.as_bytes(),
+        recursive_chain_state.ivc_proof.as_bytes(),
         &previous_public_inputs,
     );
     assert!(previous_dual_msm.clone().check(&context.universal_verifier_params));
@@ -297,17 +297,17 @@ fn build_recursive_step_output_proof(
     next_step_inputs: &NextRecursiveStepInputs,
 ) -> Vec<u8> {
     let mut recursive_step_output_random_generator = OsRng;
-    let circuit = IvcCircuit::try_new(
+    let ivc_circuit_data = IvcCircuitData::try_new(
         global.clone(),
         recursive_chain_state.state.clone(),
         next_step_inputs.recursive_witness.clone(),
         next_step_inputs.certificate_proof.clone(),
-        recursive_chain_state.proof.clone(),
+        recursive_chain_state.ivc_proof.clone(),
         recursive_chain_state.accumulator.clone(),
         context.certificate_verifying_key.vk(),
         &context.recursive_verifying_key,
     )
-    .expect("valid IvcCircuit construction");
+    .expect("valid IvcCircuitData construction");
     let public_inputs = [
         global.as_public_input(),
         next_step_inputs.next_state.as_public_input(),
@@ -320,7 +320,7 @@ fn build_recursive_step_output_proof(
     let final_proof = prove_blake2b_ivc(
         &context.recursive_commitment_parameters,
         recursive_proving_key,
-        &circuit,
+        &ivc_circuit_data,
         &public_inputs,
         &mut recursive_step_output_random_generator,
     );
@@ -347,7 +347,7 @@ fn store_recursive_step_output(
         paths.recursive_step_output.display()
     );
     let asset = RecursiveStepOutputAsset {
-        proof: IvcProofBytes::new(proof),
+        ivc_proof: IvcProofBytes::new(proof),
         next_accumulator: next_step_inputs.next_accumulator,
         next_state: next_step_inputs.next_state,
         certificate_proof: next_step_inputs.certificate_proof,
@@ -517,7 +517,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
     let current_accumulator = trivial_acc(&combined_fixed_base_names);
     let next_accumulator = current_accumulator.clone();
 
-    let circuit = IvcCircuit::try_new(
+    let ivc_circuit_data = IvcCircuitData::try_new(
         global.clone(),
         State::genesis(),
         genesis_witness,
@@ -527,7 +527,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
         context.certificate_verifying_key.vk(),
         &context.recursive_verifying_key,
     )
-    .expect("valid IvcCircuit construction");
+    .expect("valid IvcCircuitData construction");
 
     let public_inputs = [
         global.as_public_input(),
@@ -542,7 +542,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
     let proof = prove_blake2b_ivc(
         &context.recursive_commitment_parameters,
         &recursive_proving_key,
-        &circuit,
+        &ivc_circuit_data,
         &public_inputs,
         &mut rng,
     );
@@ -562,7 +562,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
         paths.genesis_step_output.display()
     );
     let asset = RecursiveStepOutputAsset {
-        proof: IvcProofBytes::new(proof),
+        ivc_proof: IvcProofBytes::new(proof),
         next_accumulator,
         next_state: genesis_next_state,
         certificate_proof: CertificateProofBytes::empty(),
@@ -631,7 +631,7 @@ pub(crate) fn generate_same_epoch_step_output_asset(
     .concat();
     let previous_dual_msm = verify_prepare_poseidon_ivc(
         &context.recursive_verifying_key,
-        chain_state.proof.as_bytes(),
+        chain_state.ivc_proof.as_bytes(),
         &previous_public_inputs,
     );
     assert!(
@@ -656,17 +656,17 @@ pub(crate) fn generate_same_epoch_step_output_asset(
         "same-epoch next accumulator check failed"
     );
 
-    let circuit = IvcCircuit::try_new(
+    let ivc_circuit_data = IvcCircuitData::try_new(
         global.clone(),
         chain_state.state.clone(),
         ivc_witness,
         certificate_proof.clone(),
-        chain_state.proof.clone(),
+        chain_state.ivc_proof.clone(),
         chain_state.accumulator.clone(),
         context.certificate_verifying_key.vk(),
         &context.recursive_verifying_key,
     )
-    .expect("valid IvcCircuit construction");
+    .expect("valid IvcCircuitData construction");
 
     let public_inputs = [
         global.as_public_input(),
@@ -680,7 +680,7 @@ pub(crate) fn generate_same_epoch_step_output_asset(
     let proof = prove_blake2b_ivc(
         &context.recursive_commitment_parameters,
         &recursive_proving_key,
-        &circuit,
+        &ivc_circuit_data,
         &public_inputs,
         &mut rng,
     );
@@ -700,7 +700,7 @@ pub(crate) fn generate_same_epoch_step_output_asset(
         paths.same_epoch_step_output.display()
     );
     let asset = RecursiveStepOutputAsset {
-        proof: IvcProofBytes::new(proof),
+        ivc_proof: IvcProofBytes::new(proof),
         next_accumulator,
         next_state,
         certificate_proof,
@@ -719,8 +719,8 @@ pub(crate) fn generate_same_epoch_step_output_asset(
 //
 // Committed assets:
 //   verification_context.bin               — VKs, combined fixed bases, verifier params, tau_g2
-//   recursive_chain_state.bin              — chain checkpoint: Poseidon proof, state, folded accumulator
-//   recursive_step_output.bin              — next-epoch step: proof, next_state, next_accumulator, cert proof
+//   recursive_chain_state.bin              — chain checkpoint: Poseidon IVC proof, state, folded accumulator
+//   recursive_step_output.bin              — next-epoch step: IVC proof, next_state, next_accumulator, certificate proof
 //   genesis_step_output.bin                — genesis step output
 //   same_epoch_step_output.bin             — same-epoch step output
 //   recursive_step_output_accumulator_bytes.bin — raw serialized bytes of recursive_step_output.next_accumulator

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -185,9 +185,9 @@ fn build_recursive_chain_snapshot(
     }
 
     assert_eq!(
-        current_state.next_merkle_root.as_field(),
-        setup.genesis_next_merkle_root,
-        "recursive_chain_state writer is about to persist a next_merkle_root that does not match setup"
+        current_state.next_merkle_tree_commitment.as_field(),
+        setup.genesis_next_merkle_tree_commitment,
+        "recursive_chain_state writer is about to persist a next_merkle_tree_commitment that does not match setup"
     );
 
     RecursiveChainSnapshot {
@@ -219,9 +219,9 @@ fn store_recursive_chain_snapshot(
     let reloaded = load_recursive_chain_state_asset(&paths.recursive_chain_state)
         .expect("failed to reload recursive_chain_state asset after writing");
     assert_eq!(
-        reloaded.state.next_merkle_root.as_field(),
-        setup.genesis_next_merkle_root,
-        "reloaded recursive_chain_state next_merkle_root does not match setup"
+        reloaded.state.next_merkle_tree_commitment.as_field(),
+        setup.genesis_next_merkle_tree_commitment,
+        "reloaded recursive_chain_state next_merkle_tree_commitment does not match setup"
     );
 }
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/proofs.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/proofs.rs
@@ -12,13 +12,13 @@ use midnight_proofs::{
 };
 use rand_core::{CryptoRng, RngCore};
 
-use crate::circuits::halo2_ivc::{C, E, F, circuit::IvcCircuit};
+use crate::circuits::halo2_ivc::{C, E, F, circuit::IvcCircuitData};
 
 /// Generates a recursive proof using the chosen transcript hash.
 fn prove_ivc_with_transcript<H: TranscriptHash>(
     commitment_parameters: &ParamsKZG<Bls12>,
     proving_key: &ProvingKey<F, KZGCommitmentScheme<E>>,
-    circuit: &IvcCircuit,
+    ivc_circuit_data: &IvcCircuitData,
     public_inputs: &[F],
     random_generator: &mut (impl RngCore + CryptoRng),
     proof_generation_error: &str,
@@ -28,10 +28,10 @@ where
     <KZGCommitmentScheme<E> as PolynomialCommitmentScheme<F>>::Commitment: Hashable<H>,
 {
     let mut transcript = CircuitTranscript::<H>::init();
-    create_proof::<F, KZGCommitmentScheme<E>, CircuitTranscript<H>, IvcCircuit>(
+    create_proof::<F, KZGCommitmentScheme<E>, CircuitTranscript<H>, IvcCircuitData>(
         commitment_parameters,
         proving_key,
-        std::slice::from_ref(circuit),
+        std::slice::from_ref(ivc_circuit_data),
         1,
         &[&[&[], public_inputs]],
         random_generator,
@@ -69,14 +69,14 @@ where
 pub(crate) fn prove_poseidon_ivc(
     commitment_parameters: &ParamsKZG<Bls12>,
     proving_key: &ProvingKey<F, KZGCommitmentScheme<E>>,
-    circuit: &IvcCircuit,
+    ivc_circuit_data: &IvcCircuitData,
     public_inputs: &[F],
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> Vec<u8> {
     prove_ivc_with_transcript::<PoseidonState<F>>(
         commitment_parameters,
         proving_key,
-        circuit,
+        ivc_circuit_data,
         public_inputs,
         random_generator,
         "IVC proof generation should not fail",
@@ -102,14 +102,14 @@ pub(crate) fn verify_prepare_poseidon_ivc(
 pub(crate) fn prove_blake2b_ivc(
     commitment_parameters: &ParamsKZG<Bls12>,
     proving_key: &ProvingKey<F, KZGCommitmentScheme<E>>,
-    circuit: &IvcCircuit,
+    ivc_circuit_data: &IvcCircuitData,
     public_inputs: &[F],
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> Vec<u8> {
     prove_ivc_with_transcript::<blake2b_simd::State>(
         commitment_parameters,
         proving_key,
-        circuit,
+        ivc_circuit_data,
         public_inputs,
         random_generator,
         "IVC Blake2b proof generation should not fail",

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -99,10 +99,10 @@ pub(crate) struct AssetGenerationSetup {
     /// Deterministic aggregate verification key committed by generated protocol messages.
     pub(crate) aggregate_verification_key:
         AggregateVerificationKeyForSnark<MithrilMembershipDigest>,
-    /// Deterministic next Merkle root committed by the genesis message.
-    pub(crate) genesis_next_merkle_root: F,
+    /// Deterministic next Merkle-tree commitment committed by the genesis message.
+    pub(crate) genesis_next_merkle_tree_commitment: F,
     /// Deterministic next protocol parameters committed by the genesis message.
-    pub(crate) genesis_next_protocol_params: F,
+    pub(crate) genesis_next_protocol_parameters: F,
 }
 
 /// Shared recursive verifier-side setup reused by generators and golden helpers.
@@ -146,7 +146,7 @@ fn build_merkle_tree(
     (signing_keys, merkle_tree_leaves, merkle_tree)
 }
 
-fn merkle_root_from_stm_tree(merkle_tree: &SignerRegistrationMerkleTree) -> F {
+fn merkle_tree_commitment_from_stm_tree(merkle_tree: &SignerRegistrationMerkleTree) -> F {
     let commitment = merkle_tree.to_merkle_tree_commitment();
     // `MidnightPoseidonDigest` emits Jubjub base-field roots with `to_bytes_le()`;
     // the recursive state stores the same root as the circuit field element.
@@ -154,10 +154,10 @@ fn merkle_root_from_stm_tree(merkle_tree: &SignerRegistrationMerkleTree) -> F {
         .root
         .as_slice()
         .try_into()
-        .expect("STM Poseidon Merkle root should be 32 bytes");
+        .expect("STM Poseidon Merkle-tree commitment should be 32 bytes");
     F::from_bytes_le(&root_bytes)
         .into_option()
-        .expect("STM Poseidon Merkle root should be a canonical field element")
+        .expect("STM Poseidon Merkle-tree commitment should be a canonical field element")
 }
 
 /// Builds the shared universal KZG parameters that both circuits derive from.
@@ -287,7 +287,7 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
     )
     .expect("certificate relation construction should not fail");
     let (signing_keys, merkle_tree_leaves, merkle_tree) = build_merkle_tree(&mut rng, SIGNER_COUNT);
-    let genesis_next_merkle_root = merkle_root_from_stm_tree(&merkle_tree);
+    let genesis_next_merkle_tree_commitment = merkle_tree_commitment_from_stm_tree(&merkle_tree);
 
     let aggregate_verification_key = {
         let commitment = merkle_tree.to_merkle_tree_commitment();
@@ -306,12 +306,12 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
     let genesis_verification_key =
         SchnorrVerificationKey::new_from_signing_key(genesis_signing_key.clone());
     let genesis_epoch = GENESIS_EPOCH;
-    let genesis_next_protocol_params = F::from(7u64);
+    let genesis_next_protocol_parameters = F::from(7u64);
 
     let genesis_message = {
         let protocol_message = build_genesis_protocol_message(
             &aggregate_verification_key,
-            genesis_next_protocol_params.to_bytes_le(),
+            genesis_next_protocol_parameters.to_bytes_le(),
             genesis_epoch,
         );
         let preimage = protocol_message
@@ -338,7 +338,7 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
         merkle_tree_leaves,
         signing_keys,
         aggregate_verification_key,
-        genesis_next_merkle_root,
-        genesis_next_protocol_params,
+        genesis_next_merkle_tree_commitment,
+        genesis_next_protocol_parameters,
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -20,7 +20,8 @@ use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2_ivc::state::fixed_bases_and_names;
 use crate::circuits::halo2_ivc::types::MessageHash;
 use crate::circuits::halo2_ivc::{
-    C, CERT_VK_NAME, E, F, IVC_ONE_NAME, circuit::IvcCircuit, state::Global,
+    C, CERTIFICATE_VERIFICATION_KEY_NAME, E, F, IVC_VERIFICATION_KEY_NAME, circuit::IvcCircuitData,
+    state::Global,
 };
 use crate::membership_commitment::{MerkleTree as StmMerkleTree, MerkleTreeSnarkLeaf};
 use crate::signature_scheme::{
@@ -154,10 +155,10 @@ fn merkle_tree_commitment_from_stm_tree(merkle_tree: &SignerRegistrationMerkleTr
         .root
         .as_slice()
         .try_into()
-        .expect("STM Poseidon Merkle-tree commitment should be 32 bytes");
+        .expect("STM Merkle-tree commitment should be 32 bytes");
     F::from_bytes_le(&root_bytes)
         .into_option()
-        .expect("STM Poseidon Merkle-tree commitment should be a canonical field element")
+        .expect("STM Merkle-tree commitment should be a canonical field element")
 }
 
 /// Builds the shared universal KZG parameters that both circuits derive from.
@@ -201,8 +202,8 @@ pub(crate) fn build_shared_recursive_context(
         &certificate_commitment_parameters,
         &setup.certificate_relation,
     );
-    let default_ivc_circuit =
-        IvcCircuit::unknown(certificate_verifying_key.vk()).expect("valid IvcCircuit unknown");
+    let default_ivc_circuit = IvcCircuitData::unknown(certificate_verifying_key.vk())
+        .expect("valid IvcCircuitData unknown");
     let recursive_verifying_key = keygen_vk_with_k(
         &recursive_commitment_parameters,
         &default_ivc_circuit,
@@ -224,8 +225,8 @@ pub(crate) fn build_shared_recursive_context(
 pub(crate) fn build_recursive_proving_key(
     context: &SharedRecursiveContext,
 ) -> ProvingKey<F, KZGCommitmentScheme<E>> {
-    let default_ivc_circuit = IvcCircuit::unknown(context.certificate_verifying_key.vk())
-        .expect("valid IvcCircuit unknown");
+    let default_ivc_circuit = IvcCircuitData::unknown(context.certificate_verifying_key.vk())
+        .expect("valid IvcCircuitData unknown");
     keygen_pk(
         context.recursive_verifying_key.clone(),
         &default_ivc_circuit,
@@ -242,9 +243,12 @@ pub(crate) fn build_recursive_fixed_bases(
     BTreeMap<String, C>,
     BTreeMap<String, C>,
 ) {
-    let (certificate_fixed_bases, _) =
-        fixed_bases_and_names(CERT_VK_NAME, certificate_verifying_key.vk());
-    let (recursive_fixed_bases, _) = fixed_bases_and_names(IVC_ONE_NAME, recursive_verifying_key);
+    let (certificate_fixed_bases, _) = fixed_bases_and_names(
+        CERTIFICATE_VERIFICATION_KEY_NAME,
+        certificate_verifying_key.vk(),
+    );
+    let (recursive_fixed_bases, _) =
+        fixed_bases_and_names(IVC_VERIFICATION_KEY_NAME, recursive_verifying_key);
     let mut combined_fixed_bases = certificate_fixed_bases.clone();
     combined_fixed_bases.extend(recursive_fixed_bases.clone());
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -55,7 +55,7 @@ pub(super) fn build_genesis_protocol_message(
 pub(crate) fn build_genesis_protocol_message_preimage(setup: &AssetGenerationSetup) -> Vec<u8> {
     build_genesis_protocol_message(
         &setup.aggregate_verification_key,
-        setup.genesis_next_protocol_params.to_bytes_le(),
+        setup.genesis_next_protocol_parameters.to_bytes_le(),
         GENESIS_EPOCH,
     )
     .try_rigid_preimage()
@@ -85,9 +85,9 @@ pub(crate) fn build_genesis_base_case_next_state(
         StepCounter::new(1),
         setup.genesis_message,
         MerkleTreeCommitment::ZERO,
-        MerkleTreeCommitment::from_field(setup.genesis_next_merkle_root),
+        MerkleTreeCommitment::from_field(setup.genesis_next_merkle_tree_commitment),
         ProtocolParametersHash::ZERO,
-        ProtocolParametersHash::from_field(setup.genesis_next_protocol_params),
+        ProtocolParametersHash::from_field(setup.genesis_next_protocol_parameters),
         EpochNumber::new(genesis_epoch),
     )
 }
@@ -101,7 +101,7 @@ pub(crate) fn build_next_certificate_asset_data(
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
-    let merkle_root = recursive_chain_state.next_merkle_root.as_field();
+    let merkle_tree_commitment = recursive_chain_state.next_merkle_tree_commitment.as_field();
     let (message, message_preimage) =
         next_message_and_preimage_for_step(setup, recursive_chain_state);
     let next_state = next_state_for_step(recursive_chain_state, message);
@@ -110,7 +110,7 @@ pub(crate) fn build_next_certificate_asset_data(
         certificate_commitment_parameters,
         certificate_relation,
         certificate_verifying_key,
-        merkle_root,
+        merkle_tree_commitment,
         message,
         message_preimage,
         next_state,
@@ -127,7 +127,7 @@ pub(crate) fn build_same_epoch_certificate_asset_data(
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
-    let merkle_root = recursive_chain_state.merkle_root.as_field();
+    let merkle_tree_commitment = recursive_chain_state.merkle_tree_commitment.as_field();
     let (message, message_preimage) =
         same_epoch_message_and_preimage_for_step(setup, recursive_chain_state);
     let next_state = same_epoch_next_state_for_step(recursive_chain_state, message);
@@ -136,7 +136,7 @@ pub(crate) fn build_same_epoch_certificate_asset_data(
         certificate_commitment_parameters,
         certificate_relation,
         certificate_verifying_key,
-        merkle_root,
+        merkle_tree_commitment,
         message,
         message_preimage,
         next_state,
@@ -146,7 +146,7 @@ pub(crate) fn build_same_epoch_certificate_asset_data(
 
 /// Shared inner implementation for building certificate asset data.
 ///
-/// `merkle_root`, `message`, `message_preimage`, and `next_state` are
+/// `merkle_tree_commitment`, `message`, `message_preimage`, and `next_state` are
 /// pre-computed by the caller according to the transition type. The signing
 /// loop and proof generation are identical for next-epoch and same-epoch steps.
 #[allow(clippy::too_many_arguments)]
@@ -155,7 +155,7 @@ fn build_certificate_asset_data_inner(
     certificate_commitment_parameters: &ParamsKZG<Bls12>,
     certificate_relation: &StmCertificateCircuit,
     certificate_verifying_key: &MidnightVK,
-    merkle_root: F,
+    merkle_tree_commitment: F,
     message: F,
     message_preimage: Vec<u8>,
     next_state: State,
@@ -166,15 +166,15 @@ fn build_certificate_asset_data_inner(
         fixed_bases_and_names(CERT_VK_NAME, certificate_verifying_key.vk());
 
     assert_eq!(
-        merkle_root, setup.genesis_next_merkle_root,
-        "merkle_root does not match deterministic setup root"
+        merkle_tree_commitment, setup.genesis_next_merkle_tree_commitment,
+        "merkle_tree_commitment does not match deterministic setup root"
     );
 
     let mut certificate_witness_entries: Vec<CircuitWitnessEntry> = vec![];
     for j in 0..QUORUM_SIZE as usize {
         let unique_schnorr_signature = setup.signing_keys[j]
             .sign_unique(
-                &[BaseFieldElement::from(merkle_root), BaseFieldElement::from(message)],
+                &[BaseFieldElement::from(merkle_tree_commitment), BaseFieldElement::from(message)],
                 random_generator,
             )
             .expect("certificate witness signature should not fail");
@@ -195,7 +195,7 @@ fn build_certificate_asset_data_inner(
         );
         unique_schnorr_signature
             .verify(
-                &[BaseFieldElement::from(merkle_root), BaseFieldElement::from(message)],
+                &[BaseFieldElement::from(merkle_tree_commitment), BaseFieldElement::from(message)],
                 &schnorr_vk,
             )
             .expect("fresh certificate signature should verify");
@@ -210,7 +210,7 @@ fn build_certificate_asset_data_inner(
         });
     }
 
-    let certificate_instance = certificate_public_inputs(merkle_root, next_state.msg.as_field());
+    let certificate_instance = certificate_public_inputs(merkle_tree_commitment, next_state.message.as_field());
 
     let certificate_proof = CertificateProofBytes::from_certificate_circuit_proof_bytes(
         zk_lib::prove::<StmCertificateCircuit, PoseidonState<F>>(
@@ -243,7 +243,7 @@ fn build_certificate_asset_data_inner(
 
     let ivc_witness = Witness::new(
         setup.genesis_signature,
-        MerkleTreeCommitment::from_field(merkle_root),
+        MerkleTreeCommitment::from_field(merkle_tree_commitment),
         MessageHash::from_field(message),
         ProtocolMessagePreimage::new(message_preimage.try_into().unwrap()),
     );
@@ -256,10 +256,10 @@ fn build_certificate_asset_data_inner(
     )
 }
 
-/// Formats a `(merkle_root, message)` pair as certificate public inputs.
-pub(super) fn certificate_public_inputs(merkle_root: F, message: F) -> Vec<F> {
+/// Formats a `(merkle_tree_commitment, message)` pair as certificate public inputs.
+pub(super) fn certificate_public_inputs(merkle_tree_commitment: F, message: F) -> Vec<F> {
     StmCertificateCircuit::format_instance(&(
-        CircuitBaseField::from(merkle_root),
+        CircuitBaseField::from(merkle_tree_commitment),
         CircuitBaseField::from(message),
     ))
     .unwrap()
@@ -271,8 +271,8 @@ pub(crate) fn certificate_public_inputs_for_step(
     next_state: &State,
 ) -> Vec<F> {
     certificate_public_inputs(
-        previous_state.next_merkle_root.as_field(),
-        next_state.msg.as_field(),
+        previous_state.next_merkle_tree_commitment.as_field(),
+        next_state.message.as_field(),
     )
 }
 
@@ -293,7 +293,7 @@ pub(crate) fn next_message_and_preimage_for_step(
     protocol_message
         .set_next_snark_aggregate_verification_key(&setup.aggregate_verification_key)
         .expect("aggregate verification key rigid slot should be produced");
-    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_params.to_bytes_le());
+    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_parameters.to_bytes_le());
     protocol_message.set_current_epoch(current_epoch + 1);
 
     let preimage = protocol_message
@@ -323,7 +323,7 @@ pub(crate) fn same_epoch_message_and_preimage_for_step(
     protocol_message
         .set_next_snark_aggregate_verification_key(&setup.aggregate_verification_key)
         .expect("aggregate verification key rigid slot should be produced");
-    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_params.to_bytes_le());
+    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_parameters.to_bytes_le());
     protocol_message.set_current_epoch(current_epoch);
 
     let preimage = protocol_message
@@ -345,10 +345,10 @@ pub(crate) fn next_state_for_step(previous_state: &State, message: F) -> State {
     State::new(
         StepCounter::new((step + 1) as u64),
         MessageHash::from_field(message),
-        previous_state.next_merkle_root,
-        previous_state.next_merkle_root,
-        previous_state.next_protocol_params,
-        previous_state.next_protocol_params,
+        previous_state.next_merkle_tree_commitment,
+        previous_state.next_merkle_tree_commitment,
+        previous_state.next_protocol_parameters,
+        previous_state.next_protocol_parameters,
         EpochNumber::new(current_epoch + 1),
     )
 }
@@ -361,10 +361,10 @@ pub(crate) fn same_epoch_next_state_for_step(previous_state: &State, message: F)
     State::new(
         StepCounter::new((step + 1) as u64),
         MessageHash::from_field(message),
-        previous_state.merkle_root,
-        previous_state.next_merkle_root,
-        previous_state.protocol_params,
-        previous_state.next_protocol_params,
+        previous_state.merkle_tree_commitment,
+        previous_state.next_merkle_tree_commitment,
+        previous_state.protocol_parameters,
+        previous_state.next_protocol_parameters,
         EpochNumber::new(current_epoch),
     )
 }
@@ -374,5 +374,5 @@ fn current_epoch_from_state(previous_state: &State) -> u64 {
 }
 
 fn step_index_from_state(previous_state: &State) -> usize {
-    previous_state.counter.as_u64() as usize
+    previous_state.step_counter.as_u64() as usize
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -72,8 +72,8 @@ pub(crate) fn build_genesis_base_case_witness(setup: &AssetGenerationSetup) -> W
         .expect("genesis protocol message preimage should be PREIMAGE_SIZE bytes");
     Witness::new(
         setup.genesis_signature,
-        MerkleTreeCommitment::ZERO,
         MessageHash::ZERO,
+        MerkleTreeCommitment::ZERO,
         ProtocolMessagePreimage::new(preimage),
     )
 }
@@ -254,8 +254,8 @@ fn build_certificate_asset_data_inner(
 
     let ivc_witness = Witness::new(
         setup.genesis_signature,
-        MerkleTreeCommitment::from_field(merkle_tree_commitment),
         MessageHash::from_field(message),
+        MerkleTreeCommitment::from_field(merkle_tree_commitment),
         ProtocolMessagePreimage::new(message_preimage.try_into().unwrap()),
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -18,7 +18,9 @@ use crate::circuits::halo2_ivc::types::{
     CertificateProofBytes, EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
     ProtocolParametersHash, StepCounter,
 };
-use crate::circuits::halo2_ivc::{Accumulator, CERT_VK_NAME, F, PREIMAGE_SIZE, S};
+use crate::circuits::halo2_ivc::{
+    Accumulator, CERTIFICATE_VERIFICATION_KEY_NAME, F, PREIMAGE_SIZE, S,
+};
 use crate::signature_scheme::{
     BaseFieldElement, SchnorrVerificationKey as StmSchnorrVerificationKey,
 };
@@ -162,8 +164,10 @@ fn build_certificate_asset_data_inner(
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
     let certificate_proving_key = zk_lib::setup_pk(certificate_relation, certificate_verifying_key);
-    let (certificate_fixed_bases, _) =
-        fixed_bases_and_names(CERT_VK_NAME, certificate_verifying_key.vk());
+    let (certificate_fixed_bases, _) = fixed_bases_and_names(
+        CERTIFICATE_VERIFICATION_KEY_NAME,
+        certificate_verifying_key.vk(),
+    );
 
     assert_eq!(
         merkle_tree_commitment, setup.genesis_next_merkle_tree_commitment,
@@ -174,7 +178,10 @@ fn build_certificate_asset_data_inner(
     for j in 0..QUORUM_SIZE as usize {
         let unique_schnorr_signature = setup.signing_keys[j]
             .sign_unique(
-                &[BaseFieldElement::from(merkle_tree_commitment), BaseFieldElement::from(message)],
+                &[
+                    BaseFieldElement::from(merkle_tree_commitment),
+                    BaseFieldElement::from(message),
+                ],
                 random_generator,
             )
             .expect("certificate witness signature should not fail");
@@ -195,7 +202,10 @@ fn build_certificate_asset_data_inner(
         );
         unique_schnorr_signature
             .verify(
-                &[BaseFieldElement::from(merkle_tree_commitment), BaseFieldElement::from(message)],
+                &[
+                    BaseFieldElement::from(merkle_tree_commitment),
+                    BaseFieldElement::from(message),
+                ],
                 &schnorr_vk,
             )
             .expect("fresh certificate signature should verify");
@@ -210,7 +220,8 @@ fn build_certificate_asset_data_inner(
         });
     }
 
-    let certificate_instance = certificate_public_inputs(merkle_tree_commitment, next_state.message.as_field());
+    let certificate_instance =
+        certificate_public_inputs(merkle_tree_commitment, next_state.message.as_field());
 
     let certificate_proof = CertificateProofBytes::from_certificate_circuit_proof_bytes(
         zk_lib::prove::<StmCertificateCircuit, PoseidonState<F>>(
@@ -293,7 +304,8 @@ pub(crate) fn next_message_and_preimage_for_step(
     protocol_message
         .set_next_snark_aggregate_verification_key(&setup.aggregate_verification_key)
         .expect("aggregate verification key rigid slot should be produced");
-    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_parameters.to_bytes_le());
+    protocol_message
+        .set_next_protocol_parameters(setup.genesis_next_protocol_parameters.to_bytes_le());
     protocol_message.set_current_epoch(current_epoch + 1);
 
     let preimage = protocol_message
@@ -323,7 +335,8 @@ pub(crate) fn same_epoch_message_and_preimage_for_step(
     protocol_message
         .set_next_snark_aggregate_verification_key(&setup.aggregate_verification_key)
         .expect("aggregate verification key rigid slot should be produced");
-    protocol_message.set_next_protocol_parameters(setup.genesis_next_protocol_parameters.to_bytes_le());
+    protocol_message
+        .set_next_protocol_parameters(setup.genesis_next_protocol_parameters.to_bytes_le());
     protocol_message.set_current_epoch(current_epoch);
 
     let preimage = protocol_message

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
@@ -12,7 +12,7 @@ use crate::{
     Parameters,
     circuits::{
         halo2::circuit::StmCertificateCircuit,
-        halo2_ivc::{circuit::IvcCircuit, tests::golden::RECURSIVE_CIRCUIT_DEGREE},
+        halo2_ivc::{circuit::IvcCircuitData, tests::golden::RECURSIVE_CIRCUIT_DEGREE},
     },
 };
 
@@ -36,8 +36,8 @@ pub(crate) fn golden_recursive_circuit_verification_key_bytes() -> Vec<u8> {
     let circuit_verification_key =
         midnight_zk_stdlib::setup_vk(&srs_for_non_recursive_circuit, &circuit);
 
-    let default_ivc_circuit =
-        IvcCircuit::unknown(circuit_verification_key.vk()).expect("valid IvcCircuit unknown");
+    let default_ivc_circuit = IvcCircuitData::unknown(circuit_verification_key.vk())
+        .expect("valid IvcCircuitData unknown");
     let recursive_verifying_key: VerifyingKey<
         <BlstrsEmulation as SelfEmulation>::F,
         KZGCommitmentScheme<<BlstrsEmulation as SelfEmulation>::Engine>,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
@@ -14,7 +14,7 @@ use midnight_zk_stdlib::MidnightVK;
 
 use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, C, E, F, K, S, VerifyingKey,
-    circuit::IvcCircuit,
+    circuit::IvcCircuitData,
     state::{Global, State, Witness, trivial_acc},
     types::{CertificateProofBytes, IvcProofBytes},
 };
@@ -131,8 +131,11 @@ pub(crate) fn build_recursive_mock_prover_setup(
 }
 
 /// Runs `MockProver` on the recursive circuit and asserts that at least one constraint fails.
-pub(crate) fn assert_recursive_mock_prover_rejects(circuit: IvcCircuit, public_inputs: Vec<F>) {
-    let prover = MockProver::run(K, &circuit, vec![vec![], public_inputs])
+pub(crate) fn assert_recursive_mock_prover_rejects(
+    ivc_circuit_data: IvcCircuitData,
+    public_inputs: Vec<F>,
+) {
+    let prover = MockProver::run(K, &ivc_circuit_data, vec![vec![], public_inputs])
         .expect("recursive MockProver setup should succeed");
     prover
         .verify()
@@ -142,11 +145,11 @@ pub(crate) fn assert_recursive_mock_prover_rejects(circuit: IvcCircuit, public_i
 /// Runs `MockProver` and asserts all constraints hold, printing `label` on failure so
 /// the failing case is identifiable when multiple scenarios share one `#[test]` function.
 pub(crate) fn assert_recursive_mock_prover_accepts_with_label(
-    circuit: IvcCircuit,
+    ivc_circuit_data: IvcCircuitData,
     public_inputs: Vec<F>,
     label: &str,
 ) {
-    let prover = MockProver::run(K, &circuit, vec![vec![], public_inputs])
+    let prover = MockProver::run(K, &ivc_circuit_data, vec![vec![], public_inputs])
         .expect("recursive MockProver setup should succeed");
     prover.verify().unwrap_or_else(|errors| {
         panic!(
@@ -159,11 +162,11 @@ pub(crate) fn assert_recursive_mock_prover_accepts_with_label(
 /// Runs `MockProver` and asserts at least one constraint fails, printing `label` on failure
 /// so the scenario that unexpectedly passed is identifiable when multiple scenarios share one `#[test]` function.
 pub(crate) fn assert_recursive_mock_prover_rejects_with_label(
-    circuit: IvcCircuit,
+    ivc_circuit_data: IvcCircuitData,
     public_inputs: Vec<F>,
     label: &str,
 ) {
-    let prover = MockProver::run(K, &circuit, vec![vec![], public_inputs])
+    let prover = MockProver::run(K, &ivc_circuit_data, vec![vec![], public_inputs])
         .expect("recursive MockProver setup should succeed");
     assert!(
         prover.verify().is_err(),
@@ -190,7 +193,7 @@ pub(crate) fn prepare_previous_recursive_proof_accumulator(
 
     let previous_dual_msm = verify_prepare_poseidon_recursive_proof(
         &setup.recursive_verifying_key,
-        recursive_chain_state.proof.as_bytes(),
+        recursive_chain_state.ivc_proof.as_bytes(),
         &previous_public_inputs,
     );
     assert!(
@@ -263,7 +266,7 @@ pub(crate) fn prepare_stored_step_certificate_accumulator(
     certificate_accumulator
 }
 
-/// Builds an `IvcCircuit` with empty proof slots and a trivial accumulator for
+/// Builds an `IvcCircuitData` with empty proof slots and a trivial accumulator for
 /// MockProver-based constraint checks.
 ///
 /// MockProver evaluates algebraic constraints directly without running the
@@ -272,8 +275,8 @@ pub(crate) fn build_trivial_mock_prover_circuit(
     setup: &MockProverSetup,
     prev_state: State,
     witness: Witness,
-) -> IvcCircuit {
-    IvcCircuit::try_new(
+) -> IvcCircuitData {
+    IvcCircuitData::try_new(
         setup.global.clone(),
         prev_state,
         witness,
@@ -283,7 +286,7 @@ pub(crate) fn build_trivial_mock_prover_circuit(
         setup.certificate_verifying_key.vk(),
         &setup.recursive_verifying_key,
     )
-    .expect("valid IvcCircuit construction")
+    .expect("valid IvcCircuitData construction")
 }
 
 /// Builds the public-input vector for a MockProver-based negative test.
@@ -364,7 +367,7 @@ pub(crate) fn build_unextracted_recursive_proof_accumulator_from_assets()
 
     let accumulator: Accumulator<S> = verify_prepare_poseidon_recursive_proof(
         &verification_context.recursive_verifying_key,
-        recursive_chain_state.proof.as_bytes(),
+        recursive_chain_state.ivc_proof.as_bytes(),
         &public_inputs,
     )
     .into();

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
@@ -234,8 +234,8 @@ pub(crate) fn compute_expected_next_accumulator(
 ///
 /// The certificate proof is verified against the public inputs implied by the
 /// stored chain transition:
-/// - `merkle_root` comes from the previous state's `next_merkle_root`
-/// - `message` is the committed `next_state.msg`
+/// - `merkle_tree_commitment` comes from the previous state's `next_merkle_tree_commitment`
+/// - `message` is the committed `next_state.message`
 pub(crate) fn prepare_stored_step_certificate_accumulator(
     setup: &RecursiveMockProverSetup,
     recursive_chain_state: &RecursiveChainStateAsset,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -5,8 +5,8 @@ use ff::Field;
 use midnight_circuits::types::Instantiable;
 
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
-    PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES,
+    AssignedAccumulator, F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
     protocol_message::{DynamicProtocolMessagePartKey, ProtocolMessage},
     state::State,
     tests::common::{
@@ -96,17 +96,17 @@ fn rigid_preimage_rejects_missing_current_epoch() {
 }
 
 #[test]
-fn next_merkle_root_tampered_public_input_is_rejected() {
+fn next_merkle_tree_commitment_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when
-    // next_merkle_root is replaced in the public inputs, confirming the field
-    // extracted from PREIMAGE_NEXT_MERKLE_ROOT_BYTES is enforced as a public input.
+    // next_merkle_tree_commitment is replaced in the public inputs, confirming the field
+    // extracted from PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES is enforced as a public input.
     let verification_context =
         load_embedded_verification_context_asset().expect("verification context asset should load");
     let recursive_step_output = load_embedded_recursive_step_output_asset()
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE);
+    tampered_state.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),
@@ -123,22 +123,22 @@ fn next_merkle_root_tampered_public_input_is_rejected() {
 
     assert!(
         !dual_msm.check(&verification_context.verifier_params),
-        "proof with tampered next_merkle_root should be rejected by the verifier"
+        "proof with tampered next_merkle_tree_commitment should be rejected by the verifier"
     );
 }
 
 #[test]
-fn next_protocol_params_tampered_public_input_is_rejected() {
+fn next_protocol_parameters_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when
-    // next_protocol_params is replaced in the public inputs, confirming the
-    // field extracted from PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES is enforced as a public input.
+    // next_protocol_parameters is replaced in the public inputs, confirming the
+    // field extracted from PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES is enforced as a public input.
     let verification_context =
         load_embedded_verification_context_asset().expect("verification context asset should load");
     let recursive_step_output = load_embedded_recursive_step_output_asset()
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.next_protocol_params = ProtocolParametersHash::from_field(F::ONE);
+    tampered_state.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),
@@ -155,7 +155,7 @@ fn next_protocol_params_tampered_public_input_is_rejected() {
 
     assert!(
         !dual_msm.check(&verification_context.verifier_params),
-        "proof with tampered next_protocol_params should be rejected by the verifier"
+        "proof with tampered next_protocol_parameters should be rejected by the verifier"
     );
 }
 
@@ -195,8 +195,8 @@ mod slow {
     use super::*;
 
     #[test]
-    fn circuit_rejects_wrong_next_merkle_root_byte_range() {
-        // MockProver constraint check: filling PREIMAGE_NEXT_MERKLE_ROOT_BYTES with 0xff
+    fn circuit_rejects_wrong_next_merkle_tree_commitment_byte_range() {
+        // MockProver constraint check: filling PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES with 0xff
         // must violate the in-circuit byte-extraction constraint for that preimage region.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
@@ -204,19 +204,19 @@ mod slow {
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
 
         let mut witness = build_genesis_base_case_witness(&setup);
-        witness.msg_preimage.as_mut_bytes()[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].fill(0xff);
+        witness.message_preimage.as_mut_bytes()[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].fill(0xff);
         let circuit =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             public_inputs,
-            "msg_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES] filled with 0xff",
+            "message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES] filled with 0xff",
         );
     }
 
     #[test]
-    fn circuit_rejects_wrong_next_protocol_params_byte_range() {
-        // MockProver constraint check: filling PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES with 0xff
+    fn circuit_rejects_wrong_next_protocol_parameters_byte_range() {
+        // MockProver constraint check: filling PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES with 0xff
         // must violate the in-circuit byte-extraction constraint for that preimage region.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
@@ -224,13 +224,13 @@ mod slow {
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
 
         let mut witness = build_genesis_base_case_witness(&setup);
-        witness.msg_preimage.as_mut_bytes()[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].fill(0xff);
+        witness.message_preimage.as_mut_bytes()[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].fill(0xff);
         let circuit =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             public_inputs,
-            "msg_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES] filled with 0xff",
+            "message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES] filled with 0xff",
         );
     }
 
@@ -244,13 +244,13 @@ mod slow {
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
 
         let mut witness = build_genesis_base_case_witness(&setup);
-        witness.msg_preimage.as_mut_bytes()[PREIMAGE_CURRENT_EPOCH_BYTES].fill(0xff);
+        witness.message_preimage.as_mut_bytes()[PREIMAGE_CURRENT_EPOCH_BYTES].fill(0xff);
         let circuit =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             public_inputs,
-            "msg_preimage[PREIMAGE_CURRENT_EPOCH_BYTES] filled with 0xff",
+            "message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES] filled with 0xff",
         );
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -5,8 +5,8 @@ use ff::Field;
 use midnight_circuits::types::Instantiable;
 
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
-    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
+    AssignedAccumulator, F, PREIMAGE_CURRENT_EPOCH_BYTES,
+    PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
     protocol_message::{DynamicProtocolMessagePartKey, ProtocolMessage},
     state::State,
     tests::common::{
@@ -117,7 +117,7 @@ fn next_merkle_tree_commitment_tampered_public_input_is_rejected() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        recursive_step_output.proof.as_bytes(),
+        recursive_step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -149,7 +149,7 @@ fn next_protocol_parameters_tampered_public_input_is_rejected() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        recursive_step_output.proof.as_bytes(),
+        recursive_step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -181,7 +181,7 @@ fn current_epoch_tampered_public_input_is_rejected() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        recursive_step_output.proof.as_bytes(),
+        recursive_step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -204,11 +204,12 @@ mod slow {
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
 
         let mut witness = build_genesis_base_case_witness(&setup);
-        witness.message_preimage.as_mut_bytes()[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].fill(0xff);
-        let circuit =
+        witness.message_preimage.as_mut_bytes()[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES]
+            .fill(0xff);
+        let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES] filled with 0xff",
         );
@@ -225,10 +226,10 @@ mod slow {
 
         let mut witness = build_genesis_base_case_witness(&setup);
         witness.message_preimage.as_mut_bytes()[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].fill(0xff);
-        let circuit =
+        let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES] filled with 0xff",
         );
@@ -245,10 +246,10 @@ mod slow {
 
         let mut witness = build_genesis_base_case_witness(&setup);
         witness.message_preimage.as_mut_bytes()[PREIMAGE_CURRENT_EPOCH_BYTES].fill(0xff);
-        let circuit =
+        let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES] filled with 0xff",
         );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
@@ -7,9 +7,9 @@ use sha2::{Digest as Sha2Digest, Sha256};
 
 use crate::circuits::halo2_ivc::{
     Accumulator, E, F, KZGCommitmentScheme, PREIMAGE_CURRENT_EPOCH_BYTES,
-    PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE, S,
-    VerifyingKey,
-    circuit::IvcCircuit,
+    PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
+    PREIMAGE_SIZE, S, VerifyingKey,
+    circuit::IvcCircuitData,
     io::{Read as IvcRead, Write as IvcWrite},
     protocol_message::{DynamicProtocolMessagePartKey, ProtocolMessage},
     state::State,
@@ -45,7 +45,8 @@ fn build_test_message() -> (ProtocolMessage, [u8; 44]) {
         DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode([2u8; 32]),
     );
-    message.set_next_snark_aggregate_verification_key(&avk)
+    message
+        .set_next_snark_aggregate_verification_key(&avk)
         .expect("test aggregate verification key should project to rigid slot");
     message.set_next_protocol_parameters([7u8; 32]);
     message.set_current_epoch(42);
@@ -186,7 +187,7 @@ fn vk_serialization_round_trip() {
         .write(&mut bytes, SerdeFormat::RawBytesUnchecked)
         .expect("verifying key serialization should succeed");
 
-    let deserialized = VerifyingKey::<F, KZGCommitmentScheme<E>>::read::<_, IvcCircuit>(
+    let deserialized = VerifyingKey::<F, KZGCommitmentScheme<E>>::read::<_, IvcCircuitData>(
         &mut bytes.as_slice(),
         SerdeFormat::RawBytesUnchecked,
         (),
@@ -217,14 +218,18 @@ fn rigid_preimage_length_is_190_bytes() {
 #[test]
 fn rigid_preimage_digest_label_is_at_offset_0() {
     let (message, _) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[0..6], b"digest");
 }
 
 #[test]
 fn rigid_preimage_dynamic_hash_is_at_offset_6() {
     let (message, _) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     // Dynamic parts: only SnapshotDigest is non-fixed; SHA256("snapshot_digest" || hex([2u8;32]))
     let mut hasher = Sha256::new();
     hasher.update(b"snapshot_digest");
@@ -236,14 +241,18 @@ fn rigid_preimage_dynamic_hash_is_at_offset_6() {
 #[test]
 fn rigid_preimage_avk_label_is_at_offset_38() {
     let (message, _) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[38..69], b"next_aggregate_verification_key");
 }
 
 #[test]
 fn rigid_preimage_avk_slot_matches_expected_output() {
     let (message, avk_slot) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     assert_eq!(PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, 69..101);
     // AVK slot occupies 69..113: root(32) || zeros(4) || stake_LE(8).
     assert_eq!(&preimage[69..113], &avk_slot);
@@ -252,14 +261,18 @@ fn rigid_preimage_avk_slot_matches_expected_output() {
 #[test]
 fn rigid_preimage_params_label_is_at_offset_113() {
     let (message, _) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[113..137], b"next_protocol_parameters");
 }
 
 #[test]
 fn rigid_preimage_params_slot_matches_input() {
     let (message, _) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     assert_eq!(PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, 137..169);
     assert_eq!(&preimage[137..169], &[7u8; 32]);
 }
@@ -267,14 +280,18 @@ fn rigid_preimage_params_slot_matches_input() {
 #[test]
 fn rigid_preimage_epoch_label_is_at_offset_169() {
     let (message, _) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[169..182], b"current_epoch");
 }
 
 #[test]
 fn rigid_preimage_epoch_slot_is_42_le() {
     let (message, _) = build_test_message();
-    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let preimage = message
+        .try_rigid_preimage()
+        .expect("try_rigid_preimage should succeed");
     assert_eq!(PREIMAGE_CURRENT_EPOCH_BYTES, 182..190);
     assert_eq!(&preimage[182..190], &42u64.to_le_bytes());
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
@@ -7,7 +7,7 @@ use sha2::{Digest as Sha2Digest, Sha256};
 
 use crate::circuits::halo2_ivc::{
     Accumulator, E, F, KZGCommitmentScheme, PREIMAGE_CURRENT_EPOCH_BYTES,
-    PREIMAGE_NEXT_MERKLE_ROOT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PREIMAGE_SIZE, S,
+    PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE, S,
     VerifyingKey,
     circuit::IvcCircuit,
     io::{Read as IvcRead, Write as IvcWrite},
@@ -40,17 +40,17 @@ fn build_test_message() -> (ProtocolMessage, [u8; 44]) {
         .to_rigid_slot_bytes()
         .expect("test aggregate verification key should project to rigid slot");
 
-    let mut msg = ProtocolMessage::new();
-    msg.set_dynamic_message_part(
+    let mut message = ProtocolMessage::new();
+    message.set_dynamic_message_part(
         DynamicProtocolMessagePartKey::SnapshotDigest,
         hex::encode([2u8; 32]),
     );
-    msg.set_next_snark_aggregate_verification_key(&avk)
+    message.set_next_snark_aggregate_verification_key(&avk)
         .expect("test aggregate verification key should project to rigid slot");
-    msg.set_next_protocol_parameters([7u8; 32]);
-    msg.set_current_epoch(42);
+    message.set_next_protocol_parameters([7u8; 32]);
+    message.set_current_epoch(42);
 
-    (msg, avk_slot)
+    (message, avk_slot)
 }
 
 #[test]
@@ -83,7 +83,7 @@ fn folded_accumulator_serialized_bytes_are_stable() {
 fn preimage_length_is_190_bytes() {
     // Off-circuit check that the genesis protocol message serializer produces
     // exactly PREIMAGE_SIZE bytes, matching the fixed byte ranges the circuit
-    // reads for next_merkle_root, next_protocol_params, and current_epoch.
+    // reads for next_merkle_tree_commitment, next_protocol_parameters, and current_epoch.
     let setup = build_asset_generation_setup();
     let preimage = build_genesis_protocol_message_preimage(&setup);
     assert_eq!(preimage.len(), PREIMAGE_SIZE);
@@ -92,34 +92,34 @@ fn preimage_length_is_190_bytes() {
 #[test]
 fn state_public_input_has_7_elements_in_correct_order() {
     // Off-circuit check that State::as_public_input() returns exactly 7 field
-    // elements in the order the circuit expects: counter, msg, merkle_root,
-    // next_merkle_root, protocol_params, next_protocol_params, current_epoch.
-    let counter = F::from(1u64);
-    let msg = F::from(2u64);
-    let merkle_root = F::from(3u64);
-    let next_merkle_root = F::from(4u64);
-    let protocol_params = F::from(5u64);
-    let next_protocol_params = F::from(6u64);
+    // elements in the order the circuit expects: step_counter, message, merkle_tree_commitment,
+    // next_merkle_tree_commitment, protocol_parameters, next_protocol_parameters, current_epoch.
+    let step_counter = F::from(1u64);
+    let message = F::from(2u64);
+    let merkle_tree_commitment = F::from(3u64);
+    let next_merkle_tree_commitment = F::from(4u64);
+    let protocol_parameters = F::from(5u64);
+    let next_protocol_parameters = F::from(6u64);
     let current_epoch = F::from(7u64);
 
     let state = State::new(
-        StepCounter::from_field(counter),
-        MessageHash::from_field(msg),
-        MerkleTreeCommitment::from_field(merkle_root),
-        MerkleTreeCommitment::from_field(next_merkle_root),
-        ProtocolParametersHash::from_field(protocol_params),
-        ProtocolParametersHash::from_field(next_protocol_params),
+        StepCounter::from_field(step_counter),
+        MessageHash::from_field(message),
+        MerkleTreeCommitment::from_field(merkle_tree_commitment),
+        MerkleTreeCommitment::from_field(next_merkle_tree_commitment),
+        ProtocolParametersHash::from_field(protocol_parameters),
+        ProtocolParametersHash::from_field(next_protocol_parameters),
         EpochNumber::from_field(current_epoch),
     );
     let public_input = state.as_public_input();
 
     assert_eq!(public_input.len(), 7);
-    assert_eq!(public_input[0], counter);
-    assert_eq!(public_input[1], msg);
-    assert_eq!(public_input[2], merkle_root);
-    assert_eq!(public_input[3], next_merkle_root);
-    assert_eq!(public_input[4], protocol_params);
-    assert_eq!(public_input[5], next_protocol_params);
+    assert_eq!(public_input[0], step_counter);
+    assert_eq!(public_input[1], message);
+    assert_eq!(public_input[2], merkle_tree_commitment);
+    assert_eq!(public_input[3], next_merkle_tree_commitment);
+    assert_eq!(public_input[4], protocol_parameters);
+    assert_eq!(public_input[5], next_protocol_parameters);
     assert_eq!(public_input[6], current_epoch);
 }
 
@@ -202,13 +202,13 @@ fn vk_serialization_round_trip() {
 
 // --- Rigid preimage layout pinning tests ---
 // These pin each label and slot to its exact byte offset in the 190-byte rigid preimage,
-// matching the layout the IVC circuit reads at PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
-// PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, and PREIMAGE_CURRENT_EPOCH_BYTES.
+// matching the layout the IVC circuit reads at PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+// PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, and PREIMAGE_CURRENT_EPOCH_BYTES.
 
 #[test]
 fn rigid_preimage_length_is_190_bytes() {
-    let (msg, _) = build_test_message();
-    let preimage = msg
+    let (message, _) = build_test_message();
+    let preimage = message
         .try_rigid_preimage()
         .expect("try_rigid_preimage should succeed for a valid message");
     assert_eq!(preimage.len(), PREIMAGE_SIZE);
@@ -216,15 +216,15 @@ fn rigid_preimage_length_is_190_bytes() {
 
 #[test]
 fn rigid_preimage_digest_label_is_at_offset_0() {
-    let (msg, _) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let (message, _) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[0..6], b"digest");
 }
 
 #[test]
 fn rigid_preimage_dynamic_hash_is_at_offset_6() {
-    let (msg, _) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let (message, _) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     // Dynamic parts: only SnapshotDigest is non-fixed; SHA256("snapshot_digest" || hex([2u8;32]))
     let mut hasher = Sha256::new();
     hasher.update(b"snapshot_digest");
@@ -235,46 +235,46 @@ fn rigid_preimage_dynamic_hash_is_at_offset_6() {
 
 #[test]
 fn rigid_preimage_avk_label_is_at_offset_38() {
-    let (msg, _) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let (message, _) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[38..69], b"next_aggregate_verification_key");
 }
 
 #[test]
 fn rigid_preimage_avk_slot_matches_expected_output() {
-    let (msg, avk_slot) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
-    assert_eq!(PREIMAGE_NEXT_MERKLE_ROOT_BYTES, 69..101);
+    let (message, avk_slot) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    assert_eq!(PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, 69..101);
     // AVK slot occupies 69..113: root(32) || zeros(4) || stake_LE(8).
     assert_eq!(&preimage[69..113], &avk_slot);
 }
 
 #[test]
 fn rigid_preimage_params_label_is_at_offset_113() {
-    let (msg, _) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let (message, _) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[113..137], b"next_protocol_parameters");
 }
 
 #[test]
 fn rigid_preimage_params_slot_matches_input() {
-    let (msg, _) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
-    assert_eq!(PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, 137..169);
+    let (message, _) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    assert_eq!(PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, 137..169);
     assert_eq!(&preimage[137..169], &[7u8; 32]);
 }
 
 #[test]
 fn rigid_preimage_epoch_label_is_at_offset_169() {
-    let (msg, _) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let (message, _) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(&preimage[169..182], b"current_epoch");
 }
 
 #[test]
 fn rigid_preimage_epoch_slot_is_42_le() {
-    let (msg, _) = build_test_message();
-    let preimage = msg.try_rigid_preimage().expect("try_rigid_preimage should succeed");
+    let (message, _) = build_test_message();
+    let preimage = message.try_rigid_preimage().expect("try_rigid_preimage should succeed");
     assert_eq!(PREIMAGE_CURRENT_EPOCH_BYTES, 182..190);
     assert_eq!(&preimage[182..190], &42u64.to_le_bytes());
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/golden/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/golden/positive.rs
@@ -49,7 +49,7 @@ fn recursive_chain_state_asset_proof_and_accumulator_are_valid() {
 
     let dual_msm = verify_prepare_poseidon_recursive_proof(
         &verification_context.recursive_verifying_key,
-        recursive_chain_state.proof.as_bytes(),
+        recursive_chain_state.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -78,7 +78,7 @@ fn recursive_step_output_asset_proof_and_accumulator_are_valid() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        recursive_step_output.proof.as_bytes(),
+        recursive_step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -109,14 +109,14 @@ mod slow {
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let next_state = build_genesis_base_case_next_state(&setup, GENESIS_EPOCH);
-        let circuit = build_trivial_mock_prover_circuit(
+        let ivc_circuit_data = build_trivial_mock_prover_circuit(
             &mock_prover_setup,
             State::genesis(),
             build_genesis_base_case_witness(&setup),
         );
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &next_state);
         assert_recursive_mock_prover_accepts_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "genesis base case",
         );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
@@ -43,7 +43,7 @@ fn assert_step_output_rejects_tampered_next_accumulator(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        step_output.proof.as_bytes(),
+        step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -92,7 +92,7 @@ mod slow {
 
     use crate::circuits::halo2_ivc::{
         AssignedAccumulator, F,
-        circuit::IvcCircuit,
+        circuit::IvcCircuitData,
         tests::common::{
             asset_readers::load_embedded_recursive_chain_state_asset,
             generators::{build_asset_generation_setup, build_same_epoch_certificate_asset_data},
@@ -130,17 +130,17 @@ mod slow {
             cert_accumulator,
         );
 
-        let circuit = IvcCircuit::try_new(
+        let ivc_circuit_data = IvcCircuitData::try_new(
             mock_prover_setup.global.clone(),
             recursive_chain_state.state.clone(),
             ivc_witness,
             certificate_proof,
-            recursive_chain_state.proof.clone(),
+            recursive_chain_state.ivc_proof.clone(),
             recursive_chain_state.accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,
         )
-        .expect("valid IvcCircuit construction");
+        .expect("valid IvcCircuitData construction");
 
         let mut accumulator_encoding = AssignedAccumulator::as_public_input(&next_accumulator);
         accumulator_encoding[0] = F::ONE;
@@ -152,6 +152,6 @@ mod slow {
         ]
         .concat();
 
-        assert_recursive_mock_prover_rejects(circuit, public_inputs);
+        assert_recursive_mock_prover_rejects(ivc_circuit_data, public_inputs);
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
@@ -114,7 +114,7 @@ mod slow {
         let recursive_chain_state = load_embedded_recursive_chain_state_asset()
             .expect("recursive chain state asset should load");
 
-        let (cert_proof, cert_accumulator, next_state, ivc_witness) =
+        let (certificate_proof, cert_accumulator, next_state, ivc_witness) =
             build_same_epoch_certificate_asset_data(
                 &setup,
                 &mock_prover_setup.certificate_commitment_parameters,
@@ -134,7 +134,7 @@ mod slow {
             mock_prover_setup.global.clone(),
             recursive_chain_state.state.clone(),
             ivc_witness,
-            cert_proof,
+            certificate_proof,
             recursive_chain_state.proof.clone(),
             recursive_chain_state.accumulator.clone(),
             mock_prover_setup.certificate_verifying_key.vk(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/certificate_proof.rs
@@ -38,7 +38,7 @@ fn assert_valid_certificate_proof_is_accepted(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        step_output.proof.as_bytes(),
+        step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
@@ -28,7 +28,7 @@ mod slow {
 
     #[test]
     fn genesis_step_accepts_garbage_certificate_proof_bytes() {
-        // MockProver constraint check: at genesis (counter = 0) the circuit gates the
+        // MockProver constraint check: at genesis (step_counter = 0) the circuit gates the
         // certificate accumulator contribution to the group identity via scale_by_bit(0, acc),
         // so 64 garbage bytes in the certificate slot must not violate any constraint.
         let setup = build_asset_generation_setup();
@@ -59,7 +59,7 @@ mod slow {
 
     #[test]
     fn genesis_step_accepts_garbage_ivc_proof_bytes() {
-        // MockProver constraint check: at genesis (counter = 0) the circuit gates the
+        // MockProver constraint check: at genesis (step_counter = 0) the circuit gates the
         // IVC accumulator contribution to the group identity via scale_by_bit(0, acc),
         // so 64 garbage bytes in the IVC slot must not violate any constraint.
         let setup = build_asset_generation_setup();

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/genesis_gating.rs
@@ -9,7 +9,7 @@ use midnight_circuits::types::Instantiable;
 
 use crate::circuits::halo2_ivc::{
     AssignedAccumulator,
-    circuit::IvcCircuit,
+    circuit::IvcCircuitData,
     state::State,
     tests::common::{
         generators::{
@@ -39,7 +39,7 @@ mod slow {
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
         ]
         .concat();
-        let circuit = IvcCircuit::try_new(
+        let ivc_circuit_data = IvcCircuitData::try_new(
             mock_prover_setup.global.clone(),
             State::genesis(),
             build_genesis_base_case_witness(&setup),
@@ -49,9 +49,9 @@ mod slow {
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,
         )
-        .expect("valid IvcCircuit construction");
+        .expect("valid IvcCircuitData construction");
         assert_recursive_mock_prover_accepts_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "garbage certificate proof bytes (64 × 0x00)",
         );
@@ -70,7 +70,7 @@ mod slow {
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator),
         ]
         .concat();
-        let circuit = IvcCircuit::try_new(
+        let ivc_circuit_data = IvcCircuitData::try_new(
             mock_prover_setup.global.clone(),
             State::genesis(),
             build_genesis_base_case_witness(&setup),
@@ -80,9 +80,9 @@ mod slow {
             mock_prover_setup.certificate_verifying_key.vk(),
             &mock_prover_setup.recursive_verifying_key,
         )
-        .expect("valid IvcCircuit construction");
+        .expect("valid IvcCircuitData construction");
         assert_recursive_mock_prover_accepts_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "garbage IVC proof bytes (64 × 0x00)",
         );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/mod.rs
@@ -9,7 +9,7 @@
 //! `certificate_proof`  — tampered certificate proof is rejected in non-genesis steps.
 //! `previous_ivc_proof` — tampered previous IVC proof is rejected in non-genesis steps.
 //! `accumulator`        — tampered next_accumulator output is rejected.
-//! `state_transition`   — next_merkle_root, next_protocol_params consistency and msg hash constraint.
+//! `state_transition`   — next_merkle_tree_commitment, next_protocol_parameters consistency and message hash constraint.
 
 mod accumulator;
 mod certificate_proof;

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/previous_ivc_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/previous_ivc_proof.rs
@@ -43,7 +43,7 @@ fn assert_valid_previous_ivc_proof_is_accepted(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        step_output.proof.as_bytes(),
+        step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -93,7 +93,7 @@ fn tampered_previous_ivc_proof_produces_invalid_accumulator() {
     ]
     .concat();
 
-    let mut tampered_ivc_proof = recursive_chain_state.proof.clone().into_vec();
+    let mut tampered_ivc_proof = recursive_chain_state.ivc_proof.clone().into_vec();
     tampered_ivc_proof[0] ^= 0xFF;
 
     // Try to parse the tampered IVC proof off-circuit. Returns None if the bytes

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
@@ -25,7 +25,7 @@ use crate::circuits::halo2_ivc::{
 /// Loads the genesis assets, applies `tamper` to the three public-input sections
 /// (`global`, `state`, `accumulator`), then asserts the verifier rejects the result.
 ///
-/// `global` layout: `[genesis_msg, genesis_verification_key.x, genesis_verification_key.y,
+/// `global` layout: `[genesis_message, genesis_verification_key.x, genesis_verification_key.y,
 /// certificate_verifying_key_repr, ivc_verifying_key_repr]`.
 fn assert_genesis_step_output_rejects_tampered_public_inputs(
     tamper: impl FnOnce(&mut Vec<F>, &mut Vec<F>, &mut Vec<F>),
@@ -58,12 +58,12 @@ fn assert_genesis_step_output_rejects_tampered_public_inputs(
 }
 
 #[test]
-fn genesis_msg_tampered_public_input_is_rejected() {
-    // Asset-based check that the verifier rejects a stored proof when genesis_msg
+fn genesis_message_tampered_public_input_is_rejected() {
+    // Asset-based check that the verifier rejects a stored proof when genesis_message
     // is replaced in the global public inputs, confirming it is committed at index 0.
     assert_genesis_step_output_rejects_tampered_public_inputs(
         |global, _, _| global[0] = F::ONE,
-        "proof with tampered genesis_msg should be rejected by the verifier",
+        "proof with tampered genesis_message should be rejected by the verifier",
     );
 }
 
@@ -123,8 +123,8 @@ mod slow {
     use super::*;
 
     #[test]
-    fn circuit_rejects_wrong_genesis_msg_global_field() {
-        // MockProver constraint check: global[0] (genesis_msg) set to ONE must violate
+    fn circuit_rejects_wrong_genesis_message_global_field() {
+        // MockProver constraint check: global[0] (genesis_message) set to ONE must violate
         // the in-circuit constraint that pins the genesis message to the global public input.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
@@ -140,7 +140,7 @@ mod slow {
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             [global, state, accumulator_encoding].concat(),
-            "global[0] (genesis_msg) set to ONE",
+            "global[0] (genesis_message) set to ONE",
         );
     }
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
@@ -26,7 +26,7 @@ use crate::circuits::halo2_ivc::{
 /// (`global`, `state`, `accumulator`), then asserts the verifier rejects the result.
 ///
 /// `global` layout: `[genesis_message, genesis_verification_key.x, genesis_verification_key.y,
-/// certificate_verifying_key_repr, ivc_verifying_key_repr]`.
+/// certificate_circuit_verification_key_representation, ivc_circuit_verification_key_representation]`.
 fn assert_genesis_step_output_rejects_tampered_public_inputs(
     tamper: impl FnOnce(&mut Vec<F>, &mut Vec<F>, &mut Vec<F>),
     rejection_message: &str,
@@ -47,7 +47,7 @@ fn assert_genesis_step_output_rejects_tampered_public_inputs(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        genesis_step_output.proof.as_bytes(),
+        genesis_step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -88,24 +88,24 @@ fn genesis_verification_key_y_tampered_public_input_is_rejected() {
 }
 
 #[test]
-fn certificate_verifying_key_repr_tampered_public_input_is_rejected() {
+fn certificate_circuit_verification_key_representation_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when
-    // certificate_verifying_key_repr is replaced in the global public inputs,
+    // certificate_circuit_verification_key_representation is replaced in the global public inputs,
     // confirming it is committed at index 3.
     assert_genesis_step_output_rejects_tampered_public_inputs(
         |global, _, _| global[3] = F::ONE,
-        "proof with tampered certificate_verifying_key_repr should be rejected by the verifier",
+        "proof with tampered certificate_circuit_verification_key_representation should be rejected by the verifier",
     );
 }
 
 #[test]
-fn ivc_verifying_key_repr_tampered_public_input_is_rejected() {
+fn ivc_circuit_verification_key_representation_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when
-    // ivc_verifying_key_repr is replaced in the global public inputs,
+    // ivc_circuit_verification_key_representation is replaced in the global public inputs,
     // confirming it is committed at index 4.
     assert_genesis_step_output_rejects_tampered_public_inputs(
         |global, _, _| global[4] = F::ONE,
-        "proof with tampered ivc_verifying_key_repr should be rejected by the verifier",
+        "proof with tampered ivc_circuit_verification_key_representation should be rejected by the verifier",
     );
 }
 
@@ -130,7 +130,7 @@ mod slow {
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let next_state = build_genesis_base_case_next_state(&setup, GENESIS_EPOCH);
         let witness = build_genesis_base_case_witness(&setup);
-        let circuit =
+        let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         let mut global = mock_prover_setup.global.as_public_input();
         let state = next_state.as_public_input();
@@ -138,21 +138,21 @@ mod slow {
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator);
         global[0] = F::ONE;
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             [global, state, accumulator_encoding].concat(),
             "global[0] (genesis_message) set to ONE",
         );
     }
 
     #[test]
-    fn circuit_rejects_wrong_certificate_vk_repr_global_field() {
-        // MockProver constraint check: global[3] (certificate_verifying_key_repr) set to ONE
-        // must violate the in-circuit constraint that pins the certificate VK hash.
+    fn circuit_rejects_wrong_certificate_circuit_verification_key_representation_global_field() {
+        // MockProver constraint check: global[3] (certificate_circuit_verification_key_representation) set to ONE
+        // must violate the in-circuit constraint that pins the certificate circuit verification key representation.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let next_state = build_genesis_base_case_next_state(&setup, GENESIS_EPOCH);
         let witness = build_genesis_base_case_witness(&setup);
-        let circuit =
+        let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         let mut global = mock_prover_setup.global.as_public_input();
         let state = next_state.as_public_input();
@@ -160,21 +160,21 @@ mod slow {
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator);
         global[3] = F::ONE;
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             [global, state, accumulator_encoding].concat(),
-            "global[3] (certificate_verifying_key_repr) set to ONE",
+            "global[3] (certificate_circuit_verification_key_representation) set to ONE",
         );
     }
 
     #[test]
-    fn circuit_rejects_wrong_ivc_vk_repr_global_field() {
-        // MockProver constraint check: global[4] (ivc_verifying_key_repr) set to ONE
-        // must violate the in-circuit constraint that pins the IVC VK hash.
+    fn circuit_rejects_wrong_ivc_circuit_verification_key_representation_global_field() {
+        // MockProver constraint check: global[4] (ivc_circuit_verification_key_representation) set to ONE
+        // must violate the in-circuit constraint that pins the IVC circuit verification key representation.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let next_state = build_genesis_base_case_next_state(&setup, GENESIS_EPOCH);
         let witness = build_genesis_base_case_witness(&setup);
-        let circuit =
+        let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         let mut global = mock_prover_setup.global.as_public_input();
         let state = next_state.as_public_input();
@@ -182,9 +182,9 @@ mod slow {
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator);
         global[4] = F::ONE;
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             [global, state, accumulator_encoding].concat(),
-            "global[4] (ivc_verifying_key_repr) set to ONE",
+            "global[4] (ivc_circuit_verification_key_representation) set to ONE",
         );
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
@@ -56,9 +56,10 @@ mod slow {
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
         tampered_state.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state),
             "next_merkle_tree_commitment set to ONE (must equal prev_state.next_merkle_tree_commitment)",
         );
@@ -87,9 +88,10 @@ mod slow {
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
         tampered_state.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state),
             "next_protocol_parameters set to ONE (must equal prev_state.next_protocol_parameters)",
         );
@@ -119,9 +121,10 @@ mod slow {
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
         tampered_state.message = MessageHash::from_field(F::ONE);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state),
             "message set to ONE (must equal Blake2b(message_preimage))",
         );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
@@ -4,11 +4,11 @@
 //! All tests are slow MockProver checks confirming the arithmetic constraint
 //! wiring for the following in-circuit invariants:
 //!
-//! `next_merkle_root` consistency    — must equal `prev_state.next_merkle_root`.
-//! `next_protocol_params` consistency — must equal `prev_state.next_protocol_params`.
-//! `msg = Blake2b(preimage)`          — must equal the Blake2b hash of the message preimage.
+//! `next_merkle_tree_commitment` consistency    — must equal `prev_state.next_merkle_tree_commitment`.
+//! `next_protocol_parameters` consistency — must equal `prev_state.next_protocol_parameters`.
+//! `message = Blake2b(preimage)`          — must equal the Blake2b hash of the message preimage.
 //!
-//! The `msg = Blake2b(preimage)` constraint is the same gate for same-epoch and
+//! The `message = Blake2b(preimage)` constraint is the same gate for same-epoch and
 //! next-epoch paths, so only the same-epoch witness is exercised here.
 
 mod slow {
@@ -34,9 +34,9 @@ mod slow {
     };
 
     #[test]
-    fn circuit_rejects_wrong_same_epoch_next_merkle_root() {
-        // MockProver constraint check: next_merkle_root set to ONE must violate the
-        // in-circuit constraint that pins it to prev_state.next_merkle_root.
+    fn circuit_rejects_wrong_same_epoch_next_merkle_tree_commitment() {
+        // MockProver constraint check: next_merkle_tree_commitment set to ONE must violate the
+        // in-circuit constraint that pins it to prev_state.next_merkle_tree_commitment.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let prev_state = load_embedded_recursive_chain_state_asset()
@@ -46,7 +46,7 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_root,
+            prev_state.merkle_tree_commitment,
             MessageHash::from_field(same_epoch_message),
             ProtocolMessagePreimage::new(
                 same_epoch_message_preimage_bytes
@@ -55,19 +55,19 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE);
+        tampered_state.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state),
-            "next_merkle_root set to ONE (must equal prev_state.next_merkle_root)",
+            "next_merkle_tree_commitment set to ONE (must equal prev_state.next_merkle_tree_commitment)",
         );
     }
 
     #[test]
-    fn circuit_rejects_wrong_same_epoch_next_protocol_params() {
-        // MockProver constraint check: next_protocol_params set to ONE must violate the
-        // in-circuit constraint that pins it to prev_state.next_protocol_params.
+    fn circuit_rejects_wrong_same_epoch_next_protocol_parameters() {
+        // MockProver constraint check: next_protocol_parameters set to ONE must violate the
+        // in-circuit constraint that pins it to prev_state.next_protocol_parameters.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let prev_state = load_embedded_recursive_chain_state_asset()
@@ -77,7 +77,7 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_root,
+            prev_state.merkle_tree_commitment,
             MessageHash::from_field(same_epoch_message),
             ProtocolMessagePreimage::new(
                 same_epoch_message_preimage_bytes
@@ -86,19 +86,19 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.next_protocol_params = ProtocolParametersHash::from_field(F::ONE);
+        tampered_state.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state),
-            "next_protocol_params set to ONE (must equal prev_state.next_protocol_params)",
+            "next_protocol_parameters set to ONE (must equal prev_state.next_protocol_parameters)",
         );
     }
 
     #[test]
     fn circuit_rejects_wrong_same_epoch_msg_blake2b_constraint() {
-        // MockProver constraint check: msg set to ONE must violate the in-circuit
-        // Blake2b constraint enforcing msg = Blake2b(msg_preimage). The same gate
+        // MockProver constraint check: message set to ONE must violate the in-circuit
+        // Blake2b constraint enforcing message = Blake2b(message_preimage). The same gate
         // is exercised by both same-epoch and next-epoch paths, so testing it once suffices.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
@@ -109,7 +109,7 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_root,
+            prev_state.merkle_tree_commitment,
             MessageHash::from_field(same_epoch_message),
             ProtocolMessagePreimage::new(
                 same_epoch_message_preimage_bytes
@@ -118,12 +118,12 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.msg = MessageHash::from_field(F::ONE);
+        tampered_state.message = MessageHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state),
-            "msg set to ONE (must equal Blake2b(msg_preimage))",
+            "message set to ONE (must equal Blake2b(message_preimage))",
         );
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
@@ -46,8 +46,8 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_tree_commitment,
             MessageHash::from_field(same_epoch_message),
+            prev_state.merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 same_epoch_message_preimage_bytes
                     .try_into()
@@ -78,8 +78,8 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_tree_commitment,
             MessageHash::from_field(same_epoch_message),
+            prev_state.merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 same_epoch_message_preimage_bytes
                     .try_into()
@@ -111,8 +111,8 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_tree_commitment,
             MessageHash::from_field(same_epoch_message),
+            prev_state.merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 same_epoch_message_preimage_bytes
                     .try_into()

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/circuit_validation.rs
@@ -1,21 +1,21 @@
-//! Tests that IvcCircuit constructor validations return the expected typed errors.
+//! Tests that IvcCircuitData constructor validations return the expected typed errors.
 
 use crate::circuits::halo2_ivc::{
-    K, circuit::IvcCircuit, errors::IvcCircuitError,
+    K, circuit::IvcCircuitData, errors::IvcCircuitError,
     tests::common::asset_readers::load_embedded_verification_context_asset,
 };
 
 #[test]
-fn validate_self_vk_degree_rejects_wrong_degree_vk() {
+fn validate_ivc_verification_key_degree_rejects_wrong_degree_vk() {
     // The certificate VK stored in the verification context has degree
     // CERTIFICATE_CIRCUIT_DEGREE (13) != K (19), so it is a cheap wrong-degree
-    // input for validate_self_vk_degree without requiring any SRS generation.
+    // input for validate_ivc_verification_key_degree without requiring any SRS generation.
     let ctx =
         load_embedded_verification_context_asset().expect("verification context asset should load");
     let wrong_degree_vk = ctx.certificate_verifying_key.vk();
     let actual_degree = wrong_degree_vk.get_domain().k();
 
-    let result = IvcCircuit::validate_self_vk_degree(wrong_degree_vk);
+    let result = IvcCircuitData::validate_ivc_verification_key_degree(wrong_degree_vk);
 
     let err = result
         .unwrap_err()
@@ -23,7 +23,7 @@ fn validate_self_vk_degree_rejects_wrong_degree_vk() {
         .expect("error should downcast to IvcCircuitError");
     assert_eq!(
         err,
-        IvcCircuitError::SelfVkDegreeMismatch {
+        IvcCircuitError::IvcVerificationKeyDegreeMismatch {
             expected: K,
             actual: actual_degree,
         }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/mod.rs
@@ -11,7 +11,7 @@
 //! `accumulator_update`          — full folding pipeline on stored assets; soundness under wrong previous accumulator.
 //! `accumulator_verification`    — `accumulator.check` accepts valid stored accumulators and rejects tampered ones.
 //! `certificate_proof_rejection` — `verify_and_prepare_accumulator` rejects garbage bytes and wrong public inputs.
-//! `circuit_validation`          — `IvcCircuit::validate_self_vk_degree` rejects a VK with degree ≠ K.
+//! `circuit_validation`          — `IvcCircuitData::validate_ivc_verification_key_degree` rejects a VK with degree ≠ K.
 //! `fixed_base_extraction`       — `extract_fixed_bases` reclassification and encoding effects.
 //! `proof_verification`          — `dual_msm.check` + `accumulator.check` combined for same-epoch and chain-state proofs.
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/proof_verification.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/proof_verification.rs
@@ -42,7 +42,7 @@ fn same_epoch_proof_passes_dual_msm_check_and_accumulator_check() {
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        same_epoch_step_output.proof.as_bytes(),
+        same_epoch_step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 
@@ -78,7 +78,7 @@ fn chain_state_proof_passes_dual_msm_check_and_accumulator_check() {
 
     let dual_msm = verify_prepare_poseidon_recursive_proof(
         &verification_context.recursive_verifying_key,
-        recursive_chain_state.proof.as_bytes(),
+        recursive_chain_state.ivc_proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
@@ -109,11 +109,11 @@ mod slow {
         let mut tampered_state = build_genesis_base_case_next_state(&setup, GENESIS_EPOCH);
         tamper(&mut tampered_state);
 
-        let circuit =
+        let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, State::genesis(), witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
 
-        assert_recursive_mock_prover_rejects(circuit, public_inputs);
+        assert_recursive_mock_prover_rejects(ivc_circuit_data, public_inputs);
     }
 
     #[test]

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
@@ -17,57 +17,57 @@ use crate::circuits::halo2_ivc::{
 };
 
 #[test]
-fn merkle_root_tampered_is_rejected() {
-    // Asset-based check: circuit enforces merkle_root = 0 at the genesis base case.
+fn merkle_tree_commitment_tampered_is_rejected() {
+    // Asset-based check: circuit enforces merkle_tree_commitment = 0 at the genesis base case.
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.merkle_root = MerkleTreeCommitment::from_field(F::ONE),
-        "proof with tampered merkle_root should be rejected by the verifier",
+        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        "proof with tampered merkle_tree_commitment should be rejected by the verifier",
     );
 }
 
 #[test]
-fn protocol_params_tampered_is_rejected() {
-    // Asset-based check: circuit enforces protocol_params = 0 at the genesis base case.
+fn protocol_parameters_tampered_is_rejected() {
+    // Asset-based check: circuit enforces protocol_parameters = 0 at the genesis base case.
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.protocol_params = ProtocolParametersHash::from_field(F::ONE),
-        "proof with tampered protocol_params should be rejected by the verifier",
+        |s| s.protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        "proof with tampered protocol_parameters should be rejected by the verifier",
     );
 }
 
 #[test]
-fn next_merkle_root_tampered_is_rejected() {
-    // Asset-based check: circuit enforces next_merkle_root is extracted from the genesis message preimage.
+fn next_merkle_tree_commitment_tampered_is_rejected() {
+    // Asset-based check: circuit enforces next_merkle_tree_commitment is extracted from the genesis message preimage.
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE),
-        "proof with tampered next_merkle_root should be rejected by the verifier",
+        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        "proof with tampered next_merkle_tree_commitment should be rejected by the verifier",
     );
 }
 
 #[test]
-fn next_protocol_params_tampered_is_rejected() {
-    // Asset-based check: circuit enforces next_protocol_params is extracted from the genesis message preimage.
+fn next_protocol_parameters_tampered_is_rejected() {
+    // Asset-based check: circuit enforces next_protocol_parameters is extracted from the genesis message preimage.
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.next_protocol_params = ProtocolParametersHash::from_field(F::ONE),
-        "proof with tampered next_protocol_params should be rejected by the verifier",
+        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        "proof with tampered next_protocol_parameters should be rejected by the verifier",
     );
 }
 
 #[test]
 fn counter_tampered_is_rejected() {
-    // Asset-based check: circuit enforces counter transitions 0 → 1 at the genesis base case.
+    // Asset-based check: circuit enforces step_counter transitions 0 → 1 at the genesis base case.
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.counter = StepCounter::new(2),
-        "proof with tampered counter should be rejected by the verifier",
+        |s| s.step_counter = StepCounter::new(2),
+        "proof with tampered step_counter should be rejected by the verifier",
     );
 }
 
@@ -84,12 +84,12 @@ fn current_epoch_tampered_is_rejected() {
 
 #[test]
 fn msg_tampered_is_rejected() {
-    // Asset-based check: circuit enforces msg equals the genesis message committed in the Global public inputs.
+    // Asset-based check: circuit enforces message equals the genesis message committed in the Global public inputs.
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.msg = MessageHash::from_field(F::ONE),
-        "proof with tampered msg should be rejected by the verifier",
+        |s| s.message = MessageHash::from_field(F::ONE),
+        "proof with tampered message should be rejected by the verifier",
     );
 }
 
@@ -119,9 +119,9 @@ mod slow {
     #[test]
     fn circuit_rejects_msg_inconsistent_with_preimage() {
         // MockProver check that the in-circuit Blake2b hash constraint between
-        // msg_preimage bytes and the resulting msg field is wired correctly.
+        // message_preimage bytes and the resulting message field is wired correctly.
         assert_genesis_circuit_rejects_tampered_next_state(|s| {
-            s.msg = MessageHash::from_field(F::ONE)
+            s.message = MessageHash::from_field(F::ONE)
         });
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/mod.rs
@@ -43,7 +43,7 @@ fn assert_step_output_rejects_tampered_state(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        step_output.proof.as_bytes(),
+        step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
@@ -21,57 +21,57 @@ use crate::circuits::halo2_ivc::{
 };
 
 #[test]
-fn merkle_root_tampered_is_rejected() {
-    // Asset-based check: circuit enforces merkle_root = prev.next_merkle_root in a next-epoch transition.
+fn merkle_tree_commitment_tampered_is_rejected() {
+    // Asset-based check: circuit enforces merkle_tree_commitment = prev.next_merkle_tree_commitment in a next-epoch transition.
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.merkle_root = MerkleTreeCommitment::from_field(F::ONE),
-        "proof with tampered merkle_root should be rejected by the verifier",
+        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        "proof with tampered merkle_tree_commitment should be rejected by the verifier",
     );
 }
 
 #[test]
-fn protocol_params_tampered_is_rejected() {
-    // Asset-based check: circuit enforces protocol_params = prev.next_protocol_params in a next-epoch transition.
+fn protocol_parameters_tampered_is_rejected() {
+    // Asset-based check: circuit enforces protocol_parameters = prev.next_protocol_parameters in a next-epoch transition.
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.protocol_params = ProtocolParametersHash::from_field(F::ONE),
-        "proof with tampered protocol_params should be rejected by the verifier",
+        |s| s.protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        "proof with tampered protocol_parameters should be rejected by the verifier",
     );
 }
 
 #[test]
-fn next_merkle_root_tampered_is_rejected() {
-    // Asset-based check: circuit enforces next_merkle_root is extracted from the certificate message preimage.
+fn next_merkle_tree_commitment_tampered_is_rejected() {
+    // Asset-based check: circuit enforces next_merkle_tree_commitment is extracted from the certificate message preimage.
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE),
-        "proof with tampered next_merkle_root should be rejected by the verifier",
+        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        "proof with tampered next_merkle_tree_commitment should be rejected by the verifier",
     );
 }
 
 #[test]
-fn next_protocol_params_tampered_is_rejected() {
-    // Asset-based check: circuit enforces next_protocol_params is extracted from the certificate message preimage.
+fn next_protocol_parameters_tampered_is_rejected() {
+    // Asset-based check: circuit enforces next_protocol_parameters is extracted from the certificate message preimage.
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.next_protocol_params = ProtocolParametersHash::from_field(F::ONE),
-        "proof with tampered next_protocol_params should be rejected by the verifier",
+        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        "proof with tampered next_protocol_parameters should be rejected by the verifier",
     );
 }
 
 #[test]
 fn counter_tampered_is_rejected() {
-    // Asset-based check: circuit enforces counter = prev.counter + 1 in a next-epoch transition.
+    // Asset-based check: circuit enforces step_counter = prev.step_counter + 1 in a next-epoch transition.
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.counter = StepCounter::from_field(F::ONE),
-        "proof with tampered counter should be rejected by the verifier",
+        |s| s.step_counter = StepCounter::from_field(F::ONE),
+        "proof with tampered step_counter should be rejected by the verifier",
     );
 }
 
@@ -88,12 +88,12 @@ fn current_epoch_tampered_is_rejected() {
 
 #[test]
 fn msg_tampered_is_rejected() {
-    // Asset-based check: circuit enforces msg equals the certificate message hash verified in-circuit.
+    // Asset-based check: circuit enforces message equals the certificate message hash verified in-circuit.
     assert_step_output_rejects_tampered_state(
         load_embedded_recursive_step_output_asset,
         "recursive step output",
-        |s| s.msg = MessageHash::from_field(F::ONE),
-        "proof with tampered msg should be rejected by the verifier",
+        |s| s.message = MessageHash::from_field(F::ONE),
+        "proof with tampered message should be rejected by the verifier",
     );
 }
 
@@ -101,9 +101,9 @@ mod slow {
     use super::*;
 
     #[test]
-    fn circuit_rejects_protocol_params_non_advance_in_next_epoch_step() {
+    fn circuit_rejects_protocol_parameters_non_advance_in_next_epoch_step() {
         // MockProver constraint check: in a next-epoch transition the circuit must advance
-        // protocol_params to prev_state.next_protocol_params. Setting it to ONE violates that.
+        // protocol_parameters to prev_state.next_protocol_parameters. Setting it to ONE violates that.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let prev_state = load_embedded_recursive_chain_state_asset()
@@ -112,7 +112,7 @@ mod slow {
         let (message, preimage_bytes) = next_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.next_merkle_root,
+            prev_state.next_merkle_tree_commitment,
             MessageHash::from_field(message),
             ProtocolMessagePreimage::new(
                 preimage_bytes
@@ -121,20 +121,20 @@ mod slow {
             ),
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
-        tampered_state.protocol_params = ProtocolParametersHash::from_field(F::ONE);
+        tampered_state.protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             public_inputs,
-            "protocol_params set to ONE (next-epoch: must advance to prev.next_protocol_params)",
+            "protocol_parameters set to ONE (next-epoch: must advance to prev.next_protocol_parameters)",
         );
     }
 
     #[test]
-    fn circuit_rejects_merkle_root_non_advance_in_next_epoch_step() {
+    fn circuit_rejects_merkle_tree_commitment_non_advance_in_next_epoch_step() {
         // MockProver constraint check: in a next-epoch transition the circuit must advance
-        // merkle_root to prev_state.next_merkle_root. Setting it to ONE violates that.
+        // merkle_tree_commitment to prev_state.next_merkle_tree_commitment. Setting it to ONE violates that.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let prev_state = load_embedded_recursive_chain_state_asset()
@@ -143,7 +143,7 @@ mod slow {
         let (message, preimage_bytes) = next_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.next_merkle_root,
+            prev_state.next_merkle_tree_commitment,
             MessageHash::from_field(message),
             ProtocolMessagePreimage::new(
                 preimage_bytes
@@ -152,13 +152,13 @@ mod slow {
             ),
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
-        tampered_state.merkle_root = MerkleTreeCommitment::from_field(F::ONE);
+        tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             public_inputs,
-            "merkle_root set to ONE (next-epoch: must advance to prev.next_merkle_root)",
+            "merkle_tree_commitment set to ONE (next-epoch: must advance to prev.next_merkle_tree_commitment)",
         );
     }
 
@@ -174,7 +174,7 @@ mod slow {
         let (message, preimage_bytes) = next_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.next_merkle_root,
+            prev_state.next_merkle_tree_commitment,
             MessageHash::from_field(message),
             ProtocolMessagePreimage::new(
                 preimage_bytes

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
@@ -112,8 +112,8 @@ mod slow {
         let (message, preimage_bytes) = next_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.next_merkle_tree_commitment,
             MessageHash::from_field(message),
+            prev_state.next_merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 preimage_bytes
                     .try_into()
@@ -144,8 +144,8 @@ mod slow {
         let (message, preimage_bytes) = next_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.next_merkle_tree_commitment,
             MessageHash::from_field(message),
+            prev_state.next_merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 preimage_bytes
                     .try_into()
@@ -176,8 +176,8 @@ mod slow {
         let (message, preimage_bytes) = next_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.next_merkle_tree_commitment,
             MessageHash::from_field(message),
+            prev_state.next_merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 preimage_bytes
                     .try_into()

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
@@ -122,10 +122,11 @@ mod slow {
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
         tampered_state.protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "protocol_parameters set to ONE (next-epoch: must advance to prev.next_protocol_parameters)",
         );
@@ -153,10 +154,11 @@ mod slow {
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
         tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "merkle_tree_commitment set to ONE (next-epoch: must advance to prev.next_merkle_tree_commitment)",
         );
@@ -184,10 +186,11 @@ mod slow {
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
         tampered_state.current_epoch = EpochNumber::new(tampered_state.current_epoch.as_u64() - 1);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "current_epoch decremented (next-epoch: must increment by exactly one)",
         );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
@@ -22,46 +22,46 @@ use crate::circuits::halo2_ivc::{
 };
 
 #[test]
-fn merkle_root_tampered_is_rejected() {
-    // Asset-based check: circuit enforces merkle_root = prev.merkle_root in a same-epoch transition.
+fn merkle_tree_commitment_tampered_is_rejected() {
+    // Asset-based check: circuit enforces merkle_tree_commitment = prev.merkle_tree_commitment in a same-epoch transition.
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.merkle_root = MerkleTreeCommitment::from_field(F::ONE),
-        "proof with tampered merkle_root should be rejected by the verifier",
+        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        "proof with tampered merkle_tree_commitment should be rejected by the verifier",
     );
 }
 
 #[test]
-fn next_merkle_root_tampered_is_rejected() {
-    // Asset-based check: circuit enforces next_merkle_root is extracted from the certificate message preimage.
+fn next_merkle_tree_commitment_tampered_is_rejected() {
+    // Asset-based check: circuit enforces next_merkle_tree_commitment is extracted from the certificate message preimage.
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.next_merkle_root = MerkleTreeCommitment::from_field(F::ONE),
-        "proof with tampered next_merkle_root should be rejected by the verifier",
+        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        "proof with tampered next_merkle_tree_commitment should be rejected by the verifier",
     );
 }
 
 #[test]
-fn protocol_params_tampered_is_rejected() {
-    // Asset-based check: circuit enforces protocol_params = prev.protocol_params in a same-epoch transition.
+fn protocol_parameters_tampered_is_rejected() {
+    // Asset-based check: circuit enforces protocol_parameters = prev.protocol_parameters in a same-epoch transition.
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.protocol_params = ProtocolParametersHash::from_field(F::ONE),
-        "proof with tampered protocol_params should be rejected by the verifier",
+        |s| s.protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        "proof with tampered protocol_parameters should be rejected by the verifier",
     );
 }
 
 #[test]
-fn next_protocol_params_tampered_is_rejected() {
-    // Asset-based check: circuit enforces next_protocol_params is extracted from the certificate message preimage.
+fn next_protocol_parameters_tampered_is_rejected() {
+    // Asset-based check: circuit enforces next_protocol_parameters is extracted from the certificate message preimage.
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.next_protocol_params = ProtocolParametersHash::from_field(F::ONE),
-        "proof with tampered next_protocol_params should be rejected by the verifier",
+        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        "proof with tampered next_protocol_parameters should be rejected by the verifier",
     );
 }
 
@@ -78,23 +78,23 @@ fn current_epoch_tampered_is_rejected() {
 
 #[test]
 fn counter_tampered_is_rejected() {
-    // Asset-based check: circuit enforces counter increments by 1 at every recursive step.
+    // Asset-based check: circuit enforces step_counter increments by 1 at every recursive step.
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.counter = StepCounter::from_field(F::ONE),
-        "proof with tampered counter should be rejected by the verifier",
+        |s| s.step_counter = StepCounter::from_field(F::ONE),
+        "proof with tampered step_counter should be rejected by the verifier",
     );
 }
 
 #[test]
 fn msg_tampered_is_rejected() {
-    // Asset-based check: circuit enforces msg equals the certificate message hash verified in-circuit.
+    // Asset-based check: circuit enforces message equals the certificate message hash verified in-circuit.
     assert_step_output_rejects_tampered_state(
         load_embedded_same_epoch_step_output_asset,
         "same-epoch step output",
-        |s| s.msg = MessageHash::from_field(F::ONE),
-        "proof with tampered msg should be rejected by the verifier",
+        |s| s.message = MessageHash::from_field(F::ONE),
+        "proof with tampered message should be rejected by the verifier",
     );
 }
 
@@ -102,9 +102,9 @@ mod slow {
     use super::*;
 
     #[test]
-    fn circuit_rejects_merkle_root_carry_violation_in_same_epoch_step() {
+    fn circuit_rejects_merkle_tree_commitment_carry_violation_in_same_epoch_step() {
         // MockProver constraint check: in a same-epoch transition the circuit must carry
-        // merkle_root unchanged from prev_state. Setting it to ONE violates that constraint.
+        // merkle_tree_commitment unchanged from prev_state. Setting it to ONE violates that constraint.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let prev_state = load_embedded_recursive_chain_state_asset()
@@ -114,7 +114,7 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_root,
+            prev_state.merkle_tree_commitment,
             MessageHash::from_field(message),
             ProtocolMessagePreimage::new(
                 preimage_bytes
@@ -123,20 +123,20 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
-        tampered_state.merkle_root = MerkleTreeCommitment::from_field(F::ONE);
+        tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             public_inputs,
-            "merkle_root set to ONE (same-epoch: must carry prev.merkle_root unchanged)",
+            "merkle_tree_commitment set to ONE (same-epoch: must carry prev.merkle_tree_commitment unchanged)",
         );
     }
 
     #[test]
-    fn circuit_rejects_protocol_params_carry_violation_in_same_epoch_step() {
+    fn circuit_rejects_protocol_parameters_carry_violation_in_same_epoch_step() {
         // MockProver constraint check: in a same-epoch transition the circuit must carry
-        // protocol_params unchanged from prev_state. Setting it to ONE violates that constraint.
+        // protocol_parameters unchanged from prev_state. Setting it to ONE violates that constraint.
         let setup = build_asset_generation_setup();
         let mock_prover_setup = build_mock_prover_setup_from_assets(&setup);
         let prev_state = load_embedded_recursive_chain_state_asset()
@@ -146,7 +146,7 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_root,
+            prev_state.merkle_tree_commitment,
             MessageHash::from_field(message),
             ProtocolMessagePreimage::new(
                 preimage_bytes
@@ -155,13 +155,13 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
-        tampered_state.protocol_params = ProtocolParametersHash::from_field(F::ONE);
+        tampered_state.protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
         let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
             circuit,
             public_inputs,
-            "protocol_params set to ONE (same-epoch: must carry prev.protocol_params unchanged)",
+            "protocol_parameters set to ONE (same-epoch: must carry prev.protocol_parameters unchanged)",
         );
     }
 
@@ -178,7 +178,7 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_root,
+            prev_state.merkle_tree_commitment,
             MessageHash::from_field(message),
             ProtocolMessagePreimage::new(
                 preimage_bytes

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
@@ -124,10 +124,11 @@ mod slow {
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
         tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "merkle_tree_commitment set to ONE (same-epoch: must carry prev.merkle_tree_commitment unchanged)",
         );
@@ -156,10 +157,11 @@ mod slow {
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
         tampered_state.protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "protocol_parameters set to ONE (same-epoch: must carry prev.protocol_parameters unchanged)",
         );
@@ -188,10 +190,11 @@ mod slow {
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
         tampered_state.current_epoch = EpochNumber::new(tampered_state.current_epoch.as_u64() + 1);
-        let circuit = build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
+        let ivc_circuit_data =
+            build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
         assert_recursive_mock_prover_rejects_with_label(
-            circuit,
+            ivc_circuit_data,
             public_inputs,
             "current_epoch incremented (same-epoch: must equal prev.current_epoch)",
         );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
@@ -114,8 +114,8 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_tree_commitment,
             MessageHash::from_field(message),
+            prev_state.merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 preimage_bytes
                     .try_into()
@@ -147,8 +147,8 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_tree_commitment,
             MessageHash::from_field(message),
+            prev_state.merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 preimage_bytes
                     .try_into()
@@ -180,8 +180,8 @@ mod slow {
             same_epoch_message_and_preimage_for_step(&setup, &prev_state);
         let witness = Witness::new(
             setup.genesis_signature,
-            prev_state.merkle_tree_commitment,
             MessageHash::from_field(message),
+            prev_state.merkle_tree_commitment,
             ProtocolMessagePreimage::new(
                 preimage_bytes
                     .try_into()

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/positive.rs
@@ -36,7 +36,7 @@ fn assert_step_proof_verifies(
 
     let dual_msm = verify_prepare_blake2b_recursive_proof(
         &verification_context.recursive_verifying_key,
-        step_output.proof.as_bytes(),
+        step_output.ivc_proof.as_bytes(),
         &public_inputs,
     );
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
@@ -11,7 +11,9 @@ use crate::{
     StmResult,
     circuits::{
         halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
-        halo2_ivc::{K, RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::IvcCircuit},
+        halo2_ivc::{
+            K, RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::IvcCircuitData,
+        },
         trusted_setup::TrustedSetupProvider,
     },
 };
@@ -31,8 +33,8 @@ fn compute_recursive_circuit_verification_key() -> StmResult<Vec<u8>> {
         MidnightVK::read(&mut non_recursive_verification_key, SerdeFormat::RawBytes)
             .with_context(|| "Failed to deserialize the circuit verification key.")?;
 
-    let default_ivc_circuit =
-        IvcCircuit::unknown(certificate_verifying_key.vk()).expect("valid IvcCircuit unknown");
+    let default_ivc_circuit = IvcCircuitData::unknown(certificate_verifying_key.vk())
+        .expect("valid IvcCircuitData unknown");
     let recursive_verification_key: VerifyingKey<
         <BlstrsEmulation as SelfEmulation>::F,
         KZGCommitmentScheme<<BlstrsEmulation as SelfEmulation>::Engine>,

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -165,9 +165,3 @@ impl IvcProofBytes {
         self.0
     }
 }
-
-impl From<Vec<u8>> for IvcProofBytes {
-    fn from(bytes: Vec<u8>) -> Self {
-        Self(bytes)
-    }
-}

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/epoch_data.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/epoch_data.rs
@@ -4,8 +4,8 @@
 use crate::{
     BaseFieldElement, StmResult,
     circuits::halo2_ivc::{
-        PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_ROOT_BYTES,
-        PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES, PREIMAGE_SIZE,
+        PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+        PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE,
     },
 };
 
@@ -19,9 +19,9 @@ pub(crate) struct EpochData {
     message_preimage: [u8; PREIMAGE_SIZE],
     /// Certificate's epoch, decoded from `PREIMAGE_CURRENT_EPOCH_BYTES`.
     current_epoch: BaseFieldElement,
-    /// Next epoch's Merkle-tree commitment, decoded from `PREIMAGE_NEXT_MERKLE_ROOT_BYTES`.
-    next_merkle_root: BaseFieldElement,
-    /// Next epoch's protocol parameters, decoded from `PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES`.
+    /// Next epoch's Merkle-tree commitment, decoded from `PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES`.
+    next_merkle_tree_commitment: BaseFieldElement,
+    /// Next epoch's protocol parameters, decoded from `PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES`.
     next_protocol_parameters: BaseFieldElement,
 }
 
@@ -37,18 +37,19 @@ impl EpochData {
             message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].try_into()?;
         let current_epoch = BaseFieldElement::from(u64::from_le_bytes(current_epoch_bytes));
 
-        let next_merkle_root_bytes: [u8; 32] =
-            message_preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].try_into()?;
-        let next_merkle_root = BaseFieldElement::from_raw(&next_merkle_root_bytes)?;
+        let next_merkle_tree_commitment_bytes: [u8; 32] =
+            message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].try_into()?;
+        let next_merkle_tree_commitment =
+            BaseFieldElement::from_raw(&next_merkle_tree_commitment_bytes)?;
 
-        let next_protocol_params_bytes: [u8; 32] =
-            message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].try_into()?;
-        let next_protocol_parameters = BaseFieldElement::from_raw(&next_protocol_params_bytes)?;
+        let next_protocol_parameters_bytes: [u8; 32] =
+            message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].try_into()?;
+        let next_protocol_parameters = BaseFieldElement::from_raw(&next_protocol_parameters_bytes)?;
 
         Ok(Self {
             message_preimage,
             current_epoch,
-            next_merkle_root,
+            next_merkle_tree_commitment,
             next_protocol_parameters,
         })
     }
@@ -64,8 +65,8 @@ impl EpochData {
     }
 
     /// Returns the next epoch's Merkle-tree commitment.
-    pub(crate) fn next_merkle_root(&self) -> BaseFieldElement {
-        self.next_merkle_root
+    pub(crate) fn next_merkle_tree_commitment(&self) -> BaseFieldElement {
+        self.next_merkle_tree_commitment
     }
 
     /// Returns the next epoch's protocol parameters.
@@ -81,15 +82,15 @@ mod tests {
     #[test]
     fn new_decodes_each_field_from_correct_range() {
         let mut preimage = [0u8; PREIMAGE_SIZE];
-        preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].copy_from_slice(&[0x11; 32]);
-        preimage[PREIMAGE_NEXT_PROTOCOL_PARAMS_BYTES].copy_from_slice(&[0x22; 32]);
+        preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].copy_from_slice(&[0x11; 32]);
+        preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].copy_from_slice(&[0x22; 32]);
         preimage[PREIMAGE_CURRENT_EPOCH_BYTES].copy_from_slice(&42u64.to_le_bytes());
 
         let epoch_data = EpochData::new(preimage).unwrap();
 
         assert_eq!(epoch_data.current_epoch(), BaseFieldElement::from(42u64));
         assert_eq!(
-            epoch_data.next_merkle_root(),
+            epoch_data.next_merkle_tree_commitment(),
             BaseFieldElement::from_raw(&[0x11; 32]).unwrap()
         );
         assert_eq!(
@@ -106,19 +107,19 @@ mod tests {
 
         let zero = BaseFieldElement::from(0u64);
         assert_eq!(epoch_data.current_epoch(), zero);
-        assert_eq!(epoch_data.next_merkle_root(), zero);
+        assert_eq!(epoch_data.next_merkle_tree_commitment(), zero);
         assert_eq!(epoch_data.next_protocol_parameters(), zero);
     }
 
     #[test]
     fn new_reduces_max_value_modulo_field() {
         let mut preimage = [0u8; PREIMAGE_SIZE];
-        preimage[PREIMAGE_NEXT_MERKLE_ROOT_BYTES].copy_from_slice(&[0xFF; 32]);
+        preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].copy_from_slice(&[0xFF; 32]);
 
         let epoch_data = EpochData::new(preimage).unwrap();
 
         assert_eq!(
-            epoch_data.next_merkle_root(),
+            epoch_data.next_merkle_tree_commitment(),
             BaseFieldElement::from_raw(&[0xFF; 32]).unwrap()
         );
     }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/setup.rs
@@ -8,7 +8,10 @@ use midnight_proofs::poly::kzg::params::ParamsKZG;
 use crate::{
     StmResult,
     circuits::{
-        halo2_ivc::{CERT_VK_NAME, IVC_ONE_NAME, state::fixed_bases_and_names},
+        halo2_ivc::{
+            CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME,
+            state::fixed_bases_and_names,
+        },
         trusted_setup::TrustedSetupProvider,
     },
     proof_system::ivc_halo2_snark::{
@@ -41,9 +44,9 @@ pub(crate) struct IvcSetup {
     pub(crate) ivc_proving_key: CircuitProvingKey,
     /// Fixed-base map used to normalize the certificate accumulator.
     pub(crate) certificate_fixed_bases: BTreeMap<String, G1Projective>,
-    /// Fixed-base map used to normalize the IVC self-proof accumulator.
+    /// Fixed-base map used to normalize the IVC proof accumulator.
     pub(crate) ivc_fixed_bases: BTreeMap<String, G1Projective>,
-    /// Fixed-base map used when folding the certificate and self-proof accumulators
+    /// Fixed-base map used when folding the certificate and IVC proof accumulators
     /// into the new IVC folded accumulator.
     pub(crate) combined_fixed_bases: BTreeMap<String, G1Projective>,
 }
@@ -84,9 +87,12 @@ impl IvcSetup {
         let ivc_verifying_key = ivc_key_provider.get_verifying_key()?;
         let ivc_proving_key = ivc_key_provider.get_proving_key()?;
 
-        let (certificate_fixed_bases, _) =
-            fixed_bases_and_names(CERT_VK_NAME, &certificate_verifying_key);
-        let (ivc_fixed_bases, _) = fixed_bases_and_names(IVC_ONE_NAME, &ivc_verifying_key);
+        let (certificate_fixed_bases, _) = fixed_bases_and_names(
+            CERTIFICATE_VERIFICATION_KEY_NAME,
+            &certificate_verifying_key,
+        );
+        let (ivc_fixed_bases, _) =
+            fixed_bases_and_names(IVC_VERIFICATION_KEY_NAME, &ivc_verifying_key);
         let mut combined_fixed_bases = certificate_fixed_bases.clone();
         combined_fixed_bases.extend(ivc_fixed_bases.clone());
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
@@ -25,7 +25,7 @@ use crate::{
     Parameters, StmResult,
     circuits::{
         halo2::circuit::StmCertificateCircuit,
-        halo2_ivc::{K, circuit::IvcCircuit},
+        halo2_ivc::{K, circuit::IvcCircuitData},
     },
     proof_system::ivc_halo2_snark::{CircuitProvingKey, CircuitVerifyingKey},
 };
@@ -109,15 +109,15 @@ impl TempIvcKeyProvider {
     /// Builds an unknown-witness IVC circuit parameterized by the certificate VK
     /// and runs `keygen_vk_with_k` at the IVC circuit's domain size `K`.
     pub(crate) fn get_verifying_key(&self) -> StmResult<CircuitVerifyingKey> {
-        let ivc_circuit = IvcCircuit::unknown(&self.certificate_verifying_key)?;
-        Ok(keygen_vk_with_k(self.srs.as_ref(), &ivc_circuit, K)?)
+        let ivc_circuit_data = IvcCircuitData::unknown(&self.certificate_verifying_key)?;
+        Ok(keygen_vk_with_k(self.srs.as_ref(), &ivc_circuit_data, K)?)
     }
 
     /// Recomputes the IVC verifying key (the temp layer has no cache, so the VK
     /// is re-derived here) and runs `keygen_pk` to produce the proving key.
     pub(crate) fn get_proving_key(&self) -> StmResult<CircuitProvingKey> {
-        let ivc_circuit = IvcCircuit::unknown(&self.certificate_verifying_key)?;
-        let ivc_verifying_key = keygen_vk_with_k(self.srs.as_ref(), &ivc_circuit, K)?;
-        Ok(keygen_pk(ivc_verifying_key, &ivc_circuit)?)
+        let ivc_circuit_data = IvcCircuitData::unknown(&self.certificate_verifying_key)?;
+        let ivc_verifying_key = keygen_vk_with_k(self.srs.as_ref(), &ivc_circuit_data, K)?;
+        Ok(keygen_pk(ivc_verifying_key, &ivc_circuit_data)?)
     }
 }


### PR DESCRIPTION
## Content

This PR completes WS5, aligning the `halo2_ivc` circuit and IVC proof-system naming with STM and certificate-circuit terminology.

### Changes
- **STM terminology**: renames state, witness, protocol-message, and accumulator identifiers to use `message`, `merkle_tree_commitment`, `protocol_parameters`, and `certificate_proof_accumulator`
- **Verification identifiers**: renames certificate and IVC verification-key fields, constants, errors, and helpers to explicit domain names
- **IVC circuit data**: renames `IvcCircuit` to `IvcCircuitData`
- **Proof-system callers**: updates IVC proof-system code to use the new canonical circuit names directly
- **Review cleanup**: normalizes witness field ordering and removes the unused `From<Vec<u8>> for IvcProofBytes`

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Closes https://github.com/input-output-hk/mithril/issues/3130