### PR TITLE
feat: add DMQ node compatibility matrix in release notes

### DIFF
--- a/.github/workflows/actions/prepare-distribution/action.yml
+++ b/.github/workflows/actions/prepare-distribution/action.yml
@@ -114,6 +114,12 @@ runs:
         ./.github/workflows/scripts/compute-cardano-compatibility.sh ./networks.json \
           >> ./release-notes-addon.txt
 
+    - name: Add DMQ node compatibility table
+      shell: bash
+      run: |
+        ./.github/workflows/scripts/compute-dmq-compatibility.sh ./networks.json \
+          >> ./release-notes-addon.txt
+
     - name: Add platform support table
       shell: bash
       run: |

--- a/.github/workflows/scripts/compute-dmq-compatibility.sh
+++ b/.github/workflows/scripts/compute-dmq-compatibility.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+JSON_FILE=$1
+
+if [[ ! -f "$JSON_FILE" ]]; then
+    echo "Error: $JSON_FILE not found!"
+    exit 1
+fi
+
+# Get all unique keys from 'cardano-minimum-version'
+MITHRIL_NODES=$(jq -r '[.[] | .["cardano-minimum-version"] | keys[]] | unique | .[]' "$JSON_FILE")
+
+# Create header of the markdown table
+header="| Network"
+separator="|----------"
+
+for key in $MITHRIL_NODES; do
+    title=$(echo "$key" | sed 's/-/ /g' | sed 's/\b\w/\U&/g')
+    header="$header | $title"
+    separator="$separator |:-------------:"
+done
+
+header="$header |"
+separator="$separator |"
+
+echo ""
+echo "## DMQ Node Compatibility"
+echo ""
+echo "$header"
+echo "$separator"
+
+# Process each top-level network (mainnet, preprod, preview)
+for MITHRIL_NETWORK in $(jq -r 'keys[]' "$JSON_FILE"); do
+    DMQ_VERSION=$(jq -r ".\"$MITHRIL_NETWORK\".\"dmq-minimum-version\" // \"N/A\"" "$JSON_FILE")
+
+    # Get all mithril-networks for this top-level network
+    jq -r ".\"$MITHRIL_NETWORK\".\"mithril-networks\"[] | keys[]" "$JSON_FILE" | while read -r MITHRIL_NETWORK_NAME; do
+        row="| $MITHRIL_NETWORK_NAME"
+
+        # Repeat the DMQ minimum version for each mithril node
+        for _ in $MITHRIL_NODES; do
+            if [[ "$DMQ_VERSION" != "N/A" ]]; then
+                row="$row | DMQ \`$DMQ_VERSION+\`<sup>(*)</sup>"
+            else
+                row="$row | N/A"
+            fi
+        done
+
+        row="$row |"
+        echo "$row"
+    done
+done
+
+echo ""
+echo "<sup>*</sup>: Up to the latest DMQ node version released at the time of this release."

--- a/.github/workflows/scripts/compute-dmq-compatibility.sh
+++ b/.github/workflows/scripts/compute-dmq-compatibility.sh
@@ -9,7 +9,8 @@ if [[ ! -f "$JSON_FILE" ]]; then
     exit 1
 fi
 
-# Get all unique keys from 'cardano-minimum-version'
+# Derive the Mithril node columns from the 'cardano-minimum-version' keys, so the
+# DMQ table stays aligned with the Cardano compatibility table
 MITHRIL_NODES=$(jq -r '[.[] | .["cardano-minimum-version"] | keys[]] | unique | .[]' "$JSON_FILE")
 
 # Create header of the markdown table
@@ -40,7 +41,7 @@ for MITHRIL_NETWORK in $(jq -r 'keys[]' "$JSON_FILE"); do
         row="| $MITHRIL_NETWORK_NAME"
 
         # Repeat the DMQ minimum version for each mithril node
-        for _ in $MITHRIL_NODES; do
+        for _mithril_node in $MITHRIL_NODES; do
             if [[ "$DMQ_VERSION" != "N/A" ]]; then
                 row="$row | DMQ \`$DMQ_VERSION+\`<sup>(*)</sup>"
             else


### PR DESCRIPTION
## Content

This PR includes the **inclusion of the DMQ node compatibility matrix in the release notes**.

Below is an example of a rendered matrix:
---------------
## DMQ Node Compatibility

| Network | Mithril Aggregator | Mithril Signer |
|---------- |:-------------: |:-------------: |
| release-mainnet | DMQ `0.6.0.0+`<sup>(*)</sup> | DMQ `0.6.0.0+`<sup>(*)</sup> |
| release-preprod | DMQ `0.6.0.0+`<sup>(*)</sup> | DMQ `0.6.0.0+`<sup>(*)</sup> |
| pre-release-preview | DMQ `0.6.0.0+`<sup>(*)</sup> | DMQ `0.6.0.0+`<sup>(*)</sup> |
| testing-preview | DMQ `0.6.0.0+`<sup>(*)</sup> | DMQ `0.6.0.0+`<sup>(*)</sup> |

<sup>*</sup>: Up to the latest DMQ node version released at the time of this release.

## Pre-submit checklist

- Branch
  - [ ] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3271 
