### PR TITLE
Package only one ledger state snapshot for Cardano node version above 10.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.6"
+version = "0.9.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.6"
+version = "0.9.7"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/artifact_builder/cardano_database.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database.rs
@@ -131,6 +131,8 @@ mod tests {
 
     use super::*;
 
+    const DUMMY_CARDANO_NODE_VERSION: Version = Version::new(1, 2, 3);
+
     fn get_test_directory(dir_name: &str) -> PathBuf {
         TempDir::create("cardano_database", dir_name)
     }
@@ -195,6 +197,7 @@ mod tests {
 
         let snapshotter = Arc::new(
             CompressedArchiveSnapshotter::new(
+                DUMMY_CARDANO_NODE_VERSION,
                 cardano_db.get_dir().to_path_buf(),
                 test_dir.join("ongoing_snapshots"),
                 CompressionAlgorithm::Gzip,

--- a/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
+++ b/mithril-aggregator/src/artifact_builder/cardano_database_artifacts/immutable.rs
@@ -282,6 +282,7 @@ mod tests {
         entities::TemplateUri,
         test::{TempDir, assert_equivalent, equivalent_to},
     };
+    use semver::Version;
 
     use crate::services::ancillary_signer::MockAncillarySigner;
     use crate::services::{CompressedArchiveSnapshotter, DumbSnapshotter, MockSnapshotter};
@@ -289,6 +290,8 @@ mod tests {
     use crate::tools::file_archiver::FileArchiver;
 
     use super::*;
+
+    const DUMMY_CARDANO_NODE_VERSION: Version = Version::new(1, 2, 3);
 
     fn fake_uploader(
         archive_paths: Vec<&str>,
@@ -353,6 +356,7 @@ mod tests {
 
         let db_directory = cardano_db.get_dir().to_path_buf();
         let snapshotter = CompressedArchiveSnapshotter::new(
+            DUMMY_CARDANO_NODE_VERSION,
             db_directory.clone(),
             db_directory.parent().unwrap().join("snapshot_dest"),
             CompressionAlgorithm::Gzip,
@@ -446,6 +450,7 @@ mod tests {
 
             let db_directory = cardano_db.get_dir().to_path_buf();
             let snapshotter = CompressedArchiveSnapshotter::new(
+                DUMMY_CARDANO_NODE_VERSION,
                 db_directory.clone(),
                 db_directory.parent().unwrap().join("snapshot_dest"),
                 CompressionAlgorithm::Gzip,
@@ -492,6 +497,7 @@ mod tests {
 
             let db_directory = cardano_db.get_dir().to_path_buf();
             let snapshotter = CompressedArchiveSnapshotter::new(
+                DUMMY_CARDANO_NODE_VERSION,
                 db_directory.clone(),
                 db_directory.parent().unwrap().join("snapshot_dest"),
                 CompressionAlgorithm::Gzip,
@@ -526,6 +532,7 @@ mod tests {
 
             let db_directory = cardano_db.get_dir().to_path_buf();
             let snapshotter = CompressedArchiveSnapshotter::new(
+                DUMMY_CARDANO_NODE_VERSION,
                 db_directory.clone(),
                 db_directory.parent().unwrap().join("snapshot_dest"),
                 CompressionAlgorithm::Gzip,
@@ -558,6 +565,7 @@ mod tests {
 
             let db_directory = cardano_db.get_dir().to_path_buf();
             let snapshotter = CompressedArchiveSnapshotter::new(
+                DUMMY_CARDANO_NODE_VERSION,
                 db_directory.clone(),
                 db_directory.parent().unwrap().join("snapshot_dest"),
                 CompressionAlgorithm::Gzip,
@@ -614,6 +622,7 @@ mod tests {
 
             let db_directory = cardano_db.get_dir().to_path_buf();
             let snapshotter = CompressedArchiveSnapshotter::new(
+                DUMMY_CARDANO_NODE_VERSION,
                 db_directory.clone(),
                 db_directory.parent().unwrap().join("snapshot_dest"),
                 CompressionAlgorithm::Gzip,

--- a/mithril-aggregator/src/configuration.rs
+++ b/mithril-aggregator/src/configuration.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use anyhow::Context;
 use config::{ConfigError, Map, Source, Value, ValueKind};
+use semver::Version;
 use serde::Deserialize;
 
 use mithril_cardano_node_chain::chain_observer::ChainObserverType;
@@ -364,6 +365,12 @@ pub trait ConfigurationSource {
         }
 
         Ok(self.snapshot_directory())
+    }
+
+    /// Get the parsed Cardano node version.
+    fn parsed_cardano_node_version(&self) -> StdResult<semver::Version> {
+        Version::parse(&self.cardano_node_version())
+        .with_context(||format!("Could not parse configuration setting 'cardano_node_version' value '{}' as Semver.", self.cardano_node_version()) )
     }
 
     /// Get the safe epoch retention limit.

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/artifacts.rs
@@ -39,8 +39,13 @@ impl DependenciesBuilder {
         let mithril_stake_distribution_artifact_builder = Arc::new(
             MithrilStakeDistributionArtifactBuilder::new(epoch_service.clone()),
         );
-        let cardano_node_version = Version::parse(&self.configuration.cardano_node_version())
-            .map_err(|e| DependenciesBuilderError::Initialization { message: format!("Could not parse configuration setting 'cardano_node_version' value '{}' as Semver.", self.configuration.cardano_node_version()), error: Some(e.into()) })?;
+        let cardano_node_version =
+            self.configuration.parsed_cardano_node_version().map_err(|e| {
+                DependenciesBuilderError::Initialization {
+                    message: "Error while retrieving cardano node version".to_string(),
+                    error: Some(e),
+                }
+            })?;
         let legacy_prover_service = self.get_legacy_prover_service().await?;
         let cardano_transactions_artifact_builder = Arc::new(
             CardanoTransactionsArtifactBuilder::new(legacy_prover_service.clone()),
@@ -144,6 +149,7 @@ impl DependenciesBuilder {
                     self.configuration.get_snapshot_dir()?.join("pending_snapshot");
 
                 Arc::new(CompressedArchiveSnapshotter::new(
+                    self.configuration.parsed_cardano_node_version()?,
                     self.configuration.db_directory().clone(),
                     ongoing_snapshot_directory,
                     self.configuration.snapshot_compression_algorithm(),

--- a/mithril-aggregator/src/services/snapshotter/compressed_archive_snapshotter.rs
+++ b/mithril-aggregator/src/services/snapshotter/compressed_archive_snapshotter.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
+use semver::Version;
 use slog::{Logger, debug, warn};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -20,8 +21,13 @@ use crate::tools::file_size;
 
 use super::{Snapshotter, ancillary_signer::AncillarySigner};
 
+const CARDANO_NODE_VERSION_WITH_UTXO_HD_SUPPORT: Version = Version::new(10, 4, 1);
+
 /// Compressed Archive Snapshotter create a compressed file.
 pub struct CompressedArchiveSnapshotter {
+    /// Cardano node version to adapt the snapshot content if needed
+    cardano_node_version: Version,
+
     /// DB directory to snapshot
     db_directory: PathBuf,
 
@@ -125,6 +131,7 @@ impl Snapshotter for CompressedArchiveSnapshotter {
 impl CompressedArchiveSnapshotter {
     /// Snapshotter factory
     pub fn new(
+        cardano_node_version: Version,
         db_directory: PathBuf,
         ongoing_snapshot_directory: PathBuf,
         compression_algorithm: CompressionAlgorithm,
@@ -152,6 +159,7 @@ impl CompressedArchiveSnapshotter {
         })?;
 
         Ok(Self {
+            cardano_node_version,
             db_directory,
             ongoing_snapshot_directory,
             compression_algorithm,
@@ -232,10 +240,17 @@ impl CompressedArchiveSnapshotter {
 
         let db_ledger_dir = self.db_directory.join(LEDGER_DIR);
         let ledger_files = LedgerStateSnapshot::list_all_in_dir(&db_ledger_dir)?;
+
+        let number_of_ledger_to_snapshot =
+            if self.cardano_node_version < CARDANO_NODE_VERSION_WITH_UTXO_HD_SUPPORT {
+                2
+            } else {
+                1
+            };
         let latest_ledger_files: Vec<PathBuf> = ledger_files
             .iter()
             .rev()
-            .take(2)
+            .take(number_of_ledger_to_snapshot)
             .flat_map(|ledger_state_snapshot| ledger_state_snapshot.get_files_relative_path())
             .map(|path| PathBuf::from(LEDGER_DIR).join(path))
             .collect();
@@ -309,6 +324,8 @@ mod tests {
 
     use super::*;
 
+    const DUMMY_CARDANO_NODE_VERSION: Version = Version::new(1, 2, 3);
+
     fn list_files(test_dir: &Path) -> Vec<String> {
         fs::read_dir(test_dir)
             .unwrap()
@@ -322,6 +339,7 @@ mod tests {
         compression_algorithm: CompressionAlgorithm,
     ) -> CompressedArchiveSnapshotter {
         CompressedArchiveSnapshotter::new(
+            DUMMY_CARDANO_NODE_VERSION,
             db_directory.to_path_buf(),
             test_directory.join("ongoing_snapshot"),
             compression_algorithm,
@@ -356,6 +374,7 @@ mod tests {
         let db_directory = test_dir.join("whatever");
 
         CompressedArchiveSnapshotter::new(
+            DUMMY_CARDANO_NODE_VERSION,
             db_directory,
             ongoing_snapshot_directory.clone(),
             CompressionAlgorithm::Gzip,
@@ -379,6 +398,7 @@ mod tests {
         File::create(ongoing_snapshot_directory.join("whatever.txt")).unwrap();
 
         CompressedArchiveSnapshotter::new(
+            DUMMY_CARDANO_NODE_VERSION,
             db_directory,
             ongoing_snapshot_directory.clone(),
             CompressionAlgorithm::Gzip,
@@ -401,6 +421,7 @@ mod tests {
             .build();
 
         let snapshotter = CompressedArchiveSnapshotter::new(
+            DUMMY_CARDANO_NODE_VERSION,
             cardano_db.get_dir().clone(),
             pending_snapshot_directory.clone(),
             CompressionAlgorithm::Gzip,
@@ -592,7 +613,8 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn create_archive_should_embed_only_two_last_ledgers_and_last_immutables() {
+        async fn create_archive_should_embed_only_two_last_ledgers_and_last_immutables_for_cardano_node_below_10_4_1()
+         {
             let test_dir = temp_dir_create!();
             let cardano_db = DummyCardanoDbBuilder::new(current_function!())
                 .with_immutables(&[1, 2, 3])
@@ -603,6 +625,7 @@ mod tests {
             fs::create_dir(cardano_db.get_dir().join("whatever")).unwrap();
 
             let snapshotter = CompressedArchiveSnapshotter {
+                cardano_node_version: Version::new(10, 4, 0),
                 ancillary_signer: Arc::new(MockAncillarySigner::that_succeeds_with_signature(
                     fake_keys::signable_manifest_signature()[0],
                 )),
@@ -622,6 +645,45 @@ mod tests {
                      ** 00003.secondary
                      * {LEDGER_DIR}/
                      ** 637
+                     ** 737
+                     * {}",
+                    AncillaryFilesManifest::ANCILLARY_MANIFEST_FILE_NAME
+                )
+            );
+        }
+
+        #[tokio::test]
+        async fn create_archive_should_embed_only_the_last_ledger_and_last_immutables_for_cardano_node_greater_or_equal_to_10_4_1()
+         {
+            let test_dir = temp_dir_create!();
+            let cardano_db = DummyCardanoDbBuilder::new(current_function!())
+                .with_immutables(&[1, 2, 3])
+                .with_legacy_ledger_snapshots(&[437, 537, 637, 737])
+                .with_non_ledger_files(&["9not_included"])
+                .with_volatile_files(&["blocks-0.dat", "blocks-1.dat", "blocks-2.dat"])
+                .build();
+            fs::create_dir(cardano_db.get_dir().join("whatever")).unwrap();
+
+            let snapshotter = CompressedArchiveSnapshotter {
+                cardano_node_version: CARDANO_NODE_VERSION_WITH_UTXO_HD_SUPPORT,
+                ancillary_signer: Arc::new(MockAncillarySigner::that_succeeds_with_signature(
+                    fake_keys::signable_manifest_signature()[0],
+                )),
+                ..snapshotter_for_test(&test_dir, cardano_db.get_dir(), CompressionAlgorithm::Gzip)
+            };
+
+            let snapshot = snapshotter.snapshot_ancillary(2, "ancillary").await.unwrap();
+
+            let unpack_dir = snapshot.unpack_gzip(&test_dir);
+            assert_dir_eq!(
+                &unpack_dir,
+                // Only the last ledger files should be included
+                format!(
+                    "* {IMMUTABLE_DIR}/
+                     ** 00003.chunk
+                     ** 00003.primary
+                     ** 00003.secondary
+                     * {LEDGER_DIR}/
                      ** 737
                      * {}",
                     AncillaryFilesManifest::ANCILLARY_MANIFEST_FILE_NAME


### PR DESCRIPTION
## Content

Package only one ledger state snapshot (instead of two) for Cardano node version above 10.4 (version introducing support of UTxO-HD) 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

this PR relates to or closes #3298