### PR TITLE
Mark stale issues and PRs with GitHub workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: Stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      debug-only:
+        description: "Enable debug-only mode"
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mark inactive issues and pull requests as stale
+        uses: actions/stale@v10
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: 90
+          days-before-issue-close: 90
+          days-before-pr-stale: 30
+          days-before-pr-close: 30
+          stale-issue-label: "stale 📆"
+          stale-pr-label: "stale 📆"
+          stale-issue-message: >-
+            This issue has been automatically marked as stale because it has been inactive for 90 days.
+          close-issue-message: >-
+            This issue has been automatically closed because it has been stale for 90 days.
+          stale-pr-message: >-
+            This pull request has been automatically marked as stale because it has been inactive for 30 days.
+          close-pr-message: >-
+            This pull request has been automatically closed because it has been stale for 30 days.
+          exempt-issue-labels: roadmap 🧭,epic ⚔️
+          exempt-pr-labels: do-not-merge 🔒
+          remove-stale-when-updated: true
+          operations-per-run: 100
+          debug-only: ${{ inputs.debug-only || false }}


### PR DESCRIPTION
## Content

Add a scheduled GitHub Actions workflow based on [actions/stale](https://github.com/actions/stale) that marks inactive issues and PRs as stale, closes them after a grace period.

- **issue** will be flagged "stale 📆" after **90 days** of inactivity then closed after 90 days in stale state.
- **Pull request** will be flagged "stale 📆" after **30 days** of inactivity then closed after 30 days in stale state.
- excluded issue labels are : "roadmap 🧭" and "epic ⚔️"
- excluded PR labels are :  "do-not-merge 🔒"

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

## Issue(s)

this PR relates to or closes #3339 
