### PR TITLE
feat: add missing ancillary data for IVC aggregate signature creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4055,7 +4055,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.8"
+version = "0.9.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4359,7 +4359,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4654,7 +4654,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.37"
+version = "0.10.38"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -185,7 +185,7 @@ impl Party {
             ancillary_input,
         );
         match msig {
-            Ok((aggregate_signature, _ancillary_verifier_data)) => {
+            Ok((aggregate_signature, _ancillary_proof_output)) => {
                 println!("Party #{}: aggregate signature computed", self.party_id);
                 self.msigs.insert(message.clone(), aggregate_signature);
                 self.get_aggregate(message)

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -175,6 +175,10 @@ impl Party {
                 #[cfg(feature = "future_snark")]
                 Vec::new(),
                 #[cfg(feature = "future_snark")]
+                [0u8; 32],
+                #[cfg(feature = "future_snark")]
+                None,
+                #[cfg(feature = "future_snark")]
                 None,
             ),
         );

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -175,8 +175,6 @@ impl Party {
                 #[cfg(feature = "future_snark")]
                 Vec::new(),
                 #[cfg(feature = "future_snark")]
-                [0u8; 32],
-                #[cfg(feature = "future_snark")]
                 None,
                 #[cfg(feature = "future_snark")]
                 None,

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -181,6 +181,8 @@ impl Party {
                 #[cfg(feature = "future_snark")]
                 None,
             ),
+            #[cfg(feature = "future_snark")]
+            Vec::new(),
         );
         let msig = self.clerk.as_ref().unwrap().aggregate_signatures_with_type(
             signatures,

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.6" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.7" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.6" }
+mithril-common = { path = "../../mithril-common", version = "0.7.7" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.2" }
-mithril-common = { path = "../../mithril-common", version = "0.7.6" }
+mithril-common = { path = "../../mithril-common", version = "0.7.7" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.8"
+version = "0.9.9"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/multi_signer.rs
+++ b/mithril-aggregator/src/multi_signer.rs
@@ -7,7 +7,7 @@ use mithril_common::{
     crypto_helper::ProtocolAggregationError,
     entities::{self},
     logging::LoggerExtensions,
-    protocol::{MultiSignatureWithAncillaryVerifierData, MultiSigner as ProtocolMultiSigner},
+    protocol::{MultiSignatureWithAncillaryData, MultiSigner as ProtocolMultiSigner},
 };
 
 use crate::dependency_injection::EpochServiceWrapper;
@@ -36,7 +36,7 @@ pub trait MultiSigner: Sync + Send {
         &self,
         open_message: &OpenMessage,
         ancillary_input: AncillaryProofInput,
-    ) -> StdResult<Option<MultiSignatureWithAncillaryVerifierData>>;
+    ) -> StdResult<Option<MultiSignatureWithAncillaryData>>;
 }
 
 /// MultiSignerImpl is an implementation of the MultiSigner
@@ -117,7 +117,7 @@ impl MultiSigner for MultiSignerImpl {
         &self,
         open_message: &OpenMessage,
         ancillary_input: AncillaryProofInput,
-    ) -> StdResult<Option<MultiSignatureWithAncillaryVerifierData>> {
+    ) -> StdResult<Option<MultiSignatureWithAncillaryData>> {
         debug!(self.logger, ">> create_multi_signature"; "open_message" => ?open_message);
 
         let epoch_service = self.epoch_service.read().await;
@@ -131,8 +131,8 @@ impl MultiSigner for MultiSignerImpl {
             self.aggregate_signature_type,
             ancillary_input,
         ) {
-            Ok(multi_signature_with_ancillary_verifier_data) => {
-                Ok(Some(multi_signature_with_ancillary_verifier_data))
+            Ok(multi_signature_with_ancillary_data) => {
+                Ok(Some(multi_signature_with_ancillary_data))
             }
             Err(err) => match err.downcast_ref::<ProtocolAggregationError>() {
                 Some(ProtocolAggregationError::NotEnoughSignatures(actual, expected)) => {

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -308,8 +308,12 @@ impl CertifierService for MithrilCertifierService {
             .await
             .with_context(|| "Certifier can not get the latest genesis certificate")?
             .ok_or_else(|| Box::new(CertifierServiceError::NoGenesisCertificateFound))?;
-        let ancillary_input =
-            build_ancillary_proof_input(&genesis_certificate, &parent_certificate);
+        let ancillary_input = build_ancillary_proof_input(
+            &genesis_certificate,
+            &parent_certificate,
+            #[cfg(feature = "future_snark")]
+            self.genesis_verifier.to_schnorr_verification_key(),
+        );
 
         let MultiSignatureWithAncillaryData {
             multi_signature,

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -12,7 +12,7 @@ use mithril_common::entities::{
 };
 use mithril_common::logging::LoggerExtensions;
 use mithril_common::protocol::{
-    MultiSignatureWithAncillaryVerifierData, ToMessage, build_ancillary_proof_input,
+    MultiSignatureWithAncillaryData, ToMessage, build_ancillary_proof_input,
 };
 use mithril_common::{CardanoNetwork, StdResult};
 
@@ -311,8 +311,9 @@ impl CertifierService for MithrilCertifierService {
         let ancillary_input =
             build_ancillary_proof_input(&genesis_certificate, &parent_certificate);
 
-        let MultiSignatureWithAncillaryVerifierData {
+        let MultiSignatureWithAncillaryData {
             multi_signature,
+            ancillary_prover_data,
             ancillary_verifier_data,
         } = match self
             .multi_signer
@@ -326,12 +327,12 @@ impl CertifierService for MithrilCertifierService {
                 );
                 return Ok(None);
             }
-            Some(multi_signature_with_ancillary_verifier_data) => {
+            Some(multi_signature_with_ancillary_data) => {
                 info!(
                     self.logger,
                     "create_certificate: multi-signature created for open message {signed_entity_type:?}"
                 );
-                multi_signature_with_ancillary_verifier_data
+                multi_signature_with_ancillary_data
             }
         };
 
@@ -364,6 +365,7 @@ impl CertifierService for MithrilCertifierService {
             open_message.protocol_message.clone(),
             epoch_service.current_aggregate_verification_key()?.clone(),
             CertificateSignature::MultiSignature(signed_entity_type.clone(), multi_signature),
+            ancillary_prover_data,
             ancillary_verifier_data,
         )?;
 

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -312,6 +312,8 @@ impl CertifierService for MithrilCertifierService {
             &genesis_certificate,
             &parent_certificate,
             #[cfg(feature = "future_snark")]
+            &open_message.protocol_message,
+            #[cfg(feature = "future_snark")]
             self.genesis_verifier.to_schnorr_verification_key(),
         );
 

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -64,7 +64,7 @@ flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.2" }
-mithril-common = { path = "../mithril-common", version = "0.7.6", default-features = false }
+mithril-common = { path = "../mithril-common", version = "0.7.7", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.6"
+version = "0.7.7"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.37", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.38", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_genesis.rs
+++ b/mithril-common/src/certificate_chain/certificate_genesis.rs
@@ -189,6 +189,7 @@ impl CertificateGenesisProducer {
             genesis_avk,
             signature,
             None,
+            None,
         )
     }
 }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -587,7 +587,7 @@ mod tests {
         let first_signer = &signers[0].protocol_signer;
         let clerk = ProtocolClerk::new_clerk_from_signer(first_signer);
         let aggregate_verification_key = clerk.compute_aggregate_verification_key();
-        let (aggregate_signature, ancillary_verifier_data) = clerk
+        let (aggregate_signature, ancillary_proof_output) = clerk
             .aggregate_signatures_with_type(
                 &single_signatures,
                 &message_hash,
@@ -595,6 +595,7 @@ mod tests {
                 AncillaryProofInput::dummy(),
             )
             .unwrap();
+        let ancillary_verifier_data = ancillary_proof_output.verifier_data().cloned();
         let multi_signature = aggregate_signature.into();
 
         let verifier = MithrilCertificateVerifier::new(
@@ -962,7 +963,7 @@ mod tests {
                 .collect::<Vec<_>>();
             let clerk =
                 ProtocolClerk::new_clerk_from_signer(&fixture.signers_fixture()[0].protocol_signer);
-            let (modified_multi_signature, _ancillary_verifier_data) = clerk
+            let (modified_multi_signature, _ancillary_proof_output) = clerk
                 .aggregate_signatures_with_type(
                     &single_signatures,
                     signed_message.as_bytes(),
@@ -1271,7 +1272,7 @@ mod tests {
                 &forged_protocol_parameters.clone().into(),
                 &fixture.signers_fixture()[0].protocol_closed_key_registration,
             );
-            let (forged_multi_signature, _ancillary_verifier_data) = forged_clerk
+            let (forged_multi_signature, _ancillary_proof_output) = forged_clerk
                 .aggregate_signatures_with_type(
                     &forged_single_signatures,
                     signed_message.as_bytes(),

--- a/mithril-common/src/crypto_helper/genesis/verifier.rs
+++ b/mithril-common/src/crypto_helper/genesis/verifier.rs
@@ -8,8 +8,8 @@ use anyhow::anyhow;
 use crate::StdResult;
 #[cfg(feature = "future_snark")]
 use crate::crypto_helper::{
-    BUNDLE_FIRST_HEX_CHAR, GenesisSchnorrSignature, GenesisSchnorrVerifier,
-    GenesisVerificationKeyBundle,
+    BUNDLE_FIRST_HEX_CHAR, GenesisSchnorrSignature, GenesisSchnorrVerificationKey,
+    GenesisSchnorrVerifier, GenesisVerificationKeyBundle,
 };
 use crate::crypto_helper::{
     GenesisEd25519Signature, GenesisEd25519VerificationKey, GenesisEd25519Verifier, GenesisSigner,
@@ -115,6 +115,13 @@ impl GenesisVerifier {
     /// Return the ed25519 (Ed25519) verification key.
     pub fn to_ed25519_verification_key(&self) -> GenesisEd25519VerificationKey {
         self.ed25519.to_verification_key()
+    }
+
+    /// Return the SNARK-friendly (Schnorr) genesis verification key, absent for a legacy
+    /// single-Ed25519 verifier.
+    #[cfg(feature = "future_snark")]
+    pub fn to_schnorr_verification_key(&self) -> Option<GenesisSchnorrVerificationKey> {
+        self.schnorr.as_ref().map(|schnorr| schnorr.to_verification_key())
     }
 
     /// Derive the matching dual verification-key bundle, suitable for serialisation to disk by the
@@ -305,6 +312,26 @@ mod tests {
                 verifier.ed25519.to_verification_key().as_bytes()
             );
             assert_eq!(bundle.schnorr.to_bytes(), expected_schnorr);
+        }
+
+        #[test]
+        fn to_schnorr_verification_key_returns_the_schnorr_half_for_a_dual_verifier() {
+            let bundle = build_bundle();
+            let expected_schnorr = bundle.schnorr.to_bytes();
+
+            let verifier = GenesisVerifier::from_bundle(bundle);
+
+            assert_eq!(
+                verifier.to_schnorr_verification_key().unwrap().to_bytes(),
+                expected_schnorr
+            );
+        }
+
+        #[test]
+        fn to_schnorr_verification_key_is_none_for_a_legacy_verifier() {
+            let verifier = GenesisVerifier::from_ed25519(deterministic_signer().verification_key());
+
+            assert!(verifier.to_schnorr_verification_key().is_none());
         }
     }
 }

--- a/mithril-common/src/entities/certificate.rs
+++ b/mithril-common/src/entities/certificate.rs
@@ -120,6 +120,7 @@ pub struct Certificate {
 
 impl Certificate {
     /// Builds a certificate and computes its hash, returning an error if hashing fails.
+    #[allow(clippy::too_many_arguments)]
     pub fn try_new<T: Into<String>>(
         previous_hash: T,
         epoch: Epoch,
@@ -127,6 +128,7 @@ impl Certificate {
         protocol_message: ProtocolMessage,
         aggregate_verification_key: ProtocolAggregateVerificationKey,
         signature: CertificateSignature,
+        ancillary_prover_data: Option<ProtocolAncillaryProverData>,
         ancillary_verifier_data: Option<ProtocolAncillaryVerifierData>,
     ) -> crate::StdResult<Certificate> {
         let signed_message = protocol_message.compute_hash();
@@ -149,7 +151,7 @@ impl Certificate {
                 .into(),
             #[cfg(feature = "future_snark")]
             aggregate_verification_key_snark,
-            ancillary_prover_data: None,
+            ancillary_prover_data,
             ancillary_verifier_data,
             signature,
         };
@@ -371,6 +373,7 @@ mod tests {
                 fake_keys::multi_signature()[0].try_into().unwrap(),
             ),
             None,
+            None,
         )
         .unwrap();
 
@@ -526,6 +529,7 @@ mod tests {
                 fake_keys::genesis_signature()[0].try_into().unwrap(),
             ),
             None,
+            None,
         )
         .unwrap();
 
@@ -579,6 +583,7 @@ mod tests {
             ),
             CertificateSignature::GenesisSignature(ed_signature),
             None,
+            None,
         )
         .unwrap();
 
@@ -607,6 +612,7 @@ mod tests {
                 None,
             ),
             CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
+            None,
             None,
         )
         .unwrap();
@@ -658,6 +664,7 @@ mod tests {
                 ),
                 CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
                 None,
+                None,
             )
             .unwrap();
             hashes.insert(certificate.try_compute_hash().unwrap());
@@ -696,6 +703,7 @@ mod tests {
                 None,
             ),
             signature,
+            None,
             None,
         )
         .unwrap()

--- a/mithril-common/src/entities/protocol_message.rs
+++ b/mithril-common/src/entities/protocol_message.rs
@@ -242,10 +242,16 @@ impl ProtocolMessage {
     /// Compute the hex-encoded SHA-256 hash of the protocol message, dispatching over
     /// [ProtocolMessage::hash_scheme].
     pub fn compute_hash(&self) -> String {
+        hex::encode(self.compute_hash_bytes())
+    }
+
+    /// Compute the SHA-256 hash bytes of the protocol message, dispatching over
+    /// [ProtocolMessage::hash_scheme].
+    pub fn compute_hash_bytes(&self) -> [u8; 32] {
         match self.hash_scheme {
-            ProtocolMessageHashScheme::Legacy => self.compute_legacy_hash(),
+            ProtocolMessageHashScheme::Legacy => self.compute_legacy_digest_bytes(),
             #[cfg(feature = "future_snark")]
-            ProtocolMessageHashScheme::Rigid => self.compute_rigid_hash(),
+            ProtocolMessageHashScheme::Rigid => self.compute_rigid_hash_bytes(),
         }
     }
 
@@ -256,10 +262,6 @@ impl ProtocolMessage {
             hasher.update(value.as_bytes());
         }
         hasher.finalize().into()
-    }
-
-    fn compute_legacy_hash(&self) -> String {
-        hex::encode(self.compute_legacy_digest_bytes())
     }
 }
 
@@ -321,8 +323,16 @@ impl ProtocolMessage {
         }
     }
 
-    fn compute_rigid_hash(&self) -> String {
-        hex::encode(Sha256::digest(self.rigid_preimage()))
+    /// Compute the SHA-256 rigid hash bytes of the protocol message (the digest of its rigid
+    /// preimage).
+    pub fn compute_rigid_hash_bytes(&self) -> [u8; 32] {
+        Self::compute_rigid_hash_bytes_from_preimage(&self.rigid_preimage())
+    }
+
+    /// Compute the SHA-256 rigid hash bytes from an already-built rigid preimage, avoiding a second
+    /// preimage assembly when the caller already holds it.
+    pub fn compute_rigid_hash_bytes_from_preimage(preimage: &[u8]) -> [u8; 32] {
+        Sha256::digest(preimage).into()
     }
 
     /// Assemble the SNARK-friendly rigid preimage from the [ProtocolMessage::message_parts] as
@@ -558,6 +568,20 @@ mod tests {
         );
 
         assert_ne!(hash_before_change, protocol_message_modified.compute_hash());
+    }
+
+    #[test]
+    fn compute_hash_is_the_hex_encoding_of_compute_hash_bytes() {
+        let mut protocol_message = ProtocolMessage::new();
+        protocol_message.set_message_part(
+            ProtocolMessagePartKey::SnapshotDigest,
+            "a-digest".to_string(),
+        );
+
+        assert_eq!(
+            protocol_message.compute_hash(),
+            hex::encode(protocol_message.compute_hash_bytes())
+        );
     }
 
     #[test]
@@ -823,6 +847,27 @@ mod tests {
         assert_eq!(hash.len(), 64);
         let decoded = hex::decode(&hash).unwrap();
         assert_eq!(decoded.len(), 32);
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn rigid_compute_hash_bytes_is_the_hex_decoded_rigid_hash() {
+        let rigid = build_rigid_protocol_message_reference();
+
+        let hash_bytes = rigid.compute_rigid_hash_bytes();
+
+        assert_eq!(hex::encode(hash_bytes), rigid.compute_hash());
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn compute_rigid_hash_bytes_from_preimage_matches_compute_rigid_hash_bytes() {
+        let rigid = build_rigid_protocol_message_reference();
+
+        assert_eq!(
+            ProtocolMessage::compute_rigid_hash_bytes_from_preimage(&rigid.rigid_preimage()),
+            rigid.compute_rigid_hash_bytes()
+        );
     }
 
     #[cfg(feature = "future_snark")]

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -31,15 +31,12 @@ pub fn build_ancillary_proof_input(
     #[cfg(feature = "future_snark")]
     let genesis_data = {
         let genesis_message_preimage = genesis_certificate.protocol_message.rigid_preimage();
-        let genesis_message =
-            ProtocolMessage::compute_rigid_hash_bytes_from_preimage(&genesis_message_preimage);
         let genesis_schnorr_signature = match &genesis_certificate.signature {
             CertificateSignature::GenesisDualSignature(_, signature) => Some(*signature),
             _ => None,
         };
         AncillaryGenesisData::new(
             genesis_message_preimage,
-            genesis_message,
             genesis_schnorr_signature,
             genesis_schnorr_verification_key,
         )
@@ -85,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    fn carries_message_preimage_genesis_message_and_schnorr_signature_for_a_dual_genesis() {
+    fn carries_message_preimage_and_schnorr_signature_for_a_dual_genesis() {
         let parent = fake_data::certificate("parent");
         let genesis = dual_signed_genesis_certificate();
         let protocol_message = ProtocolMessage::new_rigid();
@@ -104,10 +101,6 @@ mod tests {
         assert_eq!(
             input.message_preimage(),
             protocol_message.rigid_preimage().as_slice()
-        );
-        assert_eq!(
-            genesis_data.genesis_message(),
-            genesis.protocol_message.compute_rigid_hash_bytes()
         );
         assert_eq!(
             genesis_data.genesis_message_preimage(),

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -6,17 +6,19 @@ use mithril_stm::{AncillaryGenesisData, AncillaryProofInput};
 use crate::crypto_helper::GenesisSchnorrVerificationKey;
 use crate::entities::Certificate;
 #[cfg(feature = "future_snark")]
-use crate::entities::CertificateSignature;
+use crate::entities::{CertificateSignature, ProtocolMessage};
 
 /// Build the ancillary proof input for one aggregate signature creation, from the genesis
 /// certificate (the genesis data) and the parent certificate (the prover data).
 ///
 /// Under `future_snark`, the genesis message preimage is carried, the genesis Schnorr signature too
-/// when the genesis certificate is dual-signed (absent for a legacy genesis), and the genesis
-/// Schnorr verification key supplied by the caller from configuration.
+/// when the genesis certificate is dual-signed (absent for a legacy genesis), the genesis Schnorr
+/// verification key supplied by the caller from configuration, and the rigid preimage of the
+/// protocol message being aggregated.
 pub fn build_ancillary_proof_input(
     genesis_certificate: &Certificate,
     parent_certificate: &Certificate,
+    #[cfg(feature = "future_snark")] protocol_message: &ProtocolMessage,
     #[cfg(feature = "future_snark")] genesis_schnorr_verification_key: Option<
         GenesisSchnorrVerificationKey,
     >,
@@ -48,5 +50,83 @@ pub fn build_ancillary_proof_input(
         AncillaryGenesisData::new()
     };
 
-    AncillaryProofInput::new(prover_data, genesis_data)
+    #[cfg(feature = "future_snark")]
+    let message_preimage = protocol_message.rigid_preimage();
+
+    AncillaryProofInput::new(
+        prover_data,
+        genesis_data,
+        #[cfg(feature = "future_snark")]
+        message_preimage,
+    )
+}
+
+#[cfg(all(test, feature = "future_snark"))]
+mod tests {
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    use crate::crypto_helper::{GenesisEd25519Signature, GenesisSchnorrSigner};
+    use crate::test::double::{fake_data, fake_keys};
+
+    use super::*;
+
+    fn dual_signed_genesis_certificate() -> Certificate {
+        let ed_signature: GenesisEd25519Signature =
+            fake_keys::genesis_signature()[0].try_into().unwrap();
+        let mut rng = ChaCha20Rng::from_seed([9u8; 32]);
+        let schnorr_signer = GenesisSchnorrSigner::generate(&mut rng);
+        let schnorr_signature = schnorr_signer.sign(&[0u8; 32], &mut rng).unwrap();
+
+        Certificate {
+            signature: CertificateSignature::GenesisDualSignature(ed_signature, schnorr_signature),
+            ..fake_data::genesis_certificate("genesis")
+        }
+    }
+
+    #[test]
+    fn carries_message_preimage_genesis_message_and_schnorr_signature_for_a_dual_genesis() {
+        let parent = fake_data::certificate("parent");
+        let genesis = dual_signed_genesis_certificate();
+        let protocol_message = ProtocolMessage::new_rigid();
+        let schnorr_verification_key =
+            GenesisSchnorrSigner::generate(&mut ChaCha20Rng::from_seed([1u8; 32]))
+                .verification_key();
+
+        let input = build_ancillary_proof_input(
+            &genesis,
+            &parent,
+            &protocol_message,
+            Some(schnorr_verification_key),
+        );
+
+        let genesis_data = input.genesis_data();
+        assert_eq!(
+            input.message_preimage(),
+            protocol_message.rigid_preimage().as_slice()
+        );
+        assert_eq!(
+            genesis_data.genesis_message(),
+            genesis.protocol_message.compute_rigid_hash_bytes()
+        );
+        assert_eq!(
+            genesis_data.genesis_message_preimage(),
+            genesis.protocol_message.rigid_preimage().as_slice()
+        );
+        assert!(genesis_data.genesis_schnorr_signature().is_some());
+        assert!(genesis_data.genesis_schnorr_verification_key().is_some());
+        assert!(input.prover_data().is_none());
+    }
+
+    #[test]
+    fn omits_the_schnorr_signature_and_key_for_a_legacy_genesis() {
+        let parent = fake_data::certificate("parent");
+        let genesis = fake_data::genesis_certificate("genesis");
+        let protocol_message = ProtocolMessage::new_rigid();
+
+        let input = build_ancillary_proof_input(&genesis, &parent, &protocol_message, None);
+
+        assert!(input.genesis_data().genesis_schnorr_signature().is_none());
+        assert!(input.genesis_data().genesis_schnorr_verification_key().is_none());
+    }
 }

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -2,6 +2,8 @@
 
 use mithril_stm::{AncillaryGenesisData, AncillaryProofInput};
 
+#[cfg(feature = "future_snark")]
+use crate::crypto_helper::GenesisSchnorrVerificationKey;
 use crate::entities::Certificate;
 #[cfg(feature = "future_snark")]
 use crate::entities::CertificateSignature;
@@ -9,11 +11,15 @@ use crate::entities::CertificateSignature;
 /// Build the ancillary proof input for one aggregate signature creation, from the genesis
 /// certificate (the genesis data) and the parent certificate (the prover data).
 ///
-/// Under `future_snark`, the genesis message preimage is carried, and the genesis Schnorr signature
-/// too when the genesis certificate is dual-signed (absent for a legacy genesis).
+/// Under `future_snark`, the genesis message preimage is carried, the genesis Schnorr signature too
+/// when the genesis certificate is dual-signed (absent for a legacy genesis), and the genesis
+/// Schnorr verification key supplied by the caller from configuration.
 pub fn build_ancillary_proof_input(
     genesis_certificate: &Certificate,
     parent_certificate: &Certificate,
+    #[cfg(feature = "future_snark")] genesis_schnorr_verification_key: Option<
+        GenesisSchnorrVerificationKey,
+    >,
 ) -> AncillaryProofInput {
     let prover_data = parent_certificate
         .ancillary_prover_data
@@ -23,11 +29,18 @@ pub fn build_ancillary_proof_input(
     #[cfg(feature = "future_snark")]
     let genesis_data = {
         let genesis_message_preimage = genesis_certificate.protocol_message.rigid_preimage();
+        let genesis_message =
+            ProtocolMessage::compute_rigid_hash_bytes_from_preimage(&genesis_message_preimage);
         let genesis_schnorr_signature = match &genesis_certificate.signature {
             CertificateSignature::GenesisDualSignature(_, signature) => Some(*signature),
             _ => None,
         };
-        AncillaryGenesisData::new(genesis_message_preimage, genesis_schnorr_signature)
+        AncillaryGenesisData::new(
+            genesis_message_preimage,
+            genesis_message,
+            genesis_schnorr_signature,
+            genesis_schnorr_verification_key,
+        )
     };
     #[cfg(not(feature = "future_snark"))]
     let genesis_data = {

--- a/mithril-common/src/protocol/mod.rs
+++ b/mithril-common/src/protocol/mod.rs
@@ -10,7 +10,7 @@ mod signer_builder;
 mod single_signer;
 
 pub use ancillary::build_ancillary_proof_input;
-pub use multi_signer::{MultiSignatureWithAncillaryVerifierData, MultiSigner};
+pub use multi_signer::{MultiSignatureWithAncillaryData, MultiSigner};
 pub use signer_builder::{SignerBuilder, SignerBuilderError};
 pub use single_signer::SingleSigner;
 

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -4,18 +4,21 @@ use mithril_stm::{AggregateSignatureType, AncillaryProofInput, Parameters};
 use crate::{
     StdResult,
     crypto_helper::{
-        ProtocolAggregateVerificationKey, ProtocolAncillaryVerifierData, ProtocolClerk,
-        ProtocolMultiSignature,
+        ProtocolAggregateVerificationKey, ProtocolAncillaryProverData,
+        ProtocolAncillaryVerifierData, ProtocolClerk, ProtocolMultiSignature,
     },
     entities::SingleSignature,
     protocol::ToMessage,
 };
 
-/// A multi-signature together with the ancillary verifier data produced during its creation.
+/// A multi-signature together with the ancillary data produced during its creation.
 #[derive(Debug, Clone)]
-pub struct MultiSignatureWithAncillaryVerifierData {
+pub struct MultiSignatureWithAncillaryData {
     /// The produced multi-signature.
     pub multi_signature: ProtocolMultiSignature,
+
+    /// The ancillary prover data produced during aggregation needed for a following round of aggregation, absent when the proof system produces none.
+    pub ancillary_prover_data: Option<ProtocolAncillaryProverData>,
 
     /// The ancillary verifier data produced during aggregation, absent when the proof system
     /// produces none.
@@ -43,7 +46,7 @@ impl MultiSigner {
         message: &T,
         aggregate_signature_type: AggregateSignatureType,
         ancillary_input: AncillaryProofInput,
-    ) -> StdResult<MultiSignatureWithAncillaryVerifierData> {
+    ) -> StdResult<MultiSignatureWithAncillaryData> {
         let protocol_signatures: Vec<_> = single_signatures
             .iter()
             .map(|single_signature| single_signature.to_protocol_signature())
@@ -57,8 +60,12 @@ impl MultiSigner {
                 ancillary_input,
             )?;
 
-        Ok(MultiSignatureWithAncillaryVerifierData {
+        Ok(MultiSignatureWithAncillaryData {
             multi_signature: multi_signature.into(),
+            ancillary_prover_data: ancillary_proof_output
+                .prover_data()
+                .cloned()
+                .map(ProtocolAncillaryProverData::new),
             ancillary_verifier_data: ancillary_proof_output
                 .verifier_data()
                 .cloned()

--- a/mithril-common/src/protocol/multi_signer.rs
+++ b/mithril-common/src/protocol/multi_signer.rs
@@ -49,7 +49,7 @@ impl MultiSigner {
             .map(|single_signature| single_signature.to_protocol_signature())
             .collect();
 
-        let (multi_signature, ancillary_verifier_data) =
+        let (multi_signature, ancillary_proof_output) =
             self.protocol_clerk.aggregate_signatures_with_type(
                 &protocol_signatures,
                 message.to_message().as_bytes(),
@@ -59,7 +59,9 @@ impl MultiSigner {
 
         Ok(MultiSignatureWithAncillaryVerifierData {
             multi_signature: multi_signature.into(),
-            ancillary_verifier_data: ancillary_verifier_data
+            ancillary_verifier_data: ancillary_proof_output
+                .verifier_data()
+                .cloned()
                 .map(ProtocolAncillaryVerifierData::new),
         })
     }

--- a/mithril-common/src/test/builder/certificate_chain_builder.rs
+++ b/mithril-common/src/test/builder/certificate_chain_builder.rs
@@ -573,7 +573,7 @@ impl<'a> CertificateChainBuilder<'a> {
             .filter_map(|s| s.protocol_signer.sign(certificate.signed_message.as_bytes()))
             .collect::<Vec<_>>();
         let clerk = CertificateChainBuilder::compute_clerk_for_signers(&fixture.signers_fixture());
-        let (multi_signature, _ancillary_verifier_data) = clerk
+        let (multi_signature, _ancillary_proof_output) = clerk
             .aggregate_signatures_with_type(
                 &single_signatures,
                 certificate.signed_message.as_bytes(),

--- a/mithril-common/src/test/double/dummies.rs
+++ b/mithril-common/src/test/double/dummies.rs
@@ -16,8 +16,6 @@ mod stm {
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
-                    [0u8; 32],
-                    #[cfg(feature = "future_snark")]
                     None,
                     #[cfg(feature = "future_snark")]
                     None,

--- a/mithril-common/src/test/double/dummies.rs
+++ b/mithril-common/src/test/double/dummies.rs
@@ -16,6 +16,10 @@ mod stm {
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
+                    [0u8; 32],
+                    #[cfg(feature = "future_snark")]
+                    None,
+                    #[cfg(feature = "future_snark")]
                     None,
                 ),
             )

--- a/mithril-common/src/test/double/dummies.rs
+++ b/mithril-common/src/test/double/dummies.rs
@@ -22,6 +22,8 @@ mod stm {
                     #[cfg(feature = "future_snark")]
                     None,
                 ),
+                #[cfg(feature = "future_snark")]
+                Vec::new(),
             )
         }
     }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.38 (06-17-2026)
+
+### Added
+
+- Added `AncillaryProofOutput`, carrying the optional prover and verifier data produced during aggregate signature creation.
+
+### Changed
+
+- `Clerk::aggregate_signatures_with_type` now returns the aggregate signature together with an `AncillaryProofOutput` instead of the optional `AncillaryVerifierData`.
+- `AncillaryGenesisData` now also carries the genesis Schnorr verification key, gated behind the `future_snark` feature.
+- `AncillaryProofInput` now also carries the rigid preimage of the protocol message being aggregated, gated behind the `future_snark` feature.
+
 ## 0.10.37 (06-17-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.37"
+version = "0.10.38"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -136,9 +136,7 @@ for s in sigs.iter() {
 }
 
 // Aggregate a concatenation proof with random parties
-#[cfg(feature = "future_snark")]
-use sha2::{Digest, Sha256};
-let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] Sha256::digest(b"").into(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None), #[cfg(feature = "future_snark")] Vec::new());
+let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None), #[cfg(feature = "future_snark")] Vec::new());
 let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 
 match msig {

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -138,7 +138,7 @@ for s in sigs.iter() {
 // Aggregate a concatenation proof with random parties
 #[cfg(feature = "future_snark")]
 use sha2::{Digest, Sha256};
-let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] Sha256::digest(b"").into(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None));
+let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] Sha256::digest(b"").into(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None), #[cfg(feature = "future_snark")] Vec::new());
 let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 
 match msig {

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -136,7 +136,9 @@ for s in sigs.iter() {
 }
 
 // Aggregate a concatenation proof with random parties
-let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] None));
+#[cfg(feature = "future_snark")]
+use sha2::{Digest, Sha256};
+let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] Sha256::digest(b"").into(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None));
 let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 
 match msig {

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -140,9 +140,9 @@ let ancillary_input = AncillaryProofInput::new(None, AncillaryGenesisData::new(#
 let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 
 match msig {
-    Ok((aggr, ancillary_verifier_data)) => {
+    Ok((aggr, ancillary_proof_output)) => {
         println!("Aggregate ok");
-        assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data).is_ok());
+        assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned()).is_ok());
     }
     Err(error) => match error.downcast_ref::<AggregationError>() {
         Some(AggregationError::NotEnoughSignatures(n, k)) => {

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -62,6 +62,10 @@ where
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
+                    [0u8; 32],
+                    #[cfg(feature = "future_snark")]
+                    None,
+                    #[cfg(feature = "future_snark")]
                     None,
                 ),
             ),

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -68,6 +68,8 @@ where
                     #[cfg(feature = "future_snark")]
                     None,
                 ),
+                #[cfg(feature = "future_snark")]
+                Vec::new(),
             ),
         )
         .unwrap();

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -51,7 +51,7 @@ where
 
     // Aggregate with random parties
     let aggr_sig_type = AggregateSignatureType::Concatenation;
-    let (aggr, _ancillary_verifier_data) = clerk
+    let (aggr, _ancillary_proof_output) = clerk
         .aggregate_signatures_with_type(
             &sigs,
             &msg,

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -62,8 +62,6 @@ where
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
-                    [0u8; 32],
-                    #[cfg(feature = "future_snark")]
                     None,
                     #[cfg(feature = "future_snark")]
                     None,

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -81,8 +81,6 @@ fn stm_benches<D: MembershipDigest>(
                         #[cfg(feature = "future_snark")]
                         Vec::new(),
                         #[cfg(feature = "future_snark")]
-                        [0u8; 32],
-                        #[cfg(feature = "future_snark")]
                         None,
                         #[cfg(feature = "future_snark")]
                         None,
@@ -164,8 +162,6 @@ fn batch_benches<D>(
                         AncillaryGenesisData::new(
                             #[cfg(feature = "future_snark")]
                             Vec::new(),
-                            #[cfg(feature = "future_snark")]
-                            [0u8; 32],
                             #[cfg(feature = "future_snark")]
                             None,
                             #[cfg(feature = "future_snark")]

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -148,7 +148,7 @@ fn batch_benches<D>(
 
             let clerk = Clerk::new_clerk_from_signer(&signers[0]);
             let aggregate_signature_type = AggregateSignatureType::Concatenation;
-            let (msig, ancillary_verifier_data) = clerk
+            let (msig, ancillary_proof_output) = clerk
                 .aggregate_signatures_with_type(
                     &sigs,
                     &msg,
@@ -167,7 +167,7 @@ fn batch_benches<D>(
 
             batch_avks.push(clerk.compute_aggregate_verification_key());
             batch_stms.push(msig);
-            batch_ancillary_verifier_datas.push(ancillary_verifier_data);
+            batch_ancillary_verifier_datas.push(ancillary_proof_output.verifier_data().cloned());
         }
 
         group.bench_function(BenchmarkId::new("Batch Verification", batch_string), |b| {

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -87,6 +87,8 @@ fn stm_benches<D: MembershipDigest>(
                         #[cfg(feature = "future_snark")]
                         None,
                     ),
+                    #[cfg(feature = "future_snark")]
+                    Vec::new(),
                 ),
             )
         })
@@ -169,6 +171,8 @@ fn batch_benches<D>(
                             #[cfg(feature = "future_snark")]
                             None,
                         ),
+                        #[cfg(feature = "future_snark")]
+                        Vec::new(),
                     ),
                 )
                 .unwrap();

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -81,6 +81,10 @@ fn stm_benches<D: MembershipDigest>(
                         #[cfg(feature = "future_snark")]
                         Vec::new(),
                         #[cfg(feature = "future_snark")]
+                        [0u8; 32],
+                        #[cfg(feature = "future_snark")]
+                        None,
+                        #[cfg(feature = "future_snark")]
                         None,
                     ),
                 ),
@@ -158,6 +162,10 @@ fn batch_benches<D>(
                         AncillaryGenesisData::new(
                             #[cfg(feature = "future_snark")]
                             Vec::new(),
+                            #[cfg(feature = "future_snark")]
+                            [0u8; 32],
+                            #[cfg(feature = "future_snark")]
+                            None,
                             #[cfg(feature = "future_snark")]
                             None,
                         ),

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -140,8 +140,6 @@ fn main() {
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
-                    [0u8; 32],
-                    #[cfg(feature = "future_snark")]
                     None,
                     #[cfg(feature = "future_snark")]
                     None,
@@ -177,8 +175,6 @@ fn main() {
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
-                    [0u8; 32],
-                    #[cfg(feature = "future_snark")]
                     None,
                     #[cfg(feature = "future_snark")]
                     None,
@@ -212,8 +208,6 @@ fn main() {
             AncillaryGenesisData::new(
                 #[cfg(feature = "future_snark")]
                 Vec::new(),
-                #[cfg(feature = "future_snark")]
-                [0u8; 32],
                 #[cfg(feature = "future_snark")]
                 None,
                 #[cfg(feature = "future_snark")]

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -140,6 +140,10 @@ fn main() {
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
+                    [0u8; 32],
+                    #[cfg(feature = "future_snark")]
+                    None,
+                    #[cfg(feature = "future_snark")]
                     None,
                 ),
             ),
@@ -171,6 +175,10 @@ fn main() {
                     #[cfg(feature = "future_snark")]
                     Vec::new(),
                     #[cfg(feature = "future_snark")]
+                    [0u8; 32],
+                    #[cfg(feature = "future_snark")]
+                    None,
+                    #[cfg(feature = "future_snark")]
                     None,
                 ),
             ),
@@ -200,6 +208,10 @@ fn main() {
             AncillaryGenesisData::new(
                 #[cfg(feature = "future_snark")]
                 Vec::new(),
+                #[cfg(feature = "future_snark")]
+                [0u8; 32],
+                #[cfg(feature = "future_snark")]
+                None,
                 #[cfg(feature = "future_snark")]
                 None,
             ),

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -146,6 +146,8 @@ fn main() {
                     #[cfg(feature = "future_snark")]
                     None,
                 ),
+                #[cfg(feature = "future_snark")]
+                Vec::new(),
             ),
         ) {
         Ok((s, _)) => s,
@@ -181,6 +183,8 @@ fn main() {
                     #[cfg(feature = "future_snark")]
                     None,
                 ),
+                #[cfg(feature = "future_snark")]
+                Vec::new(),
             ),
         ) {
         Ok((s, _)) => s,
@@ -215,6 +219,8 @@ fn main() {
                 #[cfg(feature = "future_snark")]
                 None,
             ),
+            #[cfg(feature = "future_snark")]
+            Vec::new(),
         ),
     );
     assert!(msig_3.is_err());

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -94,7 +94,9 @@
 //! let clerk = Clerk::new_clerk_from_signer(&ps[0]);
 //!
 //! // Aggregate and verify the signatures
-//! let genesis_data = AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] None);
+//! #[cfg(feature = "future_snark")]
+//! use sha2::{Digest, Sha256};
+//! let genesis_data = AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] Sha256::digest(b"").into(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None);
 //! let ancillary_input = AncillaryProofInput::new(None, genesis_data);
 //! let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 //! match msig {

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -94,9 +94,7 @@
 //! let clerk = Clerk::new_clerk_from_signer(&ps[0]);
 //!
 //! // Aggregate and verify the signatures
-//! #[cfg(feature = "future_snark")]
-//! use sha2::{Digest, Sha256};
-//! let genesis_data = AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] Sha256::digest(b"").into(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None);
+//! let genesis_data = AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None);
 //! let ancillary_input = AncillaryProofInput::new(None, genesis_data, #[cfg(feature = "future_snark")] Vec::new());
 //! let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 //! match msig {

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -97,7 +97,7 @@
 //! #[cfg(feature = "future_snark")]
 //! use sha2::{Digest, Sha256};
 //! let genesis_data = AncillaryGenesisData::new(#[cfg(feature = "future_snark")] Vec::new(), #[cfg(feature = "future_snark")] Sha256::digest(b"").into(), #[cfg(feature = "future_snark")] None, #[cfg(feature = "future_snark")] None);
-//! let ancillary_input = AncillaryProofInput::new(None, genesis_data);
+//! let ancillary_input = AncillaryProofInput::new(None, genesis_data, #[cfg(feature = "future_snark")] Vec::new());
 //! let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 //! match msig {
 //!     Ok((aggr, ancillary_proof_output)) => {

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -98,10 +98,10 @@
 //! let ancillary_input = AncillaryProofInput::new(None, genesis_data);
 //! let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureType::Concatenation, ancillary_input);
 //! match msig {
-//!     Ok((aggr, ancillary_verifier_data)) => {
+//!     Ok((aggr, ancillary_proof_output)) => {
 //!         println!("Aggregate ok");
 //!         assert!(aggr
-//!             .verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data)
+//!             .verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned())
 //!             .is_ok());
 //!     }
 //!     Err(error) => assert!(
@@ -150,10 +150,10 @@ mod signature_scheme;
 pub use proof_system::AggregateVerificationKeyForConcatenation;
 pub use protocol::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
-    AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProverData,
-    AncillaryVerifierData, Clerk, ClosedKeyRegistration, ClosedRegistrationEntry, Initializer,
-    KeyRegistration, Parameters, RegisterError, RegistrationEntry,
-    RegistrationEntryForConcatenation, SignatureError, Signer, SingleSignature,
+    AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProofOutput,
+    AncillaryProverData, AncillaryVerifierData, Clerk, ClosedKeyRegistration,
+    ClosedRegistrationEntry, Initializer, KeyRegistration, Parameters, RegisterError,
+    RegistrationEntry, RegistrationEntryForConcatenation, SignatureError, Signer, SingleSignature,
     SingleSignatureWithRegisteredParty, VerificationKeyForConcatenation,
     VerificationKeyProofOfPossessionForConcatenation,
 };

--- a/mithril-stm/src/proof_system/concatenation/proof.rs
+++ b/mithril-stm/src/proof_system/concatenation/proof.rs
@@ -419,7 +419,7 @@ mod tests {
             let signature_1 = signer_1.create_single_signature(&msg).unwrap();
             let signature_2 = signer_2.create_single_signature(&msg).unwrap();
 
-            let (signature, _ancillary_verifier_data) = clerk
+            let (signature, _ancillary_proof_output) = clerk
                 .aggregate_signatures_with_type(
                     &[signature_1, signature_2],
                     &msg,

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -155,24 +155,31 @@ impl AncillaryGenesisData {
 
 /// Ancillary input to one aggregate signature creation.
 ///
-/// Carries the prover data from the previous certificate and the genesis data from the genesis
-/// certificate, the state the proof system needs at creation. It is always supplied to the clerk;
+/// Carries the prover data from the previous certificate, the genesis data from the genesis
+/// certificate and, under `future_snark`, the rigid preimage of the protocol message being
+/// aggregated, the state the proof system needs at creation. It is always supplied to the clerk;
 /// each proof system decides whether to consume it.
 #[derive(Clone, Debug)]
 pub struct AncillaryProofInput {
     prover_data: Option<AncillaryProverData>,
     genesis_data: AncillaryGenesisData,
+    #[cfg(feature = "future_snark")]
+    message_preimage: Vec<u8>,
 }
 
 impl AncillaryProofInput {
-    /// Build the ancillary proof input from the prover and genesis data.
+    /// Build the ancillary proof input from the prover data, the genesis data and, under
+    /// `future_snark`, the rigid preimage of the protocol message being aggregated.
     pub fn new(
         prover_data: Option<AncillaryProverData>,
         genesis_data: AncillaryGenesisData,
+        #[cfg(feature = "future_snark")] message_preimage: Vec<u8>,
     ) -> Self {
         Self {
             prover_data,
             genesis_data,
+            #[cfg(feature = "future_snark")]
+            message_preimage,
         }
     }
 
@@ -186,10 +193,21 @@ impl AncillaryProofInput {
         &self.genesis_data
     }
 
+    /// Return the rigid preimage of the protocol message being aggregated.
+    #[cfg(feature = "future_snark")]
+    pub fn message_preimage(&self) -> &[u8] {
+        &self.message_preimage
+    }
+
     /// Build an ancillary proof input carrying no data, for use in tests.
     #[cfg(test)]
     pub fn dummy() -> Self {
-        Self::new(None, AncillaryGenesisData::dummy())
+        Self::new(
+            None,
+            AncillaryGenesisData::dummy(),
+            #[cfg(feature = "future_snark")]
+            Vec::new(),
+        )
     }
 }
 
@@ -268,5 +286,19 @@ mod tests {
         assert_eq!(genesis_data.genesis_message(), message);
         assert!(genesis_data.genesis_schnorr_signature().is_none());
         assert!(genesis_data.genesis_schnorr_verification_key().is_none());
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn proof_input_returns_the_message_preimage_it_was_built_with() {
+        let message_preimage = vec![9u8, 8, 7];
+
+        let proof_input = AncillaryProofInput::new(
+            None,
+            AncillaryGenesisData::dummy(),
+            message_preimage.clone(),
+        );
+
+        assert_eq!(proof_input.message_preimage(), message_preimage.as_slice());
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -68,16 +68,13 @@ impl AncillaryVerifierData {
 
 /// Genesis-related data carried into aggregate signature creation.
 ///
-/// Under `future_snark`, holds the genesis message preimage, the genesis message (the SHA-256
-/// digest of that preimage), the genesis Schnorr signature and the genesis Schnorr verification key
-/// when the genesis certificate carries them. It is a transient input to proof creation, never
-/// stored on a certificate.
+/// Under `future_snark`, holds the genesis message preimage, the genesis Schnorr signature and the
+/// genesis Schnorr verification key when the genesis certificate carries them. It is a transient
+/// input to proof creation, never stored on a certificate.
 #[derive(Clone, Debug)]
 pub struct AncillaryGenesisData {
     #[cfg(feature = "future_snark")]
     genesis_message_preimage: Vec<u8>,
-    #[cfg(feature = "future_snark")]
-    genesis_message: [u8; 32],
     #[cfg(feature = "future_snark")]
     genesis_schnorr_signature: Option<StandardSchnorrSignature>,
     #[cfg(feature = "future_snark")]
@@ -86,13 +83,11 @@ pub struct AncillaryGenesisData {
 
 impl AncillaryGenesisData {
     /// Build the genesis ancillary data. Under `future_snark`, from the genesis message preimage,
-    /// the genesis message (the SHA-256 digest of that preimage), the genesis Schnorr signature and
-    /// the genesis Schnorr verification key (the signature absent for a legacy, non-dual genesis
-    /// certificate).
+    /// the genesis Schnorr signature and the genesis Schnorr verification key (the signature absent
+    /// for a legacy, non-dual genesis certificate).
     #[cfg_attr(not(feature = "future_snark"), allow(clippy::new_without_default))]
     pub fn new(
         #[cfg(feature = "future_snark")] genesis_message_preimage: Vec<u8>,
-        #[cfg(feature = "future_snark")] genesis_message: [u8; 32],
         #[cfg(feature = "future_snark")] genesis_schnorr_signature: Option<
             StandardSchnorrSignature,
         >,
@@ -104,8 +99,6 @@ impl AncillaryGenesisData {
             #[cfg(feature = "future_snark")]
             genesis_message_preimage,
             #[cfg(feature = "future_snark")]
-            genesis_message,
-            #[cfg(feature = "future_snark")]
             genesis_schnorr_signature,
             #[cfg(feature = "future_snark")]
             genesis_schnorr_verification_key,
@@ -116,12 +109,6 @@ impl AncillaryGenesisData {
     #[cfg(feature = "future_snark")]
     pub fn genesis_message_preimage(&self) -> &[u8] {
         &self.genesis_message_preimage
-    }
-
-    /// Return the genesis message (the SHA-256 digest of the genesis message preimage).
-    #[cfg(feature = "future_snark")]
-    pub fn genesis_message(&self) -> [u8; 32] {
-        self.genesis_message
     }
 
     /// Return the genesis Schnorr signature, absent for a legacy (non-dual) genesis certificate.
@@ -143,8 +130,6 @@ impl AncillaryGenesisData {
         Self::new(
             #[cfg(feature = "future_snark")]
             Vec::new(),
-            #[cfg(feature = "future_snark")]
-            [0u8; 32],
             #[cfg(feature = "future_snark")]
             None,
             #[cfg(feature = "future_snark")]
@@ -278,12 +263,10 @@ mod tests {
     #[test]
     fn genesis_data_getters_return_the_values_it_was_built_with() {
         let preimage = vec![1u8, 2, 3];
-        let message = [7u8; 32];
 
-        let genesis_data = AncillaryGenesisData::new(preimage.clone(), message, None, None);
+        let genesis_data = AncillaryGenesisData::new(preimage.clone(), None, None);
 
         assert_eq!(genesis_data.genesis_message_preimage(), preimage.as_slice());
-        assert_eq!(genesis_data.genesis_message(), message);
         assert!(genesis_data.genesis_schnorr_signature().is_none());
         assert!(genesis_data.genesis_schnorr_verification_key().is_none());
     }

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -161,6 +161,41 @@ impl AncillaryProofInput {
     }
 }
 
+/// Ancillary output from one aggregate signature creation.
+///
+/// Carries the prover data to store on the new certificate (the state the proof system needs to
+/// produce the next certificate) and the verifier data the new certificate exposes. It is the
+/// output counterpart of [`AncillaryProofInput`]; each proof system decides whether to produce
+/// either, so both are absent for a proof system that produces none.
+#[derive(Clone, Debug)]
+pub struct AncillaryProofOutput {
+    prover_data: Option<AncillaryProverData>,
+    verifier_data: Option<AncillaryVerifierData>,
+}
+
+impl AncillaryProofOutput {
+    /// Build the ancillary proof output from the prover and verifier data.
+    pub fn new(
+        prover_data: Option<AncillaryProverData>,
+        verifier_data: Option<AncillaryVerifierData>,
+    ) -> Self {
+        Self {
+            prover_data,
+            verifier_data,
+        }
+    }
+
+    /// Return the prover ancillary data to store on the new certificate.
+    pub fn prover_data(&self) -> Option<&AncillaryProverData> {
+        self.prover_data.as_ref()
+    }
+
+    /// Return the verifier ancillary data the new certificate exposes.
+    pub fn verifier_data(&self) -> Option<&AncillaryVerifierData> {
+        self.verifier_data.as_ref()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::codec::CODEC_VERSION_CBOR_V1;
@@ -179,5 +214,13 @@ mod tests {
         assert!(AncillaryVerifierData::from_bytes(&[]).is_err());
         assert!(AncillaryVerifierData::from_bytes(&[0, 1, 2]).is_err());
         assert!(AncillaryVerifierData::from_bytes(&[CODEC_VERSION_CBOR_V1, 0xff]).is_err());
+    }
+
+    #[test]
+    fn proof_output_exposes_the_data_it_was_built_with() {
+        let output = AncillaryProofOutput::new(None, None);
+
+        assert!(output.prover_data().is_none());
+        assert!(output.verifier_data().is_none());
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -5,10 +5,10 @@
 
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "future_snark")]
-use crate::StandardSchnorrSignature;
 use crate::StmResult;
 use crate::codec;
+#[cfg(feature = "future_snark")]
+use crate::{SchnorrVerificationKey, StandardSchnorrSignature};
 
 /// Ancillary data carried by a certificate for the prover.
 ///
@@ -68,32 +68,47 @@ impl AncillaryVerifierData {
 
 /// Genesis-related data carried into aggregate signature creation.
 ///
-/// Under `future_snark`, holds the genesis message preimage and the genesis Schnorr signature when
-/// the genesis certificate carries one. It is a transient input to proof creation, never stored on
-/// a certificate.
+/// Under `future_snark`, holds the genesis message preimage, the genesis message (the SHA-256
+/// digest of that preimage), the genesis Schnorr signature and the genesis Schnorr verification key
+/// when the genesis certificate carries them. It is a transient input to proof creation, never
+/// stored on a certificate.
 #[derive(Clone, Debug)]
 pub struct AncillaryGenesisData {
     #[cfg(feature = "future_snark")]
     genesis_message_preimage: Vec<u8>,
     #[cfg(feature = "future_snark")]
+    genesis_message: [u8; 32],
+    #[cfg(feature = "future_snark")]
     genesis_schnorr_signature: Option<StandardSchnorrSignature>,
+    #[cfg(feature = "future_snark")]
+    genesis_schnorr_verification_key: Option<SchnorrVerificationKey>,
 }
 
 impl AncillaryGenesisData {
-    /// Build the genesis ancillary data. Under `future_snark`, from the genesis message preimage and
-    /// the genesis Schnorr signature (absent for a legacy, non-dual genesis certificate).
+    /// Build the genesis ancillary data. Under `future_snark`, from the genesis message preimage,
+    /// the genesis message (the SHA-256 digest of that preimage), the genesis Schnorr signature and
+    /// the genesis Schnorr verification key (the signature absent for a legacy, non-dual genesis
+    /// certificate).
     #[cfg_attr(not(feature = "future_snark"), allow(clippy::new_without_default))]
     pub fn new(
         #[cfg(feature = "future_snark")] genesis_message_preimage: Vec<u8>,
+        #[cfg(feature = "future_snark")] genesis_message: [u8; 32],
         #[cfg(feature = "future_snark")] genesis_schnorr_signature: Option<
             StandardSchnorrSignature,
+        >,
+        #[cfg(feature = "future_snark")] genesis_schnorr_verification_key: Option<
+            SchnorrVerificationKey,
         >,
     ) -> Self {
         Self {
             #[cfg(feature = "future_snark")]
             genesis_message_preimage,
             #[cfg(feature = "future_snark")]
+            genesis_message,
+            #[cfg(feature = "future_snark")]
             genesis_schnorr_signature,
+            #[cfg(feature = "future_snark")]
+            genesis_schnorr_verification_key,
         }
     }
 
@@ -103,10 +118,23 @@ impl AncillaryGenesisData {
         &self.genesis_message_preimage
     }
 
+    /// Return the genesis message (the SHA-256 digest of the genesis message preimage).
+    #[cfg(feature = "future_snark")]
+    pub fn genesis_message(&self) -> [u8; 32] {
+        self.genesis_message
+    }
+
     /// Return the genesis Schnorr signature, absent for a legacy (non-dual) genesis certificate.
     #[cfg(feature = "future_snark")]
     pub fn genesis_schnorr_signature(&self) -> Option<&StandardSchnorrSignature> {
         self.genesis_schnorr_signature.as_ref()
+    }
+
+    /// Return the genesis Schnorr verification key, absent for a legacy (non-dual) genesis
+    /// certificate.
+    #[cfg(feature = "future_snark")]
+    pub fn genesis_schnorr_verification_key(&self) -> Option<&SchnorrVerificationKey> {
+        self.genesis_schnorr_verification_key.as_ref()
     }
 
     /// Build genesis ancillary data carrying no data, for use in tests.
@@ -115,6 +143,10 @@ impl AncillaryGenesisData {
         Self::new(
             #[cfg(feature = "future_snark")]
             Vec::new(),
+            #[cfg(feature = "future_snark")]
+            [0u8; 32],
+            #[cfg(feature = "future_snark")]
+            None,
             #[cfg(feature = "future_snark")]
             None,
         )
@@ -222,5 +254,19 @@ mod tests {
 
         assert!(output.prover_data().is_none());
         assert!(output.verifier_data().is_none());
+    }
+
+    #[cfg(feature = "future_snark")]
+    #[test]
+    fn genesis_data_getters_return_the_values_it_was_built_with() {
+        let preimage = vec![1u8, 2, 3];
+        let message = [7u8; 32];
+
+        let genesis_data = AncillaryGenesisData::new(preimage.clone(), message, None, None);
+
+        assert_eq!(genesis_data.genesis_message_preimage(), preimage.as_slice());
+        assert_eq!(genesis_data.genesis_message(), message);
+        assert!(genesis_data.genesis_schnorr_signature().is_none());
+        assert!(genesis_data.genesis_schnorr_verification_key().is_none());
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -16,7 +16,7 @@ use crate::AggregateSignatureError;
 use crate::proof_system::{MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver};
 
 use super::{
-    AggregateSignature, AggregateSignatureType, AncillaryProofInput, AncillaryVerifierData,
+    AggregateSignature, AggregateSignatureType, AncillaryProofInput, AncillaryProofOutput,
 };
 
 /// Clerk for aggregate signatures.
@@ -71,7 +71,7 @@ impl<D: MembershipDigest> Clerk<D> {
         msg: &[u8],
         aggregate_signature_type: AggregateSignatureType,
         ancillary_input: AncillaryProofInput,
-    ) -> StmResult<(AggregateSignature<D>, Option<AncillaryVerifierData>)> {
+    ) -> StmResult<(AggregateSignature<D>, AncillaryProofOutput)> {
         let _ = ancillary_input;
         match aggregate_signature_type {
             AggregateSignatureType::Concatenation => {
@@ -86,7 +86,10 @@ impl<D: MembershipDigest> Clerk<D> {
                         AggregateSignatureType::Concatenation
                     )
                 })?;
-                Ok((AggregateSignature::Concatenation(Box::new(proof)), None))
+                Ok((
+                    AggregateSignature::Concatenation(Box::new(proof)),
+                    AncillaryProofOutput::new(None, None),
+                ))
             }
             #[cfg(feature = "future_snark")]
             AggregateSignatureType::Snark => {
@@ -98,7 +101,12 @@ impl<D: MembershipDigest> Clerk<D> {
                     MERKLE_TREE_DEPTH_FOR_SNARK,
                 )?
                 .aggregate_signatures(clerk, sigs, msg)
-                .map(|p| (AggregateSignature::Snark(Box::new(p)), None))
+                .map(|p| {
+                    (
+                        AggregateSignature::Snark(Box::new(p)),
+                        AncillaryProofOutput::new(None, None),
+                    )
+                })
                 .with_context(|| {
                     format!(
                         "Signatures failed to aggregate for type {}",

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -6,7 +6,8 @@ mod signature;
 
 pub use aggregate_key::AggregateVerificationKey;
 pub use ancillary_data::{
-    AncillaryGenesisData, AncillaryProofInput, AncillaryProverData, AncillaryVerifierData,
+    AncillaryGenesisData, AncillaryProofInput, AncillaryProofOutput, AncillaryProverData,
+    AncillaryVerifierData,
 };
 pub use clerk::Clerk;
 pub use error::{AggregateSignatureError, AggregationError};
@@ -30,7 +31,7 @@ mod tests {
 
     use super::{
         AggregateSignature, AggregateSignatureType, AggregateVerificationKey, AggregationError,
-        AncillaryProofInput, AncillaryVerifierData, Clerk,
+        AncillaryProofInput, AncillaryProofOutput, Clerk,
     };
 
     type Sig = AggregateSignature<D>;
@@ -167,7 +168,7 @@ mod tests {
 
     #[derive(Debug)]
     struct ProofTest {
-        msig: StmResult<(Sig, Option<AncillaryVerifierData>)>,
+        msig: StmResult<(Sig, AncillaryProofOutput)>,
         clerk: Clerk<D>,
         msg: [u8; 16],
     }
@@ -204,14 +205,14 @@ mod tests {
         F: Fn(&mut Sig, &mut Clerk<D>, &mut [u8; 16]),
     {
         match tc.msig {
-            Ok((mut aggr, ancillary_verifier_data)) => {
+            Ok((mut aggr, ancillary_proof_output)) => {
                 f(&mut aggr, &mut tc.clerk, &mut tc.msg);
                 assert!(
                     aggr.verify(
                         &tc.msg,
                         &tc.clerk.compute_aggregate_verification_key(),
                         &tc.clerk.get_concatenation_clerk().parameters,
-                        ancillary_verifier_data
+                        ancillary_proof_output.verifier_data().cloned()
                     )
                     .is_err()
                 )
@@ -240,9 +241,9 @@ mod tests {
             let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy());
 
             match msig {
-                Ok((aggr, ancillary_verifier_data)) => {
+                Ok((aggr, ancillary_proof_output)) => {
                     println!("Aggregate ok");
-                    assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data).is_ok());
+                    assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned()).is_ok());
                 }
                 Err(error) => match error.downcast_ref::<AggregationError>() {
                     Some(AggregationError::NotEnoughSignatures(n, k)) => {
@@ -324,10 +325,10 @@ mod tests {
             let all_ps: Vec<usize> = (0..nparties).collect();
             let sigs = find_signatures(&msg, &ps, &all_ps);
             let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy());
-            if let Ok((aggr, ancillary_verifier_data)) = msig {
+            if let Ok((aggr, ancillary_proof_output)) = msig {
                     let bytes: Vec<u8> = aggr.to_bytes().expect("AggregateSignature serialization should not fail");
                     let aggr2: AggregateSignature<D> = AggregateSignature::from_bytes(&bytes).unwrap();
-                    assert!(aggr2.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_verifier_data).is_ok());
+                    assert!(aggr2.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned()).is_ok());
             }
         }
     }
@@ -420,12 +421,12 @@ mod tests {
                     let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy());
 
                     match msig {
-                        Ok((aggr, ancillary_verifier_data)) => {
+                        Ok((aggr, ancillary_proof_output)) => {
                             aggr_avks.push(clerk.compute_aggregate_verification_key());
                             aggr_stms.push(aggr);
                             batch_msgs.push(msg.to_vec());
                             batch_params.push(params);
-                            batch_ancillary_verifier_datas.push(ancillary_verifier_data);
+                            batch_ancillary_verifier_datas.push(ancillary_proof_output.verifier_data().cloned());
                         }
                         Err(error) => { assert!(
                             matches!(
@@ -473,7 +474,7 @@ mod tests {
 
                 let all_ps: Vec<usize> = (0..nparties).collect();
                 let sigs = find_signatures(&msg, &ps, &all_ps);
-                let (fake_msig, _ancillary_verifier_data) = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy()).unwrap();
+                let (fake_msig, _ancillary_proof_output) = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy()).unwrap();
 
                 aggr_stms[0] = fake_msig;
                 assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas).is_err());

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -696,7 +696,7 @@ mod tests {
             let signature_1 = signer_1.create_single_signature(&msg).unwrap();
             let signature_2 = signer_2.create_single_signature(&msg).unwrap();
 
-            let (signature, _ancillary_verifier_data) = clerk
+            let (signature, _ancillary_proof_output) = clerk
                 .aggregate_signatures_with_type(
                     &[signature_1, signature_2],
                     &msg,

--- a/mithril-stm/src/protocol/mod.rs
+++ b/mithril-stm/src/protocol/mod.rs
@@ -7,8 +7,8 @@ mod single_signature;
 
 pub use aggregate_signature::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
-    AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProverData,
-    AncillaryVerifierData, Clerk,
+    AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProofOutput,
+    AncillaryProverData, AncillaryVerifierData, Clerk,
 };
 pub use error::RegisterError;
 #[cfg(feature = "future_snark")]

--- a/mithril-stm/tests/bytes_conversion.rs
+++ b/mithril-stm/tests/bytes_conversion.rs
@@ -82,7 +82,7 @@ fn test_binary_conversions() {
     let decoded = SingleSignature::from_bytes::<D>(&encoded).unwrap();
     assert_eq!(sig, &decoded);
 
-    let (msig, _ancillary_verifier_data) = msig.unwrap();
+    let (msig, _ancillary_proof_output) = msig.unwrap();
     let encoded = msig
         .to_bytes()
         .expect("AggregateSignature serialization should not fail");

--- a/mithril-stm/tests/stm_protocol.rs
+++ b/mithril-stm/tests/stm_protocol.rs
@@ -30,9 +30,17 @@ fn test_full_protocol() {
         operation_phase(params, signers, reg_parties, msg);
 
     match msig {
-        Ok((aggr, ancillary_verifier_data)) => {
+        Ok((aggr, ancillary_proof_output)) => {
             println!("Aggregate ok");
-            assert!(aggr.verify(&msg, &avk, &params, ancillary_verifier_data).is_ok());
+            assert!(
+                aggr.verify(
+                    &msg,
+                    &avk,
+                    &params,
+                    ancillary_proof_output.verifier_data().cloned()
+                )
+                .is_ok()
+            );
         }
         Err(error) => match error.downcast_ref::<AggregationError>() {
             Some(AggregationError::NotEnoughSignatures(n, k)) => {
@@ -80,11 +88,11 @@ fn test_full_protocol_batch_verify() {
             operation_phase(params, signers, reg_parties, msg);
 
         aggr_avks.push(avk);
-        let (signature, ancillary_verifier_data) = msig.unwrap();
+        let (signature, ancillary_proof_output) = msig.unwrap();
         aggr_stms.push(signature);
         batch_msgs.push(msg.to_vec());
         batch_params.push(params);
-        batch_ancillary_verifier_datas.push(ancillary_verifier_data);
+        batch_ancillary_verifier_datas.push(ancillary_proof_output.verifier_data().cloned());
     }
     assert!(
         AggregateSignature::batch_verify(

--- a/mithril-stm/tests/test_extensions/protocol_phase.rs
+++ b/mithril-stm/tests/test_extensions/protocol_phase.rs
@@ -102,8 +102,6 @@ pub fn operation_phase(
             #[cfg(feature = "future_snark")]
             Vec::new(),
             #[cfg(feature = "future_snark")]
-            [0u8; 32],
-            #[cfg(feature = "future_snark")]
             None,
             #[cfg(feature = "future_snark")]
             None,

--- a/mithril-stm/tests/test_extensions/protocol_phase.rs
+++ b/mithril-stm/tests/test_extensions/protocol_phase.rs
@@ -108,6 +108,8 @@ pub fn operation_phase(
             #[cfg(feature = "future_snark")]
             None,
         ),
+        #[cfg(feature = "future_snark")]
+        Vec::new(),
     );
     let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, ancillary_input);
 

--- a/mithril-stm/tests/test_extensions/protocol_phase.rs
+++ b/mithril-stm/tests/test_extensions/protocol_phase.rs
@@ -4,7 +4,7 @@ use rayon::prelude::*;
 
 use mithril_stm::{
     AggregateSignature, AggregateSignatureType, AggregateVerificationKey, AncillaryGenesisData,
-    AncillaryProofInput, AncillaryVerifierData, Clerk, Initializer, KeyRegistration,
+    AncillaryProofInput, AncillaryProofOutput, Clerk, Initializer, KeyRegistration,
     MithrilMembershipDigest, Parameters, Signer, SingleSignature, Stake, StmResult,
     VerificationKeyForConcatenation,
 };
@@ -20,7 +20,7 @@ pub struct InitializationPhaseResult {
 
 /// The result of the operation phase of the STM protocol.
 pub struct OperationPhaseResult {
-    pub msig: StmResult<(AggregateSignature<D>, Option<AncillaryVerifierData>)>,
+    pub msig: StmResult<(AggregateSignature<D>, AncillaryProofOutput)>,
     pub avk: AggregateVerificationKey<D>,
     pub sigs: Vec<SingleSignature>,
 }

--- a/mithril-stm/tests/test_extensions/protocol_phase.rs
+++ b/mithril-stm/tests/test_extensions/protocol_phase.rs
@@ -102,6 +102,10 @@ pub fn operation_phase(
             #[cfg(feature = "future_snark")]
             Vec::new(),
             #[cfg(feature = "future_snark")]
+            [0u8; 32],
+            #[cfg(feature = "future_snark")]
+            None,
+            #[cfg(feature = "future_snark")]
             None,
         ),
     );


### PR DESCRIPTION
## Content

This PR includes the **remaining ancillary data plumbing for the IVC aggregate signature creation**:

- Return an `AncillaryProofOutput` (optional prover and verifier data) from the aggregate signature clerk instead of the bare verifier data.
- Propagate the ancillary prover data into the created certificate: rename `MultiSignatureWithAncillaryVerifierData` to `MultiSignatureWithAncillaryData` and thread the prover data through `Certificate::try_new` and the certifier service.
- Carry the genesis Schnorr verification key (from the configured genesis verifier) in `AncillaryGenesisData`.
- Carry the aggregated protocol message's rigid preimage in `AncillaryProofInput`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #3341 
