### PR TITLE
chore: apply prettier linting to docs

### DIFF
--- a/docs/runbook/maintain-networks-configuration-file/README.md
+++ b/docs/runbook/maintain-networks-configuration-file/README.md
@@ -17,8 +17,9 @@ The [networks.json](../../../networks.json) file provides essential information 
 ### Update policy by network:
 
 Here are the recommended update policies by Cardano network:
-| Network | Status | Policy
-|------------|------------|------------
-`preview` | **stable** | the minimum supported Cardano node version should be updated to be two stable releases behind the current release version.
-`preprod` | **stable** | the minimum supported Cardano node version should be updated to be two stable releases behind the current release version.
-`mainnet` | **stable** | the minimum supported Cardano node version should be updated to be two stable releases behind the current release version.
+
+| Network   | Status     | Policy                                                                                                                     |
+| --------- | ---------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `preview` | **stable** | the minimum supported Cardano node version should be updated to be two stable releases behind the current release version. |
+| `preprod` | **stable** | the minimum supported Cardano node version should be updated to be two stable releases behind the current release version. |
+| `mainnet` | **stable** | the minimum supported Cardano node version should be updated to be two stable releases behind the current release version. |

--- a/docs/runbook/protocol-parameters/README.md
+++ b/docs/runbook/protocol-parameters/README.md
@@ -34,10 +34,10 @@ When setting up a Mithril network with a `terraform` deployment, the protocol pa
 
 Currently, the following [Mithril networks](https://mithril.network/doc/manual/developer-docs/references#mithril-networks) are generally available, and deployed with `terraform`:
 
-- `testing-preview`: with the workflow [`.github/workflows/ci.yml`](../../github/workflows/ci.yml)
-- `pre-release-preview`: with the workflow [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml)
-- `release-preprod`: with the workflow [`.github/workflows/release.yml`](../../github/workflows/release.yml)
-- `release-mainnet`: with the workflow [`.github/workflows/release.yml`](../../github/workflows/release.yml)
+- `testing-preview`: with the workflow [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml)
+- `pre-release-preview`: with the workflow [`.github/workflows/pre-release.yml`](../../../.github/workflows/pre-release.yml)
+- `release-preprod`: with the workflow [`.github/workflows/release.yml`](../../../.github/workflows/release.yml)
+- `release-mainnet`: with the workflow [`.github/workflows/release.yml`](../../../.github/workflows/release.yml)
 
 ## Update the protocol parameters
 
@@ -69,10 +69,10 @@ The modifications should be created in a dedicated PR, and the result of the **P
 
 The update of the new protocol parameters will take place as detailed in the following table:
 
-| Workflow                                                                      | Deployed at                   | Effective at       |
-| ----------------------------------------------------------------------------- | ----------------------------- | ------------------ |
-| [`.github/workflows/ci.yml`](../../github/workflows/ci.yml)                   | Merge on `main` branch        | **3** epochs later |
-| [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml) | Pre-release of a distribution | **3** epochs later |
-| [`.github/workflows/release.yml`](../../github/workflows/release.yml)         | Release of a distribution     | **3** epochs later |
+| Workflow                                                                          | Deployed at                   | Effective at       |
+| --------------------------------------------------------------------------------- | ----------------------------- | ------------------ |
+| [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml)                   | Merge on `main` branch        | **3** epochs later |
+| [`.github/workflows/pre-release.yml`](../../../.github/workflows/pre-release.yml) | Pre-release of a distribution | **3** epochs later |
+| [`.github/workflows/release.yml`](../../../.github/workflows/release.yml)         | Release of a distribution     | **3** epochs later |
 
 For more information about the CD, please refer to [Release process and versioning](https://mithril.network/doc/adr/3).

--- a/docs/runbook/protocol-parameters/README.md
+++ b/docs/runbook/protocol-parameters/README.md
@@ -68,10 +68,11 @@ The modifications should be created in a dedicated PR, and the result of the **P
 ## Deployment of the new protocol parameters
 
 The update of the new protocol parameters will take place as detailed in the following table:
-| Workflow | Deployed at | Effective at
-|------------|------------|------------
-| [`.github/workflows/ci.yml`](../../github/workflows/ci.yml) | Merge on `main` branch | **3** epochs later
-| [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml) | Pre-release of a distribution | **3** epochs later
-| [`.github/workflows/release.yml`](../../github/workflows/release.yml) | Release of a distribution | **3** epochs later
+
+| Workflow                                                                      | Deployed at                   | Effective at       |
+| ----------------------------------------------------------------------------- | ----------------------------- | ------------------ |
+| [`.github/workflows/ci.yml`](../../github/workflows/ci.yml)                   | Merge on `main` branch        | **3** epochs later |
+| [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml) | Pre-release of a distribution | **3** epochs later |
+| [`.github/workflows/release.yml`](../../github/workflows/release.yml)         | Release of a distribution     | **3** epochs later |
 
 For more information about the CD, please refer to [Release process and versioning](https://mithril.network/doc/adr/3).

--- a/docs/runbook/upgrade-vm/README.md
+++ b/docs/runbook/upgrade-vm/README.md
@@ -8,10 +8,10 @@ From time to time, we may need to upgrade or downgrade the VM that is powering t
 
 Currently, the following [Mithril networks](https://mithril.network/doc/manual/developer-docs/references#mithril-networks) are generally available, and deployed with `terraform`:
 
-- `testing-preview`: with the workflow [`.github/workflows/ci.yml`](../../github/workflows/ci.yml)
-- `pre-release-preview`: with the workflow [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml)
-- `release-preprod`: with the workflow [`.github/workflows/release.yml`](../../github/workflows/release.yml)
-- `release-mainnet`: with the workflow [`.github/workflows/release.yml`](../../github/workflows/release.yml)
+- `testing-preview`: with the workflow [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml)
+- `pre-release-preview`: with the workflow [`.github/workflows/pre-release.yml`](../../../.github/workflows/pre-release.yml)
+- `release-preprod`: with the workflow [`.github/workflows/release.yml`](../../../.github/workflows/release.yml)
+- `release-mainnet`: with the workflow [`.github/workflows/release.yml`](../../../.github/workflows/release.yml)
 
 ## Update the VM instance type
 
@@ -59,10 +59,10 @@ Terraform will perform the following actions:
 
 The update of the new protocol parameters will take place as detailed in the following table:
 
-| Workflow                                                                      | Deployed at                   | Effective at |
-| ----------------------------------------------------------------------------- | ----------------------------- | ------------ |
-| [`.github/workflows/ci.yml`](../../github/workflows/ci.yml)                   | Merge on `main` branch        | Immediately  |
-| [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml) | Pre-release of a distribution | Immediately  |
-| [`.github/workflows/release.yml`](../../github/workflows/release.yml)         | Release of a distribution     | Immediately  |
+| Workflow                                                                          | Deployed at                   | Effective at |
+| --------------------------------------------------------------------------------- | ----------------------------- | ------------ |
+| [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml)                   | Merge on `main` branch        | Immediately  |
+| [`.github/workflows/pre-release.yml`](../../../.github/workflows/pre-release.yml) | Pre-release of a distribution | Immediately  |
+| [`.github/workflows/release.yml`](../../../.github/workflows/release.yml)         | Release of a distribution     | Immediately  |
 
 For more information about the CD, please refer to [Release process and versioning](https://mithril.network/doc/adr/3).

--- a/docs/runbook/upgrade-vm/README.md
+++ b/docs/runbook/upgrade-vm/README.md
@@ -58,10 +58,11 @@ Terraform will perform the following actions:
 ## Deployment of the new protocol parameters
 
 The update of the new protocol parameters will take place as detailed in the following table:
-| Workflow | Deployed at | Effective at
-|------------|------------|------------
-| [`.github/workflows/ci.yml`](../../github/workflows/ci.yml) | Merge on `main` branch | Immediately
-| [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml) | Pre-release of a distribution | Immediately
-| [`.github/workflows/release.yml`](../../github/workflows/release.yml) | Release of a distribution | Immediately
+
+| Workflow                                                                      | Deployed at                   | Effective at |
+| ----------------------------------------------------------------------------- | ----------------------------- | ------------ |
+| [`.github/workflows/ci.yml`](../../github/workflows/ci.yml)                   | Merge on `main` branch        | Immediately  |
+| [`.github/workflows/pre-release.yml`](../../github/workflows/pre-release.yml) | Pre-release of a distribution | Immediately  |
+| [`.github/workflows/release.yml`](../../github/workflows/release.yml)         | Release of a distribution     | Immediately  |
 
 For more information about the CD, please refer to [Release process and versioning](https://mithril.network/doc/adr/3).


### PR DESCRIPTION
## Content

This PR includes **new linting of prettier `3.9.1` for the documentation**.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

