### PR TITLE
Make kes_bytes file creation/write atomic for concurrent access

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.8"
+version = "0.7.9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.8" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.9" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.8" }
+mithril-common = { path = "../../mithril-common", version = "0.7.9" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.3" }
-mithril-common = { path = "../../mithril-common", version = "0.7.8" }
+mithril-common = { path = "../../mithril-common", version = "0.7.9" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -64,7 +64,7 @@ flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.3" }
-mithril-common = { path = "../mithril-common", version = "0.7.8", default-features = false }
+mithril-common = { path = "../mithril-common", version = "0.7.9", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.8"
+version = "0.7.9"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-common/src/crypto_helper/cardano/codec.rs
+++ b/mithril-common/src/crypto_helper/cardano/codec.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, anyhow};
 use hex::FromHex;
 use kes_summed_ed25519::kes::Sum6Kes;
 use kes_summed_ed25519::traits::KesSk;
+use rand_core::RngCore;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_with::{As, Bytes};
@@ -24,6 +25,7 @@ use std::path::Path;
 use thiserror::Error;
 
 use crate::StdError;
+use crate::test::crypto_helper::SerDeShelleyFileFormatTestExtension;
 
 /// We need to create this struct because the design of Sum6Kes takes
 /// a reference to a mutable pointer. It is therefore not possible to
@@ -62,40 +64,13 @@ pub trait SerDeShelleyFileFormat: Serialize + DeserializeOwned {
     /// Shelley file format.
     fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, CodecParseError> {
         let data = fs::read_to_string(path)
-            .with_context(|| "SerDeShelleyFileFormat can not read data from file {}")
+            .with_context(|| "SerDeShelleyFileFormat can not read data from file")
             .map_err(CodecParseError)?;
         let file: ShelleyFileFormat = serde_json::from_str(&data)
             .with_context(|| "SerDeShelleyFileFormat can not unserialize json data")
             .map_err(CodecParseError)?;
 
         Self::from_cbor_hex(&file.cbor_hex)
-    }
-
-    /// Serialize a type `T: Serialize + DeserializeOwned` to file following Cardano
-    /// Shelley file format.
-    fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), CodecParseError> {
-        let cbor_string = self
-            .to_cbor_hex()
-            .with_context(|| "SerDeShelleyFileFormat can not serialize data to cbor")
-            .map_err(CodecParseError)?;
-
-        let file_format = ShelleyFileFormat {
-            file_type: Self::TYPE.to_string(),
-            description: Self::DESCRIPTION.to_string(),
-            cbor_hex: cbor_string,
-        };
-
-        let mut file = fs::File::create(path)
-            .with_context(|| "SerDeShelleyFileFormat can not create file")
-            .map_err(CodecParseError)?;
-        let json_str = serde_json::to_string(&file_format)
-            .with_context(|| "SerDeShelleyFileFormat can not serialize data to json")
-            .map_err(CodecParseError)?;
-
-        write!(file, "{json_str}")
-            .with_context(|| "SerDeShelleyFileFormat can not write data to file")
-            .map_err(CodecParseError)?;
-        Ok(())
     }
 
     /// Serialize the structure to a CBOR bytes representation.
@@ -177,6 +152,44 @@ impl<'a> TryFrom<&'a mut Sum6KesBytes> for Sum6Kes<'a> {
     }
 }
 
+impl<T> SerDeShelleyFileFormatTestExtension for T
+where
+    T: SerDeShelleyFileFormat,
+{
+    fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), CodecParseError> {
+        let cbor_string = self
+            .to_cbor_hex()
+            .with_context(|| "SerDeShelleyFileFormat can not serialize data to cbor")
+            .map_err(CodecParseError)?;
+
+        let file_format = ShelleyFileFormat {
+            file_type: Self::TYPE.to_string(),
+            description: Self::DESCRIPTION.to_string(),
+            cbor_hex: cbor_string,
+        };
+
+        let path_ref = path.as_ref();
+        let mut rng = rand_core::OsRng;
+        let temp_path = path_ref.with_added_extension(format!("{}.tmp", rng.next_u64()));
+
+        let mut file = fs::File::create(temp_path.clone())
+            .with_context(|| "SerDeShelleyFileFormat can not create file")
+            .map_err(CodecParseError)?;
+        let json_str = serde_json::to_string(&file_format)
+            .with_context(|| "SerDeShelleyFileFormat can not serialize data to json")
+            .map_err(CodecParseError)?;
+
+        write!(file, "{json_str}")
+            .with_context(|| "SerDeShelleyFileFormat can not write data to file")
+            .map_err(CodecParseError)?;
+
+        fs::rename(&temp_path, path_ref)
+            .with_context(|| "SerDeShelleyFileFormat can not rename temporary file")
+            .map_err(CodecParseError)?;
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -205,5 +218,20 @@ mod test {
             Sum6KesBytes::from_file(&sk_dir).expect("Failure parsing Shelley file format.");
 
         assert!(Sum6Kes::try_from(&mut kes_sk_bytes).is_ok());
+    }
+
+    #[test]
+    fn to_file_must_create_a_file() {
+        let temp_dir = TempDir::create("crypto_helper", "to_file_must_create_a_file");
+        let cbor_hex_string = "590264fe77acdfa56281e4b05198f5136018057a65f425411f0990cac4aca0f2917aa00a3d51e191f6f425d870aca3c6a2a41833621f5729d7bc0e3dfc3ae77d057e5e1253b71def7a54157b9f98973ca3c49edd9f311e5f4b23ac268b56a6ac040c14c6d2217925492e42f00dc89a2a01ff363571df0ca0db5ba37001cee56790cc01cd69c6aa760fca55a65a110305ea3c11da0a27be345a589329a584ebfc499c43c55e8c6db5d9c0b014692533ee78abd7ac1e79f7ec9335c7551d31668369b4d5111db78072f010043e35e5ca7f11acc3c05b26b9c7fe56f02aa41544f00cb7685e87f34c73b617260ade3c7b8d8c4df46693694998f85ad80d2cbab0b575b6ccd65d90574e84368169578bff57f751bc94f7eec5c0d7055ec88891a69545eedbfbd3c5f1b1c1fe09c14099f6b052aa215efdc5cb6cdc84aa810db41dbe8cb7d28f7c4beb75cc53915d3ac75fc9d0bf1c734a46e401e15150c147d013a938b7e07cc4f25a582b914e94783d15896530409b8acbe31ef471de8a1988ac78dfb7510729eff008084885f07df870b65e4f382ca15908e1dcda77384b5c724350de90cec22b1dcbb1cdaed88da08bb4772a82266ec154f5887f89860d0920dba705c45957ef6d93e42f6c9509c966277d368dd0eefa67c8147aa15d40a222f7953a4f34616500b310d00aa1b5b73eb237dc4f76c0c16813d321b2fc5ac97039be25b22509d1201d61f4ccc11cd4ff40fffe39f0e937b4722074d8e073a775d7283b715d46f79ce128e3f1362f35615fa72364d20b6db841193d96e58d9d8e86b516bbd1f05e45b39823a93f6e9f29d9e01acf2c12c072d1c64e0afbbabf6903ef542e00000000";
+        let kes_bytes = Sum6KesBytes::from_cbor_hex(cbor_hex_string).unwrap();
+        let kes_file_path = temp_dir.join("kes.sk");
+
+        kes_bytes
+            .to_file(kes_file_path.clone())
+            .expect("Sum6KesBytes to_file should not fail");
+
+        assert!(kes_file_path.exists(), "KES file should be created");
+        assert_eq!(fs::read_dir(&temp_dir).unwrap().count(), 1)
     }
 }

--- a/mithril-common/src/crypto_helper/cardano/opcert.rs
+++ b/mithril-common/src/crypto_helper/cardano/opcert.rs
@@ -318,7 +318,7 @@ impl From<(OpCertWithoutColdVerificationKey, EdVerificationKey)> for OpCert {
 mod tests {
     use super::*;
     use crate::crypto_helper::cardano::ColdKeyGenerator;
-    use crate::test::TempDir;
+    use crate::test::{TempDir, crypto_helper::SerDeShelleyFileFormatTestExtension};
 
     use kes_summed_ed25519::{kes::Sum6Kes, traits::KesSk};
     use std::path::PathBuf;

--- a/mithril-common/src/crypto_helper/mod.rs
+++ b/mithril-common/src/crypto_helper/mod.rs
@@ -13,10 +13,10 @@ mod types;
 pub use cardano::ColdKeyGenerator;
 
 pub use cardano::{
-    KesEvolutions, KesPeriod, KesSigner, KesSignerStandard, KesVerifier, KesVerifierStandard,
-    KesVerifyError, OpCert, OpCertWithoutColdVerificationKey, ProtocolInitializerErrorWrapper,
-    ProtocolRegistrationErrorWrapper, SerDeShelleyFileFormat, SignerRegistrationParameters,
-    Sum6KesBytes,
+    CodecParseError, KesEvolutions, KesPeriod, KesSigner, KesSignerStandard, KesVerifier,
+    KesVerifierStandard, KesVerifyError, OpCert, OpCertWithoutColdVerificationKey,
+    ProtocolInitializerErrorWrapper, ProtocolRegistrationErrorWrapper, SerDeShelleyFileFormat,
+    SignerRegistrationParameters, Sum6KesBytes,
 };
 pub use codec::*;
 pub use ed25519_alias::{era::*, manifest::*};

--- a/mithril-common/src/test/builder/fixture_builder.rs
+++ b/mithril-common/src/test/builder/fixture_builder.rs
@@ -3,14 +3,11 @@ use rand_chacha::ChaCha20Rng;
 use rand_core::{RngCore, SeedableRng};
 
 use crate::{
-    crypto_helper::{
-        ColdKeyGenerator, KesPeriod, OpCert, ProtocolStakeDistribution, SerDeShelleyFileFormat,
-        Sum6KesBytes,
-    },
+    crypto_helper::{ColdKeyGenerator, KesPeriod, OpCert, ProtocolStakeDistribution, Sum6KesBytes},
     entities::{PartyId, ProtocolParameters, Stake, StakeDistribution},
     test::{
         builder::MithrilFixture,
-        crypto_helper,
+        crypto_helper::{self, SerDeShelleyFileFormatTestExtension},
         double::{fake_data, precomputed_kes_key},
     },
 };

--- a/mithril-common/src/test/crypto_helper/cardano/extensions.rs
+++ b/mithril-common/src/test/crypto_helper/cardano/extensions.rs
@@ -1,7 +1,15 @@
-use crate::crypto_helper::ProtocolParameters;
+use std::path::Path;
+
+use crate::crypto_helper::{CodecParseError, ProtocolParameters, SerDeShelleyFileFormat};
 
 /// Extension trait adding test utilities to [ProtocolInitializer][crate::crypto_helper::ProtocolInitializer]
 pub trait ProtocolInitializerTestExtension {
     /// `TEST ONLY` - Override the protocol parameters of the `Initializer`
     fn override_protocol_parameters(&mut self, protocol_parameters: &ProtocolParameters);
+}
+
+/// Extension trait adding test-only file export utilities to any type implementing [SerDeShelleyFileFormat].
+pub trait SerDeShelleyFileFormatTestExtension: SerDeShelleyFileFormat {
+    /// `TEST ONLY` - Serialize the structure to a Shelley-formatted file.
+    fn to_file<P: AsRef<Path>>(&self, path: P) -> Result<(), CodecParseError>;
 }

--- a/mithril-common/src/test/crypto_helper/cardano/kes/setup.rs
+++ b/mithril-common/src/test/crypto_helper/cardano/kes/setup.rs
@@ -3,9 +3,8 @@ use std::{fs, path::PathBuf};
 use kes_summed_ed25519::kes::Sum6Kes;
 use kes_summed_ed25519::traits::KesSk;
 
-use crate::crypto_helper::{
-    ColdKeyGenerator, KesPeriod, OpCert, ProtocolPartyId, SerDeShelleyFileFormat, Sum6KesBytes,
-};
+use crate::crypto_helper::{ColdKeyGenerator, KesPeriod, OpCert, ProtocolPartyId, Sum6KesBytes};
+use crate::test::crypto_helper::SerDeShelleyFileFormatTestExtension;
 
 /// A type alias for the party index used in KES cryptographic material.
 pub type KesPartyIndexForTest = u64;


### PR DESCRIPTION
## Content

Make kes_bytes file creation/write atomic for concurrent access, especially to fix CI test flakiness

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

this PR closes #3329 
