### PR TITLE
fix: aggregate signature verification uses a trusted genesis verification key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.11"
+version = "0.9.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.14.15"
+version = "0.14.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.9"
+version = "0.7.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.40"
+version = "0.10.41"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.10"
+version = "0.9.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4258,7 +4258,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.14.14"
+version = "0.14.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.39"
+version = "0.10.40"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/demo/protocol-demo/src/demonstrator.rs
+++ b/demo/protocol-demo/src/demonstrator.rs
@@ -217,6 +217,7 @@ impl Party {
                 &self.clerk.as_ref().unwrap().compute_aggregate_verification_key(),
                 &self.params.unwrap(),
                 None,
+                None,
             ) {
                 Ok(_) => {
                     println!(
@@ -320,6 +321,7 @@ impl Verifier {
             message,
             &self.clerk.as_ref().unwrap().compute_aggregate_verification_key(),
             &self.params.unwrap(),
+            None,
             None,
         ) {
             Ok(_) => {

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.9" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.10" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.9" }
+mithril-common = { path = "../../mithril-common", version = "0.7.10" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.3" }
-mithril-common = { path = "../../mithril-common", version = "0.7.9" }
+mithril-common = { path = "../../mithril-common", version = "0.7.10" }
 rand = { version = "0.10.1" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.11"
+version = "0.9.12"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.10"
+version = "0.9.11"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/commands/genesis_command.rs
+++ b/mithril-aggregator/src/commands/genesis_command.rs
@@ -9,7 +9,6 @@ use slog::{Logger, debug};
 use mithril_cardano_node_chain::chain_observer::ChainObserverType;
 #[cfg(not(feature = "future_snark"))]
 use mithril_common::crypto_helper::GenesisEd25519VerificationKey;
-#[cfg(feature = "future_snark")]
 use mithril_common::crypto_helper::GenesisVerifier;
 use mithril_common::{
     StdResult,
@@ -312,10 +311,11 @@ impl ImportGenesisSubCommand {
         genesis_tools: &GenesisTools,
         _mithril_era: SupportedEra,
     ) -> StdResult<()> {
-        let verification_key =
-            GenesisEd25519VerificationKey::from_json_hex(&self.genesis_verification_key)?;
+        let genesis_verifier = GenesisVerifier::from_ed25519(
+            GenesisEd25519VerificationKey::from_json_hex(&self.genesis_verification_key)?,
+        );
         genesis_tools
-            .import_payload_signature(&self.signed_payload_path, &verification_key)
+            .import_payload_signature(&self.signed_payload_path, &genesis_verifier)
             .await
             .with_context(|| "genesis-tools: import error")
     }
@@ -333,10 +333,7 @@ impl ImportGenesisSubCommand {
                 .await
                 .with_context(|| "genesis-tools: import error"),
             _ => genesis_tools
-                .import_payload_signature(
-                    &self.signed_payload_path,
-                    &verifier.ed25519.to_verification_key(),
-                )
+                .import_payload_signature(&self.signed_payload_path, &verifier)
                 .await
                 .with_context(|| "genesis-tools: import error"),
         }

--- a/mithril-aggregator/src/dependency_injection/builder/mod.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/mod.rs
@@ -488,7 +488,6 @@ impl DependenciesBuilder {
             network,
             chain_observer: self.get_chain_observer().await?,
             certificate_repository: self.get_certificate_repository().await?,
-            certificate_verifier: self.get_certificate_verifier().await?,
             protocol_parameters_retriever: self.get_protocol_parameters_retriever().await?,
             verification_key_store: self.get_verification_key_store().await?,
             mithril_era,

--- a/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/protocol/certificates.rs
@@ -42,6 +42,7 @@ impl DependenciesBuilder {
             Arc::new(SingleSignatureRepository::new(sqlite_connection.clone()));
         let certificate_repository = self.get_certificate_repository().await?;
         let certificate_verifier = self.get_certificate_verifier().await?;
+        #[cfg(feature = "future_snark")]
         let genesis_verifier = self.get_genesis_verifier().await?;
         let multi_signer = self.get_multi_signer().await?;
         let epoch_service = self.get_epoch_service().await?;
@@ -53,6 +54,7 @@ impl DependenciesBuilder {
             single_signature_repository,
             certificate_repository,
             certificate_verifier,
+            #[cfg(feature = "future_snark")]
             genesis_verifier,
             multi_signer,
             epoch_service,
@@ -95,13 +97,13 @@ impl DependenciesBuilder {
                 let verifier = Arc::new(MithrilCertificateVerifier::new(
                     self.root_logger(),
                     leader_aggregator_client.clone(),
+                    self.get_genesis_verifier().await?,
                 ));
 
                 Arc::new(MithrilCertificateChainSynchronizer::new(
                     leader_aggregator_client,
                     self.get_certificate_repository().await?,
                     verifier,
-                    self.get_genesis_verifier().await?,
                     self.get_open_message_repository().await?,
                     self.get_epoch_settings_store().await?,
                     self.root_logger(),
@@ -124,6 +126,7 @@ impl DependenciesBuilder {
         let verifier = Arc::new(MithrilCertificateVerifier::new(
             self.root_logger(),
             self.get_certificate_repository().await?,
+            self.get_genesis_verifier().await?,
         ));
 
         Ok(verifier)

--- a/mithril-aggregator/src/dependency_injection/containers/genesis.rs
+++ b/mithril-aggregator/src/dependency_injection/containers/genesis.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 use slog::Logger;
 
 use mithril_cardano_node_chain::chain_observer::ChainObserver;
-use mithril_common::{
-    CardanoNetwork, certificate_chain::CertificateVerifier, entities::SupportedEra,
-};
+use mithril_common::{CardanoNetwork, entities::SupportedEra};
 
 use crate::database::repository::CertificateRepository;
 use crate::{ProtocolParametersRetriever, VerificationKeyStorer};
@@ -20,9 +18,6 @@ pub struct GenesisCommandDependenciesContainer {
 
     /// Chain observer
     pub chain_observer: Arc<dyn ChainObserver>,
-
-    /// Certificate verifier service.
-    pub certificate_verifier: Arc<dyn CertificateVerifier>,
 
     /// Protocol parameters retriever service.
     pub protocol_parameters_retriever: Arc<dyn ProtocolParametersRetriever>,

--- a/mithril-aggregator/src/services/certificate_chain_synchronizer/synchronizer_service.rs
+++ b/mithril-aggregator/src/services/certificate_chain_synchronizer/synchronizer_service.rs
@@ -29,7 +29,6 @@ use std::sync::Arc;
 
 use mithril_common::StdResult;
 use mithril_common::certificate_chain::CertificateVerifier;
-use mithril_common::crypto_helper::GenesisVerifier;
 use mithril_common::entities::{Certificate, SignedEntityType};
 use mithril_common::logging::LoggerExtensions;
 
@@ -46,7 +45,6 @@ pub struct MithrilCertificateChainSynchronizer {
     remote_certificate_retriever: Arc<dyn RemoteCertificateRetriever>,
     certificate_storer: Arc<dyn SynchronizedCertificateStorer>,
     certificate_verifier: Arc<dyn CertificateVerifier>,
-    genesis_verifier: Arc<GenesisVerifier>,
     open_message_storer: Arc<dyn OpenMessageStorer>,
     epoch_settings_storer: Arc<dyn EpochSettingsStorer>,
     logger: Logger,
@@ -77,7 +75,6 @@ impl MithrilCertificateChainSynchronizer {
         remote_certificate_retriever: Arc<dyn RemoteCertificateRetriever>,
         certificate_storer: Arc<dyn SynchronizedCertificateStorer>,
         certificate_verifier: Arc<dyn CertificateVerifier>,
-        genesis_verifier: Arc<GenesisVerifier>,
         open_message_storer: Arc<dyn OpenMessageStorer>,
         epoch_settings_storer: Arc<dyn EpochSettingsStorer>,
         logger: Logger,
@@ -86,7 +83,6 @@ impl MithrilCertificateChainSynchronizer {
             remote_certificate_retriever,
             certificate_storer,
             certificate_verifier,
-            genesis_verifier,
             open_message_storer,
             epoch_settings_storer,
             logger: logger.new_with_component_name::<Self>(),
@@ -129,10 +125,7 @@ impl MithrilCertificateChainSynchronizer {
         loop {
             let parent_certificate = self
                 .certificate_verifier
-                .verify_certificate(
-                    &certificate,
-                    &self.genesis_verifier.to_ed25519_verification_key(),
-                )
+                .verify_certificate(&certificate)
                 .await
                 .with_context(
                     || format!("Failed to verify certificate: `{}`", certificate.hash,),
@@ -252,10 +245,11 @@ mod tests {
     use std::sync::RwLock;
 
     use mithril_common::certificate_chain::MithrilCertificateVerifier;
+    use mithril_common::crypto_helper::GenesisVerifier;
     use mithril_common::entities::Epoch;
     use mithril_common::test::{
         builder::{CertificateChainBuilder, CertificateChainFixture},
-        double::{Dummy, FakeCertificaterRetriever, fake_data, fake_keys},
+        double::{Dummy, FakeCertificaterRetriever, fake_data},
         mock_extensions::MockBuilder,
     };
 
@@ -277,13 +271,10 @@ mod tests {
         fn default_for_test_with_epoch_settings(
             epoch_settings: Vec<(Epoch, AggregatorEpochSettings)>,
         ) -> Self {
-            let genesis_verification_key =
-                fake_keys::genesis_verification_key()[0].try_into().unwrap();
             Self::new(
                 Arc::new(MockRemoteCertificateRetriever::new()),
                 Arc::new(MockSynchronizedCertificateStorer::new()),
                 Arc::new(MockCertificateVerifier::new()),
-                Arc::new(GenesisVerifier::from_ed25519(genesis_verification_key)),
                 Arc::new(MockOpenMessageStorer::new()),
                 Arc::new(FakeEpochSettingsStorer::new(epoch_settings)),
                 TestLogger::stdout(),
@@ -339,7 +330,7 @@ mod tests {
                     |verifier| {
                         verifier
                             .expect_verify_certificate()
-                            .return_once(move |_, _| $verify_certificate_result);
+                            .return_once(move |_| $verify_certificate_result);
                     },
                 ),
                 ..MithrilCertificateChainSynchronizer::default_for_test()
@@ -347,12 +338,16 @@ mod tests {
         };
     }
 
-    fn fake_verifier(remote_certificate_chain: &[Certificate]) -> Arc<dyn CertificateVerifier> {
+    fn fake_verifier(
+        remote_certificate_chain: &[Certificate],
+        genesis_verifier: Arc<GenesisVerifier>,
+    ) -> Arc<dyn CertificateVerifier> {
         let verifier = MithrilCertificateVerifier::new(
             TestLogger::stdout(),
             Arc::new(FakeCertificaterRetriever::from_certificates(
                 remote_certificate_chain,
             )),
+            genesis_verifier,
         );
         Arc::new(verifier)
     }
@@ -494,7 +489,7 @@ mod tests {
     }
 
     mod retrieve_validate_remote_certificate_chain {
-        use mockall::predicate::{always, eq};
+        use mockall::predicate::eq;
 
         use mithril_common::entities::Epoch;
 
@@ -504,8 +499,10 @@ mod tests {
         async fn succeed_if_the_remote_chain_only_contains_a_genesis_certificate() {
             let chain = CertificateChainBuilder::new().with_total_certificates(1).build();
             let synchronizer = MithrilCertificateChainSynchronizer {
-                certificate_verifier: fake_verifier(&chain),
-                genesis_verifier: Arc::new(chain.genesis_verifier.clone()),
+                certificate_verifier: fake_verifier(
+                    &chain,
+                    Arc::new(chain.genesis_verifier.clone()),
+                ),
                 ..MithrilCertificateChainSynchronizer::default_for_test()
             };
 
@@ -540,8 +537,10 @@ mod tests {
                 .with_certificates_per_epoch(2)
                 .build();
             let synchronizer = MithrilCertificateChainSynchronizer {
-                certificate_verifier: fake_verifier(&chain),
-                genesis_verifier: Arc::new(chain.genesis_verifier.clone()),
+                certificate_verifier: fake_verifier(
+                    &chain,
+                    Arc::new(chain.genesis_verifier.clone()),
+                ),
                 ..MithrilCertificateChainSynchronizer::default_for_test()
             };
 
@@ -584,15 +583,15 @@ mod tests {
                 certificate_verifier: MockBuilder::<MockCertificateVerifier>::configure(|mock| {
                     let cert_1 = chain[1].clone();
                     mock.expect_verify_certificate()
-                        .with(eq(chain[2].clone()), always())
-                        .return_once(move |_, _| Ok(Some(cert_1)));
+                        .with(eq(chain[2].clone()))
+                        .return_once(move |_| Ok(Some(cert_1)));
                     let genesis = chain[0].clone();
                     mock.expect_verify_certificate()
-                        .with(eq(chain[1].clone()), always())
-                        .return_once(move |_, _| Ok(Some(genesis)));
+                        .with(eq(chain[1].clone()))
+                        .return_once(move |_| Ok(Some(genesis)));
                     mock.expect_verify_certificate()
-                        .with(eq(chain[0].clone()), always())
-                        .return_once(move |_, _| Ok(None));
+                        .with(eq(chain[0].clone()))
+                        .return_once(move |_| Ok(None));
                 }),
                 ..MithrilCertificateChainSynchronizer::default_for_test()
             };
@@ -694,7 +693,10 @@ mod tests {
                         mock.expect_get_latest_certificate_details()
                             .return_once(move || Ok(Some(latest)));
                     }),
-                certificate_verifier: fake_verifier(remote_chain),
+                certificate_verifier: fake_verifier(
+                    remote_chain,
+                    Arc::new(remote_chain.genesis_verifier.clone()),
+                ),
                 open_message_storer: MockBuilder::<MockOpenMessageStorer>::configure(|mock| {
                     if expect_open_message_creation {
                         let expected_msd_epoch = latest_epoch;

--- a/mithril-aggregator/src/services/certifier/certifier_service.rs
+++ b/mithril-aggregator/src/services/certifier/certifier_service.rs
@@ -5,7 +5,9 @@ use slog::{Logger, debug, info, trace, warn};
 use std::sync::Arc;
 
 use mithril_common::certificate_chain::CertificateVerifier;
-use mithril_common::crypto_helper::{GenesisVerifier, PROTOCOL_VERSION};
+#[cfg(feature = "future_snark")]
+use mithril_common::crypto_helper::GenesisVerifier;
+use mithril_common::crypto_helper::PROTOCOL_VERSION;
 use mithril_common::entities::{
     Certificate, CertificateMetadata, CertificateSignature, Epoch, ProtocolMessage,
     SignedEntityType, SingleSignature, StakeDistributionParty,
@@ -32,6 +34,7 @@ pub struct MithrilCertifierService {
     single_signature_repository: Arc<SingleSignatureRepository>,
     certificate_repository: Arc<CertificateRepository>,
     certificate_verifier: Arc<dyn CertificateVerifier>,
+    #[cfg(feature = "future_snark")]
     genesis_verifier: Arc<GenesisVerifier>,
     multi_signer: Arc<dyn MultiSigner>,
     epoch_service: EpochServiceWrapper,
@@ -47,7 +50,7 @@ impl MithrilCertifierService {
         single_signature_repository: Arc<SingleSignatureRepository>,
         certificate_repository: Arc<CertificateRepository>,
         certificate_verifier: Arc<dyn CertificateVerifier>,
-        genesis_verifier: Arc<GenesisVerifier>,
+        #[cfg(feature = "future_snark")] genesis_verifier: Arc<GenesisVerifier>,
         multi_signer: Arc<dyn MultiSigner>,
         epoch_service: EpochServiceWrapper,
         logger: Logger,
@@ -59,6 +62,7 @@ impl MithrilCertifierService {
             certificate_repository,
             multi_signer,
             certificate_verifier,
+            #[cfg(feature = "future_snark")]
             genesis_verifier,
             epoch_service,
             logger: logger.new_with_component_name::<Self>(),
@@ -376,10 +380,7 @@ impl CertifierService for MithrilCertifierService {
         )?;
 
         self.certificate_verifier
-            .verify_certificate(
-                &certificate,
-                &self.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_certificate(&certificate)
             .await
             .with_context(|| {
                 format!(
@@ -434,10 +435,7 @@ impl CertifierService for MithrilCertifierService {
             }
 
             self.certificate_verifier
-                .verify_certificate_chain(
-                    certificate.to_owned(),
-                    &self.genesis_verifier.to_ed25519_verification_key(),
-                )
+                .verify_certificate_chain(certificate.to_owned())
                 .await
                 .with_context(|| "CertificateVerifier can not verify certificate chain")?;
 
@@ -482,6 +480,7 @@ mod tests {
                 Arc::new(SingleSignatureRepository::new(connection.clone()));
             let certificate_repository = Arc::new(CertificateRepository::new(connection));
             let certificate_verifier = dependency_builder.get_certificate_verifier().await.unwrap();
+            #[cfg(feature = "future_snark")]
             let genesis_verifier = dependency_builder.get_genesis_verifier().await.unwrap();
             let multi_signer = dependency_builder.get_multi_signer().await.unwrap();
             let epoch_service = dependency_builder.get_epoch_service().await.unwrap();
@@ -492,6 +491,7 @@ mod tests {
                 single_signature_repository,
                 certificate_repository,
                 certificate_verifier,
+                #[cfg(feature = "future_snark")]
                 genesis_verifier,
                 multi_signer,
                 epoch_service,
@@ -802,10 +802,7 @@ mod tests {
         let certificate_created = create_certificate_result.unwrap();
         certifier_service
             .certificate_verifier
-            .verify_certificate(
-                &certificate_created,
-                &certifier_service.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_certificate(&certificate_created)
             .await
             .unwrap();
 

--- a/mithril-aggregator/src/test/double/mocks.rs
+++ b/mithril-aggregator/src/test/double/mocks.rs
@@ -10,9 +10,7 @@ use mithril_cardano_node_chain::{
 use mithril_common::{
     StdResult,
     certificate_chain::CertificateVerifier,
-    crypto_helper::{
-        GenesisEd25519VerificationKey, KesPeriod, MKMap, MKMapNode, MKTreeNode, MKTreeStorer,
-    },
+    crypto_helper::{KesPeriod, MKMap, MKMapNode, MKTreeNode, MKTreeStorer},
     entities::{
         BlockNumber, BlockRange, CardanoBlockTransactionMkTreeNode, Certificate, ChainPoint, Epoch,
         StakeDistribution,
@@ -29,7 +27,6 @@ mock! {
         async fn verify_genesis_certificate(
             &self,
             genesis_certificate: &Certificate,
-            genesis_verification_key: &GenesisEd25519VerificationKey,
         ) -> StdResult<()>;
 
         async fn verify_standard_certificate(
@@ -41,13 +38,11 @@ mock! {
         async fn verify_certificate(
             &self,
             certificate: &Certificate,
-            genesis_verification_key: &GenesisEd25519VerificationKey,
         ) -> StdResult<Option<Certificate>>;
 
         async fn verify_certificate_chain(
             &self,
             certificate: Certificate,
-            genesis_verification_key: &GenesisEd25519VerificationKey,
         ) -> StdResult<()>;
     }
 }

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -10,10 +10,12 @@ use slog::Logger;
 
 use mithril_common::{
     CardanoNetwork, StdResult,
-    certificate_chain::{CertificateGenesisProducer, CertificateVerifier},
+    certificate_chain::{
+        CertificateGenesisProducer, CertificateVerifier, MithrilCertificateVerifier,
+    },
     crypto_helper::{
-        GenesisEd25519Signature, GenesisEd25519Signer, GenesisEd25519VerificationKey,
-        GenesisSigner, GenesisVerifier, ProtocolAggregateVerificationKey,
+        GenesisEd25519Signature, GenesisEd25519Signer, GenesisSigner, GenesisVerifier,
+        ProtocolAggregateVerificationKey,
     },
     entities::{CertificateSignature, Epoch, ProtocolParameters, SupportedEra},
     protocol::SignerBuilder,
@@ -52,7 +54,6 @@ pub struct GenesisToolsConfiguration {
 /// Genesis tools for creating and managing genesis certificates.
 pub struct GenesisTools {
     configuration: GenesisToolsConfiguration,
-    certificate_verifier: Arc<dyn CertificateVerifier>,
     certificate_repository: Arc<CertificateRepository>,
     logger: Logger,
 }
@@ -61,16 +62,27 @@ impl GenesisTools {
     /// GenesisTools factory
     pub fn new(
         configuration: GenesisToolsConfiguration,
-        certificate_verifier: Arc<dyn CertificateVerifier>,
         certificate_repository: Arc<CertificateRepository>,
         logger: Logger,
     ) -> Self {
         Self {
             configuration,
-            certificate_verifier,
             certificate_repository,
             logger,
         }
+    }
+
+    /// Build a certificate verifier that checks genesis certificates against the supplied genesis
+    /// verifier.
+    fn build_certificate_verifier(
+        &self,
+        genesis_verifier: &GenesisVerifier,
+    ) -> MithrilCertificateVerifier {
+        MithrilCertificateVerifier::new(
+            self.logger.clone(),
+            self.certificate_repository.clone(),
+            Arc::new(genesis_verifier.clone()),
+        )
     }
 
     pub async fn from_dependencies(
@@ -81,7 +93,6 @@ impl GenesisTools {
             .get_current_epoch()
             .await?
             .with_context(|| "Chain observer can not retrieve current epoch")?;
-        let certificate_verifier = dependencies.certificate_verifier.clone();
         let certificate_repository = dependencies.certificate_repository.clone();
         let protocol_parameters_retriever = dependencies.protocol_parameters_retriever.clone();
         let genesis_avk_epoch = epoch.offset_to_next_signer_retrieval_epoch();
@@ -113,7 +124,6 @@ impl GenesisTools {
 
         Ok(Self::new(
             configuration,
-            certificate_verifier,
             certificate_repository,
             dependencies.logger,
         ))
@@ -149,11 +159,11 @@ impl GenesisTools {
     pub async fn import_payload_signature(
         &self,
         signed_payload_path: &Path,
-        genesis_verification_key: &GenesisEd25519VerificationKey,
+        genesis_verifier: &GenesisVerifier,
     ) -> StdResult<()> {
         let signed_payload_buffer = std::fs::read(signed_payload_path)?;
         let genesis_signature = GenesisEd25519Signature::from_bytes(&signed_payload_buffer)?;
-        self.create_and_save_genesis_certificate(genesis_signature, genesis_verification_key)
+        self.create_and_save_genesis_certificate(genesis_signature, genesis_verifier)
             .await
     }
 
@@ -180,11 +190,8 @@ impl GenesisTools {
             envelope.schnorr,
             SupportedEra::Lagrange,
         )?;
-        self.certificate_verifier
-            .verify_genesis_certificate(
-                &certificate,
-                &genesis_verifier.to_ed25519_verification_key(),
-            )
+        self.build_certificate_verifier(genesis_verifier)
+            .verify_genesis_certificate(&certificate)
             .await?;
         let digest = sha256_digest(&certificate.protocol_message.rigid_preimage());
         genesis_verifier.verify_schnorr(&digest, &envelope.schnorr)?;
@@ -264,11 +271,8 @@ impl GenesisTools {
             )),
             None => GenesisVerifier::from_ed25519(ed25519_verification_key),
         };
-        self.certificate_verifier
-            .verify_genesis_certificate(
-                &genesis_certificate,
-                &genesis_verifier.to_ed25519_verification_key(),
-            )
+        self.build_certificate_verifier(&genesis_verifier)
+            .verify_genesis_certificate(&genesis_certificate)
             .await?;
         self.certificate_repository
             .create_certificate(genesis_certificate)
@@ -325,7 +329,7 @@ impl GenesisTools {
     async fn create_and_save_genesis_certificate(
         &self,
         genesis_signature: GenesisEd25519Signature,
-        genesis_verification_key: &GenesisEd25519VerificationKey,
+        genesis_verifier: &GenesisVerifier,
     ) -> StdResult<()> {
         let genesis_producer = CertificateGenesisProducer::new().with_logger(self.logger.clone());
         let genesis_certificate = genesis_producer.create_legacy_genesis_certificate(
@@ -336,8 +340,8 @@ impl GenesisTools {
             genesis_signature,
             self.configuration.mithril_era,
         )?;
-        self.certificate_verifier
-            .verify_genesis_certificate(&genesis_certificate, genesis_verification_key)
+        self.build_certificate_verifier(genesis_verifier)
+            .verify_genesis_certificate(&genesis_certificate)
             .await?;
         self.certificate_repository
             .create_certificate(genesis_certificate.clone())
@@ -454,7 +458,6 @@ mod tests {
     #[cfg(feature = "future_snark")]
     use mithril_common::crypto_helper::{
         BUNDLE_FIRST_HEX_CHAR, GenesisSchnorrSigner, GenesisSigningKeyBundle,
-        GenesisVerificationKeyBundle,
     };
     #[cfg(feature = "future_snark")]
     use mithril_common::entities::Certificate;
@@ -462,7 +465,6 @@ mod tests {
         certificate_chain::MithrilCertificateVerifier,
         crypto_helper::{
             GenesisEd25519SecretKey, GenesisEd25519Signer, GenesisEd25519VerificationKey,
-            GenesisEd25519Verifier,
         },
         test::{TempDir, builder::MithrilFixtureBuilder, double::fake_data},
     };
@@ -482,12 +484,13 @@ mod tests {
         fixture.compute_aggregate_verification_key()
     }
 
+    #[cfg(not(feature = "future_snark"))]
     fn build_tools(
         genesis_signer: &GenesisEd25519Signer,
     ) -> (
         GenesisTools,
         Arc<CertificateRepository>,
-        Arc<GenesisEd25519Verifier>,
+        Arc<GenesisVerifier>,
         Arc<dyn CertificateVerifier>,
     ) {
         build_tools_for_era(genesis_signer, SupportedEra::Pythagoras)
@@ -499,17 +502,20 @@ mod tests {
     ) -> (
         GenesisTools,
         Arc<CertificateRepository>,
-        Arc<GenesisEd25519Verifier>,
+        Arc<GenesisVerifier>,
         Arc<dyn CertificateVerifier>,
     ) {
         let connection = main_db_connection().unwrap();
         let certificate_store = Arc::new(CertificateRepository::new(Arc::new(connection)));
+        let genesis_avk = create_fake_genesis_avk();
+        let genesis_verifier = Arc::new(GenesisVerifier::from_ed25519(
+            genesis_signer.verification_key(),
+        ));
         let certificate_verifier = Arc::new(MithrilCertificateVerifier::new(
             TestLogger::stdout(),
             certificate_store.clone(),
+            genesis_verifier.clone(),
         ));
-        let genesis_avk = create_fake_genesis_avk();
-        let genesis_verifier = Arc::new(genesis_signer.create_verifier());
         let configuration = GenesisToolsConfiguration {
             network: fake_data::network(),
             epoch: Epoch(10),
@@ -519,7 +525,6 @@ mod tests {
         };
         let genesis_tools = GenesisTools::new(
             configuration,
-            certificate_verifier.clone(),
             certificate_store.clone(),
             TestLogger::stdout(),
         );
@@ -532,6 +537,7 @@ mod tests {
         )
     }
 
+    #[cfg(not(feature = "future_snark"))]
     #[tokio::test]
     async fn export_sign_then_import_genesis_payload() {
         let test_dir = get_temp_dir("export_payload_to_sign");
@@ -561,10 +567,7 @@ mod tests {
         .await
         .expect("sign_genesis_certificate should not fail");
         genesis_tools
-            .import_payload_signature(
-                &signed_payload_path,
-                &genesis_verifier.to_verification_key(),
-            )
+            .import_payload_signature(&signed_payload_path, &genesis_verifier)
             .await
             .expect("import_payload_signature should not fail");
 
@@ -572,20 +575,18 @@ mod tests {
 
         assert_eq!(1, last_certificates.len());
         certificate_verifier
-            .verify_genesis_certificate(
-                &last_certificates[0],
-                &genesis_verifier.to_verification_key(),
-            )
+            .verify_genesis_certificate(&last_certificates[0])
             .await
             .expect(
                 "verify_genesis_certificate should successfully validate the genesis certificate",
             );
     }
 
+    #[cfg(not(feature = "future_snark"))]
     #[tokio::test]
     async fn bootstrap_test_genesis_certificate_works() {
         let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
-        let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
+        let (genesis_tools, certificate_store, _genesis_verifier, certificate_verifier) =
             build_tools(&ed25519_signer);
 
         genesis_tools
@@ -597,10 +598,7 @@ mod tests {
 
         assert_eq!(1, last_certificates.len());
         certificate_verifier
-            .verify_genesis_certificate(
-                &last_certificates[0],
-                &genesis_verifier.to_verification_key(),
-            )
+            .verify_genesis_certificate(&last_certificates[0])
             .await
             .expect(
                 "verify_genesis_certificate should successfully validate the genesis certificate",
@@ -673,9 +671,8 @@ mod tests {
         #[tokio::test]
         async fn pythagoras_accepts_dual_signing_bundle() {
             let (ed25519_signer, signer) = build_dual_signer();
-            let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
+            let (genesis_tools, certificate_store, _genesis_verifier, certificate_verifier) =
                 build_tools_for_era(&ed25519_signer, SupportedEra::Pythagoras);
-
             genesis_tools
                 .bootstrap_test_genesis_certificate(signer)
                 .await
@@ -684,7 +681,7 @@ mod tests {
             let last = certificate_store.get_latest_certificates(10).await.unwrap();
             assert_eq!(1, last.len());
             certificate_verifier
-                .verify_genesis_certificate(&last[0], &genesis_verifier.to_verification_key())
+                .verify_genesis_certificate(&last[0])
                 .await
                 .expect("Ed25519 verification must pass");
         }
@@ -692,9 +689,8 @@ mod tests {
         #[tokio::test]
         async fn lagrange_runs_dual_ceremony() {
             let (ed25519_signer, signer) = build_dual_signer();
-            let (genesis_tools, certificate_store, genesis_verifier, certificate_verifier) =
+            let (genesis_tools, certificate_store, _genesis_verifier, certificate_verifier) =
                 build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
-
             genesis_tools
                 .bootstrap_test_genesis_certificate(signer)
                 .await
@@ -703,7 +699,7 @@ mod tests {
             let last = certificate_store.get_latest_certificates(10).await.unwrap();
             assert_eq!(1, last.len());
             certificate_verifier
-                .verify_genesis_certificate(&last[0], &genesis_verifier.to_verification_key())
+                .verify_genesis_certificate(&last[0])
                 .await
                 .expect("Ed25519 verification must pass on the dual variant");
         }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.14.14"
+version = "0.14.15"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.14.15"
+version = "0.14.16"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -64,7 +64,7 @@ flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.3" }
-mithril-common = { path = "../mithril-common", version = "0.7.9", default-features = false }
+mithril-common = { path = "../mithril-common", version = "0.7.10", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mithril-client/src/certificate_client/verify.rs
+++ b/mithril-client/src/certificate_client/verify.rs
@@ -47,7 +47,6 @@ pub(super) async fn verify_chain(
 pub struct MithrilCertificateVerifier {
     retriever: Arc<InternalCertificateRetriever>,
     internal_verifier: Arc<dyn CommonCertificateVerifier>,
-    genesis_verifier: GenesisVerifier,
     feedback_sender: FeedbackSender,
     #[cfg(feature = "unstable")]
     verifier_cache: Option<Arc<dyn CertificateVerifierCache>>,
@@ -65,17 +64,19 @@ impl MithrilCertificateVerifier {
     ) -> MithrilResult<MithrilCertificateVerifier> {
         let logger = logger.new_with_component_name::<Self>();
         let retriever = Arc::new(InternalCertificateRetriever::new(aggregator_requester));
+        let genesis_verifier = Arc::new(
+            GenesisVerifier::try_from_hex(genesis_verification_key)
+                .with_context(|| "Invalid genesis verification key")?,
+        );
         let internal_verifier = Arc::new(CommonMithrilCertificateVerifier::new(
             logger.clone(),
             retriever.clone(),
+            genesis_verifier,
         ));
-        let genesis_verifier = GenesisVerifier::try_from_hex(genesis_verification_key)
-            .with_context(|| "Invalid genesis verification key")?;
 
         Ok(Self {
             retriever,
             internal_verifier,
-            genesis_verifier,
             feedback_sender,
             #[cfg(feature = "unstable")]
             verifier_cache,
@@ -135,13 +136,7 @@ impl MithrilCertificateVerifier {
         certificate_chain_validation_id: &str,
         certificate: Certificate,
     ) -> MithrilResult<Option<Certificate>> {
-        let previous_certificate = self
-            .internal_verifier
-            .verify_certificate(
-                &certificate,
-                &self.genesis_verifier.to_ed25519_verification_key(),
-            )
-            .await?;
+        let previous_certificate = self.internal_verifier.verify_certificate(&certificate).await?;
 
         #[cfg(feature = "unstable")]
         if let Some(cache) = self.verifier_cache.as_ref()

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.39", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.40", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.9"
+version = "0.7.10"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.40", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.41", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/certificate_chain/certificate_verifier.rs
+++ b/mithril-common/src/certificate_chain/certificate_verifier.rs
@@ -13,13 +13,15 @@ use crate::StdResult;
 #[cfg(feature = "future_snark")]
 use crate::crypto_helper::ProtocolAggregateVerificationKeyForSnark;
 use crate::crypto_helper::{
-    GenesisEd25519Error, GenesisEd25519VerificationKey, ProtocolAggregateVerificationKey,
+    GenesisEd25519Error, GenesisVerifier, ProtocolAggregateVerificationKey,
     ProtocolAggregateVerificationKeyForConcatenation, ProtocolMultiSignature,
 };
 use crate::entities::{
     Certificate, CertificateSignature, ProtocolMessagePartKey, ProtocolParameters,
 };
 use crate::logging::LoggerExtensions;
+#[cfg(feature = "future_snark")]
+use mithril_stm::GenesisVerificationKeyBundle as StmGenesisVerificationKeyBundle;
 
 use super::CertificateRetriever;
 
@@ -97,11 +99,7 @@ pub enum CertificateVerifierError {
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub trait CertificateVerifier: Send + Sync {
     /// Verify Genesis certificate
-    async fn verify_genesis_certificate(
-        &self,
-        genesis_certificate: &Certificate,
-        genesis_verification_key: &GenesisEd25519VerificationKey,
-    ) -> StdResult<()>;
+    async fn verify_genesis_certificate(&self, genesis_certificate: &Certificate) -> StdResult<()>;
 
     /// Verify Standard certificate
     async fn verify_standard_certificate(
@@ -111,23 +109,13 @@ pub trait CertificateVerifier: Send + Sync {
     ) -> StdResult<()>;
 
     /// Verify if a Certificate is valid and returns the previous Certificate in the chain if exists
-    async fn verify_certificate(
-        &self,
-        certificate: &Certificate,
-        genesis_verification_key: &GenesisEd25519VerificationKey,
-    ) -> StdResult<Option<Certificate>>;
+    async fn verify_certificate(&self, certificate: &Certificate)
+    -> StdResult<Option<Certificate>>;
 
     /// Verify that the Certificate Chain associated to a Certificate is valid
-    async fn verify_certificate_chain(
-        &self,
-        certificate: Certificate,
-        genesis_verification_key: &GenesisEd25519VerificationKey,
-    ) -> StdResult<()> {
+    async fn verify_certificate_chain(&self, certificate: Certificate) -> StdResult<()> {
         let mut certificate = certificate;
-        while let Some(previous_certificate) = self
-            .verify_certificate(&certificate, genesis_verification_key)
-            .await?
-        {
+        while let Some(previous_certificate) = self.verify_certificate(&certificate).await? {
             certificate = previous_certificate;
         }
 
@@ -139,15 +127,21 @@ pub trait CertificateVerifier: Send + Sync {
 pub struct MithrilCertificateVerifier {
     logger: Logger,
     certificate_retriever: Arc<dyn CertificateRetriever>,
+    genesis_verifier: Arc<GenesisVerifier>,
 }
 
 impl MithrilCertificateVerifier {
     /// MithrilCertificateVerifier factory
-    pub fn new(logger: Logger, certificate_retriever: Arc<dyn CertificateRetriever>) -> Self {
+    pub fn new(
+        logger: Logger,
+        certificate_retriever: Arc<dyn CertificateRetriever>,
+        genesis_verifier: Arc<GenesisVerifier>,
+    ) -> Self {
         debug!(logger, "New MithrilCertificateVerifier created");
         Self {
             logger: logger.new_with_component_name::<Self>(),
             certificate_retriever,
+            genesis_verifier,
         }
     }
 
@@ -175,12 +169,21 @@ impl MithrilCertificateVerifier {
             message.encode_hex::<String>()
         );
 
+        #[cfg(not(feature = "future_snark"))]
+        let genesis_verification_key_bundle = None;
+        #[cfg(feature = "future_snark")]
+        let genesis_verification_key_bundle = self
+            .genesis_verifier
+            .to_schnorr_verification_key()
+            .map(StmGenesisVerificationKeyBundle::new);
+
         multi_signature
             .verify(
                 message,
                 aggregate_verification_key,
                 &protocol_parameters.to_owned().into(),
                 ancillary_verifier_data,
+                genesis_verification_key_bundle,
             )
             .map_err(|e| CertificateVerifierError::VerifyMultiSignature(e.to_string()))
     }
@@ -430,11 +433,7 @@ impl MithrilCertificateVerifier {
 #[cfg_attr(target_family = "wasm", async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl CertificateVerifier for MithrilCertificateVerifier {
-    async fn verify_genesis_certificate(
-        &self,
-        genesis_certificate: &Certificate,
-        genesis_verification_key: &GenesisEd25519VerificationKey,
-    ) -> StdResult<()> {
+    async fn verify_genesis_certificate(&self, genesis_certificate: &Certificate) -> StdResult<()> {
         let genesis_signature = match &genesis_certificate.signature {
             CertificateSignature::GenesisSignature(signature) => Ok(signature),
             // The Schnorr half is intentionally not verified here as it is needed for IVC SNARK only
@@ -446,7 +445,8 @@ impl CertificateVerifier for MithrilCertificateVerifier {
         }?;
         self.verify_hash_matches_content(genesis_certificate)?;
         self.verify_signed_message_matches_hashed_protocol_message(genesis_certificate)?;
-        genesis_verification_key
+        self.genesis_verifier
+            .to_ed25519_verification_key()
             .verify(
                 genesis_certificate.signed_message.as_bytes(),
                 genesis_signature,
@@ -478,7 +478,6 @@ impl CertificateVerifier for MithrilCertificateVerifier {
     async fn verify_certificate(
         &self,
         certificate: &Certificate,
-        genesis_verification_key: &GenesisEd25519VerificationKey,
     ) -> StdResult<Option<Certificate>> {
         debug!(
             self.logger, "Verifying certificate";
@@ -489,8 +488,7 @@ impl CertificateVerifier for MithrilCertificateVerifier {
         );
 
         if certificate.is_genesis() {
-            self.verify_genesis_certificate(certificate, genesis_verification_key)
-                .await?;
+            self.verify_genesis_certificate(certificate).await?;
 
             return Ok(None);
         }
@@ -567,12 +565,21 @@ mod tests {
             }
         }
 
-        fn build_certificate_verifier(self) -> MithrilCertificateVerifier {
+        fn build_certificate_verifier(
+            self,
+            genesis_verifier: Arc<GenesisVerifier>,
+        ) -> MithrilCertificateVerifier {
             MithrilCertificateVerifier::new(
                 TestLogger::stdout(),
                 Arc::new(self.mock_certificate_retriever),
+                genesis_verifier,
             )
         }
+    }
+
+    #[cfg(feature = "future_snark")]
+    fn fake_genesis_verifier() -> Arc<GenesisVerifier> {
+        Arc::new(setup_certificate_chain(1, 1).genesis_verifier)
     }
 
     #[test]
@@ -603,10 +610,12 @@ mod tests {
             .unwrap();
         let ancillary_verifier_data = ancillary_proof_output.verifier_data().cloned();
         let multi_signature = aggregate_signature.into();
+        let genesis_verifier = setup_certificate_chain(1, 1).genesis_verifier;
 
         let verifier = MithrilCertificateVerifier::new(
             TestLogger::stdout(),
             Arc::new(MockCertificateRetriever::new()),
+            Arc::new(genesis_verifier),
         );
         let message_tampered = message_hash[1..].to_vec();
         assert!(
@@ -636,15 +645,11 @@ mod tests {
     async fn verify_genesis_certificate_success() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let genesis_certificate = fake_certificates.genesis_certificate();
 
-        let verify = verifier
-            .verify_genesis_certificate(
-                genesis_certificate,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
-            .await;
+        let verify = verifier.verify_genesis_certificate(genesis_certificate).await;
 
         verify.expect("verify_genesis_certificate should not fail");
     }
@@ -654,9 +659,8 @@ mod tests {
     async fn verify_genesis_certificate_ignores_the_schnorr_half_of_a_dual_signature() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
-        let genesis_verification_key =
-            fake_certificates.genesis_verifier.to_ed25519_verification_key();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let ed_signature = match &fake_certificates.genesis_certificate().signature {
             CertificateSignature::GenesisSignature(signature) => *signature,
             other => panic!("expected a legacy genesis signature, got {other:?}"),
@@ -673,7 +677,7 @@ mod tests {
             genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
             verifier
-                .verify_genesis_certificate(&genesis_certificate, &genesis_verification_key)
+                .verify_genesis_certificate(&genesis_certificate)
                 .await
                 .expect("the Schnorr half is intentionally not verified, so this must succeed");
         }
@@ -683,17 +687,15 @@ mod tests {
     async fn verify_genesis_certificate_fails_if_is_not_genesis() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let standard_certificate = fake_certificates[0].clone();
         let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.signature = standard_certificate.signature.clone();
         genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
         let error = verifier
-            .verify_genesis_certificate(
-                &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_genesis_certificate(&genesis_certificate)
             .await
             .expect_err("verify_genesis_certificate should fail");
 
@@ -707,15 +709,13 @@ mod tests {
     async fn verify_genesis_certificate_fails_if_hash_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.hash = "another-hash".to_string();
 
         let error = verifier
-            .verify_genesis_certificate(
-                &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_genesis_certificate(&genesis_certificate)
             .await
             .expect_err("verify_genesis_certificate should fail");
 
@@ -726,7 +726,8 @@ mod tests {
     async fn verify_genesis_certificate_fails_if_protocol_message_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.protocol_message.set_message_part(
             ProtocolMessagePartKey::CurrentEpoch,
@@ -735,10 +736,7 @@ mod tests {
         genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
         let error = verifier
-            .verify_genesis_certificate(
-                &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_genesis_certificate(&genesis_certificate)
             .await
             .expect_err("verify_genesis_certificate should fail");
 
@@ -752,16 +750,14 @@ mod tests {
     async fn verify_genesis_certificate_fails_if_epoch_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut genesis_certificate = fake_certificates.genesis_certificate().clone();
         genesis_certificate.epoch -= 1;
         genesis_certificate.hash = genesis_certificate.try_compute_hash().unwrap();
 
         let error = verifier
-            .verify_genesis_certificate(
-                &genesis_certificate,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_genesis_certificate(&genesis_certificate)
             .await
             .expect_err("verify_genesis_certificate should fail");
 
@@ -772,7 +768,8 @@ mod tests {
     async fn verify_standard_certificate_success_with_different_epochs_as_previous() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let certificate = fake_certificates[0].clone();
         let previous_certificate = fake_certificates[1].clone();
 
@@ -787,7 +784,8 @@ mod tests {
     async fn verify_standard_certificate_success_with_same_epoch_as_previous() {
         let (total_certificates, certificates_per_epoch) = (5, 2);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let certificate = fake_certificates[0].clone();
         let previous_certificate = fake_certificates[1].clone();
 
@@ -802,7 +800,8 @@ mod tests {
     fn verify_certificate_integrity_succeeds_for_a_valid_standard_certificate() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let certificate = fake_certificates[0].clone();
 
         verifier
@@ -814,7 +813,8 @@ mod tests {
     fn verify_certificate_integrity_fails_for_a_tampered_certificate() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
         certificate.hash = "another-hash".to_string();
 
@@ -829,7 +829,8 @@ mod tests {
     fn verify_certificate_integrity_does_not_check_the_previous_certificate_link() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
 
         // Break the link to the previous certificate while keeping the certificate self-consistent.
@@ -847,7 +848,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_is_not_genesis() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let genesis_certificate = fake_certificates.genesis_certificate();
         let mut standard_certificate = fake_certificates[0].clone();
         standard_certificate.signature = genesis_certificate.signature.clone();
@@ -869,7 +871,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_infinite_loop() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
         certificate.previous_hash = certificate.hash.clone();
         let previous_certificate = fake_certificates[1].clone();
@@ -889,7 +892,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_hash_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
         certificate.hash = "another-hash".to_string();
         let previous_certificate = fake_certificates[1].clone();
@@ -906,7 +910,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_protocol_message_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
         certificate.protocol_message.set_message_part(
             ProtocolMessagePartKey::CurrentEpoch,
@@ -930,7 +935,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_epoch_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
         certificate.epoch -= 1;
         certificate.hash = certificate.try_compute_hash().unwrap();
@@ -997,7 +1003,8 @@ mod tests {
                 }
             })
             .build();
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let certificate = fake_certificates[0].clone();
         let previous_certificate = fake_certificates[1].clone();
 
@@ -1016,7 +1023,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_certificate_previous_hash_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let certificate = fake_certificates[0].clone();
         let mut previous_certificate = fake_certificates[1].clone();
         previous_certificate.previous_hash = "another-hash".to_string();
@@ -1037,7 +1045,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_certificate_chain_avk_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
         let mut previous_certificate = fake_certificates[1].clone();
         previous_certificate.protocol_message.set_message_part(
@@ -1060,7 +1069,8 @@ mod tests {
     async fn verify_standard_certificate_fails_if_certificate_chain_protocol_parameters_unmatch() {
         let (total_certificates, certificates_per_epoch) = (5, 1);
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
-        let verifier = MockDependencyInjector::new().build_certificate_verifier();
+        let verifier = MockDependencyInjector::new()
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         let mut certificate = fake_certificates[0].clone();
         let mut previous_certificate = fake_certificates[1].clone();
         previous_certificate.protocol_message.set_message_part(
@@ -1088,14 +1098,10 @@ mod tests {
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let genesis_certificate = fake_certificates.genesis_certificate();
         let mock_container = MockDependencyInjector::new();
-        let verifier = mock_container.build_certificate_verifier();
+        let verifier = mock_container
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
 
-        let verify = verifier
-            .verify_certificate(
-                genesis_certificate,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
-            .await;
+        let verify = verifier.verify_certificate(genesis_certificate).await;
 
         verify.expect("verify_certificate should not fail");
     }
@@ -1112,14 +1118,10 @@ mod tests {
             .expect_get_certificate_details()
             .returning(move |_| Ok(previous_certificate.clone()))
             .times(1);
-        let verifier = mock_container.build_certificate_verifier();
+        let verifier = mock_container
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
 
-        let verify = verifier
-            .verify_certificate(
-                &certificate,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
-            .await;
+        let verify = verifier.verify_certificate(&certificate).await;
 
         verify.expect("verify_certificate should not fail");
     }
@@ -1149,7 +1151,6 @@ mod tests {
             async fn verify_genesis_certificate(
                 &self,
                 _genesis_certificate: &Certificate,
-                _genesis_verification_key: &GenesisEd25519VerificationKey,
             ) -> StdResult<()> {
                 unimplemented!()
             }
@@ -1165,7 +1166,6 @@ mod tests {
             async fn verify_certificate(
                 &self,
                 certificate: &Certificate,
-                _genesis_verification_key: &GenesisEd25519VerificationKey,
             ) -> StdResult<Option<Certificate>> {
                 let mut certificates_unverified = self.certificates_unverified.lock().await;
                 let _verified_certificate = (*certificates_unverified).remove(&certificate.hash);
@@ -1182,12 +1182,7 @@ mod tests {
         let verifier = CertificateVerifierTest::from_certificates(&fake_certificates);
         assert!(verifier.has_unverified_certificates().await);
 
-        let verify = verifier
-            .verify_certificate_chain(
-                fake_certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
-            .await;
+        let verify = verifier.verify_certificate_chain(fake_certificate_to_verify).await;
 
         verify.expect("verify_certificate_chain should not fail");
         assert!(!verifier.has_unverified_certificates().await);
@@ -1199,16 +1194,14 @@ mod tests {
         let fake_certificates = setup_certificate_chain(total_certificates, certificates_per_epoch);
         let certificate_retriever =
             FakeCertificaterRetriever::from_certificates(&fake_certificates);
-        let verifier =
-            MithrilCertificateVerifier::new(TestLogger::stdout(), Arc::new(certificate_retriever));
+        let verifier = MithrilCertificateVerifier::new(
+            TestLogger::stdout(),
+            Arc::new(certificate_retriever),
+            Arc::new(fake_certificates.genesis_verifier.clone()),
+        );
         let certificate_to_verify = fake_certificates[0].clone();
 
-        let verify = verifier
-            .verify_certificate_chain(
-                certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
-            .await;
+        let verify = verifier.verify_certificate_chain(certificate_to_verify).await;
         verify.expect("verify_certificate_chain should not fail");
     }
 
@@ -1221,15 +1214,15 @@ mod tests {
         fake_certificates[index_certificate_fail].signed_message = "tampered-message".to_string();
         let certificate_retriever =
             FakeCertificaterRetriever::from_certificates(&fake_certificates);
-        let verifier =
-            MithrilCertificateVerifier::new(TestLogger::stdout(), Arc::new(certificate_retriever));
+        let verifier = MithrilCertificateVerifier::new(
+            TestLogger::stdout(),
+            Arc::new(certificate_retriever),
+            Arc::new(fake_certificates.genesis_verifier.clone()),
+        );
         let certificate_to_verify = fake_certificates[0].clone();
 
         let error = verifier
-            .verify_certificate_chain(
-                certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_certificate_chain(certificate_to_verify)
             .await
             .expect_err("verify_certificate_chain should fail");
 
@@ -1309,16 +1302,14 @@ mod tests {
             .build();
         let certificate_to_verify = fake_certificates[0].clone();
         let mock_container = MockDependencyInjector::new();
-        let mut verifier = mock_container.build_certificate_verifier();
+        let mut verifier = mock_container
+            .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
         verifier.certificate_retriever = Arc::new(FakeCertificaterRetriever::from_certificates(
             &fake_certificates,
         ));
 
         let error = verifier
-            .verify_certificate(
-                &certificate_to_verify,
-                &fake_certificates.genesis_verifier.to_ed25519_verification_key(),
-            )
+            .verify_certificate(&certificate_to_verify)
             .await
             .expect_err("verify_certificate_chain should fail");
 
@@ -1369,7 +1360,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             let previous_certificate = fake_certificates[1].clone();
             certificate.previous_hash.clone_from(&previous_certificate.hash);
@@ -1390,7 +1382,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let certificate = with_snark_proof_type(fake_certificates[0].clone());
             let previous_certificate = fake_certificates[1].clone();
 
@@ -1410,7 +1403,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let certificate = with_snark_proof_type(fake_certificates[0].clone());
             let mut previous_certificate = fake_certificates[1].clone();
             previous_certificate.aggregate_verification_key_snark = None;
@@ -1433,7 +1427,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             certificate.aggregate_verification_key_snark = None;
             certificate.hash = certificate.try_compute_hash().unwrap();
@@ -1456,7 +1451,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             certificate.aggregate_verification_key_snark = None;
             certificate.hash = certificate.try_compute_hash().unwrap();
@@ -1480,7 +1476,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let certificate = with_snark_proof_type(fake_certificates[0].clone());
             let mut previous_certificate = fake_certificates[1].clone();
             previous_certificate.protocol_message.set_message_part(
@@ -1505,7 +1502,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let certificate = with_snark_proof_type(fake_certificates[0].clone());
             let mut previous_certificate = fake_certificates[1].clone();
             previous_certificate
@@ -1530,7 +1528,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let mut certificate = with_snark_proof_type(fake_certificates[0].clone());
             let previous_certificate = fake_certificates[1].clone();
             certificate.previous_hash.clone_from(&previous_certificate.hash);
@@ -1550,7 +1549,8 @@ mod tests {
                 total_certificates,
                 certificates_per_epoch,
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier = MockDependencyInjector::new()
+                .build_certificate_verifier(Arc::new(fake_certificates.genesis_verifier.clone()));
             let genesis_certificate = fake_certificates.genesis_certificate().clone();
             let mut certificate = with_snark_proof_type(fake_certificates[3].clone());
             certificate.previous_hash.clone_from(&genesis_certificate.hash);
@@ -1606,7 +1606,8 @@ mod tests {
                 epoch,
                 rigid_protocol_message_for_epoch(epoch, &protocol_parameters),
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             verifier
                 .verify_epoch_matches_protocol_message(&certificate)
@@ -1620,7 +1621,8 @@ mod tests {
                 Epoch(43),
                 rigid_protocol_message_for_epoch(Epoch(42), &protocol_parameters),
             );
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             let error = verifier
                 .verify_epoch_matches_protocol_message(&certificate)
@@ -1638,7 +1640,8 @@ mod tests {
                 &current_certificate.metadata.protocol_parameters,
             );
             let previous_certificate = build_certificate(previous_epoch, rigid);
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             verifier
                 .verify_protocol_parameters_chaining(&current_certificate, &previous_certificate)
@@ -1658,7 +1661,8 @@ mod tests {
                 hex::encode([0u8; 32]),
             );
             let previous_certificate = build_certificate(previous_epoch, rigid);
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             let error = verifier
                 .verify_protocol_parameters_chaining(&current_certificate, &previous_certificate)
@@ -1721,7 +1725,8 @@ mod tests {
         #[test]
         fn concatenation_aggregate_verification_key_chains_at_era_transition() {
             let (predecessor, successor) = pythagoras_to_lagrange_era_transition_pair();
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             verifier
                 .verify_concatenation_aggregate_verification_key_chaining(
@@ -1736,7 +1741,8 @@ mod tests {
         #[test]
         fn protocol_parameters_chain_at_era_transition() {
             let (predecessor, successor) = pythagoras_to_lagrange_era_transition_pair();
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             verifier
                 .verify_protocol_parameters_chaining(&successor, &predecessor)
@@ -1748,7 +1754,8 @@ mod tests {
         #[test]
         fn epoch_chain_at_era_transition() {
             let (predecessor, successor) = pythagoras_to_lagrange_era_transition_pair();
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             verifier.verify_epoch_chaining(&successor, &predecessor).expect(
                 "epoch chaining must hold across the Pythagoras to Lagrange era transition",
@@ -1758,7 +1765,8 @@ mod tests {
         #[test]
         fn previous_hash_chain_at_era_transition() {
             let (predecessor, successor) = pythagoras_to_lagrange_era_transition_pair();
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             verifier
                 .verify_previous_hash_matches_previous_certificate_hash(&successor, &predecessor)
@@ -1770,7 +1778,8 @@ mod tests {
         #[test]
         fn aggregate_verification_key_chain_dispatches_to_concatenation_at_era_transition() {
             let (predecessor, successor) = pythagoras_to_lagrange_era_transition_pair();
-            let verifier = MockDependencyInjector::new().build_certificate_verifier();
+            let verifier =
+                MockDependencyInjector::new().build_certificate_verifier(fake_genesis_verifier());
 
             verifier
                 .verify_aggregate_verification_key_chaining(&successor, &predecessor)
@@ -1801,7 +1810,8 @@ mod tests {
             fn snark_aggregate_verification_key_chains_at_era_transition() {
                 let (predecessor, successor) = pythagoras_to_lagrange_era_transition_pair();
                 let successor = promote_to_snark_aggregate_signature(successor);
-                let verifier = MockDependencyInjector::new().build_certificate_verifier();
+                let verifier = MockDependencyInjector::new()
+                    .build_certificate_verifier(fake_genesis_verifier());
 
                 verifier
                     .verify_snark_aggregate_verification_key_chaining(&successor, &predecessor)
@@ -1814,7 +1824,8 @@ mod tests {
             fn aggregate_verification_key_chain_dispatches_to_snark_at_era_transition() {
                 let (predecessor, successor) = pythagoras_to_lagrange_era_transition_pair();
                 let successor = promote_to_snark_aggregate_signature(successor);
-                let verifier = MockDependencyInjector::new().build_certificate_verifier();
+                let verifier = MockDependencyInjector::new()
+                    .build_certificate_verifier(fake_genesis_verifier());
 
                 verifier
                     .verify_aggregate_verification_key_chaining(&successor, &predecessor)

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.40 (06-29-2026)
+
+### Added
+
+- `GenesisVerificationKeyBundle`, carrying the trusted genesis verification key supplied to aggregate signature verification.
+
+### Changed
+
+- `AggregateSignature::verify` and `AggregateSignature::batch_verify` now take a genesis verification key bundle and source the genesis Schnorr verification key from it (instead of the certificate-carried `IvcVerifierData`), returning `AggregateSignatureError::MissingGenesisVerificationKeyBundle` when it is absent.
+
+### Removed
+
+- The `genesis_schnorr_verification_key` field from `IvcVerifierData`.
+- The unused `AggregationError::MissingRollingStateForNextCertificate` variant.
+
 ## 0.10.39 (06-24-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.40"
+version = "0.10.41"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.39"
+version = "0.10.40"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -142,7 +142,7 @@ let msig = clerk.aggregate_signatures_with_type(&sigs, &msg, AggregateSignatureT
 match msig {
     Ok((aggr, ancillary_proof_output)) => {
         println!("Aggregate ok");
-        assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned()).is_ok());
+        assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned(), None).is_ok());
     }
     Err(error) => match error.downcast_ref::<AggregationError>() {
         Some(AggregationError::NotEnoughSignatures(n, k)) => {

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -118,6 +118,7 @@ fn batch_benches<D>(
         let mut batch_stms: Vec<AggregateSignature<D>> = Vec::with_capacity(nr_batches);
         let mut batch_avks = Vec::with_capacity(nr_batches);
         let mut batch_ancillary_verifier_datas = Vec::with_capacity(nr_batches);
+        let mut batch_genesis_verification_key_bundles = Vec::with_capacity(nr_batches);
 
         for _ in 0..nr_batches {
             let mut msg = [0u8; 32];
@@ -176,6 +177,7 @@ fn batch_benches<D>(
             batch_avks.push(clerk.compute_aggregate_verification_key());
             batch_stms.push(msig);
             batch_ancillary_verifier_datas.push(ancillary_proof_output.verifier_data().cloned());
+            batch_genesis_verification_key_bundles.push(None);
         }
 
         group.bench_function(BenchmarkId::new("Batch Verification", batch_string), |b| {
@@ -186,6 +188,7 @@ fn batch_benches<D>(
                     &batch_avks,
                     &batch_params,
                     &batch_ancillary_verifier_datas,
+                    &batch_genesis_verification_key_bundles,
                 )
                 .is_ok()
             })

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -159,7 +159,8 @@ fn main() {
                 &msg,
                 &clerk.compute_aggregate_verification_key(),
                 &params,
-                None
+                None,
+                None,
             )
             .is_ok()
     );
@@ -194,7 +195,8 @@ fn main() {
                 &msg,
                 &clerk.compute_aggregate_verification_key(),
                 &params,
-                None
+                None,
+                None,
             )
             .is_ok()
     );

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -101,7 +101,7 @@
 //!     Ok((aggr, ancillary_proof_output)) => {
 //!         println!("Aggregate ok");
 //!         assert!(aggr
-//!             .verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned())
+//!             .verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned(), None)
 //!             .is_ok());
 //!     }
 //!     Err(error) => assert!(
@@ -152,10 +152,10 @@ pub use protocol::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
     AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProofOutput,
     AncillaryProverData, AncillaryVerifierData, Clerk, ClosedKeyRegistration,
-    ClosedRegistrationEntry, Initializer, KeyRegistration, Parameters, RegisterError,
-    RegistrationEntry, RegistrationEntryForConcatenation, SignatureError, Signer, SingleSignature,
-    SingleSignatureWithRegisteredParty, VerificationKeyForConcatenation,
-    VerificationKeyProofOfPossessionForConcatenation,
+    ClosedRegistrationEntry, GenesisVerificationKeyBundle, Initializer, KeyRegistration,
+    Parameters, RegisterError, RegistrationEntry, RegistrationEntryForConcatenation,
+    SignatureError, Signer, SingleSignature, SingleSignatureWithRegisteredParty,
+    VerificationKeyForConcatenation, VerificationKeyProofOfPossessionForConcatenation,
 };
 pub use signature_scheme::BlsSignatureError;
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -13,7 +13,7 @@ use midnight_zk_stdlib::MidnightVK;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    SchnorrVerificationKey, StmResult,
+    StmResult,
     circuits::halo2_ivc::{
         CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME, state::fixed_bases_and_names,
         types::MessageHash,
@@ -175,7 +175,6 @@ impl IvcVerifierSetup {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IvcVerifierData {
     genesis_message: MessageHash,
-    genesis_schnorr_verification_key: SchnorrVerificationKey,
     #[serde(with = "midnight_certificate_verification_key_serde")]
     certificate_circuit_verification_key: MidnightVK,
     #[serde(with = "ivc_circuit_verification_key_serde")]
@@ -183,20 +182,18 @@ pub struct IvcVerifierData {
 }
 
 impl IvcVerifierData {
-    /// Build the verifier data from the genesis message, the genesis Schnorr verification key and
-    /// the certificate and IVC circuit verifying keys used to produce the proof.
+    /// Build the verifier data from the genesis message and the verifying keys of the recursive
+    ///  and non recursive circuit used to produce the proof.
     ///
     /// The certificate verifying key is kept as a [MidnightVK] because its serialization carries
     /// the circuit architecture required to deserialize it against the correct constraint system.
     pub(crate) fn new(
         genesis_message: MessageHash,
-        genesis_schnorr_verification_key: SchnorrVerificationKey,
         certificate_circuit_verification_key: MidnightVK,
         ivc_circuit_verification_key: CircuitVerifyingKey,
     ) -> Self {
         Self {
             genesis_message,
-            genesis_schnorr_verification_key,
             certificate_circuit_verification_key,
             ivc_circuit_verification_key,
         }
@@ -222,11 +219,6 @@ impl IvcVerifierData {
     /// stored in the IvcVerifierData
     pub(crate) fn genesis_message(&self) -> MessageHash {
         self.genesis_message
-    }
-
-    /// Returns the genesis schnorr verification key stored in the IvcVerifierData
-    pub(crate) fn genesis_schnorr_verification_key(&self) -> SchnorrVerificationKey {
-        self.genesis_schnorr_verification_key
     }
 
     /// Returns a copy of the certificate circuit verification key stored in the IvcVerifierData
@@ -295,7 +287,6 @@ mod tests {
 
         let verifier_data = IvcVerifierData::new(
             MessageHash::ZERO,
-            SchnorrVerificationKey::default(),
             context.certificate_verifying_key,
             context.recursive_verifying_key,
         );

--- a/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/ancillary_data.rs
@@ -271,7 +271,7 @@ mod tests {
     use crate::codec::CODEC_VERSION_CBOR_V1;
     #[cfg(feature = "future_snark")]
     use crate::{
-        BaseFieldElement, SchnorrSigningKey, SchnorrVerificationKey,
+        BaseFieldElement, SchnorrSigningKey,
         circuits::halo2_ivc::{
             tests::common::asset_readers::load_embedded_verification_context_asset,
             types::MessageHash,
@@ -361,7 +361,6 @@ mod tests {
             .expect("verification context asset should load");
         let verifier_data = IvcVerifierData::new(
             MessageHash::ZERO,
-            SchnorrVerificationKey::default(),
             context.certificate_verifying_key,
             context.recursive_verifying_key,
         );

--- a/mithril-stm/src/protocol/aggregate_signature/clerk.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/clerk.rs
@@ -302,7 +302,6 @@ fn ivc_prover_input_preparation_and_prove<D: MembershipDigest>(
 
     let ancillary_verifier_data = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
         genesis_message,
-        genesis_verifying_key,
         certificate_midnight_verifying_key,
         ivc_circuit_verifying_key,
     ));

--- a/mithril-stm/src/protocol/aggregate_signature/error.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/error.rs
@@ -24,10 +24,6 @@ pub enum AggregationError {
     #[error("Missing SNARK signature for lottery index {0}.")]
     MissingSnarkSignature(SignerIndex),
 
-    /// Missing the rolling state to pass along the next certificate
-    #[error("Missing the rolling state to pass along the next certificate.")]
-    MissingRollingStateForNextCertificate,
-
     /// Missing the genesis verification key in the ancillary verifier data
     #[error("Missing the genesis verification key in the ancillary verifier data.")]
     MissingGenesisVerificationKey,

--- a/mithril-stm/src/protocol/aggregate_signature/error.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/error.rs
@@ -73,4 +73,8 @@ pub enum AggregateSignatureError {
     /// Missing IVC verifier data from the AncillaryVerifierData
     #[error("Missing IVC verifier data from the AncillaryVerifierData.")]
     MissingIvcVerifierData,
+
+    /// Missing genesis verification key bundle to verify the aggregate signature
+    #[error("Missing genesis verification key bundle to verify the aggregate signature.")]
+    MissingGenesisVerificationKeyBundle,
 }

--- a/mithril-stm/src/protocol/aggregate_signature/genesis.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/genesis.rs
@@ -1,0 +1,23 @@
+//! Genesis verification keys carried into aggregate signature verification.
+
+#[cfg(feature = "future_snark")]
+use crate::SchnorrVerificationKey;
+
+/// Genesis verification keys the aggregate signature verifier needs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GenesisVerificationKeyBundle {
+    /// Schnorr-genesis verification key (Schnorr over Jubjub).
+    #[cfg(feature = "future_snark")]
+    pub schnorr: SchnorrVerificationKey,
+}
+
+impl GenesisVerificationKeyBundle {
+    /// Build a fresh bundle from the genesis Schnorr verification key.
+    #[cfg_attr(not(feature = "future_snark"), allow(clippy::new_without_default))]
+    pub fn new(#[cfg(feature = "future_snark")] schnorr: SchnorrVerificationKey) -> Self {
+        Self {
+            #[cfg(feature = "future_snark")]
+            schnorr,
+        }
+    }
+}

--- a/mithril-stm/src/protocol/aggregate_signature/mod.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/mod.rs
@@ -2,6 +2,7 @@ mod aggregate_key;
 mod ancillary_data;
 mod clerk;
 mod error;
+mod genesis;
 #[cfg(feature = "future_snark")]
 mod preimage;
 mod signature;
@@ -13,6 +14,7 @@ pub use ancillary_data::{
 };
 pub use clerk::Clerk;
 pub use error::{AggregateSignatureError, AggregationError};
+pub use genesis::GenesisVerificationKeyBundle;
 
 #[cfg(feature = "future_snark")]
 pub use preimage::GenesisMessagePreimage;
@@ -217,7 +219,8 @@ mod tests {
                         &tc.msg,
                         &tc.clerk.compute_aggregate_verification_key(),
                         &tc.clerk.get_concatenation_clerk().parameters,
-                        ancillary_proof_output.verifier_data().cloned()
+                        ancillary_proof_output.verifier_data().cloned(),
+                        None,
                     )
                     .is_err()
                 )
@@ -248,7 +251,7 @@ mod tests {
             match msig {
                 Ok((aggr, ancillary_proof_output)) => {
                     println!("Aggregate ok");
-                    assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned()).is_ok());
+                    assert!(aggr.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned(), None).is_ok());
                 }
                 Err(error) => match error.downcast_ref::<AggregationError>() {
                     Some(AggregationError::NotEnoughSignatures(n, k)) => {
@@ -333,7 +336,7 @@ mod tests {
             if let Ok((aggr, ancillary_proof_output)) = msig {
                     let bytes: Vec<u8> = aggr.to_bytes().expect("AggregateSignature serialization should not fail");
                     let aggr2: AggregateSignature<D> = AggregateSignature::from_bytes(&bytes).unwrap();
-                    assert!(aggr2.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned()).is_ok());
+                    assert!(aggr2.verify(&msg, &clerk.compute_aggregate_verification_key(), &params, ancillary_proof_output.verifier_data().cloned(), None).is_ok());
             }
         }
     }
@@ -414,6 +417,7 @@ mod tests {
                 let mut batch_msgs = Vec::new();
                 let mut batch_params = Vec::new();
                 let mut batch_ancillary_verifier_datas = Vec::new();
+                let mut batch_genesis_verification_key_bundles = Vec::new();
                 for _ in 0..batch_size {
                     let mut msg = [0u8; 32];
                     rng.fill_bytes(&mut msg);
@@ -432,6 +436,7 @@ mod tests {
                             batch_msgs.push(msg.to_vec());
                             batch_params.push(params);
                             batch_ancillary_verifier_datas.push(ancillary_proof_output.verifier_data().cloned());
+                            batch_genesis_verification_key_bundles.push(None);
                         }
                         Err(error) => { assert!(
                             matches!(
@@ -443,13 +448,13 @@ mod tests {
                     }
                 }
 
-                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas).is_ok());
+                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas, &batch_genesis_verification_key_bundles).is_ok());
 
                 if aggr_stms.len() >= 2 {
                     let mut swapped_msgs = batch_msgs.clone();
                     swapped_msgs.swap(0, 1);
                     assert!(
-                        AggregateSignature::batch_verify(&aggr_stms, &swapped_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas).is_err(),
+                        AggregateSignature::batch_verify(&aggr_stms, &swapped_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas, &batch_genesis_verification_key_bundles).is_err(),
                         "Batch verify should reject swapped messages"
                     );
 
@@ -466,7 +471,7 @@ mod tests {
                     let mut wrong_avks = aggr_avks.clone();
                     wrong_avks[0] = wrong_avk;
                     assert!(
-                        AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &wrong_avks, &batch_params, &batch_ancillary_verifier_datas).is_err(),
+                        AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &wrong_avks, &batch_params, &batch_ancillary_verifier_datas, &batch_genesis_verification_key_bundles).is_err(),
                         "Batch verify should reject a wrong avk"
                     );
                 }
@@ -482,7 +487,7 @@ mod tests {
                 let (fake_msig, _ancillary_proof_output) = clerk.aggregate_signatures_with_type(&sigs, &msg, aggr_sig_type, AncillaryProofInput::dummy()).unwrap();
 
                 aggr_stms[0] = fake_msig;
-                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas).is_err());
+                assert!(AggregateSignature::batch_verify(&aggr_stms, &batch_msgs, &aggr_avks, &batch_params, &batch_ancillary_verifier_datas, &batch_genesis_verification_key_bundles).is_err());
             }
         }
 

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -16,7 +16,10 @@ use crate::{
     },
 };
 
-use super::{AggregateSignatureError, AggregateVerificationKey, AncillaryVerifierData};
+use super::{
+    AggregateSignatureError, AggregateVerificationKey, AncillaryVerifierData,
+    GenesisVerificationKeyBundle,
+};
 
 /// The type of STM aggregate signature.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -159,8 +162,10 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         avk: &AggregateVerificationKey<D>,
         parameters: &Parameters,
         ancillary_verifier_data: Option<AncillaryVerifierData>,
+        genesis_verification_key_bundle: Option<GenesisVerificationKeyBundle>,
     ) -> StmResult<()> {
         let _ = &ancillary_verifier_data;
+        let _ = &genesis_verification_key_bundle;
         match self {
             AggregateSignature::Concatenation(concatenation_proof) => concatenation_proof.verify(
                 msg,
@@ -183,9 +188,14 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     .as_ivc_verifier_data()
                     .ok_or_else(|| anyhow!(AggregateSignatureError::MissingIvcVerifierData))?;
 
+                let genesis_verification_key_bundle =
+                    genesis_verification_key_bundle.ok_or_else(|| {
+                        anyhow!(AggregateSignatureError::MissingGenesisVerificationKeyBundle)
+                    })?;
+
                 let global = Global::new(
                     ivc_verifier_data.genesis_message(),
-                    ivc_verifier_data.genesis_schnorr_verification_key(),
+                    genesis_verification_key_bundle.schnorr,
                     ivc_verifier_data.certificate_circuit_verification_key(),
                     ivc_verifier_data.ivc_circuit_verification_key(),
                 );
@@ -207,6 +217,7 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         avks: &[AggregateVerificationKey<D>],
         parameters: &[Parameters],
         ancillary_verifier_datas: &[Option<AncillaryVerifierData>],
+        genesis_verification_key_bundles: &[Option<GenesisVerificationKeyBundle>],
     ) -> StmResult<()> {
         type AggregateEntriesForAggregateSignatureType<D> = (
             AggregateSignature<D>,
@@ -214,6 +225,7 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             Vec<u8>,
             Parameters,
             Option<AncillaryVerifierData>,
+            Option<GenesisVerificationKeyBundle>,
         );
 
         fn check_input_lengths(
@@ -241,6 +253,9 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         if aggregate_signatures.len() != ancillary_verifier_datas.len() {
             return Err(anyhow!(AggregateSignatureError::BatchInvalid));
         }
+        if aggregate_signatures.len() != genesis_verification_key_bundles.len() {
+            return Err(anyhow!(AggregateSignatureError::BatchInvalid));
+        }
 
         let aggregate_entries_by_aggregate_signature_type: HashMap<
             AggregateSignatureType,
@@ -251,10 +266,14 @@ impl<D: MembershipDigest> AggregateSignature<D> {
             .zip(avks.iter())
             .zip(parameters.iter())
             .zip(ancillary_verifier_datas.iter())
+            .zip(genesis_verification_key_bundles.iter())
             .fold(
                 HashMap::new(),
                 |mut acc,
-                 ((((aggregate_signature, msg), avk), parameters), ancillary_verifier_data)| {
+                 (
+                    ((((aggregate_signature, msg), avk), parameters), ancillary_verifier_data),
+                    genesis_verification_key_bundle,
+                )| {
                     let signature_type = AggregateSignatureType::from(aggregate_signature);
                     acc.entry(signature_type).or_default().push((
                         aggregate_signature.clone(),
@@ -262,6 +281,7 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                         msg.clone(),
                         *parameters,
                         ancillary_verifier_data.clone(),
+                        genesis_verification_key_bundle.clone(),
                     ));
                     acc
                 },
@@ -274,24 +294,24 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     AggregateSignatureType::Concatenation => {
                         let avks = aggregate_entries
                             .iter()
-                            .map(|(_, avk, _, _, _)| {
+                            .map(|(_, avk, _, _, _, _)| {
                                 avk.to_concatenation_aggregate_verification_key()
                             })
                             .cloned()
                             .collect::<Vec<_>>();
                         let concatenation_proofs = aggregate_entries
                             .iter()
-                            .filter_map(|(aggregate_signature, _, _, _, _)| {
+                            .filter_map(|(aggregate_signature, _, _, _, _, _)| {
                                 aggregate_signature.to_concatenation_proof().cloned()
                             })
                             .collect::<Vec<_>>();
                         let msgs = aggregate_entries
                             .iter()
-                            .map(|(_, _, msg, _, _)| msg.clone())
+                            .map(|(_, _, msg, _, _, _)| msg.clone())
                             .collect::<Vec<_>>();
                         let parameters = aggregate_entries
                             .iter()
-                            .map(|(_, _, _, parameters, _)| *parameters)
+                            .map(|(_, _, _, parameters, _, _)| *parameters)
                             .collect::<Vec<_>>();
                         check_input_lengths(
                             concatenation_proofs.len(),
@@ -308,14 +328,21 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     }
                     #[cfg(feature = "future_snark")]
                     AggregateSignatureType::Snark => {
-                        for (aggregate_signature, avk, msg, parameters, ancillary_verifier_data) in
-                            aggregate_entries
+                        for (
+                            aggregate_signature,
+                            avk,
+                            msg,
+                            parameters,
+                            ancillary_verifier_data,
+                            genesis_verification_key_bundle,
+                        ) in aggregate_entries
                         {
                             aggregate_signature.verify(
                                 &msg,
                                 &avk,
                                 &parameters,
                                 ancillary_verifier_data,
+                                genesis_verification_key_bundle,
                             )?;
                         }
 
@@ -323,14 +350,21 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                     }
                     #[cfg(feature = "future_snark")]
                     AggregateSignatureType::IvcSnark => {
-                        for (aggregate_signature, avk, msg, parameters, ancillary_verifier_data) in
-                            aggregate_entries
+                        for (
+                            aggregate_signature,
+                            avk,
+                            msg,
+                            parameters,
+                            ancillary_verifier_data,
+                            genesis_verification_key_bundle,
+                        ) in aggregate_entries
                         {
                             aggregate_signature.verify(
                                 &msg,
                                 &avk,
                                 &parameters,
                                 ancillary_verifier_data,
+                                genesis_verification_key_bundle,
                             )?;
                         }
 
@@ -468,10 +502,62 @@ mod tests {
         use crate::{Clerk, Parameters, protocol::aggregate_signature::tests::setup_equal_parties};
 
         use crate::{
-            AggregateSignature, AggregateSignatureError, MithrilMembershipDigest,
-            circuits::halo2_ivc::tests::common::asset_readers::load_embedded_next_epoch_step_output_asset,
-            proof_system::ivc_halo2_snark::proof::IvcProof,
+            AggregateSignature, AggregateSignatureError, AncillaryVerifierData,
+            MithrilMembershipDigest,
+            circuits::halo2_ivc::{
+                tests::common::asset_readers::{
+                    load_embedded_next_epoch_step_output_asset,
+                    load_embedded_verification_context_asset,
+                },
+                types::MessageHash,
+            },
+            proof_system::ivc_halo2_snark::{proof::IvcProof, verifier_setup::IvcVerifierData},
         };
+
+        #[test]
+        fn ivc_verify_fails_without_genesis_verification_key_bundle() {
+            let step_output = load_embedded_next_epoch_step_output_asset()
+                .expect("recursive step output asset should load");
+            let context = load_embedded_verification_context_asset()
+                .expect("verification context asset should load");
+
+            let params = Parameters {
+                m: 10,
+                k: 3,
+                phi_f: 0.9,
+            };
+            let ps = setup_equal_parties(params, 5);
+            let avk = Clerk::new_clerk_from_signer(&ps[0]).compute_aggregate_verification_key();
+
+            let msg = &[
+                22, 148, 87, 37, 149, 0, 124, 10, 156, 94, 108, 6, 78, 59, 239, 80, 126, 213, 158,
+                211, 191, 213, 128, 70, 128, 30, 235, 80, 192, 191, 159, 67,
+            ];
+
+            let ancillary = AncillaryVerifierData::IvcSnark(IvcVerifierData::new(
+                MessageHash::ZERO,
+                context.certificate_verifying_key,
+                context.recursive_verifying_key,
+            ));
+            let proof = IvcProof::<blake2b_simd::State>::new(
+                step_output.ivc_proof,
+                step_output.next_state,
+                step_output.next_accumulator,
+            );
+            let ivc_proof =
+                AggregateSignature::<MithrilMembershipDigest>::IvcSnark(Box::new(proof));
+
+            let error = ivc_proof
+                .verify(msg, &avk, &params, Some(ancillary), None)
+                .expect_err(
+                    "verification must fail when the genesis verification key bundle is absent",
+                );
+            assert_eq!(
+                error.downcast_ref::<AggregateSignatureError>(),
+                Some(&AggregateSignatureError::MissingGenesisVerificationKeyBundle),
+                "an absent genesis verification key bundle must be rejected, got: {error}"
+            );
+        }
 
         #[test]
         fn ivc_verify_fails_without_ancillary_verifier_data() {
@@ -501,7 +587,7 @@ mod tests {
                 AggregateSignature::<MithrilMembershipDigest>::IvcSnark(Box::new(proof));
 
             let err = ivc_proof
-                .verify(msg, &avk, &params, None)
+                .verify(msg, &avk, &params, None, None)
                 .expect_err("Should fail without ancillary verifier data.");
             assert_eq!(
                 err.downcast_ref::<AggregateSignatureError>(),
@@ -599,7 +685,8 @@ mod tests {
 
         #[test]
         fn returns_error_when_messages_length_differs_from_signatures() {
-            let result = AggregateSignature::<D>::batch_verify(&[], &[vec![1u8]], &[], &[], &[]);
+            let result =
+                AggregateSignature::<D>::batch_verify(&[], &[vec![1u8]], &[], &[], &[], &[]);
 
             assert_batch_invalid_error(result);
         }
@@ -607,7 +694,7 @@ mod tests {
         #[test]
         fn returns_error_when_avks_length_differs_from_signatures() {
             let avk = build_aggregate_verification_key();
-            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[avk], &[], &[]);
+            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[avk], &[], &[], &[]);
 
             assert_batch_invalid_error(result);
         }
@@ -624,6 +711,7 @@ mod tests {
                     phi_f: 0.2,
                 }],
                 &[],
+                &[],
             );
 
             assert_batch_invalid_error(result);
@@ -631,14 +719,21 @@ mod tests {
 
         #[test]
         fn returns_error_when_ancillary_verifier_datas_length_differs_from_signatures() {
-            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[], &[None]);
+            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[], &[None], &[]);
+
+            assert_batch_invalid_error(result);
+        }
+
+        #[test]
+        fn returns_error_when_genesis_verification_key_bundles_length_differs_from_signatures() {
+            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[], &[], &[None]);
 
             assert_batch_invalid_error(result);
         }
 
         #[test]
         fn succeeds_when_all_inputs_are_empty() {
-            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[], &[]);
+            let result = AggregateSignature::<D>::batch_verify(&[], &[], &[], &[], &[], &[]);
 
             assert!(result.is_ok());
         }

--- a/mithril-stm/src/protocol/aggregate_signature/signature.rs
+++ b/mithril-stm/src/protocol/aggregate_signature/signature.rs
@@ -229,33 +229,32 @@ impl<D: MembershipDigest> AggregateSignature<D> {
         );
 
         fn check_input_lengths(
-            proofs_length: usize,
-            msgs_length: usize,
-            avks_length: usize,
-            parameters_length: usize,
+            expected_length: usize,
+            labeled_lengths: &[(&str, usize)],
         ) -> StmResult<()> {
-            if proofs_length != msgs_length
-                || proofs_length != avks_length
-                || proofs_length != parameters_length
-            {
-                Err(anyhow!(AggregateSignatureError::BatchInvalid))
-            } else {
-                Ok(())
+            for (name, length) in labeled_lengths {
+                if *length != expected_length {
+                    return Err(anyhow!(AggregateSignatureError::BatchInvalid).context(format!(
+                        "the number of {name} ({length}) does not match the number of aggregate signatures ({expected_length})"
+                    )));
+                }
             }
+            Ok(())
         }
 
         check_input_lengths(
             aggregate_signatures.len(),
-            msgs.len(),
-            avks.len(),
-            parameters.len(),
+            &[
+                ("messages", msgs.len()),
+                ("aggregate verification keys", avks.len()),
+                ("parameters", parameters.len()),
+                ("ancillary verifier data", ancillary_verifier_datas.len()),
+                (
+                    "genesis verification key bundles",
+                    genesis_verification_key_bundles.len(),
+                ),
+            ],
         )?;
-        if aggregate_signatures.len() != ancillary_verifier_datas.len() {
-            return Err(anyhow!(AggregateSignatureError::BatchInvalid));
-        }
-        if aggregate_signatures.len() != genesis_verification_key_bundles.len() {
-            return Err(anyhow!(AggregateSignatureError::BatchInvalid));
-        }
 
         let aggregate_entries_by_aggregate_signature_type: HashMap<
             AggregateSignatureType,
@@ -315,9 +314,11 @@ impl<D: MembershipDigest> AggregateSignature<D> {
                             .collect::<Vec<_>>();
                         check_input_lengths(
                             concatenation_proofs.len(),
-                            msgs.len(),
-                            avks.len(),
-                            parameters.len(),
+                            &[
+                                ("messages", msgs.len()),
+                                ("aggregate verification keys", avks.len()),
+                                ("parameters", parameters.len()),
+                            ],
                         )?;
                         ConcatenationProof::batch_verify(
                             &concatenation_proofs,

--- a/mithril-stm/src/protocol/mod.rs
+++ b/mithril-stm/src/protocol/mod.rs
@@ -8,7 +8,7 @@ mod single_signature;
 pub use aggregate_signature::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
     AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProofOutput,
-    AncillaryProverData, AncillaryVerifierData, Clerk,
+    AncillaryProverData, AncillaryVerifierData, Clerk, GenesisVerificationKeyBundle,
 };
 pub use error::RegisterError;
 #[cfg(feature = "future_snark")]

--- a/mithril-stm/tests/stm_protocol.rs
+++ b/mithril-stm/tests/stm_protocol.rs
@@ -37,7 +37,8 @@ fn test_full_protocol() {
                     &msg,
                     &avk,
                     &params,
-                    ancillary_proof_output.verifier_data().cloned()
+                    ancillary_proof_output.verifier_data().cloned(),
+                    None,
                 )
                 .is_ok()
             );
@@ -68,6 +69,7 @@ fn test_full_protocol_batch_verify() {
     let mut batch_msgs = Vec::new();
     let mut batch_params = Vec::new();
     let mut batch_ancillary_verifier_datas = Vec::new();
+    let mut batch_genesis_verification_key_bundles = Vec::new();
 
     let params = Parameters {
         k: 357,
@@ -93,6 +95,7 @@ fn test_full_protocol_batch_verify() {
         batch_msgs.push(msg.to_vec());
         batch_params.push(params);
         batch_ancillary_verifier_datas.push(ancillary_proof_output.verifier_data().cloned());
+        batch_genesis_verification_key_bundles.push(None);
     }
     assert!(
         AggregateSignature::batch_verify(
@@ -100,7 +103,8 @@ fn test_full_protocol_batch_verify() {
             &batch_msgs,
             &aggr_avks,
             &batch_params,
-            &batch_ancillary_verifier_datas
+            &batch_ancillary_verifier_datas,
+            &batch_genesis_verification_key_bundles
         )
         .is_ok()
     );


### PR DESCRIPTION
## Content

This PR includes a **fix to source the genesis verification key from a trusted input during aggregate signature verification**:
- Fix `AggregateSignature::verify` to read the genesis Schnorr verification key from the `genesis_verification_key_bundle` input instead of the certificate-carried `IvcVerifierData`.
- Remove the `genesis_schnorr_verification_key` field from `IvcVerifierData`.
- Replace the per-call genesis verification key parameter on the `CertificateVerifier` methods with a `GenesisVerifier` injected into `MithrilCertificateVerifier`.
- Verify genesis certificates against the operator-supplied key in the genesis ceremony tools (mithril-aggregator).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3141 
