### PR TITLE
fix(explorer): unresponsive UI

### DIFF
--- a/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
+++ b/.github/workflows/actions/deploy-terraform-infrastructure/action.yml
@@ -338,8 +338,11 @@ runs:
     - name: Init Terraform
       shell: bash
       working-directory: mithril-infra
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS: ./google-application-credentials.json
+        TF_REGISTRY_CLIENT_TIMEOUT: 60
       run: |
-        GOOGLE_APPLICATION_CREDENTIALS=./google-application-credentials.json terraform init -backend-config="bucket=${{ inputs.terraform_backend_bucket }}" -backend-config="prefix=terraform/mithril-${{ inputs.environment }}" -upgrade
+        terraform init -backend-config="bucket=${{ inputs.terraform_backend_bucket }}" -backend-config="prefix=terraform/mithril-${{ inputs.environment }}" -upgrade
 
     - name: Check Terraform
       shell: bash

--- a/mithril-explorer/__tests__/parseSignedEntity.test.js
+++ b/mithril-explorer/__tests__/parseSignedEntity.test.js
@@ -5,7 +5,7 @@ describe("parseSignedEntity", () => {
   it("parse correctly formed `MithrilStakeDistribution` signed entity", () => {
     const epoch = 1432;
     const signed_entity = {
-      [signedEntityType.MithrilStakeDistribution]: [epoch],
+      [signedEntityType.MithrilStakeDistribution]: epoch,
     };
 
     expect(parseSignedEntity(signed_entity)).toEqual({
@@ -19,7 +19,7 @@ describe("parseSignedEntity", () => {
   it("parse correctly formed `CardanoStakeDistribution` signed entity", () => {
     const epoch = 1432;
     const signed_entity = {
-      [signedEntityType.CardanoStakeDistribution]: [epoch],
+      [signedEntityType.CardanoStakeDistribution]: epoch,
     };
 
     expect(parseSignedEntity(signed_entity)).toEqual({

--- a/mithril-explorer/package-lock.json
+++ b/mithril-explorer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mithril-explorer",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mithril-explorer",
-      "version": "0.8.2",
+      "version": "0.8.3",
       "dependencies": {
         "@mithril-dev/mithril-client-wasm": "file:../mithril-client-wasm",
         "@popperjs/core": "^2.11.8",

--- a/mithril-explorer/package.json
+++ b/mithril-explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mithril-explorer",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/mithril-explorer/src/store/poolsSlice.js
+++ b/mithril-explorer/src/store/poolsSlice.js
@@ -57,13 +57,13 @@ export const updatePoolsForAggregator = createAsyncThunk(
 );
 
 const poolsForAggregator = (poolsSlice, aggregator) => {
-  return poolsSlice.list.find((poolsData) => poolsData.aggregator === aggregator.url);
+  return poolsSlice.list.find((poolsData) => poolsData.aggregator === aggregator);
 };
 
 export const getPoolForSelectedAggregator = createSelector(
   [(state) => state.settings.selectedAggregator, (state) => state.pools, (state, poolId) => poolId],
   (aggregator, pools, poolId) => {
-    const aggregatorPools = poolsForAggregator(pools, aggregator);
+    const aggregatorPools = poolsForAggregator(pools, aggregator.url);
     const data = aggregatorPools?.pools.find((pool) => pool.party_id === poolId);
 
     return {
@@ -76,14 +76,14 @@ export const getPoolForSelectedAggregator = createSelector(
 export const getSelectedAggregatorPools = createSelector(
   [(state) => state.settings.selectedAggregator, (state) => state.pools],
   (aggregator, pools) => {
-    return poolsForAggregator(pools, aggregator);
+    return poolsForAggregator(pools, aggregator.url);
   },
 );
 
 export const getSelectedAggregatorNetwork = createSelector(
   [(state) => state.settings.selectedAggregator, (state) => state.pools],
   (aggregator, pools) => {
-    const aggregatorPools = poolsForAggregator(pools, aggregator);
+    const aggregatorPools = poolsForAggregator(pools, aggregator.url);
     return aggregatorPools?.network;
   },
 );

--- a/mithril-explorer/src/utils.js
+++ b/mithril-explorer/src/utils.js
@@ -187,7 +187,7 @@ function parseSignedEntity(entityType) {
     type_name === signedEntityType.CardanoStakeDistribution
   ) {
     result.fields = {
-      epoch: entityType[type_name][0],
+      epoch: entityType[type_name],
     };
   } else if (type_name === signedEntityType.CardanoBlocksTransactions) {
     result.fields = {


### PR DESCRIPTION
## Content

This PR fixes a cache issue in the explorer pools slice:
When saving retrieved pools from an aggregator, the `poolsSlice` reducer retrieved existing pools if any by calling  `poolsForAggregator` and passing to it the url string, but since the last refactor (#3291) this method expected an object instead of a string, making it returns null.

This lead to a cascading effect:
1.  The reducer would never re-use existing keys, saving each the whole pools list each time an aggregator if switched in the UI
2. This evergrowing state is saved into the local storage
3. Given that for mainnet the pools list is ~1MB, it would quickly hit the storage api browser limit (10Mb for firefox, [see mdn](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria#web_storage))
4. When the storage api limit is hit, all changes sent to the redux store (including current aggregator, auto-refresh, ...) would fails because the configuration persistence to local storage fails

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #3328
