### PR TITLE
fix(aggregator): reject legacy Lagrange genesis key and fix epoch pruning order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.13"
+version = "0.9.14"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.13"
+version = "0.9.14"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/dependency_injection/builder/support/upkeep.rs
+++ b/mithril-aggregator/src/dependency_injection/builder/support/upkeep.rs
@@ -16,21 +16,32 @@ impl DependenciesBuilder {
         )))
     }
 
-    async fn build_upkeep_service(&mut self) -> Result<Arc<dyn UpkeepService>> {
+    /// Build the epoch pruning tasks ordered so that they respect foreign key constraints.
+    ///
+    /// `signer_registration` references `epoch_setting`, so it must be pruned before
+    /// `epoch_setting`, otherwise deleting a still referenced `epoch_setting` row fails the
+    /// constraint.
+    async fn build_epoch_pruning_tasks(&mut self) -> Result<Vec<Arc<dyn EpochPruningTask>>> {
         let stake_pool_pruning_task = self.get_stake_store().await?;
         let epoch_settings_pruning_task = self.get_epoch_settings_store().await?;
         let signer_registration_pruning_task = self.get_signer_registration_pruning_task().await?;
 
+        let pruning_tasks: Vec<Arc<dyn EpochPruningTask>> = vec![
+            stake_pool_pruning_task,
+            signer_registration_pruning_task,
+            epoch_settings_pruning_task,
+        ];
+
+        Ok(pruning_tasks)
+    }
+
+    async fn build_upkeep_service(&mut self) -> Result<Arc<dyn UpkeepService>> {
         let upkeep_service = Arc::new(AggregatorUpkeepService::new(
             self.get_sqlite_connection().await?,
             self.get_sqlite_connection_cardano_transaction_pool().await?,
             self.get_event_store_sqlite_connection().await?,
             self.get_signed_entity_type_lock().await?,
-            vec![
-                stake_pool_pruning_task,
-                epoch_settings_pruning_task,
-                signer_registration_pruning_task,
-            ],
+            self.build_epoch_pruning_tasks().await?,
             self.root_logger(),
         ));
 
@@ -40,5 +51,63 @@ impl DependenciesBuilder {
     /// Get the [UpkeepService] instance
     pub async fn get_upkeep_service(&mut self) -> Result<Arc<dyn UpkeepService>> {
         get_dependency!(self.upkeep_service)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::Utc;
+
+    use mithril_common::entities::Epoch;
+    use mithril_common::temp_dir_create;
+    use mithril_common::test::double::fake_data;
+
+    use crate::database::record::SignerRecord;
+    use crate::database::test_helper::{
+        insert_epoch_settings, insert_signer_registrations, insert_signers,
+    };
+    use crate::{ExecutionEnvironment, ServeCommandConfiguration};
+
+    use super::*;
+
+    #[tokio::test]
+    async fn epoch_pruning_tasks_are_ordered_to_respect_foreign_keys() {
+        let configuration = ServeCommandConfiguration {
+            environment: ExecutionEnvironment::Test,
+            store_retention_limit: Some(3),
+            ..ServeCommandConfiguration::new_sample(temp_dir_create!())
+        };
+        let mut builder = DependenciesBuilder::new_with_stdout_logger(Arc::new(configuration));
+
+        let connection = builder.get_sqlite_connection().await.unwrap();
+        let signers = fake_data::signers_with_stakes(2);
+        insert_signers(
+            &connection,
+            signers
+                .iter()
+                .map(|signer| SignerRecord {
+                    signer_id: signer.party_id.clone(),
+                    pool_ticker: None,
+                    created_at: Utc::now(),
+                    updated_at: Utc::now(),
+                    last_registered_at: None,
+                })
+                .collect(),
+        )
+        .unwrap();
+        insert_epoch_settings(&connection, &[1, 2, 3, 4, 5, 6]).unwrap();
+        let signer_registrations = (3..=6).map(|epoch| (Epoch(epoch), signers.clone())).collect();
+        insert_signer_registrations(&connection, signer_registrations).unwrap();
+
+        let pruning_tasks = builder.build_epoch_pruning_tasks().await.unwrap();
+
+        for task in &pruning_tasks {
+            task.prune(Epoch(17)).await.unwrap_or_else(|error| {
+                panic!(
+                    "Pruning '{}' should not fail with a foreign key constraint error: {error:?}",
+                    task.pruned_data()
+                )
+            });
+        }
     }
 }

--- a/mithril-aggregator/src/tools/genesis/operations.rs
+++ b/mithril-aggregator/src/tools/genesis/operations.rs
@@ -204,23 +204,20 @@ impl GenesisTools {
 
     /// Automatic bootstrap of the genesis certificate (test only).
     ///
-    /// Pythagoras runs a single Ed25519 ceremony; Lagrange runs the dual ceremony with the SNARK
-    /// signer attached to the producer.
+    /// Pythagoras runs a single Ed25519 ceremony; Lagrange runs the dual ceremony and requires a
+    /// dual signing key, erroring on a legacy single-Ed25519 key.
     pub async fn bootstrap_test_genesis_certificate(
         &self,
         genesis_signer: GenesisSigner,
     ) -> StdResult<()> {
         #[cfg(feature = "future_snark")]
-        let genesis_signer = if matches!(self.configuration.mithril_era, SupportedEra::Lagrange)
+        if matches!(self.configuration.mithril_era, SupportedEra::Lagrange)
             && genesis_signer.schnorr.is_none()
         {
-            GenesisSigner {
-                ed25519: genesis_signer.ed25519,
-                schnorr: Some(GenesisSchnorrSigner::create_non_deterministic_signer()),
-            }
-        } else {
-            genesis_signer
-        };
+            return Err(anyhow::anyhow!(
+                "Lagrange genesis bootstrap requires a dual signing key (Ed25519 + Schnorr), but the provided `GENESIS_SECRET_KEY` is a legacy single-Ed25519 key; generate a dual keypair with `mithril-aggregator genesis generate-keypair --mithril-era lagrange`"
+            ));
+        }
         let ed25519_verification_key = genesis_signer.ed25519.verification_key();
         #[cfg(feature = "future_snark")]
         let schnorr_verification_key =
@@ -705,7 +702,7 @@ mod tests {
         }
 
         #[tokio::test]
-        async fn lagrange_auto_augments_a_legacy_signer_with_a_fresh_schnorr_signer() {
+        async fn lagrange_rejects_a_legacy_signer() {
             let ed25519_signer = GenesisEd25519Signer::create_deterministic_signer();
             let (genesis_tools, certificate_store, _, _) =
                 build_tools_for_era(&ed25519_signer, SupportedEra::Lagrange);
@@ -713,13 +710,11 @@ mod tests {
             genesis_tools
                 .bootstrap_test_genesis_certificate(GenesisSigner::from_ed25519(ed25519_signer))
                 .await
-                .expect(
-                    "Lagrange bootstrap must auto-augment a legacy signer for test convenience",
-                );
+                .expect_err("Lagrange bootstrap must reject a legacy single-Ed25519 signer");
 
             let last: Vec<Certificate> =
                 certificate_store.get_latest_certificates(10).await.unwrap();
-            assert_eq!(1, last.len());
+            assert!(last.is_empty());
         }
     }
 


### PR DESCRIPTION
## Content

This PR includes **two aggregator startup and upkeep fixes**:

- Reject a legacy single-Ed25519 genesis key when bootstrapping a Lagrange genesis, instead of fabricating an ephemeral Schnorr signer.
- Prune signer registrations before epoch settings so the foreign key constraint is respected after a large epoch gap.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3142 