### PR TITLE
Improve balance build/run time for future snark tests in CI

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -17,13 +17,19 @@ jobs:
         include:
           - os: ubuntu-24.04
             test-args: --features full,unstable --workspace
+            cargo-profile: ci-tests
           - os: ubuntu-24.04
             test-args: --features future_snark -p mithril-stm -p mithril-common -p mithril-aggregator -p mithril-signer -p mithril-relay
             artifact-suffix: -future-snark
+            # Dedicated profile that optimizes (opt-level 3) the crypto deps and `mithril-stm`
+            # so the slow SNARK tests run faster, at the cost of a longer (cache-amortized) build.
+            cargo-profile: ci-tests-snark
           - os: ubuntu-24.04-arm
             test-args: --features full,unstable --workspace
+            cargo-profile: ci-tests
           # Exclude nodes not officially supported on Windows and macOS (only mithril-client is supported)
           - os: macos-14
+            cargo-profile: ci-tests
             test-args: >
               --features full,unstable --workspace
               --exclude mithril-aggregator
@@ -33,6 +39,7 @@ jobs:
               --exclude mithril-aggregator-fake
           # Windows has a larger list of exclusion because some tests are too slow (ie: mithril-stm) or can't compile (ie: mithril-end-to-end)
           - os: windows-latest
+            cargo-profile: ci-tests
             test-args: >
               --features full,unstable --workspace
               --exclude mithril-aggregator
@@ -76,16 +83,16 @@ jobs:
           echo "filterset=$FILTERSET" >> $GITHUB_OUTPUT
 
       - name: Build tests
-        run: cargo nextest run --cargo-profile ci-tests --no-run ${{ matrix.test-args }}
+        run: cargo nextest run --cargo-profile ${{ matrix.cargo-profile }} --no-run ${{ matrix.test-args }}
 
       - name: Run tests
-        run: cargo nextest run --profile ci --cargo-profile ci-tests --filterset "${{ steps.prepare.outputs.filterset }}" ${{ matrix.test-args }}
+        run: cargo nextest run --profile ci --cargo-profile ${{ matrix.cargo-profile }} --filterset "${{ steps.prepare.outputs.filterset }}" ${{ matrix.test-args }}
 
       - name: Run doc tests
-        run: cargo test --profile ci-tests --doc ${{ matrix.test-args }}
+        run: cargo test --profile ${{ matrix.cargo-profile }} --doc ${{ matrix.test-args }}
 
       - name: Ensure examples build
-        run: cargo build --profile ci-tests --examples ${{ matrix.test-args }}
+        run: cargo build --profile ${{ matrix.cargo-profile }} --examples ${{ matrix.test-args }}
 
       - name: Rename junit file to include runner info
         shell: bash

--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -21,9 +21,13 @@ jobs:
           - os: ubuntu-24.04
             test-args: --features future_snark -p mithril-stm -p mithril-common -p mithril-aggregator -p mithril-signer -p mithril-relay
             artifact-suffix: -future-snark
-            # Dedicated profile that optimizes (opt-level 3) the crypto deps and `mithril-stm`
-            # so the slow SNARK tests run faster, at the cost of a longer (cache-amortized) build.
-            cargo-profile: ci-tests-snark
+            # Default to the fast profile; the `prepare` step upgrades to `slow-cargo-profile`
+            # only when the slow SNARK tests are actually in scope for this run (so we don't pay
+            # the opt-level 3 build cost on PRs that filter those tests out).
+            cargo-profile: ci-tests
+            # Optimizes (opt-level 3) the crypto deps and `mithril-stm` so the slow SNARK tests
+            # run faster, at the cost of a longer (cache-amortized) build.
+            slow-cargo-profile: ci-tests-snark
           - os: ubuntu-24.04-arm
             test-args: --features full,unstable --workspace
             cargo-profile: ci-tests
@@ -72,27 +76,45 @@ jobs:
         run: |
           if [[ "${{ inputs.include-slow-tests }}" == "true" ]]; then
             FILTERSET="$(.github/workflows/scripts/filter-slow-tests.sh --all)"
+            SLOW_TESTS=true
           else
             # For pull-request HEAD^1 targets the "simulated merge commit" created by GitHub Actions.
             # For push (i.e. merging on main branch), HEAD^1 refers be an actual, not simulated, merge commit.
             # Note: this approach does not correctly detect changes when multiple commits are pushed directly to the main branch at once.
             FILTERSET="$(.github/workflows/scripts/filter-slow-tests.sh --commit-ref "HEAD^1")"
+            # The filter script only appends a `package(mithril-stm)` slow-test allowance when the
+            # changed files touch a slow SNARK test path, so its presence tells us whether the slow
+            # tests are in scope for this run.
+            if [[ "$FILTERSET" == *"package(mithril-stm)"* ]]; then
+              SLOW_TESTS=true
+            else
+              SLOW_TESTS=false
+            fi
+          fi
+
+          # Use the heavier opt-level 3 profile only when the slow tests will actually run; the
+          # longer build only pays off then. Other jobs (no `slow-cargo-profile`) keep `cargo-profile`.
+          CARGO_PROFILE="${{ matrix.cargo-profile }}"
+          if [[ "$SLOW_TESTS" == "true" && -n "${{ matrix.slow-cargo-profile }}" ]]; then
+            CARGO_PROFILE="${{ matrix.slow-cargo-profile }}"
           fi
 
           echo "Tests filterset: $FILTERSET"
+          echo "Cargo profile: $CARGO_PROFILE"
           echo "filterset=$FILTERSET" >> $GITHUB_OUTPUT
+          echo "cargo-profile=$CARGO_PROFILE" >> $GITHUB_OUTPUT
 
       - name: Build tests
-        run: cargo nextest run --cargo-profile ${{ matrix.cargo-profile }} --no-run ${{ matrix.test-args }}
+        run: cargo nextest run --cargo-profile ${{ steps.prepare.outputs.cargo-profile }} --no-run ${{ matrix.test-args }}
 
       - name: Run tests
-        run: cargo nextest run --profile ci --cargo-profile ${{ matrix.cargo-profile }} --filterset "${{ steps.prepare.outputs.filterset }}" ${{ matrix.test-args }}
+        run: cargo nextest run --profile ci --cargo-profile ${{ steps.prepare.outputs.cargo-profile }} --filterset "${{ steps.prepare.outputs.filterset }}" ${{ matrix.test-args }}
 
       - name: Run doc tests
-        run: cargo test --profile ${{ matrix.cargo-profile }} --doc ${{ matrix.test-args }}
+        run: cargo test --profile ${{ steps.prepare.outputs.cargo-profile }} --doc ${{ matrix.test-args }}
 
       - name: Ensure examples build
-        run: cargo build --profile ${{ matrix.cargo-profile }} --examples ${{ matrix.test-args }}
+        run: cargo build --profile ${{ steps.prepare.outputs.cargo-profile }} --examples ${{ matrix.test-args }}
 
       - name: Rename junit file to include runner info
         shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,3 +84,26 @@ inherits = "dev"
 debug = "line-tables-only"
 # Not cached by `Swatinem/rust-cache`, so generating them is a waste of resources
 incremental = false
+
+# Variant of `ci-tests` used *only* by the `future_snark` Rust test job (selected via
+# `--cargo-profile ci-tests-snark` in the matching CI matrix entry). All other test jobs keep
+# using `ci-tests` and are unaffected by the `opt-level = 3` overrides below.
+[profile.ci-tests-snark]
+inherits = "ci-tests"
+
+# Optimize all dependencies while leaving the workspace crates at the profile's base
+# `opt-level = 0` (fast to compile, the part under active iteration). The `future_snark`
+# crypto stack (`midnight-proofs`, `midnight-curves`, `midnight-circuits`, `blst`, `ff`,
+# `group`, ...) does heavy proof-system arithmetic (FFTs, MSM, polynomial ops) that runs
+# considerably slower unoptimized and dominates the slow circuit/proof tests. The dependency
+# build cost is paid once per `Swatinem/rust-cache` key, not per CI run.
+[profile.ci-tests-snark.package."*"]
+opt-level = 3
+
+# The `mithril-stm` circuit/synthesis code (cert + IVC circuits, gadget assignment) runs
+# during keygen / MockProver / proving and measured as the dominant remaining hotspot after
+# the dependency stack was optimized: MockProver synthesis sped up 5.6× and IVC keygen ~2.2×
+# only once this crate was optimized too (deps alone gave ~1.5×). This trades slower
+# incremental recompiles of `mithril-stm` for substantially faster `future_snark` test runs.
+[profile.ci-tests-snark.package.mithril-stm]
+opt-level = 3


### PR DESCRIPTION
## Content

This PR targets to optimise the CI build / run time balance for the future snark slow tests.

That is, if we run the slow tests, there is a valuable time decrease in running the test by letting the compiler optimising the underlying used libs like `blst`/`ff` and others expensive crypto heave functions like FFT over the scalar field.

This optimisation at compile time increases build time, so empericly we need to check if the total time the test takes improves. Also, having such flags enabled for all tests is undesired, because they will definitly not decrease their run time. This is why we target only the future snark tests for the nightly and in PR's that change the circuit.

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

An overview of the benchmarks of the CI:

- 1. An initial clean run with no changes was forced by an empty commit + the `run-slow-tests` label
- 2. A run with `opt-level = 3` profile on the future-snark tests only + the `run-slow-tests` label
- 3. A run with `opt-level = 3` profile on the future-snark test + no label
- 4. A run with `opt-level = 3` profile on the future snark test and filter on which jobs to use it + no label
- 5. A run with `opt-level = 3` profile on the future snark test and filter on which jobs to use it + the `run-slow-tests` label

| Test | Build time future-snark test | Run time future-snark test | Total time of CI |
|---|---|---|---|
| [1. Initial clean run + label](https://github.com/input-output-hk/mithril/actions/runs/27678632115/job/81889890565) | 3m 19s | 2h 19m 18s | 2h 24m 6s |
| [2. With opt profile + label](https://github.com/input-output-hk/mithril/actions/runs/27688270378/job/81892321522) | 13m 31s (+307.5%) | 56m 1s (-59.8%) | 1h 13m 25s (-49.1%) |
| [3. With opt profile](https://github.com/input-output-hk/mithril/actions/runs/27694046049/job/81912355872) | 12m 56s | 1m 58s | 18m 42s |
| [4. With opt profile + changed filter](https://github.com/input-output-hk/mithril/actions/runs/27744714584/job/82080081138) | 2m 47s | 6m 42s | 11m 0s |
| [5. With opt profile + changed filter + label](https://github.com/input-output-hk/mithril/actions/runs/27745540394/job/82082801512) | 13m 25s | 55m 40s | 1h 13m 26s |

We see that in test 1 (no changes) the building time is fast for all tests, but the full future snark tests take a long time.

In test 2 and 3 we see what the `opt-level = 3` profile gains in time wrt test 1. Build time increase (with our without the label forcing the long test), and if the label is there, the long testing time is halved (outweighing the increased build time).

In test 4 and 5 we see that we can have our cake an eat it to; have best of both worlds. That is, when we do not use the label, the build is quick and the rest is quick since it skips the slow tests. And in the case we have the label, the build time increase but the decreased testing time outweights this (effectifly decreasing the total CI time).

Test 4 and 5 are ran over the current changes.

## Issue(s)

Relates to https://github.com/input-output-hk/mithril/issues/3343
