### PR TITLE
feat(e2e): support `IvcSnark` proofs and harden the e2e test suite waits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4439,7 +4439,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.3"
+version = "0.5.4"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/lib.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/lib.rs
@@ -28,6 +28,9 @@ pub enum AggregateSignatureType {
     /// SNARK proof system.
     #[value(name = "Snark")]
     Snark,
+    /// IVC SNARK proof system.
+    #[value(name = "IvcSnark")]
+    IvcSnark,
 }
 
 impl std::fmt::Display for AggregateSignatureType {
@@ -35,6 +38,7 @@ impl std::fmt::Display for AggregateSignatureType {
         match self {
             AggregateSignatureType::Concatenation => write!(f, "Concatenation"),
             AggregateSignatureType::Snark => write!(f, "Snark"),
+            AggregateSignatureType::IvcSnark => write!(f, "IvcSnark"),
         }
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -280,7 +280,7 @@ async fn main_exec() -> StdResult<()> {
         return cmd.execute(&mut Cli::command()).map_err(|message| anyhow!(message));
     }
 
-    info!("Starting Mithril End-to-End test suite"; "args" => ?args);
+    info!("Starting Mithril End-to-End test suite"; "args" => #?args);
 
     let work_dir = {
         let dir = match &args.work_directory {

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/client.rs
@@ -55,8 +55,9 @@ impl CardanoDbV2Command {
                 vec![
                     "download".to_string(),
                     "--include-ancillary".to_string(),
+                    "--allow-override".to_string(),
                     "--download-dir".to_string(),
-                    "v2".to_string(),
+                    format!("v2"),
                     hash.clone(),
                 ]
             }

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/infrastructure.rs
@@ -278,11 +278,13 @@ impl MithrilInfrastructure {
                 m: 105,
                 phi_f: 0.95,
             },
-            AggregateSignatureType::Snark => ProtocolParameters {
-                k: 5,
-                m: 9,
-                phi_f: 0.95,
-            },
+            AggregateSignatureType::Snark | AggregateSignatureType::IvcSnark => {
+                ProtocolParameters {
+                    k: 5,
+                    m: 9,
+                    phi_f: 0.95,
+                }
+            }
         };
         aggregator.set_protocol_parameters(&protocol_parameters_new).await;
 

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
@@ -117,8 +117,8 @@ impl FullScenario {
         let chain_observer = leader_aggregator.chain_observer();
         let start_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
 
-        // Wait 4 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
-        let mut target_epoch = start_epoch + 4;
+        // Wait 2 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
+        let mut target_epoch = start_epoch + 2;
         self.toolkit
             .wait
             .for_aggregator_at_target_epoch(

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
@@ -124,8 +124,8 @@ impl MinimalScenario {
         let chain_observer = aggregator.chain_observer();
         let start_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
 
-        // Wait 2 epochs after genesis certificate creation
-        let target_epoch = start_epoch + 2;
+        // Wait 3 epochs after genesis certificate creation
+        let target_epoch = start_epoch + 3;
         self.toolkit
             .wait
             .for_aggregator_at_target_epoch(

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/minimal.rs
@@ -96,8 +96,8 @@ impl MinimalScenario {
         let chain_observer = leader_aggregator.chain_observer();
         let start_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
 
-        // Wait 4 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
-        let target_epoch = start_epoch + 4;
+        // Wait 2 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
+        let target_epoch = start_epoch + 2;
         self.toolkit
             .wait
             .for_aggregator_at_target_epoch(

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/run_only.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/run_only.rs
@@ -42,8 +42,8 @@ impl RunOnlyScenario {
         let chain_observer = leader_aggregator.chain_observer();
         let start_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
 
-        // Wait 3 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
-        let target_epoch = start_epoch + 3;
+        // Wait 2 epochs after start epoch for the aggregator to be able to bootstrap a genesis certificate
+        let target_epoch = start_epoch + 2;
         self.toolkit
             .wait
             .for_aggregator_at_target_epoch(

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_blocks_transactions.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_blocks_transactions.rs
@@ -35,8 +35,7 @@ impl CheckCardanoBlocksTransactionsToolkit {
     ) -> StdResult<()> {
         let certificate_toolkit = CheckCertificateToolkit::new(self.context.clone());
 
-        let artifact = self.wait_for_artifact(aggregator).await?;
-        self.check_artifact(&artifact, expected_epoch_min)?;
+        let artifact = self.wait_for_artifact(aggregator, expected_epoch_min).await?;
         certificate_toolkit
             .is_creating_certificate_with_enough_signers(
                 aggregator,
@@ -53,23 +52,22 @@ impl CheckCardanoBlocksTransactionsToolkit {
     pub async fn wait_for_artifact(
         &self,
         aggregator: &Aggregator,
+        expected_epoch_min: Epoch,
     ) -> StdResult<CardanoBlocksTransactionsSnapshotListItemMessage> {
-        utils::wait_for_latest_artifact::<CardanoBlocksTransactionsSnapshotListItemMessage>(
+        utils::wait_for_latest_artifact_with_condition(
             "Cardano blocks transactions",
             "/artifact/cardano-blocks-transactions",
-            |a| a.hash.clone(),
+            |a: &CardanoBlocksTransactionsSnapshotListItemMessage| a.hash.clone(),
             &self.context,
             aggregator,
+            |a| a.epoch >= expected_epoch_min,
+            |last_invalid_artifact| {
+                format!(
+                    "no Cardano blocks transactions found with epoch >= {expected_epoch_min}\nlast artifact: {last_invalid_artifact:?}"
+                )
+            },
         )
         .await
-    }
-
-    pub fn check_artifact(
-        &self,
-        artifact: &CardanoBlocksTransactionsSnapshotListItemMessage,
-        expected_epoch_min: Epoch,
-    ) -> StdResult<()> {
-        utils::assert_minimal_epoch(artifact, |a| a.epoch, expected_epoch_min)
     }
 
     pub async fn verify_transactions_with_client(

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
@@ -8,7 +8,7 @@ use mithril_common::{
 };
 
 use crate::{
-    Aggregator, CardanoDbV2Command, Client, ClientCommand, attempt,
+    Aggregator, CardanoDbV2Command, Client, ClientCommand, poll_until,
     toolkit::{CheckCertificateToolkit, ScenarioToolkitContext},
     utils::AttemptResult,
 };
@@ -97,7 +97,7 @@ impl CheckCardanoDatabaseToolkit {
             }
         }
 
-        match attempt!(10, self.context.tenth_epoch_delay(), {
+        match poll_until!(self.context.artifact_production_timeout(), self.context.poll_backoff(), {
             fetch_cardano_database_digests_map(url.clone()).await
         }) {
             AttemptResult::Ok(cardano_database_digests_map) => {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_database.rs
@@ -34,8 +34,7 @@ impl CheckCardanoDatabaseToolkit {
     ) -> StdResult<()> {
         let certificate_toolkit = CheckCertificateToolkit::new(self.context.clone());
 
-        let artifact = self.wait_for_artifact(aggregator).await?;
-        self.check_artifact(&artifact, expected_epoch_min)?;
+        let artifact = self.wait_for_artifact(aggregator, expected_epoch_min).await?;
         certificate_toolkit
             .is_creating_certificate_with_enough_signers(
                 aggregator,
@@ -52,23 +51,22 @@ impl CheckCardanoDatabaseToolkit {
     pub async fn wait_for_artifact(
         &self,
         aggregator: &Aggregator,
+        expected_epoch_min: Epoch,
     ) -> StdResult<CardanoDatabaseSnapshotListItemMessage> {
-        utils::wait_for_latest_artifact::<CardanoDatabaseSnapshotListItemMessage>(
+        utils::wait_for_latest_artifact_with_condition(
             "Cardano database snapshot",
             "/artifact/cardano-database",
-            |a| a.hash.clone(),
+            |a: &CardanoDatabaseSnapshotListItemMessage| a.hash.clone(),
             &self.context,
             aggregator,
+            |a| a.beacon.epoch >= expected_epoch_min,
+            |last_invalid_artifact| {
+                format!(
+                    "no Cardano database snapshot found with epoch >= {expected_epoch_min}\nlast artifact: {last_invalid_artifact:?}"
+                )
+            },
         )
         .await
-    }
-
-    pub fn check_artifact(
-        &self,
-        artifact: &CardanoDatabaseSnapshotListItemMessage,
-        expected_epoch_min: Epoch,
-    ) -> StdResult<()> {
-        utils::assert_minimal_epoch(artifact, |a| a.beacon.epoch, expected_epoch_min)
     }
 
     pub async fn node_producing_cardano_database_digests_map(

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_stake_distribution.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_stake_distribution.rs
@@ -30,8 +30,7 @@ impl CheckCardanoStakeDistributionToolkit {
     ) -> StdResult<()> {
         let certificate_toolkit = CheckCertificateToolkit::new(self.context.clone());
 
-        let artifact = self.wait_for_artifact(aggregator).await?;
-        self.check_artifact(&artifact, expected_epoch_min)?;
+        let artifact = self.wait_for_artifact(aggregator, expected_epoch_min).await?;
         certificate_toolkit
             .is_creating_certificate_with_enough_signers(
                 aggregator,
@@ -48,23 +47,22 @@ impl CheckCardanoStakeDistributionToolkit {
     pub async fn wait_for_artifact(
         &self,
         aggregator: &Aggregator,
+        expected_epoch_min: Epoch,
     ) -> StdResult<CardanoStakeDistributionListItemMessage> {
-        utils::wait_for_latest_artifact::<CardanoStakeDistributionListItemMessage>(
+        utils::wait_for_latest_artifact_with_condition(
             "Cardano stake distribution",
             "/artifact/cardano-stake-distributions",
-            |a| a.hash.clone(),
+            |a: &CardanoStakeDistributionListItemMessage| a.hash.clone(),
             &self.context,
             aggregator,
+            |a| a.epoch >= expected_epoch_min,
+            |last_invalid_artifact| {
+                format!(
+                    "no Cardano stake distribution found with epoch >= {expected_epoch_min}\nlast artifact: {last_invalid_artifact:?}"
+                )
+            },
         )
         .await
-    }
-
-    pub fn check_artifact(
-        &self,
-        artifact: &CardanoStakeDistributionListItemMessage,
-        expected_epoch_min: Epoch,
-    ) -> StdResult<()> {
-        utils::assert_minimal_epoch(artifact, |a| a.epoch, expected_epoch_min)
     }
 
     pub async fn verify_with_client(

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_transactions.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/cardano_transactions.rs
@@ -34,8 +34,7 @@ impl CheckCardanoTransactionsToolkit {
     ) -> StdResult<()> {
         let certificate_toolkit = CheckCertificateToolkit::new(self.context.clone());
 
-        let artifact = self.wait_for_artifact(aggregator).await?;
-        self.check_artifact(&artifact, expected_epoch_min)?;
+        let artifact = self.wait_for_artifact(aggregator, expected_epoch_min).await?;
         certificate_toolkit
             .is_creating_certificate_with_enough_signers(
                 aggregator,
@@ -51,23 +50,22 @@ impl CheckCardanoTransactionsToolkit {
     pub async fn wait_for_artifact(
         &self,
         aggregator: &Aggregator,
+        expected_epoch_min: Epoch,
     ) -> StdResult<CardanoTransactionSnapshotListItemMessage> {
-        utils::wait_for_latest_artifact::<CardanoTransactionSnapshotListItemMessage>(
+        utils::wait_for_latest_artifact_with_condition(
             "Cardano transactions",
             "/artifact/cardano-transactions",
-            |a| a.hash.clone(),
+            |a: &CardanoTransactionSnapshotListItemMessage| a.hash.clone(),
             &self.context,
             aggregator,
+            |a| a.epoch >= expected_epoch_min,
+            |last_invalid_artifact| {
+                format!(
+                    "no Cardano transactions found with epoch >= {expected_epoch_min}\nlast artifact: {last_invalid_artifact:?}"
+                )
+            },
         )
         .await
-    }
-
-    pub fn check_artifact(
-        &self,
-        artifact: &CardanoTransactionSnapshotListItemMessage,
-        expected_epoch_min: Epoch,
-    ) -> StdResult<()> {
-        utils::assert_minimal_epoch(artifact, |a| a.epoch, expected_epoch_min)
     }
 
     pub async fn verify_with_client(

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
@@ -7,7 +7,7 @@ use mithril_common::{
     messages::{CertificateListItemMessage, CertificateMessage},
 };
 
-use crate::{Aggregator, attempt, toolkit::ScenarioToolkitContext, utils::AttemptResult};
+use crate::{Aggregator, poll_until, toolkit::ScenarioToolkitContext, utils::AttemptResult};
 
 use super::utils;
 
@@ -58,9 +58,11 @@ impl CheckCertificateToolkit {
             }
         }
 
-        match attempt!(10, self.context.tenth_epoch_delay(), {
-            fetch_certificate_message(url.clone()).await
-        }) {
+        match poll_until!(
+            self.context.artifact_production_timeout(),
+            self.context.poll_backoff(),
+            { fetch_certificate_message(url.clone()).await }
+        ) {
             AttemptResult::Ok(certificate) => {
                 info!("Aggregator produced a certificate"; "certificate" => ?certificate);
                 if certificate.metadata.signers.len() == total_signers_expected {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/mithril_stake_distribution.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/mithril_stake_distribution.rs
@@ -30,8 +30,7 @@ impl CheckMithrilStakeDistributionToolkit {
     ) -> StdResult<()> {
         let certificate_toolkit = CheckCertificateToolkit::new(self.context.clone());
 
-        let artifact = self.wait_for_artifact(aggregator).await?;
-        self.check_artifact(&artifact, expected_epoch_min)?;
+        let artifact = self.wait_for_artifact(aggregator, expected_epoch_min).await?;
         certificate_toolkit
             .is_creating_certificate_with_enough_signers(
                 aggregator,
@@ -47,23 +46,22 @@ impl CheckMithrilStakeDistributionToolkit {
     pub async fn wait_for_artifact(
         &self,
         aggregator: &Aggregator,
+        expected_epoch_min: Epoch,
     ) -> StdResult<MithrilStakeDistributionListItemMessage> {
-        utils::wait_for_latest_artifact::<MithrilStakeDistributionListItemMessage>(
+        utils::wait_for_latest_artifact_with_condition(
             "Mithril stake distribution",
             "/artifact/mithril-stake-distributions",
-            |a| a.hash.clone(),
+            |a: &MithrilStakeDistributionListItemMessage| a.hash.clone(),
             &self.context,
             aggregator,
+            |a| a.epoch >= expected_epoch_min,
+            |last_invalid_artifact| {
+                format!(
+                    "no Mithril stake distribution found with epoch >= {expected_epoch_min}\nlast artifact: {last_invalid_artifact:?}"
+                )
+            },
         )
         .await
-    }
-
-    pub fn check_artifact(
-        &self,
-        artifact: &MithrilStakeDistributionListItemMessage,
-        expected_epoch_min: Epoch,
-    ) -> StdResult<()> {
-        utils::assert_minimal_epoch(artifact, |a| a.epoch, expected_epoch_min)
     }
 
     pub async fn verify_with_client(&self, client: &mut Client, hash: &str) -> StdResult<()> {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
@@ -3,7 +3,7 @@ use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 use slog_scope::info;
 
-use mithril_common::{StdResult, entities::Epoch};
+use mithril_common::StdResult;
 
 use crate::utils::TimeoutReason;
 use crate::{Aggregator, attempt, toolkit::ScenarioToolkitContext, utils::AttemptResult};
@@ -19,28 +19,6 @@ pub async fn get_json_response<T: DeserializeOwned>(url: String) -> StdResult<re
         }
         Err(err) => Err(anyhow!(err).context(format!("Request to `{url}` failed"))),
     }
-}
-
-/// Wait until the aggregator produces an artifact, returning the latest one
-///
-/// Note: the `artifact_list_url` must start with a `/`
-pub async fn wait_for_latest_artifact<T: DeserializeOwned>(
-    artifact_name: &str,
-    artifact_list_url: &str,
-    hash_extractor: fn(&T) -> String,
-    context: &ScenarioToolkitContext,
-    aggregator: &Aggregator,
-) -> StdResult<T> {
-    wait_for_latest_artifact_with_condition(
-        artifact_name,
-        artifact_list_url,
-        hash_extractor,
-        context,
-        aggregator,
-        |_| true,
-        |_| String::new(),
-    )
-    .await
 }
 
 /// Wait until the aggregator produces an artifact, returning the latest one
@@ -90,17 +68,4 @@ where
         )),
     }
         .with_context(|| format!("Requesting aggregator `{}`", aggregator.name()))
-}
-
-pub fn assert_minimal_epoch<T>(
-    artifact: &T,
-    epoch_extractor: fn(&T) -> Epoch,
-    expected_epoch_min: Epoch,
-) -> StdResult<()> {
-    match epoch_extractor(artifact) {
-        epoch if epoch >= expected_epoch_min => Ok(()),
-        epoch => Err(anyhow!(
-            "Minimum expected artifact epoch not reached: {epoch} < {expected_epoch_min}"
-        )),
-    }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/utils.rs
@@ -6,7 +6,7 @@ use slog_scope::info;
 use mithril_common::StdResult;
 
 use crate::utils::TimeoutReason;
-use crate::{Aggregator, attempt, toolkit::ScenarioToolkitContext, utils::AttemptResult};
+use crate::{Aggregator, poll_until, toolkit::ScenarioToolkitContext, utils::AttemptResult};
 
 pub async fn get_json_response<T: DeserializeOwned>(url: String) -> StdResult<reqwest::Result<T>> {
     match reqwest::get(url.clone()).await {
@@ -52,7 +52,7 @@ where
         }
     }
 
-    match attempt!(20, context.tenth_epoch_delay(), {
+    match poll_until!(context.artifact_production_timeout(), context.poll_backoff(), {
         fetch_last_artifact(artifact_name, url.clone()).await
     }, until &condition) {
         AttemptResult::Ok(last_artifact) => {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
@@ -69,9 +69,9 @@ impl AttemptPolicy {
         ))
     }
 
-    /// Returns a timeout covering the given number of epochs, saturating at [`Duration::MAX`].
+    /// Returns a timeout covering the given number of epochs.
     pub fn timeout_for_epochs(self, epochs: u32) -> Duration {
-        self.epoch_duration.checked_mul(epochs).unwrap_or(Duration::MAX)
+        self.epoch_duration * epochs
     }
 }
 
@@ -94,13 +94,6 @@ mod tests {
         assert_eq!(policy.timeout_for_epochs(0), Duration::from_secs(0));
         assert_eq!(policy.timeout_for_epochs(1), Duration::from_secs(10));
         assert_eq!(policy.timeout_for_epochs(5), Duration::from_secs(50));
-    }
-
-    #[test]
-    fn timeout_for_epochs_saturates_on_overflow() {
-        let policy = AttemptPolicy::new(Duration::MAX);
-
-        assert_eq!(policy.timeout_for_epochs(2), Duration::MAX);
     }
 
     #[test]

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
@@ -1,15 +1,22 @@
 use std::time::Duration;
 
+use crate::utils::Backoff;
+
+/// Context shared across scenario toolkits, carrying the polling policy derived from the Cardano
+/// epoch duration.
 #[derive(Debug, Clone)]
 pub struct ScenarioToolkitContext {
+    /// Policy used to derive polling timeouts from the epoch duration.
     attempt_policy: AttemptPolicy,
 }
 
 impl ScenarioToolkitContext {
+    /// Builds a context from the given attempt policy.
     pub fn new(attempt_policy: AttemptPolicy) -> Self {
         Self { attempt_policy }
     }
 
+    /// Builds a context from the Cardano slot length and number of slots per epoch.
     pub fn new_from_cardano_epoch(slot_length_in_s: f64, number_of_slot_per_epoch: f64) -> Self {
         Self {
             attempt_policy: AttemptPolicy::from_cardano_epoch(
@@ -19,43 +26,52 @@ impl ScenarioToolkitContext {
         }
     }
 
-    pub fn attempt_policy(&self) -> AttemptPolicy {
-        self.attempt_policy
+    /// Backoff spacing out polling attempts while waiting for a condition.
+    pub fn poll_backoff(&self) -> Backoff {
+        Backoff::default()
     }
 
-    pub fn tenth_epoch_delay(&self) -> Duration {
-        self.attempt_policy.delay(0.10)
+    /// Timeout covering the given number of Cardano epochs.
+    pub fn timeout_for_epochs(&self, epochs: u32) -> Duration {
+        self.attempt_policy.timeout_for_epochs(epochs)
     }
 
-    pub fn half_epoch_delay(&self) -> Duration {
-        self.attempt_policy.delay(0.5)
+    /// Timeout to wait for the aggregator to produce a signed artifact once it is running.
+    pub fn artifact_production_timeout(&self) -> Duration {
+        self.timeout_for_epochs(1)
     }
 
-    pub fn full_epoch_delay(&self) -> Duration {
-        self.attempt_policy.epoch_duration
+    /// Timeout to wait for the devnet and aggregator to become ready during startup.
+    pub fn startup_readiness_timeout(&self) -> Duration {
+        self.timeout_for_epochs(10)
     }
 }
 
+/// Policy deriving polling timeouts from the Cardano epoch duration.
 #[derive(Debug, Clone, Copy)]
 pub struct AttemptPolicy {
+    /// Wall-clock duration of a single Cardano epoch.
     epoch_duration: Duration,
 }
 
 impl AttemptPolicy {
+    /// Builds a policy from the given epoch duration.
     pub const fn new(base_duration: Duration) -> Self {
         Self {
             epoch_duration: base_duration,
         }
     }
 
+    /// Builds a policy from the Cardano slot length and number of slots per epoch.
     pub fn from_cardano_epoch(slot_length_in_s: f64, number_of_slot_per_epoch: f64) -> Self {
         Self::new(Duration::from_secs_f64(
             slot_length_in_s * number_of_slot_per_epoch,
         ))
     }
 
-    pub fn delay(self, multiplier: f32) -> Duration {
-        self.epoch_duration.mul_f32(multiplier)
+    /// Returns a timeout covering the given number of epochs, saturating at [`Duration::MAX`].
+    pub fn timeout_for_epochs(self, epochs: u32) -> Duration {
+        self.epoch_duration.checked_mul(epochs).unwrap_or(Duration::MAX)
     }
 }
 
@@ -72,9 +88,32 @@ mod tests {
     }
 
     #[test]
-    fn delay_calculation() {
+    fn timeout_for_epochs_scales_with_epoch_duration() {
         let policy = AttemptPolicy::new(Duration::from_secs(10));
-        assert_eq!(policy.delay(0.5), Duration::from_secs(5));
-        assert_eq!(policy.delay(2.0), Duration::from_secs(20));
+
+        assert_eq!(policy.timeout_for_epochs(0), Duration::from_secs(0));
+        assert_eq!(policy.timeout_for_epochs(1), Duration::from_secs(10));
+        assert_eq!(policy.timeout_for_epochs(5), Duration::from_secs(50));
+    }
+
+    #[test]
+    fn timeout_for_epochs_saturates_on_overflow() {
+        let policy = AttemptPolicy::new(Duration::MAX);
+
+        assert_eq!(policy.timeout_for_epochs(2), Duration::MAX);
+    }
+
+    #[test]
+    fn named_timeouts_cover_expected_epochs() {
+        let context = ScenarioToolkitContext::new(AttemptPolicy::new(Duration::from_secs(10)));
+
+        assert_eq!(
+            context.artifact_production_timeout(),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            context.startup_readiness_timeout(),
+            Duration::from_secs(100)
+        );
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/exec.rs
@@ -111,6 +111,12 @@ impl ExecToolkit {
                 m: 10,
                 phi_f: 0.95,
             },
+            // The IVC parameters must not change as this means a new genesis certificate must be created.
+            AggregateSignatureType::IvcSnark => ProtocolParameters {
+                k: 5,
+                m: 9,
+                phi_f: 0.95,
+            },
         };
 
         info!(

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
@@ -13,7 +13,8 @@ pub struct WaitToolkit {
 }
 
 impl WaitToolkit {
-    /// Extra epoch added on top of the epochs remaining until the target epoch.
+    /// Extra epoch of timeout margin on top of the number of epochs remaining until the target,
+    /// so block-production and chain-observation jitter near the boundary does not trip the deadline.
     const TARGET_EPOCH_SLACK: u64 = 1;
 
     pub fn new(context: ScenarioToolkitContext) -> Self {
@@ -110,10 +111,7 @@ impl WaitToolkit {
             .ok()
             .flatten()
             .unwrap_or(Epoch(0));
-        let epochs_to_wait =
-            (*target_epoch).saturating_sub(*current_epoch) + Self::TARGET_EPOCH_SLACK;
-        let epochs_to_wait = u32::try_from(epochs_to_wait)
-            .with_context(|| format!("Number of epochs to wait is too large: {epochs_to_wait}"))?;
+        let epochs_to_wait = Self::compute_number_of_epochs_to_wait(target_epoch, current_epoch);
         let timeout = self.context.timeout_for_epochs(epochs_to_wait);
 
         match poll_until!(timeout, self.context.poll_backoff(), {
@@ -144,5 +142,12 @@ impl WaitToolkit {
         }?;
 
         Ok(())
+    }
+
+    /// Number of epochs to wait for the chain to reach `target_epoch` from `current_epoch`,
+    /// including the target epoch slack.
+    fn compute_number_of_epochs_to_wait(target_epoch: Epoch, current_epoch: Epoch) -> u32 {
+        let epochs_to_wait = target_epoch - current_epoch + Self::TARGET_EPOCH_SLACK;
+        u32::try_from(*epochs_to_wait).expect("Number of epochs to wait should fit in a u32")
     }
 }

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
@@ -5,7 +5,7 @@ use slog_scope::{info, warn};
 use mithril_cardano_node_internal_database::entities::ImmutableFile;
 use mithril_common::{StdResult, entities::Epoch, messages::EpochSettingsMessage};
 
-use crate::{Aggregator, attempt, toolkit::ScenarioToolkitContext, utils::AttemptResult};
+use crate::{Aggregator, poll_until, toolkit::ScenarioToolkitContext, utils::AttemptResult};
 
 #[derive(Debug, Clone)]
 pub struct WaitToolkit {
@@ -13,6 +13,9 @@ pub struct WaitToolkit {
 }
 
 impl WaitToolkit {
+    /// Extra epoch added on top of the epochs remaining until the target epoch.
+    const TARGET_EPOCH_SLACK: u64 = 1;
+
     pub fn new(context: ScenarioToolkitContext) -> Self {
         Self { context }
     }
@@ -21,20 +24,24 @@ impl WaitToolkit {
         info!("Waiting that enough immutable have been written in the devnet"; "aggregator" => aggregator.name());
 
         let db_directory = aggregator.db_directory();
-        match attempt!(20, self.context.half_epoch_delay(), {
-            match ImmutableFile::list_completed_in_dir(db_directory)
-                .with_context(|| {
-                    format!(
-                        "Immutable file listing failed in dir `{}`",
-                        db_directory.display(),
-                    )
-                })?
-                .last()
+        match poll_until!(
+            self.context.startup_readiness_timeout(),
+            self.context.poll_backoff(),
             {
-                Some(_) => Ok(Some(())),
-                None => Ok(None),
+                match ImmutableFile::list_completed_in_dir(db_directory)
+                    .with_context(|| {
+                        format!(
+                            "Immutable file listing failed in dir `{}`",
+                            db_directory.display(),
+                        )
+                    })?
+                    .last()
+                {
+                    Some(_) => Ok(Some(())),
+                    None => Ok(None),
+                }
             }
-        }) {
+        ) {
             AttemptResult::Ok(_) => Ok(()),
             AttemptResult::Err(error) => Err(error),
             AttemptResult::Timeout(..) => Err(anyhow!(
@@ -52,26 +59,30 @@ impl WaitToolkit {
         let url = format!("{aggregator_endpoint}/epoch-settings");
         info!("Waiting for the aggregator to expose epoch settings"; "aggregator" => aggregator.name());
 
-        match attempt!(20, self.context.half_epoch_delay(), {
-            match reqwest::get(url.clone()).await {
-                Ok(response) => match response.status() {
-                    StatusCode::OK => {
-                        let epoch_settings = response
-                            .json::<EpochSettingsMessage>()
-                            .await
-                            .with_context(|| "Invalid EpochSettings body")?;
-                        info!("Aggregator ready"; "epoch_settings"  => ?epoch_settings);
-                        Ok(Some(epoch_settings))
-                    }
-                    s if s.is_server_error() => {
-                        warn!( "Server error while waiting for the Aggregator, http code: {s}"; "aggregator" => aggregator.name());
-                        Ok(None)
-                    }
-                    _ => Ok(None),
-                },
-                Err(_) => Ok(None),
+        match poll_until!(
+            self.context.startup_readiness_timeout(),
+            self.context.poll_backoff(),
+            {
+                match reqwest::get(url.clone()).await {
+                    Ok(response) => match response.status() {
+                        StatusCode::OK => {
+                            let epoch_settings = response
+                                .json::<EpochSettingsMessage>()
+                                .await
+                                .with_context(|| "Invalid EpochSettings body")?;
+                            info!("Aggregator ready"; "epoch_settings"  => ?epoch_settings);
+                            Ok(Some(epoch_settings))
+                        }
+                        s if s.is_server_error() => {
+                            warn!( "Server error while waiting for the Aggregator, http code: {s}"; "aggregator" => aggregator.name());
+                            Ok(None)
+                        }
+                        _ => Ok(None),
+                    },
+                    Err(_) => Ok(None),
+                }
             }
-        }) {
+        ) {
             AttemptResult::Ok(epoch_settings) => Ok(epoch_settings),
             AttemptResult::Err(error) => Err(error),
             AttemptResult::Timeout(..) => Err(anyhow!(
@@ -92,7 +103,20 @@ impl WaitToolkit {
             "target_epoch" => ?target_epoch
         );
 
-        match attempt!(90, self.context.half_epoch_delay(), {
+        let current_epoch = aggregator
+            .chain_observer()
+            .get_current_epoch()
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or(Epoch(0));
+        let epochs_to_wait =
+            (*target_epoch).saturating_sub(*current_epoch) + Self::TARGET_EPOCH_SLACK;
+        let epochs_to_wait = u32::try_from(epochs_to_wait)
+            .with_context(|| format!("Number of epochs to wait is too large: {epochs_to_wait}"))?;
+        let timeout = self.context.timeout_for_epochs(epochs_to_wait);
+
+        match poll_until!(timeout, self.context.poll_backoff(), {
             match aggregator
                 .chain_observer()
                 .get_current_epoch()

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mod.rs
@@ -11,7 +11,7 @@ pub use compatibility_checker::*;
 pub use formatting::*;
 pub use immutable_files_utils::*;
 pub use mithril_command::MithrilCommand;
-pub use spec_utils::{AttemptResult, TimeoutReason};
+pub use spec_utils::{AttemptResult, Backoff, TimeoutReason};
 pub use version_req::NodeVersion;
 
 pub fn is_running_in_github_actions() -> bool {

--- a/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/spec_utils.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 #[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
 pub enum AttemptResult<T, E> {
     Ok(T),
@@ -14,10 +16,57 @@ pub enum TimeoutReason<T> {
     PredicateNotSatisfied(T),
 }
 
+/// Exponential backoff bounded between a floor and a ceiling, used to space out polling attempts.
+#[derive(Debug, Clone, Copy)]
+pub struct Backoff {
+    /// Delay returned by the next call to [`Backoff::next_delay`].
+    current: Duration,
+    /// Maximum delay the backoff grows to.
+    max: Duration,
+    /// Factor applied to the delay after each attempt.
+    factor: u32,
+}
+
+impl Backoff {
+    /// Floor of the polling delay.
+    const DEFAULT_MIN: Duration = Duration::from_secs(1);
+    /// Ceiling of the polling delay.
+    const DEFAULT_MAX: Duration = Duration::from_secs(30);
+    /// Growth factor applied after each attempt.
+    const DEFAULT_FACTOR: u32 = 2;
+
+    /// Builds a backoff growing from `min` to `max` by the given `factor`.
+    ///
+    /// A `factor` of `0` is treated as `1` so the delay never collapses to zero.
+    pub const fn new(min: Duration, max: Duration, factor: u32) -> Self {
+        Self {
+            current: min,
+            max,
+            factor: if factor == 0 { 1 } else { factor },
+        }
+    }
+
+    /// Returns the current delay, then grows it toward the ceiling.
+    pub fn next_delay(&mut self) -> Duration {
+        let delay = self.current;
+        self.current = (self.current * self.factor).min(self.max);
+        delay
+    }
+}
+
+impl Default for Backoff {
+    fn default() -> Self {
+        Self::new(Self::DEFAULT_MIN, Self::DEFAULT_MAX, Self::DEFAULT_FACTOR)
+    }
+}
+
+/// Polls `$block` until it satisfies `$predicate` or `$timeout` elapses, sleeping between attempts
+/// according to `$backoff`.
 #[macro_export]
-macro_rules! attempt {
-    ( $remaining_attempts:expr, $sleep_duration:expr, $block:block, until $predicate:expr ) => {{
-        let mut remaining_attempts = $remaining_attempts;
+macro_rules! poll_until {
+    ( $timeout:expr, $backoff:expr, $block:block, until $predicate:expr ) => {{
+        let deadline = tokio::time::Instant::now() + $timeout;
+        let mut backoff = $backoff;
         let mut last_received_response = None;
 
         loop {
@@ -35,48 +84,50 @@ macro_rules! attempt {
                 Err(error) => break $crate::utils::AttemptResult::Err(error),
             }
 
-            if remaining_attempts > 1 {
-                tokio::time::sleep($sleep_duration).await;
-                remaining_attempts -= 1;
-                continue;
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                break match last_received_response {
+                    Some(value) => $crate::utils::AttemptResult::Timeout(
+                        $crate::utils::TimeoutReason::PredicateNotSatisfied(value),
+                    ),
+                    None => $crate::utils::AttemptResult::Timeout(
+                        $crate::utils::TimeoutReason::NoResponse,
+                    ),
+                };
             }
 
-            break match last_received_response {
-                Some(value) => $crate::utils::AttemptResult::Timeout(
-                    $crate::utils::TimeoutReason::PredicateNotSatisfied(value),
-                ),
-                None => {
-                    $crate::utils::AttemptResult::Timeout($crate::utils::TimeoutReason::NoResponse)
-                }
-            };
+            tokio::time::sleep(backoff.next_delay().min(deadline - now)).await;
         }
     }};
-    ( $remaining_attempts:expr, $sleep_duration:expr, $block:block ) => {{
-        $crate::attempt!(
-            $remaining_attempts,
-            $sleep_duration,
-            $block,
-            until | _ | true
-        )
-    }};
+    ( $timeout:expr, $backoff:expr, $block:block ) => {{ $crate::poll_until!($timeout, $backoff, $block, until | _ | true) }};
 }
 
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
-    use tokio::time::Instant;
 
     use super::*;
 
     const EMPTY_RESULT: Result<Option<()>, String> = Ok(None);
 
+    #[test]
+    fn backoff_grows_until_ceiling() {
+        let mut backoff = Backoff::new(Duration::from_secs(1), Duration::from_secs(8), 2);
+
+        assert_eq!(backoff.next_delay(), Duration::from_secs(1));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(2));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(4));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(8));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(8));
+    }
+
     #[tokio::test]
-    async fn returns_ok_value() {
+    async fn poll_until_returns_ok_value() {
         let expected = "correct";
 
         assert_eq!(
             AttemptResult::Ok(expected),
-            attempt!(1, Duration::from_millis(2), {
+            poll_until!(Duration::from_millis(50), Backoff::default(), {
                 let result: Result<Option<&str>, String> = Ok(Some(expected));
                 result
             })
@@ -84,29 +135,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn returns_ok_when_response_satisfies_predicate() {
-        assert_eq!(
-            AttemptResult::Ok(42),
-            attempt!(
-                3,
-                Duration::from_millis(2),
-                {
-                    let result: Result<Option<i32>, String> = Ok(Some(42));
-                    result
-                },
-                until |value: &i32| *value == 42
-            )
-        );
-    }
-
-    #[tokio::test]
-    async fn retries_until_response_satisfies_predicate() {
+    async fn poll_until_retries_until_predicate_satisfied() {
         let mut attempt_count = 0;
+
         assert_eq!(
             AttemptResult::Ok(3),
-            attempt!(
-                5,
-                Duration::from_millis(2),
+            poll_until!(
+                Duration::from_millis(500),
+                Backoff::new(Duration::from_millis(1), Duration::from_millis(1), 1),
                 {
                     attempt_count += 1;
                     let result: Result<Option<i32>, String> = Ok(Some(attempt_count));
@@ -118,72 +154,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn timeout_is_no_response_when_no_value_was_received() {
+    async fn poll_until_times_out_when_no_value_received() {
         assert_eq!(
             AttemptResult::Timeout(TimeoutReason::NoResponse),
-            attempt!(1, Duration::from_millis(2), { EMPTY_RESULT })
-        );
-    }
-
-    #[tokio::test]
-    async fn timeout_when_no_response_satisfies_predicate() {
-        let mut attempt_count = 0;
-        assert_eq!(
-            AttemptResult::Timeout(TimeoutReason::PredicateNotSatisfied(3)),
-            attempt!(
-                3,
-                Duration::from_millis(2),
-                {
-                    attempt_count += 1;
-                    let result: Result<Option<i32>, String> = Ok(Some(attempt_count));
-                    result
-                },
-                until | _ | false
+            poll_until!(
+                Duration::from_millis(5),
+                Backoff::new(Duration::from_millis(1), Duration::from_millis(1), 1),
+                { EMPTY_RESULT }
             )
         );
     }
 
     #[tokio::test]
-    async fn returns_after_error() {
+    async fn poll_until_times_out_with_last_response_when_predicate_unsatisfied() {
+        let result = poll_until!(
+            Duration::from_millis(5),
+            Backoff::new(Duration::from_millis(1), Duration::from_millis(1), 1),
+            {
+                let result: Result<Option<i32>, String> = Ok(Some(42));
+                result
+            },
+            until | _ | false
+        );
+
+        assert!(matches!(
+            result,
+            AttemptResult::Timeout(TimeoutReason::PredicateNotSatisfied(42))
+        ));
+    }
+
+    #[tokio::test]
+    async fn poll_until_returns_after_error() {
         assert_eq!(
             AttemptResult::Err("test error".to_string()),
-            attempt!(1, Duration::from_millis(2), {
+            poll_until!(Duration::from_millis(50), Backoff::default(), {
                 let err_result: Result<Option<()>, String> = Err("test error".to_string());
                 err_result
             })
         );
     }
 
-    #[tokio::test]
-    async fn do_the_expected_number_of_loop() {
-        let expected_number_of_loop = 5;
-        let mut number_of_loop = 0;
+    #[test]
+    fn backoff_zero_factor_does_not_collapse_delay() {
+        let mut backoff = Backoff::new(Duration::from_secs(1), Duration::from_secs(8), 0);
 
-        assert_eq!(
-            AttemptResult::Timeout(TimeoutReason::NoResponse),
-            attempt!(expected_number_of_loop, Duration::from_millis(2), {
-                number_of_loop += 1;
-                EMPTY_RESULT
-            })
-        );
-        assert_eq!(expected_number_of_loop, number_of_loop);
+        assert_eq!(backoff.next_delay(), Duration::from_secs(1));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(1));
     }
 
     #[tokio::test]
-    async fn wait_for_the_expected_time() {
-        let now = Instant::now();
+    async fn poll_until_does_not_sleep_past_the_deadline() {
+        let start = std::time::Instant::now();
 
-        assert_eq!(
-            AttemptResult::Timeout(TimeoutReason::NoResponse),
-            // Note: the attempt! macro wait only after the first loop so we must attempt to two times
-            // to have it wait its given duration once.
-            attempt!(2, Duration::from_millis(10), { EMPTY_RESULT })
+        let _: AttemptResult<(), String> = poll_until!(
+            Duration::from_millis(5),
+            Backoff::new(Duration::from_secs(10), Duration::from_secs(10), 1),
+            { EMPTY_RESULT }
         );
 
-        let elapsed = now.elapsed().as_millis();
-        assert!(
-            (10..=30).contains(&elapsed),
-            "Failure, after one loop the elapsed time was not ~10ms, elapsed: {elapsed}"
-        );
+        assert!(start.elapsed() < Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
## Content

This PR includes the **support for IVC Snark proofs and several enhancements to the end to end tests**:

- Add support for the `IvcSnark` aggregate signature type.
- Replace the fixed attempt count `attempt!` polling with a deadline-based `poll_until!` macro that decouples the polling interval (bounded exponential backoff) from the total timeout, keeping detection responsive on long epochs.
- Make the artifact checks (Mithril/Cardano stake distributions, Cardano transactions, Cardano blocks transactions, and Cardano database) poll until an artifact reaches the expected epoch instead of asserting once on the latest one.
- Derive the target epoch wait timeout from the actual epoch gap plus a fixed slack, rather than a fixed number of attempts.
- Tune the minimal scenario timing: run genesis earlier and adjust the epoch waits around genesis certificate creation.
- Improve the startup display of the CLI arguments.
- Remove the now dead helpers left by the refactor (the `attempt!` macro and its tests, `assert_minimal_epoch`, and the condition-less `wait_for_latest_artifact`).

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3142
