### PR TITLE
feat: certificate chain support for IVC SNARK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 As a minor extension, we have adopted a slightly different versioning convention for the Mithril distributions (<https://mithril.network/doc/adr/3#decision>)
 
-## Mithril Distribution [2624.0] - UNRELEASED
+## Mithril Distribution [XXXX] - UNRELEASED
 
 - **REMOVED** support for `CardanoImmutableFilesFull` in Mithril signer and aggregator:
   - Use `CardanoDatabase` (also known as "cardano database v2") instead, which supports partial database restoration and
@@ -34,16 +34,18 @@ As a minor extension, we have adopted a slightly different versioning convention
   - Support for SNARK-friendly rigid protocol message openable in recursive circuit.
   - Support for SNARK-friendly genesis certificate primitives.
   - Support for dual-signature genesis certificate.
+  - Support for ancillary prover and verifier data carried on certificates.
+  - Support for stopping certificate chain verification early on full-chain certifying certificates.
 
-| Crate               | Version   |
-| ------------------- | --------- |
-| mithril-aggregator  | `0.9.6`   |
-| mithril-client      | `0.14.14` |
-| mithril-client-cli  | `0.13.15` |
-| mithril-client-wasm | `0.10.6`  |
-| mithril-common      | `0.7.4`   |
-| mithril-signer      | `1.1.2`   |
-| mithril-stm         | `0.10.32` |
+| Crate               | Version |
+| ------------------- | ------- |
+| mithril-aggregator  | `-`     |
+| mithril-client      | `-`     |
+| mithril-client-cli  | `-`     |
+| mithril-client-wasm | `-`     |
+| mithril-common      | `-`     |
+| mithril-signer      | `-`     |
+| mithril-stm         | `-`     |
 
 ## Mithril Distribution [2617.0] - 2026-04-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.7"
+version = "0.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4302,7 +4302,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.13.15"
+version = "0.13.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.34"
+version = "0.10.35"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",
@@ -4714,7 +4714,7 @@ dependencies = [
 
 [[package]]
 name = "mithrildemo"
-version = "0.1.57"
+version = "0.1.58"
 dependencies = [
  "clap",
  "hex",

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithrildemo"
-version = "0.1.57"
+version = "0.1.58"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -1,5 +1,5 @@
 use hex::ToHex;
-use mithril_stm::AggregateSignatureType;
+use mithril_stm::{AggregateSignatureType, AncillaryGenesisData, AncillaryProofInput};
 use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -169,13 +169,22 @@ impl Party {
         signatures: &[ProtocolSingleSignature],
     ) -> Option<&ProtocolMultiSignature> {
         let aggregate_signature_type = AggregateSignatureType::Concatenation;
+        let ancillary_input = AncillaryProofInput::new(
+            None,
+            AncillaryGenesisData::new(
+                Vec::new(),
+                #[cfg(feature = "future_snark")]
+                None,
+            ),
+        );
         let msig = self.clerk.as_ref().unwrap().aggregate_signatures_with_type(
             signatures,
             message,
             aggregate_signature_type,
+            ancillary_input,
         );
         match msig {
-            Ok(aggregate_signature) => {
+            Ok((aggregate_signature, _ancillary_verifier_data)) => {
                 println!("Party #{}: aggregate signature computed", self.party_id);
                 self.msigs.insert(message.clone(), aggregate_signature);
                 self.get_aggregate(message)
@@ -202,6 +211,7 @@ impl Party {
                 message,
                 &self.clerk.as_ref().unwrap().compute_aggregate_verification_key(),
                 &self.params.unwrap(),
+                None,
             ) {
                 Ok(_) => {
                     println!(
@@ -305,6 +315,7 @@ impl Verifier {
             message,
             &self.clerk.as_ref().unwrap().compute_aggregate_verification_key(),
             &self.params.unwrap(),
+            None,
         ) {
             Ok(_) => {
                 println!(

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.4" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.5" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.4" }
+mithril-common = { path = "../../mithril-common", version = "0.7.5" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.2" }
-mithril-common = { path = "../../mithril-common", version = "0.7.4" }
+mithril-common = { path = "../../mithril-common", version = "0.7.5" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.7"
+version = "0.9.8"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/database/migration.rs
+++ b/mithril-aggregator/src/database/migration.rs
@@ -332,5 +332,14 @@ delete from buffered_single_signature where buffered_single_signature.signed_ent
 delete from signed_entity_type where signed_entity_type.signed_entity_type_id = 2;
         "#,
         ),
+        // Migration 44
+        // Add `ancillary_prover_data` and `ancillary_verifier_data` columns to `certificate` table.
+        SqlMigration::new(
+            44,
+            r#"
+alter table certificate add column ancillary_prover_data text;
+alter table certificate add column ancillary_verifier_data text;
+        "#,
+        ),
     ]
 }

--- a/mithril-aggregator/src/database/query/certificate/conditions.rs
+++ b/mithril-aggregator/src/database/query/certificate/conditions.rs
@@ -24,9 +24,11 @@ pub(super) fn insert_many(certificates_records: Vec<CertificateRecord>) -> Where
         protocol_message, \
         signers, \
         initiated_at, \
-        sealed_at)";
+        sealed_at, \
+        ancillary_prover_data, \
+        ancillary_verifier_data)";
     let values_columns: Vec<&str> = repeat_n(
-        "(?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*)",
+        "(?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*, ?*)",
         certificates_records.len(),
     )
     .collect();
@@ -65,6 +67,14 @@ pub(super) fn insert_many(certificates_records: Vec<CertificateRecord>) -> Where
                 Value::String(serde_json::to_string(&certificate_record.signers).unwrap()),
                 Value::String(certificate_record.initiated_at.to_rfc3339()),
                 Value::String(certificate_record.sealed_at.to_rfc3339()),
+                certificate_record
+                    .ancillary_prover_data
+                    .map(Value::String)
+                    .unwrap_or(Value::Null),
+                certificate_record
+                    .ancillary_verifier_data
+                    .map(Value::String)
+                    .unwrap_or(Value::Null),
             ]
         })
         .collect();

--- a/mithril-aggregator/src/database/record/certificate.rs
+++ b/mithril-aggregator/src/database/record/certificate.rs
@@ -113,6 +113,12 @@ pub struct CertificateRecord {
     /// Aggregate verification key for SNARK
     pub aggregate_verification_key_snark: Option<HexEncodedVerificationKeyForSnark>,
 
+    /// Ancillary data used by the prover to produce the next certificate, hex-encoded.
+    pub ancillary_prover_data: Option<HexEncodedKey>,
+
+    /// Ancillary data used to verify the certificate, hex-encoded.
+    pub ancillary_verifier_data: Option<HexEncodedKey>,
+
     /// Epoch of creation of the certificate.
     pub epoch: Epoch,
 
@@ -180,6 +186,8 @@ impl CertificateRecord {
                 [0]
             .to_owned(),
             aggregate_verification_key_snark: None,
+            ancillary_prover_data: None,
+            ancillary_verifier_data: None,
             epoch,
             network: fake_data::network().to_string(),
             signed_entity_type,
@@ -230,6 +238,15 @@ impl TryFrom<Certificate> for CertificateRecord {
         #[cfg(not(feature = "future_snark"))]
         let aggregate_verification_key_snark: Option<HexEncodedKey> = None;
 
+        let ancillary_prover_data = other
+            .ancillary_prover_data
+            .map(|data| data.to_bytes_hex())
+            .transpose()?;
+        let ancillary_verifier_data = other
+            .ancillary_verifier_data
+            .map(|data| data.to_bytes_hex())
+            .transpose()?;
+
         let certificate_record = CertificateRecord {
             certificate_id: other.hash,
             parent_certificate_id,
@@ -237,6 +254,8 @@ impl TryFrom<Certificate> for CertificateRecord {
             signature,
             aggregate_verification_key: other.aggregate_verification_key.to_json_hex()?,
             aggregate_verification_key_snark,
+            ancillary_prover_data,
+            ancillary_verifier_data,
             epoch: other.epoch,
             network: other.metadata.network,
             signed_entity_type,
@@ -289,6 +308,15 @@ impl TryFrom<CertificateRecord> for Certificate {
             .map(|hex| hex.as_str().try_into())
             .transpose()?;
 
+        let ancillary_prover_data = other
+            .ancillary_prover_data
+            .map(|hex_data| hex_data.try_into())
+            .transpose()?;
+        let ancillary_verifier_data = other
+            .ancillary_verifier_data
+            .map(|hex_data| hex_data.try_into())
+            .transpose()?;
+
         let certificate = Certificate {
             hash: other.certificate_id,
             previous_hash,
@@ -299,6 +327,8 @@ impl TryFrom<CertificateRecord> for Certificate {
             aggregate_verification_key: other.aggregate_verification_key.try_into()?,
             #[cfg(feature = "future_snark")]
             aggregate_verification_key_snark,
+            ancillary_prover_data,
+            ancillary_verifier_data,
             signature,
         };
 
@@ -350,6 +380,8 @@ impl From<CertificateRecord> for CertificateMessage {
             aggregate_verification_key: value.aggregate_verification_key,
             #[cfg(feature = "future_snark")]
             aggregate_verification_key_snark: value.aggregate_verification_key_snark,
+            ancillary_prover_data: value.ancillary_prover_data,
+            ancillary_verifier_data: value.ancillary_verifier_data,
             multi_signature,
             genesis_signature,
             #[cfg(feature = "future_snark")]
@@ -404,6 +436,8 @@ impl SqLiteEntity for CertificateRecord {
         let signers_string = row.read::<&str, _>(13);
         let initiated_at = row.read::<&str, _>(14);
         let sealed_at = row.read::<&str, _>(15);
+        let ancillary_prover_data = row.read::<Option<&str>, _>(16).map(|s| s.to_owned());
+        let ancillary_verifier_data = row.read::<Option<&str>, _>(17).map(|s| s.to_owned());
 
         let certificate_record = Self {
             certificate_id,
@@ -412,6 +446,8 @@ impl SqLiteEntity for CertificateRecord {
             signature,
             aggregate_verification_key,
             aggregate_verification_key_snark,
+            ancillary_prover_data,
+            ancillary_verifier_data,
             epoch: Epoch(epoch_int.try_into().map_err(|e| {
                 HydrationError::InvalidData(format!(
                     "Could not cast i64 ({epoch_int}) to u64. Error: '{e}'"
@@ -517,6 +553,16 @@ impl SqLiteEntity for CertificateRecord {
         projection.add_field("signers", "{:certificate:}.signers", "text");
         projection.add_field("initiated_at", "{:certificate:}.initiated_at", "text");
         projection.add_field("sealed_at", "{:certificate:}.sealed_at", "text");
+        projection.add_field(
+            "ancillary_prover_data",
+            "{:certificate:}.ancillary_prover_data",
+            "text",
+        );
+        projection.add_field(
+            "ancillary_verifier_data",
+            "{:certificate:}.ancillary_verifier_data",
+            "text",
+        );
 
         projection
     }

--- a/mithril-aggregator/src/database/repository/certificate_repository.rs
+++ b/mithril-aggregator/src/database/repository/certificate_repository.rs
@@ -212,7 +212,9 @@ mod tests {
                 }}]',
                 '2023-06-23T08:37:49.066Z',
                 '2023-06-23T08:37:49.066Z',
-                {snark_avk}
+                {snark_avk},
+                null,
+                null
             );
             
             -- multi-signature certificate
@@ -243,7 +245,9 @@ mod tests {
                 }}]',
                 '2023-03-16T01:51:00.880Z',
                 '2023-03-16T02:07:22.145Z',
-                {snark_avk}
+                {snark_avk},
+                null,
+                null
             );
             "#
             ))

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -3,11 +3,11 @@ use async_trait::async_trait;
 use slog::{Logger, debug, warn};
 
 use mithril_common::{
-    AggregateSignatureType, StdResult,
-    crypto_helper::{ProtocolAggregationError, ProtocolMultiSignature},
+    AggregateSignatureType, AncillaryProofInput, StdResult,
+    crypto_helper::ProtocolAggregationError,
     entities::{self},
     logging::LoggerExtensions,
-    protocol::MultiSigner as ProtocolMultiSigner,
+    protocol::{MultiSignatureWithAncillaryVerifierData, MultiSigner as ProtocolMultiSigner},
 };
 
 use crate::dependency_injection::EpochServiceWrapper;
@@ -35,7 +35,8 @@ pub trait MultiSigner: Sync + Send {
     async fn create_multi_signature(
         &self,
         open_message: &OpenMessage,
-    ) -> StdResult<Option<ProtocolMultiSignature>>;
+        ancillary_input: AncillaryProofInput,
+    ) -> StdResult<Option<MultiSignatureWithAncillaryVerifierData>>;
 }
 
 /// MultiSignerImpl is an implementation of the MultiSigner
@@ -115,7 +116,8 @@ impl MultiSigner for MultiSignerImpl {
     async fn create_multi_signature(
         &self,
         open_message: &OpenMessage,
-    ) -> StdResult<Option<ProtocolMultiSignature>> {
+        ancillary_input: AncillaryProofInput,
+    ) -> StdResult<Option<MultiSignatureWithAncillaryVerifierData>> {
         debug!(self.logger, ">> create_multi_signature"; "open_message" => ?open_message);
 
         let epoch_service = self.epoch_service.read().await;
@@ -127,8 +129,11 @@ impl MultiSigner for MultiSignerImpl {
             &open_message.single_signatures,
             &open_message.protocol_message,
             self.aggregate_signature_type,
+            ancillary_input,
         ) {
-            Ok(multi_signature) => Ok(Some(multi_signature)),
+            Ok(multi_signature_with_ancillary_verifier_data) => {
+                Ok(Some(multi_signature_with_ancillary_verifier_data))
+            }
             Err(err) => match err.downcast_ref::<ProtocolAggregationError>() {
                 Some(ProtocolAggregationError::NotEnoughSignatures(actual, expected)) => {
                     warn!(
@@ -300,7 +305,7 @@ mod tests {
         // No signatures registered: multi-signer can't create the multi-signature
         assert!(
             multi_signer
-                .create_multi_signature(&open_message)
+                .create_multi_signature(&open_message, AncillaryProofInput::dummy())
                 .await
                 .expect("create multi signature should not fail")
                 .is_none()
@@ -311,7 +316,7 @@ mod tests {
 
         assert!(
             multi_signer
-                .create_multi_signature(&open_message)
+                .create_multi_signature(&open_message, AncillaryProofInput::dummy())
                 .await
                 .expect("create multi signature should not fail")
                 .is_none()
@@ -322,7 +327,7 @@ mod tests {
 
         assert!(
             multi_signer
-                .create_multi_signature(&open_message)
+                .create_multi_signature(&open_message, AncillaryProofInput::dummy())
                 .await
                 .expect("create multi signature should not fail")
                 .is_some(),

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -11,7 +11,9 @@ use mithril_common::entities::{
     SignedEntityType, SingleSignature, StakeDistributionParty,
 };
 use mithril_common::logging::LoggerExtensions;
-use mithril_common::protocol::ToMessage;
+use mithril_common::protocol::{
+    MultiSignatureWithAncillaryVerifierData, ToMessage, build_ancillary_proof_input,
+};
 use mithril_common::{CardanoNetwork, StdResult};
 
 use crate::MultiSigner;
@@ -289,7 +291,34 @@ impl CertifierService for MithrilCertifierService {
             return Err(CertifierServiceError::Expired(signed_entity_type.clone()).into());
         }
 
-        let multi_signature = match self.multi_signer.create_multi_signature(&open_message).await? {
+        let parent_certificate = self
+            .certificate_repository
+            .get_master_certificate_for_epoch::<Certificate>(open_message.epoch)
+            .await
+            .with_context(|| {
+                format!(
+                    "Certifier can not get leader certificate for epoch: '{}'",
+                    open_message.epoch
+                )
+            })?
+            .ok_or_else(|| Box::new(CertifierServiceError::NoParentCertificateFound))?;
+        let genesis_certificate = self
+            .certificate_repository
+            .get_latest_genesis_certificate::<Certificate>()
+            .await
+            .with_context(|| "Certifier can not get the latest genesis certificate")?
+            .ok_or_else(|| Box::new(CertifierServiceError::NoGenesisCertificateFound))?;
+        let ancillary_input =
+            build_ancillary_proof_input(&genesis_certificate, &parent_certificate);
+
+        let MultiSignatureWithAncillaryVerifierData {
+            multi_signature,
+            ancillary_verifier_data,
+        } = match self
+            .multi_signer
+            .create_multi_signature(&open_message, ancillary_input)
+            .await?
+        {
             None => {
                 debug!(
                     self.logger,
@@ -297,12 +326,12 @@ impl CertifierService for MithrilCertifierService {
                 );
                 return Ok(None);
             }
-            Some(signature) => {
+            Some(multi_signature_with_ancillary_verifier_data) => {
                 info!(
                     self.logger,
                     "create_certificate: multi-signature created for open message {signed_entity_type:?}"
                 );
-                signature
+                multi_signature_with_ancillary_verifier_data
             }
         };
 
@@ -326,18 +355,7 @@ impl CertifierService for MithrilCertifierService {
             sealed_at,
             StakeDistributionParty::from_signers(signers),
         );
-        let parent_certificate_hash = self
-            .certificate_repository
-            .get_master_certificate_for_epoch::<Certificate>(open_message.epoch)
-            .await
-            .with_context(|| {
-                format!(
-                    "Certifier can not get leader certificate for epoch: '{}'",
-                    open_message.epoch
-                )
-            })?
-            .map(|cert| cert.hash)
-            .ok_or_else(|| Box::new(CertifierServiceError::NoParentCertificateFound))?;
+        let parent_certificate_hash = parent_certificate.hash;
 
         let certificate = Certificate::try_new(
             parent_certificate_hash,
@@ -346,6 +364,7 @@ impl CertifierService for MithrilCertifierService {
             open_message.protocol_message.clone(),
             epoch_service.current_aggregate_verification_key()?.clone(),
             CertificateSignature::MultiSignature(signed_entity_type.clone(), multi_signature),
+            ancillary_verifier_data,
         )?;
 
         self.certificate_verifier
@@ -852,8 +871,8 @@ mod tests {
         let mut mock_multi_signer = MockMultiSigner::new();
         mock_multi_signer
             .expect_create_multi_signature()
-            .return_once(move |_| Ok(None));
-        let beacon = CardanoDbBeacon::new(1, 1);
+            .return_once(move |_, _| Ok(None));
+        let beacon = CardanoDbBeacon::new(3, 1);
         let signed_entity_type = SignedEntityType::CardanoDatabase(beacon.clone());
         let protocol_message = ProtocolMessage::new();
         let fixture = MithrilFixtureBuilder::default().with_signers(5).build();
@@ -864,6 +883,15 @@ mod tests {
             .create_open_message(&signed_entity_type, &protocol_message)
             .await
             .unwrap();
+
+        let genesis_certificate =
+            fixture.create_genesis_certificate(certifier_service.network, beacon.epoch - 1);
+        certifier_service
+            .certificate_repository
+            .create_certificate(genesis_certificate)
+            .await
+            .unwrap();
+
         let create_certificate_result = certifier_service
             .create_certificate(&signed_entity_type)
             .await

--- a/mithril-aggregator/src/services/certifier/interface.rs
+++ b/mithril-aggregator/src/services/certifier/interface.rs
@@ -36,6 +36,10 @@ pub enum CertifierServiceError {
     )]
     NoParentCertificateFound,
 
+    /// No genesis certificate could be found, the certificate chain is not initialized.
+    #[error("No genesis certificate could be found, the certificate chain is not initialized.")]
+    NoGenesisCertificateFound,
+
     /// No certificate for this epoch
     #[error(
         "There is an epoch gap between the last certificate epoch ({certificate_epoch:?}) and current epoch ({current_epoch:?}). A leader aggregator must be re-genesis by the owner of the genesis keys, a follower aggregator will automatically catchup with the leader's certificate chain."

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.13.15"
+version = "0.13.16"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_db/shared_steps.rs
+++ b/mithril-client-cli/src/commands/cardano_db/shared_steps.rs
@@ -302,6 +302,8 @@ mod tests {
             aggregate_verification_key: String::new(),
             #[cfg(feature = "future_snark")]
             aggregate_verification_key_snark: None,
+            ancillary_prover_data: None,
+            ancillary_verifier_data: None,
             multi_signature: String::new(),
             genesis_signature: String::new(),
             #[cfg(feature = "future_snark")]

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -64,7 +64,7 @@ flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.2" }
-mithril-common = { path = "../mithril-common", version = "0.7.4", default-features = false }
+mithril-common = { path = "../mithril-common", version = "0.7.5", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.4"
+version = "0.7.5"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.34", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.35", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -188,6 +188,7 @@ impl CertificateGenesisProducer {
             genesis_protocol_message,
             genesis_avk,
             signature,
+            None,
         )
     }
 }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -7,7 +7,7 @@ use slog::{Logger, debug};
 use std::sync::Arc;
 use thiserror::Error;
 
-use mithril_stm::AggregateSignatureType;
+use mithril_stm::{AggregateSignatureType, AncillaryVerifierData};
 
 use crate::StdResult;
 #[cfg(feature = "future_snark")]
@@ -167,6 +167,7 @@ impl MithrilCertificateVerifier {
         multi_signature: &ProtocolMultiSignature,
         aggregate_verification_key: &ProtocolAggregateVerificationKey,
         protocol_parameters: &ProtocolParameters,
+        ancillary_verifier_data: Option<AncillaryVerifierData>,
     ) -> Result<(), CertificateVerifierError> {
         debug!(
             self.logger,
@@ -179,9 +180,34 @@ impl MithrilCertificateVerifier {
                 message,
                 aggregate_verification_key,
                 &protocol_parameters.to_owned().into(),
-                None,
+                ancillary_verifier_data,
             )
             .map_err(|e| CertificateVerifierError::VerifyMultiSignature(e.to_string()))
+    }
+
+    /// Verify the parts of a standard certificate that do not depend on its predecessor: its hash,
+    /// signed message, multi-signature and epoch.
+    fn verify_standard_certificate_integrity(&self, certificate: &Certificate) -> StdResult<()> {
+        let multi_signature = match &certificate.signature {
+            CertificateSignature::MultiSignature(_, signature) => Ok(signature),
+            _ => Err(CertificateVerifierError::InvalidStandardCertificateProvided),
+        }?;
+        self.verify_is_not_in_infinite_loop(certificate)?;
+        self.verify_hash_matches_content(certificate)?;
+        self.verify_signed_message_matches_hashed_protocol_message(certificate)?;
+        self.verify_multi_signature(
+            certificate.signed_message.as_bytes(),
+            multi_signature,
+            &certificate.create_aggregate_verification_key(),
+            &certificate.metadata.protocol_parameters,
+            certificate
+                .ancillary_verifier_data
+                .clone()
+                .map(|ancillary_verifier_data| ancillary_verifier_data.into_inner()),
+        )?;
+        self.verify_epoch_matches_protocol_message(certificate)?;
+
+        Ok(())
     }
 
     fn verify_is_not_in_infinite_loop(&self, certificate: &Certificate) -> StdResult<()> {
@@ -430,20 +456,7 @@ impl CertificateVerifier for MithrilCertificateVerifier {
         certificate: &Certificate,
         previous_certificate: &Certificate,
     ) -> StdResult<()> {
-        let multi_signature = match &certificate.signature {
-            CertificateSignature::MultiSignature(_, signature) => Ok(signature),
-            _ => Err(CertificateVerifierError::InvalidStandardCertificateProvided),
-        }?;
-        self.verify_is_not_in_infinite_loop(certificate)?;
-        self.verify_hash_matches_content(certificate)?;
-        self.verify_signed_message_matches_hashed_protocol_message(certificate)?;
-        self.verify_multi_signature(
-            certificate.signed_message.as_bytes(),
-            multi_signature,
-            &certificate.create_aggregate_verification_key(),
-            &certificate.metadata.protocol_parameters,
-        )?;
-        self.verify_epoch_matches_protocol_message(certificate)?;
+        self.verify_standard_certificate_integrity(certificate)?;
         self.verify_epoch_chaining(certificate, previous_certificate)?;
         self.verify_previous_hash_matches_previous_certificate_hash(
             certificate,
@@ -472,6 +485,16 @@ impl CertificateVerifier for MithrilCertificateVerifier {
         if certificate.is_genesis() {
             self.verify_genesis_certificate(certificate, genesis_verification_key)
                 .await?;
+
+            return Ok(None);
+        }
+
+        // Stopping here is sound only because such a signature's verification attests to the whole
+        // certificate chain back to the genesis certificate, so the integrity checks alone suffice.
+        if certificate.signature.aggregate_signature_type().is_some_and(
+            |aggregate_signature_type| aggregate_signature_type.certifies_full_certificate_chain(),
+        ) {
+            self.verify_standard_certificate_integrity(certificate)?;
 
             return Ok(None);
         }
@@ -564,7 +587,7 @@ mod tests {
         let first_signer = &signers[0].protocol_signer;
         let clerk = ProtocolClerk::new_clerk_from_signer(first_signer);
         let aggregate_verification_key = clerk.compute_aggregate_verification_key();
-        let (aggregate_signature, _ancillary_verifier_data) = clerk
+        let (aggregate_signature, ancillary_verifier_data) = clerk
             .aggregate_signatures_with_type(
                 &single_signatures,
                 &message_hash,
@@ -586,6 +609,7 @@ mod tests {
                     &multi_signature,
                     &aggregate_verification_key,
                     &fixture.protocol_parameters(),
+                    ancillary_verifier_data.clone(),
                 )
                 .is_err(),
             "multi signature verification should have failed"
@@ -596,6 +620,7 @@ mod tests {
                 &multi_signature,
                 &aggregate_verification_key,
                 &fixture.protocol_parameters(),
+                ancillary_verifier_data,
             )
             .expect("multi signature verification should have succeeded");
     }
@@ -764,6 +789,51 @@ mod tests {
             .await;
 
         verify.expect("verify_standard_certificate should not fail");
+    }
+
+    #[test]
+    fn verify_certificate_integrity_succeeds_for_a_valid_standard_certificate() {
+        let (total_certificates, certificates_per_epoch) = (5, 1);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let certificate = fake_certificates[0].clone();
+
+        verifier
+            .verify_standard_certificate_integrity(&certificate)
+            .expect("verify_certificate_integrity should not fail for a valid certificate");
+    }
+
+    #[test]
+    fn verify_certificate_integrity_fails_for_a_tampered_certificate() {
+        let (total_certificates, certificates_per_epoch) = (5, 1);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let mut certificate = fake_certificates[0].clone();
+        certificate.hash = "another-hash".to_string();
+
+        let error = verifier
+            .verify_standard_certificate_integrity(&certificate)
+            .expect_err("verify_certificate_integrity should fail for a tampered certificate");
+
+        assert_error_matches!(CertificateVerifierError::CertificateHashUnmatch, error)
+    }
+
+    #[test]
+    fn verify_certificate_integrity_does_not_check_the_previous_certificate_link() {
+        let (total_certificates, certificates_per_epoch) = (5, 1);
+        let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
+        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let mut certificate = fake_certificates[0].clone();
+
+        // Break the link to the previous certificate while keeping the certificate self-consistent.
+        certificate.previous_hash = "unrelated-previous-hash".to_string();
+        certificate.hash = certificate.try_compute_hash().unwrap();
+
+        // The self-contained checks accept it because they never look at the previous certificate,
+        // which is exactly what lets a full-chain-certifying certificate stop the chain walk early.
+        verifier
+            .verify_standard_certificate_integrity(&certificate)
+            .expect("integrity verification must ignore the previous certificate link");
     }
 
     #[tokio::test]

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -179,6 +179,7 @@ impl MithrilCertificateVerifier {
                 message,
                 aggregate_verification_key,
                 &protocol_parameters.to_owned().into(),
+                None,
             )
             .map_err(|e| CertificateVerifierError::VerifyMultiSignature(e.to_string()))
     }
@@ -490,13 +491,13 @@ mod tests {
     use async_trait::async_trait;
     use tokio::sync::Mutex;
 
-    use mithril_stm::AggregateSignatureType;
+    use mithril_stm::{AggregateSignatureType, AncillaryProofInput};
 
     use crate::test::{
         TestLogger,
         builder::{CertificateChainBuilder, CertificateChainBuilderContext, MithrilFixtureBuilder},
         crypto_helper::{setup_certificate_chain, setup_message, setup_protocol_parameters},
-        double::FakeCertificaterRetriever,
+        double::{Dummy, FakeCertificaterRetriever},
     };
     use crate::{
         certificate_chain::certificate_retriever::MockCertificateRetriever,
@@ -563,14 +564,15 @@ mod tests {
         let first_signer = &signers[0].protocol_signer;
         let clerk = ProtocolClerk::new_clerk_from_signer(first_signer);
         let aggregate_verification_key = clerk.compute_aggregate_verification_key();
-        let multi_signature = clerk
+        let (aggregate_signature, _ancillary_verifier_data) = clerk
             .aggregate_signatures_with_type(
                 &single_signatures,
                 &message_hash,
                 AggregateSignatureType::default(),
+                AncillaryProofInput::dummy(),
             )
-            .unwrap()
-            .into();
+            .unwrap();
+        let multi_signature = aggregate_signature.into();
 
         let verifier = MithrilCertificateVerifier::new(
             TestLogger::stdout(),
@@ -890,11 +892,12 @@ mod tests {
                 .collect::<Vec<_>>();
             let clerk =
                 ProtocolClerk::new_clerk_from_signer(&fixture.signers_fixture()[0].protocol_signer);
-            let modified_multi_signature = clerk
+            let (modified_multi_signature, _ancillary_verifier_data) = clerk
                 .aggregate_signatures_with_type(
                     &single_signatures,
                     signed_message.as_bytes(),
                     AggregateSignatureType::default(),
+                    AncillaryProofInput::dummy(),
                 )
                 .unwrap();
             modified_certificate.signature = CertificateSignature::MultiSignature(
@@ -1198,11 +1201,12 @@ mod tests {
                 &forged_protocol_parameters.clone().into(),
                 &fixture.signers_fixture()[0].protocol_closed_key_registration,
             );
-            let forged_multi_signature = forged_clerk
+            let (forged_multi_signature, _ancillary_verifier_data) = forged_clerk
                 .aggregate_signatures_with_type(
                     &forged_single_signatures,
                     signed_message.as_bytes(),
                     AggregateSignatureType::default(),
+                    AncillaryProofInput::dummy(),
                 )
                 .unwrap();
             forged_certificate.signature = CertificateSignature::MultiSignature(

--- a/mithril-common/src/crypto_helper/codec/binary.rs
+++ b/mithril-common/src/crypto_helper/codec/binary.rs
@@ -31,9 +31,10 @@ pub trait TryFromBytes: Sized {
 mod binary_mithril_stm {
 
     use mithril_stm::{
-        AggregateSignature, AggregateVerificationKeyForConcatenation, Initializer,
-        MithrilMembershipDigest, Parameters, SingleSignature, SingleSignatureWithRegisteredParty,
-        VerificationKeyForConcatenation, VerificationKeyProofOfPossessionForConcatenation,
+        AggregateSignature, AggregateVerificationKeyForConcatenation, AncillaryProverData,
+        AncillaryVerifierData, Initializer, MithrilMembershipDigest, Parameters, SingleSignature,
+        SingleSignatureWithRegisteredParty, VerificationKeyForConcatenation,
+        VerificationKeyProofOfPossessionForConcatenation,
     };
     #[cfg(feature = "future_snark")]
     use mithril_stm::{AggregateVerificationKeyForSnark, VerificationKeyForSnark};
@@ -162,6 +163,30 @@ mod binary_mithril_stm {
     }
 
     impl TryFromBytes for Initializer {
+        fn try_from_bytes(bytes: &[u8]) -> StdResult<Self> {
+            Self::from_bytes(bytes)
+        }
+    }
+
+    impl TryToBytes for AncillaryProverData {
+        fn to_bytes_vec(&self) -> StdResult<Vec<u8>> {
+            self.to_bytes()
+        }
+    }
+
+    impl TryFromBytes for AncillaryProverData {
+        fn try_from_bytes(bytes: &[u8]) -> StdResult<Self> {
+            Self::from_bytes(bytes)
+        }
+    }
+
+    impl TryToBytes for AncillaryVerifierData {
+        fn to_bytes_vec(&self) -> StdResult<Vec<u8>> {
+            self.to_bytes()
+        }
+    }
+
+    impl TryFromBytes for AncillaryVerifierData {
         fn try_from_bytes(bytes: &[u8]) -> StdResult<Self> {
             Self::from_bytes(bytes)
         }

--- a/mithril-common/src/crypto_helper/types/wrappers.rs
+++ b/mithril-common/src/crypto_helper/types/wrappers.rs
@@ -1,7 +1,8 @@
 use kes_summed_ed25519::kes::Sum6KesSig;
 use mithril_stm::{
     AggregateSignature, AggregateVerificationKey, AggregateVerificationKeyForConcatenation,
-    SingleSignature, VerificationKeyProofOfPossessionForConcatenation,
+    AncillaryProverData, AncillaryVerifierData, SingleSignature,
+    VerificationKeyProofOfPossessionForConcatenation,
 };
 #[cfg(feature = "future_snark")]
 use mithril_stm::{AggregateVerificationKeyForSnark, VerificationKeyForSnark};
@@ -52,13 +53,19 @@ pub type ProtocolAggregateVerificationKeyForSnark =
 /// Wrapper of [MKProof] to add serialization utilities.
 pub type ProtocolMkProof = ProtocolKey<MKMapProof<BlockRange>>;
 
+/// Wrapper of [MithrilStm:AncillaryProverData](enum@AncillaryProverData) to add serialization utilities.
+pub type ProtocolAncillaryProverData = ProtocolKey<AncillaryProverData>;
+
+/// Wrapper of [MithrilStm:AncillaryVerifierData](enum@AncillaryVerifierData) to add serialization utilities.
+pub type ProtocolAncillaryVerifierData = ProtocolKey<AncillaryVerifierData>;
+
 impl_codec_and_type_conversions_for_protocol_key!(
     json_hex_codec => AggregateSignature<ProtocolMembershipDigest>, ed25519_dalek::VerifyingKey, ed25519_dalek::SigningKey, AggregateVerificationKeyForConcatenation<ProtocolMembershipDigest>,
         MKProof, VerificationKeyProofOfPossessionForConcatenation, Sum6KesSig, OpCert, SingleSignature
 );
 
 impl_codec_and_type_conversions_for_protocol_key!(
-    bytes_hex_codec => ed25519_dalek::Signature
+    bytes_hex_codec => ed25519_dalek::Signature, AncillaryProverData, AncillaryVerifierData
 );
 
 #[cfg(feature = "future_snark")]

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -127,6 +127,7 @@ impl Certificate {
         protocol_message: ProtocolMessage,
         aggregate_verification_key: ProtocolAggregateVerificationKey,
         signature: CertificateSignature,
+        ancillary_verifier_data: Option<ProtocolAncillaryVerifierData>,
     ) -> crate::StdResult<Certificate> {
         let signed_message = protocol_message.compute_hash();
 
@@ -149,7 +150,7 @@ impl Certificate {
             #[cfg(feature = "future_snark")]
             aggregate_verification_key_snark,
             ancillary_prover_data: None,
-            ancillary_verifier_data: None,
+            ancillary_verifier_data,
             signature,
         };
         certificate.hash = certificate.try_compute_hash()?;
@@ -369,6 +370,7 @@ mod tests {
                 signed_entity_type.clone(),
                 fake_keys::multi_signature()[0].try_into().unwrap(),
             ),
+            None,
         )
         .unwrap();
 
@@ -523,6 +525,7 @@ mod tests {
             CertificateSignature::GenesisSignature(
                 fake_keys::genesis_signature()[0].try_into().unwrap(),
             ),
+            None,
         )
         .unwrap();
 
@@ -575,6 +578,7 @@ mod tests {
                 None,
             ),
             CertificateSignature::GenesisSignature(ed_signature),
+            None,
         )
         .unwrap();
 
@@ -603,6 +607,7 @@ mod tests {
                 None,
             ),
             CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
+            None,
         )
         .unwrap();
 
@@ -652,6 +657,7 @@ mod tests {
                     None,
                 ),
                 CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
+                None,
             )
             .unwrap();
             hashes.insert(certificate.try_compute_hash().unwrap());
@@ -690,6 +696,7 @@ mod tests {
                 None,
             ),
             signature,
+            None,
         )
         .unwrap()
     }

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -10,7 +10,8 @@ use crate::crypto_helper::GenesisSchnorrSignature;
 use crate::crypto_helper::ProtocolAggregateVerificationKeyForSnark;
 use crate::crypto_helper::{
     GenesisEd25519Signature, ProtocolAggregateVerificationKey,
-    ProtocolAggregateVerificationKeyForConcatenation, ProtocolMultiSignature,
+    ProtocolAggregateVerificationKeyForConcatenation, ProtocolAncillaryProverData,
+    ProtocolAncillaryVerifierData, ProtocolMultiSignature,
 };
 use crate::entities::{CertificateMetadata, Epoch, ProtocolMessage, SignedEntityType};
 
@@ -107,6 +108,12 @@ pub struct Certificate {
     #[cfg(feature = "future_snark")]
     pub aggregate_verification_key_snark: Option<ProtocolAggregateVerificationKeyForSnark>,
 
+    /// Ancillary data used by the prover to produce the next certificate.
+    pub ancillary_prover_data: Option<ProtocolAncillaryProverData>,
+
+    /// Ancillary data used to verify the certificate.
+    pub ancillary_verifier_data: Option<ProtocolAncillaryVerifierData>,
+
     /// Certificate signature
     pub signature: CertificateSignature,
 }
@@ -141,6 +148,8 @@ impl Certificate {
                 .into(),
             #[cfg(feature = "future_snark")]
             aggregate_verification_key_snark,
+            ancillary_prover_data: None,
+            ancillary_verifier_data: None,
             signature,
         };
         certificate.hash = certificate.try_compute_hash()?;
@@ -169,6 +178,12 @@ impl Certificate {
             signed_entity_type.feed_hash(&mut hasher);
         }
         hasher.update(self.signature.to_bytes_hex_for_certificate_hash()?);
+        if let Some(ancillary_prover_data) = &self.ancillary_prover_data {
+            hasher.update(ancillary_prover_data.to_bytes()?);
+        }
+        if let Some(ancillary_verifier_data) = &self.ancillary_verifier_data {
+            hasher.update(ancillary_verifier_data.to_bytes()?);
+        }
         Ok(hex::encode(hasher.finalize()))
     }
 
@@ -259,6 +274,8 @@ impl Debug for Certificate {
                             .map(|avk| avk.to_bytes_hex())
                     ),
                 );
+                debug.field("ancillary_prover_data", &self.ancillary_prover_data);
+                debug.field("ancillary_verifier_data", &self.ancillary_verifier_data);
                 debug
                     .field("signature", &format_args!("{:?}", self.signature))
                     .finish()

--- a/mithril-common/src/lib.rs
+++ b/mithril-common/src/lib.rs
@@ -22,7 +22,7 @@ pub mod test;
 
 pub use entities::{CardanoNetwork, MagicId};
 
-pub use mithril_stm::AggregateSignatureType;
+pub use mithril_stm::{AggregateSignatureType, AncillaryProofInput};
 
 /// Generic error type
 pub type StdError = anyhow::Error;

--- a/mithril-common/src/messages/certificate.rs
+++ b/mithril-common/src/messages/certificate.rs
@@ -56,6 +56,14 @@ pub struct CertificateMessage {
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub aggregate_verification_key_snark: Option<String>,
 
+    /// Ancillary data used by the prover to produce the next certificate, hex-encoded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ancillary_prover_data: Option<String>,
+
+    /// Ancillary data used to verify the certificate, hex-encoded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ancillary_verifier_data: Option<String>,
+
     /// STM multi signature created from a quorum of single signatures from the signers
     /// aka MULTI_SIG(H(MSG(p,n) || AVK(n-1)))
     pub multi_signature: String,
@@ -163,6 +171,8 @@ impl Debug for CertificateMessage {
                     "aggregate_verification_key_snark",
                     &self.aggregate_verification_key_snark,
                 );
+                debug.field("ancillary_prover_data", &self.ancillary_prover_data);
+                debug.field("ancillary_verifier_data", &self.ancillary_verifier_data);
                 debug
                     .field("multi_signature", &self.multi_signature)
                     .field("genesis_signature", &self.genesis_signature);
@@ -209,6 +219,20 @@ impl TryFrom<CertificateMessage> for Certificate {
                 .with_context(|| {
                 "Can not convert message to certificate: can not decode the aggregate verification key for SNARK"
             })?,
+            ancillary_prover_data: certificate_message
+                .ancillary_prover_data
+                .map(|hex_data| hex_data.try_into())
+                .transpose()
+                .with_context(|| {
+                    "Can not convert message to certificate: can not decode the ancillary prover data"
+                })?,
+            ancillary_verifier_data: certificate_message
+                .ancillary_verifier_data
+                .map(|hex_data| hex_data.try_into())
+                .transpose()
+                .with_context(|| {
+                    "Can not convert message to certificate: can not decode the ancillary verifier data"
+                })?,
             signature: if certificate_message.genesis_signature.is_empty() {
                 CertificateMessage::multi_signature_from_message(
                     certificate_message.signed_entity_type,
@@ -290,6 +314,20 @@ impl TryFrom<Certificate> for CertificateMessage {
                 .with_context(|| {
                     "Can not convert certificate to message: can not encode aggregate verification key for SNARK"
                 })?,
+            ancillary_prover_data: certificate
+                .ancillary_prover_data
+                .map(|data| data.to_bytes_hex())
+                .transpose()
+                .with_context(|| {
+                    "Can not convert certificate to message: can not encode the ancillary prover data"
+                })?,
+            ancillary_verifier_data: certificate
+                .ancillary_verifier_data
+                .map(|data| data.to_bytes_hex())
+                .transpose()
+                .with_context(|| {
+                    "Can not convert certificate to message: can not encode the ancillary verifier data"
+                })?,
             multi_signature,
             genesis_signature,
             #[cfg(feature = "future_snark")]
@@ -357,6 +395,8 @@ mod tests {
             aggregate_verification_key: "aggregate_verification_key".to_string(),
             #[cfg(feature = "future_snark")]
             aggregate_verification_key_snark: None,
+            ancillary_prover_data: None,
+            ancillary_verifier_data: None,
             multi_signature: "multi_signature".to_string(),
             genesis_signature: "genesis_signature".to_string(),
             #[cfg(feature = "future_snark")]

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -1,0 +1,37 @@
+//! Building the ancillary proof input fed to aggregate signature creation.
+
+use mithril_stm::{AncillaryGenesisData, AncillaryProofInput};
+
+use crate::entities::Certificate;
+#[cfg(feature = "future_snark")]
+use crate::entities::CertificateSignature;
+
+/// Build the ancillary proof input for one aggregate signature creation, from the genesis
+/// certificate (the genesis data) and the parent certificate (the prover data).
+///
+/// The genesis message is always carried. Under `future_snark`, the genesis Schnorr signature is
+/// carried too when the genesis certificate is dual-signed, and absent for a legacy genesis.
+pub fn build_ancillary_proof_input(
+    genesis_certificate: &Certificate,
+    parent_certificate: &Certificate,
+) -> AncillaryProofInput {
+    let prover_data = parent_certificate
+        .ancillary_prover_data
+        .clone()
+        .map(|prover_data| prover_data.into_inner());
+
+    #[cfg(feature = "future_snark")]
+    let genesis_data = {
+        let genesis_message = genesis_certificate.protocol_message.rigid_preimage();
+        let genesis_schnorr_signature = match &genesis_certificate.signature {
+            CertificateSignature::GenesisDualSignature(_, signature) => Some(*signature),
+            _ => None,
+        };
+        AncillaryGenesisData::new(genesis_message, genesis_schnorr_signature)
+    };
+    #[cfg(not(feature = "future_snark"))]
+    let genesis_data =
+        AncillaryGenesisData::new(genesis_certificate.signed_message.as_bytes().to_vec());
+
+    AncillaryProofInput::new(prover_data, genesis_data)
+}

--- a/mithril-common/src/protocol/mod.rs
+++ b/mithril-common/src/protocol/mod.rs
@@ -4,11 +4,13 @@
 //! such as issuing single signatures, aggregating them as multi-signatures or computing
 //! aggregate verification keys.
 
+mod ancillary;
 mod multi_signer;
 mod signer_builder;
 mod single_signer;
 
-pub use multi_signer::MultiSigner;
+pub use ancillary::build_ancillary_proof_input;
+pub use multi_signer::{MultiSignatureWithAncillaryVerifierData, MultiSigner};
 pub use signer_builder::{SignerBuilder, SignerBuilderError};
 pub use single_signer::SingleSigner;
 

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -1,12 +1,26 @@
 use anyhow::Context;
-use mithril_stm::{AggregateSignatureType, Parameters};
+use mithril_stm::{AggregateSignatureType, AncillaryProofInput, Parameters};
 
 use crate::{
     StdResult,
-    crypto_helper::{ProtocolAggregateVerificationKey, ProtocolClerk, ProtocolMultiSignature},
+    crypto_helper::{
+        ProtocolAggregateVerificationKey, ProtocolAncillaryVerifierData, ProtocolClerk,
+        ProtocolMultiSignature,
+    },
     entities::SingleSignature,
     protocol::ToMessage,
 };
+
+/// A multi-signature together with the ancillary verifier data produced during its creation.
+#[derive(Debug, Clone)]
+pub struct MultiSignatureWithAncillaryVerifierData {
+    /// The produced multi-signature.
+    pub multi_signature: ProtocolMultiSignature,
+
+    /// The ancillary verifier data produced during aggregation, absent when the proof system
+    /// produces none.
+    pub ancillary_verifier_data: Option<ProtocolAncillaryVerifierData>,
+}
 
 /// MultiSigner is the cryptographic engine in charge of producing multi-signatures from individual signatures
 pub struct MultiSigner {
@@ -28,19 +42,26 @@ impl MultiSigner {
         single_signatures: &[SingleSignature],
         message: &T,
         aggregate_signature_type: AggregateSignatureType,
-    ) -> StdResult<ProtocolMultiSignature> {
+        ancillary_input: AncillaryProofInput,
+    ) -> StdResult<MultiSignatureWithAncillaryVerifierData> {
         let protocol_signatures: Vec<_> = single_signatures
             .iter()
             .map(|single_signature| single_signature.to_protocol_signature())
             .collect();
 
-        self.protocol_clerk
-            .aggregate_signatures_with_type(
+        let (multi_signature, ancillary_verifier_data) =
+            self.protocol_clerk.aggregate_signatures_with_type(
                 &protocol_signatures,
                 message.to_message().as_bytes(),
                 aggregate_signature_type,
-            )
-            .map(|multi_sig| multi_sig.into())
+                ancillary_input,
+            )?;
+
+        Ok(MultiSignatureWithAncillaryVerifierData {
+            multi_signature: multi_signature.into(),
+            ancillary_verifier_data: ancillary_verifier_data
+                .map(ProtocolAncillaryVerifierData::new),
+        })
     }
 
     /// Compute aggregate verification key from stake distribution
@@ -96,7 +117,7 @@ mod test {
         protocol::SignerBuilder,
         test::{
             builder::{MithrilFixture, MithrilFixtureBuilder, StakeDistributionGenerationMethod},
-            double::fake_keys,
+            double::{Dummy, fake_keys},
         },
     };
 
@@ -118,7 +139,12 @@ mod test {
         let message = ProtocolMessage::default();
 
         let error = multi_signer
-            .aggregate_single_signatures(&[], &message, AggregateSignatureType::default())
+            .aggregate_single_signatures(
+                &[],
+                &message,
+                AggregateSignatureType::default(),
+                AncillaryProofInput::dummy(),
+            )
             .expect_err(
                 "Multi-signature should not be created with an empty single signatures list",
             );
@@ -144,7 +170,12 @@ mod test {
             .collect();
 
         multi_signer
-            .aggregate_single_signatures(&signatures, &message, AggregateSignatureType::default())
+            .aggregate_single_signatures(
+                &signatures,
+                &message,
+                AggregateSignatureType::default(),
+                AncillaryProofInput::dummy(),
+            )
             .expect("Multi-signature should be created");
     }
 
@@ -165,7 +196,12 @@ mod test {
         signatures[4].signature = fake_keys::single_signature()[3].try_into().unwrap();
 
         multi_signer
-            .aggregate_single_signatures(&signatures, &message, AggregateSignatureType::default())
+            .aggregate_single_signatures(
+                &signatures,
+                &message,
+                AggregateSignatureType::default(),
+                AncillaryProofInput::dummy(),
+            )
             .expect("Multi-signature should be created even with one invalid signature");
     }
 

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::iter::repeat_n;
 use std::ops::{Deref, DerefMut};
 
-use mithril_stm::AggregateSignatureType;
+use mithril_stm::{AggregateSignatureType, AncillaryProofInput};
 
 use crate::{
     certificate_chain::CertificateGenesisProducer,
@@ -17,7 +17,7 @@ use crate::{
     },
     test::{
         builder::{MithrilFixture, MithrilFixtureBuilder, SignerFixture},
-        double::fake_data,
+        double::{Dummy, fake_data},
     },
 };
 
@@ -573,11 +573,12 @@ impl<'a> CertificateChainBuilder<'a> {
             .filter_map(|s| s.protocol_signer.sign(certificate.signed_message.as_bytes()))
             .collect::<Vec<_>>();
         let clerk = CertificateChainBuilder::compute_clerk_for_signers(&fixture.signers_fixture());
-        let multi_signature = clerk
+        let (multi_signature, _ancillary_verifier_data) = clerk
             .aggregate_signatures_with_type(
                 &single_signatures,
                 certificate.signed_message.as_bytes(),
                 self.aggregate_signature_type,
+                AncillaryProofInput::dummy(),
             )
             .unwrap();
         certificate.signature = CertificateSignature::MultiSignature(

--- a/mithril-common/src/test/double/dummies.rs
+++ b/mithril-common/src/test/double/dummies.rs
@@ -2,6 +2,26 @@ use chrono::{DateTime, Utc};
 
 use crate::test::double::{Dummy, fake_data, fake_keys};
 
+mod stm {
+    use mithril_stm::{AncillaryGenesisData, AncillaryProofInput};
+
+    use super::*;
+
+    impl Dummy for AncillaryProofInput {
+        /// Return a dummy [AncillaryProofInput] carrying no data (test-only).
+        fn dummy() -> Self {
+            Self::new(
+                None,
+                AncillaryGenesisData::new(
+                    Vec::new(),
+                    #[cfg(feature = "future_snark")]
+                    None,
+                ),
+            )
+        }
+    }
+}
+
 mod entities {
     use crate::crypto_helper::MKTreeStoreInMemory;
     use crate::entities::*;

--- a/mithril-common/src/test/double/dummies.rs
+++ b/mithril-common/src/test/double/dummies.rs
@@ -539,6 +539,8 @@ mod messages {
                     fake_keys::aggregate_verification_key_for_concatenation()[0].to_owned(),
                 #[cfg(feature = "future_snark")]
                 aggregate_verification_key_snark: None,
+                ancillary_prover_data: None,
+                ancillary_verifier_data: None,
                 multi_signature: fake_keys::multi_signature()[0].to_owned(),
                 genesis_signature: String::new(),
                 #[cfg(feature = "future_snark")]

--- a/mithril-common/src/test/double/fake_data.rs
+++ b/mithril-common/src/test/double/fake_data.rs
@@ -142,6 +142,8 @@ pub fn certificate<T: Into<String>>(certificate_hash: T) -> entities::Certificat
         aggregate_verification_key,
         #[cfg(feature = "future_snark")]
         aggregate_verification_key_snark: None,
+        ancillary_prover_data: None,
+        ancillary_verifier_data: None,
         signature: CertificateSignature::MultiSignature(
             SignedEntityType::CardanoDatabase(beacon),
             multi_signature,

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.35 (06-12-2026)
+
+### Added
+
+- Added proof-system-agnostic ancillary data carriers (`AncillaryProverData`, `AncillaryVerifierData`, `AncillaryGenesisData`, and `AncillaryProofInput`) with versioned CBOR `to_bytes`/`from_bytes`.
+- Added the `AggregateSignatureType::certifies_full_certificate_chain` predicate.
+
+### Changed
+
+- `Clerk::aggregate_signatures_with_type` now takes an `AncillaryProofInput` and returns the aggregate signature together with the optional `AncillaryVerifierData`.
+- `AggregateSignature::verify` and `AggregateSignature::batch_verify` now accept the optional `AncillaryVerifierData`.
+
 ## 0.10.34 (06-12-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.34"
+version = "0.10.35"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -68,8 +68,9 @@ use rand_core::{RngCore, SeedableRng};
 use rayon::prelude::*;
 
 use mithril_stm::{
-    AggregateSignatureType, AggregationError, Clerk, Initializer, KeyRegistration, Parameters,
-    RegistrationEntry, Signer, SingleSignature, MithrilMembershipDigest, AggregateVerificationKey,
+    AggregateSignatureType, AggregationError, AncillaryGenesisData, AncillaryProofInput, Clerk,
+    Initializer, KeyRegistration, Parameters, RegistrationEntry, Signer, SingleSignature,
+    MithrilMembershipDigest, AggregateVerificationKey,
 };
 
 type D = MithrilMembershipDigest;
@@ -135,12 +136,13 @@ for s in sigs.iter() {
 }
 
 // Aggregate a concatenation proof with random parties
-let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation);
+let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(Vec::new(), #[cfg(feature = "future_snark")] None));
+let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 
 match msig {
-    Ok(aggr) => {
+    Ok((aggr, ancillary_verifier_data)) => {
         println!("Aggregate ok");
-        assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params).is_ok());
+        assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data).is_ok());
     }
     Err(error) => match error.downcast_ref::<AggregationError>() {
         Some(AggregationError::NotEnoughSignatures(n, k)) => {

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -5,8 +5,9 @@ use rayon::iter::ParallelIterator;
 use rayon::prelude::{IntoParallelIterator, IntoParallelRefIterator};
 
 use mithril_stm::{
-    AggregateSignatureType, Clerk, Initializer, KeyRegistration, MembershipDigest,
-    MithrilMembershipDigest, Parameters, Signer, SingleSignature,
+    AggregateSignatureType, AncillaryGenesisData, AncillaryProofInput, Clerk, Initializer,
+    KeyRegistration, MembershipDigest, MithrilMembershipDigest, Parameters, Signer,
+    SingleSignature,
 };
 
 #[cfg(feature = "future_snark")]
@@ -50,8 +51,20 @@ where
 
     // Aggregate with random parties
     let aggr_sig_type = AggregateSignatureType::Concatenation;
-    let aggr = clerk
-        .aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type)
+    let (aggr, _ancillary_verifier_data) = clerk
+        .aggregate_signatures_with_type(
+            &sigs,
+            &msg,
+            aggr_sig_type,
+            AncillaryProofInput::new(
+                None,
+                AncillaryGenesisData::new(
+                    Vec::new(),
+                    #[cfg(feature = "future_snark")]
+                    None,
+                ),
+            ),
+        )
         .unwrap();
 
     println!(

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -4,8 +4,8 @@ use rand_core::{RngCore, SeedableRng};
 use rayon::prelude::*;
 
 use mithril_stm::{
-    AggregateSignature, AggregateSignatureType, Clerk, Initializer, KeyRegistration,
-    MembershipDigest, MithrilMembershipDigest, Parameters, Signer,
+    AggregateSignature, AggregateSignatureType, AncillaryGenesisData, AncillaryProofInput, Clerk,
+    Initializer, KeyRegistration, MembershipDigest, MithrilMembershipDigest, Parameters, Signer,
 };
 
 /// This benchmark framework is not ideal. We really have to think what is the best mechanism for
@@ -70,7 +70,21 @@ fn stm_benches<D: MembershipDigest>(
     let aggregate_signature_type = AggregateSignatureType::Concatenation;
 
     group.bench_function(BenchmarkId::new("Aggregation", &param_string), |b| {
-        b.iter(|| clerk.aggregate_signatures_with_type(&sigs, &msg, aggregate_signature_type))
+        b.iter(|| {
+            clerk.aggregate_signatures_with_type(
+                &sigs,
+                &msg,
+                aggregate_signature_type,
+                AncillaryProofInput::new(
+                    None,
+                    AncillaryGenesisData::new(
+                        Vec::new(),
+                        #[cfg(feature = "future_snark")]
+                        None,
+                    ),
+                ),
+            )
+        })
     });
 }
 
@@ -98,6 +112,7 @@ fn batch_benches<D>(
         let mut batch_params = Vec::with_capacity(nr_batches);
         let mut batch_stms: Vec<AggregateSignature<D>> = Vec::with_capacity(nr_batches);
         let mut batch_avks = Vec::with_capacity(nr_batches);
+        let mut batch_ancillary_verifier_datas = Vec::with_capacity(nr_batches);
 
         for _ in 0..nr_batches {
             let mut msg = [0u8; 32];
@@ -132,12 +147,25 @@ fn batch_benches<D>(
 
             let clerk = Clerk::new_clerk_from_signer(&signers[0]);
             let aggregate_signature_type = AggregateSignatureType::Concatenation;
-            let msig = clerk
-                .aggregate_signatures_with_type(&sigs, &msg, aggregate_signature_type)
+            let (msig, ancillary_verifier_data) = clerk
+                .aggregate_signatures_with_type(
+                    &sigs,
+                    &msg,
+                    aggregate_signature_type,
+                    AncillaryProofInput::new(
+                        None,
+                        AncillaryGenesisData::new(
+                            Vec::new(),
+                            #[cfg(feature = "future_snark")]
+                            None,
+                        ),
+                    ),
+                )
                 .unwrap();
 
             batch_avks.push(clerk.compute_aggregate_verification_key());
             batch_stms.push(msig);
+            batch_ancillary_verifier_datas.push(ancillary_verifier_data);
         }
 
         group.bench_function(BenchmarkId::new("Batch Verification", batch_string), |b| {
@@ -147,6 +175,7 @@ fn batch_benches<D>(
                     &batch_msgs,
                     &batch_avks,
                     &batch_params,
+                    &batch_ancillary_verifier_datas,
                 )
                 .is_ok()
             })

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -5,9 +5,9 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 
 use mithril_stm::{
-    AggregateSignature, AggregateSignatureType, Clerk, ClosedKeyRegistration, Initializer,
-    KeyRegistration, MithrilMembershipDigest, Parameters, RegistrationEntry, Stake,
-    VerificationKeyProofOfPossessionForConcatenation,
+    AggregateSignature, AggregateSignatureType, AncillaryGenesisData, AncillaryProofInput, Clerk,
+    ClosedKeyRegistration, Initializer, KeyRegistration, MithrilMembershipDigest, Parameters,
+    RegistrationEntry, Stake, VerificationKeyProofOfPossessionForConcatenation,
 };
 
 type D = MithrilMembershipDigest;
@@ -129,33 +129,79 @@ fn main() {
 
     // Now we aggregate the signatures
     let aggr_sig_type = AggregateSignatureType::Concatenation;
-    let msig_1: AggregateSignature<MithrilMembershipDigest> =
-        match clerk.aggregate_signatures_with_type(&complete_sigs_1, &msg, aggr_sig_type) {
-            Ok(s) => s,
-            Err(e) => {
-                panic!("Aggregation failed: {e:?}")
-            }
-        };
+    let msig_1: AggregateSignature<MithrilMembershipDigest> = match clerk
+        .aggregate_signatures_with_type(
+            &complete_sigs_1,
+            &msg,
+            aggr_sig_type,
+            AncillaryProofInput::new(
+                None,
+                AncillaryGenesisData::new(
+                    Vec::new(),
+                    #[cfg(feature = "future_snark")]
+                    None,
+                ),
+            ),
+        ) {
+        Ok((s, _)) => s,
+        Err(e) => {
+            panic!("Aggregation failed: {e:?}")
+        }
+    };
     assert!(
         msig_1
-            .verify(&msg, &clerk.compute_aggregate_verification_key(), &params)
+            .verify(
+                &msg,
+                &clerk.compute_aggregate_verification_key(),
+                &params,
+                None
+            )
             .is_ok()
     );
 
-    let msig_2: AggregateSignature<MithrilMembershipDigest> =
-        match clerk.aggregate_signatures_with_type(&complete_sigs_2, &msg, aggr_sig_type) {
-            Ok(s) => s,
-            Err(e) => {
-                panic!("Aggregation failed: {e:?}")
-            }
-        };
+    let msig_2: AggregateSignature<MithrilMembershipDigest> = match clerk
+        .aggregate_signatures_with_type(
+            &complete_sigs_2,
+            &msg,
+            aggr_sig_type,
+            AncillaryProofInput::new(
+                None,
+                AncillaryGenesisData::new(
+                    Vec::new(),
+                    #[cfg(feature = "future_snark")]
+                    None,
+                ),
+            ),
+        ) {
+        Ok((s, _)) => s,
+        Err(e) => {
+            panic!("Aggregation failed: {e:?}")
+        }
+    };
     assert!(
         msig_2
-            .verify(&msg, &clerk.compute_aggregate_verification_key(), &params)
+            .verify(
+                &msg,
+                &clerk.compute_aggregate_verification_key(),
+                &params,
+                None
+            )
             .is_ok()
     );
 
-    let msig_3 = clerk.aggregate_signatures_with_type(&incomplete_sigs_3, &msg, aggr_sig_type);
+    let msig_3 = clerk.aggregate_signatures_with_type(
+        &incomplete_sigs_3,
+        &msg,
+        aggr_sig_type,
+        AncillaryProofInput::new(
+            None,
+            AncillaryGenesisData::new(
+                Vec::new(),
+                #[cfg(feature = "future_snark")]
+                None,
+            ),
+        ),
+    );
     assert!(msig_3.is_err());
 }
 

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -147,9 +147,9 @@ mod signature_scheme;
 pub use proof_system::AggregateVerificationKeyForConcatenation;
 pub use protocol::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
-    AggregationError, Clerk, ClosedKeyRegistration, ClosedRegistrationEntry, Initializer,
-    KeyRegistration, Parameters, RegisterError, RegistrationEntry,
-    RegistrationEntryForConcatenation, SignatureError, Signer, SingleSignature,
+    AggregationError, AncillaryProverData, AncillaryVerifierData, Clerk, ClosedKeyRegistration,
+    ClosedRegistrationEntry, Initializer, KeyRegistration, Parameters, RegisterError,
+    RegistrationEntry, RegistrationEntryForConcatenation, SignatureError, Signer, SingleSignature,
     SingleSignatureWithRegisteredParty, VerificationKeyForConcatenation,
     VerificationKeyProofOfPossessionForConcatenation,
 };

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -14,8 +14,9 @@
 //! use rayon::prelude::*; // We use par_iter to speed things up
 //!
 //! use mithril_stm::{
-//!    AggregateSignatureType, AggregationError, Clerk, Initializer, KeyRegistration, Parameters,
-//!    RegistrationEntry, Signer, SingleSignature, MithrilMembershipDigest,
+//!    AggregateSignatureType, AggregationError, AncillaryGenesisData, AncillaryProofInput, Clerk,
+//!    Initializer, KeyRegistration, Parameters, RegistrationEntry, Signer, SingleSignature,
+//!    MithrilMembershipDigest,
 //! };
 //!
 //! let nparties = 4; // Use a small number of parties for this example
@@ -93,12 +94,14 @@
 //! let clerk = Clerk::new_clerk_from_signer(&ps[0]);
 //!
 //! // Aggregate and verify the signatures
-//! let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation);
+//! let genesis_data = AncillaryGenesisData::new(Vec::new(), #[cfg(feature = "future_snark")] None);
+//! let ancillary_input = AncillaryProofInput::new(None, genesis_data);
+//! let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 //! match msig {
-//!     Ok(aggr) => {
+//!     Ok((aggr, ancillary_verifier_data)) => {
 //!         println!("Aggregate ok");
 //!         assert!(aggr
-//!             .verify(&msg, &clerk.compute_aggregate_verification_key(), &params)
+//!             .verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data)
 //!             .is_ok());
 //!     }
 //!     Err(error) => assert!(
@@ -147,9 +150,10 @@ mod signature_scheme;
 pub use proof_system::AggregateVerificationKeyForConcatenation;
 pub use protocol::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
-    AggregationError, AncillaryProverData, AncillaryVerifierData, Clerk, ClosedKeyRegistration,
-    ClosedRegistrationEntry, Initializer, KeyRegistration, Parameters, RegisterError,
-    RegistrationEntry, RegistrationEntryForConcatenation, SignatureError, Signer, SingleSignature,
+    AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProverData,
+    AncillaryVerifierData, Clerk, ClosedKeyRegistration, ClosedRegistrationEntry, Initializer,
+    KeyRegistration, Parameters, RegisterError, RegistrationEntry,
+    RegistrationEntryForConcatenation, SignatureError, Signer, SingleSignature,
     SingleSignatureWithRegisteredParty, VerificationKeyForConcatenation,
     VerificationKeyProofOfPossessionForConcatenation,
 };

--- a/mithril-stm/src/proof_system/concatenation/proof.rs
+++ b/mithril-stm/src/proof_system/concatenation/proof.rs
@@ -339,8 +339,9 @@ mod tests {
         use rand_core::SeedableRng;
 
         use crate::{
-            AggregateSignatureType, Clerk, KeyRegistration, MithrilMembershipDigest, Parameters,
-            RegistrationEntry, Signer, VerificationKeyProofOfPossessionForConcatenation,
+            AggregateSignatureType, AncillaryProofInput, Clerk, KeyRegistration,
+            MithrilMembershipDigest, Parameters, RegistrationEntry, Signer,
+            VerificationKeyProofOfPossessionForConcatenation,
             proof_system::ConcatenationProofSigner, protocol::AggregateSignature,
             signature_scheme::BlsSigningKey,
         };
@@ -418,13 +419,15 @@ mod tests {
             let signature_1 = signer_1.create_single_signature(&msg).unwrap();
             let signature_2 = signer_2.create_single_signature(&msg).unwrap();
 
-            clerk
+            let (signature, _ancillary_verifier_data) = clerk
                 .aggregate_signatures_with_type(
                     &[signature_1, signature_2],
                     &msg,
                     AggregateSignatureType::Concatenation,
+                    AncillaryProofInput::dummy(),
                 )
-                .unwrap()
+                .unwrap();
+            signature
         }
 
         const GOLDEN_CBOR_BYTES: &[u8; 2974] = &[

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "future_snark")]
+use crate::StandardSchnorrSignature;
 use crate::StmResult;
 use crate::codec;
 
@@ -61,6 +63,96 @@ impl AncillaryVerifierData {
                 "AncillaryVerifierData: unsupported encoding, expected a CBOR v1 prefix"
             ))
         }
+    }
+}
+
+/// Genesis-related data carried into aggregate signature creation.
+///
+/// Holds the genesis message and, under `future_snark`, the genesis Schnorr signature when the
+/// genesis certificate carries one. It is a transient input to proof creation, never stored on a
+/// certificate.
+#[derive(Clone, Debug)]
+pub struct AncillaryGenesisData {
+    genesis_message: Vec<u8>,
+    #[cfg(feature = "future_snark")]
+    genesis_schnorr_signature: Option<StandardSchnorrSignature>,
+}
+
+impl AncillaryGenesisData {
+    /// Build the genesis ancillary data from the genesis message and, under `future_snark`, the
+    /// genesis Schnorr signature (absent for a legacy, non-dual genesis certificate).
+    pub fn new(
+        genesis_message: Vec<u8>,
+        #[cfg(feature = "future_snark")] genesis_schnorr_signature: Option<
+            StandardSchnorrSignature,
+        >,
+    ) -> Self {
+        Self {
+            genesis_message,
+            #[cfg(feature = "future_snark")]
+            genesis_schnorr_signature,
+        }
+    }
+
+    /// Return the genesis message.
+    pub fn genesis_message(&self) -> &[u8] {
+        &self.genesis_message
+    }
+
+    /// Return the genesis Schnorr signature, absent for a legacy (non-dual) genesis certificate.
+    #[cfg(feature = "future_snark")]
+    pub fn genesis_schnorr_signature(&self) -> Option<&StandardSchnorrSignature> {
+        self.genesis_schnorr_signature.as_ref()
+    }
+
+    /// Build genesis ancillary data carrying no data, for use in tests.
+    #[cfg(test)]
+    pub fn dummy() -> Self {
+        Self::new(
+            Vec::new(),
+            #[cfg(feature = "future_snark")]
+            None,
+        )
+    }
+}
+
+/// Ancillary input to one aggregate signature creation.
+///
+/// Carries the prover data from the previous certificate and the genesis data from the genesis
+/// certificate, the state the proof system needs at creation. It is always supplied to the clerk;
+/// each proof system decides whether to consume it.
+#[derive(Clone, Debug)]
+pub struct AncillaryProofInput {
+    prover_data: Option<AncillaryProverData>,
+    genesis_data: AncillaryGenesisData,
+}
+
+impl AncillaryProofInput {
+    /// Build the ancillary proof input from the prover and genesis data.
+    pub fn new(
+        prover_data: Option<AncillaryProverData>,
+        genesis_data: AncillaryGenesisData,
+    ) -> Self {
+        Self {
+            prover_data,
+            genesis_data,
+        }
+    }
+
+    /// Return the prover ancillary data carried from the previous certificate.
+    pub fn prover_data(&self) -> Option<&AncillaryProverData> {
+        self.prover_data.as_ref()
+    }
+
+    /// Return the genesis ancillary data.
+    pub fn genesis_data(&self) -> &AncillaryGenesisData {
+        &self.genesis_data
+    }
+
+    /// Build an ancillary proof input carrying no data, for use in tests.
+    #[cfg(test)]
+    pub fn dummy() -> Self {
+        Self::new(None, AncillaryGenesisData::dummy())
     }
 }
 

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -1,0 +1,86 @@
+//! Ancillary data carried by a certificate for the prover and the verifier.
+//!
+//! These are proof-system-agnostic carriers whose variants map to the aggregate signature types
+//! that need them. They start with no variants and grow as those schemes land.
+
+use serde::{Deserialize, Serialize};
+
+use crate::StmResult;
+use crate::codec;
+
+/// Ancillary data carried by a certificate for the prover.
+///
+/// Holds the prover-side state needed to produce the next certificate. Carried in the certificate,
+/// hashed into the certificate hash and transmitted in the certificate message. Variants map to the
+/// aggregate signature types that require prover data; none exist yet.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AncillaryProverData {}
+
+impl AncillaryProverData {
+    /// Serialize to versioned CBOR bytes, following `CODEC.md`.
+    pub fn to_bytes(&self) -> StmResult<Vec<u8>> {
+        codec::to_cbor_bytes(self)
+    }
+
+    /// Deserialize from versioned CBOR bytes, following `CODEC.md`.
+    ///
+    /// With no variants this always fails; it gains meaning once a variant is added.
+    pub fn from_bytes(bytes: &[u8]) -> StmResult<Self> {
+        if codec::has_cbor_v1_prefix(bytes) {
+            codec::from_cbor_bytes(&bytes[1..])
+        } else {
+            Err(anyhow::anyhow!(
+                "AncillaryProverData: unsupported encoding, expected a CBOR v1 prefix"
+            ))
+        }
+    }
+}
+
+/// Ancillary data carried by a certificate for the verifier.
+///
+/// Holds the data a verifier needs to verify the certificate. Stored and transmitted in the
+/// certificate message. Variants map to the aggregate signature types that require verifier
+/// data; none exist yet.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AncillaryVerifierData {}
+
+impl AncillaryVerifierData {
+    /// Serialize to versioned CBOR bytes, following `CODEC.md`.
+    pub fn to_bytes(&self) -> StmResult<Vec<u8>> {
+        codec::to_cbor_bytes(self)
+    }
+
+    /// Deserialize from versioned CBOR bytes, following `CODEC.md`.
+    ///
+    /// With no variants this always fails; it gains meaning once a variant is added.
+    pub fn from_bytes(bytes: &[u8]) -> StmResult<Self> {
+        if codec::has_cbor_v1_prefix(bytes) {
+            codec::from_cbor_bytes(&bytes[1..])
+        } else {
+            Err(anyhow::anyhow!(
+                "AncillaryVerifierData: unsupported encoding, expected a CBOR v1 prefix"
+            ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::codec::CODEC_VERSION_CBOR_V1;
+
+    use super::*;
+
+    #[test]
+    fn prover_data_from_bytes_rejects_every_input() {
+        assert!(AncillaryProverData::from_bytes(&[]).is_err());
+        assert!(AncillaryProverData::from_bytes(&[0, 1, 2]).is_err());
+        assert!(AncillaryProverData::from_bytes(&[CODEC_VERSION_CBOR_V1, 0xff]).is_err());
+    }
+
+    #[test]
+    fn verifier_data_from_bytes_rejects_every_input() {
+        assert!(AncillaryVerifierData::from_bytes(&[]).is_err());
+        assert!(AncillaryVerifierData::from_bytes(&[0, 1, 2]).is_err());
+        assert!(AncillaryVerifierData::from_bytes(&[CODEC_VERSION_CBOR_V1, 0xff]).is_err());
+    }
+}

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -15,7 +15,9 @@ use crate::AggregateSignatureError;
 #[cfg(feature = "future_snark")]
 use crate::proof_system::{MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver};
 
-use super::{AggregateSignature, AggregateSignatureType};
+use super::{
+    AggregateSignature, AggregateSignatureType, AncillaryProofInput, AncillaryVerifierData,
+};
 
 /// Clerk for aggregate signatures.
 ///
@@ -68,22 +70,23 @@ impl<D: MembershipDigest> Clerk<D> {
         sigs: &[SingleSignature],
         msg: &[u8],
         aggregate_signature_type: AggregateSignatureType,
-    ) -> StmResult<AggregateSignature<D>> {
+        ancillary_input: AncillaryProofInput,
+    ) -> StmResult<(AggregateSignature<D>, Option<AncillaryVerifierData>)> {
+        let _ = ancillary_input;
         match aggregate_signature_type {
             AggregateSignatureType::Concatenation => {
-                Ok(AggregateSignature::Concatenation(Box::new(
-                    ConcatenationProof::aggregate_signatures(
-                        self.get_concatenation_clerk(),
-                        sigs,
-                        msg,
+                let proof = ConcatenationProof::aggregate_signatures(
+                    self.get_concatenation_clerk(),
+                    sigs,
+                    msg,
+                )
+                .with_context(|| {
+                    format!(
+                        "Signatures failed to aggregate for type {}",
+                        AggregateSignatureType::Concatenation
                     )
-                    .with_context(|| {
-                        format!(
-                            "Signatures failed to aggregate for type {}",
-                            AggregateSignatureType::Concatenation
-                        )
-                    })?,
-                )))
+                })?;
+                Ok((AggregateSignature::Concatenation(Box::new(proof)), None))
             }
             #[cfg(feature = "future_snark")]
             AggregateSignatureType::Snark => {
@@ -95,7 +98,7 @@ impl<D: MembershipDigest> Clerk<D> {
                     MERKLE_TREE_DEPTH_FOR_SNARK,
                 )?
                 .aggregate_signatures(clerk, sigs, msg)
-                .map(|p| AggregateSignature::Snark(Box::new(p)))
+                .map(|p| (AggregateSignature::Snark(Box::new(p)), None))
                 .with_context(|| {
                     format!(
                         "Signatures failed to aggregate for type {}",

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -5,7 +5,9 @@ mod error;
 mod signature;
 
 pub use aggregate_key::AggregateVerificationKey;
-pub use ancillary_data::{AncillaryProverData, AncillaryVerifierData};
+pub use ancillary_data::{
+    AncillaryGenesisData, AncillaryProofInput, AncillaryProverData, AncillaryVerifierData,
+};
 pub use clerk::Clerk;
 pub use error::{AggregateSignatureError, AggregationError};
 pub use signature::{AggregateSignature, AggregateSignatureType};
@@ -28,7 +30,7 @@ mod tests {
 
     use super::{
         AggregateSignature, AggregateSignatureType, AggregateVerificationKey, AggregationError,
-        Clerk,
+        AncillaryProofInput, AncillaryVerifierData, Clerk,
     };
 
     type Sig = AggregateSignature<D>;
@@ -165,7 +167,7 @@ mod tests {
 
     #[derive(Debug)]
     struct ProofTest {
-        msig: StmResult<Sig>,
+        msig: StmResult<(Sig, Option<AncillaryVerifierData>)>,
         clerk: Clerk<D>,
         msg: [u8; 16],
     }
@@ -186,7 +188,12 @@ mod tests {
                 let sigs = find_signatures(&msg, &ps, &all_ps);
 
                 let aggr_sig_type = AggregateSignatureType::Concatenation;
-                let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
+                let msig = clerk.aggregate_signatures_with_type(
+                    &sigs,
+                    &msg,
+                    aggr_sig_type,
+                    AncillaryProofInput::dummy(),
+                );
                 ProofTest { msig, clerk, msg }
             })
         })
@@ -197,13 +204,14 @@ mod tests {
         F: Fn(&mut Sig, &mut Clerk<D>, &mut [u8; 16]),
     {
         match tc.msig {
-            Ok(mut aggr) => {
+            Ok((mut aggr, ancillary_verifier_data)) => {
                 f(&mut aggr, &mut tc.clerk, &mut tc.msg);
                 assert!(
                     aggr.verify(
                         &tc.msg,
                         &tc.clerk.compute_aggregate_verification_key(),
-                        &tc.clerk.get_concatenation_clerk().parameters
+                        &tc.clerk.get_concatenation_clerk().parameters,
+                        ancillary_verifier_data
                     )
                     .is_err()
                 )
@@ -229,12 +237,12 @@ mod tests {
 
             let all_ps: Vec<usize> = (0..nparties).collect();
             let sigs = find_signatures(&msg, &ps, &all_ps);
-            let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
+            let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy());
 
             match msig {
-                Ok(aggr) => {
+                Ok((aggr, ancillary_verifier_data)) => {
                     println!("Aggregate ok");
-                    assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params).is_ok());
+                    assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data).is_ok());
                 }
                 Err(error) => match error.downcast_ref::<AggregationError>() {
                     Some(AggregationError::NotEnoughSignatures(n, k)) => {
@@ -315,11 +323,11 @@ mod tests {
 
             let all_ps: Vec<usize> = (0..nparties).collect();
             let sigs = find_signatures(&msg, &ps, &all_ps);
-            let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
-            if let Ok(aggr) = msig {
+            let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy());
+            if let Ok((aggr, ancillary_verifier_data)) = msig {
                     let bytes: Vec<u8> = aggr.to_bytes().expect("AggregateSignature serialization should not fail");
                     let aggr2: AggregateSignature<D> = AggregateSignature::from_bytes(&bytes).unwrap();
-                    assert!(aggr2.verify(&msg, &clerk.compute_aggregate_verification_key(), &params).is_ok());
+                    assert!(aggr2.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data).is_ok());
             }
         }
     }
@@ -399,6 +407,7 @@ mod tests {
                 let mut aggr_stms = Vec::new();
                 let mut batch_msgs = Vec::new();
                 let mut batch_params = Vec::new();
+                let mut batch_ancillary_verifier_datas = Vec::new();
                 for _ in 0..batch_size {
                     let mut msg = [0u8; 32];
                     rng.fill_bytes(&mut msg);
@@ -408,14 +417,15 @@ mod tests {
 
                     let all_ps: Vec<usize> = (0..nparties).collect();
                     let sigs = find_signatures(&msg, &ps, &all_ps);
-                    let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
+                    let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy());
 
                     match msig {
-                        Ok(aggr) => {
+                        Ok((aggr, ancillary_verifier_data)) => {
                             aggr_avks.push(clerk.compute_aggregate_verification_key());
                             aggr_stms.push(aggr);
                             batch_msgs.push(msg.to_vec());
                             batch_params.push(params);
+                            batch_ancillary_verifier_datas.push(ancillary_verifier_data);
                         }
                         Err(error) => { assert!(
                             matches!(
@@ -427,13 +437,13 @@ mod tests {
                     }
                 }
 
-                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params).is_ok());
+                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas).is_ok());
 
                 if aggr_stms.len() >= 2 {
                     let mut swapped_msgs = batch_msgs.clone();
                     swapped_msgs.swap(0, 1);
                     assert!(
-                        AggregateSignature::batch_verify(&aggr_stms, &swapped_msgs, &aggr_avks, &batch_params).is_err(),
+                        AggregateSignature::batch_verify(&aggr_stms, &swapped_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas).is_err(),
                         "Batch verify should reject swapped messages"
                     );
 
@@ -450,7 +460,7 @@ mod tests {
                     let mut wrong_avks = aggr_avks.clone();
                     wrong_avks[0] = wrong_avk;
                     assert!(
-                        AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &wrong_avks, &batch_params).is_err(),
+                        AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &wrong_avks, &batch_params, &batch_ancillary_verifier_datas).is_err(),
                         "Batch verify should reject a wrong avk"
                     );
                 }
@@ -463,10 +473,10 @@ mod tests {
 
                 let all_ps: Vec<usize> = (0..nparties).collect();
                 let sigs = find_signatures(&msg, &ps, &all_ps);
-                let fake_msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
+                let (fake_msig, _ancillary_verifier_data) = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy()).unwrap();
 
-                aggr_stms[0] = fake_msig.unwrap();
-                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params).is_err());
+                aggr_stms[0] = fake_msig;
+                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas).is_err());
             }
         }
 
@@ -500,7 +510,7 @@ mod tests {
                 let clerk = Clerk::new_clerk_from_signer(&ps[0]);
                 let aggr_sig_type = AggregateSignatureType::Concatenation;
 
-                let error = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type).expect_err("Not enough quorum should fail!");
+                let error = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy()).expect_err("Not enough quorum should fail!");
                 assert!(
                     matches!(
                         error.downcast_ref::<AggregationError>(),

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -1,9 +1,11 @@
 mod aggregate_key;
+mod ancillary_data;
 mod clerk;
 mod error;
 mod signature;
 
 pub use aggregate_key::AggregateVerificationKey;
+pub use ancillary_data::{AncillaryProverData, AncillaryVerifierData};
 pub use clerk::Clerk;
 pub use error::{AggregateSignatureError, AggregationError};
 pub use signature::{AggregateSignature, AggregateSignatureType};

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -47,6 +47,20 @@ impl AggregateSignatureType {
             _ => None,
         }
     }
+
+    /// Whether a valid certificate carrying this aggregate signature type certifies the full
+    /// certificate chain back to the genesis certificate on its own.
+    ///
+    /// Returns `false` for the current proof systems. Recursive proof systems (e.g. IVC) return
+    /// `true`, which lets certificate chain verification stop at the first valid such certificate
+    /// instead of walking back to the genesis certificate.
+    pub fn certifies_full_certificate_chain(&self) -> bool {
+        match self {
+            AggregateSignatureType::Concatenation => false,
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::Snark => false,
+        }
+    }
 }
 
 impl<D: MembershipDigest> From<&AggregateSignature<D>> for AggregateSignatureType {
@@ -525,6 +539,21 @@ mod tests {
                 Some(AggregateSignatureType::Snark)
             );
         }
+    }
+
+    #[test]
+    fn golden_certifies_full_certificate_chain_per_aggregate_signature_type() {
+        fn assert_golden_value(aggregate_signature_type: AggregateSignatureType, expected: bool) {
+            assert_eq!(
+                expected,
+                aggregate_signature_type.certifies_full_certificate_chain(),
+                "golden 'certifies_full_certificate_chain' value changed for {aggregate_signature_type}, this alters certificate chain verification semantics"
+            );
+        }
+
+        assert_golden_value(AggregateSignatureType::Concatenation, false);
+        #[cfg(feature = "future_snark")]
+        assert_golden_value(AggregateSignatureType::Snark, false);
     }
 
     mod aggregate_signature_golden_concatenation {

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -11,7 +11,7 @@ use crate::{
 #[cfg(feature = "future_snark")]
 use crate::proof_system::{SnarkProof, SnarkVerifierSetup};
 
-use super::{AggregateSignatureError, AggregateVerificationKey};
+use super::{AggregateSignatureError, AggregateVerificationKey, AncillaryVerifierData};
 
 /// The type of STM aggregate signature.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -120,7 +120,9 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         msg: &[u8],
         avk: &AggregateVerificationKey<D>,
         parameters: &Parameters,
+        ancillary_verifier_data: Option<AncillaryVerifierData>,
     ) -> StmResult<()> {
+        let _ = ancillary_verifier_data;
         match self {
             AggregateSignature::Concatenation(concatenation_proof) => concatenation_proof.verify(
                 msg,
@@ -144,12 +146,14 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         msgs: &[Vec<u8>],
         avks: &[AggregateVerificationKey<D>],
         parameters: &[Parameters],
+        ancillary_verifier_datas: &[Option<AncillaryVerifierData>],
     ) -> StmResult<()> {
         type AggregateEntriesForAggregateSignatureType<D> = (
             AggregateSignature<D>,
             AggregateVerificationKey<D>,
             Vec<u8>,
             Parameters,
+            Option<AncillaryVerifierData>,
         );
 
         fn check_input_lengths(
@@ -174,6 +178,9 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             avks.len(),
             parameters.len(),
         )?;
+        if aggregate_signatures.len() != ancillary_verifier_datas.len() {
+            return Err(anyhow!(AggregateSignatureError::BatchInvalid));
+        }
 
         let aggregate_entries_by_aggregate_signature_type: HashMap<
             AggregateSignatureType,
@@ -183,15 +190,18 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             .zip(msgs.iter())
             .zip(avks.iter())
             .zip(parameters.iter())
+            .zip(ancillary_verifier_datas.iter())
             .fold(
                 HashMap::new(),
-                |mut acc, (((aggregate_signature, msg), avk), parameters)| {
+                |mut acc,
+                 ((((aggregate_signature, msg), avk), parameters), ancillary_verifier_data)| {
                     let signature_type = AggregateSignatureType::from(aggregate_signature);
                     acc.entry(signature_type).or_default().push((
                         aggregate_signature.clone(),
                         avk.clone(),
                         msg.clone(),
                         *parameters,
+                        ancillary_verifier_data.clone(),
                     ));
                     acc
                 },
@@ -204,22 +214,24 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     AggregateSignatureType::Concatenation => {
                         let avks = aggregate_entries
                             .iter()
-                            .map(|(_, avk, _, _)| avk.to_concatenation_aggregate_verification_key())
+                            .map(|(_, avk, _, _, _)| {
+                                avk.to_concatenation_aggregate_verification_key()
+                            })
                             .cloned()
                             .collect::<Vec<_>>();
                         let concatenation_proofs = aggregate_entries
                             .iter()
-                            .filter_map(|(aggregate_signature, _, _, _)| {
+                            .filter_map(|(aggregate_signature, _, _, _, _)| {
                                 aggregate_signature.to_concatenation_proof().cloned()
                             })
                             .collect::<Vec<_>>();
                         let msgs = aggregate_entries
                             .iter()
-                            .map(|(_, _, msg, _)| msg.clone())
+                            .map(|(_, _, msg, _, _)| msg.clone())
                             .collect::<Vec<_>>();
                         let parameters = aggregate_entries
                             .iter()
-                            .map(|(_, _, _, parameters)| *parameters)
+                            .map(|(_, _, _, parameters, _)| *parameters)
                             .collect::<Vec<_>>();
                         check_input_lengths(
                             concatenation_proofs.len(),
@@ -236,8 +248,15 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     }
                     #[cfg(feature = "future_snark")]
                     AggregateSignatureType::Snark => {
-                        for (aggregate_signature, avk, msg, parameters) in aggregate_entries {
-                            aggregate_signature.verify(&msg, &avk, &parameters)?;
+                        for (aggregate_signature, avk, msg, parameters, ancillary_verifier_data) in
+                            aggregate_entries
+                        {
+                            aggregate_signature.verify(
+                                &msg,
+                                &avk,
+                                &parameters,
+                                ancillary_verifier_data,
+                            )?;
                         }
 
                         Ok(())
@@ -434,7 +453,7 @@ mod tests {
 
         #[test]
         fn returns_error_when_messages_length_differs_from_signatures() {
-            let result = AggregateSignature::<D>::batch_verify(&[], &[vec![1u8]], &[], &[]);
+            let result = AggregateSignature::<D>::batch_verify(&[], &[vec![1u8]], &[], &[], &[]);
 
             assert_batch_invalid_error(result);
         }
@@ -442,7 +461,7 @@ mod tests {
         #[test]
         fn returns_error_when_avks_length_differs_from_signatures() {
             let avk = build_aggregate_verification_key();
-            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[avk], &[]);
+            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[avk], &[], &[]);
 
             assert_batch_invalid_error(result);
         }
@@ -458,14 +477,22 @@ mod tests {
                     m: 100,
                     phi_f: 0.2,
                 }],
+                &[],
             );
 
             assert_batch_invalid_error(result);
         }
 
         #[test]
+        fn returns_error_when_ancillary_verifier_datas_length_differs_from_signatures() {
+            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[], &[None]);
+
+            assert_batch_invalid_error(result);
+        }
+
+        #[test]
         fn succeeds_when_all_inputs_are_empty() {
-            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[]);
+            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[], &[]);
 
             assert!(result.is_ok());
         }
@@ -506,8 +533,8 @@ mod tests {
 
         use super::{AggregateSignature, AggregateSignatureType};
         use crate::{
-            Clerk, KeyRegistration, MithrilMembershipDigest, Parameters, RegistrationEntry, Signer,
-            VerificationKeyProofOfPossessionForConcatenation,
+            AncillaryProofInput, Clerk, KeyRegistration, MithrilMembershipDigest, Parameters,
+            RegistrationEntry, Signer, VerificationKeyProofOfPossessionForConcatenation,
             proof_system::ConcatenationProofSigner, signature_scheme::BlsSigningKey,
         };
 
@@ -640,13 +667,15 @@ mod tests {
             let signature_1 = signer_1.create_single_signature(&msg).unwrap();
             let signature_2 = signer_2.create_single_signature(&msg).unwrap();
 
-            clerk
+            let (signature, _ancillary_verifier_data) = clerk
                 .aggregate_signatures_with_type(
                     &[signature_1, signature_2],
                     &msg,
                     AggregateSignatureType::Concatenation,
+                    AncillaryProofInput::dummy(),
                 )
-                .unwrap()
+                .unwrap();
+            signature
         }
 
         #[test]

--- a/mithril-stm/src/protocol/mod.rs
+++ b/mithril-stm/src/protocol/mod.rs
@@ -7,7 +7,7 @@ mod single_signature;
 
 pub use aggregate_signature::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
-    AggregationError, Clerk,
+    AggregationError, AncillaryProverData, AncillaryVerifierData, Clerk,
 };
 pub use error::RegisterError;
 #[cfg(feature = "future_snark")]

--- a/mithril-stm/src/protocol/mod.rs
+++ b/mithril-stm/src/protocol/mod.rs
@@ -7,7 +7,8 @@ mod single_signature;
 
 pub use aggregate_signature::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
-    AggregationError, AncillaryProverData, AncillaryVerifierData, Clerk,
+    AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProverData,
+    AncillaryVerifierData, Clerk,
 };
 pub use error::RegisterError;
 #[cfg(feature = "future_snark")]

--- a/mithril-stm/tests/bytes_conversion.rs
+++ b/mithril-stm/tests/bytes_conversion.rs
@@ -82,7 +82,7 @@ fn test_binary_conversions() {
     let decoded = SingleSignature::from_bytes::<D>(&encoded).unwrap();
     assert_eq!(sig, &decoded);
 
-    let msig = msig.unwrap();
+    let (msig, _ancillary_verifier_data) = msig.unwrap();
     let encoded = msig
         .to_bytes()
         .expect("AggregateSignature serialization should not fail");

--- a/mithril-stm/tests/stm_protocol.rs
+++ b/mithril-stm/tests/stm_protocol.rs
@@ -30,9 +30,9 @@ fn test_full_protocol() {
         operation_phase(params, signers, reg_parties, msg);
 
     match msig {
-        Ok(aggr) => {
+        Ok((aggr, ancillary_verifier_data)) => {
             println!("Aggregate ok");
-            assert!(aggr.verify(&msg, &avk, &params).is_ok());
+            assert!(aggr.verify(&msg, &avk, &params, ancillary_verifier_data).is_ok());
         }
         Err(error) => match error.downcast_ref::<AggregationError>() {
             Some(AggregationError::NotEnoughSignatures(n, k)) => {
@@ -59,6 +59,7 @@ fn test_full_protocol_batch_verify() {
     let mut aggr_stms = Vec::new();
     let mut batch_msgs = Vec::new();
     let mut batch_params = Vec::new();
+    let mut batch_ancillary_verifier_datas = Vec::new();
 
     let params = Parameters {
         k: 357,
@@ -79,12 +80,20 @@ fn test_full_protocol_batch_verify() {
             operation_phase(params, signers, reg_parties, msg);
 
         aggr_avks.push(avk);
-        aggr_stms.push(msig.unwrap());
+        let (signature, ancillary_verifier_data) = msig.unwrap();
+        aggr_stms.push(signature);
         batch_msgs.push(msg.to_vec());
         batch_params.push(params);
+        batch_ancillary_verifier_datas.push(ancillary_verifier_data);
     }
     assert!(
-        AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params)
-            .is_ok()
+        AggregateSignature::batch_verify(
+            &aggr_stms,
+            &batch_msgs,
+            &aggr_avks,
+            &batch_params,
+            &batch_ancillary_verifier_datas
+        )
+        .is_ok()
     );
 }

--- a/mithril-stm/tests/test_extensions/protocol_phase.rs
+++ b/mithril-stm/tests/test_extensions/protocol_phase.rs
@@ -3,9 +3,10 @@ use rand_core::RngCore;
 use rayon::prelude::*;
 
 use mithril_stm::{
-    AggregateSignature, AggregateSignatureType, AggregateVerificationKey, Clerk, Initializer,
-    KeyRegistration, MithrilMembershipDigest, Parameters, Signer, SingleSignature, Stake,
-    StmResult, VerificationKeyForConcatenation,
+    AggregateSignature, AggregateSignatureType, AggregateVerificationKey, AncillaryGenesisData,
+    AncillaryProofInput, AncillaryVerifierData, Clerk, Initializer, KeyRegistration,
+    MithrilMembershipDigest, Parameters, Signer, SingleSignature, Stake, StmResult,
+    VerificationKeyForConcatenation,
 };
 
 type D = MithrilMembershipDigest;
@@ -19,7 +20,7 @@ pub struct InitializationPhaseResult {
 
 /// The result of the operation phase of the STM protocol.
 pub struct OperationPhaseResult {
-    pub msig: StmResult<AggregateSignature<D>>,
+    pub msig: StmResult<(AggregateSignature<D>, Option<AncillaryVerifierData>)>,
     pub avk: AggregateVerificationKey<D>,
     pub sigs: Vec<SingleSignature>,
 }
@@ -95,7 +96,15 @@ pub fn operation_phase(
         );
     }
 
-    let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type);
+    let ancillary_input = AncillaryProofInput::new(
+        None,
+        AncillaryGenesisData::new(
+            Vec::new(),
+            #[cfg(feature = "future_snark")]
+            None,
+        ),
+    );
+    let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, ancillary_input);
 
     OperationPhaseResult { msig, avk, sigs }
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1761,6 +1761,18 @@ components:
             remain compatible with the pre-Lagrange wire format.
           type: string
           format: bytes
+        ancillary_prover_data:
+          description: |
+            Hex-encoded ancillary data used by the prover to produce the next certificate. Omitted
+            when absent. Its shape depends on the aggregate signature type.
+          type: string
+          format: bytes
+        ancillary_verifier_data:
+          description: |
+            Hex-encoded ancillary data used to verify the certificate. Omitted when absent. Its
+            shape depends on the aggregate signature type.
+          type: string
+          format: bytes
         multi_signature:
           description: STM multi signature created from a quorum of single signatures from the signers
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,7 +4,7 @@ info:
   # `mithril-common/src/lib.rs` file. If you plan to update it
   # here to reflect changes in the API, please also update the constant in the
   # Rust file.
-  version: 0.1.65
+  version: 0.1.66
   title: Mithril Aggregator Server
   description: |
     The REST API provided by a Mithril Aggregator Node in a Mithril network.


### PR DESCRIPTION
## Content

This PR includes **support for the IVC proofs in the certificate chain**:

- **Ancillary data types (mithril-stm)**
  - New proof-system-agnostic carriers: `AncillaryProverData` and `AncillaryVerifierData` (both uninhabited for now, growing as schemes land), plus `AncillaryGenesisData` and `AncillaryProofInput` as the transient input to aggregate signature creation.
  - The clerk's `aggregate_signatures_with_type` function takes the `AncillaryProofInput` unconditionally and returns the aggregate signature plus optional `AncillaryVerifierData`. Each proof system decides whether to consume the input.
  - The aggregate signature `verify` and `batch_verify` functions take an optional `AncillaryVerifierData`.
- **Certificate carriage (mithril-common)**
  - Certificate gains optional `ancillary_prover_data` and `ancillary_verifier_data` fields, folded into the certificate hash (no change when absent), the certificate message, and the OpenAPI schema.
  - `build_ancillary_proof_input` function assembles the input from the latest genesis certificate (genesis data) and the parent certificate (prover data).
- **Persistence and creation (mithril-aggregator)**
  - A migration adds the two ancillary columns to the certificate table, threaded through the record, queries, and message conversions.
  - `create_certificate` function builds the ancillary input from the genesis and parent certificates and stores the verifier data the clerk returns.
- **Early-stop verification (mithril-common)**
  - `AggregateSignatureType::certifies_full_certificate_chain()` function reports whether a signature attests to the whole chain (`false` for current types, `true` for upcoming recursive proofs), pinned by a golden test.
  - When such a certificate is valid, chain verification stops at it (via the extracted `verify_certificate_integrity` function) instead of walking back to genesis.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #3147 
