### PR TITLE
refactor: genesis preimage ancillary data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.35"
+version = "0.10.36"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -172,6 +172,7 @@ impl Party {
         let ancillary_input = AncillaryProofInput::new(
             None,
             AncillaryGenesisData::new(
+                #[cfg(feature = "future_snark")]
                 Vec::new(),
                 #[cfg(feature = "future_snark")]
                 None,

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.5" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.6" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.5" }
+mithril-common = { path = "../../mithril-common", version = "0.7.6" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.2" }
-mithril-common = { path = "../../mithril-common", version = "0.7.5" }
+mithril-common = { path = "../../mithril-common", version = "0.7.6" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -64,7 +64,7 @@ flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.2" }
-mithril-common = { path = "../mithril-common", version = "0.7.5", default-features = false }
+mithril-common = { path = "../mithril-common", version = "0.7.6", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.5"
+version = "0.7.6"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.35", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.36", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -11,7 +11,6 @@ use crate::entities::CertificateSignature;
 ///
 /// Under `future_snark`, the genesis message preimage is carried, and the genesis Schnorr signature
 /// too when the genesis certificate is dual-signed (absent for a legacy genesis).
-#[cfg_attr(not(feature = "future_snark"), allow(unused_variables))]
 pub fn build_ancillary_proof_input(
     genesis_certificate: &Certificate,
     parent_certificate: &Certificate,
@@ -31,7 +30,10 @@ pub fn build_ancillary_proof_input(
         AncillaryGenesisData::new(genesis_message_preimage, genesis_schnorr_signature)
     };
     #[cfg(not(feature = "future_snark"))]
-    let genesis_data = AncillaryGenesisData::new();
+    let genesis_data = {
+        let _ = genesis_certificate;
+        AncillaryGenesisData::new()
+    };
 
     AncillaryProofInput::new(prover_data, genesis_data)
 }

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -9,8 +9,9 @@ use crate::entities::CertificateSignature;
 /// Build the ancillary proof input for one aggregate signature creation, from the genesis
 /// certificate (the genesis data) and the parent certificate (the prover data).
 ///
-/// The genesis message is always carried. Under `future_snark`, the genesis Schnorr signature is
-/// carried too when the genesis certificate is dual-signed, and absent for a legacy genesis.
+/// Under `future_snark`, the genesis message preimage is carried, and the genesis Schnorr signature
+/// too when the genesis certificate is dual-signed (absent for a legacy genesis).
+#[cfg_attr(not(feature = "future_snark"), allow(unused_variables))]
 pub fn build_ancillary_proof_input(
     genesis_certificate: &Certificate,
     parent_certificate: &Certificate,
@@ -22,16 +23,15 @@ pub fn build_ancillary_proof_input(
 
     #[cfg(feature = "future_snark")]
     let genesis_data = {
-        let genesis_message = genesis_certificate.protocol_message.rigid_preimage();
+        let genesis_message_preimage = genesis_certificate.protocol_message.rigid_preimage();
         let genesis_schnorr_signature = match &genesis_certificate.signature {
             CertificateSignature::GenesisDualSignature(_, signature) => Some(*signature),
             _ => None,
         };
-        AncillaryGenesisData::new(genesis_message, genesis_schnorr_signature)
+        AncillaryGenesisData::new(genesis_message_preimage, genesis_schnorr_signature)
     };
     #[cfg(not(feature = "future_snark"))]
-    let genesis_data =
-        AncillaryGenesisData::new(genesis_certificate.signed_message.as_bytes().to_vec());
+    let genesis_data = AncillaryGenesisData::new();
 
     AncillaryProofInput::new(prover_data, genesis_data)
 }

--- a/mithril-common/src/test/double/dummies.rs
+++ b/mithril-common/src/test/double/dummies.rs
@@ -13,6 +13,7 @@ mod stm {
             Self::new(
                 None,
                 AncillaryGenesisData::new(
+                    #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
                     None,

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.36 (06-15-2026)
+
+### Changed
+
+- Renamed the `AncillaryGenesisData` `genesis_message` field to `genesis_message_preimage` and gated it, with its getter, behind the `future_snark` feature.
+
 ## 0.10.35 (06-12-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.35"
+version = "0.10.36"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -136,7 +136,7 @@ for s in sigs.iter() {
 }
 
 // Aggregate a concatenation proof with random parties
-let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(Vec::new(), #[cfg(feature = "future_snark")] None));
+let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] None));
 let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 
 match msig {

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -59,6 +59,7 @@ where
             AncillaryProofInput::new(
                 None,
                 AncillaryGenesisData::new(
+                    #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
                     None,

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -78,6 +78,7 @@ fn stm_benches<D: MembershipDigest>(
                 AncillaryProofInput::new(
                     None,
                     AncillaryGenesisData::new(
+                        #[cfg(feature = "future_snark")]
                         Vec::new(),
                         #[cfg(feature = "future_snark")]
                         None,
@@ -155,6 +156,7 @@ fn batch_benches<D>(
                     AncillaryProofInput::new(
                         None,
                         AncillaryGenesisData::new(
+                            #[cfg(feature = "future_snark")]
                             Vec::new(),
                             #[cfg(feature = "future_snark")]
                             None,

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -137,6 +137,7 @@ fn main() {
             AncillaryProofInput::new(
                 None,
                 AncillaryGenesisData::new(
+                    #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
                     None,
@@ -167,6 +168,7 @@ fn main() {
             AncillaryProofInput::new(
                 None,
                 AncillaryGenesisData::new(
+                    #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
                     None,
@@ -196,6 +198,7 @@ fn main() {
         AncillaryProofInput::new(
             None,
             AncillaryGenesisData::new(
+                #[cfg(feature = "future_snark")]
                 Vec::new(),
                 #[cfg(feature = "future_snark")]
                 None,

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -94,7 +94,7 @@
 //! let clerk = Clerk::new_clerk_from_signer(&ps[0]);
 //!
 //! // Aggregate and verify the signatures
-//! let genesis_data = AncillaryGenesisData::new(Vec::new(), #[cfg(feature = "future_snark")] None);
+//! let genesis_data = AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] None);
 //! let ancillary_input = AncillaryProofInput::new(None, genesis_data);
 //! let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 //! match msig {

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -68,35 +68,39 @@ impl AncillaryVerifierData {
 
 /// Genesis-related data carried into aggregate signature creation.
 ///
-/// Holds the genesis message and, under `future_snark`, the genesis Schnorr signature when the
-/// genesis certificate carries one. It is a transient input to proof creation, never stored on a
-/// certificate.
+/// Under `future_snark`, holds the genesis message preimage and the genesis Schnorr signature when
+/// the genesis certificate carries one. It is a transient input to proof creation, never stored on
+/// a certificate.
 #[derive(Clone, Debug)]
 pub struct AncillaryGenesisData {
-    genesis_message: Vec<u8>,
+    #[cfg(feature = "future_snark")]
+    genesis_message_preimage: Vec<u8>,
     #[cfg(feature = "future_snark")]
     genesis_schnorr_signature: Option<StandardSchnorrSignature>,
 }
 
 impl AncillaryGenesisData {
-    /// Build the genesis ancillary data from the genesis message and, under `future_snark`, the
-    /// genesis Schnorr signature (absent for a legacy, non-dual genesis certificate).
+    /// Build the genesis ancillary data. Under `future_snark`, from the genesis message preimage and
+    /// the genesis Schnorr signature (absent for a legacy, non-dual genesis certificate).
+    #[cfg_attr(not(feature = "future_snark"), allow(clippy::new_without_default))]
     pub fn new(
-        genesis_message: Vec<u8>,
+        #[cfg(feature = "future_snark")] genesis_message_preimage: Vec<u8>,
         #[cfg(feature = "future_snark")] genesis_schnorr_signature: Option<
             StandardSchnorrSignature,
         >,
     ) -> Self {
         Self {
-            genesis_message,
+            #[cfg(feature = "future_snark")]
+            genesis_message_preimage,
             #[cfg(feature = "future_snark")]
             genesis_schnorr_signature,
         }
     }
 
-    /// Return the genesis message.
-    pub fn genesis_message(&self) -> &[u8] {
-        &self.genesis_message
+    /// Return the genesis message preimage.
+    #[cfg(feature = "future_snark")]
+    pub fn genesis_message_preimage(&self) -> &[u8] {
+        &self.genesis_message_preimage
     }
 
     /// Return the genesis Schnorr signature, absent for a legacy (non-dual) genesis certificate.
@@ -109,6 +113,7 @@ impl AncillaryGenesisData {
     #[cfg(test)]
     pub fn dummy() -> Self {
         Self::new(
+            #[cfg(feature = "future_snark")]
             Vec::new(),
             #[cfg(feature = "future_snark")]
             None,

--- a/mithril-stm/tests/test_extensions/protocol_phase.rs
+++ b/mithril-stm/tests/test_extensions/protocol_phase.rs
@@ -99,6 +99,7 @@ pub fn operation_phase(
     let ancillary_input = AncillaryProofInput::new(
         None,
         AncillaryGenesisData::new(
+            #[cfg(feature = "future_snark")]
             Vec::new(),
             #[cfg(feature = "future_snark")]
             None,


### PR DESCRIPTION
## Content

This PR includes the **rename and feature gating of the genesis message preimage carried in the ancillary genesis data**.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3139
