### PR TITLE
chore(ci): extend timeout for e2e workflow to 120 minutes

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -171,7 +171,7 @@ jobs:
           shell: bash
           max_attempts: 3
           retry_on_exit_code: 2
-          timeout_minutes: 10
+          timeout_minutes: 120
           warning_on_retry: true
           command: |
             ./mithril-binaries/mithril-end-to-end -vvv \
@@ -248,7 +248,7 @@ jobs:
           shell: bash
           max_attempts: 3
           retry_on_exit_code: 2
-          timeout_minutes: 10
+          timeout_minutes: 120
           warning_on_retry: true
           command: |
             ./mithril-binaries/mithril-end-to-end -vvv \

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -197,7 +197,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
         with:
-          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-sig_type_${{ matrix.aggregate_signature_type }}--scenario_minimal--cardano-${{ matrix.cardano_node_version }}
+          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-sig_type_${{ matrix.aggregate_signature_type }}-scenario_minimal-cardano-${{ matrix.cardano_node_version }}
           path: |
             ./artifacts/*
             # including node.sock makes the upload fails so exclude them:
@@ -274,7 +274,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v7
         with:
-          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-sig_type_${{ matrix.aggregate_signature_type }}--scenario_full--cardano-${{ matrix.cardano_node_version }}
+          name: mithril-e2e-tests-artifacts-run_${{ github.run_number }}-attempt_${{ github.run_attempt }}-sig_type_${{ matrix.aggregate_signature_type }}-scenario_full-cardano-${{ matrix.cardano_node_version }}
           path: |
             ./artifacts/*
             # including node.sock makes the upload fails so exclude them:


### PR DESCRIPTION
## Content

This PR increase timeout of end-to-end jobs in the `test-e2e.yml` workflow from 10 minutes to 120 minutes, the former was not enough for slow runs (which will be even slower once snark case are added).

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Relates to #3151