### PR TITLE
feat(ci): e2e light scenario for snark running in nightly ci

### DIFF
--- a/.github/workflows/nightly-dispatcher.yml
+++ b/.github/workflows/nightly-dispatcher.yml
@@ -23,9 +23,18 @@ jobs:
   test-client:
     uses: ./.github/workflows/test-client.yml
 
+  test-e2e:
+    uses: ./.github/workflows/test-e2e.yml
+
   notify-on-failure:
     uses: ./.github/workflows/test-notify-on-failure.yml
     needs:
-      [backward-compatibility, aggregator-stress-test, test-client, test-rust]
+      [
+        backward-compatibility,
+        aggregator-stress-test,
+        test-client,
+        test-rust,
+        test-e2e,
+      ]
     if: failure()
     secrets: inherit

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,284 @@
+name: End-to-end tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      cardano-node-versions:
+        description: "Cardano node version used in e2e (comma separated list of versions)"
+        required: true
+        type: string
+        default: "11.0.1"
+      full-scenario-signed-entity-types:
+        description: "Signed entity types parameters for full scenarios (discriminants names in an ordered comma separated list)"
+        required: true
+        type: string
+        default: "CardanoTransactions,CardanoStakeDistribution,CardanoDatabase"
+      minimal-scenario-signed-entity-types:
+        description: "Signed entity type parameters for minimal scenarios (one discriminants name)"
+        required: true
+        type: string
+        default: "CardanoDatabase"
+      ref-to-build-nodes:
+        description: "Git tag or commit hash of the Mithril nodes to test"
+        required: true
+        type: string
+        default: "unstable"
+      ref-to-build-e2e:
+        description: "Git tag or commit hash to build the end-to-end binary"
+        required: true
+        type: string
+        default: "unstable"
+      additional-nodes-build-args:
+        description: "Additional arguments to pass to the Mithril nodes build command"
+        required: false
+        type: string
+        default: "--features future_snark"
+  workflow_call:
+    inputs:
+      cardano-node-versions:
+        type: string
+        default: "11.0.1"
+      full-scenario-signed-entity-types:
+        type: string
+        default: "CardanoTransactions,CardanoStakeDistribution,CardanoDatabase"
+      minimal-scenario-signed-entity-types:
+        type: string
+        default: "CardanoDatabase"
+      ref-to-build-nodes:
+        type: string
+        default: "unstable"
+      ref-to-build-e2e:
+        type: string
+        default: "unstable"
+      additional-nodes-build-args:
+        description: "Additional arguments to pass to the Mithril nodes build command"
+        required: false
+        type: string
+        default: "--features future_snark"
+
+jobs:
+  prepare-env-variables:
+    runs-on: ubuntu-24.04
+    outputs:
+      cardano_node_versions: ${{ steps.set-env.outputs.cardano_node_versions }}
+    steps:
+      - name: Prepare env variables
+        id: set-env
+        shell: bash
+        run: |
+          versions=$(echo '${{ inputs.cardano-node-versions }}' | jq -R -c 'def trim: gsub("^\\s+|\\s+$"; ""); split(",") | map(trim)')
+          echo "cardano_node_versions=$versions" >> "$GITHUB_OUTPUT"
+
+  prepare-binaries:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref-to-build-nodes }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          target: x86_64-unknown-linux-musl
+
+      - name: Install musl toolchain prerequisites
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools build-essential pkg-config
+
+      - name: Build Mithril nodes
+        shell: bash
+        run: |
+          cargo build --release --bins --target=x86_64-unknown-linux-musl ${{ inputs.additional-nodes-build-args }} \
+            --package mithril-aggregator --package mithril-signer \
+            --package mithril-client-cli --package mithril-relay
+
+      - name: Upload Mithril binaries
+        uses: actions/upload-artifact@v7
+        with:
+          name: mithril-binaries
+          path: |
+            target/x86_64-unknown-linux-musl/release/mithril-aggregator
+            target/x86_64-unknown-linux-musl/release/mithril-client
+            target/x86_64-unknown-linux-musl/release/mithril-relay
+            target/x86_64-unknown-linux-musl/release/mithril-signer
+
+  prepare-e2e-runner:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref-to-build-e2e }}
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+
+      - name: Build E2E runner
+        shell: bash
+        run: |
+          cargo build --release --bin mithril-end-to-end
+
+      - name: Upload E2E runner
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-runner
+          path: target/release/mithril-end-to-end
+
+  minimal-e2e:
+    runs-on: ubuntu-24.04
+    needs: [prepare-env-variables, prepare-binaries, prepare-e2e-runner]
+    strategy:
+      fail-fast: false
+      matrix:
+        cardano_node_version: ${{ fromJSON(needs.prepare-env-variables.outputs.cardano_node_versions) }}
+        aggregate_signature_type: ["Concatenation"] #  Todo: add "Snark" once the snark certificate chain is ready
+        extra_args: ["--cardano-slot-length 1.0 --cardano-epoch-length 60"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: mithril-binaries
+          path: ./mithril-binaries
+
+      - name: Download e2e runner
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-runner
+          path: ./mithril-binaries
+
+      - name: Prepare binaries
+        shell: bash
+        run: |
+          chmod +x ./mithril-binaries/mithril-aggregator
+          chmod +x ./mithril-binaries/mithril-client
+          chmod +x ./mithril-binaries/mithril-signer
+          chmod +x ./mithril-binaries/mithril-relay
+          chmod +x ./mithril-binaries/mithril-end-to-end
+          mkdir -p artifacts
+
+      - name: Run E2E tests
+        uses: nick-fields/retry@v4
+        with:
+          shell: bash
+          max_attempts: 3
+          retry_on_exit_code: 2
+          timeout_minutes: 10
+          warning_on_retry: true
+          command: |
+            ./mithril-binaries/mithril-end-to-end -vvv \
+              --bin-directory ./mithril-binaries/ \
+              --work-directory=./artifacts \
+              --devnet-scripts-directory=./mithril-test-lab/cardano-devnet \
+              --cardano-node-version ${{ matrix.cardano_node_version }} \
+              --aggregate-signature-type ${{ matrix.aggregate_signature_type }} \
+              ${{ matrix.extra_args }} minimal --signed-entity-type ${{ inputs.minimal-scenario-signed-entity-types }}
+
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "RESULT=success" >> $GITHUB_ENV
+            elif [ $EXIT_CODE -eq 3 ]; then
+              echo "RESULT=incompatible" >> $GITHUB_ENV
+              exit 0
+            else
+              echo "RESULT=failure" >> $GITHUB_ENV
+            fi
+            exit $EXIT_CODE
+
+      - name: Upload E2E Tests Artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-sig_type_${{ matrix.aggregate_signature_type }}--scenario_minimal--cardano-${{ matrix.cardano_node_version }}
+          path: |
+            ./artifacts/*
+            # including node.sock makes the upload fails so exclude them:
+            !./artifacts/**/node.sock
+            # exclude cardano tools, saving ~500mb of data:
+            !./artifacts/devnet/bin/
+          if-no-files-found: error
+
+  full-e2e:
+    runs-on: ubuntu-24.04
+    needs: [prepare-env-variables, prepare-binaries, prepare-e2e-runner]
+    strategy:
+      fail-fast: false
+      matrix:
+        cardano_node_version: ${{ fromJSON(needs.prepare-env-variables.outputs.cardano_node_versions) }}
+        aggregate_signature_type: ["Concatenation"]
+        extra_args: ["--cardano-slot-length 1.0 --cardano-epoch-length 60"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          name: mithril-binaries
+          path: ./mithril-binaries
+
+      - name: Download e2e runner
+        uses: actions/download-artifact@v8
+        with:
+          name: e2e-runner
+          path: ./mithril-binaries
+
+      - name: Prepare binaries
+        shell: bash
+        run: |
+          chmod +x ./mithril-binaries/mithril-aggregator
+          chmod +x ./mithril-binaries/mithril-client
+          chmod +x ./mithril-binaries/mithril-signer
+          chmod +x ./mithril-binaries/mithril-relay
+          chmod +x ./mithril-binaries/mithril-end-to-end
+          mkdir -p artifacts
+
+      - name: Run E2E tests
+        uses: nick-fields/retry@v4
+        with:
+          shell: bash
+          max_attempts: 3
+          retry_on_exit_code: 2
+          timeout_minutes: 10
+          warning_on_retry: true
+          command: |
+            ./mithril-binaries/mithril-end-to-end -vvv \
+              --bin-directory ./mithril-binaries/ \
+              --work-directory=./artifacts \
+              --devnet-scripts-directory=./mithril-test-lab/cardano-devnet \
+              --cardano-node-version ${{ matrix.cardano_node_version }} \
+              --aggregate-signature-type ${{ matrix.aggregate_signature_type }} \
+              ${{ matrix.extra_args }} full --signed-entity-types ${{ inputs.full-scenario-signed-entity-types }}
+
+            EXIT_CODE=$?
+            if [ $EXIT_CODE -eq 0 ]; then
+              echo "RESULT=success" >> $GITHUB_ENV
+            elif [ $EXIT_CODE -eq 3 ]; then
+              echo "RESULT=incompatible" >> $GITHUB_ENV
+              exit 0
+            else
+              echo "RESULT=failure" >> $GITHUB_ENV
+            fi
+            exit $EXIT_CODE
+
+      - name: Upload E2E Tests Artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-sig_type_${{ matrix.aggregate_signature_type }}--scenario_full--cardano-${{ matrix.cardano_node_version }}
+          path: |
+            ./artifacts/*
+            # including node.sock makes the upload fails so exclude them:
+            !./artifacts/**/node.sock
+            # exclude cardano tools, saving ~500mb of data:
+            !./artifacts/devnet/bin/
+          if-no-files-found: error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4444,7 +4444,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.0"
+version = "0.5.1"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -17,9 +17,9 @@ use tokio::{
     task::JoinSet,
 };
 
-use mithril_common::StdResult;
+use mithril_common::{StdResult, entities::SignedEntityTypeDiscriminants};
 use mithril_doc::GenerateDocCommands;
-use mithril_end_to_end::scenario::{FullScenario, RunOnlyScenario};
+use mithril_end_to_end::scenario::{FullScenario, MinimalScenario, RunOnlyScenario};
 use mithril_end_to_end::toolkit::{ScenarioToolkit, ScenarioToolkitContext};
 use mithril_end_to_end::{
     AggregateSignatureType, Aggregator, Client, CompatibilityChecker, CompatibilityCheckerError,
@@ -90,6 +90,11 @@ enum ScenarioArgs {
         )]
         signed_entity_types: Vec<String>,
     },
+    Minimal {
+        /// Additional signed entity type to enable.
+        #[clap(long, default_value_t = SignedEntityTypeDiscriminants::CardanoDatabase)]
+        signed_entity_type: SignedEntityTypeDiscriminants,
+    },
     /// Bootstrap a Cardano devnet, Mithril Aggregators and Signers, and run continuously
     RunOnly {
         /// Signed entity types parameters (discriminants names in an ordered comma separated list).
@@ -121,6 +126,7 @@ impl ScenarioArgs {
                 signed_entity_types,
                 ..
             } => signed_entity_types.clone(),
+            ScenarioArgs::Minimal { signed_entity_type } => vec![signed_entity_type.to_string()],
             ScenarioArgs::RunOnly {
                 signed_entity_types,
                 ..
@@ -531,6 +537,12 @@ impl App {
                 .await;
                 (runner, false)
             }
+            ScenarioArgs::Minimal { signed_entity_type } => (
+                MinimalScenario::new(toolkit, infrastructure, signed_entity_type)
+                    .run()
+                    .await,
+                false,
+            ),
             ScenarioArgs::RunOnly { .. } => (
                 RunOnlyScenario::new(toolkit, infrastructure).run().await,
                 true,

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -15,9 +15,9 @@ use mithril_common::{CardanoNetwork, StdResult, entities};
 
 use crate::utils::{MithrilCommand, NodeVersion};
 use crate::{
-    ANCILLARY_MANIFEST_SECRET_KEY, DEVNET_DMQ_MAGIC_ID, DEVNET_MAGIC_ID, DmqNodeFlavor,
-    ERA_MARKERS_SECRET_KEY, ERA_MARKERS_VERIFICATION_KEY, FullNode, GENESIS_SECRET_KEY,
-    GENESIS_VERIFICATION_KEY, RetryableDevnetError,
+    ANCILLARY_MANIFEST_SECRET_KEY, AggregateSignatureType, DEVNET_DMQ_MAGIC_ID, DEVNET_MAGIC_ID,
+    DmqNodeFlavor, ERA_MARKERS_SECRET_KEY, ERA_MARKERS_VERIFICATION_KEY, FullNode,
+    GENESIS_SECRET_KEY, GENESIS_VERIFICATION_KEY, RetryableDevnetError,
 };
 
 #[derive(Debug)]
@@ -37,7 +37,7 @@ pub struct AggregatorConfig<'a> {
     pub mithril_era_reader_adapter: &'a str,
     pub mithril_era_marker_address: &'a str,
     pub signed_entity_types: &'a [String],
-    pub aggregate_signature_type: &'a str,
+    pub aggregate_signature_type: AggregateSignatureType,
     pub chain_observer_type: &'a str,
     pub leader_aggregator_endpoint: &'a Option<String>,
     pub use_dmq: bool,

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -265,7 +265,7 @@ impl MithrilInfrastructure {
             mithril_era_reader_adapter: &config.mithril_era_reader_adapter,
             mithril_era_marker_address: &config.devnet.mithril_era_marker_address()?,
             signed_entity_types: &config.signed_entity_types,
-            aggregate_signature_type: &config.aggregate_signature_type.to_string(),
+            aggregate_signature_type: config.aggregate_signature_type,
             chain_observer_type,
             leader_aggregator_endpoint: &leader_aggregator_endpoint,
             use_dmq: config.use_dmq,

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
@@ -264,19 +264,24 @@ impl FullScenario {
         let transaction_hashes = randomly_take_transactions_hashes(&blocks_transactions, 5);
         let block_hashes = randomly_take_blocks_hashes(&blocks_transactions, 5);
 
+        // Verify that the aggregator is still producing a certificate chain
+        self.toolkit
+            .check
+            .certificate
+            .is_creating_certificate_with_min_epoch(aggregator, expected_epoch_min)
+            .await?;
+
         // Verify that mithril stake distribution artifacts are produced and signed correctly
-        {
-            self.toolkit
-                .check
-                .mithril_stake_distribution
-                .is_certified_and_verified(
-                    aggregator,
-                    &mut client,
-                    expected_epoch_min,
-                    infrastructure.signers().len(),
-                )
-                .await?;
-        }
+        self.toolkit
+            .check
+            .mithril_stake_distribution
+            .is_certified_and_verified(
+                aggregator,
+                &mut client,
+                expected_epoch_min,
+                infrastructure.signers().len(),
+            )
+            .await?;
 
         // Verify that Cardano database snapshot artifacts are produced and signed correctly
         if self.is_signing_cardano_database {

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
@@ -1,0 +1,239 @@
+use std::sync::Arc;
+
+use slog_scope::info;
+use tokio::task::JoinSet;
+
+use mithril_common::{
+    StdResult,
+    entities::{Epoch, SignedEntityTypeDiscriminants},
+};
+
+use crate::{
+    Aggregator, MithrilInfrastructure,
+    toolkit::ScenarioToolkit,
+    utils::{
+        randomly_take_blocks_hashes, randomly_take_transactions_hashes,
+        retrieve_blocks_transactions_from_immutable_files,
+    },
+};
+
+pub struct MinimalScenario {
+    toolkit: ScenarioToolkit,
+    infrastructure: Arc<MithrilInfrastructure>,
+    signed_entity_type: SignedEntityTypeDiscriminants,
+}
+
+impl MinimalScenario {
+    pub fn new(
+        toolkit: ScenarioToolkit,
+        infrastructure: Arc<MithrilInfrastructure>,
+        signed_entity_type: SignedEntityTypeDiscriminants,
+    ) -> Self {
+        Self {
+            infrastructure,
+            toolkit,
+            signed_entity_type,
+        }
+    }
+
+    pub async fn run(self) -> StdResult<()> {
+        let mut join_set = JoinSet::new();
+        let spec = Arc::new(self);
+
+        // Delegate some stakes to pools
+        let delegation_round = 1;
+        spec.toolkit
+            .exec
+            .delegate_stakes_to_pools(spec.infrastructure.devnet(), delegation_round)
+            .await?;
+
+        if matches!(
+            &spec.signed_entity_type,
+            SignedEntityTypeDiscriminants::CardanoStakeDistribution
+                | SignedEntityTypeDiscriminants::CardanoTransactions
+        ) {
+            // Transfer some funds on the devnet to have some Cardano transactions to sign.
+            // This step needs to be executed early in the process so that the transactions are available
+            // for signing in the penultimate immutable chunk before the end of the test.
+            // As we get closer to the tip of the chain when signing, we'll be able to relax this constraint.
+            spec.toolkit.exec.transfer_funds(spec.infrastructure.devnet()).await?;
+        }
+
+        info!("Bootstrapping leader aggregator");
+        spec.bootstrap_leader_aggregator(&spec.infrastructure).await?;
+
+        info!("Starting followers");
+        for follower_aggregator in spec.infrastructure.follower_aggregators() {
+            follower_aggregator.serve().await?;
+        }
+
+        info!("Running scenarios");
+        for index in 0..spec.infrastructure.aggregators().len() {
+            let spec_clone = spec.clone();
+            join_set.spawn(async move {
+                let infrastructure = &spec_clone.infrastructure;
+
+                spec_clone
+                    .run_scenario(infrastructure.aggregator(index), infrastructure)
+                    .await
+            });
+        }
+
+        while let Some(res) = join_set.join_next().await {
+            res??;
+        }
+
+        Ok(())
+    }
+
+    pub async fn bootstrap_leader_aggregator(
+        &self,
+        infrastructure: &MithrilInfrastructure,
+    ) -> StdResult<()> {
+        let leader_aggregator = infrastructure.leader_aggregator();
+
+        self.toolkit.wait.for_enough_immutable(leader_aggregator).await?;
+        let chain_observer = leader_aggregator.chain_observer();
+        let start_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
+
+        // Wait 4 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
+        let target_epoch = start_epoch + 4;
+        self.toolkit
+            .wait
+            .for_aggregator_at_target_epoch(
+                leader_aggregator,
+                target_epoch,
+                "minimal epoch for the aggregator to be able to bootstrap genesis certificate"
+                    .to_string(),
+            )
+            .await?;
+        self.toolkit
+            .exec
+            .bootstrap_genesis_certificate(leader_aggregator)
+            .await?;
+        self.toolkit.wait.for_epoch_settings(leader_aggregator).await?;
+
+        Ok(())
+    }
+
+    pub async fn run_scenario(
+        &self,
+        aggregator: &Aggregator,
+        infrastructure: &MithrilInfrastructure,
+    ) -> StdResult<()> {
+        let chain_observer = aggregator.chain_observer();
+        let start_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
+
+        // Wait 2 epochs after genesis certificate creation
+        let target_epoch = start_epoch + 2;
+        self.toolkit
+            .wait
+            .for_aggregator_at_target_epoch(
+                aggregator,
+                target_epoch,
+                "epoch after which a minimal number of certificates have been produced".to_string(),
+            )
+            .await?;
+
+        // Verify that artifacts are produced and signed correctly
+        self.verify_artifacts_production(target_epoch, aggregator, infrastructure)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn verify_artifacts_production(
+        &self,
+        target_epoch: Epoch,
+        aggregator: &Aggregator,
+        infrastructure: &MithrilInfrastructure,
+    ) -> StdResult<Epoch> {
+        let mut client = infrastructure.build_client(aggregator).await?;
+
+        let expected_epoch_min = target_epoch - 1;
+        let immutable_files_directory = aggregator.db_directory().join("immutable");
+        let blocks_transactions =
+            retrieve_blocks_transactions_from_immutable_files(&immutable_files_directory)?;
+
+        let transaction_hashes = randomly_take_transactions_hashes(&blocks_transactions, 5);
+        let block_hashes = randomly_take_blocks_hashes(&blocks_transactions, 5);
+
+        // Verify that mithril stake distribution artifacts are produced and signed correctly
+        {
+            let mut client = infrastructure.build_client(aggregator).await?;
+            self.toolkit
+                .check
+                .mithril_stake_distribution
+                .is_certified_and_verified(
+                    aggregator,
+                    &mut client,
+                    expected_epoch_min,
+                    infrastructure.signers().len(),
+                )
+                .await?;
+        }
+
+        // Verify that Cardano database snapshot artifacts are produced and signed correctly
+        if self.signed_entity_type == SignedEntityTypeDiscriminants::CardanoDatabase {
+            self.toolkit
+                .check
+                .cardano_database
+                .is_certified_and_verified(
+                    aggregator,
+                    &mut client,
+                    expected_epoch_min,
+                    infrastructure.signers().len(),
+                )
+                .await?;
+        }
+
+        // Verify that Cardano transactions artifacts are produced and signed correctly
+        if self.signed_entity_type == SignedEntityTypeDiscriminants::CardanoTransactions {
+            self.toolkit
+                .check
+                .cardano_transactions
+                .is_certified_and_verified(
+                    aggregator,
+                    &mut client,
+                    expected_epoch_min,
+                    infrastructure.signers().len(),
+                    transaction_hashes.clone(),
+                )
+                .await?;
+        }
+
+        // Verify that Cardano blocks transactions artifacts are produced and signed correctly
+        if self.signed_entity_type == SignedEntityTypeDiscriminants::CardanoBlocksTransactions {
+            self.toolkit
+                .check
+                .cardano_blocks_transactions
+                .is_certified_and_verified(
+                    aggregator,
+                    &mut client,
+                    expected_epoch_min,
+                    infrastructure.signers().len(),
+                    block_hashes.clone(),
+                    transaction_hashes.clone(),
+                )
+                .await?;
+        }
+
+        // Verify that Cardano stake distribution artifacts are produced and signed correctly
+        if self.signed_entity_type == SignedEntityTypeDiscriminants::CardanoStakeDistribution {
+            {
+                self.toolkit
+                    .check
+                    .cardano_stake_distribution
+                    .is_certified_and_verified(
+                        aggregator,
+                        &mut client,
+                        expected_epoch_min,
+                        infrastructure.signers().len(),
+                    )
+                    .await?;
+            }
+        }
+
+        Ok(target_epoch)
+    }
+}

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
@@ -158,20 +158,24 @@ impl MinimalScenario {
         let transaction_hashes = randomly_take_transactions_hashes(&blocks_transactions, 5);
         let block_hashes = randomly_take_blocks_hashes(&blocks_transactions, 5);
 
+        // Verify that the aggregator is still producing a certificate chain
+        self.toolkit
+            .check
+            .certificate
+            .is_creating_certificate_with_min_epoch(aggregator, expected_epoch_min)
+            .await?;
+
         // Verify that mithril stake distribution artifacts are produced and signed correctly
-        {
-            let mut client = infrastructure.build_client(aggregator).await?;
-            self.toolkit
-                .check
-                .mithril_stake_distribution
-                .is_certified_and_verified(
-                    aggregator,
-                    &mut client,
-                    expected_epoch_min,
-                    infrastructure.signers().len(),
-                )
-                .await?;
-        }
+        self.toolkit
+            .check
+            .mithril_stake_distribution
+            .is_certified_and_verified(
+                aggregator,
+                &mut client,
+                expected_epoch_min,
+                infrastructure.signers().len(),
+            )
+            .await?;
 
         // Verify that Cardano database snapshot artifacts are produced and signed correctly
         if self.signed_entity_type == SignedEntityTypeDiscriminants::CardanoDatabase {

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/mod.rs
@@ -1,5 +1,7 @@
 mod full;
+mod minimal;
 mod run_only;
 
 pub use full::FullScenario;
+pub use minimal::MinimalScenario;
 pub use run_only::RunOnlyScenario;

--- a/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/stress_test/aggregator_helpers.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use mithril_common::{StdResult, entities::Epoch, test::builder::MithrilFixture};
 
 use crate::{
-    Aggregator, AggregatorConfig,
+    AggregateSignatureType, Aggregator, AggregatorConfig,
     stress_test::{entities::AggregatorParameters, fake_chain, fake_signer, wait},
 };
 
@@ -34,7 +34,7 @@ pub async fn bootstrap_aggregator(
         mithril_era_marker_address: "",
         mithril_era_reader_adapter: "dummy",
         signed_entity_types: &signed_entity_types,
-        aggregate_signature_type: "Concatenation",
+        aggregate_signature_type: AggregateSignatureType::Concatenation,
         chain_observer_type,
         leader_aggregator_endpoint: &None,
         use_dmq: false,

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
@@ -99,7 +99,7 @@ impl CheckCardanoDatabaseToolkit {
             }
         }
 
-        match attempt!(30, self.context.tenth_epoch_delay(), {
+        match attempt!(10, self.context.tenth_epoch_delay(), {
             fetch_cardano_database_digests_map(url.clone()).await
         }) {
             AttemptResult::Ok(cardano_database_digests_map) => {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
@@ -107,7 +107,7 @@ impl CheckCardanoDatabaseToolkit {
                 Ok(cardano_database_digests_map)
             }
             AttemptResult::Err(error) => Err(error),
-            AttemptResult::Timeout() => Err(anyhow!(
+            AttemptResult::Timeout(..) => Err(anyhow!(
             "Timeout exhausted assert_node_producing_cardano_database_digests_map, no response from `{url}`"
         )),
         }.with_context(|| {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
@@ -55,7 +55,7 @@ impl CheckCertificateToolkit {
                 }
             }
             AttemptResult::Err(error) => Err(error),
-            AttemptResult::Timeout() => Err(anyhow!(
+            AttemptResult::Timeout(..) => Err(anyhow!(
                 "Timeout exhausted assert_is_creating_certificate, no response from `{url}`"
             )),
         }

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
@@ -1,7 +1,11 @@
 use anyhow::{Context, anyhow};
 use slog_scope::info;
 
-use mithril_common::{StdResult, messages::CertificateMessage};
+use mithril_common::{
+    StdResult,
+    entities::Epoch,
+    messages::{CertificateListItemMessage, CertificateMessage},
+};
 
 use crate::{Aggregator, attempt, toolkit::ScenarioToolkitContext, utils::AttemptResult};
 
@@ -15,6 +19,27 @@ pub struct CheckCertificateToolkit {
 impl CheckCertificateToolkit {
     pub fn new(context: ScenarioToolkitContext) -> Self {
         Self { context }
+    }
+
+    pub async fn is_creating_certificate_with_min_epoch(
+        &self,
+        aggregator: &Aggregator,
+        min_epoch_expected: Epoch,
+    ) -> StdResult<CertificateListItemMessage> {
+        utils::wait_for_latest_artifact_with_condition(
+            &format!("Certificate for epoch {}", min_epoch_expected),
+            "/certificates",
+            |a: &CertificateListItemMessage| a.hash.clone(),
+            &self.context,
+            aggregator,
+            |c| c.epoch >= min_epoch_expected,
+            |last_invalid_cert| {
+                format!(
+                    "no certificate found with epoch >= {min_epoch_expected}\nlast certificate: {last_invalid_cert:?}",
+                )
+            },
+        )
+        .await
     }
 
     pub async fn is_creating_certificate_with_enough_signers(

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
@@ -44,7 +44,7 @@ pub async fn wait_for_latest_artifact<T: DeserializeOwned>(
         }
     }
 
-    match attempt!(30, context.tenth_epoch_delay(), {
+    match attempt!(20, context.tenth_epoch_delay(), {
         fetch_last_artifact(artifact_name, url.clone()).await
     }) {
         AttemptResult::Ok(last_artifact) => {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
@@ -5,6 +5,7 @@ use slog_scope::info;
 
 use mithril_common::{StdResult, entities::Epoch};
 
+use crate::utils::TimeoutReason;
 use crate::{Aggregator, attempt, toolkit::ScenarioToolkitContext, utils::AttemptResult};
 
 pub async fn get_json_response<T: DeserializeOwned>(url: String) -> StdResult<reqwest::Result<T>> {
@@ -30,8 +31,37 @@ pub async fn wait_for_latest_artifact<T: DeserializeOwned>(
     context: &ScenarioToolkitContext,
     aggregator: &Aggregator,
 ) -> StdResult<T> {
+    wait_for_latest_artifact_with_condition(
+        artifact_name,
+        artifact_list_url,
+        hash_extractor,
+        context,
+        aggregator,
+        |_| true,
+        |_| String::new(),
+    )
+    .await
+}
+
+/// Wait until the aggregator produces an artifact, returning the latest one
+///
+/// Note: the `artifact_list_url` must start with a `/`
+pub async fn wait_for_latest_artifact_with_condition<T, P, E>(
+    artifact_name: &str,
+    artifact_list_url: &str,
+    hash_extractor: fn(&T) -> String,
+    context: &ScenarioToolkitContext,
+    aggregator: &Aggregator,
+    condition: P,
+    invalid_condition_error_msg_callback: E,
+) -> StdResult<T>
+where
+    T: DeserializeOwned,
+    P: Fn(&T) -> bool,
+    E: Fn(T) -> String,
+{
     let url = format!("{}{artifact_list_url}", aggregator.endpoint());
-    info!("Waiting for the aggregator to produce a {artifact_name} artifact"; "aggregator" => &aggregator.name());
+    info!("Waiting for the aggregator to produce a {artifact_name} "; "aggregator" => &aggregator.name());
 
     async fn fetch_last_artifact<T: DeserializeOwned>(
         artifact_name: &str,
@@ -46,14 +76,17 @@ pub async fn wait_for_latest_artifact<T: DeserializeOwned>(
 
     match attempt!(20, context.tenth_epoch_delay(), {
         fetch_last_artifact(artifact_name, url.clone()).await
-    }) {
+    }, until &condition) {
         AttemptResult::Ok(last_artifact) => {
             info!("Aggregator produced a {artifact_name} artifact"; "hash" => hash_extractor(&last_artifact), "aggregator" => &aggregator.name());
             Ok(last_artifact)
         }
         AttemptResult::Err(error) => Err(error),
-        AttemptResult::Timeout(..) => Err(anyhow!(
+        AttemptResult::Timeout(TimeoutReason::NoResponse) => Err(anyhow!(
             "Timeout exhausted waiting for {artifact_name}, no response from `{url}`"
+        )),
+        AttemptResult::Timeout(TimeoutReason::PredicateNotSatisfied(last_response)) => Err(anyhow!(
+            "Timeout exhausted waiting for {artifact_name}, {}", invalid_condition_error_msg_callback(last_response)
         )),
     }
         .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
@@ -52,7 +52,7 @@ pub async fn wait_for_latest_artifact<T: DeserializeOwned>(
             Ok(last_artifact)
         }
         AttemptResult::Err(error) => Err(error),
-        AttemptResult::Timeout() => Err(anyhow!(
+        AttemptResult::Timeout(..) => Err(anyhow!(
             "Timeout exhausted waiting for {artifact_name}, no response from `{url}`"
         )),
     }

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
@@ -37,7 +37,7 @@ impl WaitToolkit {
         }) {
             AttemptResult::Ok(_) => Ok(()),
             AttemptResult::Err(error) => Err(error),
-            AttemptResult::Timeout() => Err(anyhow!(
+            AttemptResult::Timeout(..) => Err(anyhow!(
                 "Timeout exhausted for enough immutable to be written in `{}`",
                 db_directory.display()
             )),
@@ -74,7 +74,7 @@ impl WaitToolkit {
         }) {
             AttemptResult::Ok(epoch_settings) => Ok(epoch_settings),
             AttemptResult::Err(error) => Err(error),
-            AttemptResult::Timeout() => Err(anyhow!(
+            AttemptResult::Timeout(..) => Err(anyhow!(
                 "Timeout exhausted for aggregator to be up, no response from `{url}`"
             )),
         }
@@ -114,7 +114,7 @@ impl WaitToolkit {
                 Ok(())
             }
             AttemptResult::Err(error) => Err(error),
-            AttemptResult::Timeout() => {
+            AttemptResult::Timeout(..) => {
                 Err(anyhow!("Timeout exhausted for target epoch to be reached"))
             }
         }?;

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mod.rs
@@ -11,7 +11,7 @@ pub use compatibility_checker::*;
 pub use formatting::*;
 pub use immutable_files_utils::*;
 pub use mithril_command::MithrilCommand;
-pub use spec_utils::AttemptResult;
+pub use spec_utils::{AttemptResult, TimeoutReason};
 pub use version_req::NodeVersion;
 
 pub fn is_running_in_github_actions() -> bool {

--- a/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
@@ -1,30 +1,63 @@
-#[derive(PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 pub enum AttemptResult<T, E> {
     Ok(T),
     Err(E),
-    Timeout(),
+    Timeout(TimeoutReason<T>),
+}
+
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+pub enum TimeoutReason<T> {
+    /// No response was received after the given number of attempts
+    NoResponse,
+    /// The predicate was not satisfied after the given number of attempts, containing the last
+    /// response received
+    PredicateNotSatisfied(T),
 }
 
 #[macro_export]
 macro_rules! attempt {
-    ( $remaining_attempts:expr, $sleep_duration:expr, $block:block ) => {{
+    ( $remaining_attempts:expr, $sleep_duration:expr, $block:block, until $predicate:expr ) => {{
         let mut remaining_attempts = $remaining_attempts;
+        let mut last_received_response = None;
+
         loop {
             let res = $block;
-            if let Ok(None) = res {
-                if remaining_attempts > 1 {
-                    tokio::time::sleep($sleep_duration).await;
-                    remaining_attempts -= 1;
-                    continue;
+
+            match res {
+                Ok(Some(value)) => {
+                    if $predicate(&value) {
+                        break $crate::utils::AttemptResult::Ok(value);
+                    } else {
+                        last_received_response = Some(value);
+                    }
                 }
+                Ok(None) => (),
+                Err(error) => break $crate::utils::AttemptResult::Err(error),
             }
 
-            break match res {
-                Ok(Some(value)) => AttemptResult::Ok(value),
-                Err(error) => AttemptResult::Err(error),
-                Ok(None) => AttemptResult::Timeout(),
+            if remaining_attempts > 1 {
+                tokio::time::sleep($sleep_duration).await;
+                remaining_attempts -= 1;
+                continue;
+            }
+
+            break match last_received_response {
+                Some(value) => $crate::utils::AttemptResult::Timeout(
+                    $crate::utils::TimeoutReason::PredicateNotSatisfied(value),
+                ),
+                None => {
+                    $crate::utils::AttemptResult::Timeout($crate::utils::TimeoutReason::NoResponse)
+                }
             };
         }
+    }};
+    ( $remaining_attempts:expr, $sleep_duration:expr, $block:block ) => {{
+        $crate::attempt!(
+            $remaining_attempts,
+            $sleep_duration,
+            $block,
+            until | _ | true
+        )
     }};
 }
 
@@ -33,7 +66,7 @@ mod tests {
     use std::time::Duration;
     use tokio::time::Instant;
 
-    use crate::utils::AttemptResult;
+    use super::*;
 
     const EMPTY_RESULT: Result<Option<()>, String> = Ok(None);
 
@@ -51,10 +84,62 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn can_timeout() {
+    async fn returns_ok_when_response_satisfies_predicate() {
         assert_eq!(
-            AttemptResult::Timeout(),
+            AttemptResult::Ok(42),
+            attempt!(
+                3,
+                Duration::from_millis(2),
+                {
+                    let result: Result<Option<i32>, String> = Ok(Some(42));
+                    result
+                },
+                until |value: &i32| *value == 42
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn retries_until_response_satisfies_predicate() {
+        let mut attempt_count = 0;
+        assert_eq!(
+            AttemptResult::Ok(3),
+            attempt!(
+                5,
+                Duration::from_millis(2),
+                {
+                    attempt_count += 1;
+                    let result: Result<Option<i32>, String> = Ok(Some(attempt_count));
+                    result
+                },
+                until |value: &i32| *value == 3
+            )
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_is_no_response_when_no_value_was_received() {
+        assert_eq!(
+            AttemptResult::Timeout(TimeoutReason::NoResponse),
             attempt!(1, Duration::from_millis(2), { EMPTY_RESULT })
+        );
+    }
+
+    #[tokio::test]
+    async fn timeout_when_no_response_satisfies_predicate() {
+        let mut attempt_count = 0;
+        assert_eq!(
+            AttemptResult::Timeout(TimeoutReason::PredicateNotSatisfied(3)),
+            attempt!(
+                3,
+                Duration::from_millis(2),
+                {
+                    attempt_count += 1;
+                    let result: Result<Option<i32>, String> = Ok(Some(attempt_count));
+                    result
+                },
+                until | _ | false
+            )
         );
     }
 
@@ -75,7 +160,7 @@ mod tests {
         let mut number_of_loop = 0;
 
         assert_eq!(
-            AttemptResult::Timeout(),
+            AttemptResult::Timeout(TimeoutReason::NoResponse),
             attempt!(expected_number_of_loop, Duration::from_millis(2), {
                 number_of_loop += 1;
                 EMPTY_RESULT
@@ -89,7 +174,7 @@ mod tests {
         let now = Instant::now();
 
         assert_eq!(
-            AttemptResult::Timeout(),
+            AttemptResult::Timeout(TimeoutReason::NoResponse),
             // Note: the attempt! macro wait only after the first loop so we must attempt to two times
             // to have it wait its given duration once.
             attempt!(2, Duration::from_millis(10), { EMPTY_RESULT })


### PR DESCRIPTION
## Content

This PR includes a new `minimal` scenario in the end-to-end runner and a `test-e2e` workflow which is run in the nightly dispatcher.

### `mithril-end-to-end` changes 

- New scenario: `minimal`, 
  - A light scenario to be used with compute intensive mode such as with Snark as it needs significantly less epochs to finish
  - differences compared to the `full` scenario:
    - it does not check propagation of protocol parameters and stakes distribution changes 
    - it does not support era switching
    - it only support activation of a single signed entity type (in addition of the default `MithrilStakeDistribution`)
  - What does not changes compared to the `full` scenario:
    - it run the same check procedures against activated signed entity types
    - it support multiple aggregators

- New check for `full` and `minimal`: `is_creating_certificate_with_min_epoch`, run before any artifact validation to ensure that the aggregator certificate chain is still running and is not in a "epoch gap" state (this is better than finding it when checking mithril stake distributions).

- enhanced `attempt!` macro to support providing a predicate to check the returned value and wait if it's not satisfied.

- better type enforcement by using `AggregateSignatureType` instead of string where applicable

### CI changes

- new `test-e2e.yml` workflow
  - it support both workflow call and dispatch
  - key differences from the e2e integrated in `ci.yml`:
    - it build the runner and the nodes itself (no-reuse of built artifact)
    - it by default build with `--features future_snark`
    - it run the two scenario `minimal` and `full`
    - scenarios are run with slower network (1s slot length, 60 slot per epoch vs 0.1 and 30)

- integrate `test-e2e.yml` to the nightly dispatcher

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - ~~No new TODOs introduced~~ One todo is added to advise to add `Snark` case in the new `test-e2e` workflow when they are ready

## Issue(s)

Closes #3151
