### PR TITLE
fix: pools tickers missing in mithril-explorer

### DIFF
--- a/mithril-explorer/__tests__/PoolTicker.test.js
+++ b/mithril-explorer/__tests__/PoolTicker.test.js
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import { initStore } from "./helpers";
+import { dummyAggregator, initStore } from "./helpers";
 import { Provider } from "react-redux";
 import PoolTicker from "#/PoolTicker";
 import { settingsSlice } from "@/store/settingsSlice";
@@ -31,13 +31,13 @@ describe("PoolTicker", () => {
     renderPoolTickerComponent(partyId, {
       settings: {
         ...settingsSlice.getInitialState(),
-        selectedAggregator: "myaggregator",
+        selectedAggregator: dummyAggregator("my_aggregator", "my://aggregator.url"),
       },
       pools: {
         ...poolsSlice.getInitialState(),
         list: [
           {
-            aggregator: "myaggregator",
+            aggregator: "my://aggregator.url",
             network: "devnet",
             pools: [
               {
@@ -63,13 +63,13 @@ describe("PoolTicker", () => {
       renderPoolTickerComponent(partyId, {
         settings: {
           ...settingsSlice.getInitialState(),
-          selectedAggregator: "myaggregator",
+          selectedAggregator: dummyAggregator("my_aggregator", "my://aggregator.url"),
         },
         pools: {
           ...poolsSlice.getInitialState(),
           list: [
             {
-              aggregator: "myaggregator",
+              aggregator: "my://aggregator.url",
               network: network,
               pools: [
                 {
@@ -98,13 +98,13 @@ describe("PoolTicker", () => {
       renderPoolTickerComponent(partyId, {
         settings: {
           ...settingsSlice.getInitialState(),
-          selectedAggregator: "myaggregator",
+          selectedAggregator: dummyAggregator("my_aggregator", "my://aggregator.url"),
         },
         pools: {
           ...poolsSlice.getInitialState(),
           list: [
             {
-              aggregator: "myaggregator",
+              aggregator: "my://aggregator.url",
               network: network,
               pools: [
                 {
@@ -132,13 +132,13 @@ describe("PoolTicker", () => {
       renderPoolTickerComponent(partyId, {
         settings: {
           ...settingsSlice.getInitialState(),
-          selectedAggregator: "myaggregator",
+          selectedAggregator: dummyAggregator("my_aggregator", "my://aggregator.url"),
         },
         pools: {
           ...poolsSlice.getInitialState(),
           list: [
             {
-              aggregator: "myaggregator",
+              aggregator: "my://aggregator.url",
               network: network,
               pools: [],
             },

--- a/mithril-explorer/__tests__/helpers.js
+++ b/mithril-explorer/__tests__/helpers.js
@@ -3,6 +3,8 @@ import * as mockRouter from "next-router-mock";
 
 const baseLocation = "http://localhost";
 
+const dummyAggregator = (name, url) => ({ name, url, genesisVerificationKey: "whatever" });
+
 function initStore(default_state = undefined) {
   if (default_state) {
     saveToLocalStorage(default_state);
@@ -71,6 +73,7 @@ function reg(party_id, stake) {
 }
 
 module.exports = {
+  dummyAggregator,
   initStore,
   mockNextNavigation,
   setLocation,

--- a/mithril-explorer/__tests__/store.test.js
+++ b/mithril-explorer/__tests__/store.test.js
@@ -10,13 +10,11 @@ import {
 } from "@/store/settingsSlice";
 import { getPreloadedStateFromLocalStorage, saveToLocalStorage, storeBuilder } from "@/store/store";
 import { waitFor } from "@testing-library/react";
-import { initStore } from "./helpers";
+import { dummyAggregator, initStore } from "./helpers";
 
 const expectedCapabilities = {
   signed_entity_types: [signedEntityType.CardanoTransactions],
 };
-
-const dummyAggregator = (name, url) => ({ name, url, genesisVerificationKey: "whatever" });
 
 jest.mock("../src/aggregator-api", () => {
   return {

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm",
         "@popperjs/core": "^2.11.8",

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/mithril-explorer/src/store/poolsSlice.js
+++ b/mithril-explorer/src/store/poolsSlice.js
@@ -57,7 +57,7 @@ export const updatePoolsForAggregator = createAsyncThunk(
 );
 
 const poolsForAggregator = (poolsSlice, aggregator) => {
-  return poolsSlice.list.find((poolsData) => poolsData.aggregator === aggregator);
+  return poolsSlice.list.find((poolsData) => poolsData.aggregator === aggregator.url);
 };
 
 export const getPoolForSelectedAggregator = createSelector(


### PR DESCRIPTION
## Content

This PR includes a fix for a regression the mithril explorer introduced with #3291: all pools tickers were missing.

Explanation:
The pools slice, which stores for each pools their party ids and tickers, was not adapted to the change of the aggregator structure in the explorer (from a list of urls strings to a list of objects).
This makes the retrieval of tickers fails since each list of party ids / tickers is associated with an aggregator url, and to identify which aggregator list to use it's now comparing an aggregator object to an url.

> [!NOTE]
>  A test existed for that specific case but ... given the unchecked types in javascript it was still using the previous aggregator structure without raising any issue even if it was changed everywhere else.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #3310
