### PR TITLE
feat(stm): wire IVC snark prover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.38"
+version = "0.10.39"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.38", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.39", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -302,6 +302,8 @@ impl MithrilCertificateVerifier {
                 certificate,
                 previous_certificate,
             ),
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::IvcSnark => todo!(),
         }
     }
 

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -303,7 +303,11 @@ impl MithrilCertificateVerifier {
                 previous_certificate,
             ),
             #[cfg(feature = "future_snark")]
-            AggregateSignatureType::IvcSnark => todo!(),
+            AggregateSignatureType::IvcSnark => self
+                .verify_snark_aggregate_verification_key_chaining(
+                    certificate,
+                    previous_certificate,
+                ),
         }
     }
 

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -103,7 +103,7 @@ mod tests {
             protocol_message.rigid_preimage().as_slice()
         );
         assert_eq!(
-            genesis_data.genesis_message_preimage().0,
+            genesis_data.genesis_message_preimage().to_vec(),
             genesis.protocol_message.rigid_preimage().as_slice()
         );
         assert!(genesis_data.genesis_schnorr_signature().is_some());

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -60,6 +60,8 @@ pub fn build_ancillary_proof_input(
 
 #[cfg(all(test, feature = "future_snark"))]
 mod tests {
+    use std::ops::Deref;
+
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
@@ -103,7 +105,7 @@ mod tests {
             protocol_message.rigid_preimage().as_slice()
         );
         assert_eq!(
-            genesis_data.genesis_message_preimage().to_vec(),
+            genesis_data.genesis_message_preimage().deref(),
             genesis.protocol_message.rigid_preimage().as_slice()
         );
         assert!(genesis_data.genesis_schnorr_signature().is_some());

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -103,7 +103,7 @@ mod tests {
             protocol_message.rigid_preimage().as_slice()
         );
         assert_eq!(
-            genesis_data.genesis_message_preimage(),
+            genesis_data.genesis_message_preimage().0,
             genesis.protocol_message.rigid_preimage().as_slice()
         );
         assert!(genesis_data.genesis_schnorr_signature().is_some());

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Clerk::aggregate_signatures_with_type` IVC variant is completed.
 - `AggregateSignature::verify` IVC variant is completed.
 - `IvcProof::verify` now also checks that the input message is the same as the one used to create the proof.
-- More fixed the how the circuit verification keys are handled and computed.
+- More fixes: downsizing the srs properly for the ivc keys, proper deserialization of `VerifyingKey`, carrying the `AncillaryVerifierData` in the certificate.
 
 ## 0.10.38 (06-17-2026)
 

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.39 (06-24-2026)
+
+### Added
+
+- Added wiring of the IVC prover and verifier in the `Clerk` and `AggregateSignature`.
+
+### Changed
+
+- `Clerk::aggregate_signatures_with_type` IVC variant is completed.
+- `AggregateSignature::verify` IVC variant is completed.
+- `IvcProof::verify` now also checks that the input message is the same as the one used to create the proof.
+- More fixed the how the circuit verification keys are handled and computed.
+
 ## 0.10.38 (06-17-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.38"
+version = "0.10.39"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -7,6 +7,7 @@
 //! proof, so it can be wrapped into a certificate accumulator for IVC
 //! aggregation.
 
+use anyhow::Context;
 use group::Group;
 
 use midnight_circuits::hash::poseidon::PoseidonState;
@@ -55,14 +56,17 @@ pub(crate) fn verify_and_prepare_accumulator(
         &[&[public_inputs]],
         &mut transcript,
     )
-    .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
+    .map_err(|_| IvcCircuitError::CertificateProofRejected)
+    .with_context(|| "Error during the preparation of the dual msm.")?;
 
     transcript
         .assert_empty()
-        .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
+        .map_err(|_| IvcCircuitError::CertificateProofRejected)
+        .with_context(|| "Transcript is not empty after the dual msm prepare.")?;
 
     if !dual_msm.clone().check(verifier_params) {
-        return Err(IvcCircuitError::CertificateProofRejected.into());
+        return Err(IvcCircuitError::CertificateProofRejected)
+            .with_context(|| "Dual msm check failed");
     }
 
     Ok(dual_msm)

--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -43,6 +43,8 @@ pub(crate) fn verify_and_prepare_accumulator(
     let mut transcript =
         CircuitTranscript::<PoseidonState<CircuitBase>>::init_from_bytes(proof_bytes);
 
+    println!("Preparing the dual msm");
+
     let dual_msm = prepare::<
         CircuitBase,
         KZGCommitmentScheme<Bls12>,
@@ -57,13 +59,18 @@ pub(crate) fn verify_and_prepare_accumulator(
     )
     .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
 
+    println!("Checking the transcript");
+
     transcript
         .assert_empty()
         .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
 
+    println!("Checking the dualMSM");
+
     if !dual_msm.clone().check(verifier_params) {
         return Err(IvcCircuitError::CertificateProofRejected.into());
     }
+    println!("DONE Checking the dualMSM");
 
     Ok(dual_msm)
 }

--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -43,8 +43,6 @@ pub(crate) fn verify_and_prepare_accumulator(
     let mut transcript =
         CircuitTranscript::<PoseidonState<CircuitBase>>::init_from_bytes(proof_bytes);
 
-    println!("Preparing the dual msm");
-
     let dual_msm = prepare::<
         CircuitBase,
         KZGCommitmentScheme<Bls12>,
@@ -59,18 +57,13 @@ pub(crate) fn verify_and_prepare_accumulator(
     )
     .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
 
-    println!("Checking the transcript");
-
     transcript
         .assert_empty()
         .map_err(|_| IvcCircuitError::CertificateProofRejected)?;
 
-    println!("Checking the dualMSM");
-
     if !dual_msm.clone().check(verifier_params) {
         return Err(IvcCircuitError::CertificateProofRejected.into());
     }
-    println!("DONE Checking the dualMSM");
 
     Ok(dual_msm)
 }

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -53,7 +53,7 @@ pub(crate) mod circuit;
 pub(crate) mod config;
 pub(crate) mod errors;
 pub(crate) mod gadget;
-#[cfg(test)]
+// #[cfg(test)]
 pub(crate) mod io;
 #[cfg(test)]
 pub(crate) mod protocol_message;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -53,7 +53,6 @@ pub(crate) mod circuit;
 pub(crate) mod config;
 pub(crate) mod errors;
 pub(crate) mod gadget;
-// #[cfg(test)]
 pub(crate) mod io;
 #[cfg(test)]
 pub(crate) mod protocol_message;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -63,6 +63,8 @@ pub(crate) mod types;
 #[cfg(test)]
 pub(crate) mod tests;
 
+pub(crate) use types::ProtocolMessagePreimage;
+
 type S = BlstrsEmulation;
 type F = <S as SelfEmulation>::F;
 type C = <S as SelfEmulation>::C;

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -2,6 +2,7 @@ use std::collections::BTreeMap;
 
 use ff::Field;
 use group::Group;
+use serde::{Deserialize, Serialize};
 
 use crate::signature_scheme::{SchnorrVerificationKey, StandardSchnorrSignature};
 
@@ -17,7 +18,7 @@ use super::{
     verifier,
 };
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct State {
     pub(crate) step_counter: StepCounter,
     pub(crate) message: MessageHash,

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -4,6 +4,7 @@
 //! elements or bytes at lower circuit/gadget boundaries.
 
 use ff::Field;
+use serde::{Deserialize, Serialize};
 
 use super::{
     F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
@@ -13,7 +14,7 @@ use crate::BaseFieldElement;
 
 macro_rules! field_wrapper {
     ($name:ident, zero) => {
-        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
         pub(crate) struct $name(F);
 
         impl $name {
@@ -52,7 +53,7 @@ field_wrapper!(IvcCircuitVerificationKeyRepresentation);
 
 macro_rules! u64_wrapper {
     ($name:ident) => {
-        #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
         pub(crate) struct $name(u64);
 
         impl $name {
@@ -232,7 +233,7 @@ impl CertificateProofBytes {
 }
 
 /// Provisional recursive proof-byte wrapper until `IvcProof` is wired end-to-end.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct IvcProofBytes(Vec<u8>);
 
 impl IvcProofBytes {

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -87,7 +87,7 @@ u64_wrapper!(EpochNumber);
 u64_wrapper!(StepCounter);
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ProtocolMessagePreimage([u8; PREIMAGE_SIZE]);
+pub(crate) struct ProtocolMessagePreimage(pub(crate) [u8; PREIMAGE_SIZE]);
 
 impl ProtocolMessagePreimage {
     #[cfg(test)]

--- a/mithril-stm/src/proof_system/halo2_snark/circuit_verification_key.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/circuit_verification_key.rs
@@ -6,7 +6,9 @@ use crate::StmResult;
 
 /// Wrapper type of MidnightVK, the circuit verification key
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct CircuitVerificationKey(#[serde(with = "midnight_vk_serde")] MidnightVK);
+pub struct CircuitVerificationKey(
+    #[serde(with = "midnight_certificate_verification_key_serde")] MidnightVK,
+);
 
 impl CircuitVerificationKey {
     /// Creates a new CircuitVerificationKey from a MidnightVK
@@ -39,9 +41,11 @@ impl CircuitVerificationKey {
     }
 }
 
-/// Module implementing serialize and deserialize functions
-/// for the MidnightVK struct
-pub mod midnight_vk_serde {
+/// Serialize and deserialize functions for the certificate circuit [MidnightVK].
+///
+/// [MidnightVK] serialization carries the circuit architecture, so deserialization rebuilds the
+/// correct constraint system and round-trips byte-for-byte.
+pub(crate) mod midnight_certificate_verification_key_serde {
     use midnight_proofs::utils::SerdeFormat;
     use midnight_zk_stdlib::MidnightVK;
     use serde::{Deserializer, Serializer};

--- a/mithril-stm/src/proof_system/halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/mod.rs
@@ -14,6 +14,7 @@ pub use aggregate_key::AggregateVerificationKeyForSnark;
 pub(crate) use aggregate_key::RIGID_SLOT_BYTES;
 #[cfg(test)]
 pub(crate) use circuit_verification_key::CircuitVerificationKey;
+pub(crate) use circuit_verification_key::midnight_certificate_verification_key_serde;
 pub(crate) use clerk::SnarkClerk;
 pub(crate) use eligibility::{
     compute_target_value_for_snark_lottery, compute_winning_lottery_indices,

--- a/mithril-stm/src/proof_system/halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/proof.rs
@@ -110,8 +110,6 @@ impl<D: MembershipDigest> SnarkProof<D> {
         }
     }
 
-    // TODO: remove this allow dead_code directive when the IVC prover consumes this method
-    #[allow(dead_code)]
     pub(crate) fn into_circuit_proof_bytes(self) -> CertificateProofBytes {
         CertificateProofBytes::from_certificate_circuit_proof_bytes(self.circuit_proof)
     }
@@ -148,8 +146,6 @@ impl<D: MembershipDigest> SnarkProof<D> {
     }
 
     /// Returns a reference to the circuit verification key embedded in SNARK proof
-    // TODO: remove this allow dead_code directive when the IVC prover consumes this method
-    #[allow(dead_code)]
     pub(crate) fn circuit_verification_key(&self) -> &CircuitVerificationKey {
         &self.circuit_verification_key
     }
@@ -168,8 +164,6 @@ impl<D: MembershipDigest> SnarkProof<D> {
     /// the off-circuit twin of the one an in-circuit IVC verifier gadget would
     /// compute on the same proof, so it can be wrapped into a certificate
     /// accumulator for recursive aggregation.
-    // TODO: remove this allow dead_code directive when the IVC prover consumes this method
-    #[allow(dead_code)]
     pub(crate) fn prepare_and_check(
         &self,
         message: &[u8],
@@ -246,8 +240,6 @@ impl<D: MembershipDigest> SnarkProof<D> {
 /// The type parameter `R` selects the randomness source used during proof generation.
 /// Use `try_new_non_deterministic` for production (`OsRng`) and `try_new_deterministic` for
 /// reproducible tests.
-// TODO: remove this allow dead_code directive when function is called or future_snark is activated
-#[allow(dead_code)]
 pub struct SnarkProver<R: RngCore + CryptoRng> {
     setup: SnarkSetup,
     rng: R,
@@ -271,7 +263,6 @@ impl SnarkProver<rand_core::OsRng> {
     }
 }
 
-// TODO: remove this allow dead_code directive when function is called or future_snark is activated
 #[cfg(test)]
 impl SnarkProver<ChaCha20Rng> {
     /// Create a new prover with a deterministic randomness source seeded from `seed` (for tests only).
@@ -293,8 +284,6 @@ impl SnarkProver<ChaCha20Rng> {
     }
 }
 
-// TODO: remove this allow dead_code directive when function is called or future_snark is activated
-#[allow(dead_code)]
 impl<R: RngCore + CryptoRng> SnarkProver<R> {
     /// Aggregate a set of single signatures into a SNARK proof.
     ///

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
@@ -33,9 +33,9 @@ pub(crate) enum IvcProofError {
     )]
     InvalidProvingContext,
 
-    /// Mismatch between the protocol messages
+    /// Mismatch between the messages
     #[error(
-        "IVC proof rejected: the protocol message used to create the proof is different from the input message"
+        "IVC proof rejected: the message used to create the proof is different from the input message"
     )]
-    InvalidProtocolMessage,
+    InvalidMessage,
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/errors.rs
@@ -32,4 +32,10 @@ pub(crate) enum IvcProofError {
         "IVC prover called with invalid context: rolling_state must not be a genesis (step_counter == 0) state; pass None to bootstrap from genesis"
     )]
     InvalidProvingContext,
+
+    /// Mismatch between the protocol messages
+    #[error(
+        "IVC proof rejected: the protocol message used to create the proof is different from the input message"
+    )]
+    InvalidProtocolMessage,
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
@@ -14,6 +14,9 @@ pub(crate) mod rolling_state;
 mod unsafe_setup_helpers;
 pub(crate) mod verifier_setup;
 
+pub(crate) use setup::IvcProverSetup;
+pub(crate) use unsafe_setup_helpers::{TempCertificateKeyProvider, TempIvcKeyProvider};
+
 /// PLONK verifying key used across the IVC setup
 /// (certificate and recursive circuits share the same field/curve parameterization).
 pub(crate) type CircuitVerifyingKey = VerifyingKey<CircuitBase, KZGCommitmentScheme<Bls12>>;

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
@@ -14,7 +14,7 @@ pub(crate) mod rolling_state;
 mod unsafe_setup_helpers;
 pub(crate) mod verifier_setup;
 
-pub(crate) use setup::IvcProverSetup;
+pub(crate) use prover_setup::IvcProverSetup;
 pub(crate) use unsafe_setup_helpers::{TempCertificateKeyProvider, TempIvcKeyProvider};
 
 /// PLONK verifying key used across the IVC setup

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
@@ -11,10 +11,12 @@ pub(crate) mod proof;
 mod prover_input;
 mod prover_setup;
 pub(crate) mod rolling_state;
+pub(crate) mod temp_ivc_prover_cache;
 mod unsafe_setup_helpers;
 pub(crate) mod verifier_setup;
 
 pub(crate) use prover_setup::IvcProverSetup;
+pub(crate) use temp_ivc_prover_cache::load_ivc_prover_setup;
 pub(crate) use unsafe_setup_helpers::{TempCertificateKeyProvider, TempIvcKeyProvider};
 
 /// PLONK verifying key used across the IVC setup

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/mod.rs
@@ -10,7 +10,7 @@ pub(crate) mod errors;
 pub(crate) mod proof;
 mod prover_input;
 mod prover_setup;
-mod rolling_state;
+pub(crate) mod rolling_state;
 mod unsafe_setup_helpers;
 pub(crate) mod verifier_setup;
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -835,6 +835,11 @@ mod tests {
             );
             let epoch1_preimage = wrap_protocol_message_preimage(&first_step.message_preimage);
             let bootstrap = genesis_bootstrap(&ctx.asset_setup);
+            println!(
+                "Genesis message preimage: {:?}",
+                bootstrap.genesis_protocol_message_preimage
+            );
+            println!("epoch1_preimage: {:?}", epoch1_preimage);
 
             let mut prover = IvcProver {
                 ivc_setup: Arc::clone(&ctx.ivc_setup),
@@ -960,6 +965,8 @@ mod tests {
             );
             let preimage = wrap_protocol_message_preimage(&step.message_preimage);
 
+            println!("preimage next certificate: {:?}", preimage);
+
             let mut prover = IvcProver {
                 ivc_setup: Arc::clone(&ctx.ivc_setup),
                 rng: OsRng,
@@ -1051,8 +1058,8 @@ mod tests {
                 verification_context,
             };
 
-            run_bootstrap_path(&ctx);
-            run_next_epoch_path(&ctx);
+            // run_bootstrap_path(&ctx);
+            // run_next_epoch_path(&ctx);
             run_same_epoch_path(&ctx);
         }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -551,6 +551,27 @@ mod tests {
     }
 
     #[test]
+    fn ivc_proof_to_from_bytes_round_trip() {
+        let step_output = load_embedded_next_epoch_step_output_asset()
+            .expect("recursive step output asset should load");
+
+        let proof = IvcProof::<blake2b_simd::State>::new(
+            step_output.ivc_proof,
+            step_output.next_state,
+            step_output.next_accumulator,
+        );
+
+        let bytes = proof.to_bytes().expect("serialization should not fail");
+        let restored = IvcProof::<blake2b_simd::State>::from_bytes(&bytes)
+            .expect("deserialization should not fail");
+
+        assert_eq!(
+            bytes,
+            restored.to_bytes().expect("re-serialization should not fail")
+        );
+    }
+
+    #[test]
     fn ivc_proof_message_verification_accepts_correct_message() {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
@@ -674,7 +695,35 @@ mod tests {
     }
 
     #[test]
-    fn ivc_proof_verify_rejects_tampered_message_bytes() {
+    fn ivc_proof_verify_rejects_tampered_message_bytes_with_correct_input_message() {
+        let (global, verifier_setup) = build_proof_verifier_context();
+        let mut step_output = load_embedded_next_epoch_step_output_asset()
+            .expect("recursive step output asset should load");
+
+        let msg = &[
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+        step_output.next_state.message = MessageHash::ZERO;
+
+        let proof = IvcProof::<blake2b_simd::State>::new(
+            step_output.ivc_proof,
+            step_output.next_state,
+            step_output.next_accumulator,
+        );
+
+        let err = proof
+            .verify(msg, &global, &verifier_setup)
+            .expect_err("different protocol message should be rejected by IvcProof::verify");
+        assert_eq!(
+            err.downcast_ref::<IvcProofError>(),
+            Some(&IvcProofError::KzgOpeningFailed),
+            "different protocol message must fail the KZG opening check, got: {err}"
+        );
+    }
+
+    #[test]
+    fn ivc_proof_verify_rejects_tampered_message_bytes_with_tampered_input_message() {
         let (global, verifier_setup) = build_proof_verifier_context();
         let mut step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
@@ -773,6 +822,7 @@ mod tests {
         let chain_state = load_embedded_recursive_chain_state_asset()
             .expect("recursive chain state asset should load");
 
+        // I don't know what the correct bytes are...
         let msg = &[
             22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
             191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -33,6 +33,7 @@ use crate::{
             types::{CertificateProofBytes, IvcProofBytes, ProtocolMessagePreimage},
         },
     },
+    codec,
     proof_system::ivc_halo2_snark::{
         CircuitProvingKey,
         errors::IvcProofError,
@@ -45,8 +46,6 @@ use crate::{
 };
 
 /// Per-session IVC prover handle.
-// TODO: remove this allow dead_code directive when the IVC prover is wired into STM
-#[allow(dead_code)]
 pub(crate) struct IvcProver<R: RngCore + CryptoRng> {
     /// Shared, cached setup (SRS, verifying keys, proving key, fixed-base maps).
     pub(crate) ivc_setup: Arc<IvcProverSetup>,
@@ -58,8 +57,6 @@ pub(crate) struct IvcProver<R: RngCore + CryptoRng> {
 ///
 /// Always supplied to [`IvcProver::prove`] by reference; used only when `rolling_state = None`
 /// (the first certificate) to run the internal genesis IVC step before processing it.
-// TODO: remove this allow dead_code directive when IvcProver::prove is wired into STM
-#[allow(dead_code)]
 pub(crate) struct IvcGenesisBootstrapInput {
     /// Schnorr half of the Lagrange-era dual genesis signature (Ed25519 + Schnorr). Carried
     /// forward through every rolling state for in-circuit verification of the genesis message.
@@ -71,12 +68,14 @@ pub(crate) struct IvcGenesisBootstrapInput {
     pub(crate) genesis_protocol_message_preimage: ProtocolMessagePreimage,
 }
 
+/// Fails if the genesis Schnorr signature is absent
+/// or if the message preimage is not exactly 190 bytes.
 impl TryFrom<&AncillaryGenesisData> for IvcGenesisBootstrapInput {
     type Error = anyhow::Error;
     fn try_from(ancillary_genesis_data: &AncillaryGenesisData) -> StmResult<Self> {
         let genesis_signature = ancillary_genesis_data
             .genesis_schnorr_signature()
-            .ok_or_else(|| anyhow!("Missing genesis signature!"))?;
+            .ok_or_else(|| anyhow!("Missing genesis Schnorr signature."))?;
 
         let genesis_protocol_message_preimage: [u8; 190] =
             ancillary_genesis_data.genesis_message_preimage().try_into()?;
@@ -93,8 +92,6 @@ impl TryFrom<&AncillaryGenesisData> for IvcGenesisBootstrapInput {
 /// `H` is the transcript hash used to produce this proof and must be used to verify it.
 /// It is a zero-cost phantom: no `H`-dependent data is stored, but it prevents accidentally
 /// verifying a Poseidon-produced proof via the Blake2b path and vice versa.
-// TODO: remove this allow dead_code directive when the IVC prover emits this proof
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IvcProof<H: TranscriptHash> {
     /// Externally-verifiable proof bytes.
@@ -113,7 +110,6 @@ impl<H: TranscriptHash> IvcProof<H> {
     ///
     /// `H` is inferred from the prover's own type parameter, so the proof's hash type
     /// is bound to the hash used to produce it without any runtime check.
-    #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn new(
         proof_bytes: IvcProofBytes,
         state: State,
@@ -126,10 +122,24 @@ impl<H: TranscriptHash> IvcProof<H> {
             hash: PhantomData,
         }
     }
+
+    /// Converts a IvcProof to CBOR bytes with a version prefix.
+    pub fn to_bytes(&self) -> StmResult<Vec<u8>> {
+        codec::to_cbor_bytes(self)
+    }
+
+    /// Deserialise an IVC proof from bytes.
+    pub fn from_bytes(bytes: &[u8]) -> StmResult<Self> {
+        if codec::has_cbor_v1_prefix(bytes) {
+            codec::from_cbor_bytes(&bytes[1..])
+        } else {
+            Err(anyhow::anyhow!(
+                "IvcProof: unsupported encoding, expected a CBOR v1 prefix"
+            ))
+        }
+    }
 }
 
-// TODO: remove this allow dead_code directive when IvcProof::verify is called
-#[allow(dead_code)]
 impl<H: TranscriptHash> IvcProof<H>
 where
     CircuitBase: Sampleable<H> + Hashable<H>,
@@ -239,8 +249,6 @@ fn ensure_advanceable_rolling_state(rolling_state: Option<&IvcRollingState>) -> 
     Ok(())
 }
 
-// TODO: remove this allow dead_code directive when the IVC prover is wired into STM
-#[allow(dead_code)]
 impl<R: RngCore + CryptoRng> IvcProver<R> {
     /// Advances the IVC chain by one step.
     ///
@@ -1051,8 +1059,8 @@ mod tests {
                 verification_context,
             };
 
-            // run_bootstrap_path(&ctx);
-            // run_next_epoch_path(&ctx);
+            run_bootstrap_path(&ctx);
+            run_next_epoch_path(&ctx);
             run_same_epoch_path(&ctx);
         }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -492,6 +492,21 @@ mod tests {
 
     use super::IvcProof;
 
+    const STEP_OUTPUT_MSG: [u8; 32] = [
+        22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+        191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+    ];
+
+    const SAME_EPOCH_MSG: [u8; 32] = [
+        147, 84, 244, 74, 250, 60, 153, 155, 8, 94, 236, 150, 53, 39, 132, 61, 99, 153, 192, 207,
+        20, 90, 16, 130, 216, 12, 87, 134, 230, 4, 190, 175,
+    ];
+
+    const CHAIN_STATE_MSG: [u8; 32] = [
+        253, 10, 116, 221, 249, 84, 222, 35, 101, 84, 229, 73, 90, 91, 97, 173, 36, 63, 47, 98,
+        189, 1, 99, 75, 183, 186, 225, 31, 226, 29, 121, 122,
+    ];
+
     fn build_proof_verifier_context() -> (Global, IvcVerifierSetup) {
         let ctx = load_embedded_verification_context_asset()
             .expect("verification context asset should load");
@@ -520,11 +535,6 @@ mod tests {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let msg = &[
-            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
-
         let setup = build_asset_generation_setup();
         let global = build_recursive_global(
             &setup,
@@ -546,7 +556,7 @@ mod tests {
         );
 
         proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(&STEP_OUTPUT_MSG, &global, &verifier_setup)
             .expect("stored recursive step output should pass IvcProof::verify");
     }
 
@@ -576,11 +586,6 @@ mod tests {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let msg = &[
-            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
-
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
             step_output.next_state,
@@ -588,7 +593,7 @@ mod tests {
         );
 
         proof
-            .check_input_message_matches_state_message(msg)
+            .check_input_message_matches_state_message(&STEP_OUTPUT_MSG)
             .expect("Correct message should be accepted by verification function");
     }
 
@@ -597,10 +602,8 @@ mod tests {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let wrong_msg = &[
-            21, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
+        let mut wrong_msg = STEP_OUTPUT_MSG;
+        wrong_msg[0] ^= 0xff;
 
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
@@ -609,7 +612,7 @@ mod tests {
         );
 
         let err = proof
-            .check_input_message_matches_state_message(wrong_msg)
+            .check_input_message_matches_state_message(&wrong_msg)
             .expect_err("wrong message should be rejected by verification function");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -625,10 +628,8 @@ mod tests {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let wrong_msg = &[
-            21, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
+        let mut wrong_msg = STEP_OUTPUT_MSG;
+        wrong_msg[0] ^= 0xff;
 
         let setup = build_asset_generation_setup();
         let global = build_recursive_global(
@@ -651,7 +652,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(wrong_msg, &global, &verifier_setup)
+            .verify(&wrong_msg, &global, &verifier_setup)
             .expect_err("tampered message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -669,11 +670,6 @@ mod tests {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let msg = &[
-            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
-
         let mut tampered_bytes = step_output.ivc_proof.as_bytes().to_vec();
         let mid = tampered_bytes.len() / 2;
         tampered_bytes[mid] ^= 0xff;
@@ -685,7 +681,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(&STEP_OUTPUT_MSG, &global, &verifier_setup)
             .expect_err("tampered proof bytes should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -700,10 +696,6 @@ mod tests {
         let mut step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let msg = &[
-            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
         step_output.next_state.message = MessageHash::ZERO;
 
         let proof = IvcProof::<blake2b_simd::State>::new(
@@ -713,7 +705,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(&STEP_OUTPUT_MSG, &global, &verifier_setup)
             .expect_err("different protocol message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -760,11 +752,6 @@ mod tests {
         let same_epoch = load_embedded_following_certificate_in_epoch_asset()
             .expect("same-epoch step output asset should load");
 
-        let msg = &[
-            147, 84, 244, 74, 250, 60, 153, 155, 8, 94, 236, 150, 53, 39, 132, 61, 99, 153, 192,
-            207, 20, 90, 16, 130, 216, 12, 87, 134, 230, 4, 190, 175,
-        ];
-
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
             same_epoch.next_state,
@@ -772,7 +759,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(&SAME_EPOCH_MSG, &global, &verifier_setup)
             .expect_err("state from a different proof should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -792,18 +779,13 @@ mod tests {
         let same_epoch = load_embedded_following_certificate_in_epoch_asset()
             .expect("same-epoch step output asset should load");
 
-        let msg = &[
-            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
-
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
             step_output.next_state,
             same_epoch.next_accumulator,
         );
 
-        let err = proof.verify(msg, &global, &verifier_setup).expect_err(
+        let err = proof.verify(&STEP_OUTPUT_MSG, &global, &verifier_setup).expect_err(
             "accumulator from a different proof should be rejected by IvcProof::verify",
         );
         assert_eq!(
@@ -822,12 +804,6 @@ mod tests {
         let chain_state = load_embedded_recursive_chain_state_asset()
             .expect("recursive chain state asset should load");
 
-        // I don't know what the correct bytes are...
-        let msg = &[
-            253, 10, 116, 221, 249, 84, 222, 35, 101, 84, 229, 73, 90, 91, 97, 173, 36, 63, 47, 98,
-            189, 1, 99, 75, 183, 186, 225, 31, 226, 29, 121, 122,
-        ];
-
         let proof = IvcProof::<blake2b_simd::State>::new(
             chain_state.ivc_proof,
             chain_state.state,
@@ -835,7 +811,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(&CHAIN_STATE_MSG, &global, &verifier_setup)
             .expect_err("Poseidon proof bytes should be rejected by IvcProof::<Blake2b>::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -865,10 +841,6 @@ mod tests {
             ctx.recursive_verifying_key,
             ctx.combined_fixed_bases,
         );
-        let msg = &[
-            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-        ];
 
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
@@ -877,7 +849,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(&STEP_OUTPUT_MSG, &global, &verifier_setup)
             .expect_err("wrong tau_g2 should cause the accumulator pairing check to fail");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -710,6 +710,7 @@ mod tests {
         use midnight_circuits::{
             hash::poseidon::PoseidonState, verifier::Accumulator, verifier::BlstrsEmulation,
         };
+        use midnight_proofs::poly::commitment::Params;
         use midnight_proofs::utils::SerdeFormat;
         use rand_core::OsRng;
         use tempfile::tempdir;
@@ -1053,6 +1054,55 @@ mod tests {
             run_bootstrap_path(&ctx);
             run_next_epoch_path(&ctx);
             run_same_epoch_path(&ctx);
+        }
+
+        // The IVC circuit is degree `K`, but production builds its setup from the larger degree-22
+        // SRS. Keygen and the stored proving SRS must both downsize to `K`, otherwise their Lagrange
+        // basis differs and proofs do not verify. A larger unsafe SRS shares the smaller one's tau,
+        // so a correctly downsized setup reproduces the embedded degree-`K` assets exactly.
+        #[test]
+        fn ivc_setup_downsizes_keys_and_srs_to_the_circuit_degree() {
+            let temp_dir = tempdir().expect("temp dir creation should succeed");
+            let trusted_setup_provider = build_provider_with_unsafe_srs(temp_dir.path(), K + 1);
+            let srs = Arc::new(
+                trusted_setup_provider
+                    .get_trusted_setup_parameters()
+                    .expect("oversized unsafe SRS should load"),
+            );
+            let parameters = Parameters {
+                k: QUORUM_SIZE as u64,
+                m: (QUORUM_SIZE * 10) as u64,
+                phi_f: 0.2,
+            };
+            let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
+            let cert_provider =
+                TempCertificateKeyProvider::new(Arc::clone(&srs), parameters, merkle_tree_depth);
+            let cert_vk = cert_provider
+                .get_verifying_key()
+                .expect("certificate verifying key keygen should succeed");
+            let ivc_provider = TempIvcKeyProvider::new(srs, cert_vk);
+            let ivc_setup =
+                IvcProverSetup::load(&trusted_setup_provider, &cert_provider, &ivc_provider)
+                    .expect("IvcProverSetup::load should succeed");
+
+            let verification_context = load_embedded_verification_context_asset()
+                .expect("verification context asset should load");
+
+            assert_eq!(
+                verification_context.certificate_verifying_key.vk().transcript_repr(),
+                ivc_setup.certificate_verifying_key.transcript_repr(),
+                "cert VK must be independent of the SRS degree (downsized at keygen)"
+            );
+            assert_eq!(
+                verification_context.recursive_verifying_key.transcript_repr(),
+                ivc_setup.ivc_verifying_key.transcript_repr(),
+                "IVC VK must be independent of the SRS degree (downsized at keygen)"
+            );
+            assert_eq!(
+                ivc_setup.srs.max_k(),
+                K,
+                "the proving SRS stored in IvcProverSetup must be downsized to the IVC circuit degree"
+            );
         }
     }
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -96,7 +96,7 @@ impl TryFrom<&AncillaryGenesisData> for IvcGenesisBootstrapInput {
 // TODO: remove this allow dead_code directive when the IVC prover emits this proof
 #[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub(crate) struct IvcProof<H: TranscriptHash> {
+pub struct IvcProof<H: TranscriptHash> {
     /// Externally-verifiable proof bytes.
     proof_bytes: IvcProofBytes,
     /// Chain state the proof commits to.

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -835,11 +835,6 @@ mod tests {
             );
             let epoch1_preimage = wrap_protocol_message_preimage(&first_step.message_preimage);
             let bootstrap = genesis_bootstrap(&ctx.asset_setup);
-            println!(
-                "Genesis message preimage: {:?}",
-                bootstrap.genesis_protocol_message_preimage
-            );
-            println!("epoch1_preimage: {:?}", epoch1_preimage);
 
             let mut prover = IvcProver {
                 ivc_setup: Arc::clone(&ctx.ivc_setup),
@@ -964,8 +959,6 @@ mod tests {
                 &ctx.verification_context,
             );
             let preimage = wrap_protocol_message_preimage(&step.message_preimage);
-
-            println!("preimage next certificate: {:?}", preimage);
 
             let mut prover = IvcProver {
                 ivc_setup: Arc::clone(&ctx.ivc_setup),

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -19,6 +19,7 @@ use midnight_proofs::{
     transcript::{CircuitTranscript, Hashable, Sampleable, Transcript, TranscriptHash},
 };
 use rand_core::{CryptoRng, RngCore};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     AggregateVerificationKeyForSnark, MembershipDigest, SnarkProof, StmResult,
@@ -30,6 +31,7 @@ use crate::{
             types::{CertificateProofBytes, IvcProofBytes, ProtocolMessagePreimage},
         },
     },
+    proof_system::ivc_halo2_snark::rolling_state::midnight_accumulator_serde,
     proof_system::ivc_halo2_snark::{
         CircuitProvingKey, errors::IvcProofError, prover_input::IvcProverInput,
         prover_setup::IvcProverSetup, rolling_state::IvcRollingState,
@@ -72,12 +74,14 @@ pub(crate) struct IvcGenesisBootstrapInput {
 /// verifying a Poseidon-produced proof via the Blake2b path and vice versa.
 // TODO: remove this allow dead_code directive when the IVC prover emits this proof
 #[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct IvcProof<H: TranscriptHash> {
     /// Externally-verifiable proof bytes.
     proof_bytes: IvcProofBytes,
     /// Chain state the proof commits to.
     state: State,
     /// Folded accumulator the proof commits to.
+    #[serde(with = "midnight_accumulator_serde")]
     accumulator: Accumulator<BlstrsEmulation>,
     /// Phantom marker tying the proof to its transcript hash type.
     hash: PhantomData<H>,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -2,6 +2,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
+use anyhow::anyhow;
 use ff::FromUniformBytes;
 use group::Group;
 use midnight_circuits::{
@@ -22,7 +23,8 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AggregateVerificationKeyForSnark, MembershipDigest, SnarkProof, StmResult,
+    AggregateVerificationKeyForSnark, AncillaryGenesisData, MembershipDigest, SnarkProof,
+    StmResult,
     circuits::{
         halo2::types::CircuitBase,
         halo2_ivc::{
@@ -31,10 +33,12 @@ use crate::{
             types::{CertificateProofBytes, IvcProofBytes, ProtocolMessagePreimage},
         },
     },
-    proof_system::ivc_halo2_snark::rolling_state::midnight_accumulator_serde,
     proof_system::ivc_halo2_snark::{
-        CircuitProvingKey, errors::IvcProofError, prover_input::IvcProverInput,
-        prover_setup::IvcProverSetup, rolling_state::IvcRollingState,
+        CircuitProvingKey,
+        errors::IvcProofError,
+        prover_input::IvcProverInput,
+        prover_setup::IvcProverSetup,
+        rolling_state::{IvcRollingState, midnight_accumulator_serde},
         verifier_setup::IvcVerifierSetup,
     },
     signature_scheme::StandardSchnorrSignature,
@@ -65,6 +69,23 @@ pub(crate) struct IvcGenesisBootstrapInput {
     /// step to set the lookahead fields in the genesis output state.
     /// Populated from `AncillaryGenesisData::genesis_message_preimage()` (see issue #3141).
     pub(crate) genesis_protocol_message_preimage: ProtocolMessagePreimage,
+}
+
+impl TryFrom<&AncillaryGenesisData> for IvcGenesisBootstrapInput {
+    type Error = anyhow::Error;
+    fn try_from(ancillary_genesis_data: &AncillaryGenesisData) -> StmResult<Self> {
+        let genesis_signature = ancillary_genesis_data
+            .genesis_schnorr_signature()
+            .ok_or_else(|| anyhow!("Missing genesis signature!"))?;
+
+        let genesis_protocol_message_preimage: [u8; 190] =
+            ancillary_genesis_data.genesis_message_preimage().try_into()?;
+
+        Ok(Self {
+            genesis_protocol_message_preimage: genesis_protocol_message_preimage.into(),
+            genesis_signature: *genesis_signature,
+        })
+    }
 }
 
 /// IVC proof emitted at the end of a proving step.

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -2,7 +2,7 @@
 
 use std::{marker::PhantomData, sync::Arc};
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use ff::FromUniformBytes;
 use group::Group;
 use midnight_circuits::{
@@ -23,14 +23,15 @@ use rand_core::{CryptoRng, RngCore};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    AggregateVerificationKeyForSnark, AncillaryGenesisData, MembershipDigest, SnarkProof,
-    StmResult,
+    AggregateVerificationKeyForSnark, AncillaryGenesisData, BaseFieldElement, MembershipDigest,
+    SnarkProof, StmResult,
     circuits::{
         halo2::types::CircuitBase,
         halo2_ivc::{
+            PREIMAGE_SIZE,
             circuit::IvcCircuitData,
             state::{Global, State},
-            types::{CertificateProofBytes, IvcProofBytes, ProtocolMessagePreimage},
+            types::{CertificateProofBytes, IvcProofBytes, MessageHash, ProtocolMessagePreimage},
         },
     },
     codec,
@@ -69,7 +70,7 @@ pub(crate) struct IvcGenesisBootstrapInput {
 }
 
 /// Fails if the genesis Schnorr signature is absent
-/// or if the message preimage is not exactly 190 bytes.
+/// or if the message preimage is not exactly PREIMAGE_SIZE bytes.
 impl TryFrom<&AncillaryGenesisData> for IvcGenesisBootstrapInput {
     type Error = anyhow::Error;
     fn try_from(ancillary_genesis_data: &AncillaryGenesisData) -> StmResult<Self> {
@@ -77,8 +78,11 @@ impl TryFrom<&AncillaryGenesisData> for IvcGenesisBootstrapInput {
             .genesis_schnorr_signature()
             .ok_or_else(|| anyhow!("Missing genesis Schnorr signature."))?;
 
-        let genesis_protocol_message_preimage: [u8; 190] =
-            ancillary_genesis_data.genesis_message_preimage().try_into()?;
+        let genesis_protocol_message_preimage: [u8; PREIMAGE_SIZE] = ancillary_genesis_data
+            .genesis_message_preimage()
+            .0
+            .as_slice()
+            .try_into()?;
 
         Ok(Self {
             genesis_protocol_message_preimage: genesis_protocol_message_preimage.into(),
@@ -159,9 +163,11 @@ where
     /// proof transcript and verification will return [`IvcProofError::KzgOpeningFailed`].
     pub(crate) fn verify(
         &self,
+        msg: &[u8],
         global: &Global,
         verifier_setup: &IvcVerifierSetup,
     ) -> StmResult<()> {
+        self.input_message_matches_state_message(msg)?;
         let public_inputs: Vec<CircuitBase> = [
             global.as_public_input(),
             self.state.as_public_input(),
@@ -192,6 +198,33 @@ where
             verifier_setup.combined_fixed_bases(),
         ) {
             return Err(IvcProofError::AccumulatorFailed.into());
+        }
+
+        Ok(())
+    }
+
+    /// Verifies that the input protocol message is the same as the one used to generate
+    /// the proof.
+    ///
+    /// Returns an error if the input message has a wrong format, cannot be converted to a field
+    /// element or is different from the message store in the proof state.
+    fn input_message_matches_state_message(&self, msg: &[u8]) -> StmResult<()> {
+        let mut msg_bytes = [0u8; 32];
+        match TryInto::<[u8; 32]>::try_into(msg) {
+            Ok(bytes) => msg_bytes = bytes,
+            Err(_) => {
+                // If the message is not 32 bytes, try to decode it as hex.
+                hex::decode_to_slice(msg, &mut msg_bytes).with_context(
+                || "Message must be exactly 32 bytes hex encoded in 64 bytes if it is not exactly 32 bytes.",
+            )?;
+            }
+        }
+
+        let message_as_base_field_element = BaseFieldElement::from_raw(&msg_bytes)
+            .with_context(|| "Failed to convert message to BaseFieldElement.")?;
+
+        if self.state.message != MessageHash::from_field(message_as_base_field_element.0) {
+            return Err(IvcProofError::InvalidProtocolMessage.into());
         }
 
         Ok(())
@@ -452,7 +485,7 @@ mod tests {
                 },
                 generators::{build_asset_generation_setup, build_recursive_global},
             },
-            types::IvcProofBytes,
+            types::{IvcProofBytes, MessageHash},
         },
         proof_system::ivc_halo2_snark::{errors::IvcProofError, verifier_setup::IvcVerifierSetup},
     };
@@ -487,6 +520,11 @@ mod tests {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
+        let msg = &[
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+
         let setup = build_asset_generation_setup();
         let global = build_recursive_global(
             &setup,
@@ -508,8 +546,97 @@ mod tests {
         );
 
         proof
-            .verify(&global, &verifier_setup)
+            .verify(msg, &global, &verifier_setup)
             .expect("stored recursive step output should pass IvcProof::verify");
+    }
+
+    #[test]
+    fn ivc_proof_message_verification_accepts_correct_message() {
+        let step_output = load_embedded_next_epoch_step_output_asset()
+            .expect("recursive step output asset should load");
+
+        let msg = &[
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+
+        let proof = IvcProof::<blake2b_simd::State>::new(
+            step_output.ivc_proof,
+            step_output.next_state,
+            step_output.next_accumulator,
+        );
+
+        proof
+            .input_message_matches_state_message(msg)
+            .expect("Correct message should be accepted by verification function");
+    }
+
+    #[test]
+    fn ivc_proof_message_verification_rejects_wrong_message() {
+        let step_output = load_embedded_next_epoch_step_output_asset()
+            .expect("recursive step output asset should load");
+
+        let msg = &[
+            21, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+
+        let proof = IvcProof::<blake2b_simd::State>::new(
+            step_output.ivc_proof,
+            step_output.next_state,
+            step_output.next_accumulator,
+        );
+
+        let err = proof
+            .input_message_matches_state_message(msg)
+            .expect_err("wrong message should be rejected by verification function");
+        assert_eq!(
+            err.downcast_ref::<IvcProofError>(),
+            Some(&IvcProofError::InvalidProtocolMessage),
+            "wrong message must be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn ivc_proof_verify_rejects_wrong_input_message() {
+        let verification_context = load_embedded_verification_context_asset()
+            .expect("verification context asset should load");
+        let step_output = load_embedded_next_epoch_step_output_asset()
+            .expect("recursive step output asset should load");
+
+        let msg = &[
+            21, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+
+        let setup = build_asset_generation_setup();
+        let global = build_recursive_global(
+            &setup,
+            &verification_context.certificate_verifying_key,
+            &verification_context.recursive_verifying_key,
+        );
+
+        let verifier_setup = IvcVerifierSetup::from_parts(
+            verification_context.verifier_params,
+            verification_context.verifier_tau_in_g2,
+            verification_context.recursive_verifying_key,
+            verification_context.combined_fixed_bases,
+        );
+
+        let proof = IvcProof::<blake2b_simd::State>::new(
+            step_output.ivc_proof,
+            step_output.next_state,
+            step_output.next_accumulator,
+        );
+
+        let err = proof
+            .verify(msg, &global, &verifier_setup)
+            .expect_err("tampered message should be rejected by IvcProof::verify");
+        assert_eq!(
+            err.downcast_ref::<IvcProofError>(),
+            Some(&IvcProofError::InvalidProtocolMessage),
+            "tampered message must fail the KZG opening check, got: {err}"
+        );
     }
 
     #[test]
@@ -520,6 +647,11 @@ mod tests {
         let (global, verifier_setup) = build_proof_verifier_context();
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
+
+        let msg = &[
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
 
         let mut tampered_bytes = step_output.ivc_proof.as_bytes().to_vec();
         let mid = tampered_bytes.len() / 2;
@@ -532,12 +664,39 @@ mod tests {
         );
 
         let err = proof
-            .verify(&global, &verifier_setup)
+            .verify(msg, &global, &verifier_setup)
             .expect_err("tampered proof bytes should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
             Some(&IvcProofError::KzgOpeningFailed),
             "tampered bytes must fail the KZG opening check, got: {err}"
+        );
+    }
+
+    #[test]
+    fn ivc_proof_verify_rejects_tampered_message_bytes() {
+        let (global, verifier_setup) = build_proof_verifier_context();
+        let mut step_output = load_embedded_next_epoch_step_output_asset()
+            .expect("recursive step output asset should load");
+
+        // Set the message and the MessageHash to zero so they match between
+        // them but they don't match what was used to create the proof
+        let msg = &[0u8; 32];
+        step_output.next_state.message = MessageHash::ZERO;
+
+        let proof = IvcProof::<blake2b_simd::State>::new(
+            step_output.ivc_proof,
+            step_output.next_state,
+            step_output.next_accumulator,
+        );
+
+        let err = proof
+            .verify(msg, &global, &verifier_setup)
+            .expect_err("different protocol message should be rejected by IvcProof::verify");
+        assert_eq!(
+            err.downcast_ref::<IvcProofError>(),
+            Some(&IvcProofError::KzgOpeningFailed),
+            "different protocol message must fail the KZG opening check, got: {err}"
         );
     }
 
@@ -552,6 +711,11 @@ mod tests {
         let same_epoch = load_embedded_following_certificate_in_epoch_asset()
             .expect("same-epoch step output asset should load");
 
+        let msg = &[
+            147, 84, 244, 74, 250, 60, 153, 155, 8, 94, 236, 150, 53, 39, 132, 61, 99, 153, 192,
+            207, 20, 90, 16, 130, 216, 12, 87, 134, 230, 4, 190, 175,
+        ];
+
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
             same_epoch.next_state,
@@ -559,7 +723,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(&global, &verifier_setup)
+            .verify(msg, &global, &verifier_setup)
             .expect_err("state from a different proof should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -579,13 +743,18 @@ mod tests {
         let same_epoch = load_embedded_following_certificate_in_epoch_asset()
             .expect("same-epoch step output asset should load");
 
+        let msg = &[
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
             step_output.next_state,
             same_epoch.next_accumulator,
         );
 
-        let err = proof.verify(&global, &verifier_setup).expect_err(
+        let err = proof.verify(msg, &global, &verifier_setup).expect_err(
             "accumulator from a different proof should be rejected by IvcProof::verify",
         );
         assert_eq!(
@@ -604,6 +773,11 @@ mod tests {
         let chain_state = load_embedded_recursive_chain_state_asset()
             .expect("recursive chain state asset should load");
 
+        let msg = &[
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+
         let proof = IvcProof::<blake2b_simd::State>::new(
             chain_state.ivc_proof,
             chain_state.state,
@@ -611,7 +785,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(&global, &verifier_setup)
+            .verify(msg, &global, &verifier_setup)
             .expect_err("Poseidon proof bytes should be rejected by IvcProof::<Blake2b>::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -641,6 +815,10 @@ mod tests {
             ctx.recursive_verifying_key,
             ctx.combined_fixed_bases,
         );
+        let msg = &[
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
 
         let proof = IvcProof::<blake2b_simd::State>::new(
             step_output.ivc_proof,
@@ -649,7 +827,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(&global, &verifier_setup)
+            .verify(msg, &global, &verifier_setup)
             .expect_err("wrong tau_g2 should cause the accumulator pairing check to fail");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -874,7 +1052,11 @@ mod tests {
             );
 
             blake2b_proof
-                .verify(&ctx.global, &ctx.verifier_setup)
+                .verify(
+                    first_step.message.as_ref(),
+                    &ctx.global,
+                    &ctx.verifier_setup,
+                )
                 .expect("bootstrap Blake2b proof must verify");
 
             IvcProof::<PoseidonState<CircuitBase>>::new(
@@ -882,7 +1064,11 @@ mod tests {
                 epoch1_rolling.state().clone(),
                 epoch1_rolling.accumulator().clone(),
             )
-            .verify(&ctx.global, &ctx.verifier_setup)
+            .verify(
+                first_step.message.as_ref(),
+                &ctx.global,
+                &ctx.verifier_setup,
+            )
             .expect("bootstrap Poseidon proof must verify");
 
             println!("[bootstrap] {:.1}s", t.elapsed().as_secs_f64());
@@ -938,7 +1124,7 @@ mod tests {
             );
 
             blake2b_proof
-                .verify(&ctx.global, &ctx.verifier_setup)
+                .verify(step.message.as_ref(), &ctx.global, &ctx.verifier_setup)
                 .expect("next-epoch Blake2b proof must verify");
 
             IvcProof::<PoseidonState<CircuitBase>>::new(
@@ -946,7 +1132,7 @@ mod tests {
                 next_rolling.state().clone(),
                 next_rolling.accumulator().clone(),
             )
-            .verify(&ctx.global, &ctx.verifier_setup)
+            .verify(step.message.as_ref(), &ctx.global, &ctx.verifier_setup)
             .expect("next-epoch Poseidon proof must verify");
 
             println!("[next-epoch] {:.1}s", t.elapsed().as_secs_f64());
@@ -995,7 +1181,7 @@ mod tests {
             );
 
             blake2b_proof
-                .verify(&ctx.global, &ctx.verifier_setup)
+                .verify(step.message.as_ref(), &ctx.global, &ctx.verifier_setup)
                 .expect("same-epoch Blake2b proof must verify");
 
             println!("[same-epoch] {:.1}s", t.elapsed().as_secs_f64());

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -597,7 +597,7 @@ mod tests {
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let msg = &[
+        let wrong_msg = &[
             21, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
             191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
         ];
@@ -609,7 +609,7 @@ mod tests {
         );
 
         let err = proof
-            .check_input_message_matches_state_message(msg)
+            .check_input_message_matches_state_message(wrong_msg)
             .expect_err("wrong message should be rejected by verification function");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -619,13 +619,13 @@ mod tests {
     }
 
     #[test]
-    fn ivc_proof_verify_rejects_wrong_input_message() {
+    fn ivc_proof_verify_rejects_wrong_message() {
         let verification_context = load_embedded_verification_context_asset()
             .expect("verification context asset should load");
         let step_output = load_embedded_next_epoch_step_output_asset()
             .expect("recursive step output asset should load");
 
-        let msg = &[
+        let wrong_msg = &[
             21, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
             191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
         ];
@@ -651,7 +651,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(wrong_msg, &global, &verifier_setup)
             .expect_err("tampered message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -717,7 +717,7 @@ mod tests {
             .expect_err("different protocol message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::KzgOpeningFailed),
+            Some(&IvcProofError::InvalidMessage),
             "different protocol message must fail the KZG opening check, got: {err}"
         );
     }
@@ -730,7 +730,7 @@ mod tests {
 
         // Set the message and the MessageHash to zero so they match between
         // them but they don't match what was used to create the proof
-        let msg = &[0u8; 32];
+        let tampered_msg = &[0u8; 32];
         step_output.next_state.message = MessageHash::ZERO;
 
         let proof = IvcProof::<blake2b_simd::State>::new(
@@ -740,7 +740,7 @@ mod tests {
         );
 
         let err = proof
-            .verify(msg, &global, &verifier_setup)
+            .verify(tampered_msg, &global, &verifier_setup)
             .expect_err("different protocol message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
@@ -824,8 +824,8 @@ mod tests {
 
         // I don't know what the correct bytes are...
         let msg = &[
-            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
-            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+            253, 10, 116, 221, 249, 84, 222, 35, 101, 84, 229, 73, 90, 91, 97, 173, 36, 63, 47, 98,
+            189, 1, 99, 75, 183, 186, 225, 31, 226, 29, 121, 122,
         ];
 
         let proof = IvcProof::<blake2b_simd::State>::new(

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/proof.rs
@@ -167,7 +167,7 @@ where
         global: &Global,
         verifier_setup: &IvcVerifierSetup,
     ) -> StmResult<()> {
-        self.input_message_matches_state_message(msg)?;
+        self.check_input_message_matches_state_message(msg)?;
         let public_inputs: Vec<CircuitBase> = [
             global.as_public_input(),
             self.state.as_public_input(),
@@ -208,7 +208,7 @@ where
     ///
     /// Returns an error if the input message has a wrong format, cannot be converted to a field
     /// element or is different from the message store in the proof state.
-    fn input_message_matches_state_message(&self, msg: &[u8]) -> StmResult<()> {
+    fn check_input_message_matches_state_message(&self, msg: &[u8]) -> StmResult<()> {
         let mut msg_bytes = [0u8; 32];
         match TryInto::<[u8; 32]>::try_into(msg) {
             Ok(bytes) => msg_bytes = bytes,
@@ -224,7 +224,7 @@ where
             .with_context(|| "Failed to convert message to BaseFieldElement.")?;
 
         if self.state.message != MessageHash::from_field(message_as_base_field_element.0) {
-            return Err(IvcProofError::InvalidProtocolMessage.into());
+            return Err(IvcProofError::InvalidMessage.into());
         }
 
         Ok(())
@@ -588,7 +588,7 @@ mod tests {
         );
 
         proof
-            .input_message_matches_state_message(msg)
+            .check_input_message_matches_state_message(msg)
             .expect("Correct message should be accepted by verification function");
     }
 
@@ -609,11 +609,11 @@ mod tests {
         );
 
         let err = proof
-            .input_message_matches_state_message(msg)
+            .check_input_message_matches_state_message(msg)
             .expect_err("wrong message should be rejected by verification function");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::InvalidProtocolMessage),
+            Some(&IvcProofError::InvalidMessage),
             "wrong message must be rejected, got: {err}"
         );
     }
@@ -655,7 +655,7 @@ mod tests {
             .expect_err("tampered message should be rejected by IvcProof::verify");
         assert_eq!(
             err.downcast_ref::<IvcProofError>(),
-            Some(&IvcProofError::InvalidProtocolMessage),
+            Some(&IvcProofError::InvalidMessage),
             "tampered message must fail the KZG opening check, got: {err}"
         );
     }
@@ -946,7 +946,6 @@ mod tests {
         use midnight_circuits::{
             hash::poseidon::PoseidonState, verifier::Accumulator, verifier::BlstrsEmulation,
         };
-        use midnight_proofs::poly::commitment::Params;
         use midnight_proofs::utils::SerdeFormat;
         use rand_core::OsRng;
         use tempfile::tempdir;
@@ -1298,55 +1297,6 @@ mod tests {
             run_bootstrap_path(&ctx);
             run_next_epoch_path(&ctx);
             run_same_epoch_path(&ctx);
-        }
-
-        // The IVC circuit is degree `K`, but production builds its setup from the larger degree-22
-        // SRS. Keygen and the stored proving SRS must both downsize to `K`, otherwise their Lagrange
-        // basis differs and proofs do not verify. A larger unsafe SRS shares the smaller one's tau,
-        // so a correctly downsized setup reproduces the embedded degree-`K` assets exactly.
-        #[test]
-        fn ivc_setup_downsizes_keys_and_srs_to_the_circuit_degree() {
-            let temp_dir = tempdir().expect("temp dir creation should succeed");
-            let trusted_setup_provider = build_provider_with_unsafe_srs(temp_dir.path(), K + 1);
-            let srs = Arc::new(
-                trusted_setup_provider
-                    .get_trusted_setup_parameters()
-                    .expect("oversized unsafe SRS should load"),
-            );
-            let parameters = Parameters {
-                k: QUORUM_SIZE as u64,
-                m: (QUORUM_SIZE * 10) as u64,
-                phi_f: 0.2,
-            };
-            let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
-            let cert_provider =
-                TempCertificateKeyProvider::new(Arc::clone(&srs), parameters, merkle_tree_depth);
-            let cert_vk = cert_provider
-                .get_verifying_key()
-                .expect("certificate verifying key keygen should succeed");
-            let ivc_provider = TempIvcKeyProvider::new(srs, cert_vk);
-            let ivc_setup =
-                IvcProverSetup::load(&trusted_setup_provider, &cert_provider, &ivc_provider)
-                    .expect("IvcProverSetup::load should succeed");
-
-            let verification_context = load_embedded_verification_context_asset()
-                .expect("verification context asset should load");
-
-            assert_eq!(
-                verification_context.certificate_verifying_key.vk().transcript_repr(),
-                ivc_setup.certificate_verifying_key.transcript_repr(),
-                "cert VK must be independent of the SRS degree (downsized at keygen)"
-            );
-            assert_eq!(
-                verification_context.recursive_verifying_key.transcript_repr(),
-                ivc_setup.ivc_verifying_key.transcript_repr(),
-                "IVC VK must be independent of the SRS degree (downsized at keygen)"
-            );
-            assert_eq!(
-                ivc_setup.srs.max_k(),
-                K,
-                "the proving SRS stored in IvcProverSetup must be downsized to the IVC circuit degree"
-            );
         }
     }
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -22,8 +22,6 @@ use crate::{
 };
 
 /// Pre-circuit inputs consumed by the IVC prover's circuit-construction and proof-generation steps.
-// TODO: remove this allow dead_code directive when the IVC prover consumes this input
-#[allow(dead_code)]
 #[derive(Debug)]
 pub(crate) struct IvcProverInput {
     /// In-circuit witness for the new step.
@@ -34,8 +32,6 @@ pub(crate) struct IvcProverInput {
     pub(crate) next_accumulator: Accumulator<BlstrsEmulation>,
 }
 
-// TODO: remove this allow dead_code directive when the IVC prover consumes this input
-#[allow(dead_code)]
 impl IvcProverInput {
     /// Advances the chain state by one step and bundles the in-circuit witness, the
     /// new state, and the new folded accumulator.

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -54,6 +54,8 @@ impl IvcProverInput {
         rolling_state: &IvcRollingState,
         setup: &IvcProverSetup,
     ) -> StmResult<Self> {
+        println!("Entering prepare function");
+
         let chain_epoch = rolling_state.state().current_epoch;
         let certificate_epoch = protocol_message_preimage.current_epoch();
 
@@ -66,6 +68,8 @@ impl IvcProverInput {
         // signature, build the base-case witness/state, and pass the rolling state's
         // trivial accumulator through unchanged.
         if is_genesis {
+            println!("Preparing the genesis");
+
             rolling_state.verify_genesis_signature(global)?;
 
             let new_step_counter = rolling_state.new_step_counter()?;
@@ -93,6 +97,8 @@ impl IvcProverInput {
             });
         }
 
+        println!("Preparing after the genesis");
+
         // Non-genesis path: Reject upfront if the proof's embedded verifying key differs
         // from `setup.certificate_verifying_key`: the off-circuit accumulator built here
         // would not match the one the in-circuit verifier produces.
@@ -105,6 +111,7 @@ impl IvcProverInput {
         {
             return Err(IvcCircuitError::CertificateVerifyingKeyMismatch.into());
         }
+        println!("verification that the transcript repr matches done");
 
         let verifier_params = setup.srs.verifier_params();
         let dual_msm = snark_proof.prepare_and_check(
@@ -112,6 +119,8 @@ impl IvcProverInput {
             aggregate_verification_key_for_snark,
             &verifier_params,
         )?;
+
+        println!("verification of the snark proof done");
 
         if !is_same_epoch && !is_next_epoch {
             return Err(IvcCircuitError::InvalidEpochTransition {

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -54,8 +54,6 @@ impl IvcProverInput {
         rolling_state: &IvcRollingState,
         setup: &IvcProverSetup,
     ) -> StmResult<Self> {
-        println!("Entering prepare function");
-
         let chain_epoch = rolling_state.state().current_epoch;
         let certificate_epoch = protocol_message_preimage.current_epoch();
 
@@ -68,8 +66,6 @@ impl IvcProverInput {
         // signature, build the base-case witness/state, and pass the rolling state's
         // trivial accumulator through unchanged.
         if is_genesis {
-            println!("Preparing the genesis");
-
             rolling_state.verify_genesis_signature(global)?;
 
             let new_step_counter = rolling_state.new_step_counter()?;
@@ -97,8 +93,6 @@ impl IvcProverInput {
             });
         }
 
-        println!("Preparing after the genesis");
-
         // Non-genesis path: Reject upfront if the proof's embedded verifying key differs
         // from `setup.certificate_verifying_key`: the off-circuit accumulator built here
         // would not match the one the in-circuit verifier produces.
@@ -111,7 +105,6 @@ impl IvcProverInput {
         {
             return Err(IvcCircuitError::CertificateVerifyingKeyMismatch.into());
         }
-        println!("verification that the transcript repr matches done");
 
         let verifier_params = setup.srs.verifier_params();
         let dual_msm = snark_proof.prepare_and_check(
@@ -119,8 +112,6 @@ impl IvcProverInput {
             aggregate_verification_key_for_snark,
             &verifier_params,
         )?;
-
-        println!("verification of the snark proof done");
 
         if !is_same_epoch && !is_next_epoch {
             return Err(IvcCircuitError::InvalidEpochTransition {

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -12,8 +12,7 @@ use crate::{
         halo2::types::CircuitBase,
         halo2_ivc::{
             CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME, K,
-            certificate_proof::verify_and_prepare_accumulator,
-            state::{fixed_bases_and_names, trivial_acc},
+            certificate_proof::verify_and_prepare_accumulator, state::fixed_bases_and_names,
         },
         trusted_setup::TrustedSetupProvider,
     },
@@ -122,20 +121,6 @@ impl IvcProverSetup {
         accumulator.extract_fixed_bases(&self.certificate_fixed_bases);
         accumulator.collapse();
         accumulator
-    }
-
-    /// Trivial previous-IVC-proof collapsed accumulator used at genesis. The in-circuit
-    /// gadget zeros the prepared accumulator via `scale_by_bit(is_not_genesis, ...)`;
-    /// off-circuit we construct a fresh trivial accumulator over the combined fixed-base
-    /// names.
-    // TODO: remove this allow dead_code directive when the function is used or remove the function
-    #[allow(dead_code)]
-    pub(crate) fn trivial_previous_ivc_proof_collapsed_accumulator(
-        &self,
-    ) -> Accumulator<BlstrsEmulation> {
-        let combined_fixed_base_names: Vec<String> =
-            self.combined_fixed_bases.keys().cloned().collect();
-        trivial_acc(&combined_fixed_base_names)
     }
 
     /// Off-circuit verify of the previous step's IVC proof, returning the collapsed

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -11,7 +11,7 @@ use crate::{
     circuits::{
         halo2::types::CircuitBase,
         halo2_ivc::{
-            CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME,
+            CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME, K,
             certificate_proof::verify_and_prepare_accumulator,
             state::{fixed_bases_and_names, trivial_acc},
         },
@@ -37,11 +37,11 @@ use crate::{
 // TODO: remove this allow dead_code directive when the IVC prover consumes this setup
 #[allow(dead_code)]
 pub(crate) struct IvcProverSetup {
-    /// Full KZG parameters used during proof generation.
+    /// KZG parameters used during proof generation, downsized to the IVC circuit degree `K`.
     ///
-    /// Stored in full to support `create_proof`, which requires the prover-side
-    /// commitment material. Verifier params are derived on demand via
-    /// `self.srs.verifier_params()`.
+    /// `create_proof` commits in the Lagrange basis of the circuit domain, so the SRS must match
+    /// that domain: a larger SRS carries a different basis and yields an unverifiable proof.
+    /// Verifier params are derived on demand via `self.srs.verifier_params()`.
     pub(crate) srs: ParamsKZG<Bls12>,
     /// Verifying key of the certificate circuit.
     pub(crate) certificate_verifying_key: CircuitVerifyingKey,
@@ -89,7 +89,8 @@ impl IvcProverSetup {
         certificate_key_provider: &TempCertificateKeyProvider,
         ivc_key_provider: &TempIvcKeyProvider,
     ) -> StmResult<Self> {
-        let srs = trusted_setup_provider.get_trusted_setup_parameters()?;
+        let mut srs = trusted_setup_provider.get_trusted_setup_parameters()?;
+        srs.downsize(K);
 
         let certificate_verifying_key = certificate_key_provider.get_verifying_key()?;
         let ivc_verifying_key = ivc_key_provider.get_verifying_key()?;

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -34,8 +34,6 @@ use crate::{
 /// and values must agree across the three maps for any shared key. The in-circuit IVC
 /// verifier gadget builds a single merged fixed-base list from these names; any mismatch
 /// here produces folded accumulators the circuit will reject.
-// TODO: remove this allow dead_code directive when the IVC prover consumes this setup
-#[allow(dead_code)]
 pub(crate) struct IvcProverSetup {
     /// KZG parameters used during proof generation, downsized to the IVC circuit degree `K`.
     ///
@@ -58,8 +56,6 @@ pub(crate) struct IvcProverSetup {
     pub(crate) combined_fixed_bases: BTreeMap<String, G1Projective>,
 }
 
-// TODO: remove this allow dead_code directive when the IVC prover uses this setup
-#[allow(dead_code)]
 impl IvcProverSetup {
     /// Derives the full IVC setup by orchestrating the key providers.
     ///
@@ -132,6 +128,8 @@ impl IvcProverSetup {
     /// gadget zeros the prepared accumulator via `scale_by_bit(is_not_genesis, ...)`;
     /// off-circuit we construct a fresh trivial accumulator over the combined fixed-base
     /// names.
+    // TODO: remove this allow dead_code directive when the function is used or remove the function
+    #[allow(dead_code)]
     pub(crate) fn trivial_previous_ivc_proof_collapsed_accumulator(
         &self,
     ) -> Accumulator<BlstrsEmulation> {

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -139,7 +139,7 @@ pub(crate) mod midnight_accumulator_serde {
 
     use crate::circuits::halo2_ivc::io::{Read, Write};
 
-    /// Serialization function based on the write function of the MidnightVK
+    /// Serialization function based on the write function of Midnight's Accumulator
     pub fn serialize<S: Serializer>(
         accumulator: &Accumulator<BlstrsEmulation>,
         serializer: S,
@@ -151,7 +151,7 @@ pub(crate) mod midnight_accumulator_serde {
         serializer.serialize_bytes(&buf)
     }
 
-    /// Deserialization function based on the read function of the MidnightVK
+    /// Deserialization function based on the read function of Midnight's Accumulator
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Accumulator<BlstrsEmulation>, D::Error> {

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -24,7 +24,7 @@ use crate::{
 // TODO: remove this allow dead_code directive when the IVC prover consumes this rolling state
 #[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub(crate) struct IvcRollingState {
+pub struct IvcRollingState {
     /// Last committed chain state.
     state: State,
     /// Bytes of the last IVC proof under the Poseidon transcript

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -4,6 +4,7 @@ use midnight_circuits::{
     types::Instantiable,
     verifier::{Accumulator, BlstrsEmulation},
 };
+use serde::{Deserialize, Serialize};
 
 use crate::{
     StmResult,
@@ -22,13 +23,14 @@ use crate::{
 /// Caller-owned bridge between consecutive IVC proving steps.
 // TODO: remove this allow dead_code directive when the IVC prover consumes this rolling state
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct IvcRollingState {
     /// Last committed chain state.
     state: State,
     /// Bytes of the last IVC proof under the Poseidon transcript
     ivc_proof: IvcProofBytes,
     /// Folded accumulator the new step will build on top of
+    #[serde(with = "midnight_accumulator_serde")]
     accumulator: Accumulator<BlstrsEmulation>,
     /// Chain-specific Schnorr signature over the genesis message
     genesis_signature: StandardSchnorrSignature,
@@ -131,6 +133,35 @@ impl IvcRollingState {
     pub(crate) fn is_next_epoch(&self, certificate_epoch: EpochNumber) -> bool {
         certificate_epoch.as_field()
             == self.state.current_epoch.as_field() + EpochNumber::new(1).as_field()
+    }
+}
+
+pub mod midnight_accumulator_serde {
+    use midnight_circuits::verifier::{Accumulator, BlstrsEmulation};
+    use midnight_proofs::utils::SerdeFormat;
+    use serde::{Deserializer, Serializer};
+
+    use crate::circuits::halo2_ivc::io::{Read, Write};
+
+    /// Serialization function based on the write function of the MidnightVK
+    pub fn serialize<S: Serializer>(
+        accumulator: &Accumulator<BlstrsEmulation>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut buf = Vec::new();
+        accumulator
+            .write(&mut buf, SerdeFormat::RawBytesUnchecked)
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&buf)
+    }
+
+    /// Deserialization function based on the read function of the MidnightVK
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Accumulator<BlstrsEmulation>, D::Error> {
+        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
+        Accumulator::<BlstrsEmulation>::read(&mut bytes.as_slice(), SerdeFormat::RawBytesUnchecked)
+            .map_err(serde::de::Error::custom)
     }
 }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -21,8 +21,6 @@ use crate::{
 };
 
 /// Caller-owned bridge between consecutive IVC proving steps.
-// TODO: remove this allow dead_code directive when the IVC prover consumes this rolling state
-#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IvcRollingState {
     /// Last committed chain state.
@@ -36,8 +34,6 @@ pub struct IvcRollingState {
     genesis_signature: StandardSchnorrSignature,
 }
 
-// TODO: remove this allow dead_code directive when the IVC prover uses this rolling state
-#[allow(dead_code)]
 impl IvcRollingState {
     /// Builds a rolling state from the four fields produced by an IVC proving step.
     pub(crate) fn new(
@@ -136,7 +132,7 @@ impl IvcRollingState {
     }
 }
 
-pub mod midnight_accumulator_serde {
+pub(crate) mod midnight_accumulator_serde {
     use midnight_circuits::verifier::{Accumulator, BlstrsEmulation};
     use midnight_proofs::utils::SerdeFormat;
     use serde::{Deserializer, Serializer};

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/temp_ivc_prover_cache.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/temp_ivc_prover_cache.rs
@@ -1,3 +1,4 @@
+// TODO: remove when the `IvcSnarkSetup` is final
 #[cfg(feature = "future_snark")]
 use std::{
     collections::HashMap,
@@ -69,4 +70,81 @@ pub(crate) fn load_ivc_prover_setup(
         .insert(cache_key, cached.clone());
 
     Ok(cached)
+}
+
+#[cfg(test)]
+mod tests {
+
+    mod slow {
+        use std::sync::Arc;
+
+        use midnight_proofs::poly::commitment::Params;
+        use tempfile::tempdir;
+
+        use crate::{
+            Parameters,
+            circuits::{
+                halo2_ivc::{
+                    K,
+                    tests::common::{
+                        asset_readers::load_embedded_verification_context_asset,
+                        generators::setup::{QUORUM_SIZE, SIGNER_COUNT},
+                    },
+                },
+                trusted_setup::build_provider_with_unsafe_srs,
+            },
+            proof_system::ivc_halo2_snark::{
+                IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
+            },
+        };
+
+        // The IVC circuit is degree `K`, but production builds its setup from the larger degree-22
+        // SRS. Keygen and the stored proving SRS must both downsize to `K`, otherwise their Lagrange
+        // basis differs and proofs do not verify. A larger unsafe SRS shares the smaller one's tau,
+        // so a correctly downsized setup reproduces the embedded degree-`K` assets exactly.
+        #[test]
+        fn ivc_setup_downsizes_keys_and_srs_to_the_circuit_degree() {
+            let temp_dir = tempdir().expect("temp dir creation should succeed");
+            let trusted_setup_provider = build_provider_with_unsafe_srs(temp_dir.path(), K + 1);
+            let srs = Arc::new(
+                trusted_setup_provider
+                    .get_trusted_setup_parameters()
+                    .expect("oversized unsafe SRS should load"),
+            );
+            let parameters = Parameters {
+                k: QUORUM_SIZE as u64,
+                m: (QUORUM_SIZE * 10) as u64,
+                phi_f: 0.2,
+            };
+            let merkle_tree_depth = SIGNER_COUNT.next_power_of_two().trailing_zeros();
+            let cert_provider =
+                TempCertificateKeyProvider::new(Arc::clone(&srs), parameters, merkle_tree_depth);
+            let cert_vk = cert_provider
+                .get_verifying_key()
+                .expect("certificate verifying key keygen should succeed");
+            let ivc_provider = TempIvcKeyProvider::new(srs, cert_vk);
+            let ivc_setup =
+                IvcProverSetup::load(&trusted_setup_provider, &cert_provider, &ivc_provider)
+                    .expect("IvcProverSetup::load should succeed");
+
+            let verification_context = load_embedded_verification_context_asset()
+                .expect("verification context asset should load");
+
+            assert_eq!(
+                verification_context.certificate_verifying_key.vk().transcript_repr(),
+                ivc_setup.certificate_verifying_key.transcript_repr(),
+                "cert VK must be independent of the SRS degree (downsized at keygen)"
+            );
+            assert_eq!(
+                verification_context.recursive_verifying_key.transcript_repr(),
+                ivc_setup.ivc_verifying_key.transcript_repr(),
+                "IVC VK must be independent of the SRS degree (downsized at keygen)"
+            );
+            assert_eq!(
+                ivc_setup.srs.max_k(),
+                K,
+                "the proving SRS stored in IvcProverSetup must be downsized to the IVC circuit degree"
+            );
+        }
+    }
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/temp_ivc_prover_cache.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/temp_ivc_prover_cache.rs
@@ -1,0 +1,72 @@
+#[cfg(feature = "future_snark")]
+use std::{
+    collections::HashMap,
+    sync::{Arc, LazyLock, Mutex},
+};
+
+#[cfg(feature = "future_snark")]
+use anyhow::anyhow;
+#[cfg(feature = "future_snark")]
+use midnight_zk_stdlib::MidnightVK;
+
+#[cfg(feature = "future_snark")]
+use crate::{
+    Parameters, StmResult,
+    circuits::trusted_setup::TrustedSetupProvider,
+    proof_system::ivc_halo2_snark::{
+        IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
+    },
+};
+
+/// Process-wide cache of the IVC prover setup keyed by the certificate circuit shape.
+///
+/// The setup (SRS plus the certificate and IVC circuit keys) only depends on the protocol
+/// parameters and the Merkle tree depth, so it is computed once per shape and reused across
+/// certificates instead of being rebuilt on every proof. The certificate [MidnightVK] is cached
+/// alongside it because it is needed to expose the verifier data.
+#[cfg(feature = "future_snark")]
+type IvcProverSetupCache = HashMap<(Vec<u8>, u32), (Arc<IvcProverSetup>, MidnightVK)>;
+
+#[cfg(feature = "future_snark")]
+static IVC_PROVER_SETUP_CACHE: LazyLock<Mutex<IvcProverSetupCache>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Load the IVC prover setup and the certificate [MidnightVK] for the given certificate circuit
+/// shape, building them on the first call and serving cached clones afterwards.
+#[cfg(feature = "future_snark")]
+pub(crate) fn load_ivc_prover_setup(
+    parameters: Parameters,
+    merkle_tree_depth: u32,
+) -> StmResult<(Arc<IvcProverSetup>, MidnightVK)> {
+    let cache_key = (parameters.to_bytes()?, merkle_tree_depth);
+
+    if let Some(cached) = IVC_PROVER_SETUP_CACHE
+        .lock()
+        .map_err(|_| anyhow!("IVC prover setup cache lock poisoned."))?
+        .get(&cache_key)
+    {
+        return Ok(cached.clone());
+    }
+
+    let trusted_setup_provider = TrustedSetupProvider::default();
+    let srs = Arc::new(trusted_setup_provider.get_trusted_setup_parameters()?);
+    let certificate_key_provider =
+        TempCertificateKeyProvider::new(srs.clone(), parameters, merkle_tree_depth);
+    let certificate_midnight_verifying_key =
+        certificate_key_provider.get_midnight_verifying_key()?;
+    let ivc_key_provider =
+        TempIvcKeyProvider::new(srs.clone(), certificate_key_provider.get_verifying_key()?);
+    let ivc_setup = Arc::new(IvcProverSetup::load(
+        &trusted_setup_provider,
+        &certificate_key_provider,
+        &ivc_key_provider,
+    )?);
+
+    let cached = (ivc_setup, certificate_midnight_verifying_key);
+    IVC_PROVER_SETUP_CACHE
+        .lock()
+        .map_err(|_| anyhow!("IVC prover setup cache lock poisoned."))?
+        .insert(cache_key, cached.clone());
+
+    Ok(cached)
+}

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
@@ -33,7 +33,6 @@ use crate::{
 /// Recomputes the certificate-circuit verifying key and proving key from a
 /// shared SRS plus the `Parameters` and Merkle tree depth that pin the circuit
 /// shape.
-#[allow(dead_code)]
 pub(crate) struct TempCertificateKeyProvider {
     /// Shared KZG structured reference string, sized for the IVC circuit. Cloned
     /// on demand and downsized in place before certificate-circuit keygen.
@@ -44,7 +43,6 @@ pub(crate) struct TempCertificateKeyProvider {
     merkle_tree_depth: u32,
 }
 
-#[allow(dead_code)]
 impl TempCertificateKeyProvider {
     /// Stores the prerequisites needed to recompute the certificate keys.
     pub(crate) fn new(
@@ -80,6 +78,7 @@ impl TempCertificateKeyProvider {
 
     /// Recomputes the verifying key (the temp layer has no cache, so the VK is
     /// re-derived here) and runs `zk::setup_pk` to produce the proving key.
+    #[allow(dead_code)]
     pub(crate) fn get_proving_key(&self) -> StmResult<CircuitProvingKey> {
         let certificate_circuit =
             StmCertificateCircuit::try_new(&self.parameters, self.merkle_tree_depth)?;
@@ -93,7 +92,6 @@ impl TempCertificateKeyProvider {
 /// Recomputes the IVC-circuit verifying key and proving key from a shared SRS
 /// and the already-computed certificate verifying key (which the IVC circuit
 /// recursively verifies).
-#[allow(dead_code)]
 pub(crate) struct TempIvcKeyProvider {
     /// Shared KZG structured reference string, sized for the IVC circuit.
     srs: Arc<ParamsKZG<Bls12>>,
@@ -102,7 +100,6 @@ pub(crate) struct TempIvcKeyProvider {
     certificate_verifying_key: CircuitVerifyingKey,
 }
 
-#[allow(dead_code)]
 impl TempIvcKeyProvider {
     /// Stores the prerequisites needed to recompute the IVC keys.
     pub(crate) fn new(

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
@@ -110,14 +110,18 @@ impl TempIvcKeyProvider {
     /// and runs `keygen_vk_with_k` at the IVC circuit's domain size `K`.
     pub(crate) fn get_verifying_key(&self) -> StmResult<CircuitVerifyingKey> {
         let ivc_circuit_data = IvcCircuitData::unknown(&self.certificate_verifying_key)?;
-        Ok(keygen_vk_with_k(self.srs.as_ref(), &ivc_circuit_data, K)?)
+        let mut ivc_srs = (*self.srs).clone();
+        ivc_srs.downsize(K);
+        Ok(keygen_vk_with_k(&ivc_srs, &ivc_circuit_data, K)?)
     }
 
     /// Recomputes the IVC verifying key (the temp layer has no cache, so the VK
     /// is re-derived here) and runs `keygen_pk` to produce the proving key.
     pub(crate) fn get_proving_key(&self) -> StmResult<CircuitProvingKey> {
         let ivc_circuit_data = IvcCircuitData::unknown(&self.certificate_verifying_key)?;
-        let ivc_verifying_key = keygen_vk_with_k(self.srs.as_ref(), &ivc_circuit_data, K)?;
+        let mut ivc_srs = (*self.srs).clone();
+        ivc_srs.downsize(K);
+        let ivc_verifying_key = keygen_vk_with_k(&ivc_srs, &ivc_circuit_data, K)?;
         Ok(keygen_pk(ivc_verifying_key, &ivc_circuit_data)?)
     }
 }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
@@ -75,18 +75,6 @@ impl TempCertificateKeyProvider {
     pub(crate) fn get_verifying_key(&self) -> StmResult<CircuitVerifyingKey> {
         Ok(self.get_midnight_verifying_key()?.vk().clone())
     }
-
-    /// Recomputes the verifying key (the temp layer has no cache, so the VK is
-    /// re-derived here) and runs `zk::setup_pk` to produce the proving key.
-    #[allow(dead_code)]
-    pub(crate) fn get_proving_key(&self) -> StmResult<CircuitProvingKey> {
-        let certificate_circuit =
-            StmCertificateCircuit::try_new(&self.parameters, self.merkle_tree_depth)?;
-        let mut certificate_srs = (*self.srs).clone();
-        zk::downsize_srs_for_relation(&mut certificate_srs, &certificate_circuit);
-        let midnight_vk = zk::setup_vk(&certificate_srs, &certificate_circuit);
-        Ok(zk::setup_pk(&certificate_circuit, &midnight_vk).pk().clone())
-    }
 }
 
 /// Recomputes the IVC-circuit verifying key and proving key from a shared SRS

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/unsafe_setup_helpers.rs
@@ -19,7 +19,7 @@ use midnight_proofs::{
     plonk::{keygen_pk, keygen_vk_with_k},
     poly::kzg::params::ParamsKZG,
 };
-use midnight_zk_stdlib::{self as zk};
+use midnight_zk_stdlib::{self as zk, MidnightVK};
 
 use crate::{
     Parameters, StmResult,
@@ -60,13 +60,22 @@ impl TempCertificateKeyProvider {
     }
 
     /// Builds the certificate circuit, clones the shared SRS so it can be
-    /// downsized in place, and runs `zk::setup_vk` to produce the verifying key.
-    pub(crate) fn get_verifying_key(&self) -> StmResult<CircuitVerifyingKey> {
+    /// downsized in place, and runs `zk::setup_vk` to produce the [MidnightVK].
+    ///
+    /// The [MidnightVK] carries the circuit architecture, which is required to
+    /// deserialize the verifying key against the correct constraint system.
+    pub(crate) fn get_midnight_verifying_key(&self) -> StmResult<MidnightVK> {
         let certificate_circuit =
             StmCertificateCircuit::try_new(&self.parameters, self.merkle_tree_depth)?;
         let mut certificate_srs = (*self.srs).clone();
         zk::downsize_srs_for_relation(&mut certificate_srs, &certificate_circuit);
-        Ok(zk::setup_vk(&certificate_srs, &certificate_circuit).vk().clone())
+        Ok(zk::setup_vk(&certificate_srs, &certificate_circuit))
+    }
+
+    /// Builds the certificate circuit, clones the shared SRS so it can be
+    /// downsized in place, and runs `zk::setup_vk` to produce the verifying key.
+    pub(crate) fn get_verifying_key(&self) -> StmResult<CircuitVerifyingKey> {
+        Ok(self.get_midnight_verifying_key()?.vk().clone())
     }
 
     /// Recomputes the verifying key (the temp layer has no cache, so the VK is

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -183,6 +183,22 @@ pub struct IvcVerifierData {
 // This implementation is copied from another one and needs to be
 // updated and tested. It is temporary to test the wiring of the prove and verification
 impl IvcVerifierData {
+    /// Build the verifier data from the genesis message, the genesis Schnorr verification key and
+    /// the certificate and IVC circuit verifying keys used to produce the proof.
+    pub(crate) fn new(
+        genesis_message: MessageHash,
+        genesis_schnorr_verification_key: SchnorrVerificationKey,
+        certificate_circuit_verification_key: CircuitVerifyingKey,
+        ivc_circuit_verification_key: CircuitVerifyingKey,
+    ) -> Self {
+        Self {
+            genesis_message,
+            genesis_schnorr_verification_key,
+            certificate_circuit_verification_key,
+            ivc_circuit_verification_key,
+        }
+    }
+
     /// Serialize to versioned CBOR bytes, following `CODEC.md`.
     pub fn to_bytes(&self) -> StmResult<Vec<u8>> {
         codec::to_cbor_bytes(self)

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -9,12 +9,15 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use midnight_curves::{Bls12, G1Projective, G2Affine};
 use midnight_proofs::{poly::kzg::params::ParamsVerifierKZG, utils::SerdeFormat};
+use serde::{Deserialize, Serialize};
 
 use crate::{
-    StmResult,
+    SchnorrVerificationKey, StmResult,
     circuits::halo2_ivc::{
         CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME, state::fixed_bases_and_names,
+        types::MessageHash,
     },
+    codec,
     proof_system::{
         KZG_VERIFIER_PARAMS,
         ivc_halo2_snark::{CircuitVerifyingKey, prover_setup::IvcProverSetup},
@@ -164,6 +167,94 @@ impl IvcVerifierSetup {
     /// Returns the combined fixed-base map (certificate ∪ IVC) used by the accumulator check.
     pub(crate) fn combined_fixed_bases(&self) -> &BTreeMap<String, G1Projective> {
         &self.combined_fixed_bases
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IvcVerifierData {
+    genesis_message: MessageHash,
+    genesis_schnorr_verification_key: SchnorrVerificationKey,
+    #[serde(with = "verification_key_serde")]
+    certificate_circuit_verification_key: CircuitVerifyingKey,
+    #[serde(with = "verification_key_serde")]
+    ivc_circuit_verification_key: CircuitVerifyingKey,
+}
+
+// This implementation is copied from another one and needs to be
+// updated and tested. It is temporary to test the wiring of the prove and verification
+impl IvcVerifierData {
+    /// Serialize to versioned CBOR bytes, following `CODEC.md`.
+    pub fn to_bytes(&self) -> StmResult<Vec<u8>> {
+        codec::to_cbor_bytes(self)
+    }
+
+    /// Deserialize from versioned CBOR bytes, following `CODEC.md`.
+    ///
+    /// With no variants this always fails; it gains meaning once a variant is added.
+    pub fn from_bytes(bytes: &[u8]) -> StmResult<Self> {
+        if codec::has_cbor_v1_prefix(bytes) {
+            codec::from_cbor_bytes(&bytes[1..])
+        } else {
+            Err(anyhow::anyhow!(
+                "AncillaryProverData: unsupported encoding, expected a CBOR v1 prefix"
+            ))
+        }
+    }
+
+    pub fn genesis_message(&self) -> MessageHash {
+        self.genesis_message
+    }
+
+    pub fn genesis_schnorr_verification_key(&self) -> SchnorrVerificationKey {
+        self.genesis_schnorr_verification_key
+    }
+
+    pub fn certificate_circuit_verification_key(&self) -> CircuitVerifyingKey {
+        self.certificate_circuit_verification_key.clone()
+    }
+
+    pub fn ivc_circuit_verification_key(&self) -> CircuitVerifyingKey {
+        self.ivc_circuit_verification_key.clone()
+    }
+}
+
+/// Module implementing serialize and deserialize functions
+/// for the VerifyingKey struct
+// TODO: Needs to be tested
+pub mod verification_key_serde {
+    use midnight_curves::Bls12;
+    use midnight_proofs::plonk::ConstraintSystem;
+    use midnight_proofs::utils::SerdeFormat;
+    use midnight_proofs::{plonk::VerifyingKey, poly::kzg::KZGCommitmentScheme};
+    use serde::{Deserializer, Serializer};
+
+    use crate::circuits::halo2::types::CircuitBase;
+
+    /// Serialization function based on the write function of the VerifyingKey
+    pub fn serialize<S: Serializer>(
+        verification_key: &VerifyingKey<CircuitBase, KZGCommitmentScheme<Bls12>>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut buf = Vec::new();
+        verification_key
+            .write(&mut buf, SerdeFormat::RawBytes)
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&buf)
+    }
+
+    /// Deserialization function based on the read function of the VerifyingKey
+    pub fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<VerifyingKey<CircuitBase, KZGCommitmentScheme<Bls12>>, D::Error> {
+        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
+        let cs = ConstraintSystem::default();
+
+        VerifyingKey::<CircuitBase, KZGCommitmentScheme<Bls12>>::read_from_cs(
+            &mut bytes.as_slice(),
+            SerdeFormat::RawBytes,
+            cs,
+        )
+        .map_err(serde::de::Error::custom)
     }
 }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -21,6 +21,7 @@ use crate::{
     codec,
     proof_system::{
         KZG_VERIFIER_PARAMS,
+        halo2_snark::midnight_certificate_verification_key_serde,
         ivc_halo2_snark::{CircuitVerifyingKey, prover_setup::IvcProverSetup},
     },
 };
@@ -42,8 +43,6 @@ use crate::{
 /// [`Global`]: crate::circuits::halo2_ivc::state::Global
 /// [`IvcProof::verify`]: crate::proof_system::ivc_halo2_snark::proof::IvcProof::verify
 /// [`IvcProofError::KzgOpeningFailed`]: crate::proof_system::ivc_halo2_snark::errors::IvcProofError::KzgOpeningFailed
-// TODO: remove this allow dead_code directive when IvcVerifierSetup is wired into STM
-#[allow(dead_code)]
 pub(crate) struct IvcVerifierSetup {
     /// Stabilized KZG verifier parameters (embedded constant, no SRS load required).
     verifier_params: ParamsVerifierKZG<Bls12>,
@@ -171,6 +170,8 @@ impl IvcVerifierSetup {
     }
 }
 
+/// Represent the data needed by the verifier in order to verify an IVC proof. It contains
+/// genesis information and circuit verification keys.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IvcVerifierData {
     genesis_message: MessageHash,
@@ -236,35 +237,6 @@ impl IvcVerifierData {
     /// Returns a copy of the ivc circuit verification key stored in the IvcVerifierData
     pub(crate) fn ivc_circuit_verification_key(&self) -> &CircuitVerifyingKey {
         &self.ivc_circuit_verification_key
-    }
-}
-
-/// Serialize and deserialize functions for the certificate circuit [MidnightVK].
-///
-/// [MidnightVK] serialization carries the circuit architecture, so deserialization rebuilds the
-/// correct constraint system and round-trips byte-for-byte.
-mod midnight_certificate_verification_key_serde {
-    use midnight_proofs::utils::SerdeFormat;
-    use midnight_zk_stdlib::MidnightVK;
-    use serde::{Deserializer, Serializer};
-
-    /// Serialization based on the write function of the [MidnightVK].
-    pub fn serialize<S: Serializer>(
-        verification_key: &MidnightVK,
-        serializer: S,
-    ) -> Result<S::Ok, S::Error> {
-        let mut buf = Vec::new();
-        verification_key
-            .write(&mut buf, SerdeFormat::RawBytes)
-            .map_err(serde::ser::Error::custom)?;
-        serializer.serialize_bytes(&buf)
-    }
-
-    /// Deserialization based on the read function of the [MidnightVK].
-    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<MidnightVK, D::Error> {
-        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
-        MidnightVK::read(&mut bytes.as_slice(), SerdeFormat::RawBytes)
-            .map_err(serde::de::Error::custom)
     }
 }
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use anyhow::Context;
 use midnight_curves::{Bls12, G1Projective, G2Affine};
 use midnight_proofs::{poly::kzg::params::ParamsVerifierKZG, utils::SerdeFormat};
+use midnight_zk_stdlib::MidnightVK;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -174,9 +175,9 @@ impl IvcVerifierSetup {
 pub struct IvcVerifierData {
     genesis_message: MessageHash,
     genesis_schnorr_verification_key: SchnorrVerificationKey,
-    #[serde(with = "verification_key_serde")]
-    certificate_circuit_verification_key: CircuitVerifyingKey,
-    #[serde(with = "verification_key_serde")]
+    #[serde(with = "midnight_certificate_verification_key_serde")]
+    certificate_circuit_verification_key: MidnightVK,
+    #[serde(with = "ivc_circuit_verification_key_serde")]
     ivc_circuit_verification_key: CircuitVerifyingKey,
 }
 
@@ -185,10 +186,13 @@ pub struct IvcVerifierData {
 impl IvcVerifierData {
     /// Build the verifier data from the genesis message, the genesis Schnorr verification key and
     /// the certificate and IVC circuit verifying keys used to produce the proof.
+    ///
+    /// The certificate verifying key is kept as a [MidnightVK] because its serialization carries
+    /// the circuit architecture required to deserialize it against the correct constraint system.
     pub(crate) fn new(
         genesis_message: MessageHash,
         genesis_schnorr_verification_key: SchnorrVerificationKey,
-        certificate_circuit_verification_key: CircuitVerifyingKey,
+        certificate_circuit_verification_key: MidnightVK,
         ivc_circuit_verification_key: CircuitVerifyingKey,
     ) -> Self {
         Self {
@@ -226,7 +230,7 @@ impl IvcVerifierData {
     }
 
     pub fn certificate_circuit_verification_key(&self) -> CircuitVerifyingKey {
-        self.certificate_circuit_verification_key.clone()
+        self.certificate_circuit_verification_key.vk().clone()
     }
 
     pub fn ivc_circuit_verification_key(&self) -> CircuitVerifyingKey {
@@ -234,19 +238,49 @@ impl IvcVerifierData {
     }
 }
 
-/// Module implementing serialize and deserialize functions
-/// for the VerifyingKey struct
-// TODO: Needs to be tested
-pub mod verification_key_serde {
+/// Serialize and deserialize functions for the certificate circuit [MidnightVK].
+///
+/// [MidnightVK] serialization carries the circuit architecture, so deserialization rebuilds the
+/// correct constraint system and round-trips byte-for-byte.
+pub mod midnight_certificate_verification_key_serde {
+    use midnight_proofs::utils::SerdeFormat;
+    use midnight_zk_stdlib::MidnightVK;
+    use serde::{Deserializer, Serializer};
+
+    /// Serialization based on the write function of the [MidnightVK].
+    pub fn serialize<S: Serializer>(
+        verification_key: &MidnightVK,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        let mut buf = Vec::new();
+        verification_key
+            .write(&mut buf, SerdeFormat::RawBytes)
+            .map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&buf)
+    }
+
+    /// Deserialization based on the read function of the [MidnightVK].
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<MidnightVK, D::Error> {
+        let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
+        MidnightVK::read(&mut bytes.as_slice(), SerdeFormat::RawBytes)
+            .map_err(serde::de::Error::custom)
+    }
+}
+
+/// Serialize and deserialize functions for the IVC circuit verifying key.
+///
+/// Deserialization rebuilds the constraint system from the [IvcCircuitData] circuit so the
+/// verifying key round-trips byte-for-byte.
+pub mod ivc_circuit_verification_key_serde {
     use midnight_curves::Bls12;
-    use midnight_proofs::plonk::ConstraintSystem;
     use midnight_proofs::utils::SerdeFormat;
     use midnight_proofs::{plonk::VerifyingKey, poly::kzg::KZGCommitmentScheme};
     use serde::{Deserializer, Serializer};
 
     use crate::circuits::halo2::types::CircuitBase;
+    use crate::circuits::halo2_ivc::circuit::IvcCircuitData;
 
-    /// Serialization function based on the write function of the VerifyingKey
+    /// Serialization based on the write function of the VerifyingKey.
     pub fn serialize<S: Serializer>(
         verification_key: &VerifyingKey<CircuitBase, KZGCommitmentScheme<Bls12>>,
         serializer: S,
@@ -258,17 +292,16 @@ pub mod verification_key_serde {
         serializer.serialize_bytes(&buf)
     }
 
-    /// Deserialization function based on the read function of the VerifyingKey
+    /// Deserialization based on the read function of the VerifyingKey, parameterized by the IVC
+    /// circuit so the constraint system is rebuilt correctly.
     pub fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<VerifyingKey<CircuitBase, KZGCommitmentScheme<Bls12>>, D::Error> {
         let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
-        let cs = ConstraintSystem::default();
-
-        VerifyingKey::<CircuitBase, KZGCommitmentScheme<Bls12>>::read_from_cs(
+        VerifyingKey::<CircuitBase, KZGCommitmentScheme<Bls12>>::read::<_, IvcCircuitData>(
             &mut bytes.as_slice(),
             SerdeFormat::RawBytes,
-            cs,
+            (),
         )
         .map_err(serde::de::Error::custom)
     }
@@ -281,6 +314,29 @@ mod tests {
         halo2_ivc::tests::common::asset_readers::load_embedded_verification_context_asset,
         trusted_setup::TrustedSetupProvider,
     };
+
+    #[test]
+    fn ivc_verifier_data_round_trips_byte_for_byte() {
+        let context = load_embedded_verification_context_asset()
+            .expect("verification context asset should load");
+
+        let verifier_data = IvcVerifierData::new(
+            MessageHash::ZERO,
+            SchnorrVerificationKey::default(),
+            context.certificate_verifying_key,
+            context.recursive_verifying_key,
+        );
+
+        let bytes = verifier_data.to_bytes().expect("serialization should not fail");
+        let restored =
+            IvcVerifierData::from_bytes(&bytes).expect("deserialization should not fail");
+        let reencoded = restored.to_bytes().expect("re-serialization should not fail");
+
+        assert_eq!(
+            bytes, reencoded,
+            "IvcVerifierData must round-trip byte-for-byte so the aggregator and client compute the same certificate hash"
+        );
+    }
 
     #[test]
     fn try_new_merges_certificate_and_ivc_fixed_bases() {

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -181,8 +181,6 @@ pub struct IvcVerifierData {
     ivc_circuit_verification_key: CircuitVerifyingKey,
 }
 
-// This implementation is copied from another one and needs to be
-// updated and tested. It is temporary to test the wiring of the prove and verification
 impl IvcVerifierData {
     /// Build the verifier data from the genesis message, the genesis Schnorr verification key and
     /// the certificate and IVC circuit verifying keys used to produce the proof.
@@ -209,31 +207,29 @@ impl IvcVerifierData {
     }
 
     /// Deserialize from versioned CBOR bytes, following `CODEC.md`.
-    ///
-    /// With no variants this always fails; it gains meaning once a variant is added.
     pub fn from_bytes(bytes: &[u8]) -> StmResult<Self> {
         if codec::has_cbor_v1_prefix(bytes) {
             codec::from_cbor_bytes(&bytes[1..])
         } else {
             Err(anyhow::anyhow!(
-                "AncillaryProverData: unsupported encoding, expected a CBOR v1 prefix"
+                "IvcVerifierData: unsupported encoding, expected a CBOR v1 prefix"
             ))
         }
     }
 
-    pub fn genesis_message(&self) -> MessageHash {
+    pub(crate) fn genesis_message(&self) -> MessageHash {
         self.genesis_message
     }
 
-    pub fn genesis_schnorr_verification_key(&self) -> SchnorrVerificationKey {
+    pub(crate) fn genesis_schnorr_verification_key(&self) -> SchnorrVerificationKey {
         self.genesis_schnorr_verification_key
     }
 
-    pub fn certificate_circuit_verification_key(&self) -> CircuitVerifyingKey {
+    pub(crate) fn certificate_circuit_verification_key(&self) -> CircuitVerifyingKey {
         self.certificate_circuit_verification_key.vk().clone()
     }
 
-    pub fn ivc_circuit_verification_key(&self) -> CircuitVerifyingKey {
+    pub(crate) fn ivc_circuit_verification_key(&self) -> CircuitVerifyingKey {
         self.ivc_circuit_verification_key.clone()
     }
 }
@@ -242,7 +238,7 @@ impl IvcVerifierData {
 ///
 /// [MidnightVK] serialization carries the circuit architecture, so deserialization rebuilds the
 /// correct constraint system and round-trips byte-for-byte.
-pub mod midnight_certificate_verification_key_serde {
+mod midnight_certificate_verification_key_serde {
     use midnight_proofs::utils::SerdeFormat;
     use midnight_zk_stdlib::MidnightVK;
     use serde::{Deserializer, Serializer};
@@ -271,7 +267,7 @@ pub mod midnight_certificate_verification_key_serde {
 ///
 /// Deserialization rebuilds the constraint system from the [IvcCircuitData] circuit so the
 /// verifying key round-trips byte-for-byte.
-pub mod ivc_circuit_verification_key_serde {
+mod ivc_circuit_verification_key_serde {
     use midnight_curves::Bls12;
     use midnight_proofs::utils::SerdeFormat;
     use midnight_proofs::{plonk::VerifyingKey, poly::kzg::KZGCommitmentScheme};

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -63,21 +63,21 @@ impl IvcVerifierSetup {
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn try_new(
         certificate_verifying_key: &CircuitVerifyingKey,
-        ivc_verifying_key: CircuitVerifyingKey,
+        ivc_verifying_key: &CircuitVerifyingKey,
     ) -> StmResult<Self> {
         let (verifier_params, tau_g2) = Self::read_embedded_params()?;
 
         let (certificate_fixed_bases, _) =
             fixed_bases_and_names(CERTIFICATE_VERIFICATION_KEY_NAME, certificate_verifying_key);
         let (ivc_fixed_bases, _) =
-            fixed_bases_and_names(IVC_VERIFICATION_KEY_NAME, &ivc_verifying_key);
+            fixed_bases_and_names(IVC_VERIFICATION_KEY_NAME, ivc_verifying_key);
         let mut combined_fixed_bases = certificate_fixed_bases;
         combined_fixed_bases.extend(ivc_fixed_bases);
 
         Ok(Self {
             verifier_params,
             tau_g2,
-            ivc_verifying_key,
+            ivc_verifying_key: ivc_verifying_key.clone(),
             combined_fixed_bases,
         })
     }
@@ -217,20 +217,25 @@ impl IvcVerifierData {
         }
     }
 
+    /// Returns the genesis message (hash of the genesis preimage converted to a field element)
+    /// stored in the IvcVerifierData
     pub(crate) fn genesis_message(&self) -> MessageHash {
         self.genesis_message
     }
 
+    /// Returns the genesis schnorr verification key stored in the IvcVerifierData
     pub(crate) fn genesis_schnorr_verification_key(&self) -> SchnorrVerificationKey {
         self.genesis_schnorr_verification_key
     }
 
-    pub(crate) fn certificate_circuit_verification_key(&self) -> CircuitVerifyingKey {
-        self.certificate_circuit_verification_key.vk().clone()
+    /// Returns a copy of the certificate circuit verification key stored in the IvcVerifierData
+    pub(crate) fn certificate_circuit_verification_key(&self) -> &CircuitVerifyingKey {
+        self.certificate_circuit_verification_key.vk()
     }
 
-    pub(crate) fn ivc_circuit_verification_key(&self) -> CircuitVerifyingKey {
-        self.ivc_circuit_verification_key.clone()
+    /// Returns a copy of the ivc circuit verification key stored in the IvcVerifierData
+    pub(crate) fn ivc_circuit_verification_key(&self) -> &CircuitVerifyingKey {
+        &self.ivc_circuit_verification_key
     }
 }
 
@@ -340,7 +345,7 @@ mod tests {
             .expect("verification context asset should load");
         let setup = IvcVerifierSetup::try_new(
             ctx.certificate_verifying_key.vk(),
-            ctx.recursive_verifying_key,
+            &ctx.recursive_verifying_key,
         )
         .expect("try_new must succeed with valid verifying keys");
         assert_eq!(

--- a/mithril-stm/src/proof_system/mod.rs
+++ b/mithril-stm/src/proof_system/mod.rs
@@ -69,4 +69,4 @@ pub(crate) use halo2_snark::{
 pub(crate) use halo2_snark::RIGID_SLOT_BYTES as SNARK_AGGREGATE_VERIFICATION_KEY_RIGID_SLOT_BYTES;
 
 #[cfg(feature = "future_snark")]
-pub(crate) use ivc_halo2_snark::CircuitVerifyingKey;
+pub(crate) use ivc_halo2_snark::{CircuitVerifyingKey, rolling_state::IvcRollingState};

--- a/mithril-stm/src/proof_system/mod.rs
+++ b/mithril-stm/src/proof_system/mod.rs
@@ -58,7 +58,7 @@ pub use halo2_snark::AggregateVerificationKeyForSnark;
 pub use halo2_snark::{MERKLE_TREE_DEPTH_FOR_SNARK, SnarkProof};
 
 #[cfg(all(test, feature = "future_snark"))]
-pub(crate) use halo2_snark::SnarkSetup;
+pub(crate) use halo2_snark::{CircuitVerificationKey, SnarkSetup};
 #[cfg(feature = "future_snark")]
 pub(crate) use halo2_snark::{
     SingleSignatureForSnark, SnarkClerk, SnarkProofSigner, SnarkProver, SnarkVerifierSetup,

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -38,6 +38,12 @@ impl AncillaryProverData {
             ))
         }
     }
+
+    pub fn as_ivc_rolling_state(&self) -> IvcRollingState {
+        match self {
+            Self::IvcSnark(state) => state.clone(),
+        }
+    }
 }
 
 /// Ancillary data carried by a certificate for the verifier.

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -7,6 +7,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::StmResult;
 use crate::codec;
+use crate::proof_system::IvcRollingState;
+use crate::proof_system::ivc_halo2_snark::verifier_setup::IvcVerifierData;
 #[cfg(feature = "future_snark")]
 use crate::{SchnorrVerificationKey, StandardSchnorrSignature};
 
@@ -51,8 +53,10 @@ impl AncillaryProverData {
 /// Holds the data a verifier needs to verify the certificate. Stored and transmitted in the
 /// certificate message. Variants map to the aggregate signature types that require verifier
 /// data; none exist yet.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AncillaryVerifierData {}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AncillaryVerifierData {
+    IvcSnark(IvcVerifierData),
+}
 
 impl AncillaryVerifierData {
     /// Serialize to versioned CBOR bytes, following `CODEC.md`.
@@ -70,6 +74,12 @@ impl AncillaryVerifierData {
             Err(anyhow::anyhow!(
                 "AncillaryVerifierData: unsupported encoding, expected a CBOR v1 prefix"
             ))
+        }
+    }
+
+    pub fn as_ivc_verifier_data(&self) -> IvcVerifierData {
+        match self {
+            Self::IvcSnark(state) => state.clone(),
         }
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -18,6 +18,7 @@ use crate::{StmResult, codec};
 /// Holds the prover-side state needed to produce the next certificate. Carried in the certificate,
 /// hashed into the certificate hash and transmitted in the certificate message. Variants map to the
 /// aggregate signature types that require prover data.
+#[cfg_attr(test, allow(clippy::large_enum_variant))]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AncillaryProverData {
     #[cfg(feature = "future_snark")]

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -15,8 +15,10 @@ use crate::{SchnorrVerificationKey, StandardSchnorrSignature};
 /// Holds the prover-side state needed to produce the next certificate. Carried in the certificate,
 /// hashed into the certificate hash and transmitted in the certificate message. Variants map to the
 /// aggregate signature types that require prover data; none exist yet.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AncillaryProverData {}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum AncillaryProverData {
+    IvcSnark(IvcRollingState),
+}
 
 impl AncillaryProverData {
     /// Serialize to versioned CBOR bytes, following `CODEC.md`.

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     SchnorrVerificationKey, StandardSchnorrSignature,
     proof_system::{IvcRollingState, ivc_halo2_snark::verifier_setup::IvcVerifierData},
-    protocol::aggregate_signature::GenesisMessagePreimage,
+    protocol::aggregate_signature::MessagePreimage,
 };
 use crate::{StmResult, codec};
 
@@ -99,7 +99,7 @@ impl AncillaryVerifierData {
 #[derive(Clone, Debug)]
 pub struct AncillaryGenesisData {
     #[cfg(feature = "future_snark")]
-    genesis_message_preimage: GenesisMessagePreimage,
+    genesis_message_preimage: MessagePreimage,
     #[cfg(feature = "future_snark")]
     genesis_schnorr_signature: Option<StandardSchnorrSignature>,
     #[cfg(feature = "future_snark")]
@@ -122,7 +122,7 @@ impl AncillaryGenesisData {
     ) -> Self {
         Self {
             #[cfg(feature = "future_snark")]
-            genesis_message_preimage: GenesisMessagePreimage(genesis_message_preimage),
+            genesis_message_preimage: MessagePreimage(genesis_message_preimage),
             #[cfg(feature = "future_snark")]
             genesis_schnorr_signature,
             #[cfg(feature = "future_snark")]
@@ -132,7 +132,7 @@ impl AncillaryGenesisData {
 
     /// Return the genesis message preimage.
     #[cfg(feature = "future_snark")]
-    pub fn genesis_message_preimage(&self) -> &GenesisMessagePreimage {
+    pub fn genesis_message_preimage(&self) -> &MessagePreimage {
         &self.genesis_message_preimage
     }
 

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::StmResult;
 use crate::codec;
+#[cfg(feature = "future_snark")]
 use crate::proof_system::IvcRollingState;
+#[cfg(feature = "future_snark")]
 use crate::proof_system::ivc_halo2_snark::verifier_setup::IvcVerifierData;
 #[cfg(feature = "future_snark")]
 use crate::{SchnorrVerificationKey, StandardSchnorrSignature};
@@ -19,6 +21,7 @@ use crate::{SchnorrVerificationKey, StandardSchnorrSignature};
 /// aggregate signature types that require prover data; none exist yet.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AncillaryProverData {
+    #[cfg(feature = "future_snark")]
     IvcSnark(IvcRollingState),
 }
 
@@ -41,6 +44,7 @@ impl AncillaryProverData {
         }
     }
 
+    #[cfg(feature = "future_snark")]
     pub fn as_ivc_rolling_state(&self) -> IvcRollingState {
         match self {
             Self::IvcSnark(state) => state.clone(),
@@ -55,6 +59,7 @@ impl AncillaryProverData {
 /// data; none exist yet.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AncillaryVerifierData {
+    #[cfg(feature = "future_snark")]
     IvcSnark(IvcVerifierData),
 }
 
@@ -77,6 +82,7 @@ impl AncillaryVerifierData {
         }
     }
 
+    #[cfg(feature = "future_snark")]
     pub fn as_ivc_verifier_data(&self) -> IvcVerifierData {
         match self {
             Self::IvcSnark(state) => state.clone(),

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -251,9 +251,27 @@ impl AncillaryProofOutput {
 
 #[cfg(test)]
 mod tests {
-    use crate::codec::CODEC_VERSION_CBOR_V1;
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    use crate::{
+        BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey,
+        circuits::halo2_ivc::{
+            tests::common::asset_readers::load_embedded_verification_context_asset,
+            types::MessageHash,
+        },
+        codec::CODEC_VERSION_CBOR_V1,
+    };
 
     use super::*;
+
+    // Duplicate from rolling_state.rs tests
+    fn build_genesis_signature() -> StandardSchnorrSignature {
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let signing_key = SchnorrSigningKey::generate(&mut rng);
+        let message = vec![BaseFieldElement::from(1u64)];
+        signing_key.sign_standard(&message, &mut rng).unwrap()
+    }
 
     #[test]
     fn prover_data_from_bytes_rejects_every_input() {
@@ -301,5 +319,36 @@ mod tests {
         );
 
         assert_eq!(proof_input.message_preimage(), message_preimage.as_slice());
+    }
+
+    #[test]
+    fn ancillary_prover_data_to_from_bytes_round_trip() {
+        let genesis_signature = build_genesis_signature();
+        let fixed_base_names = vec!["base_one".to_string(), "base_two".to_string()];
+        let rolling_state = IvcRollingState::genesis(genesis_signature, &fixed_base_names);
+        let ancillary_prover_data = AncillaryProverData::IvcSnark(rolling_state);
+
+        let bytes = ancillary_prover_data.to_bytes().unwrap();
+        let reconstructed = AncillaryProverData::from_bytes(&bytes).unwrap();
+
+        assert_eq!(bytes, reconstructed.to_bytes().unwrap());
+    }
+
+    #[test]
+    fn ancillary_verifier_data_to_from_bytes_round_trip() {
+        let context = load_embedded_verification_context_asset()
+            .expect("verification context asset should load");
+        let verifier_data = IvcVerifierData::new(
+            MessageHash::ZERO,
+            SchnorrVerificationKey::default(),
+            context.certificate_verifying_key,
+            context.recursive_verifying_key,
+        );
+        let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(verifier_data);
+
+        let bytes = ancillary_verifier_data.to_bytes().unwrap();
+        let reconstructed = AncillaryVerifierData::from_bytes(&bytes).unwrap();
+
+        assert_eq!(bytes, reconstructed.to_bytes().unwrap());
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     SchnorrVerificationKey, StandardSchnorrSignature,
     proof_system::{IvcRollingState, ivc_halo2_snark::verifier_setup::IvcVerifierData},
-    protocol::aggregate_signature::MessagePreimage,
+    protocol::aggregate_signature::GenesisMessagePreimage,
 };
 use crate::{StmResult, codec};
 
@@ -22,6 +22,8 @@ use crate::{StmResult, codec};
 pub enum AncillaryProverData {
     #[cfg(feature = "future_snark")]
     IvcSnark(IvcRollingState),
+    #[cfg(all(feature = "future_snark", test))]
+    FutureVariant,
 }
 
 impl AncillaryProverData {
@@ -43,11 +45,13 @@ impl AncillaryProverData {
         }
     }
 
-    /// Returns the wrapped IvcRollingState of an AncillaryProverData.
+    /// Returns the wrapped IvcRollingState of an AncillaryProverData if it exists.
     #[cfg(feature = "future_snark")]
     pub fn as_ivc_rolling_state(&self) -> Option<&IvcRollingState> {
         match self {
             Self::IvcSnark(state) => Some(state),
+            #[cfg(test)]
+            Self::FutureVariant => None,
         }
     }
 }
@@ -99,7 +103,7 @@ impl AncillaryVerifierData {
 #[derive(Clone, Debug)]
 pub struct AncillaryGenesisData {
     #[cfg(feature = "future_snark")]
-    genesis_message_preimage: MessagePreimage,
+    genesis_message_preimage: GenesisMessagePreimage,
     #[cfg(feature = "future_snark")]
     genesis_schnorr_signature: Option<StandardSchnorrSignature>,
     #[cfg(feature = "future_snark")]
@@ -122,7 +126,7 @@ impl AncillaryGenesisData {
     ) -> Self {
         Self {
             #[cfg(feature = "future_snark")]
-            genesis_message_preimage: MessagePreimage(genesis_message_preimage),
+            genesis_message_preimage: GenesisMessagePreimage(genesis_message_preimage),
             #[cfg(feature = "future_snark")]
             genesis_schnorr_signature,
             #[cfg(feature = "future_snark")]
@@ -132,7 +136,7 @@ impl AncillaryGenesisData {
 
     /// Return the genesis message preimage.
     #[cfg(feature = "future_snark")]
-    pub fn genesis_message_preimage(&self) -> &MessagePreimage {
+    pub fn genesis_message_preimage(&self) -> &GenesisMessagePreimage {
         &self.genesis_message_preimage
     }
 
@@ -258,7 +262,9 @@ impl AncillaryProofOutput {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "future_snark")]
     use rand_chacha::ChaCha20Rng;
+    #[cfg(feature = "future_snark")]
     use rand_core::SeedableRng;
 
     use crate::codec::CODEC_VERSION_CBOR_V1;

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -18,7 +18,7 @@ use crate::{SchnorrVerificationKey, StandardSchnorrSignature};
 ///
 /// Holds the prover-side state needed to produce the next certificate. Carried in the certificate,
 /// hashed into the certificate hash and transmitted in the certificate message. Variants map to the
-/// aggregate signature types that require prover data; none exist yet.
+/// aggregate signature types that require prover data.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AncillaryProverData {
     #[cfg(feature = "future_snark")]
@@ -44,10 +44,11 @@ impl AncillaryProverData {
         }
     }
 
+    /// Returns the wrapped IvcRollingState of an AncillaryProverData.
     #[cfg(feature = "future_snark")]
-    pub fn as_ivc_rolling_state(&self) -> IvcRollingState {
+    pub fn as_ivc_rolling_state(&self) -> &IvcRollingState {
         match self {
-            Self::IvcSnark(state) => state.clone(),
+            Self::IvcSnark(state) => state,
         }
     }
 }
@@ -56,7 +57,7 @@ impl AncillaryProverData {
 ///
 /// Holds the data a verifier needs to verify the certificate. Stored and transmitted in the
 /// certificate message. Variants map to the aggregate signature types that require verifier
-/// data; none exist yet.
+/// data.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum AncillaryVerifierData {
     #[cfg(feature = "future_snark")]
@@ -82,10 +83,11 @@ impl AncillaryVerifierData {
         }
     }
 
+    /// Returns the wrapped IvcVerifierData of an AncillaryVerifierData.
     #[cfg(feature = "future_snark")]
-    pub fn as_ivc_verifier_data(&self) -> IvcVerifierData {
+    pub fn as_ivc_verifier_data(&self) -> &IvcVerifierData {
         match self {
-            Self::IvcSnark(state) => state.clone(),
+            Self::IvcSnark(state) => state,
         }
     }
 }
@@ -260,18 +262,20 @@ mod tests {
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
+    use crate::codec::CODEC_VERSION_CBOR_V1;
+    #[cfg(feature = "future_snark")]
     use crate::{
         BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey,
         circuits::halo2_ivc::{
             tests::common::asset_readers::load_embedded_verification_context_asset,
             types::MessageHash,
         },
-        codec::CODEC_VERSION_CBOR_V1,
     };
 
     use super::*;
 
     // Duplicate from rolling_state.rs tests
+    #[cfg(feature = "future_snark")]
     fn build_genesis_signature() -> StandardSchnorrSignature {
         let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
         let signing_key = SchnorrSigningKey::generate(&mut rng);
@@ -327,6 +331,7 @@ mod tests {
         assert_eq!(proof_input.message_preimage(), message_preimage.as_slice());
     }
 
+    #[cfg(feature = "future_snark")]
     #[test]
     fn ancillary_prover_data_to_from_bytes_round_trip() {
         let genesis_signature = build_genesis_signature();
@@ -340,6 +345,7 @@ mod tests {
         assert_eq!(bytes, reconstructed.to_bytes().unwrap());
     }
 
+    #[cfg(feature = "future_snark")]
     #[test]
     fn ancillary_verifier_data_to_from_bytes_round_trip() {
         let context = load_embedded_verification_context_asset()

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -5,14 +5,13 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::StmResult;
-use crate::codec;
 #[cfg(feature = "future_snark")]
-use crate::proof_system::IvcRollingState;
-#[cfg(feature = "future_snark")]
-use crate::proof_system::ivc_halo2_snark::verifier_setup::IvcVerifierData;
-#[cfg(feature = "future_snark")]
-use crate::{SchnorrVerificationKey, StandardSchnorrSignature};
+use crate::{
+    SchnorrVerificationKey, StandardSchnorrSignature,
+    proof_system::{IvcRollingState, ivc_halo2_snark::verifier_setup::IvcVerifierData},
+    protocol::aggregate_signature::GenesisMessagePreimage,
+};
+use crate::{StmResult, codec};
 
 /// Ancillary data carried by a certificate for the prover.
 ///
@@ -46,9 +45,9 @@ impl AncillaryProverData {
 
     /// Returns the wrapped IvcRollingState of an AncillaryProverData.
     #[cfg(feature = "future_snark")]
-    pub fn as_ivc_rolling_state(&self) -> &IvcRollingState {
+    pub fn as_ivc_rolling_state(&self) -> Option<&IvcRollingState> {
         match self {
-            Self::IvcSnark(state) => state,
+            Self::IvcSnark(state) => Some(state),
         }
     }
 }
@@ -85,9 +84,9 @@ impl AncillaryVerifierData {
 
     /// Returns the wrapped IvcVerifierData of an AncillaryVerifierData.
     #[cfg(feature = "future_snark")]
-    pub fn as_ivc_verifier_data(&self) -> &IvcVerifierData {
+    pub fn as_ivc_verifier_data(&self) -> Option<&IvcVerifierData> {
         match self {
-            Self::IvcSnark(state) => state,
+            Self::IvcSnark(state) => Some(state),
         }
     }
 }
@@ -100,7 +99,7 @@ impl AncillaryVerifierData {
 #[derive(Clone, Debug)]
 pub struct AncillaryGenesisData {
     #[cfg(feature = "future_snark")]
-    genesis_message_preimage: Vec<u8>,
+    genesis_message_preimage: GenesisMessagePreimage,
     #[cfg(feature = "future_snark")]
     genesis_schnorr_signature: Option<StandardSchnorrSignature>,
     #[cfg(feature = "future_snark")]
@@ -123,7 +122,7 @@ impl AncillaryGenesisData {
     ) -> Self {
         Self {
             #[cfg(feature = "future_snark")]
-            genesis_message_preimage,
+            genesis_message_preimage: GenesisMessagePreimage(genesis_message_preimage),
             #[cfg(feature = "future_snark")]
             genesis_schnorr_signature,
             #[cfg(feature = "future_snark")]
@@ -133,7 +132,7 @@ impl AncillaryGenesisData {
 
     /// Return the genesis message preimage.
     #[cfg(feature = "future_snark")]
-    pub fn genesis_message_preimage(&self) -> &[u8] {
+    pub fn genesis_message_preimage(&self) -> &GenesisMessagePreimage {
         &self.genesis_message_preimage
     }
 
@@ -312,7 +311,10 @@ mod tests {
 
         let genesis_data = AncillaryGenesisData::new(preimage.clone(), None, None);
 
-        assert_eq!(genesis_data.genesis_message_preimage(), preimage.as_slice());
+        assert_eq!(
+            genesis_data.genesis_message_preimage().0,
+            preimage.as_slice()
+        );
         assert!(genesis_data.genesis_schnorr_signature().is_none());
         assert!(genesis_data.genesis_schnorr_verification_key().is_none());
     }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -1,4 +1,5 @@
 use anyhow::Context;
+use midnight_proofs::transcript::TranscriptHash;
 use std::marker::PhantomData;
 
 #[cfg(feature = "future_snark")]
@@ -12,6 +13,8 @@ use crate::{
 
 #[cfg(feature = "future_snark")]
 use crate::AggregateSignatureError;
+#[cfg(feature = "future_snark")]
+use crate::proof_system::ivc_halo2_snark::proof::IvcProver;
 #[cfg(feature = "future_snark")]
 use crate::proof_system::{MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver};
 
@@ -113,6 +116,21 @@ impl<D: MembershipDigest> Clerk<D> {
                         AggregateSignatureType::Snark
                     )
                 })
+            }
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::IvcSnark => {
+                let clerk = self
+                    .get_snark_clerk()
+                    .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
+
+                let preimage = todo!();
+                let genvk = todo!();
+
+                // let prover = IvcProver {
+                //     ivc_setup:
+                // }
+
+                todo!()
             }
         }
     }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -95,7 +95,7 @@ impl<D: MembershipDigest> Clerk<D> {
         aggregate_signature_type: AggregateSignatureType,
         ancillary_input: AncillaryProofInput,
     ) -> StmResult<(AggregateSignature<D>, AncillaryProofOutput)> {
-        let _ = ancillary_input;
+        let _ = &ancillary_input;
         match aggregate_signature_type {
             AggregateSignatureType::Concatenation => {
                 let proof = ConcatenationProof::aggregate_signatures(
@@ -291,7 +291,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     );
 
     let mut prover = IvcProver {
-        ivc_setup: ivc_prover_setup.clone().into(),
+        ivc_setup: ivc_prover_setup,
         rng: OsRng,
     };
 
@@ -302,7 +302,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         &global,
         &ProtocolMessagePreimage(protocol_message_preimage_bytes),
         genesis_bootstrap,
-        rolling_state.as_ref(),
+        rolling_state,
     )?;
 
     let verifier_data = IvcVerifierData::new(
@@ -337,7 +337,11 @@ fn load_ivc_prover_setup(
 ) -> StmResult<(Arc<IvcProverSetup>, MidnightVK)> {
     let cache_key = (parameters.to_bytes()?, merkle_tree_depth);
 
-    if let Some(cached) = IVC_PROVER_SETUP_CACHE.lock().unwrap().get(&cache_key) {
+    if let Some(cached) = IVC_PROVER_SETUP_CACHE
+        .lock()
+        .map_err(|_| anyhow!("IVC prover setup cache lock poisoned."))?
+        .get(&cache_key)
+    {
         return Ok(cached.clone());
     }
 
@@ -358,7 +362,7 @@ fn load_ivc_prover_setup(
     let cached = (ivc_setup, certificate_midnight_verifying_key);
     IVC_PROVER_SETUP_CACHE
         .lock()
-        .unwrap()
+        .map_err(|_| anyhow!("IVC prover setup cache lock poisoned."))?
         .insert(cache_key, cached.clone());
 
     Ok(cached)

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -152,9 +152,12 @@ impl<D: MembershipDigest> Clerk<D> {
 
                 println!("First certificate proof generated, starting the IVC proof");
 
-                // For now the function will fail as we give two Some values
-                // which should not happen but this might be changed
-                let (ivc_proof, rolling_state, verifier_data) =
+                // A same-epoch step does not advance the rolling state, so the prover returns
+                // none: carry the input rolling state forward so the next certificate keeps
+                // building on it.
+                let previous_prover_data = ancillary_input.prover_data().cloned();
+
+                let (ivc_proof, next_rolling_state, verifier_data) =
                     ivc_prover_input_preparation_and_prove(
                         snark_proof,
                         msg,
@@ -162,9 +165,8 @@ impl<D: MembershipDigest> Clerk<D> {
                         ancillary_input,
                     )?;
 
-                let ancillary_prover_data = AncillaryProverData::IvcSnark(
-                    rolling_state.ok_or_else(|| anyhow!("missing rolling state"))?,
-                );
+                let ancillary_prover_data =
+                    resolve_ivc_ancillary_prover_data(next_rolling_state, previous_prover_data)?;
                 let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(verifier_data);
 
                 Ok((
@@ -344,262 +346,61 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     Ok((ivc_proof, next_rolling_state, verifier_data))
 }
 
-#[cfg(test)]
+/// Resolve the prover data to store on a new IVC certificate.
+///
+/// A next-epoch step advances the rolling state, which is stored as is. A same-epoch step does not
+/// advance it (the prover returns none), so the input rolling state carried from the parent
+/// certificate is reused for the next certificate.
+fn resolve_ivc_ancillary_prover_data(
+    next_rolling_state: Option<IvcRollingState>,
+    previous_prover_data: Option<AncillaryProverData>,
+) -> StmResult<AncillaryProverData> {
+    match next_rolling_state {
+        Some(rolling_state) => Ok(AncillaryProverData::IvcSnark(rolling_state)),
+        None => previous_prover_data.ok_or_else(|| anyhow!("missing rolling state")),
+    }
+}
+
+#[cfg(all(test, feature = "future_snark"))]
 mod tests {
-    #[cfg(feature = "future_snark")]
-    mod slow {
-        use std::sync::Arc;
-        use std::time::Instant;
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
 
-        use rand_chacha::ChaCha20Rng;
-        use rand_core::SeedableRng;
-        use sha2::{Digest, Sha256};
-        use tempfile::tempdir;
+    use crate::AncillaryProverData;
+    use crate::proof_system::IvcRollingState;
+    use crate::signature_scheme::{BaseFieldElement, SchnorrSigningKey};
 
-        use crate::AggregateSignature::IvcSnark;
-        use crate::circuits::halo2_ivc::K;
-        use crate::circuits::halo2_ivc::state::Global;
-        use crate::circuits::halo2_ivc::tests::common::asset_readers::load_embedded_verification_context_asset;
-        use crate::circuits::halo2_ivc::tests::common::generators::build_recursive_global;
-        use crate::circuits::halo2_ivc::tests::common::generators::setup::{
-            QUORUM_SIZE, SIGNER_COUNT,
-        };
-        use crate::circuits::halo2_ivc::types::MessageHash;
-        use crate::circuits::trusted_setup::{
-            TrustedSetupProvider, build_provider_with_unsafe_srs,
-        };
-        use crate::proof_system::ivc_halo2_snark::verifier_setup::{self, IvcVerifierSetup};
-        use crate::proof_system::ivc_halo2_snark::{
-            IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
-        };
-        use crate::protocol::aggregate_signature::{
-            AggregateSignatureType, AncillaryGenesisData, AncillaryProofInput,
-        };
-        use crate::{
-            AggregateVerificationKey, AggregateVerificationKeyForSnark, AncillaryProverData,
-            BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey,
-        };
-        use crate::{
-            Initializer, KeyRegistration, MithrilMembershipDigest, Parameters, RegistrationEntry,
-            Signer, SingleSignature,
-            circuits::halo2_ivc::tests::common::{
-                asset_readers::load_embedded_first_certificate_in_epoch_asset,
-                generators::{
-                    build_asset_generation_setup, build_genesis_protocol_message_preimage,
-                },
-            },
-        };
+    use super::resolve_ivc_ancillary_prover_data;
 
-        use super::super::Clerk;
+    fn build_rolling_state() -> IvcRollingState {
+        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+        let signing_key = SchnorrSigningKey::generate(&mut rng);
+        let message = vec![BaseFieldElement::from(1u64)];
+        let genesis_signature = signing_key.sign_standard(&message, &mut rng).unwrap();
+        IvcRollingState::genesis(genesis_signature, &[])
+    }
 
-        type D = MithrilMembershipDigest;
+    #[test]
+    fn next_epoch_step_stores_the_advanced_rolling_state() {
+        let prover_data =
+            resolve_ivc_ancillary_prover_data(Some(build_rolling_state()), None).unwrap();
 
-        fn setup_parties_with_snark_keys(params: Parameters, nparties: usize) -> Vec<Signer<D>> {
-            let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
-            let mut key_reg = KeyRegistration::initialize();
-            let mut initializers = Vec::with_capacity(nparties);
+        assert!(matches!(prover_data, AncillaryProverData::IvcSnark(_)));
+    }
 
-            for i in 0..nparties {
-                let stake = (i as u64 + 1) * 10;
-                let init = Initializer::new(params, stake, &mut rng);
-                let entry = RegistrationEntry::new(
-                    init.get_verification_key_proof_of_possession_for_concatenation(),
-                    init.stake,
-                    init.schnorr_verification_key.clone(),
-                )
-                .unwrap();
-                key_reg.register_by_entry(&entry).unwrap();
-                initializers.push(init);
-            }
+    #[test]
+    fn same_epoch_step_carries_the_previous_rolling_state_forward() {
+        let previous = AncillaryProverData::IvcSnark(build_rolling_state());
 
-            let closed_reg = key_reg.close_registration(&params).unwrap();
-            initializers
-                .into_iter()
-                .map(|init| init.try_create_signer::<D>(&closed_reg).unwrap())
-                .collect()
-        }
+        let prover_data = resolve_ivc_ancillary_prover_data(None, Some(previous)).unwrap();
 
-        fn get_signatures(msg: &[u8], signers: &[Signer<D>]) -> Vec<SingleSignature> {
-            signers
-                .iter()
-                .filter_map(|s| s.create_single_signature(msg).ok())
-                .collect()
-        }
+        assert!(matches!(prover_data, AncillaryProverData::IvcSnark(_)));
+    }
 
-        #[test]
-        fn aggregate_signatures_with_type_ivc_snark_succeeds_on_genesis_step() {
-            /*
-                What I need to test:
-                    The call to agg sig should work as follow: generate a snark proof of the current signatures then call the ivc prove.
-                    If the current signatures are the first after genesis then the prover runs the genesis step and then runs the first step.
-                    If not then it just runs the step.
-                    If the epoch is the same, it bases itself on the first ivc proof of the epoch and runs the step.
-                    If not it runs the step to change epoch and create the first ivc proof of the new epoch
+    #[test]
+    fn fails_when_neither_an_advanced_nor_a_previous_rolling_state_is_available() {
+        let error = resolve_ivc_ancillary_prover_data(None, None).unwrap_err();
 
-                What is needed to run the tests
-                    Genesis information
-                    prover input information
-                        protocol message
-                        ...
-            */
-
-            let temp_dir = tempdir().expect("temp dir creation should succeed");
-
-            let parameters = Parameters {
-                k: QUORUM_SIZE as u64,
-                m: (QUORUM_SIZE * 10) as u64,
-                phi_f: 1.0,
-            };
-
-            // Generate the Clerk
-            let nparties = 5;
-            let message_preimage = [
-                100, 105, 103, 101, 115, 116, 16, 176, 3, 177, 117, 37, 103, 12, 53, 79, 204, 177,
-                5, 29, 166, 175, 219, 238, 208, 244, 237, 50, 243, 235, 78, 116, 175, 115, 115,
-                216, 50, 89, 110, 101, 120, 116, 95, 97, 103, 103, 114, 101, 103, 97, 116, 101, 95,
-                118, 101, 114, 105, 102, 105, 99, 97, 116, 105, 111, 110, 95, 107, 101, 121, 171,
-                31, 233, 204, 25, 208, 111, 243, 26, 55, 65, 207, 108, 15, 61, 48, 94, 190, 72,
-                235, 26, 159, 69, 15, 113, 189, 8, 159, 172, 209, 98, 17, 0, 0, 0, 0, 64, 66, 15,
-                0, 0, 0, 0, 0, 110, 101, 120, 116, 95, 112, 114, 111, 116, 111, 99, 111, 108, 95,
-                112, 97, 114, 97, 109, 101, 116, 101, 114, 115, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 117, 114, 114, 101,
-                110, 116, 95, 101, 112, 111, 99, 104, 6, 0, 0, 0, 0, 0, 0, 0,
-            ];
-            let msg: [u8; 32] = Sha256::digest(message_preimage).into();
-            let ps = setup_parties_with_snark_keys(parameters, nparties);
-            let clerk = Clerk::new_clerk_from_signer(&ps[0]);
-            let avk: AggregateVerificationKey<MithrilMembershipDigest> =
-                clerk.compute_aggregate_verification_key();
-
-            let sigs = get_signatures(&msg, &ps);
-
-            // First verify that the regular SNARK works
-            // let (agg_sig_snark, _) = clerk
-            //     .aggregate_signatures_with_type(
-            //         &sigs,
-            //         &msg,
-            //         AggregateSignatureType::Snark,
-            //         AncillaryProofInput::dummy(),
-            //     )
-            //     .unwrap();
-
-            // agg_sig_snark.verify(&msg, &avk, &parameters, None).unwrap();
-
-            // Generating Ancillary data
-
-            // Genesis data
-            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-            let genesis_message_preimage = [
-                100, 105, 103, 101, 115, 116, 188, 195, 32, 175, 25, 79, 116, 67, 229, 98, 109,
-                154, 196, 202, 248, 54, 145, 200, 225, 104, 140, 210, 217, 43, 122, 186, 71, 208,
-                221, 55, 131, 213, 110, 101, 120, 116, 95, 97, 103, 103, 114, 101, 103, 97, 116,
-                101, 95, 118, 101, 114, 105, 102, 105, 99, 97, 116, 105, 111, 110, 95, 107, 101,
-                121, 171, 31, 233, 204, 25, 208, 111, 243, 26, 55, 65, 207, 108, 15, 61, 48, 94,
-                190, 72, 235, 26, 159, 69, 15, 113, 189, 8, 159, 172, 209, 98, 17, 0, 0, 0, 0, 64,
-                66, 15, 0, 0, 0, 0, 0, 110, 101, 120, 116, 95, 112, 114, 111, 116, 111, 99, 111,
-                108, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115, 7, 0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 117, 114,
-                114, 101, 110, 116, 95, 101, 112, 111, 99, 104, 5, 0, 0, 0, 0, 0, 0, 0,
-            ];
-            let genesis_schnorr_signing_key = SchnorrSigningKey::generate(&mut rng);
-            let genesis_message =
-                BaseFieldElement::try_from(genesis_message_preimage.as_slice()).unwrap();
-            let genesis_message_signature = genesis_schnorr_signing_key
-                .sign_standard(&[genesis_message], &mut rng)
-                .unwrap();
-            let genesis_schnorr_verification_key =
-                SchnorrVerificationKey::new_from_signing_key(genesis_schnorr_signing_key);
-
-            let genesis_data = AncillaryGenesisData::new(
-                genesis_message_preimage.to_vec(),
-                Some(genesis_message_signature),
-                Some(genesis_schnorr_verification_key),
-            );
-
-            // Prover data
-            // let prover_data = AncillaryProverData::IvcSnark(())
-
-            let ancillary_proof_input =
-                AncillaryProofInput::new(None, genesis_data.clone(), message_preimage.to_vec());
-
-            println!("Proving first step");
-            let (proof, ancillary_output_data) = clerk
-                .aggregate_signatures_with_type(
-                    &sigs,
-                    &msg,
-                    AggregateSignatureType::IvcSnark,
-                    ancillary_proof_input,
-                )
-                .unwrap();
-
-            println!("Verifying first step");
-
-            let ivc_proof = match proof.clone() {
-                IvcSnark(ivc_proof) => ivc_proof,
-                _ => todo!(),
-            };
-
-            let certificate_circuit_verification_key = ancillary_output_data
-                .verifier_data()
-                .unwrap()
-                .as_ivc_verifier_data()
-                .certificate_circuit_verification_key();
-
-            let ivc_circuit_verification_key = ancillary_output_data
-                .verifier_data()
-                .unwrap()
-                .as_ivc_verifier_data()
-                .ivc_circuit_verification_key();
-
-            let global = Global::new(
-                MessageHash::from_field(genesis_message.0),
-                genesis_schnorr_verification_key,
-                &certificate_circuit_verification_key,
-                &ivc_circuit_verification_key,
-            );
-            let verifier_setup = IvcVerifierSetup::try_new(
-                &certificate_circuit_verification_key,
-                ivc_circuit_verification_key,
-            )
-            .unwrap();
-
-            let verify_proof = ivc_proof.verify(&global, &verifier_setup);
-
-            println!("result of trying to verify the proof: {:?}", verify_proof);
-
-            let verify_status = proof.verify(
-                &msg,
-                &avk,
-                &parameters,
-                ancillary_output_data.verifier_data().cloned(),
-            );
-
-            println!("verifying status for first step: {:?}", verify_status);
-
-            // let ancillary_proof_input = AncillaryProofInput::new(
-            //     ancillary_output_data.prover_data().cloned(),
-            //     genesis_data,
-            //     message_preimage.to_vec(),
-            // );
-            // println!("Proving second step");
-            // let (proof, ancillary_output_data) = clerk
-            //     .aggregate_signatures_with_type(
-            //         &sigs,
-            //         &msg,
-            //         AggregateSignatureType::IvcSnark,
-            //         ancillary_proof_input,
-            //     )
-            //     .unwrap();
-
-            // println!("Verifying second step");
-            // proof
-            //     .verify(
-            //         &msg,
-            //         &avk,
-            //         &parameters,
-            //         ancillary_output_data.verifier_data().cloned(),
-            //     )
-            //     .unwrap()
-        }
+        assert!(error.to_string().contains("missing rolling state"));
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -294,7 +294,9 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let avk = clerk.compute_aggregate_verification_key_for_snark();
 
     let genesis_message = MessageHash::from_field(genesis_message_field_elem);
-    let certificate_circuit_verification_key = certificate_key_provider.get_verifying_key()?;
+    let certificate_midnight_verifying_key =
+        certificate_key_provider.get_midnight_verifying_key()?;
+    let certificate_circuit_verification_key = certificate_midnight_verifying_key.vk().clone();
     let ivc_circuit_verification_key = ivc_key_provider.get_verifying_key()?;
     println!("Creating the global value");
 
@@ -308,7 +310,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let verifier_data = IvcVerifierData::new(
         genesis_message,
         genesis_verification_key,
-        certificate_circuit_verification_key,
+        certificate_midnight_verifying_key,
         ivc_circuit_verification_key,
     );
 

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -135,6 +135,9 @@ impl<D: MembershipDigest> Clerk<D> {
                 let clerk = self
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
+
+                println!("Clerk ready to prove the first certificate");
+
                 let snark_proof = SnarkProver::try_new_non_deterministic(
                     &clerk.parameters,
                     MERKLE_TREE_DEPTH_FOR_SNARK,
@@ -146,6 +149,8 @@ impl<D: MembershipDigest> Clerk<D> {
                         AggregateSignatureType::Snark
                     )
                 })?;
+
+                println!("First certificate proof generated, starting the IVC proof");
 
                 // For now the function will fail as we give two Some values
                 // which should not happen but this might be changed
@@ -235,23 +240,39 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let protocol_message_preimage_bytes: [u8; 190] =
         ancillary_input.message_preimage().try_into()?;
 
+    println!("Getting the genesis_verification_key");
+
     let genesis_verification_key = ancillary_input
         .genesis_data()
         .genesis_schnorr_verification_key()
         .cloned()
         .ok_or_else(|| anyhow!("Missing genesis verification key from ancillary data"))?;
 
+    println!("Getting the genesis_preimage");
+
     let genesis_preimage = ancillary_input.genesis_data().genesis_message_preimage();
 
+    println!("Converting the genesis_preimage to field element");
     // TODO: clean this to have proper call to SHA256
+    // the try_from function applies the Sha256 hash
     let genesis_message_field_elem = BaseFieldElement::try_from(genesis_preimage)?.0;
 
+    println!("Starting the trusted_setup generation via the provider");
+
     let trusted_setup_provider = TrustedSetupProvider::default();
+    println!("Getting the srs");
+
     let srs = Arc::new(trusted_setup_provider.get_trusted_setup_parameters()?);
+    println!("Creating the certificate_key_provider from srs");
+
     let certificate_key_provider =
         TempCertificateKeyProvider::new(srs.clone(), clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK);
+    println!("Creating the ivc_key_provider from srs");
+
     let ivc_key_provider =
         TempIvcKeyProvider::new(srs.clone(), certificate_key_provider.get_verifying_key()?);
+
+    println!("Creating the ivc_setup from providers");
 
     let ivc_setup = IvcProverSetup::load(
         &trusted_setup_provider,
@@ -259,10 +280,14 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         &ivc_key_provider,
     )?;
 
+    println!("Creating the prover from ivc_setup");
+
     let mut prover = IvcProver {
         ivc_setup: ivc_setup.into(),
         rng: OsRng,
     };
+
+    println!("Computing the avk");
 
     // This is only used to get the root of the tree so maybe we can replace
     // the avk inputs by the root directly
@@ -271,6 +296,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let genesis_message = MessageHash::from_field(genesis_message_field_elem);
     let certificate_circuit_verification_key = certificate_key_provider.get_verifying_key()?;
     let ivc_circuit_verification_key = ivc_key_provider.get_verifying_key()?;
+    println!("Creating the global value");
 
     let global = Global::new(
         genesis_message,
@@ -286,14 +312,20 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         ivc_circuit_verification_key,
     );
 
+    println!("Extracting the rolling state if present");
+
     let rolling_state = match ancillary_input.prover_data() {
         Some(input) => Some(input.as_ivc_rolling_state()),
         None => None,
     };
 
+    println!("Converting the genesis bootstrap data");
+
     // IvcGenesisBootstrapInput contains the same values as AncillaryGenesisData
     // We might consider dropping one or implementing a conversion between the two
     let genesis_bootstrap = &ancillary_input.genesis_data().try_into()?;
+
+    println!("Starting the IVC proof");
 
     // For now the function will fail as we give two Some values
     // which should not happen but this might be changed
@@ -308,4 +340,264 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     )?;
 
     Ok((ivc_proof, next_rolling_state, verifier_data))
+}
+
+#[cfg(test)]
+mod tests {
+    #[cfg(feature = "future_snark")]
+    mod slow {
+        use std::sync::Arc;
+        use std::time::Instant;
+
+        use rand_chacha::ChaCha20Rng;
+        use rand_core::SeedableRng;
+        use sha2::{Digest, Sha256};
+        use tempfile::tempdir;
+
+        use crate::AggregateSignature::IvcSnark;
+        use crate::circuits::halo2_ivc::K;
+        use crate::circuits::halo2_ivc::state::Global;
+        use crate::circuits::halo2_ivc::tests::common::asset_readers::load_embedded_verification_context_asset;
+        use crate::circuits::halo2_ivc::tests::common::generators::build_recursive_global;
+        use crate::circuits::halo2_ivc::tests::common::generators::setup::{
+            QUORUM_SIZE, SIGNER_COUNT,
+        };
+        use crate::circuits::halo2_ivc::types::MessageHash;
+        use crate::circuits::trusted_setup::{
+            TrustedSetupProvider, build_provider_with_unsafe_srs,
+        };
+        use crate::proof_system::ivc_halo2_snark::verifier_setup::{self, IvcVerifierSetup};
+        use crate::proof_system::ivc_halo2_snark::{
+            IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
+        };
+        use crate::protocol::aggregate_signature::{
+            AggregateSignatureType, AncillaryGenesisData, AncillaryProofInput,
+        };
+        use crate::{
+            AggregateVerificationKey, AggregateVerificationKeyForSnark, AncillaryProverData,
+            BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey,
+        };
+        use crate::{
+            Initializer, KeyRegistration, MithrilMembershipDigest, Parameters, RegistrationEntry,
+            Signer, SingleSignature,
+            circuits::halo2_ivc::tests::common::{
+                asset_readers::load_embedded_first_certificate_in_epoch_asset,
+                generators::{
+                    build_asset_generation_setup, build_genesis_protocol_message_preimage,
+                },
+            },
+        };
+
+        use super::super::Clerk;
+
+        type D = MithrilMembershipDigest;
+
+        fn setup_parties_with_snark_keys(params: Parameters, nparties: usize) -> Vec<Signer<D>> {
+            let mut rng = ChaCha20Rng::from_seed([42u8; 32]);
+            let mut key_reg = KeyRegistration::initialize();
+            let mut initializers = Vec::with_capacity(nparties);
+
+            for i in 0..nparties {
+                let stake = (i as u64 + 1) * 10;
+                let init = Initializer::new(params, stake, &mut rng);
+                let entry = RegistrationEntry::new(
+                    init.get_verification_key_proof_of_possession_for_concatenation(),
+                    init.stake,
+                    init.schnorr_verification_key.clone(),
+                )
+                .unwrap();
+                key_reg.register_by_entry(&entry).unwrap();
+                initializers.push(init);
+            }
+
+            let closed_reg = key_reg.close_registration(&params).unwrap();
+            initializers
+                .into_iter()
+                .map(|init| init.try_create_signer::<D>(&closed_reg).unwrap())
+                .collect()
+        }
+
+        fn get_signatures(msg: &[u8], signers: &[Signer<D>]) -> Vec<SingleSignature> {
+            signers
+                .iter()
+                .filter_map(|s| s.create_single_signature(msg).ok())
+                .collect()
+        }
+
+        #[test]
+        fn aggregate_signatures_with_type_ivc_snark_succeeds_on_genesis_step() {
+            /*
+                What I need to test:
+                    The call to agg sig should work as follow: generate a snark proof of the current signatures then call the ivc prove.
+                    If the current signatures are the first after genesis then the prover runs the genesis step and then runs the first step.
+                    If not then it just runs the step.
+                    If the epoch is the same, it bases itself on the first ivc proof of the epoch and runs the step.
+                    If not it runs the step to change epoch and create the first ivc proof of the new epoch
+
+                What is needed to run the tests
+                    Genesis information
+                    prover input information
+                        protocol message
+                        ...
+            */
+
+            let temp_dir = tempdir().expect("temp dir creation should succeed");
+
+            let parameters = Parameters {
+                k: QUORUM_SIZE as u64,
+                m: (QUORUM_SIZE * 10) as u64,
+                phi_f: 1.0,
+            };
+
+            // Generate the Clerk
+            let nparties = 5;
+            let message_preimage = [
+                100, 105, 103, 101, 115, 116, 16, 176, 3, 177, 117, 37, 103, 12, 53, 79, 204, 177,
+                5, 29, 166, 175, 219, 238, 208, 244, 237, 50, 243, 235, 78, 116, 175, 115, 115,
+                216, 50, 89, 110, 101, 120, 116, 95, 97, 103, 103, 114, 101, 103, 97, 116, 101, 95,
+                118, 101, 114, 105, 102, 105, 99, 97, 116, 105, 111, 110, 95, 107, 101, 121, 171,
+                31, 233, 204, 25, 208, 111, 243, 26, 55, 65, 207, 108, 15, 61, 48, 94, 190, 72,
+                235, 26, 159, 69, 15, 113, 189, 8, 159, 172, 209, 98, 17, 0, 0, 0, 0, 64, 66, 15,
+                0, 0, 0, 0, 0, 110, 101, 120, 116, 95, 112, 114, 111, 116, 111, 99, 111, 108, 95,
+                112, 97, 114, 97, 109, 101, 116, 101, 114, 115, 7, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 117, 114, 114, 101,
+                110, 116, 95, 101, 112, 111, 99, 104, 6, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            let msg: [u8; 32] = Sha256::digest(message_preimage).into();
+            let ps = setup_parties_with_snark_keys(parameters, nparties);
+            let clerk = Clerk::new_clerk_from_signer(&ps[0]);
+            let avk: AggregateVerificationKey<MithrilMembershipDigest> =
+                clerk.compute_aggregate_verification_key();
+
+            let sigs = get_signatures(&msg, &ps);
+
+            // First verify that the regular SNARK works
+            // let (agg_sig_snark, _) = clerk
+            //     .aggregate_signatures_with_type(
+            //         &sigs,
+            //         &msg,
+            //         AggregateSignatureType::Snark,
+            //         AncillaryProofInput::dummy(),
+            //     )
+            //     .unwrap();
+
+            // agg_sig_snark.verify(&msg, &avk, &parameters, None).unwrap();
+
+            // Generating Ancillary data
+
+            // Genesis data
+            let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
+            let genesis_message_preimage = [
+                100, 105, 103, 101, 115, 116, 188, 195, 32, 175, 25, 79, 116, 67, 229, 98, 109,
+                154, 196, 202, 248, 54, 145, 200, 225, 104, 140, 210, 217, 43, 122, 186, 71, 208,
+                221, 55, 131, 213, 110, 101, 120, 116, 95, 97, 103, 103, 114, 101, 103, 97, 116,
+                101, 95, 118, 101, 114, 105, 102, 105, 99, 97, 116, 105, 111, 110, 95, 107, 101,
+                121, 171, 31, 233, 204, 25, 208, 111, 243, 26, 55, 65, 207, 108, 15, 61, 48, 94,
+                190, 72, 235, 26, 159, 69, 15, 113, 189, 8, 159, 172, 209, 98, 17, 0, 0, 0, 0, 64,
+                66, 15, 0, 0, 0, 0, 0, 110, 101, 120, 116, 95, 112, 114, 111, 116, 111, 99, 111,
+                108, 95, 112, 97, 114, 97, 109, 101, 116, 101, 114, 115, 7, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 117, 114,
+                114, 101, 110, 116, 95, 101, 112, 111, 99, 104, 5, 0, 0, 0, 0, 0, 0, 0,
+            ];
+            let genesis_schnorr_signing_key = SchnorrSigningKey::generate(&mut rng);
+            let genesis_message =
+                BaseFieldElement::try_from(genesis_message_preimage.as_slice()).unwrap();
+            let genesis_message_signature = genesis_schnorr_signing_key
+                .sign_standard(&[genesis_message], &mut rng)
+                .unwrap();
+            let genesis_schnorr_verification_key =
+                SchnorrVerificationKey::new_from_signing_key(genesis_schnorr_signing_key);
+
+            let genesis_data = AncillaryGenesisData::new(
+                genesis_message_preimage.to_vec(),
+                Some(genesis_message_signature),
+                Some(genesis_schnorr_verification_key),
+            );
+
+            // Prover data
+            // let prover_data = AncillaryProverData::IvcSnark(())
+
+            let ancillary_proof_input =
+                AncillaryProofInput::new(None, genesis_data.clone(), message_preimage.to_vec());
+
+            println!("Proving first step");
+            let (proof, ancillary_output_data) = clerk
+                .aggregate_signatures_with_type(
+                    &sigs,
+                    &msg,
+                    AggregateSignatureType::IvcSnark,
+                    ancillary_proof_input,
+                )
+                .unwrap();
+
+            println!("Verifying first step");
+
+            let ivc_proof = match proof.clone() {
+                IvcSnark(ivc_proof) => ivc_proof,
+                _ => todo!(),
+            };
+
+            let certificate_circuit_verification_key = ancillary_output_data
+                .verifier_data()
+                .unwrap()
+                .as_ivc_verifier_data()
+                .certificate_circuit_verification_key();
+
+            let ivc_circuit_verification_key = ancillary_output_data
+                .verifier_data()
+                .unwrap()
+                .as_ivc_verifier_data()
+                .ivc_circuit_verification_key();
+
+            let global = Global::new(
+                MessageHash::from_field(genesis_message.0),
+                genesis_schnorr_verification_key,
+                &certificate_circuit_verification_key,
+                &ivc_circuit_verification_key,
+            );
+            let verifier_setup = IvcVerifierSetup::try_new(
+                &certificate_circuit_verification_key,
+                ivc_circuit_verification_key,
+            )
+            .unwrap();
+
+            let verify_proof = ivc_proof.verify(&global, &verifier_setup);
+
+            println!("result of trying to verify the proof: {:?}", verify_proof);
+
+            let verify_status = proof.verify(
+                &msg,
+                &avk,
+                &parameters,
+                ancillary_output_data.verifier_data().cloned(),
+            );
+
+            println!("verifying status for first step: {:?}", verify_status);
+
+            // let ancillary_proof_input = AncillaryProofInput::new(
+            //     ancillary_output_data.prover_data().cloned(),
+            //     genesis_data,
+            //     message_preimage.to_vec(),
+            // );
+            // println!("Proving second step");
+            // let (proof, ancillary_output_data) = clerk
+            //     .aggregate_signatures_with_type(
+            //         &sigs,
+            //         &msg,
+            //         AggregateSignatureType::IvcSnark,
+            //         ancillary_proof_input,
+            //     )
+            //     .unwrap();
+
+            // println!("Verifying second step");
+            // proof
+            //     .verify(
+            //         &msg,
+            //         &avk,
+            //         &parameters,
+            //         ancillary_output_data.verifier_data().cloned(),
+            //     )
+            //     .unwrap()
+        }
+    }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -1,13 +1,17 @@
 use anyhow::Context;
 use rand_core::OsRng;
-use std::marker::PhantomData;
+use std::{marker::PhantomData, sync::Arc};
 
 #[cfg(feature = "future_snark")]
 use anyhow::anyhow;
+#[cfg(feature = "future_snark")]
+use sha2::{Digest, Sha256};
 
 use crate::{
-    AggregateVerificationKey, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
-    Signer, SingleSignature, SnarkProof, Stake, StmResult, VerificationKeyForConcatenation,
+    AggregateVerificationKey, BaseFieldElement, ClosedKeyRegistration, LotteryIndex,
+    MembershipDigest, Parameters, Signer, SingleSignature, SnarkProof, Stake, StmResult,
+    VerificationKeyForConcatenation,
+    circuits::halo2_ivc::{ProtocolMessagePreimage, types::MessageHash},
     proof_system::{
         ConcatenationClerk, ConcatenationProof, IvcRollingState, ivc_halo2_snark::proof::IvcProof,
     },
@@ -18,7 +22,6 @@ use crate::{
     circuits::{halo2_ivc::state::Global, trusted_setup::TrustedSetupProvider},
     proof_system::ivc_halo2_snark::{
         IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
-        proof::IvcGenesisBootstrapInput,
     },
 };
 
@@ -159,7 +162,10 @@ impl<D: MembershipDigest> Clerk<D> {
                 );
 
                 // TODO: add the AncillaryProverData and AncillaryVerifierData to the output
-                Ok((AggregateSignature::IvcSnark(Box::new(proof_output.0)), None))
+                Ok((
+                    AggregateSignature::IvcSnark(Box::new(proof_output.0)),
+                    AncillaryProofOutput::new(Some(ancillary_prover_data), None),
+                ))
             }
         }
     }
@@ -219,19 +225,26 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     clerk: &SnarkClerk,
     ancillary_input: AncillaryProofInput,
 ) -> StmResult<(IvcProof<blake2b_simd::State>, Option<IvcRollingState>)> {
-    // TODO: get the protocol message preimage
-    let protocol_message_preimage = todo!();
-    // TODO: get the protocol message preimage
-    let genesis_verification_key = todo!();
-    // TODO: get the genesis message
-    let genesis_message = todo!();
+    let protocol_message_preimage_bytes: [u8; 190] =
+        ancillary_input.message_preimage().try_into()?;
+
+    let genesis_verification_key = ancillary_input
+        .genesis_data()
+        .genesis_schnorr_verification_key()
+        .cloned()
+        .ok_or_else(|| anyhow!("Missing genesis verification key from ancillary data"))?;
+
+    let genesis_preimage = ancillary_input.genesis_data().genesis_message_preimage();
+
+    // TODO: clean this to have proper call to SHA256
+    let genesis_message_field_elem = BaseFieldElement::try_from(genesis_preimage)?.0;
 
     let trusted_setup_provider = TrustedSetupProvider::default();
-    let srs = trusted_setup_provider.get_trusted_setup_parameters()?;
+    let srs = Arc::new(trusted_setup_provider.get_trusted_setup_parameters()?);
     let certificate_key_provider =
-        TempCertificateKeyProvider::new(srs.into(), clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK);
+        TempCertificateKeyProvider::new(srs.clone(), clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK);
     let ivc_key_provider =
-        TempIvcKeyProvider::new(srs.into(), certificate_key_provider.get_verifying_key()?);
+        TempIvcKeyProvider::new(srs.clone(), certificate_key_provider.get_verifying_key()?);
 
     let ivc_setup = IvcProverSetup::load(
         &trusted_setup_provider,
@@ -239,7 +252,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         &ivc_key_provider,
     )?;
 
-    let prover = IvcProver {
+    let mut prover = IvcProver {
         ivc_setup: ivc_setup.into(),
         rng: OsRng,
     };
@@ -249,16 +262,16 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let avk = clerk.compute_aggregate_verification_key_for_snark();
 
     let global = Global::new(
-        genesis_message,
+        MessageHash::from_field(genesis_message_field_elem),
         genesis_verification_key,
         &certificate_key_provider.get_verifying_key()?,
         &ivc_key_provider.get_verifying_key()?,
     );
 
-    let rolling_state = ancillary_input
-        .prover_data()
-        .ok_or_else(|| anyhow!("Missing prover data"))?
-        .as_ivc_rolling_state();
+    let rolling_state = match ancillary_input.prover_data() {
+        Some(input) => Some(input.as_ivc_rolling_state()),
+        None => None,
+    };
 
     // IvcGenesisBootstrapInput contains the same values as AncillaryGenesisData
     // We might consider dropping one or implementing a conversion between the two
@@ -271,8 +284,8 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         msg,
         &avk,
         &global,
-        protocol_message_preimage,
-        Some(&rolling_state),
+        &ProtocolMessagePreimage(protocol_message_preimage_bytes),
+        rolling_state.as_ref(),
         Some(genesis_bootstrap),
     )
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -1,5 +1,9 @@
 use anyhow::Context;
+#[cfg(feature = "future_snark")]
+use midnight_zk_stdlib::MidnightVK;
 use std::marker::PhantomData;
+#[cfg(feature = "future_snark")]
+use std::sync::Arc;
 
 #[cfg(feature = "future_snark")]
 use anyhow::anyhow;
@@ -13,7 +17,9 @@ use crate::{
 };
 #[cfg(feature = "future_snark")]
 use crate::{
-    circuits::halo2_ivc::PREIMAGE_SIZE, proof_system::ivc_halo2_snark::load_ivc_prover_setup,
+    AggregationError,
+    circuits::halo2_ivc::PREIMAGE_SIZE,
+    proof_system::ivc_halo2_snark::{IvcProverSetup, load_ivc_prover_setup},
 };
 
 #[cfg(feature = "future_snark")]
@@ -147,18 +153,25 @@ impl<D: MembershipDigest> Clerk<D> {
                     )
                 })?;
 
-                // ancillary_prover_data is Some() when moving to the next epoch and None otherwise
-                let (ivc_proof, ancillary_prover_data, ancillary_verifier_data) =
+                let (ivc_prover_setup, certificate_midnight_verifying_key) =
+                    load_ivc_prover_setup(snark_clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
+
+                let (ivc_proof, next_ancillary_prover_data, ancillary_verifier_data) =
                     ivc_prover_input_preparation_and_prove(
                         snark_proof,
                         msg,
                         snark_clerk,
                         &ancillary_input,
+                        ivc_prover_setup,
+                        certificate_midnight_verifying_key,
                     )?;
 
                 Ok((
                     AggregateSignature::IvcSnark(Box::new(ivc_proof)),
-                    AncillaryProofOutput::new(ancillary_prover_data, Some(ancillary_verifier_data)),
+                    AncillaryProofOutput::new(
+                        next_ancillary_prover_data,
+                        Some(ancillary_verifier_data),
+                    ),
                 ))
             }
         }
@@ -213,21 +226,23 @@ impl<D: MembershipDigest> Clerk<D> {
     }
 }
 
-/// Prepares the IVC prover inputs from `ancillary_input`, loads the cached prover setup,
-/// builds the [`Global`] chain constants, and runs [`IvcProver::prove`].
+/// Prepares the IVC prover inputs from `ancillary_input` and the cached prover setup to
+/// build the [`Global`] chain constants, and run [`IvcProver::prove`].
 ///
-/// Returns `(proof, next_rolling_state, verifier_data)`. `next_rolling_state` is `Some` when
+/// Returns `(proof, ancillary_prover_data, ancillary_verifier_data)`. `ancillary_prover_data` is `Some` when
 /// the step advances the epoch and `None` for same-epoch steps.
 ///
 /// # Errors
 /// Fails if the genesis Schnorr verifying key is absent, the message preimage is not PREIMAGE_SIZE bytes,
-/// the prover setup cannot be loaded, or the proof itself fails.
+/// or the proof itself fails.
 #[cfg(feature = "future_snark")]
 fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     snark_proof: SnarkProof<D>,
     msg: &[u8],
     clerk: &SnarkClerk,
     ancillary_input: &AncillaryProofInput,
+    ivc_prover_setup: Arc<IvcProverSetup>,
+    certificate_midnight_verifying_key: MidnightVK,
 ) -> StmResult<(
     IvcProof<blake2b_simd::State>,
     Option<AncillaryProverData>,
@@ -241,20 +256,21 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let genesis_verifying_key = genesis_data
         .genesis_schnorr_verification_key()
         .cloned()
-        .ok_or_else(|| anyhow!("Missing genesis verifying key from ancillary data"))?;
+        .ok_or_else(|| anyhow!(AggregationError::MissingGenesisVerificationKey))?;
 
     let genesis_message = genesis_data.genesis_message_preimage().try_into()?;
 
-    let (ivc_prover_setup, certificate_midnight_verifying_key) =
-        load_ivc_prover_setup(clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
     let certificate_circuit_verifying_key = certificate_midnight_verifying_key.vk().clone();
     let ivc_circuit_verifying_key = ivc_prover_setup.ivc_verifying_key.clone();
 
-    // Get a rolling state if there is some ancillary prover data and some rolling state
-    // otherwise get None
-    let rolling_state = ancillary_input
+    let current_rolling_state = ancillary_input
         .prover_data()
-        .and_then(|prover_data| prover_data.as_ivc_rolling_state());
+        .map(|prover_data| {
+            prover_data.as_ivc_rolling_state().ok_or(anyhow!(
+                AggregationError::MissingIvcRollingStateInAncillaryProverData
+            ))
+        })
+        .transpose()?;
 
     let genesis_bootstrap = &genesis_data.try_into()?;
 
@@ -279,13 +295,10 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         &global,
         &ProtocolMessagePreimage(protocol_message_preimage_bytes),
         genesis_bootstrap,
-        rolling_state,
+        current_rolling_state,
     )?;
 
-    // A same-epoch step does not advance the rolling state, so the prover returns
-    // none: carry the input rolling state forward so the next certificate keeps
-    // building on it.
-    let ancillary_prover_data = next_rolling_state.map(AncillaryProverData::IvcSnark);
+    let next_ancillary_prover_data = next_rolling_state.map(AncillaryProverData::IvcSnark);
 
     let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
         genesis_message,
@@ -294,5 +307,154 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         ivc_circuit_verifying_key,
     ));
 
-    Ok((ivc_proof, ancillary_prover_data, ancillary_verifier_data))
+    Ok((
+        ivc_proof,
+        next_ancillary_prover_data,
+        ancillary_verifier_data,
+    ))
+}
+
+#[cfg(feature = "future_snark")]
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use midnight_curves::Bls12;
+    use midnight_proofs::poly::kzg::params::ParamsKZG;
+    use midnight_zk_stdlib as zk;
+    use midnight_zk_stdlib::MidnightVK;
+    use rand_chacha::ChaCha20Rng;
+    use rand_core::SeedableRng;
+
+    use crate::{
+        AncillaryGenesisData, AncillaryProofInput, MithrilMembershipDigest, Parameters,
+        circuits::halo2::circuit::StmCertificateCircuit,
+        circuits::halo2_ivc::PREIMAGE_SIZE,
+        proof_system::{CircuitVerificationKey, SnarkClerk},
+        proof_system::{MERKLE_TREE_DEPTH_FOR_SNARK, ivc_halo2_snark::IvcProverSetup},
+        protocol::aggregate_signature::tests::setup_equal_parties,
+        {AggregationError, AncillaryProverData, SnarkProof},
+    };
+
+    use super::ivc_prover_input_preparation_and_prove;
+
+    fn build_fast_dummy_ivc_setup(
+        params: Parameters,
+        depth: u32,
+    ) -> (Arc<IvcProverSetup>, MidnightVK) {
+        let srs: Arc<ParamsKZG<Bls12>> = Arc::new(ParamsKZG::<Bls12>::unsafe_setup(
+            12,
+            ChaCha20Rng::from_seed([42u8; 32]),
+        ));
+        let circuit = StmCertificateCircuit::try_new(&params, depth)
+            .expect("certificate circuit should build");
+
+        let mut cert_srs = (*srs).clone();
+        zk::downsize_srs_for_relation(&mut cert_srs, &circuit);
+
+        let midnight_vk = zk::setup_vk(&cert_srs, &circuit);
+        let midnight_pk = zk::setup_pk(&circuit, &midnight_vk);
+        let cert_vk = midnight_vk.vk().clone();
+        // Not the correct key but we only need a dummy
+        let cert_pk = midnight_pk.pk().clone();
+
+        let ivc_setup = Arc::new(IvcProverSetup {
+            srs: cert_srs,
+            certificate_verifying_key: cert_vk.clone(),
+            ivc_verifying_key: cert_vk,
+            ivc_proving_key: cert_pk,
+            certificate_fixed_bases: BTreeMap::new(),
+            ivc_fixed_bases: BTreeMap::new(),
+            combined_fixed_bases: BTreeMap::new(),
+        });
+
+        (ivc_setup, midnight_vk)
+    }
+
+    #[test]
+    fn ivc_prover_input_preparation_fails_when_prover_data_carries_no_ivc_rolling_state() {
+        use crate::SchnorrVerificationKey;
+
+        let tiny_params = Parameters {
+            k: 1,
+            m: 10,
+            phi_f: 0.9,
+        };
+        let (ivc_prover_setup, certificate_midnight_verifying_key) =
+            build_fast_dummy_ivc_setup(tiny_params, 1);
+
+        let ps = setup_equal_parties(tiny_params, 1);
+        let snark_clerk = SnarkClerk::new_clerk_from_signer(&ps[0]);
+        let snark_proof = SnarkProof::<MithrilMembershipDigest>::from_parts(
+            vec![],
+            tiny_params,
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+            CircuitVerificationKey::new(certificate_midnight_verifying_key.clone()),
+        );
+
+        let ancillary_input = AncillaryProofInput::new(
+            Some(AncillaryProverData::FutureVariant),
+            AncillaryGenesisData::new(vec![0u8; 32], None, Some(SchnorrVerificationKey::default())),
+            vec![0u8; PREIMAGE_SIZE],
+        );
+
+        let err = ivc_prover_input_preparation_and_prove(
+            snark_proof,
+            &[0u8; 32],
+            &snark_clerk,
+            &ancillary_input,
+            ivc_prover_setup,
+            certificate_midnight_verifying_key,
+        )
+        .expect_err("Should fail without IVC rolling state.");
+
+        assert_eq!(
+            err.downcast_ref::<AggregationError>(),
+            Some(&AggregationError::MissingIvcRollingStateInAncillaryProverData),
+            "missing IVC rolling state in ancillary prover data must be rejected, got: {err}"
+        );
+    }
+
+    #[test]
+    fn ivc_prover_input_preparation_fails_when_genesis_verification_key_is_absent() {
+        let tiny_params = Parameters {
+            k: 1,
+            m: 10,
+            phi_f: 0.9,
+        };
+        let (ivc_prover_setup, certificate_midnight_verifying_key) =
+            build_fast_dummy_ivc_setup(tiny_params, 1);
+
+        let ps = setup_equal_parties(tiny_params, 1);
+        let snark_clerk = SnarkClerk::new_clerk_from_signer(&ps[0]);
+        let snark_proof = SnarkProof::<MithrilMembershipDigest>::from_parts(
+            vec![],
+            tiny_params,
+            MERKLE_TREE_DEPTH_FOR_SNARK,
+            CircuitVerificationKey::new(certificate_midnight_verifying_key.clone()),
+        );
+
+        let ancillary_input = AncillaryProofInput::new(
+            None,
+            AncillaryGenesisData::new(vec![0u8; 32], None, None),
+            vec![0u8; PREIMAGE_SIZE],
+        );
+
+        let err = ivc_prover_input_preparation_and_prove(
+            snark_proof,
+            &[0u8; 32],
+            &snark_clerk,
+            &ancillary_input,
+            ivc_prover_setup,
+            certificate_midnight_verifying_key,
+        )
+        .expect_err("Should fail without genesis verification key.");
+
+        assert_eq!(
+            err.downcast_ref::<AggregationError>(),
+            Some(&AggregationError::MissingGenesisVerificationKey),
+            "missing genesis verification key must be rejected, got: {err}"
+        );
+    }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -16,10 +16,11 @@ use crate::{
 };
 
 use crate::{
-    AncillaryProverData, MithrilMembershipDigest,
+    AncillaryProverData, AncillaryVerifierData, MithrilMembershipDigest,
     circuits::{halo2_ivc::state::Global, trusted_setup::TrustedSetupProvider},
     proof_system::ivc_halo2_snark::{
         IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
+        verifier_setup::IvcVerifierData,
     },
 };
 
@@ -148,21 +149,25 @@ impl<D: MembershipDigest> Clerk<D> {
 
                 // For now the function will fail as we give two Some values
                 // which should not happen but this might be changed
-                let proof_output = ivc_prover_input_preparation_and_prove(
-                    snark_proof,
-                    msg,
-                    clerk,
-                    ancillary_input,
-                )?;
+                let (ivc_proof, rolling_state, verifier_data) =
+                    ivc_prover_input_preparation_and_prove(
+                        snark_proof,
+                        msg,
+                        clerk,
+                        ancillary_input,
+                    )?;
 
                 let ancillary_prover_data = AncillaryProverData::IvcSnark(
-                    proof_output.1.ok_or_else(|| anyhow!("missing rolling state"))?,
+                    rolling_state.ok_or_else(|| anyhow!("missing rolling state"))?,
                 );
+                let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(verifier_data);
 
-                // TODO: add the AncillaryProverData and AncillaryVerifierData to the output
                 Ok((
-                    AggregateSignature::IvcSnark(Box::new(proof_output.0)),
-                    AncillaryProofOutput::new(Some(ancillary_prover_data), None),
+                    AggregateSignature::IvcSnark(Box::new(ivc_proof)),
+                    AncillaryProofOutput::new(
+                        Some(ancillary_prover_data),
+                        Some(ancillary_verifier_data),
+                    ),
                 ))
             }
         }
@@ -222,7 +227,11 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     msg: &[u8],
     clerk: &SnarkClerk,
     ancillary_input: AncillaryProofInput,
-) -> StmResult<(IvcProof<blake2b_simd::State>, Option<IvcRollingState>)> {
+) -> StmResult<(
+    IvcProof<blake2b_simd::State>,
+    Option<IvcRollingState>,
+    IvcVerifierData,
+)> {
     let protocol_message_preimage_bytes: [u8; 190] =
         ancillary_input.message_preimage().try_into()?;
 
@@ -259,11 +268,22 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     // the avk inputs by the root directly
     let avk = clerk.compute_aggregate_verification_key_for_snark();
 
+    let genesis_message = MessageHash::from_field(genesis_message_field_elem);
+    let certificate_circuit_verification_key = certificate_key_provider.get_verifying_key()?;
+    let ivc_circuit_verification_key = ivc_key_provider.get_verifying_key()?;
+
     let global = Global::new(
-        MessageHash::from_field(genesis_message_field_elem),
+        genesis_message,
         genesis_verification_key,
-        &certificate_key_provider.get_verifying_key()?,
-        &ivc_key_provider.get_verifying_key()?,
+        &certificate_circuit_verification_key,
+        &ivc_circuit_verification_key,
+    );
+
+    let verifier_data = IvcVerifierData::new(
+        genesis_message,
+        genesis_verification_key,
+        certificate_circuit_verification_key,
+        ivc_circuit_verification_key,
     );
 
     let rolling_state = match ancillary_input.prover_data() {
@@ -277,7 +297,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
 
     // For now the function will fail as we give two Some values
     // which should not happen but this might be changed
-    prover.prove(
+    let (ivc_proof, next_rolling_state) = prover.prove(
         snark_proof,
         msg,
         &avk,
@@ -285,5 +305,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         &ProtocolMessagePreimage(protocol_message_preimage_bytes),
         genesis_bootstrap,
         rolling_state.as_ref(),
-    )
+    )?;
+
+    Ok((ivc_proof, next_rolling_state, verifier_data))
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -22,7 +22,7 @@ use crate::{
     SnarkProof,
     circuits::halo2_ivc::{ProtocolMessagePreimage, state::Global},
     proof_system::{
-        IvcRollingState, MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver,
+        MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver,
         ivc_halo2_snark::{
             proof::{IvcProof, IvcProver},
             verifier_setup::IvcVerifierData,
@@ -147,6 +147,7 @@ impl<D: MembershipDigest> Clerk<D> {
                     )
                 })?;
 
+                // ancillary_prover_data is Some() when moving to the next epoch and None otherwise
                 let (ivc_proof, ancillary_prover_data, ancillary_verifier_data) =
                     ivc_prover_input_preparation_and_prove(
                         snark_proof,
@@ -157,10 +158,7 @@ impl<D: MembershipDigest> Clerk<D> {
 
                 Ok((
                     AggregateSignature::IvcSnark(Box::new(ivc_proof)),
-                    AncillaryProofOutput::new(
-                        Some(ancillary_prover_data),
-                        Some(ancillary_verifier_data),
-                    ),
+                    AncillaryProofOutput::new(ancillary_prover_data, Some(ancillary_verifier_data)),
                 ))
             }
         }
@@ -219,8 +217,7 @@ impl<D: MembershipDigest> Clerk<D> {
 /// builds the [`Global`] chain constants, and runs [`IvcProver::prove`].
 ///
 /// Returns `(proof, next_rolling_state, verifier_data)`. `next_rolling_state` is `Some` when
-/// the step advances the epoch and `None` for same-epoch steps — in that case the caller
-/// carries the previous rolling state forward.
+/// the step advances the epoch and `None` for same-epoch steps.
 ///
 /// # Errors
 /// Fails if the genesis Schnorr verifying key is absent, the message preimage is not PREIMAGE_SIZE bytes,
@@ -233,7 +230,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     ancillary_input: &AncillaryProofInput,
 ) -> StmResult<(
     IvcProof<blake2b_simd::State>,
-    AncillaryProverData,
+    Option<AncillaryProverData>,
     AncillaryVerifierData,
 )> {
     let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
@@ -253,10 +250,11 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let certificate_circuit_verifying_key = certificate_midnight_verifying_key.vk().clone();
     let ivc_circuit_verifying_key = ivc_prover_setup.ivc_verifying_key.clone();
 
-    let prover_data = ancillary_input.prover_data();
     // Get a rolling state if there is some ancillary prover data and some rolling state
     // otherwise get None
-    let rolling_state = prover_data.and_then(|prover_data| prover_data.as_ivc_rolling_state());
+    let rolling_state = ancillary_input
+        .prover_data()
+        .and_then(|prover_data| prover_data.as_ivc_rolling_state());
 
     let genesis_bootstrap = &genesis_data.try_into()?;
 
@@ -287,8 +285,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     // A same-epoch step does not advance the rolling state, so the prover returns
     // none: carry the input rolling state forward so the next certificate keeps
     // building on it.
-    let ancillary_prover_data =
-        resolve_ivc_ancillary_prover_data(next_rolling_state, prover_data.cloned())?;
+    let ancillary_prover_data = next_rolling_state.map(AncillaryProverData::IvcSnark);
 
     let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
         genesis_message,
@@ -298,65 +295,4 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     ));
 
     Ok((ivc_proof, ancillary_prover_data, ancillary_verifier_data))
-}
-
-/// Resolve the prover data to store on a new IVC certificate.
-///
-/// A next-epoch step advances the rolling state, which is stored as is. A same-epoch step does not
-/// advance it (the prover returns none), so the input rolling state carried from the parent
-/// certificate is reused for the next certificate.
-#[cfg(feature = "future_snark")]
-fn resolve_ivc_ancillary_prover_data(
-    next_rolling_state: Option<IvcRollingState>,
-    previous_prover_data: Option<AncillaryProverData>,
-) -> StmResult<AncillaryProverData> {
-    match next_rolling_state {
-        Some(rolling_state) => Ok(AncillaryProverData::IvcSnark(rolling_state)),
-        None => previous_prover_data
-            .ok_or_else(|| AggregateSignatureError::MissingRollingStateForNextCertificate.into()),
-    }
-}
-
-#[cfg(all(test, feature = "future_snark"))]
-mod tests {
-    use rand_chacha::ChaCha20Rng;
-    use rand_core::SeedableRng;
-
-    use crate::AncillaryProverData;
-    use crate::proof_system::IvcRollingState;
-    use crate::signature_scheme::{BaseFieldElement, SchnorrSigningKey};
-
-    use super::resolve_ivc_ancillary_prover_data;
-
-    fn build_rolling_state() -> IvcRollingState {
-        let mut rng = ChaCha20Rng::from_seed([0u8; 32]);
-        let signing_key = SchnorrSigningKey::generate(&mut rng);
-        let message = vec![BaseFieldElement::from(1u64)];
-        let genesis_signature = signing_key.sign_standard(&message, &mut rng).unwrap();
-        IvcRollingState::genesis(genesis_signature, &[])
-    }
-
-    #[test]
-    fn next_epoch_step_stores_the_advanced_rolling_state() {
-        let prover_data =
-            resolve_ivc_ancillary_prover_data(Some(build_rolling_state()), None).unwrap();
-
-        assert!(matches!(prover_data, AncillaryProverData::IvcSnark(_)));
-    }
-
-    #[test]
-    fn same_epoch_step_carries_the_previous_rolling_state_forward() {
-        let previous = AncillaryProverData::IvcSnark(build_rolling_state());
-
-        let prover_data = resolve_ivc_ancillary_prover_data(None, Some(previous)).unwrap();
-
-        assert!(matches!(prover_data, AncillaryProverData::IvcSnark(_)));
-    }
-
-    #[test]
-    fn fails_when_neither_an_advanced_nor_a_previous_rolling_state_is_available() {
-        let error = resolve_ivc_ancillary_prover_data(None, None).unwrap_err();
-
-        assert!(error.to_string().contains("missing rolling state"));
-    }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use midnight_proofs::transcript::TranscriptHash;
+use rand_core::OsRng;
 use std::marker::PhantomData;
 
 #[cfg(feature = "future_snark")]
@@ -7,8 +7,19 @@ use anyhow::anyhow;
 
 use crate::{
     AggregateVerificationKey, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
-    Signer, SingleSignature, Stake, StmResult, VerificationKeyForConcatenation,
-    proof_system::{ConcatenationClerk, ConcatenationProof},
+    Signer, SingleSignature, SnarkProof, Stake, StmResult, VerificationKeyForConcatenation,
+    proof_system::{
+        ConcatenationClerk, ConcatenationProof, IvcRollingState, ivc_halo2_snark::proof::IvcProof,
+    },
+};
+
+use crate::{
+    AncillaryProverData, MithrilMembershipDigest,
+    circuits::{halo2_ivc::state::Global, trusted_setup::TrustedSetupProvider},
+    proof_system::ivc_halo2_snark::{
+        IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
+        proof::IvcGenesisBootstrapInput,
+    },
 };
 
 #[cfg(feature = "future_snark")]
@@ -122,15 +133,33 @@ impl<D: MembershipDigest> Clerk<D> {
                 let clerk = self
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
+                let snark_proof = SnarkProver::try_new_non_deterministic(
+                    &clerk.parameters,
+                    MERKLE_TREE_DEPTH_FOR_SNARK,
+                )?
+                .aggregate_signatures::<MithrilMembershipDigest>(clerk, sigs, msg)
+                .with_context(|| {
+                    format!(
+                        "Signatures failed to aggregate for type {}",
+                        AggregateSignatureType::Snark
+                    )
+                })?;
 
-                let preimage = todo!();
-                let genvk = todo!();
+                // For now the function will fail as we give two Some values
+                // which should not happen but this might be changed
+                let proof_output = ivc_prover_input_preparation_and_prove(
+                    snark_proof,
+                    msg,
+                    clerk,
+                    ancillary_input,
+                )?;
 
-                // let prover = IvcProver {
-                //     ivc_setup:
-                // }
+                let ancillary_prover_data = AncillaryProverData::IvcSnark(
+                    proof_output.1.ok_or_else(|| anyhow!("missing rolling state"))?,
+                );
 
-                todo!()
+                // TODO: add the AncillaryProverData and AncillaryVerifierData to the output
+                Ok((AggregateSignature::IvcSnark(Box::new(proof_output.0)), None))
             }
         }
     }
@@ -182,4 +211,68 @@ impl<D: MembershipDigest> Clerk<D> {
     pub fn update_m(&mut self, m: u64) {
         self.concatenation_proof_clerk.update_m(m);
     }
+}
+
+fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
+    snark_proof: SnarkProof<D>,
+    msg: &[u8],
+    clerk: &SnarkClerk,
+    ancillary_input: AncillaryProofInput,
+) -> StmResult<(IvcProof<blake2b_simd::State>, Option<IvcRollingState>)> {
+    // TODO: get the protocol message preimage
+    let protocol_message_preimage = todo!();
+    // TODO: get the protocol message preimage
+    let genesis_verification_key = todo!();
+    // TODO: get the genesis message
+    let genesis_message = todo!();
+
+    let trusted_setup_provider = TrustedSetupProvider::default();
+    let srs = trusted_setup_provider.get_trusted_setup_parameters()?;
+    let certificate_key_provider =
+        TempCertificateKeyProvider::new(srs.into(), clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK);
+    let ivc_key_provider =
+        TempIvcKeyProvider::new(srs.into(), certificate_key_provider.get_verifying_key()?);
+
+    let ivc_setup = IvcProverSetup::load(
+        &trusted_setup_provider,
+        &certificate_key_provider,
+        &ivc_key_provider,
+    )?;
+
+    let prover = IvcProver {
+        ivc_setup: ivc_setup.into(),
+        rng: OsRng,
+    };
+
+    // This is only used to get the root of the tree so maybe we can replace
+    // the avk inputs by the root directly
+    let avk = clerk.compute_aggregate_verification_key_for_snark();
+
+    let global = Global::new(
+        genesis_message,
+        genesis_verification_key,
+        &certificate_key_provider.get_verifying_key()?,
+        &ivc_key_provider.get_verifying_key()?,
+    );
+
+    let rolling_state = ancillary_input
+        .prover_data()
+        .ok_or_else(|| anyhow!("Missing prover data"))?
+        .as_ivc_rolling_state();
+
+    // IvcGenesisBootstrapInput contains the same values as AncillaryGenesisData
+    // We might consider dropping one or implementing a conversion between the two
+    let genesis_bootstrap = ancillary_input.genesis_data().try_into()?;
+
+    // For now the function will fail as we give two Some values
+    // which should not happen but this might be changed
+    prover.prove(
+        snark_proof,
+        msg,
+        &avk,
+        &global,
+        protocol_message_preimage,
+        Some(&rolling_state),
+        Some(genesis_bootstrap),
+    )
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -1,37 +1,29 @@
 use anyhow::Context;
-#[cfg(feature = "future_snark")]
-use sha2::{Digest, Sha256};
 use std::marker::PhantomData;
 
 #[cfg(feature = "future_snark")]
 use anyhow::anyhow;
 #[cfg(feature = "future_snark")]
-use midnight_zk_stdlib::MidnightVK;
-#[cfg(feature = "future_snark")]
 use rand_core::OsRng;
-#[cfg(feature = "future_snark")]
-use std::collections::HashMap;
-#[cfg(feature = "future_snark")]
-use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::{
     AggregateVerificationKey, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
     Signer, SingleSignature, Stake, StmResult, VerificationKeyForConcatenation,
     proof_system::{ConcatenationClerk, ConcatenationProof},
 };
+#[cfg(feature = "future_snark")]
+use crate::{
+    circuits::halo2_ivc::PREIMAGE_SIZE, proof_system::ivc_halo2_snark::load_ivc_prover_setup,
+};
 
 #[cfg(feature = "future_snark")]
 use crate::{
-    AggregateSignatureError, AncillaryProverData, AncillaryVerifierData, BaseFieldElement,
-    MithrilMembershipDigest, SnarkProof,
-    circuits::{
-        halo2_ivc::{ProtocolMessagePreimage, state::Global, types::MessageHash},
-        trusted_setup::TrustedSetupProvider,
-    },
+    AggregateSignatureError, AncillaryProverData, AncillaryVerifierData, MithrilMembershipDigest,
+    SnarkProof,
+    circuits::halo2_ivc::{ProtocolMessagePreimage, state::Global},
     proof_system::{
         IvcRollingState, MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver,
         ivc_halo2_snark::{
-            IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
             proof::{IvcProof, IvcProver},
             verifier_setup::IvcVerifierData,
         },
@@ -139,15 +131,15 @@ impl<D: MembershipDigest> Clerk<D> {
             }
             #[cfg(feature = "future_snark")]
             AggregateSignatureType::IvcSnark => {
-                let clerk = self
+                let snark_clerk = self
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
 
                 let snark_proof = SnarkProver::try_new_non_deterministic(
-                    &clerk.parameters,
+                    &snark_clerk.parameters,
                     MERKLE_TREE_DEPTH_FOR_SNARK,
                 )?
-                .aggregate_signatures::<MithrilMembershipDigest>(clerk, sigs, msg)
+                .aggregate_signatures::<MithrilMembershipDigest>(snark_clerk, sigs, msg)
                 .with_context(|| {
                     format!(
                         "Signatures failed to aggregate for type {}",
@@ -164,7 +156,7 @@ impl<D: MembershipDigest> Clerk<D> {
                     ivc_prover_input_preparation_and_prove(
                         snark_proof,
                         msg,
-                        clerk,
+                        snark_clerk,
                         ancillary_input,
                     )?;
 
@@ -240,7 +232,7 @@ impl<D: MembershipDigest> Clerk<D> {
 /// carries the previous rolling state forward.
 ///
 /// # Errors
-/// Fails if the genesis Schnorr verifying key is absent, the message preimage is not 190 bytes,
+/// Fails if the genesis Schnorr verifying key is absent, the message preimage is not PREIMAGE_SIZE bytes,
 /// the prover setup cannot be loaded, or the proof itself fails.
 #[cfg(feature = "future_snark")]
 fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
@@ -253,7 +245,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     Option<IvcRollingState>,
     IvcVerifierData,
 )> {
-    let protocol_message_preimage_bytes: [u8; 190] =
+    let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
         ancillary_input.message_preimage().try_into()?;
 
     let genesis_data = ancillary_input.genesis_data();
@@ -263,10 +255,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         .cloned()
         .ok_or_else(|| anyhow!("Missing genesis verifying key from ancillary data"))?;
 
-    let genesis_preimage = genesis_data.genesis_message_preimage();
-    let genesis_preimage_hash: [u8; 32] = Sha256::digest(genesis_preimage).into();
-    let genesis_message_field_elem = BaseFieldElement::from_raw(&genesis_preimage_hash)?.0;
-    let genesis_message = MessageHash::from_field(genesis_message_field_elem);
+    let genesis_message = genesis_data.genesis_message_preimage().try_into()?;
 
     let (ivc_prover_setup, certificate_midnight_verifying_key) =
         load_ivc_prover_setup(clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
@@ -275,12 +264,10 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
 
     let rolling_state = ancillary_input
         .prover_data()
-        .map(|prover_data| prover_data.as_ivc_rolling_state());
+        .and_then(|prover_data| prover_data.as_ivc_rolling_state());
 
     let genesis_bootstrap = &genesis_data.try_into()?;
 
-    // This is only used to get the root of the tree so maybe we can replace
-    // the avk inputs by the root directly?
     let avk = clerk.compute_aggregate_verification_key_for_snark();
 
     let global = Global::new(
@@ -315,59 +302,6 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     Ok((ivc_proof, next_rolling_state, verifier_data))
 }
 
-/// Process-wide cache of the IVC prover setup keyed by the certificate circuit shape.
-///
-/// The setup (SRS plus the certificate and IVC circuit keys) only depends on the protocol
-/// parameters and the Merkle tree depth, so it is computed once per shape and reused across
-/// certificates instead of being rebuilt on every proof. The certificate [MidnightVK] is cached
-/// alongside it because it is needed to expose the verifier data.
-#[cfg(feature = "future_snark")]
-type IvcProverSetupCache = HashMap<(Vec<u8>, u32), (Arc<IvcProverSetup>, MidnightVK)>;
-
-#[cfg(feature = "future_snark")]
-static IVC_PROVER_SETUP_CACHE: LazyLock<Mutex<IvcProverSetupCache>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// Load the IVC prover setup and the certificate [MidnightVK] for the given certificate circuit
-/// shape, building them on the first call and serving cached clones afterwards.
-#[cfg(feature = "future_snark")]
-fn load_ivc_prover_setup(
-    parameters: Parameters,
-    merkle_tree_depth: u32,
-) -> StmResult<(Arc<IvcProverSetup>, MidnightVK)> {
-    let cache_key = (parameters.to_bytes()?, merkle_tree_depth);
-
-    if let Some(cached) = IVC_PROVER_SETUP_CACHE
-        .lock()
-        .map_err(|_| anyhow!("IVC prover setup cache lock poisoned."))?
-        .get(&cache_key)
-    {
-        return Ok(cached.clone());
-    }
-
-    let trusted_setup_provider = TrustedSetupProvider::default();
-    let srs = Arc::new(trusted_setup_provider.get_trusted_setup_parameters()?);
-    let certificate_key_provider =
-        TempCertificateKeyProvider::new(srs.clone(), parameters, merkle_tree_depth);
-    let certificate_midnight_verifying_key =
-        certificate_key_provider.get_midnight_verifying_key()?;
-    let ivc_key_provider =
-        TempIvcKeyProvider::new(srs.clone(), certificate_key_provider.get_verifying_key()?);
-    let ivc_setup = Arc::new(IvcProverSetup::load(
-        &trusted_setup_provider,
-        &certificate_key_provider,
-        &ivc_key_provider,
-    )?);
-
-    let cached = (ivc_setup, certificate_midnight_verifying_key);
-    IVC_PROVER_SETUP_CACHE
-        .lock()
-        .map_err(|_| anyhow!("IVC prover setup cache lock poisoned."))?
-        .insert(cache_key, cached.clone());
-
-    Ok(cached)
-}
-
 /// Resolve the prover data to store on a new IVC certificate.
 ///
 /// A next-epoch step advances the rolling state, which is stored as is. A same-epoch step does not
@@ -380,7 +314,8 @@ fn resolve_ivc_ancillary_prover_data(
 ) -> StmResult<AncillaryProverData> {
     match next_rolling_state {
         Some(rolling_state) => Ok(AncillaryProverData::IvcSnark(rolling_state)),
-        None => previous_prover_data.ok_or_else(|| anyhow!("missing rolling state")),
+        None => previous_prover_data
+            .ok_or_else(|| AggregateSignatureError::MissingRollingStateForNextCertificate.into()),
     }
 }
 

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -147,22 +147,13 @@ impl<D: MembershipDigest> Clerk<D> {
                     )
                 })?;
 
-                // A same-epoch step does not advance the rolling state, so the prover returns
-                // none: carry the input rolling state forward so the next certificate keeps
-                // building on it.
-                let previous_prover_data = ancillary_input.prover_data().cloned();
-
-                let (ivc_proof, next_rolling_state, verifier_data) =
+                let (ivc_proof, ancillary_prover_data, ancillary_verifier_data) =
                     ivc_prover_input_preparation_and_prove(
                         snark_proof,
                         msg,
                         snark_clerk,
-                        ancillary_input,
+                        &ancillary_input,
                     )?;
-
-                let ancillary_prover_data =
-                    resolve_ivc_ancillary_prover_data(next_rolling_state, previous_prover_data)?;
-                let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(verifier_data);
 
                 Ok((
                     AggregateSignature::IvcSnark(Box::new(ivc_proof)),
@@ -239,11 +230,11 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     snark_proof: SnarkProof<D>,
     msg: &[u8],
     clerk: &SnarkClerk,
-    ancillary_input: AncillaryProofInput,
+    ancillary_input: &AncillaryProofInput,
 ) -> StmResult<(
     IvcProof<blake2b_simd::State>,
-    Option<IvcRollingState>,
-    IvcVerifierData,
+    AncillaryProverData,
+    AncillaryVerifierData,
 )> {
     let protocol_message_preimage_bytes: [u8; PREIMAGE_SIZE] =
         ancillary_input.message_preimage().try_into()?;
@@ -262,9 +253,10 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let certificate_circuit_verifying_key = certificate_midnight_verifying_key.vk().clone();
     let ivc_circuit_verifying_key = ivc_prover_setup.ivc_verifying_key.clone();
 
-    let rolling_state = ancillary_input
-        .prover_data()
-        .and_then(|prover_data| prover_data.as_ivc_rolling_state());
+    let prover_data = ancillary_input.prover_data();
+    // Get a rolling state if there is some ancillary prover data and some rolling state
+    // otherwise get None
+    let rolling_state = prover_data.and_then(|prover_data| prover_data.as_ivc_rolling_state());
 
     let genesis_bootstrap = &genesis_data.try_into()?;
 
@@ -292,14 +284,20 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         rolling_state,
     )?;
 
-    let verifier_data = IvcVerifierData::new(
+    // A same-epoch step does not advance the rolling state, so the prover returns
+    // none: carry the input rolling state forward so the next certificate keeps
+    // building on it.
+    let ancillary_prover_data =
+        resolve_ivc_ancillary_prover_data(next_rolling_state, prover_data.cloned())?;
+
+    let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
         genesis_message,
         genesis_verifying_key,
         certificate_midnight_verifying_key,
         ivc_circuit_verifying_key,
-    );
+    ));
 
-    Ok((ivc_proof, next_rolling_state, verifier_data))
+    Ok((ivc_proof, ancillary_prover_data, ancillary_verifier_data))
 }
 
 /// Resolve the prover data to store on a new IVC certificate.

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -1,35 +1,42 @@
 use anyhow::Context;
-use rand_core::OsRng;
-use std::{marker::PhantomData, sync::Arc};
+#[cfg(feature = "future_snark")]
+use sha2::{Digest, Sha256};
+use std::marker::PhantomData;
 
 #[cfg(feature = "future_snark")]
 use anyhow::anyhow;
+#[cfg(feature = "future_snark")]
+use midnight_zk_stdlib::MidnightVK;
+#[cfg(feature = "future_snark")]
+use rand_core::OsRng;
+#[cfg(feature = "future_snark")]
+use std::collections::HashMap;
+#[cfg(feature = "future_snark")]
+use std::sync::{Arc, LazyLock, Mutex};
 
 use crate::{
-    AggregateVerificationKey, BaseFieldElement, ClosedKeyRegistration, LotteryIndex,
-    MembershipDigest, Parameters, Signer, SingleSignature, SnarkProof, Stake, StmResult,
-    VerificationKeyForConcatenation,
-    circuits::halo2_ivc::{ProtocolMessagePreimage, types::MessageHash},
+    AggregateVerificationKey, ClosedKeyRegistration, LotteryIndex, MembershipDigest, Parameters,
+    Signer, SingleSignature, Stake, StmResult, VerificationKeyForConcatenation,
+    proof_system::{ConcatenationClerk, ConcatenationProof},
+};
+
+#[cfg(feature = "future_snark")]
+use crate::{
+    AggregateSignatureError, AncillaryProverData, AncillaryVerifierData, BaseFieldElement,
+    MithrilMembershipDigest, SnarkProof,
+    circuits::{
+        halo2_ivc::{ProtocolMessagePreimage, state::Global, types::MessageHash},
+        trusted_setup::TrustedSetupProvider,
+    },
     proof_system::{
-        ConcatenationClerk, ConcatenationProof, IvcRollingState, ivc_halo2_snark::proof::IvcProof,
+        IvcRollingState, MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver,
+        ivc_halo2_snark::{
+            IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
+            proof::{IvcProof, IvcProver},
+            verifier_setup::IvcVerifierData,
+        },
     },
 };
-
-use crate::{
-    AncillaryProverData, AncillaryVerifierData, MithrilMembershipDigest,
-    circuits::{halo2_ivc::state::Global, trusted_setup::TrustedSetupProvider},
-    proof_system::ivc_halo2_snark::{
-        IvcProverSetup, TempCertificateKeyProvider, TempIvcKeyProvider,
-        verifier_setup::IvcVerifierData,
-    },
-};
-
-#[cfg(feature = "future_snark")]
-use crate::AggregateSignatureError;
-#[cfg(feature = "future_snark")]
-use crate::proof_system::ivc_halo2_snark::proof::IvcProver;
-#[cfg(feature = "future_snark")]
-use crate::proof_system::{MERKLE_TREE_DEPTH_FOR_SNARK, SnarkClerk, SnarkProver};
 
 use super::{
     AggregateSignature, AggregateSignatureType, AncillaryProofInput, AncillaryProofOutput,
@@ -136,8 +143,6 @@ impl<D: MembershipDigest> Clerk<D> {
                     .get_snark_clerk()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingSnarkClerk))?;
 
-                println!("Clerk ready to prove the first certificate");
-
                 let snark_proof = SnarkProver::try_new_non_deterministic(
                     &clerk.parameters,
                     MERKLE_TREE_DEPTH_FOR_SNARK,
@@ -149,8 +154,6 @@ impl<D: MembershipDigest> Clerk<D> {
                         AggregateSignatureType::Snark
                     )
                 })?;
-
-                println!("First certificate proof generated, starting the IVC proof");
 
                 // A same-epoch step does not advance the rolling state, so the prover returns
                 // none: carry the input rolling state forward so the next certificate keeps
@@ -229,6 +232,17 @@ impl<D: MembershipDigest> Clerk<D> {
     }
 }
 
+/// Prepares the IVC prover inputs from `ancillary_input`, loads the cached prover setup,
+/// builds the [`Global`] chain constants, and runs [`IvcProver::prove`].
+///
+/// Returns `(proof, next_rolling_state, verifier_data)`. `next_rolling_state` is `Some` when
+/// the step advances the epoch and `None` for same-epoch steps — in that case the caller
+/// carries the previous rolling state forward.
+///
+/// # Errors
+/// Fails if the genesis Schnorr verifying key is absent, the message preimage is not 190 bytes,
+/// the prover setup cannot be loaded, or the proof itself fails.
+#[cfg(feature = "future_snark")]
 fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     snark_proof: SnarkProof<D>,
     msg: &[u8],
@@ -242,97 +256,45 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
     let protocol_message_preimage_bytes: [u8; 190] =
         ancillary_input.message_preimage().try_into()?;
 
-    println!("Getting the genesis_verification_key");
+    let genesis_data = ancillary_input.genesis_data();
 
-    let genesis_verification_key = ancillary_input
-        .genesis_data()
+    let genesis_verifying_key = genesis_data
         .genesis_schnorr_verification_key()
         .cloned()
-        .ok_or_else(|| anyhow!("Missing genesis verification key from ancillary data"))?;
+        .ok_or_else(|| anyhow!("Missing genesis verifying key from ancillary data"))?;
 
-    println!("Getting the genesis_preimage");
+    let genesis_preimage = genesis_data.genesis_message_preimage();
+    let genesis_preimage_hash: [u8; 32] = Sha256::digest(genesis_preimage).into();
+    let genesis_message_field_elem = BaseFieldElement::from_raw(&genesis_preimage_hash)?.0;
+    let genesis_message = MessageHash::from_field(genesis_message_field_elem);
 
-    let genesis_preimage = ancillary_input.genesis_data().genesis_message_preimage();
+    let (ivc_prover_setup, certificate_midnight_verifying_key) =
+        load_ivc_prover_setup(clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK)?;
+    let certificate_circuit_verifying_key = certificate_midnight_verifying_key.vk().clone();
+    let ivc_circuit_verifying_key = ivc_prover_setup.ivc_verifying_key.clone();
 
-    println!("Converting the genesis_preimage to field element");
-    // TODO: clean this to have proper call to SHA256
-    // the try_from function applies the Sha256 hash
-    let genesis_message_field_elem = BaseFieldElement::try_from(genesis_preimage)?.0;
+    let rolling_state = ancillary_input
+        .prover_data()
+        .map(|prover_data| prover_data.as_ivc_rolling_state());
 
-    println!("Starting the trusted_setup generation via the provider");
-
-    let trusted_setup_provider = TrustedSetupProvider::default();
-    println!("Getting the srs");
-
-    let srs = Arc::new(trusted_setup_provider.get_trusted_setup_parameters()?);
-    println!("Creating the certificate_key_provider from srs");
-
-    let certificate_key_provider =
-        TempCertificateKeyProvider::new(srs.clone(), clerk.parameters, MERKLE_TREE_DEPTH_FOR_SNARK);
-    println!("Creating the ivc_key_provider from srs");
-
-    let ivc_key_provider =
-        TempIvcKeyProvider::new(srs.clone(), certificate_key_provider.get_verifying_key()?);
-
-    println!("Creating the ivc_setup from providers");
-
-    let ivc_setup = IvcProverSetup::load(
-        &trusted_setup_provider,
-        &certificate_key_provider,
-        &ivc_key_provider,
-    )?;
-
-    println!("Creating the prover from ivc_setup");
-
-    let mut prover = IvcProver {
-        ivc_setup: ivc_setup.into(),
-        rng: OsRng,
-    };
-
-    println!("Computing the avk");
+    let genesis_bootstrap = &genesis_data.try_into()?;
 
     // This is only used to get the root of the tree so maybe we can replace
-    // the avk inputs by the root directly
+    // the avk inputs by the root directly?
     let avk = clerk.compute_aggregate_verification_key_for_snark();
-
-    let genesis_message = MessageHash::from_field(genesis_message_field_elem);
-    let certificate_midnight_verifying_key =
-        certificate_key_provider.get_midnight_verifying_key()?;
-    let certificate_circuit_verification_key = certificate_midnight_verifying_key.vk().clone();
-    let ivc_circuit_verification_key = ivc_key_provider.get_verifying_key()?;
-    println!("Creating the global value");
 
     let global = Global::new(
         genesis_message,
-        genesis_verification_key,
-        &certificate_circuit_verification_key,
-        &ivc_circuit_verification_key,
+        genesis_verifying_key,
+        &certificate_circuit_verifying_key,
+        &ivc_circuit_verifying_key,
     );
 
-    let verifier_data = IvcVerifierData::new(
-        genesis_message,
-        genesis_verification_key,
-        certificate_midnight_verifying_key,
-        ivc_circuit_verification_key,
-    );
-
-    println!("Extracting the rolling state if present");
-
-    let rolling_state = match ancillary_input.prover_data() {
-        Some(input) => Some(input.as_ivc_rolling_state()),
-        None => None,
+    let mut prover = IvcProver {
+        ivc_setup: ivc_prover_setup.clone().into(),
+        rng: OsRng,
     };
 
-    println!("Converting the genesis bootstrap data");
-
-    // IvcGenesisBootstrapInput contains the same values as AncillaryGenesisData
-    // We might consider dropping one or implementing a conversion between the two
-    let genesis_bootstrap = &ancillary_input.genesis_data().try_into()?;
-
-    println!("Starting the IVC proof");
-
-    // For now the function will fail as we give two Some values
-    // which should not happen but this might be changed
     let (ivc_proof, next_rolling_state) = prover.prove(
         snark_proof,
         msg,
@@ -343,7 +305,63 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         rolling_state.as_ref(),
     )?;
 
+    let verifier_data = IvcVerifierData::new(
+        genesis_message,
+        genesis_verifying_key,
+        certificate_midnight_verifying_key,
+        ivc_circuit_verifying_key,
+    );
+
     Ok((ivc_proof, next_rolling_state, verifier_data))
+}
+
+/// Process-wide cache of the IVC prover setup keyed by the certificate circuit shape.
+///
+/// The setup (SRS plus the certificate and IVC circuit keys) only depends on the protocol
+/// parameters and the Merkle tree depth, so it is computed once per shape and reused across
+/// certificates instead of being rebuilt on every proof. The certificate [MidnightVK] is cached
+/// alongside it because it is needed to expose the verifier data.
+#[cfg(feature = "future_snark")]
+type IvcProverSetupCache = HashMap<(Vec<u8>, u32), (Arc<IvcProverSetup>, MidnightVK)>;
+
+#[cfg(feature = "future_snark")]
+static IVC_PROVER_SETUP_CACHE: LazyLock<Mutex<IvcProverSetupCache>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Load the IVC prover setup and the certificate [MidnightVK] for the given certificate circuit
+/// shape, building them on the first call and serving cached clones afterwards.
+#[cfg(feature = "future_snark")]
+fn load_ivc_prover_setup(
+    parameters: Parameters,
+    merkle_tree_depth: u32,
+) -> StmResult<(Arc<IvcProverSetup>, MidnightVK)> {
+    let cache_key = (parameters.to_bytes()?, merkle_tree_depth);
+
+    if let Some(cached) = IVC_PROVER_SETUP_CACHE.lock().unwrap().get(&cache_key) {
+        return Ok(cached.clone());
+    }
+
+    let trusted_setup_provider = TrustedSetupProvider::default();
+    let srs = Arc::new(trusted_setup_provider.get_trusted_setup_parameters()?);
+    let certificate_key_provider =
+        TempCertificateKeyProvider::new(srs.clone(), parameters, merkle_tree_depth);
+    let certificate_midnight_verifying_key =
+        certificate_key_provider.get_midnight_verifying_key()?;
+    let ivc_key_provider =
+        TempIvcKeyProvider::new(srs.clone(), certificate_key_provider.get_verifying_key()?);
+    let ivc_setup = Arc::new(IvcProverSetup::load(
+        &trusted_setup_provider,
+        &certificate_key_provider,
+        &ivc_key_provider,
+    )?);
+
+    let cached = (ivc_setup, certificate_midnight_verifying_key);
+    IVC_PROVER_SETUP_CACHE
+        .lock()
+        .unwrap()
+        .insert(cache_key, cached.clone());
+
+    Ok(cached)
 }
 
 /// Resolve the prover data to store on a new IVC certificate.
@@ -351,6 +369,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
 /// A next-epoch step advances the rolling state, which is stored as is. A same-epoch step does not
 /// advance it (the prover returns none), so the input rolling state carried from the parent
 /// certificate is reused for the next certificate.
+#[cfg(feature = "future_snark")]
 fn resolve_ivc_ancillary_prover_data(
     next_rolling_state: Option<IvcRollingState>,
     previous_prover_data: Option<AncillaryProverData>,

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -4,8 +4,6 @@ use std::{marker::PhantomData, sync::Arc};
 
 #[cfg(feature = "future_snark")]
 use anyhow::anyhow;
-#[cfg(feature = "future_snark")]
-use sha2::{Digest, Sha256};
 
 use crate::{
     AggregateVerificationKey, BaseFieldElement, ClosedKeyRegistration, LotteryIndex,
@@ -275,7 +273,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
 
     // IvcGenesisBootstrapInput contains the same values as AncillaryGenesisData
     // We might consider dropping one or implementing a conversion between the two
-    let genesis_bootstrap = ancillary_input.genesis_data().try_into()?;
+    let genesis_bootstrap = &ancillary_input.genesis_data().try_into()?;
 
     // For now the function will fail as we give two Some values
     // which should not happen but this might be changed
@@ -285,7 +283,7 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
         &avk,
         &global,
         &ProtocolMessagePreimage(protocol_message_preimage_bytes),
+        genesis_bootstrap,
         rolling_state.as_ref(),
-        Some(genesis_bootstrap),
     )
 }

--- a/mithril-stm/src/protocol/aggregate_signature/error.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/error.rs
@@ -54,7 +54,15 @@ pub enum AggregateSignatureError {
     #[error("Unknown proof system: {0}")]
     UnknownProofSystem(String),
 
-    /// Missing ancillary data to verify the IVC proof
-    #[error("Missing ancillary data to verify the IVC proof.")]
-    MissingAncillaryData,
+    /// Missing ancillary verifier data to verify the IVC proof
+    #[error("Missing ancillary verifier data to verify the IVC proof.")]
+    MissingAncillaryVerifierData,
+
+    /// Missing IVC verifier data from the AncillaryVerifierData
+    #[error("Missing IVC verifier data from the AncillaryVerifierData.")]
+    MissingIvcVerifierData,
+
+    /// Missing the rolling state to pass along the next certificate
+    #[error("Missing the rolling state to pass along the next certificate.")]
+    MissingRollingStateForNextCertificate,
 }

--- a/mithril-stm/src/protocol/aggregate_signature/error.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/error.rs
@@ -3,7 +3,7 @@ use crate::SignerIndex;
 use super::AggregateSignatureType;
 
 /// Error types for aggregation.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error, PartialEq)]
 pub enum AggregationError {
     /// Not enough signatures were collected, got this many instead.
     #[error("Not enough signatures. Got only {0} out of {1}.")]
@@ -23,6 +23,18 @@ pub enum AggregationError {
     /// A signature selected for witness assembly is missing its SNARK component.
     #[error("Missing SNARK signature for lottery index {0}.")]
     MissingSnarkSignature(SignerIndex),
+
+    /// Missing the rolling state to pass along the next certificate
+    #[error("Missing the rolling state to pass along the next certificate.")]
+    MissingRollingStateForNextCertificate,
+
+    /// Missing the genesis verification key in the ancillary verifier data
+    #[error("Missing the genesis verification key in the ancillary verifier data.")]
+    MissingGenesisVerificationKey,
+
+    /// Missing IVC rolling state in the ancillary prover data
+    #[error("Missing IVC rolling state in the ancillary prover data.")]
+    MissingIvcRollingStateInAncillaryProverData,
 }
 
 /// Errors which can be output by Mithril aggregate verification.
@@ -61,8 +73,4 @@ pub enum AggregateSignatureError {
     /// Missing IVC verifier data from the AncillaryVerifierData
     #[error("Missing IVC verifier data from the AncillaryVerifierData.")]
     MissingIvcVerifierData,
-
-    /// Missing the rolling state to pass along the next certificate
-    #[error("Missing the rolling state to pass along the next certificate.")]
-    MissingRollingStateForNextCertificate,
 }

--- a/mithril-stm/src/protocol/aggregate_signature/error.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/error.rs
@@ -26,7 +26,7 @@ pub enum AggregationError {
 }
 
 /// Errors which can be output by Mithril aggregate verification.
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum AggregateSignatureError {
     /// This error occurs when the serialization of the raw bytes failed
     #[error("Invalid bytes")]

--- a/mithril-stm/src/protocol/aggregate_signature/error.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/error.rs
@@ -53,4 +53,8 @@ pub enum AggregateSignatureError {
     /// The proof system is unknown
     #[error("Unknown proof system: {0}")]
     UnknownProofSystem(String),
+
+    /// Missing ancillary data to verify the IVC proof
+    #[error("Missing ancillary data to verify the IVC proof.")]
+    MissingAncillaryData,
 }

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -56,7 +56,7 @@ mod tests {
     type Sig = AggregateSignature<D>;
     type D = MithrilMembershipDigest;
 
-    fn setup_equal_parties(params: Parameters, nparties: usize) -> Vec<Signer<D>> {
+    pub(crate) fn setup_equal_parties(params: Parameters, nparties: usize) -> Vec<Signer<D>> {
         let stake = vec![1; nparties];
         setup_parties(params, stake)
     }

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -32,6 +32,7 @@ impl TryInto<MessageHash> for &MessagePreimage {
     }
 }
 
+#[cfg(feature = "future_snark")]
 impl MessagePreimage {
     pub fn to_vec(&self) -> Vec<u8> {
         self.0.clone()

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -20,15 +20,21 @@ use crate::{BaseFieldElement, StmResult, circuits::halo2_ivc::types::MessageHash
 
 #[cfg(feature = "future_snark")]
 #[derive(Clone, Debug)]
-pub struct GenesisMessagePreimage(pub Vec<u8>);
+pub struct MessagePreimage(pub Vec<u8>);
 
 #[cfg(feature = "future_snark")]
-impl TryInto<MessageHash> for &GenesisMessagePreimage {
+impl TryInto<MessageHash> for &MessagePreimage {
     type Error = anyhow::Error;
     fn try_into(self) -> StmResult<MessageHash> {
         let genesis_preimage_hash: [u8; 32] = Sha256::digest(self.0.clone()).into();
         let genesis_message_field_elem = BaseFieldElement::from_raw(&genesis_preimage_hash)?.0;
         Ok(MessageHash::from_field(genesis_message_field_elem))
+    }
+}
+
+impl MessagePreimage {
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.0.clone()
     }
 }
 

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -2,6 +2,8 @@ mod aggregate_key;
 mod ancillary_data;
 mod clerk;
 mod error;
+#[cfg(feature = "future_snark")]
+mod preimage;
 mod signature;
 
 pub use aggregate_key::AggregateVerificationKey;
@@ -11,33 +13,10 @@ pub use ancillary_data::{
 };
 pub use clerk::Clerk;
 pub use error::{AggregateSignatureError, AggregationError};
+
 #[cfg(feature = "future_snark")]
-use sha2::{Digest, Sha256};
+pub use preimage::GenesisMessagePreimage;
 pub use signature::{AggregateSignature, AggregateSignatureType};
-
-#[cfg(feature = "future_snark")]
-use crate::{BaseFieldElement, StmResult, circuits::halo2_ivc::types::MessageHash};
-
-#[cfg(feature = "future_snark")]
-#[derive(Clone, Debug)]
-pub struct MessagePreimage(pub Vec<u8>);
-
-#[cfg(feature = "future_snark")]
-impl TryInto<MessageHash> for &MessagePreimage {
-    type Error = anyhow::Error;
-    fn try_into(self) -> StmResult<MessageHash> {
-        let genesis_preimage_hash: [u8; 32] = Sha256::digest(self.0.clone()).into();
-        let genesis_message_field_elem = BaseFieldElement::from_raw(&genesis_preimage_hash)?.0;
-        Ok(MessageHash::from_field(genesis_message_field_elem))
-    }
-}
-
-#[cfg(feature = "future_snark")]
-impl MessagePreimage {
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.0.clone()
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -11,7 +11,26 @@ pub use ancillary_data::{
 };
 pub use clerk::Clerk;
 pub use error::{AggregateSignatureError, AggregationError};
+#[cfg(feature = "future_snark")]
+use sha2::{Digest, Sha256};
 pub use signature::{AggregateSignature, AggregateSignatureType};
+
+#[cfg(feature = "future_snark")]
+use crate::{BaseFieldElement, StmResult, circuits::halo2_ivc::types::MessageHash};
+
+#[cfg(feature = "future_snark")]
+#[derive(Clone, Debug)]
+pub struct GenesisMessagePreimage(pub Vec<u8>);
+
+#[cfg(feature = "future_snark")]
+impl TryInto<MessageHash> for &GenesisMessagePreimage {
+    type Error = anyhow::Error;
+    fn try_into(self) -> StmResult<MessageHash> {
+        let genesis_preimage_hash: [u8; 32] = Sha256::digest(self.0.clone()).into();
+        let genesis_message_field_elem = BaseFieldElement::from_raw(&genesis_preimage_hash)?.0;
+        Ok(MessageHash::from_field(genesis_message_field_elem))
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/mithril-stm/src/protocol/aggregate_signature/preimage.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/preimage.rs
@@ -1,0 +1,24 @@
+use sha2::{Digest, Sha256};
+use std::ops::Deref;
+
+use crate::{BaseFieldElement, StmResult, circuits::halo2_ivc::types::MessageHash};
+
+#[derive(Clone, Debug)]
+pub struct GenesisMessagePreimage(pub Vec<u8>);
+
+impl TryInto<MessageHash> for &GenesisMessagePreimage {
+    type Error = anyhow::Error;
+    fn try_into(self) -> StmResult<MessageHash> {
+        let genesis_preimage_hash: [u8; 32] = Sha256::digest(self.0.clone()).into();
+        let genesis_message_field_elem = BaseFieldElement::from_raw(&genesis_preimage_hash)?.0;
+        Ok(MessageHash::from_field(genesis_message_field_elem))
+    }
+}
+
+impl Deref for GenesisMessagePreimage {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        &self.0
+    }
+}

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -328,7 +328,18 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     }
                     #[cfg(feature = "future_snark")]
                     AggregateSignatureType::IvcSnark => {
-                        todo!()
+                        for (aggregate_signature, avk, msg, parameters, ancillary_verifier_data) in
+                            aggregate_entries
+                        {
+                            aggregate_signature.verify(
+                                &msg,
+                                &avk,
+                                &parameters,
+                                ancillary_verifier_data,
+                            )?;
+                        }
+
+                        Ok(())
                     }
                 }
             })

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -183,20 +183,17 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     .as_ivc_verifier_data()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingIvcVerifierData))?;
 
-                let certificate_verifying_key =
-                    ivc_verifier_data.certificate_circuit_verification_key();
-
-                let ivc_verifying_key = ivc_verifier_data.ivc_circuit_verification_key();
-
                 let global = Global::new(
                     ivc_verifier_data.genesis_message(),
                     ivc_verifier_data.genesis_schnorr_verification_key(),
-                    certificate_verifying_key,
-                    ivc_verifying_key,
+                    ivc_verifier_data.certificate_circuit_verification_key(),
+                    ivc_verifier_data.ivc_circuit_verification_key(),
                 );
 
-                let verifier_setup =
-                    IvcVerifierSetup::try_new(certificate_verifying_key, ivc_verifying_key)?;
+                let verifier_setup = IvcVerifierSetup::try_new(
+                    ivc_verifier_data.certificate_circuit_verification_key(),
+                    ivc_verifier_data.ivc_circuit_verification_key(),
+                )?;
 
                 ivc_proof.verify(msg, &global, &verifier_setup)
             }
@@ -509,7 +506,7 @@ mod tests {
                 .expect_err("Should fail without ancillary verifier data.");
             assert_eq!(
                 err.downcast_ref::<IvcProofError>(),
-                Some(&IvcProofError::InvalidProtocolMessage),
+                Some(&IvcProofError::InvalidMessage),
                 "missing ancillary verifier data must be rejected, got: {err}"
             );
         }

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -468,9 +468,9 @@ mod tests {
 
         #[cfg(feature = "future_snark")]
         use crate::{
-            AggregateSignature, MithrilMembershipDigest,
+            AggregateSignature, AggregateSignatureError, MithrilMembershipDigest,
             circuits::halo2_ivc::tests::common::asset_readers::load_embedded_next_epoch_step_output_asset,
-            proof_system::ivc_halo2_snark::{errors::IvcProofError, proof::IvcProof},
+            proof_system::ivc_halo2_snark::proof::IvcProof,
         };
 
         #[cfg(feature = "future_snark")]
@@ -505,8 +505,8 @@ mod tests {
                 .verify(msg, &avk, &params, None)
                 .expect_err("Should fail without ancillary verifier data.");
             assert_eq!(
-                err.downcast_ref::<IvcProofError>(),
-                Some(&IvcProofError::InvalidMessage),
+                err.downcast_ref::<AggregateSignatureError>(),
+                Some(&AggregateSignatureError::MissingAncillaryVerifierData),
                 "missing ancillary verifier data must be rejected, got: {err}"
             );
         }

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -463,17 +463,16 @@ impl<D: MembershipDigest> AggregateSignature<D> {
 mod tests {
     use super::*;
 
+    #[cfg(feature = "future_snark")]
     mod ivc_proof {
         use crate::{Clerk, Parameters, protocol::aggregate_signature::tests::setup_equal_parties};
 
-        #[cfg(feature = "future_snark")]
         use crate::{
             AggregateSignature, AggregateSignatureError, MithrilMembershipDigest,
             circuits::halo2_ivc::tests::common::asset_readers::load_embedded_next_epoch_step_output_asset,
             proof_system::ivc_halo2_snark::proof::IvcProof,
         };
 
-        #[cfg(feature = "future_snark")]
         #[test]
         fn ivc_verify_fails_without_ancillary_verifier_data() {
             let step_output = load_embedded_next_epoch_step_output_asset()

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 
 #[cfg(feature = "future_snark")]
-use crate::proof_system::{SnarkProof, SnarkVerifierSetup};
+use crate::proof_system::{SnarkProof, SnarkVerifierSetup, ivc_halo2_snark::proof::IvcProof};
 
 use super::{AggregateSignatureError, AggregateVerificationKey, AncillaryVerifierData};
 
@@ -22,6 +22,9 @@ pub enum AggregateSignatureType {
     /// SNARK proof system.
     #[cfg(feature = "future_snark")]
     Snark,
+    /// IVC SNARK proof system.
+    #[cfg(feature = "future_snark")]
+    IvcSnark,
 }
 
 impl AggregateSignatureType {
@@ -33,6 +36,8 @@ impl AggregateSignatureType {
             AggregateSignatureType::Concatenation => 0,
             #[cfg(feature = "future_snark")]
             AggregateSignatureType::Snark => 1,
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::IvcSnark => 2,
         }
     }
 
@@ -44,6 +49,8 @@ impl AggregateSignatureType {
             0 => Some(AggregateSignatureType::Concatenation),
             #[cfg(feature = "future_snark")]
             1 => Some(AggregateSignatureType::Snark),
+            #[cfg(feature = "future_snark")]
+            2 => Some(AggregateSignatureType::IvcSnark),
             _ => None,
         }
     }
@@ -59,6 +66,8 @@ impl AggregateSignatureType {
             AggregateSignatureType::Concatenation => false,
             #[cfg(feature = "future_snark")]
             AggregateSignatureType::Snark => false,
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::IvcSnark => true,
         }
     }
 }
@@ -69,6 +78,8 @@ impl<D: MembershipDigest> From<&AggregateSignature<D>> for AggregateSignatureTyp
             AggregateSignature::Concatenation(_) => AggregateSignatureType::Concatenation,
             #[cfg(feature = "future_snark")]
             AggregateSignature::Snark(_) => AggregateSignatureType::Snark,
+            #[cfg(feature = "future_snark")]
+            AggregateSignature::IvcSnark(_) => AggregateSignatureType::IvcSnark,
         }
     }
 }
@@ -81,6 +92,8 @@ impl FromStr for AggregateSignatureType {
             "Concatenation" => Ok(AggregateSignatureType::Concatenation),
             #[cfg(feature = "future_snark")]
             "Snark" => Ok(AggregateSignatureType::Snark),
+            #[cfg(feature = "future_snark")]
+            "IvcSnark" => Ok(AggregateSignatureType::IvcSnark),
             _ => Err(anyhow!(AggregateSignatureError::UnknownProofSystem(
                 s.to_string()
             ))),
@@ -94,6 +107,8 @@ impl Display for AggregateSignatureType {
             AggregateSignatureType::Concatenation => write!(f, "Concatenation"),
             #[cfg(feature = "future_snark")]
             AggregateSignatureType::Snark => write!(f, "Snark"),
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::IvcSnark => write!(f, "IvcSnark"),
         }
     }
 }
@@ -118,6 +133,10 @@ pub enum AggregateSignature<D: MembershipDigest> {
     /// SNARK proof system.
     #[cfg(feature = "future_snark")]
     Snark(Box<SnarkProof<D>>),
+
+    /// IVC SNARK proof system.
+    #[cfg(feature = "future_snark")]
+    IvcSnark(Box<IvcProof<blake2b_simd::State>>),
 
     /// Concatenation proof system.
     // The 'untagged' attribute is required for backward compatibility.
@@ -150,6 +169,10 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                 })?;
                 let verifier_setup = SnarkVerifierSetup::try_new()?;
                 snark_proof.verify(msg, snark_avk, &verifier_setup.verifier_params)
+            }
+            #[cfg(feature = "future_snark")]
+            AggregateSignature::IvcSnark(ivc_proof) => {
+                todo!()
             }
         }
     }
@@ -275,6 +298,10 @@ impl<D: MembershipDigest> AggregateSignature<D> {
 
                         Ok(())
                     }
+                    #[cfg(feature = "future_snark")]
+                    AggregateSignatureType::IvcSnark => {
+                        todo!()
+                    }
                 }
             })
     }
@@ -291,6 +318,8 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             }
             #[cfg(feature = "future_snark")]
             AggregateSignature::Snark(snark_proof) => snark_proof.to_bytes()?,
+            #[cfg(feature = "future_snark")]
+            AggregateSignature::IvcSnark(ivc_proof) => todo!(),
         };
         let envelope = AggregateSignatureCborEnvelope {
             signature_type: aggregate_signature_type.get_byte_encoding_prefix(),
@@ -336,6 +365,8 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             AggregateSignatureType::Snark => Ok(AggregateSignature::Snark(Box::new(
                 SnarkProof::from_bytes(&envelope.proof_bytes)?,
             ))),
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::IvcSnark => todo!(),
         }
     }
 
@@ -353,6 +384,8 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             AggregateSignatureType::Snark => Ok(AggregateSignature::Snark(Box::new(
                 SnarkProof::from_bytes(proof_bytes)?,
             ))),
+            #[cfg(feature = "future_snark")]
+            AggregateSignatureType::IvcSnark => todo!(),
         }
     }
 
@@ -362,6 +395,8 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             AggregateSignature::Concatenation(proof) => Some(proof),
             #[cfg(feature = "future_snark")]
             AggregateSignature::Snark(_) => None,
+            #[cfg(feature = "future_snark")]
+            AggregateSignature::IvcSnark(_) => None,
         }
     }
 
@@ -371,6 +406,18 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         match self {
             AggregateSignature::Snark(proof) => Some(proof),
             AggregateSignature::Concatenation(_) => None,
+            AggregateSignature::IvcSnark(_) => None,
+        }
+    }
+
+    /// If the aggregate signature is an IVC proof, return it.
+    /// TODO: replace the proof type to IvcProof
+    #[cfg(feature = "future_snark")]
+    pub fn get_ivc_proof(&self) -> Option<&IvcProof<blake2b_simd::State>> {
+        match self {
+            AggregateSignature::IvcSnark(proof) => Some(proof),
+            AggregateSignature::Concatenation(_) => None,
+            AggregateSignature::Snark(_) => None,
         }
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -9,7 +9,12 @@ use crate::{
 };
 
 #[cfg(feature = "future_snark")]
-use crate::proof_system::{SnarkProof, SnarkVerifierSetup, ivc_halo2_snark::proof::IvcProof};
+use crate::circuits::halo2_ivc::state::Global;
+#[cfg(feature = "future_snark")]
+use crate::proof_system::{
+    SnarkProof, SnarkVerifierSetup,
+    ivc_halo2_snark::{proof::IvcProof, verifier_setup::IvcVerifierSetup},
+};
 
 use super::{AggregateSignatureError, AggregateVerificationKey, AncillaryVerifierData};
 
@@ -172,7 +177,30 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             }
             #[cfg(feature = "future_snark")]
             AggregateSignature::IvcSnark(ivc_proof) => {
-                todo!()
+                let ivc_verifier_data = ancillary_verifier_data
+                    .ok_or_else(|| {
+                        anyhow!("Ancillary verifier data needed to verify the IVC proof")
+                    })?
+                    .as_ivc_verifier_data();
+
+                let certificate_verifying_key =
+                    ivc_verifier_data.certificate_circuit_verification_key();
+
+                let ivc_verifying_key = ivc_verifier_data.ivc_circuit_verification_key();
+
+                let global = &Global::new(
+                    ivc_verifier_data.genesis_message(),
+                    ivc_verifier_data.genesis_schnorr_verification_key(),
+                    &certificate_verifying_key,
+                    &ivc_verifying_key,
+                );
+
+                // Need to clone the ivc_verifying_key here because try_new does not
+                // take a reference, can we change that? do we want to?
+                let verifier_setup =
+                    IvcVerifierSetup::try_new(&certificate_verifying_key, ivc_verifying_key)?;
+
+                ivc_proof.verify(global, &verifier_setup)
             }
         }
     }

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -7,13 +7,13 @@ use crate::{
     MembershipDigest, Parameters, StmError, StmResult, codec,
     membership_commitment::MerkleBatchPath, proof_system::ConcatenationProof,
 };
-
 #[cfg(feature = "future_snark")]
-use crate::circuits::halo2_ivc::state::Global;
-#[cfg(feature = "future_snark")]
-use crate::proof_system::{
-    SnarkProof, SnarkVerifierSetup,
-    ivc_halo2_snark::{proof::IvcProof, verifier_setup::IvcVerifierSetup},
+use crate::{
+    circuits::halo2_ivc::state::Global,
+    proof_system::{
+        SnarkProof, SnarkVerifierSetup,
+        ivc_halo2_snark::{proof::IvcProof, verifier_setup::IvcVerifierSetup},
+    },
 };
 
 use super::{AggregateSignatureError, AggregateVerificationKey, AncillaryVerifierData};
@@ -179,25 +179,26 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             AggregateSignature::IvcSnark(ivc_proof) => {
                 let ivc_verifier_data = ancillary_verifier_data
                     .as_ref()
-                    .ok_or_else(|| anyhow!(AggregateSignatureError::MissingAncillaryData))?
-                    .as_ivc_verifier_data();
+                    .ok_or_else(|| anyhow!(AggregateSignatureError::MissingAncillaryVerifierData))?
+                    .as_ivc_verifier_data()
+                    .ok_or_else(|| anyhow!(AggregateSignatureError::MissingIvcVerifierData))?;
 
                 let certificate_verifying_key =
                     ivc_verifier_data.certificate_circuit_verification_key();
 
                 let ivc_verifying_key = ivc_verifier_data.ivc_circuit_verification_key();
 
-                let global = &Global::new(
+                let global = Global::new(
                     ivc_verifier_data.genesis_message(),
                     ivc_verifier_data.genesis_schnorr_verification_key(),
-                    &certificate_verifying_key,
-                    &ivc_verifying_key,
+                    certificate_verifying_key,
+                    ivc_verifying_key,
                 );
 
                 let verifier_setup =
-                    IvcVerifierSetup::try_new(&certificate_verifying_key, ivc_verifying_key)?;
+                    IvcVerifierSetup::try_new(certificate_verifying_key, ivc_verifying_key)?;
 
-                ivc_proof.verify(global, &verifier_setup)
+                ivc_proof.verify(msg, &global, &verifier_setup)
             }
         }
     }

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -160,7 +160,7 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         parameters: &Parameters,
         ancillary_verifier_data: Option<AncillaryVerifierData>,
     ) -> StmResult<()> {
-        let _ = ancillary_verifier_data;
+        let _ = &ancillary_verifier_data;
         match self {
             AggregateSignature::Concatenation(concatenation_proof) => concatenation_proof.verify(
                 msg,
@@ -178,9 +178,8 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             #[cfg(feature = "future_snark")]
             AggregateSignature::IvcSnark(ivc_proof) => {
                 let ivc_verifier_data = ancillary_verifier_data
-                    .ok_or_else(|| {
-                        anyhow!("Ancillary verifier data needed to verify the IVC proof")
-                    })?
+                    .as_ref()
+                    .ok_or_else(|| anyhow!(AggregateSignatureError::MissingAncillaryData))?
                     .as_ivc_verifier_data();
 
                 let certificate_verifying_key =
@@ -195,8 +194,6 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     &ivc_verifying_key,
                 );
 
-                // Need to clone the ivc_verifying_key here because try_new does not
-                // take a reference, can we change that? do we want to?
                 let verifier_setup =
                     IvcVerifierSetup::try_new(&certificate_verifying_key, ivc_verifying_key)?;
 
@@ -358,7 +355,7 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             #[cfg(feature = "future_snark")]
             AggregateSignature::Snark(snark_proof) => snark_proof.to_bytes()?,
             #[cfg(feature = "future_snark")]
-            AggregateSignature::IvcSnark(ivc_proof) => todo!(),
+            AggregateSignature::IvcSnark(ivc_proof) => ivc_proof.to_bytes()?,
         };
         let envelope = AggregateSignatureCborEnvelope {
             signature_type: aggregate_signature_type.get_byte_encoding_prefix(),
@@ -405,7 +402,9 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                 SnarkProof::from_bytes(&envelope.proof_bytes)?,
             ))),
             #[cfg(feature = "future_snark")]
-            AggregateSignatureType::IvcSnark => todo!(),
+            AggregateSignatureType::IvcSnark => Ok(AggregateSignature::IvcSnark(Box::new(
+                IvcProof::from_bytes(&envelope.proof_bytes)?,
+            ))),
         }
     }
 
@@ -424,7 +423,9 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                 SnarkProof::from_bytes(proof_bytes)?,
             ))),
             #[cfg(feature = "future_snark")]
-            AggregateSignatureType::IvcSnark => todo!(),
+            AggregateSignatureType::IvcSnark => Ok(AggregateSignature::IvcSnark(Box::new(
+                IvcProof::from_bytes(proof_bytes)?,
+            ))),
         }
     }
 
@@ -450,7 +451,6 @@ impl<D: MembershipDigest> AggregateSignature<D> {
     }
 
     /// If the aggregate signature is an IVC proof, return it.
-    /// TODO: replace the proof type to IvcProof
     #[cfg(feature = "future_snark")]
     pub fn get_ivc_proof(&self) -> Option<&IvcProof<blake2b_simd::State>> {
         match self {

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -466,6 +466,55 @@ impl<D: MembershipDigest> AggregateSignature<D> {
 mod tests {
     use super::*;
 
+    mod ivc_proof {
+        use crate::{Clerk, Parameters, protocol::aggregate_signature::tests::setup_equal_parties};
+
+        #[cfg(feature = "future_snark")]
+        use crate::{
+            AggregateSignature, MithrilMembershipDigest,
+            circuits::halo2_ivc::tests::common::asset_readers::load_embedded_next_epoch_step_output_asset,
+            proof_system::ivc_halo2_snark::{errors::IvcProofError, proof::IvcProof},
+        };
+
+        #[cfg(feature = "future_snark")]
+        #[test]
+        fn ivc_verify_fails_without_ancillary_verifier_data() {
+            let step_output = load_embedded_next_epoch_step_output_asset()
+                .expect("recursive step output asset should load");
+
+            let nparties = 5;
+            let m = 10;
+            let k = 3;
+            let params = Parameters { m, k, phi_f: 0.9 };
+            let ps = setup_equal_parties(params, nparties);
+            let clerk = Clerk::new_clerk_from_signer(&ps[0]);
+            let avk = clerk.compute_aggregate_verification_key();
+
+            let msg = &[
+                22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158,
+                211, 191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+            ];
+
+            let proof = IvcProof::<blake2b_simd::State>::new(
+                step_output.ivc_proof,
+                step_output.next_state,
+                step_output.next_accumulator,
+            );
+
+            let ivc_proof =
+                AggregateSignature::<MithrilMembershipDigest>::IvcSnark(Box::new(proof));
+
+            let err = ivc_proof
+                .verify(msg, &avk, &params, None)
+                .expect_err("Should fail without ancillary verifier data.");
+            assert_eq!(
+                err.downcast_ref::<IvcProofError>(),
+                Some(&IvcProofError::InvalidProtocolMessage),
+                "missing ancillary verifier data must be rejected, got: {err}"
+            );
+        }
+    }
+
     mod envelope_compatibility {
         use super::*;
         use crate::codec;


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes the wiring of the IVC prove and verify function inside the `Clerk` and `AggregateSignature` structures. Those structures can now compute and represent a proof generated by the IVC circuit along with all the information necessary to continue the computations or to verify the proof.

Changes:
- `IvcRollingState` serialization: now derives Serialize/Deserialize.
- `IvcVerifierData`: New struct in `verifier_setup.rs` that contains the genesis message, genesis Schnorr verifying key, and the certificate and IVC circuit verifying keys needed to verify a proof chain.
- `AncillaryProverData` / `AncillaryVerifierData`: Enum wrappers around `IvcRollingState` and `IvcVerifierData` for now.
- `AggregateSignature::IvcSnark`: New variant wired through `verify` (and `batch_verify`).
- Clerk: Added `ivc_prover_input_preparation_and_prove` function to drive a single IVC step and implement the IVC variant of `Clerk::aggregate_signatures_with_type`.


The PR also contains some fixes for bugs that appeared during end-to-end testing. 

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->


## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3141 
