### PR TITLE
refactor(stm): applying final comments of PR #3348

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.41"
+version = "0.10.42"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.41", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.42", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/protocol/ancillary.rs
+++ b/mithril-common/src/protocol/ancillary.rs
@@ -60,8 +60,6 @@ pub fn build_ancillary_proof_input(
 
 #[cfg(all(test, feature = "future_snark"))]
 mod tests {
-    use std::ops::Deref;
-
     use rand_chacha::ChaCha20Rng;
     use rand_core::SeedableRng;
 
@@ -105,7 +103,7 @@ mod tests {
             protocol_message.rigid_preimage().as_slice()
         );
         assert_eq!(
-            genesis_data.genesis_message_preimage().deref(),
+            genesis_data.genesis_message_preimage(),
             genesis.protocol_message.rigid_preimage().as_slice()
         );
         assert!(genesis_data.genesis_schnorr_signature().is_some());

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.10.40 (06-29-2026)
+## 0.10.42 (06-29-2026)
+
+### Changed
+
+- Better context for the `IvcCircuitError::CertificateProofRejected` error
+- Better handling of the `GenesisMessagePreimage` in tests
+- Name change for the `AncillaryProverData` variant
+
+## 0.10.41 (06-29-2026)
 
 ### Added
 

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.41"
+version = "0.10.42"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -55,24 +55,24 @@ pub(crate) fn verify_and_prepare_accumulator(
         &[&[public_inputs]],
         &mut transcript,
     )
-    .map_err(|err| IvcCircuitError::CertificateProofRejected {
-        context: format!("Error from plonk verifier prepare function: {}", err),
+    .map_err(|err| {
+        IvcCircuitError::CertificateProofRejected(format!(
+            "Error from plonk verifier prepare function: {}",
+            err
+        ))
     })?;
 
-    transcript
-        .assert_empty()
-        .map_err(|err| IvcCircuitError::CertificateProofRejected {
-            context: format!(
-                "Transcript is not empty after the dual msm prepare: {}",
-                err
-            ),
-        })?;
+    transcript.assert_empty().map_err(|err| {
+        IvcCircuitError::CertificateProofRejected(format!(
+            "Transcript is not empty after the dual msm prepare: {}",
+            err
+        ))
+    })?;
 
     if !dual_msm.clone().check(verifier_params) {
-        return Err(IvcCircuitError::CertificateProofRejected {
-            context: "Dual msm check failed".to_string(),
-        }
-        .into());
+        return Err(
+            IvcCircuitError::CertificateProofRejected("Dual msm check failed".to_string()).into(),
+        );
     }
 
     Ok(dual_msm)

--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -7,7 +7,6 @@
 //! proof, so it can be wrapped into a certificate accumulator for IVC
 //! aggregation.
 
-use anyhow::Context;
 use group::Group;
 
 use midnight_circuits::hash::poseidon::PoseidonState;
@@ -56,17 +55,24 @@ pub(crate) fn verify_and_prepare_accumulator(
         &[&[public_inputs]],
         &mut transcript,
     )
-    .map_err(|_| IvcCircuitError::CertificateProofRejected)
-    .with_context(|| "Error during the preparation of the dual msm.")?;
+    .map_err(|err| IvcCircuitError::CertificateProofRejected {
+        context: format!("Error from plonk verifier prepare function: {}", err),
+    })?;
 
     transcript
         .assert_empty()
-        .map_err(|_| IvcCircuitError::CertificateProofRejected)
-        .with_context(|| "Transcript is not empty after the dual msm prepare.")?;
+        .map_err(|err| IvcCircuitError::CertificateProofRejected {
+            context: format!(
+                "Transcript is not empty after the dual msm prepare: {}",
+                err
+            ),
+        })?;
 
     if !dual_msm.clone().check(verifier_params) {
-        return Err(IvcCircuitError::CertificateProofRejected)
-            .with_context(|| "Dual msm check failed");
+        return Err(IvcCircuitError::CertificateProofRejected {
+            context: "Dual msm check failed".to_string(),
+        }
+        .into());
     }
 
     Ok(dual_msm)

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 pub enum IvcCircuitError {
     /// Off-circuit verifier rejected a certificate proof.
     #[error("Certificate proof verification rejected")]
-    CertificateProofRejected,
+    CertificateProofRejected { context: String },
 
     /// IVC verification key degree does not match the IVC circuit degree constant K.
     #[error(

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum IvcCircuitError {
     /// Off-circuit verifier rejected a certificate proof.
-    #[error("Certificate proof verification rejected")]
-    CertificateProofRejected { context: String },
+    #[error("Certificate proof verification rejected: {0}")]
+    CertificateProofRejected(String),
 
     /// IVC verification key degree does not match the IVC circuit degree constant K.
     #[error(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
@@ -34,12 +34,7 @@ fn verify_and_prepare_accumulator_rejects_garbage_proof_bytes() {
         .unwrap_err()
         .downcast::<IvcCircuitError>()
         .expect("error should downcast to IvcCircuitError");
-    assert_eq!(
-        err,
-        IvcCircuitError::CertificateProofRejected {
-            context: "Error from plonk verifier prepare function: Transcript error: Invalid BLS12-381 point encoding in proof".to_string()
-        }
-    );
+    assert!(matches!(err, IvcCircuitError::CertificateProofRejected(..)));
 }
 
 #[test]
@@ -64,10 +59,5 @@ fn verify_and_prepare_accumulator_rejects_valid_proof_with_wrong_public_inputs()
         .unwrap_err()
         .downcast::<IvcCircuitError>()
         .expect("error should downcast to IvcCircuitError");
-    assert_eq!(
-        err,
-        IvcCircuitError::CertificateProofRejected {
-            context: "Dual msm check failed".to_string()
-        }
-    );
+    assert!(matches!(err, IvcCircuitError::CertificateProofRejected(..)));
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/certificate_proof_rejection.rs
@@ -34,7 +34,12 @@ fn verify_and_prepare_accumulator_rejects_garbage_proof_bytes() {
         .unwrap_err()
         .downcast::<IvcCircuitError>()
         .expect("error should downcast to IvcCircuitError");
-    assert_eq!(err, IvcCircuitError::CertificateProofRejected);
+    assert_eq!(
+        err,
+        IvcCircuitError::CertificateProofRejected {
+            context: "Error from plonk verifier prepare function: Transcript error: Invalid BLS12-381 point encoding in proof".to_string()
+        }
+    );
 }
 
 #[test]
@@ -59,5 +64,10 @@ fn verify_and_prepare_accumulator_rejects_valid_proof_with_wrong_public_inputs()
         .unwrap_err()
         .downcast::<IvcCircuitError>()
         .expect("error should downcast to IvcCircuitError");
-    assert_eq!(err, IvcCircuitError::CertificateProofRejected);
+    assert_eq!(
+        err,
+        IvcCircuitError::CertificateProofRejected {
+            context: "Dual msm check failed".to_string()
+        }
+    );
 }

--- a/mithril-stm/src/circuits/mod.rs
+++ b/mithril-stm/src/circuits/mod.rs
@@ -8,9 +8,7 @@
 pub(crate) mod common;
 pub mod halo2;
 pub mod halo2_ivc;
-#[cfg(not(target_family = "wasm"))]
 pub mod key_cache;
-#[cfg(not(target_family = "wasm"))]
 pub mod trusted_setup;
 
 #[cfg(test)]
@@ -21,7 +19,6 @@ pub(crate) use halo2::witness::{
 };
 
 /// Constant holding the current path of the cached values related to the circuits
-#[cfg(not(target_family = "wasm"))]
 const MITHRIL_CIRCUIT_CACHE_FOLDER: &str = "mithril-circuit";
 
 #[cfg(all(

--- a/mithril-stm/src/circuits/trusted_setup.rs
+++ b/mithril-stm/src/circuits/trusted_setup.rs
@@ -45,8 +45,10 @@ pub struct TrustedSetupProvider {
     /// Expected hash of the downloaded SRS file
     srs_expected_hash: String,
     /// URL where to download the SRS file if it is not present locally
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     url_to_download_srs: String,
     /// The timeout limit when trying to download the SRS file
+    #[cfg_attr(target_family = "wasm", allow(dead_code))]
     download_timeout_limit: Duration,
 }
 
@@ -89,6 +91,7 @@ impl TrustedSetupProvider {
     }
 
     /// Fetches the SRS from `self.url_to_download_srs` and returns its bytes.
+    #[cfg(not(target_family = "wasm"))]
     fn download_srs_file(&self) -> StmResult<Vec<u8>> {
         let response = reqwest::blocking::Client::builder()
             .timeout(self.download_timeout_limit)
@@ -100,6 +103,15 @@ impl TrustedSetupProvider {
         let bytes = response.bytes()?;
 
         Ok(bytes.to_vec())
+    }
+
+    /// The SRS download relies on a blocking HTTP client that is unavailable on wasm targets,
+    /// where the prover is never executed.
+    #[cfg(target_family = "wasm")]
+    fn download_srs_file(&self) -> StmResult<Vec<u8>> {
+        Err(anyhow::anyhow!(
+            "SRS download is not supported on wasm targets"
+        ))
     }
 
     /// Saves the given bytes in a temporary file then atomically moves it to the stored path

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -520,7 +520,12 @@ mod tests {
                 .expect_err("prepare should reject a corrupted certificate proof")
                 .downcast::<IvcCircuitError>()
                 .expect("error should downcast to IvcCircuitError");
-            assert_eq!(err, IvcCircuitError::CertificateProofRejected);
+            assert_eq!(
+                err,
+                IvcCircuitError::CertificateProofRejected {
+                    context: "Error from plonk verifier prepare function: Transcript error: Invalid BLS12-381 point encoding in proof".to_string()
+                }
+            );
         }
 
         #[test]

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input.rs
@@ -520,12 +520,7 @@ mod tests {
                 .expect_err("prepare should reject a corrupted certificate proof")
                 .downcast::<IvcCircuitError>()
                 .expect("error should downcast to IvcCircuitError");
-            assert_eq!(
-                err,
-                IvcCircuitError::CertificateProofRejected {
-                    context: "Error from plonk verifier prepare function: Transcript error: Invalid BLS12-381 point encoding in proof".to_string()
-                }
-            );
+            assert!(matches!(err, IvcCircuitError::CertificateProofRejected(..)));
         }
 
         #[test]

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -24,7 +24,7 @@ pub enum AncillaryProverData {
     #[cfg(feature = "future_snark")]
     IvcSnark(IvcRollingState),
     #[cfg(all(feature = "future_snark", test))]
-    FutureVariant,
+    Future,
 }
 
 impl AncillaryProverData {
@@ -52,7 +52,7 @@ impl AncillaryProverData {
         match self {
             Self::IvcSnark(state) => Some(state),
             #[cfg(test)]
-            Self::FutureVariant => None,
+            Self::Future => None,
         }
     }
 }

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -328,6 +328,7 @@ mod tests {
 
     use crate::{
         AncillaryGenesisData, AncillaryProofInput, MithrilMembershipDigest, Parameters,
+        SchnorrVerificationKey,
         circuits::halo2::circuit::StmCertificateCircuit,
         circuits::halo2_ivc::PREIMAGE_SIZE,
         proof_system::{CircuitVerificationKey, SnarkClerk},
@@ -373,8 +374,6 @@ mod tests {
 
     #[test]
     fn ivc_prover_input_preparation_fails_when_prover_data_carries_no_ivc_rolling_state() {
-        use crate::SchnorrVerificationKey;
-
         let tiny_params = Parameters {
             k: 1,
             m: 10,
@@ -393,7 +392,7 @@ mod tests {
         );
 
         let ancillary_input = AncillaryProofInput::new(
-            Some(AncillaryProverData::FutureVariant),
+            Some(AncillaryProverData::Future),
             AncillaryGenesisData::new(vec![0u8; 32], None, Some(SchnorrVerificationKey::default())),
             vec![0u8; PREIMAGE_SIZE],
         );

--- a/mithril-stm/src/protocol/aggregate_signature/preimage.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/preimage.rs
@@ -22,3 +22,9 @@ impl Deref for GenesisMessagePreimage {
         &self.0
     }
 }
+
+impl PartialEq<[u8]> for GenesisMessagePreimage {
+    fn eq(&self, other: &[u8]) -> bool {
+        self.0 == other
+    }
+}

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -515,6 +515,11 @@ mod tests {
             proof_system::ivc_halo2_snark::{proof::IvcProof, verifier_setup::IvcVerifierData},
         };
 
+        const LOADED_CONTEXT_MSG: [u8; 32] = [
+            22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158, 211,
+            191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+        ];
+
         #[test]
         fn ivc_verify_fails_without_genesis_verification_key_bundle() {
             let step_output = load_embedded_next_epoch_step_output_asset()
@@ -530,11 +535,6 @@ mod tests {
             let ps = setup_equal_parties(params, 5);
             let avk = Clerk::new_clerk_from_signer(&ps[0]).compute_aggregate_verification_key();
 
-            let msg = &[
-                22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158,
-                211, 191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-            ];
-
             let ancillary = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
                 MessageHash::ZERO,
                 context.certificate_verifying_key,
@@ -549,7 +549,7 @@ mod tests {
                 AggregateSignature::<MithrilMembershipDigest>::IvcSnark(Box::new(proof));
 
             let error = ivc_proof
-                .verify(msg, &avk, &params, Some(ancillary), None)
+                .verify(&LOADED_CONTEXT_MSG, &avk, &params, Some(ancillary), None)
                 .expect_err(
                     "verification must fail when the genesis verification key bundle is absent",
                 );
@@ -573,11 +573,6 @@ mod tests {
             let clerk = Clerk::new_clerk_from_signer(&ps[0]);
             let avk = clerk.compute_aggregate_verification_key();
 
-            let msg = &[
-                22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158,
-                211, 191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
-            ];
-
             let proof = IvcProof::<blake2b_simd::State>::new(
                 step_output.ivc_proof,
                 step_output.next_state,
@@ -588,7 +583,7 @@ mod tests {
                 AggregateSignature::<MithrilMembershipDigest>::IvcSnark(Box::new(proof));
 
             let err = ivc_proof
-                .verify(msg, &avk, &params, None, None)
+                .verify(&LOADED_CONTEXT_MSG, &avk, &params, None, None)
                 .expect_err("Should fail without ancillary verifier data.");
             assert_eq!(
                 err.downcast_ref::<AggregateSignatureError>(),


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes some small fixes from the leftover comments of PR #3348, mainly:

- Better context for the `IvcCircuitError::CertificateProofRejected` error
- Better handling of the `GenesisMessagePreimage` in tests
- Name change for the `AncillaryProverData` variant

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Relates to #3141 
