### PR TITLE
refactor(stm): rename recursive-circuit backend aliases to meaningful names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,7 +4651,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.44"
+version = "0.10.45"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.44", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.45", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.45 (07-07-2026)
+
+### Changed
+
+- Renamed the recursive (IVC) circuit's Midnight backend type aliases to meaningful names
+
 ## 0.10.44 (07-06-2026)
 
 ### Changed

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.44"
+version = "0.10.45"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2/keys.rs
+++ b/mithril-stm/src/circuits/halo2/keys.rs
@@ -9,7 +9,7 @@ use midnight_zk_stdlib::{self as zk, MidnightCircuit, MidnightPK, MidnightVK};
 use serde::{Deserialize, Serialize};
 
 use crate::StmResult;
-use crate::circuits::halo2_ivc::{E, F, KZGCommitmentScheme, VerifyingKey};
+use crate::circuits::halo2_ivc::{KZGCommitmentScheme, NativeField, PairingEngine, VerifyingKey};
 use crate::circuits::key_generator::KeyGenerator;
 use crate::codec::{TryFromBytes, TryToBytes};
 
@@ -37,8 +37,10 @@ impl NonRecursiveCircuitVerifyingKey {
     }
 }
 
-impl AsRef<VerifyingKey<F, KZGCommitmentScheme<E>>> for NonRecursiveCircuitVerifyingKey {
-    fn as_ref(&self) -> &VerifyingKey<F, KZGCommitmentScheme<E>> {
+impl AsRef<VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>>
+    for NonRecursiveCircuitVerifyingKey
+{
+    fn as_ref(&self) -> &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
         self.0.vk()
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/certificate_proof.rs
@@ -21,7 +21,7 @@ use crate::{
     StmResult,
     circuits::{
         halo2::types::CircuitBase,
-        halo2_ivc::{E, F, VerifyingKey, errors::IvcCircuitError},
+        halo2_ivc::{NativeField, PairingEngine, VerifyingKey, errors::IvcCircuitError},
     },
 };
 
@@ -39,7 +39,7 @@ use crate::{
 pub(crate) fn verify_and_prepare_accumulator(
     proof_bytes: &[u8],
     public_inputs: &[CircuitBase],
-    circuit_verification_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    circuit_verification_key: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
     verifier_params: &ParamsVerifierKZG<Bls12>,
 ) -> StmResult<DualMSM<Bls12>> {
     let mut transcript =

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -4,10 +4,11 @@ use crate::circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey;
 use anyhow::anyhow;
 
 use super::{
-    Accumulator, BinaryInstructions, C, Circuit, ComposableChip, ConstraintSystem, Error,
-    EvaluationDomain, F, Layouter, NB_ARITH_COLS, NB_ARITH_FIXED_COLS, NB_EDWARDS_COLS,
-    NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS,
-    NG, PublicInputInstructions, RECURSIVE_CIRCUIT_DEGREE, S, SimpleFloorPlanner, Value,
+    Accumulator, BinaryInstructions, Circuit, ComposableChip, ConstraintSystem, EmulatedCurve,
+    Error, EvaluationDomain, IvcNativeGadget, Layouter, NB_ARITH_COLS, NB_ARITH_FIXED_COLS,
+    NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_ADVICE_COLS,
+    NB_SHA256_FIXED_COLS, NativeField, PublicInputInstructions, RECURSIVE_CIRCUIT_DEGREE,
+    RecursiveEmulation, SimpleFloorPlanner, Value,
     config::{IvcConfig, configure_ivc_circuit, ivc_column_pool_sizes},
     errors::IvcCircuitError,
     gadget::IvcGadget,
@@ -34,11 +35,13 @@ pub struct IvcCircuitData {
     // Latest IVC proof
     ivc_proof: Value<Vec<u8>>,
     // Latest Accumulator
-    acc: Value<Accumulator<S>>,
+    acc: Value<Accumulator<RecursiveEmulation>>,
     // Domain and ConstraintSystem associated with certificate circuit VerifyingKey
-    certificate_circuit_domain_and_constraint_system: (EvaluationDomain<F>, ConstraintSystem<F>),
+    certificate_circuit_domain_and_constraint_system:
+        (EvaluationDomain<NativeField>, ConstraintSystem<NativeField>),
     // Domain and ConstraintSystem associated with IVC circuit VerifyingKey
-    ivc_circuit_domain_and_constraint_system: (EvaluationDomain<F>, ConstraintSystem<F>),
+    ivc_circuit_domain_and_constraint_system:
+        (EvaluationDomain<NativeField>, ConstraintSystem<NativeField>),
 }
 
 impl IvcCircuitData {
@@ -70,7 +73,8 @@ impl IvcCircuitData {
             NB_EDWARDS_COLS,
             NB_POSEIDON_ADVICE_COLS,
             NB_SHA256_ADVICE_COLS,
-            nb_foreign_ecc_chip_columns::<F, C, C, NG>(),
+            nb_foreign_ecc_chip_columns::<NativeField, EmulatedCurve, EmulatedCurve, IvcNativeGadget>(
+            ),
         ] {
             if needed > nb_advice_cols {
                 return Err(anyhow!(IvcCircuitError::InsufficientAdviceColumns {
@@ -108,7 +112,7 @@ impl IvcCircuitData {
         witness: Witness,
         certificate_proof: CertificateProofBytes,
         ivc_proof: IvcProofBytes,
-        acc: Accumulator<S>,
+        acc: Accumulator<RecursiveEmulation>,
         certificate_verification_key: &NonRecursiveCircuitVerifyingKey,
         ivc_verification_key: &RecursiveCircuitVerifyingKey,
     ) -> StmResult<Self> {
@@ -163,7 +167,7 @@ impl IvcCircuitData {
     }
 }
 
-impl Circuit<F> for IvcCircuitData {
+impl Circuit<NativeField> for IvcCircuitData {
     type Config = IvcConfig;
     type FloorPlanner = SimpleFloorPlanner;
     type Params = ();
@@ -185,14 +189,14 @@ impl Circuit<F> for IvcCircuitData {
         }
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystem<NativeField>) -> Self::Config {
         configure_ivc_circuit(meta)
     }
 
     fn synthesize(
         &self,
         config: Self::Config,
-        mut layouter: impl Layouter<F>,
+        mut layouter: impl Layouter<NativeField>,
     ) -> Result<(), Error> {
         let ivc_gadget = IvcGadget::new(&config);
 
@@ -254,7 +258,7 @@ mod tests {
 
     #[test]
     fn ivc_circuit_constraint_count() {
-        let mut cs = ConstraintSystem::<F>::default();
+        let mut cs = ConstraintSystem::<NativeField>::default();
         configure_ivc_circuit(&mut cs);
 
         let poly_constraints: usize = cs.gates().iter().map(|g| g.polynomials().len()).sum();

--- a/mithril-stm/src/circuits/halo2_ivc/config.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/config.rs
@@ -1,9 +1,9 @@
 use super::{
-    C, CBase, ComposableChip, ConstraintSystem, EccChip, EccConfig, F, FieldChip, ForeignEccChip,
-    ForeignEccConfig, Jubjub, NB_ARITH_COLS, NB_ARITH_FIXED_COLS, NB_EDWARDS_COLS,
-    NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, NG, NativeChip, NativeConfig,
-    P2RDecompositionChip, P2RDecompositionConfig, PoseidonChip, PoseidonConfig, Pow2RangeChip,
-    nb_foreign_ecc_chip_columns,
+    ComposableChip, ConstraintSystem, EccChip, EccConfig, EmulatedCurve, EmulatedCurveBaseField,
+    FieldChip, ForeignEccChip, ForeignEccConfig, IvcNativeGadget, Jubjub, NB_ARITH_COLS,
+    NB_ARITH_FIXED_COLS, NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS,
+    NativeChip, NativeConfig, NativeField, P2RDecompositionChip, P2RDecompositionConfig,
+    PoseidonChip, PoseidonConfig, Pow2RangeChip, nb_foreign_ecc_chip_columns,
 };
 use midnight_circuits::hash::sha256::{
     NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS, Sha256Chip, Sha256Config,
@@ -14,8 +14,8 @@ pub struct IvcConfig {
     pub(crate) native_config: NativeConfig,
     pub(crate) core_decomp_config: P2RDecompositionConfig,
     pub(crate) jubjub_config: EccConfig,
-    pub(crate) bls12_381_config: ForeignEccConfig<C>,
-    pub(crate) poseidon_config: PoseidonConfig<F>,
+    pub(crate) bls12_381_config: ForeignEccConfig<EmulatedCurve>,
+    pub(crate) poseidon_config: PoseidonConfig<NativeField>,
     pub(crate) sha256_config: Sha256Config,
 }
 
@@ -29,7 +29,7 @@ pub(crate) fn ivc_column_pool_sizes() -> (usize, usize) {
         NB_EDWARDS_COLS,
         NB_POSEIDON_ADVICE_COLS,
         NB_SHA256_ADVICE_COLS,
-        nb_foreign_ecc_chip_columns::<F, C, C, NG>(),
+        nb_foreign_ecc_chip_columns::<NativeField, EmulatedCurve, EmulatedCurve, IvcNativeGadget>(),
     ]
     .into_iter()
     .max()
@@ -43,7 +43,7 @@ pub(crate) fn ivc_column_pool_sizes() -> (usize, usize) {
     (nb_advice_cols, nb_fixed_cols)
 }
 
-pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
+pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<NativeField>) -> IvcConfig {
     let (nb_advice_cols, nb_fixed_cols) = ivc_column_pool_sizes();
 
     let advice_columns: Vec<_> = (0..nb_advice_cols).map(|_| meta.advice_column()).collect();
@@ -75,9 +75,19 @@ pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<F>) -> IvcConfig {
             .expect("column counts pre-validated by validate_column_counts"),
     );
 
-    let base_config = FieldChip::<F, CBase, C, NG>::configure(meta, &advice_columns);
-    let bls12_381_config =
-        ForeignEccChip::<F, C, C, NG, NG>::configure(meta, &base_config, &advice_columns);
+    let base_config = FieldChip::<
+        NativeField,
+        EmulatedCurveBaseField,
+        EmulatedCurve,
+        IvcNativeGadget,
+    >::configure(meta, &advice_columns);
+    let bls12_381_config = ForeignEccChip::<
+        NativeField,
+        EmulatedCurve,
+        EmulatedCurve,
+        IvcNativeGadget,
+        IvcNativeGadget,
+    >::configure(meta, &base_config, &advice_columns);
 
     let poseidon_config = PoseidonChip::configure(
         meta,

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -9,14 +9,14 @@ use crate::signature_scheme::DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE;
 use super::{
     Accumulator, ArithInstructions, AssertionInstructions, AssignedAccumulator, AssignedBit,
     AssignedForeignPoint, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignedVk, AssignmentInstructions, BinaryInstructions, C, CERTIFICATE_VERIFICATION_KEY_NAME,
+    AssignedVk, AssignmentInstructions, BinaryInstructions, CERTIFICATE_VERIFICATION_KEY_NAME,
     CircuitCurve, ComposableChip, ConstraintSystem, ControlFlowInstructions,
-    ConversionInstructions, EccChip, EccInstructions, EqualityInstructions, Error,
-    EvaluationDomain, F, ForeignEccChip, HashInstructions, IVC_VERIFICATION_KEY_NAME, Jubjub,
-    Layouter, NG, NativeChip, NativeGadget, P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES,
-    PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
-    PoseidonChip, PublicInputInstructions, RECURSIVE_CIRCUIT_DEGREE, S, Value, VerifierGadget,
-    ZeroInstructions,
+    ConversionInstructions, EccChip, EccInstructions, EmulatedCurve, EqualityInstructions, Error,
+    EvaluationDomain, ForeignEccChip, HashInstructions, IVC_VERIFICATION_KEY_NAME, IvcNativeGadget,
+    Jubjub, Layouter, NativeChip, NativeField, NativeGadget, P2RDecompositionChip,
+    PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions,
+    RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, Value, VerifierGadget, ZeroInstructions,
     config::IvcConfig,
     errors::{IvcCircuitError, to_synthesis_error},
     state::{
@@ -26,29 +26,33 @@ use super::{
 
 #[derive(Debug, Clone)]
 pub struct IvcGadget {
-    pub(crate) core_decomp_chip: P2RDecompositionChip<F>,
-    pub(crate) native_gadget: NG,
+    pub(crate) core_decomp_chip: P2RDecompositionChip<NativeField>,
+    pub(crate) native_gadget: IvcNativeGadget,
     pub(crate) jubjub_chip: EccChip<Jubjub>,
-    pub(crate) poseidon_chip: PoseidonChip<F>,
-    pub(crate) sha2_256_chip: Sha256Chip<F>,
-    pub(crate) bls12_381_chip: ForeignEccChip<F, C, C, NG, NG>,
-    pub(crate) verifier_gadget: VerifierGadget<S>,
+    pub(crate) poseidon_chip: PoseidonChip<NativeField>,
+    pub(crate) sha2_256_chip: Sha256Chip<NativeField>,
+    pub(crate) bls12_381_chip:
+        ForeignEccChip<NativeField, EmulatedCurve, EmulatedCurve, IvcNativeGadget, IvcNativeGadget>,
+    pub(crate) verifier_gadget: VerifierGadget<RecursiveEmulation>,
 }
 
 impl IvcGadget {
     pub fn new(config: &IvcConfig) -> Self {
-        let native_chip = <NativeChip<F> as ComposableChip<F>>::new(&config.native_config, &());
+        let native_chip = <NativeChip<NativeField> as ComposableChip<NativeField>>::new(
+            &config.native_config,
+            &(),
+        );
         let core_decomp_chip = P2RDecompositionChip::new(
             &config.core_decomp_config,
             &(RECURSIVE_CIRCUIT_DEGREE as usize - 1),
         );
         let native_gadget = NativeGadget::new(core_decomp_chip.clone(), native_chip.clone());
         let jubjub_chip = EccChip::<Jubjub>::new(&config.jubjub_config, &native_gadget);
-        let bls12_381_chip: ForeignEccChip<_, C, C, _, _> =
+        let bls12_381_chip: ForeignEccChip<_, EmulatedCurve, EmulatedCurve, _, _> =
             { ForeignEccChip::new(&config.bls12_381_config, &native_gadget, &native_gadget) };
         let poseidon_chip = PoseidonChip::new(&config.poseidon_config, &native_chip);
         let sha2_256_chip = Sha256Chip::new(&config.sha256_config, &native_gadget);
-        let verifier_gadget: VerifierGadget<S> =
+        let verifier_gadget: VerifierGadget<RecursiveEmulation> =
             VerifierGadget::new(&bls12_381_chip, &native_gadget, &poseidon_chip);
 
         IvcGadget {
@@ -64,13 +68,16 @@ impl IvcGadget {
 
     pub fn assign_global_as_public_input(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         global: &Value<Global>,
         certificate_circuit_domain_and_constraint_system: &(
-            EvaluationDomain<F>,
-            ConstraintSystem<F>,
+            EvaluationDomain<NativeField>,
+            ConstraintSystem<NativeField>,
         ),
-        ivc_circuit_domain_and_constraint_system: &(EvaluationDomain<F>, ConstraintSystem<F>),
+        ivc_circuit_domain_and_constraint_system: &(
+            EvaluationDomain<NativeField>,
+            ConstraintSystem<NativeField>,
+        ),
     ) -> Result<AssignedGlobal, Error> {
         let genesis_message: AssignedNative<_> = self.native_gadget.assign_as_public_input(
             layouter,
@@ -86,7 +93,7 @@ impl IvcGadget {
 
         let (certificate_circuit_domain, certificate_circuit_constraint_system) =
             &certificate_circuit_domain_and_constraint_system;
-        let certificate_verification_key: AssignedVk<S> =
+        let certificate_verification_key: AssignedVk<RecursiveEmulation> =
             self.verifier_gadget.assign_vk_as_public_input(
                 layouter,
                 CERTIFICATE_VERIFICATION_KEY_NAME,
@@ -100,15 +107,16 @@ impl IvcGadget {
         // Assign for IVC proof verification
         let (ivc_circuit_domain, ivc_circuit_constraint_system) =
             &ivc_circuit_domain_and_constraint_system;
-        let ivc_verification_key: AssignedVk<S> = self.verifier_gadget.assign_vk_as_public_input(
-            layouter,
-            IVC_VERIFICATION_KEY_NAME,
-            ivc_circuit_domain,
-            ivc_circuit_constraint_system,
-            global
-                .clone()
-                .map(|gl| gl.ivc_circuit_verification_key_representation.as_field()),
-        )?;
+        let ivc_verification_key: AssignedVk<RecursiveEmulation> =
+            self.verifier_gadget.assign_vk_as_public_input(
+                layouter,
+                IVC_VERIFICATION_KEY_NAME,
+                ivc_circuit_domain,
+                ivc_circuit_constraint_system,
+                global
+                    .clone()
+                    .map(|gl| gl.ivc_circuit_verification_key_representation.as_field()),
+            )?;
 
         let fixed_base_names = {
             let mut names = fixed_base_names(
@@ -136,7 +144,7 @@ impl IvcGadget {
 
     pub fn assign_state(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         state: &Value<State>,
     ) -> Result<AssignedState, Error> {
         let values = state
@@ -187,7 +195,7 @@ impl IvcGadget {
 
     pub fn constrain_state_as_public_input(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         state: &AssignedState,
     ) -> Result<(), Error> {
         for value in [
@@ -207,7 +215,7 @@ impl IvcGadget {
 
     pub fn assign_witness(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         witness: &Value<Witness>,
     ) -> Result<AssignedWitness, Error> {
         let genesis_signature = {
@@ -222,7 +230,8 @@ impl IvcGadget {
             (s, c)
         };
 
-        let [certificate_message, certificate_merkle_tree_commitment]: [AssignedNative<F>; 2] = {
+        let [certificate_message, certificate_merkle_tree_commitment]: [AssignedNative<NativeField>;
+            2] = {
             let values = witness
                 .clone()
                 .map(|w| {
@@ -261,9 +270,9 @@ impl IvcGadget {
 
     pub fn is_genesis(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         state: &AssignedState,
-    ) -> Result<AssignedBit<F>, Error> {
+    ) -> Result<AssignedBit<NativeField>, Error> {
         self.native_gadget.is_zero(layouter, &state.step_counter)
     }
 
@@ -275,10 +284,10 @@ impl IvcGadget {
     /// Returns an `AssignedBit` that is `true` when the signature is valid.
     pub fn is_genesis_signature_valid(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         global: &AssignedGlobal,
         witness: &AssignedWitness,
-    ) -> Result<AssignedBit<F>, Error> {
+    ) -> Result<AssignedBit<NativeField>, Error> {
         let s = witness.genesis_signature.0.clone();
         let c_native = witness.genesis_signature.1.clone();
         let c: AssignedScalarOfNativeCurve<_> = self.jubjub_chip.convert(layouter, &c_native)?;
@@ -319,8 +328,8 @@ impl IvcGadget {
 
     pub fn assert_genesis(
         &self,
-        layouter: &mut impl Layouter<F>,
-        is_not_genesis: &AssignedBit<F>,
+        layouter: &mut impl Layouter<NativeField>,
+        is_not_genesis: &AssignedBit<NativeField>,
         global: &AssignedGlobal,
         witness: &AssignedWitness,
     ) -> Result<(), Error> {
@@ -339,9 +348,9 @@ impl IvcGadget {
 
     pub fn global_as_public_input(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         global: &AssignedGlobal,
-    ) -> Result<Vec<AssignedNative<F>>, Error> {
+    ) -> Result<Vec<AssignedNative<NativeField>>, Error> {
         let pi = [
             vec![
                 global.genesis_message.clone(),
@@ -359,31 +368,32 @@ impl IvcGadget {
 
     fn combine_bytes(
         &self,
-        layouter: &mut impl Layouter<F>,
-        bytes: impl IntoIterator<Item = impl Into<AssignedNative<F>>>,
-        bases: &[F],
-    ) -> Result<AssignedNative<F>, Error> {
+        layouter: &mut impl Layouter<NativeField>,
+        bytes: impl IntoIterator<Item = impl Into<AssignedNative<NativeField>>>,
+        bases: &[NativeField],
+    ) -> Result<AssignedNative<NativeField>, Error> {
         let items: Vec<_> = bytes
             .into_iter()
             .zip(bases.iter())
             .map(|(v, base)| (*base, v.into()))
             .collect();
 
-        self.native_gadget.linear_combination(layouter, &items, F::ZERO)
+        self.native_gadget
+            .linear_combination(layouter, &items, NativeField::ZERO)
     }
 
     pub fn transition(
         &self,
-        layouter: &mut impl Layouter<F>,
-        is_genesis: &AssignedBit<F>,
-        is_not_genesis: &AssignedBit<F>,
+        layouter: &mut impl Layouter<NativeField>,
+        is_genesis: &AssignedBit<NativeField>,
+        is_not_genesis: &AssignedBit<NativeField>,
         global: &AssignedGlobal,
         state: &AssignedState,
         witness: &AssignedWitness,
     ) -> Result<AssignedState, Error> {
         let step_counter =
             self.native_gadget
-                .add_constant(layouter, &state.step_counter, F::ONE)?;
+                .add_constant(layouter, &state.step_counter, NativeField::ONE)?;
 
         let (certificate_message, certificate_merkle_tree_commitment) = (
             witness.certificate_message.clone(),
@@ -401,9 +411,9 @@ impl IvcGadget {
 
         let hash = self.sha2_256_chip.hash(layouter, &witness.message_preimage)?;
 
-        let factor = F::from(256u64);
+        let factor = NativeField::from(256u64);
         let bases: Vec<_> = (0..32)
-            .scan(F::ONE, |s, _| {
+            .scan(NativeField::ONE, |s, _| {
                 let out = *s;
                 *s *= factor;
                 Some(out)
@@ -417,7 +427,7 @@ impl IvcGadget {
         }
 
         // If it is genesis, merkle_tree_commitment = 0; otherwise, merkle_tree_commitment = certificate_merkle_tree_commitment.
-        let zero = self.native_gadget.assign_fixed(layouter, F::ZERO)?;
+        let zero = self.native_gadget.assign_fixed(layouter, NativeField::ZERO)?;
         let merkle_tree_commitment = self.native_gadget.select(
             layouter,
             is_genesis,
@@ -455,9 +465,11 @@ impl IvcGadget {
                     .is_equal(layouter, &current_epoch, &state.current_epoch)?;
 
             //  current_epoch == state.current_epoch + 1
-            let next = self
-                .native_gadget
-                .add_constant(layouter, &state.current_epoch, F::ONE)?;
+            let next = self.native_gadget.add_constant(
+                layouter,
+                &state.current_epoch,
+                NativeField::ONE,
+            )?;
             let is_next_epoch = self.native_gadget.is_equal(layouter, &current_epoch, &next)?;
 
             (is_same_epoch, is_next_epoch)
@@ -468,9 +480,11 @@ impl IvcGadget {
             // the current certificate is the first certificate after the genesis and
             // its epoch number must be the next epoch number.
             // Assert true: is_not_first or is_next_epoch
-            let is_first =
-                self.native_gadget
-                    .is_equal_to_fixed(layouter, &state.step_counter, F::ONE)?;
+            let is_first = self.native_gadget.is_equal_to_fixed(
+                layouter,
+                &state.step_counter,
+                NativeField::ONE,
+            )?;
             let is_not_first = self.native_gadget.not(layouter, &is_first)?;
 
             let is_valid = self
@@ -568,17 +582,18 @@ impl IvcGadget {
     #[allow(clippy::too_many_arguments)]
     pub fn verify_prepare(
         &self,
-        layouter: &mut impl Layouter<F>,
+        layouter: &mut impl Layouter<NativeField>,
         global: &AssignedGlobal,
-        is_not_genesis: &AssignedBit<F>,
+        is_not_genesis: &AssignedBit<NativeField>,
         state: &AssignedState,
         witness: &AssignedWitness,
         certificate_proof: &Value<Vec<u8>>,
         ivc_proof: &Value<Vec<u8>>,
-        acc_value: &Value<Accumulator<S>>,
-    ) -> Result<AssignedAccumulator<S>, Error> {
-        let id_point: AssignedForeignPoint<_, _, _> =
-            self.bls12_381_chip.assign_fixed(layouter, C::identity())?;
+        acc_value: &Value<Accumulator<RecursiveEmulation>>,
+    ) -> Result<AssignedAccumulator<RecursiveEmulation>, Error> {
+        let id_point: AssignedForeignPoint<_, _, _> = self
+            .bls12_381_chip
+            .assign_fixed(layouter, EmulatedCurve::identity())?;
 
         let mut certificate_proof_accumulator = self.verifier_gadget.prepare(
             layouter,
@@ -646,7 +661,7 @@ impl IvcGadget {
         ivc_proof_accumulator.collapse(layouter, &self.bls12_381_chip, &self.native_gadget)?;
 
         // Accumulate the certificate and IVC proof accumulators.
-        let mut next_acc = AssignedAccumulator::<S>::accumulate(
+        let mut next_acc = AssignedAccumulator::<RecursiveEmulation>::accumulate(
             layouter,
             &self.verifier_gadget,
             &self.native_gadget,

--- a/mithril-stm/src/circuits/halo2_ivc/io.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/io.rs
@@ -1,4 +1,4 @@
-use super::{Accumulator, C, F, Msm, S};
+use super::{Accumulator, EmulatedCurve, Msm, NativeField, RecursiveEmulation};
 use midnight_curves::serde::SerdeObject;
 use midnight_proofs::utils::{SerdeFormat, helpers::ProcessedSerdeObject};
 use std::{collections::BTreeMap, io};
@@ -10,7 +10,7 @@ pub trait Read: Sized {
     fn read<R: io::Read>(r: &mut R, format: SerdeFormat) -> io::Result<Self>;
 }
 
-impl Write for Msm<S> {
+impl Write for Msm<RecursiveEmulation> {
     fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         let bases = self.bases();
         let scalars = self.scalars();
@@ -38,14 +38,17 @@ impl Write for Msm<S> {
     }
 }
 
-impl Read for Msm<S> {
-    fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Msm<S>> {
+impl Read for Msm<RecursiveEmulation> {
+    fn read<R: io::Read>(
+        reader: &mut R,
+        format: SerdeFormat,
+    ) -> io::Result<Msm<RecursiveEmulation>> {
         let mut num_bases = [0u8; 4];
         reader.read_exact(&mut num_bases)?;
         let num_bases = u32::from_le_bytes(num_bases);
 
         let bases: Vec<_> = (0..num_bases)
-            .map(|_| C::read(reader, format))
+            .map(|_| EmulatedCurve::read(reader, format))
             .collect::<Result<_, _>>()?;
 
         let mut num_scalars = [0u8; 4];
@@ -53,7 +56,7 @@ impl Read for Msm<S> {
         let num_scalars = u32::from_le_bytes(num_scalars);
 
         let scalars: Vec<_> = (0..num_scalars)
-            .map(|_| F::read_raw(reader))
+            .map(|_| NativeField::read_raw(reader))
             .collect::<Result<_, _>>()?;
 
         let mut num_fixed_base_scalars = [0u8; 4];
@@ -71,7 +74,7 @@ impl Read for Msm<S> {
             let key = String::from_utf8(key_bytes)
                 .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid UTF-8 key"))?;
 
-            let value = F::read_raw(reader)?;
+            let value = NativeField::read_raw(reader)?;
 
             fixed_base_scalars.insert(key, value);
         }
@@ -80,17 +83,17 @@ impl Read for Msm<S> {
     }
 }
 
-impl Write for Accumulator<S> {
+impl Write for Accumulator<RecursiveEmulation> {
     fn write<W: io::Write>(&self, writer: &mut W, format: SerdeFormat) -> io::Result<()> {
         self.lhs().write(writer, format)?;
         self.rhs().write(writer, format)
     }
 }
 
-impl Read for Accumulator<S> {
+impl Read for Accumulator<RecursiveEmulation> {
     fn read<R: io::Read>(reader: &mut R, format: SerdeFormat) -> io::Result<Self> {
         let lhs = Msm::read(reader, format)?;
         let rhs = Msm::read(reader, format)?;
-        Ok(Accumulator::<S>::new(lhs, rhs))
+        Ok(Accumulator::<RecursiveEmulation>::new(lhs, rhs))
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/key_serialization.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/key_serialization.rs
@@ -13,14 +13,17 @@ use midnight_proofs::utils::SerdeFormat;
 use crate::StmResult;
 use crate::codec::{TryFromBytes, TryToBytes};
 
-use super::{E, F, KZGCommitmentScheme, ProvingKey, VerifyingKey, circuit::IvcCircuitData};
+use super::{
+    KZGCommitmentScheme, NativeField, PairingEngine, ProvingKey, VerifyingKey,
+    circuit::IvcCircuitData,
+};
 
 /// Serde format used for the on-disk / in-cache production keys.
 const KEY_SERDE_FORMAT: SerdeFormat = SerdeFormat::RawBytes;
 
 // Recursive (IVC) circuit verifying key. The raw PLONK `read` is generic over the circuit and
 // takes its `Params`, so it is pinned to `IvcCircuitData` with its `()` params below.
-impl TryToBytes for VerifyingKey<F, KZGCommitmentScheme<E>> {
+impl TryToBytes for VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
     fn to_bytes_vec(&self) -> StmResult<Vec<u8>> {
         let mut bytes = Vec::new();
         self.write(&mut bytes, KEY_SERDE_FORMAT)
@@ -29,10 +32,10 @@ impl TryToBytes for VerifyingKey<F, KZGCommitmentScheme<E>> {
     }
 }
 
-impl TryFromBytes for VerifyingKey<F, KZGCommitmentScheme<E>> {
+impl TryFromBytes for VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
     fn try_from_bytes(bytes: &[u8]) -> StmResult<Self> {
         let mut reader = bytes;
-        VerifyingKey::<F, KZGCommitmentScheme<E>>::read::<_, IvcCircuitData>(
+        VerifyingKey::<NativeField, KZGCommitmentScheme<PairingEngine>>::read::<_, IvcCircuitData>(
             &mut reader,
             KEY_SERDE_FORMAT,
             (),
@@ -42,7 +45,7 @@ impl TryFromBytes for VerifyingKey<F, KZGCommitmentScheme<E>> {
 }
 
 // Recursive (IVC) circuit proving key.
-impl TryToBytes for ProvingKey<F, KZGCommitmentScheme<E>> {
+impl TryToBytes for ProvingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
     fn to_bytes_vec(&self) -> StmResult<Vec<u8>> {
         let mut bytes = Vec::new();
         self.write(&mut bytes, KEY_SERDE_FORMAT)
@@ -51,10 +54,10 @@ impl TryToBytes for ProvingKey<F, KZGCommitmentScheme<E>> {
     }
 }
 
-impl TryFromBytes for ProvingKey<F, KZGCommitmentScheme<E>> {
+impl TryFromBytes for ProvingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
     fn try_from_bytes(bytes: &[u8]) -> StmResult<Self> {
         let mut reader = bytes;
-        ProvingKey::<F, KZGCommitmentScheme<E>>::read::<_, IvcCircuitData>(
+        ProvingKey::<NativeField, KZGCommitmentScheme<PairingEngine>>::read::<_, IvcCircuitData>(
             &mut reader,
             KEY_SERDE_FORMAT,
             (),
@@ -70,10 +73,11 @@ mod tests {
 
     #[test]
     fn production_verifying_key_serializes_to_the_embedded_bytes() {
-        let verifying_key = VerifyingKey::<F, KZGCommitmentScheme<E>>::try_from_bytes(
-            RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
-        )
-        .expect("production recursive verifying key bytes should deserialize");
+        let verifying_key =
+            VerifyingKey::<NativeField, KZGCommitmentScheme<PairingEngine>>::try_from_bytes(
+                RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+            )
+            .expect("production recursive verifying key bytes should deserialize");
         assert_eq!(
             verifying_key.to_bytes_vec().expect("serialize should succeed"),
             RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,

--- a/mithril-stm/src/circuits/halo2_ivc/keys.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/keys.rs
@@ -16,45 +16,58 @@ use crate::circuits::key_provider::KeyProvider;
 use crate::codec::{TryFromBytes, TryToBytes};
 
 use super::{
-    E, F, KZGCommitmentScheme, ProvingKey, RECURSIVE_CIRCUIT_DEGREE, VerifyingKey,
-    circuit::IvcCircuitData,
+    KZGCommitmentScheme, NativeField, PairingEngine, ProvingKey, RECURSIVE_CIRCUIT_DEGREE,
+    VerifyingKey, circuit::IvcCircuitData,
 };
 
 /// Verifying key of the recursive (IVC) circuit.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct RecursiveCircuitVerifyingKey(
-    #[serde(with = "recursive_verifying_key_serde")] VerifyingKey<F, KZGCommitmentScheme<E>>,
+    #[serde(with = "recursive_verifying_key_serde")]
+    VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
 );
 
 /// Proving key of the recursive (IVC) circuit.
-pub(crate) struct RecursiveCircuitProvingKey(ProvingKey<F, KZGCommitmentScheme<E>>);
+pub(crate) struct RecursiveCircuitProvingKey(
+    ProvingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
+);
 
 impl RecursiveCircuitVerifyingKey {
     /// Wraps a raw recursive verifying key.
-    pub(crate) fn new(verifying_key: VerifyingKey<F, KZGCommitmentScheme<E>>) -> Self {
+    pub(crate) fn new(
+        verifying_key: VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
+    ) -> Self {
         Self(verifying_key)
     }
 
     /// Borrows the wrapped raw verifying key, for the prover/verifier and fixed-base construction.
-    pub(crate) fn verifying_key(&self) -> &VerifyingKey<F, KZGCommitmentScheme<E>> {
+    pub(crate) fn verifying_key(
+        &self,
+    ) -> &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
         &self.0
     }
 }
 
-impl AsRef<VerifyingKey<F, KZGCommitmentScheme<E>>> for RecursiveCircuitVerifyingKey {
-    fn as_ref(&self) -> &VerifyingKey<F, KZGCommitmentScheme<E>> {
+impl AsRef<VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>>
+    for RecursiveCircuitVerifyingKey
+{
+    fn as_ref(&self) -> &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
         &self.0
     }
 }
 
 impl RecursiveCircuitProvingKey {
     /// Wraps a raw recursive proving key.
-    pub(crate) fn new(proving_key: ProvingKey<F, KZGCommitmentScheme<E>>) -> Self {
+    pub(crate) fn new(
+        proving_key: ProvingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
+    ) -> Self {
         Self(proving_key)
     }
 
     /// Borrows the wrapped raw proving key, for proof generation.
-    pub(crate) fn proving_key(&self) -> &ProvingKey<F, KZGCommitmentScheme<E>> {
+    pub(crate) fn proving_key(
+        &self,
+    ) -> &ProvingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
         &self.0
     }
 }
@@ -67,9 +80,10 @@ impl TryToBytes for RecursiveCircuitVerifyingKey {
 
 impl TryFromBytes for RecursiveCircuitVerifyingKey {
     fn try_from_bytes(bytes: &[u8]) -> StmResult<Self> {
-        Ok(Self(
-            VerifyingKey::<F, KZGCommitmentScheme<E>>::try_from_bytes(bytes)?,
-        ))
+        Ok(Self(VerifyingKey::<
+            NativeField,
+            KZGCommitmentScheme<PairingEngine>,
+        >::try_from_bytes(bytes)?))
     }
 }
 
@@ -81,9 +95,10 @@ impl TryToBytes for RecursiveCircuitProvingKey {
 
 impl TryFromBytes for RecursiveCircuitProvingKey {
     fn try_from_bytes(bytes: &[u8]) -> StmResult<Self> {
-        Ok(Self(
-            ProvingKey::<F, KZGCommitmentScheme<E>>::try_from_bytes(bytes)?,
-        ))
+        Ok(Self(ProvingKey::<
+            NativeField,
+            KZGCommitmentScheme<PairingEngine>,
+        >::try_from_bytes(bytes)?))
     }
 }
 
@@ -92,11 +107,11 @@ impl TryFromBytes for RecursiveCircuitProvingKey {
 mod recursive_verifying_key_serde {
     use serde::{Deserializer, Serializer};
 
-    use super::{E, F, KZGCommitmentScheme, VerifyingKey};
+    use super::{KZGCommitmentScheme, NativeField, PairingEngine, VerifyingKey};
     use crate::codec::{TryFromBytes, TryToBytes};
 
     pub(super) fn serialize<S: Serializer>(
-        verifying_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+        verifying_key: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         let bytes = verifying_key.to_bytes_vec().map_err(serde::ser::Error::custom)?;
@@ -105,9 +120,9 @@ mod recursive_verifying_key_serde {
 
     pub(super) fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
-    ) -> Result<VerifyingKey<F, KZGCommitmentScheme<E>>, D::Error> {
+    ) -> Result<VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>, D::Error> {
         let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
-        VerifyingKey::<F, KZGCommitmentScheme<E>>::try_from_bytes(&bytes)
+        VerifyingKey::<NativeField, KZGCommitmentScheme<PairingEngine>>::try_from_bytes(&bytes)
             .map_err(serde::de::Error::custom)
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -68,14 +68,15 @@ pub(crate) mod tests;
 
 pub(crate) use types::ProtocolMessagePreimage;
 
-type S = BlstrsEmulation;
-pub(crate) type F = <S as SelfEmulation>::F;
-type C = <S as SelfEmulation>::C;
+type RecursiveEmulation = BlstrsEmulation;
+pub(crate) type NativeField = <RecursiveEmulation as SelfEmulation>::F;
+type EmulatedCurve = <RecursiveEmulation as SelfEmulation>::C;
 
-pub(crate) type E = <S as SelfEmulation>::Engine;
-type CBase = <C as CircuitCurve>::Base;
+pub(crate) type PairingEngine = <RecursiveEmulation as SelfEmulation>::Engine;
+type EmulatedCurveBaseField = <EmulatedCurve as CircuitCurve>::Base;
 
-type NG = NativeGadget<F, P2RDecompositionChip<F>, NativeChip<F>>;
+type IvcNativeGadget =
+    NativeGadget<NativeField, P2RDecompositionChip<NativeField>, NativeChip<NativeField>>;
 
 // Degree of the recursive circuit
 pub(crate) const RECURSIVE_CIRCUIT_DEGREE: u32 = 19;

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -65,7 +65,6 @@ impl State {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn as_public_input(&self) -> Vec<NativeField> {
         let state = self.clone();
         // Public-input order is part of the recursive circuit statement contract:
@@ -143,7 +142,6 @@ impl Global {
         }
     }
 
-    #[allow(dead_code)]
     pub(crate) fn as_public_input(&self) -> Vec<NativeField> {
         [
             vec![self.genesis_message.as_field()],

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -10,8 +10,8 @@ use crate::signature_scheme::{SchnorrVerificationKey, StandardSchnorrSignature};
 
 use super::{
     Accumulator, AssignedByte, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignedVk, C, ConstraintSystem, E, F, Instantiable, Jubjub, KZGCommitmentScheme, Msm, S,
-    VerifyingKey,
+    AssignedVk, ConstraintSystem, EmulatedCurve, Instantiable, Jubjub, KZGCommitmentScheme, Msm,
+    NativeField, PairingEngine, RecursiveEmulation, VerifyingKey,
     types::{
         CertificateCircuitVerificationKeyRepresentation, EpochNumber,
         IvcCircuitVerificationKeyRepresentation, MerkleTreeCommitment, MessageHash,
@@ -66,7 +66,7 @@ impl State {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn as_public_input(&self) -> Vec<F> {
+    pub(crate) fn as_public_input(&self) -> Vec<NativeField> {
         let state = self.clone();
         // Public-input order is part of the recursive circuit statement contract:
         // [step_counter, message, merkle_tree_commitment, next_merkle_tree_commitment, protocol_parameters, next_protocol_parameters, current_epoch].
@@ -85,17 +85,17 @@ impl State {
 /// In-circuit counterpart of [`State`].
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedState {
-    pub(crate) step_counter: AssignedNative<F>,
-    pub(crate) message: AssignedNative<F>,
-    pub(crate) merkle_tree_commitment: AssignedNative<F>,
-    pub(crate) next_merkle_tree_commitment: AssignedNative<F>,
-    pub(crate) protocol_parameters: AssignedNative<F>,
-    pub(crate) next_protocol_parameters: AssignedNative<F>,
-    pub(crate) current_epoch: AssignedNative<F>,
+    pub(crate) step_counter: AssignedNative<NativeField>,
+    pub(crate) message: AssignedNative<NativeField>,
+    pub(crate) merkle_tree_commitment: AssignedNative<NativeField>,
+    pub(crate) next_merkle_tree_commitment: AssignedNative<NativeField>,
+    pub(crate) protocol_parameters: AssignedNative<NativeField>,
+    pub(crate) next_protocol_parameters: AssignedNative<NativeField>,
+    pub(crate) current_epoch: AssignedNative<NativeField>,
 }
 
 impl AssignedState {
-    pub(crate) fn as_public_input(&self) -> Vec<AssignedNative<F>> {
+    pub(crate) fn as_public_input(&self) -> Vec<AssignedNative<NativeField>> {
         let state = self.clone();
         vec![
             state.step_counter,
@@ -144,7 +144,7 @@ impl Global {
     }
 
     #[allow(dead_code)]
-    pub(crate) fn as_public_input(&self) -> Vec<F> {
+    pub(crate) fn as_public_input(&self) -> Vec<NativeField> {
         [
             vec![self.genesis_message.as_field()],
             AssignedNativePoint::<Jubjub>::as_public_input(
@@ -162,10 +162,10 @@ impl Global {
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedGlobal {
     //Persistent values that do not change through an ivc stream
-    pub(crate) genesis_message: AssignedNative<F>,
+    pub(crate) genesis_message: AssignedNative<NativeField>,
     pub(crate) genesis_verification_key: AssignedNativePoint<Jubjub>,
-    pub(crate) certificate_verification_key: AssignedVk<S>,
-    pub(crate) ivc_verification_key: AssignedVk<S>,
+    pub(crate) certificate_verification_key: AssignedVk<RecursiveEmulation>,
+    pub(crate) ivc_verification_key: AssignedVk<RecursiveEmulation>,
     // Combined fixed base names for certificate and IVC verification keys.
     pub(crate) fixed_base_names: Vec<String>,
 }
@@ -198,38 +198,48 @@ impl Witness {
 
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedWitness {
-    pub(crate) genesis_signature: (AssignedScalarOfNativeCurve<Jubjub>, AssignedNative<F>),
-    pub(crate) certificate_message: AssignedNative<F>,
-    pub(crate) certificate_merkle_tree_commitment: AssignedNative<F>,
+    pub(crate) genesis_signature: (
+        AssignedScalarOfNativeCurve<Jubjub>,
+        AssignedNative<NativeField>,
+    ),
+    pub(crate) certificate_message: AssignedNative<NativeField>,
+    pub(crate) certificate_merkle_tree_commitment: AssignedNative<NativeField>,
     // Protocol message preimage bytes
-    pub(crate) message_preimage: Vec<AssignedByte<F>>,
+    pub(crate) message_preimage: Vec<AssignedByte<NativeField>>,
 }
 
-pub(crate) fn trivial_acc(fixed_base_names: &[String]) -> Accumulator<S> {
-    Accumulator::<S>::new(
-        Msm::new(&[C::default()], &[F::ONE], &BTreeMap::new()),
+pub(crate) fn trivial_acc(fixed_base_names: &[String]) -> Accumulator<RecursiveEmulation> {
+    Accumulator::<RecursiveEmulation>::new(
         Msm::new(
-            &[C::default()],
-            &[F::ONE],
-            &fixed_base_names.iter().map(|name| (name.clone(), F::ZERO)).collect(),
+            &[EmulatedCurve::default()],
+            &[NativeField::ONE],
+            &BTreeMap::new(),
+        ),
+        Msm::new(
+            &[EmulatedCurve::default()],
+            &[NativeField::ONE],
+            &fixed_base_names
+                .iter()
+                .map(|name| (name.clone(), NativeField::ZERO))
+                .collect(),
         ),
     )
 }
 
 pub(crate) fn fixed_bases_and_names(
     vk_name: &str,
-    vk: &VerifyingKey<F, KZGCommitmentScheme<E>>,
-) -> (BTreeMap<String, C>, Vec<String>) {
+    vk: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
+) -> (BTreeMap<String, EmulatedCurve>, Vec<String>) {
     let mut fixed_bases = BTreeMap::new();
-    fixed_bases.insert(String::from("com_instance"), C::identity());
-    fixed_bases.extend(verifier::fixed_bases::<S>(vk_name, vk));
+    fixed_bases.insert(String::from("com_instance"), EmulatedCurve::identity());
+    fixed_bases.extend(verifier::fixed_bases::<RecursiveEmulation>(vk_name, vk));
     let fixed_base_names = fixed_bases.keys().cloned().collect::<Vec<_>>();
     (fixed_bases, fixed_base_names)
 }
 
-pub(crate) fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<F>) -> Vec<String> {
+pub(crate) fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<NativeField>) -> Vec<String> {
     let mut fixed_base_names = vec![String::from("com_instance")];
-    fixed_base_names.extend(verifier::fixed_base_names::<S>(
+    fixed_base_names.extend(verifier::fixed_base_names::<RecursiveEmulation>(
         vk_name,
         cs.num_fixed_columns() + cs.num_selectors(),
         cs.permutation().columns.len(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/asset_readers.rs
@@ -17,7 +17,8 @@ use crate::StmResult;
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::{
-    Accumulator, C, E, F, KZGCommitmentScheme, PREIMAGE_SIZE, S, VerifyingKey,
+    Accumulator, EmulatedCurve, KZGCommitmentScheme, NativeField, PREIMAGE_SIZE, PairingEngine,
+    RecursiveEmulation, VerifyingKey,
     circuit::IvcCircuitData,
     io::{Read as IvcRead, Write as IvcWrite},
     state::State,
@@ -34,13 +35,13 @@ use super::field_encoding::jubjub_base_from_raw_le_bytes;
 #[derive(Debug)]
 pub(crate) struct RecursiveChainStateAsset {
     /// Stored global public inputs for the recursive flow.
-    pub(crate) global_field_elements: Vec<F>,
+    pub(crate) global_field_elements: Vec<NativeField>,
     /// Stored recursive state checkpoint.
     pub(crate) state: State,
     /// Stored previous recursive proof bytes.
     pub(crate) ivc_proof: IvcProofBytes,
     /// Stored folded accumulator for the checkpoint.
-    pub(crate) accumulator: Accumulator<S>,
+    pub(crate) accumulator: Accumulator<RecursiveEmulation>,
     /// Stored chain-specific Schnorr signature over the genesis state.
     pub(crate) genesis_signature: StandardSchnorrSignature,
 }
@@ -49,15 +50,15 @@ pub(crate) struct RecursiveChainStateAsset {
 #[derive(Debug)]
 pub(crate) struct VerificationContextAsset {
     /// Shared global public inputs used by the committed assets.
-    pub(crate) global_field_elements: Vec<F>,
+    pub(crate) global_field_elements: Vec<NativeField>,
     /// Stored recursive verifying key.
     pub(crate) recursive_verifying_key: RecursiveCircuitVerifyingKey,
     /// Combined fixed bases needed to check recursive accumulators.
-    pub(crate) combined_fixed_bases: BTreeMap<String, C>,
+    pub(crate) combined_fixed_bases: BTreeMap<String, EmulatedCurve>,
     /// Shared verifier-side KZG parameters.
-    pub(crate) verifier_params: ParamsVerifierKZG<E>,
+    pub(crate) verifier_params: ParamsVerifierKZG<PairingEngine>,
     /// The verifier-side `s_g2` element extracted from the stored params.
-    pub(crate) verifier_tau_in_g2: <E as Engine>::G2Affine,
+    pub(crate) verifier_tau_in_g2: <PairingEngine as Engine>::G2Affine,
     /// Stored certificate verifying key, enabling MockProver tests to skip SRS generation.
     pub(crate) certificate_verifying_key: NonRecursiveCircuitVerifyingKey,
 }
@@ -88,7 +89,7 @@ pub(crate) struct GenesisStepOutputAsset {
     /// Stored final recursive proof bytes for the genesis step.
     pub(crate) ivc_proof: IvcProofBytes,
     /// Stored folded accumulator after the genesis step.
-    pub(crate) next_accumulator: Accumulator<S>,
+    pub(crate) next_accumulator: Accumulator<RecursiveEmulation>,
     /// Stored next recursive state.
     pub(crate) next_state: State,
     /// Empty: genesis carries no certificate proof.
@@ -108,7 +109,7 @@ pub(crate) struct NextEpochStepOutputAsset {
     /// Stored final recursive proof bytes for the next-epoch step.
     pub(crate) ivc_proof: IvcProofBytes,
     /// Stored folded accumulator after the next-epoch step.
-    pub(crate) next_accumulator: Accumulator<S>,
+    pub(crate) next_accumulator: Accumulator<RecursiveEmulation>,
     /// Stored next recursive state.
     pub(crate) next_state: State,
     /// Stored certificate proof consumed by the next-epoch step.
@@ -130,7 +131,7 @@ pub(crate) struct FollowingCertificateInEpochAsset {
     /// Stored final recursive proof bytes for the same-epoch step.
     pub(crate) ivc_proof: IvcProofBytes,
     /// Stored folded accumulator after the same-epoch step.
-    pub(crate) next_accumulator: Accumulator<S>,
+    pub(crate) next_accumulator: Accumulator<RecursiveEmulation>,
     /// Stored next recursive state.
     pub(crate) next_state: State,
     /// Stored certificate proof consumed by the same-epoch step.
@@ -171,14 +172,14 @@ fn create_asset_file(path: &Path) -> StmResult<BufWriter<File>> {
 }
 
 /// Reads one field element encoded as 32 little-endian bytes.
-fn read_field_element<R: Read>(reader: &mut R) -> StmResult<F> {
+fn read_field_element<R: Read>(reader: &mut R) -> StmResult<NativeField> {
     let mut bytes = [0u8; 32];
     reader.read_exact(&mut bytes)?;
     Ok(jubjub_base_from_raw_le_bytes(&bytes))
 }
 
 /// Writes one field element as 32 little-endian bytes.
-fn write_field_element<W: Write>(writer: &mut W, value: &F) -> StmResult<()> {
+fn write_field_element<W: Write>(writer: &mut W, value: &NativeField) -> StmResult<()> {
     writer.write_all(&value.to_bytes_le())?;
     Ok(())
 }
@@ -252,7 +253,7 @@ fn write_length_prefixed_proof<W: Write>(writer: &mut W, proof: &[u8]) -> StmRes
 }
 
 /// Reads the named fixed-base map stored in the verification-context asset.
-fn read_named_fixed_bases<R: Read>(reader: &mut R) -> StmResult<BTreeMap<String, C>> {
+fn read_named_fixed_bases<R: Read>(reader: &mut R) -> StmResult<BTreeMap<String, EmulatedCurve>> {
     let mut count = [0u8; 4];
     reader.read_exact(&mut count)?;
     let count = u32::from_le_bytes(count) as usize;
@@ -268,7 +269,7 @@ fn read_named_fixed_bases<R: Read>(reader: &mut R) -> StmResult<BTreeMap<String,
         let name = String::from_utf8(name_bytes)
             .map_err(|_| anyhow!("invalid UTF-8 key in verification-context fixed-base map"))?;
 
-        let point = C::read(reader, SerdeFormat::RawBytesUnchecked)?;
+        let point = EmulatedCurve::read(reader, SerdeFormat::RawBytesUnchecked)?;
         map.insert(name, point);
     }
 
@@ -278,7 +279,7 @@ fn read_named_fixed_bases<R: Read>(reader: &mut R) -> StmResult<BTreeMap<String,
 /// Writes the named fixed-base map stored in the verification-context asset.
 fn write_named_fixed_bases<W: Write>(
     writer: &mut W,
-    fixed_bases: &BTreeMap<String, C>,
+    fixed_bases: &BTreeMap<String, EmulatedCurve>,
 ) -> StmResult<()> {
     writer.write_all(&(fixed_bases.len() as u32).to_le_bytes())?;
     for (name, point) in fixed_bases {
@@ -299,7 +300,8 @@ fn load_recursive_chain_state_asset_from_reader<R: Read>(
         .collect::<Result<Vec<_>, _>>()?;
     let state = read_state_public_input(reader)?;
     let ivc_proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
-    let accumulator = Accumulator::<S>::read(reader, SerdeFormat::RawBytesUnchecked)?;
+    let accumulator =
+        Accumulator::<RecursiveEmulation>::read(reader, SerdeFormat::RawBytesUnchecked)?;
     let genesis_signature = read_schnorr_signature(reader)?;
 
     Ok(RecursiveChainStateAsset {
@@ -374,25 +376,32 @@ fn load_verification_context_asset_from_reader<R: Read>(
     let global_field_elements = (0..5)
         .map(|_| read_field_element(reader))
         .collect::<Result<Vec<_>, _>>()?;
-    let recursive_verifying_key = VerifyingKey::<F, KZGCommitmentScheme<E>>::read::<
-        _,
-        IvcCircuitData,
-    >(reader, SerdeFormat::RawBytesUnchecked, ())?;
+    let recursive_verifying_key =
+        VerifyingKey::<NativeField, KZGCommitmentScheme<PairingEngine>>::read::<_, IvcCircuitData>(
+            reader,
+            SerdeFormat::RawBytesUnchecked,
+            (),
+        )?;
     let combined_fixed_bases = read_named_fixed_bases(reader)?;
 
     // verifier_params is length-prefixed so the certificate verification key can follow it.
     let verifier_param_bytes = read_length_prefixed_proof(reader)?;
 
     let mut verifier_params_reader = Cursor::new(&verifier_param_bytes);
-    let verifier_params =
-        ParamsVerifierKZG::<E>::read(&mut verifier_params_reader, SerdeFormat::RawBytesUnchecked)?;
+    let verifier_params = ParamsVerifierKZG::<PairingEngine>::read(
+        &mut verifier_params_reader,
+        SerdeFormat::RawBytesUnchecked,
+    )?;
 
     // `ParamsVerifierKZG` does not expose `s_g2()` in this path, so we re-read
     // the raw verifier-param bytes and rely on the current upstream raw
     // serialization layout where the first serialized G2 element is `s_g2`.
     let mut verifier_tau_reader = Cursor::new(&verifier_param_bytes);
-    let verifier_tau_in_g2 =
-        <E as Engine>::G2::read(&mut verifier_tau_reader, SerdeFormat::RawBytesUnchecked)?.into();
+    let verifier_tau_in_g2 = <PairingEngine as Engine>::G2::read(
+        &mut verifier_tau_reader,
+        SerdeFormat::RawBytesUnchecked,
+    )?
+    .into();
 
     let certificate_verification_key_bytes = read_length_prefixed_proof(reader)?;
     let certificate_verifying_key = MidnightVK::read(
@@ -468,7 +477,7 @@ pub(crate) fn store_verification_context_asset(
 /// `NextEpochStepOutputAsset`, and `FollowingCertificateInEpochAsset`.
 pub(crate) trait StepOutputAsset {
     fn next_state(&self) -> &State;
-    fn next_accumulator(&self) -> &Accumulator<S>;
+    fn next_accumulator(&self) -> &Accumulator<RecursiveEmulation>;
     fn ivc_proof(&self) -> &IvcProofBytes;
 }
 
@@ -476,7 +485,7 @@ impl StepOutputAsset for GenesisStepOutputAsset {
     fn next_state(&self) -> &State {
         &self.next_state
     }
-    fn next_accumulator(&self) -> &Accumulator<S> {
+    fn next_accumulator(&self) -> &Accumulator<RecursiveEmulation> {
         &self.next_accumulator
     }
     fn ivc_proof(&self) -> &IvcProofBytes {
@@ -488,7 +497,7 @@ impl StepOutputAsset for NextEpochStepOutputAsset {
     fn next_state(&self) -> &State {
         &self.next_state
     }
-    fn next_accumulator(&self) -> &Accumulator<S> {
+    fn next_accumulator(&self) -> &Accumulator<RecursiveEmulation> {
         &self.next_accumulator
     }
     fn ivc_proof(&self) -> &IvcProofBytes {
@@ -500,7 +509,7 @@ impl StepOutputAsset for FollowingCertificateInEpochAsset {
     fn next_state(&self) -> &State {
         &self.next_state
     }
-    fn next_accumulator(&self) -> &Accumulator<S> {
+    fn next_accumulator(&self) -> &Accumulator<RecursiveEmulation> {
         &self.next_accumulator
     }
     fn ivc_proof(&self) -> &IvcProofBytes {
@@ -512,7 +521,7 @@ impl StepOutputAsset for FollowingCertificateInEpochAsset {
 /// transport struct between the byte-level codec and the typed public assets.
 struct StepOutputFields {
     ivc_proof: IvcProofBytes,
-    next_accumulator: Accumulator<S>,
+    next_accumulator: Accumulator<RecursiveEmulation>,
     next_state: State,
     certificate_proof: CertificateProofBytes,
     message: [u8; 32],
@@ -565,7 +574,8 @@ impl From<StepOutputFields> for FollowingCertificateInEpochAsset {
 /// Reads the step-output common shape from the committed binary asset layout.
 fn read_step_output_fields_from_reader<R: Read>(reader: &mut R) -> StmResult<StepOutputFields> {
     let ivc_proof = IvcProofBytes::new(read_length_prefixed_proof(reader)?);
-    let next_accumulator = Accumulator::<S>::read(reader, SerdeFormat::RawBytesUnchecked)?;
+    let next_accumulator =
+        Accumulator::<RecursiveEmulation>::read(reader, SerdeFormat::RawBytesUnchecked)?;
     let next_state = read_state_public_input(reader)?;
     let certificate_proof = CertificateProofBytes::from_certificate_circuit_proof_bytes(
         read_length_prefixed_proof(reader)?,
@@ -592,7 +602,7 @@ fn read_step_output_fields_from_reader<R: Read>(reader: &mut R) -> StmResult<Ste
 fn write_step_output_fields<W: Write>(
     writer: &mut W,
     ivc_proof: &IvcProofBytes,
-    next_accumulator: &Accumulator<S>,
+    next_accumulator: &Accumulator<RecursiveEmulation>,
     next_state: &State,
     certificate_proof: &CertificateProofBytes,
     message: &[u8; 32],

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/field_encoding.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/field_encoding.rs
@@ -1,4 +1,4 @@
-use crate::circuits::halo2_ivc::F;
+use crate::circuits::halo2_ivc::NativeField;
 
 /// Interprets 32 little-endian bytes as an integer and maps it to a Jubjub
 /// base-field element.
@@ -6,9 +6,9 @@ use crate::circuits::halo2_ivc::F;
 /// This intentionally uses `from_raw` instead of canonical decoding: SHA256
 /// digests and legacy asset/test bytes may be non-canonical, and `from_raw`
 /// converts them into the congruent field element modulo the field order.
-pub(crate) fn jubjub_base_from_raw_le_bytes(bytes: &[u8]) -> F {
+pub(crate) fn jubjub_base_from_raw_le_bytes(bytes: &[u8]) -> NativeField {
     assert_eq!(bytes.len(), 32);
-    F::from_raw([
+    NativeField::from_raw([
         u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
         u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
         u64::from_le_bytes(bytes[16..24].try_into().unwrap()),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -25,7 +25,7 @@ use crate::circuits::halo2_ivc::tests::common::asset_readers::{
     store_verification_context_asset,
 };
 use crate::circuits::halo2_ivc::{
-    Accumulator, AssignedAccumulator, C, PREIMAGE_SIZE, S,
+    Accumulator, AssignedAccumulator, EmulatedCurve, PREIMAGE_SIZE, RecursiveEmulation,
     circuit::IvcCircuitData,
     keys::RecursiveCircuitProvingKey,
     state::{Global, State, trivial_acc},
@@ -34,7 +34,7 @@ use crate::circuits::halo2_ivc::{
 
 struct CertificateChainArtifacts {
     certificate_proofs: Vec<CertificateProofBytes>,
-    certificate_accumulators: Vec<Accumulator<S>>,
+    certificate_accumulators: Vec<Accumulator<RecursiveEmulation>>,
     recursive_next_states: Vec<State>,
     recursive_witnesses: Vec<crate::circuits::halo2_ivc::state::Witness>,
 }
@@ -42,14 +42,14 @@ struct CertificateChainArtifacts {
 struct RecursiveChainSnapshot {
     state: State,
     ivc_proof: IvcProofBytes,
-    accumulator: Accumulator<S>,
+    accumulator: Accumulator<RecursiveEmulation>,
 }
 
 struct NextRecursiveStepInputs {
     certificate_proof: CertificateProofBytes,
     next_state: State,
     recursive_witness: crate::circuits::halo2_ivc::state::Witness,
-    next_accumulator: Accumulator<S>,
+    next_accumulator: Accumulator<RecursiveEmulation>,
 }
 
 fn build_certificate_chain_artifacts(
@@ -107,8 +107,8 @@ fn build_recursive_chain_snapshot(
     context: &super::setup::SharedRecursiveContext,
     global: &Global,
     recursive_proving_key: &RecursiveCircuitProvingKey,
-    recursive_fixed_bases: &std::collections::BTreeMap<String, C>,
-    combined_fixed_bases: &std::collections::BTreeMap<String, C>,
+    recursive_fixed_bases: &std::collections::BTreeMap<String, EmulatedCurve>,
+    combined_fixed_bases: &std::collections::BTreeMap<String, EmulatedCurve>,
     artifacts: CertificateChainArtifacts,
 ) -> RecursiveChainSnapshot {
     let combined_fixed_base_names = combined_fixed_bases.keys().cloned().collect::<Vec<_>>();
@@ -158,7 +158,7 @@ fn build_recursive_chain_snapshot(
         );
         assert!(dual_msm.clone().check(&context.universal_verifier_params));
 
-        let mut proof_accumulator: Accumulator<S> = dual_msm.into();
+        let mut proof_accumulator: Accumulator<RecursiveEmulation> = dual_msm.into();
         proof_accumulator.extract_fixed_bases(recursive_fixed_bases);
         proof_accumulator.collapse();
 
@@ -238,8 +238,8 @@ fn build_next_recursive_step_inputs(
     context: &super::setup::SharedRecursiveContext,
     global: &Global,
     recursive_chain_state: &RecursiveChainStateAsset,
-    recursive_fixed_bases: &std::collections::BTreeMap<String, C>,
-    combined_fixed_bases: &std::collections::BTreeMap<String, C>,
+    recursive_fixed_bases: &std::collections::BTreeMap<String, EmulatedCurve>,
+    combined_fixed_bases: &std::collections::BTreeMap<String, EmulatedCurve>,
 ) -> NextRecursiveStepInputs {
     let mut recursive_step_output_random_generator = OsRng;
     println!("generate_recursive_step_output: building next certificate");
@@ -270,7 +270,7 @@ fn build_next_recursive_step_inputs(
         &previous_public_inputs,
     );
     assert!(previous_dual_msm.clone().check(&context.universal_verifier_params));
-    let mut previous_proof_accumulator: Accumulator<S> = previous_dual_msm.into();
+    let mut previous_proof_accumulator: Accumulator<RecursiveEmulation> = previous_dual_msm.into();
     previous_proof_accumulator.extract_fixed_bases(recursive_fixed_bases);
     previous_proof_accumulator.collapse();
 
@@ -664,7 +664,7 @@ pub(crate) fn generate_same_epoch_step_output_asset(
         previous_dual_msm.clone().check(&context.universal_verifier_params),
         "previous chain state proof verification failed"
     );
-    let mut previous_proof_accumulator: Accumulator<S> = previous_dual_msm.into();
+    let mut previous_proof_accumulator: Accumulator<RecursiveEmulation> = previous_dual_msm.into();
     previous_proof_accumulator.extract_fixed_bases(&recursive_fixed_bases);
     previous_proof_accumulator.collapse();
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/proofs.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/proofs.rs
@@ -13,23 +13,31 @@ use midnight_proofs::{
 use rand_core::{CryptoRng, RngCore};
 
 use crate::circuits::halo2_ivc::keys::RecursiveCircuitProvingKey;
-use crate::circuits::halo2_ivc::{C, E, F, VerifyingKey, circuit::IvcCircuitData};
+use crate::circuits::halo2_ivc::{
+    EmulatedCurve, NativeField, PairingEngine, VerifyingKey, circuit::IvcCircuitData,
+};
 
 /// Generates a recursive proof using the chosen transcript hash.
 fn prove_ivc_with_transcript<H: TranscriptHash>(
     commitment_parameters: &ParamsKZG<Bls12>,
     proving_key: &RecursiveCircuitProvingKey,
     ivc_circuit_data: &IvcCircuitData,
-    public_inputs: &[F],
+    public_inputs: &[NativeField],
     random_generator: &mut (impl RngCore + CryptoRng),
     proof_generation_error: &str,
 ) -> Vec<u8>
 where
-    F: Sampleable<H> + Hashable<H> + Hash + Ord + FromUniformBytes<64>,
-    <KZGCommitmentScheme<E> as PolynomialCommitmentScheme<F>>::Commitment: Hashable<H>,
+    NativeField: Sampleable<H> + Hashable<H> + Hash + Ord + FromUniformBytes<64>,
+    <KZGCommitmentScheme<PairingEngine> as PolynomialCommitmentScheme<NativeField>>::Commitment:
+        Hashable<H>,
 {
     let mut transcript = CircuitTranscript::<H>::init();
-    create_proof::<F, KZGCommitmentScheme<E>, CircuitTranscript<H>, IvcCircuitData>(
+    create_proof::<
+        NativeField,
+        KZGCommitmentScheme<PairingEngine>,
+        CircuitTranscript<H>,
+        IvcCircuitData,
+    >(
         commitment_parameters,
         proving_key.proving_key(),
         std::slice::from_ref(ivc_circuit_data),
@@ -44,24 +52,26 @@ where
 
 /// Verifies a recursive proof and returns the prepared MSM.
 fn verify_prepare_ivc_with_transcript<H: TranscriptHash>(
-    verifying_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    verifying_key: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
     proof: &[u8],
-    public_inputs: &[F],
+    public_inputs: &[NativeField],
     verification_error: &str,
     transcript_error: &str,
-) -> DualMSM<E>
+) -> DualMSM<PairingEngine>
 where
-    F: Sampleable<H> + Hashable<H> + Hash + Ord + FromUniformBytes<64>,
-    <KZGCommitmentScheme<E> as PolynomialCommitmentScheme<F>>::Commitment: Hashable<H>,
+    NativeField: Sampleable<H> + Hashable<H> + Hash + Ord + FromUniformBytes<64>,
+    <KZGCommitmentScheme<PairingEngine> as PolynomialCommitmentScheme<NativeField>>::Commitment:
+        Hashable<H>,
 {
     let mut transcript = CircuitTranscript::<H>::init_from_bytes(proof);
-    let dual_msm = prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<H>>(
-        verifying_key,
-        &[&[C::identity()]],
-        &[&[public_inputs]],
-        &mut transcript,
-    )
-    .expect(verification_error);
+    let dual_msm =
+        prepare::<NativeField, KZGCommitmentScheme<PairingEngine>, CircuitTranscript<H>>(
+            verifying_key,
+            &[&[EmulatedCurve::identity()]],
+            &[&[public_inputs]],
+            &mut transcript,
+        )
+        .expect(verification_error);
     transcript.assert_empty().expect(transcript_error);
     dual_msm
 }
@@ -71,10 +81,10 @@ pub(crate) fn prove_poseidon_ivc(
     commitment_parameters: &ParamsKZG<Bls12>,
     proving_key: &RecursiveCircuitProvingKey,
     ivc_circuit_data: &IvcCircuitData,
-    public_inputs: &[F],
+    public_inputs: &[NativeField],
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> Vec<u8> {
-    prove_ivc_with_transcript::<PoseidonState<F>>(
+    prove_ivc_with_transcript::<PoseidonState<NativeField>>(
         commitment_parameters,
         proving_key,
         ivc_circuit_data,
@@ -86,11 +96,11 @@ pub(crate) fn prove_poseidon_ivc(
 
 /// Verifies a recursive proof using the Poseidon transcript and returns the prepared MSM.
 pub(crate) fn verify_prepare_poseidon_ivc(
-    verifying_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    verifying_key: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
     proof: &[u8],
-    public_inputs: &[F],
-) -> DualMSM<E> {
-    verify_prepare_ivc_with_transcript::<PoseidonState<F>>(
+    public_inputs: &[NativeField],
+) -> DualMSM<PairingEngine> {
+    verify_prepare_ivc_with_transcript::<PoseidonState<NativeField>>(
         verifying_key,
         proof,
         public_inputs,
@@ -104,7 +114,7 @@ pub(crate) fn prove_blake2b_ivc(
     commitment_parameters: &ParamsKZG<Bls12>,
     proving_key: &RecursiveCircuitProvingKey,
     ivc_circuit_data: &IvcCircuitData,
-    public_inputs: &[F],
+    public_inputs: &[NativeField],
     random_generator: &mut (impl RngCore + CryptoRng),
 ) -> Vec<u8> {
     prove_ivc_with_transcript::<blake2b_simd::State>(
@@ -127,14 +137,18 @@ pub(crate) fn prove_blake2b_ivc(
 /// Use this instead of `verify_prepare_poseidon_ivc` when testing with tampered
 /// bytes where a panic-on-error would be inappropriate.
 pub(crate) fn try_verify_prepare_poseidon_ivc(
-    verifying_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    verifying_key: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
     proof: &[u8],
-    public_inputs: &[F],
-) -> Option<DualMSM<E>> {
-    let mut transcript = CircuitTranscript::<PoseidonState<F>>::init_from_bytes(proof);
-    let dual_msm = prepare::<F, KZGCommitmentScheme<E>, CircuitTranscript<PoseidonState<F>>>(
+    public_inputs: &[NativeField],
+) -> Option<DualMSM<PairingEngine>> {
+    let mut transcript = CircuitTranscript::<PoseidonState<NativeField>>::init_from_bytes(proof);
+    let dual_msm = prepare::<
+        NativeField,
+        KZGCommitmentScheme<PairingEngine>,
+        CircuitTranscript<PoseidonState<NativeField>>,
+    >(
         verifying_key,
-        &[&[C::identity()]],
+        &[&[EmulatedCurve::identity()]],
         &[&[public_inputs]],
         &mut transcript,
     )
@@ -145,10 +159,10 @@ pub(crate) fn try_verify_prepare_poseidon_ivc(
 
 /// Verifies the final recursive proof using the Blake2b transcript.
 pub(crate) fn verify_prepare_blake2b_ivc(
-    verifying_key: &VerifyingKey<F, KZGCommitmentScheme<E>>,
+    verifying_key: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
     proof: &[u8],
-    public_inputs: &[F],
-) -> DualMSM<E> {
+    public_inputs: &[NativeField],
+) -> DualMSM<PairingEngine> {
     verify_prepare_ivc_with_transcript::<blake2b_simd::State>(
         verifying_key,
         proof,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -19,8 +19,8 @@ use crate::circuits::halo2_ivc::keys::{RecursiveCircuitProvingKey, RecursiveCirc
 use crate::circuits::halo2_ivc::state::fixed_bases_and_names;
 use crate::circuits::halo2_ivc::types::MessageHash;
 use crate::circuits::halo2_ivc::{
-    C, CERTIFICATE_VERIFICATION_KEY_NAME, E, F, IVC_VERIFICATION_KEY_NAME, circuit::IvcCircuitData,
-    state::Global,
+    CERTIFICATE_VERIFICATION_KEY_NAME, EmulatedCurve, IVC_VERIFICATION_KEY_NAME, NativeField,
+    PairingEngine, circuit::IvcCircuitData, state::Global,
 };
 use crate::membership_commitment::{MerkleTree as StmMerkleTree, MerkleTreeSnarkLeaf};
 use crate::signature_scheme::{
@@ -105,9 +105,9 @@ pub(crate) struct AssetGenerationSetup {
     pub(crate) aggregate_verification_key:
         AggregateVerificationKeyForSnark<MithrilMembershipDigest>,
     /// Deterministic next Merkle-tree commitment committed by the genesis message.
-    pub(crate) genesis_next_merkle_tree_commitment: F,
+    pub(crate) genesis_next_merkle_tree_commitment: NativeField,
     /// Deterministic next protocol parameters committed by the genesis message.
-    pub(crate) genesis_next_protocol_parameters: F,
+    pub(crate) genesis_next_protocol_parameters: NativeField,
 }
 
 /// Shared recursive verifier-side setup reused by generators and golden helpers.
@@ -115,7 +115,7 @@ pub(crate) struct SharedRecursiveContext {
     /// Shared universal KZG parameters built at the maximum circuit degree.
     pub(crate) universal_kzg_parameters: ParamsKZG<Bls12>,
     /// Verifier-side view of the shared universal KZG parameters.
-    pub(crate) universal_verifier_params: ParamsVerifierKZG<E>,
+    pub(crate) universal_verifier_params: ParamsVerifierKZG<PairingEngine>,
     /// Certificate-sized commitment parameters derived from the shared SRS.
     pub(crate) certificate_commitment_parameters: ParamsKZG<Bls12>,
     /// Recursive-circuit-sized commitment parameters derived from the shared SRS.
@@ -142,7 +142,7 @@ fn build_merkle_tree(
         let schnorr_vk = SchnorrVerificationKey::new_from_signing_key(signing_key.clone());
         merkle_tree_leaves.push(MerkleTreeSnarkLeaf(
             schnorr_vk,
-            BaseFieldElement::from(-F::ONE),
+            BaseFieldElement::from(-NativeField::ONE),
         ));
         signing_keys.push(signing_key);
     }
@@ -151,7 +151,7 @@ fn build_merkle_tree(
     (signing_keys, merkle_tree_leaves, merkle_tree)
 }
 
-fn merkle_tree_commitment_from_stm_tree(merkle_tree: &SignerRegistrationMerkleTree) -> F {
+fn merkle_tree_commitment_from_stm_tree(merkle_tree: &SignerRegistrationMerkleTree) -> NativeField {
     let commitment = merkle_tree.to_merkle_tree_commitment();
     // `MidnightPoseidonDigest` emits Jubjub base-field roots with `to_bytes_le()`;
     // the recursive state stores the same root as the circuit field element.
@@ -160,7 +160,7 @@ fn merkle_tree_commitment_from_stm_tree(merkle_tree: &SignerRegistrationMerkleTr
         .as_slice()
         .try_into()
         .expect("STM Merkle-tree commitment should be 32 bytes");
-    F::from_bytes_le(&root_bytes)
+    NativeField::from_bytes_le(&root_bytes)
         .into_option()
         .expect("STM Merkle-tree commitment should be a canonical field element")
 }
@@ -247,9 +247,9 @@ pub(crate) fn build_recursive_fixed_bases(
     certificate_verifying_key: &NonRecursiveCircuitVerifyingKey,
     recursive_verifying_key: &RecursiveCircuitVerifyingKey,
 ) -> (
-    BTreeMap<String, C>,
-    BTreeMap<String, C>,
-    BTreeMap<String, C>,
+    BTreeMap<String, EmulatedCurve>,
+    BTreeMap<String, EmulatedCurve>,
+    BTreeMap<String, EmulatedCurve>,
 ) {
     let (certificate_fixed_bases, _) = fixed_bases_and_names(
         CERTIFICATE_VERIFICATION_KEY_NAME,
@@ -318,7 +318,7 @@ pub(crate) fn build_asset_generation_setup() -> AssetGenerationSetup {
     let genesis_verification_key =
         SchnorrVerificationKey::new_from_signing_key(genesis_signing_key.clone());
     let genesis_epoch = GENESIS_EPOCH;
-    let genesis_next_protocol_parameters = F::from(7u64);
+    let genesis_next_protocol_parameters = NativeField::from(7u64);
 
     let genesis_message = {
         let protocol_message = build_genesis_protocol_message(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -20,7 +20,7 @@ use crate::circuits::halo2_ivc::types::{
     ProtocolParametersHash, StepCounter,
 };
 use crate::circuits::halo2_ivc::{
-    Accumulator, CERTIFICATE_VERIFICATION_KEY_NAME, F, PREIMAGE_SIZE, S,
+    Accumulator, CERTIFICATE_VERIFICATION_KEY_NAME, NativeField, PREIMAGE_SIZE, RecursiveEmulation,
 };
 use crate::signature_scheme::{
     BaseFieldElement, SchnorrVerificationKey as StmSchnorrVerificationKey,
@@ -103,7 +103,12 @@ pub(crate) fn build_next_certificate_asset_data(
     certificate_verifying_key: &NonRecursiveCircuitVerifyingKey,
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
-) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
+) -> (
+    CertificateProofBytes,
+    Accumulator<RecursiveEmulation>,
+    State,
+    Witness,
+) {
     let merkle_tree_commitment = recursive_chain_state.next_merkle_tree_commitment.as_field();
     let (message, message_preimage) =
         next_message_and_preimage_for_step(setup, recursive_chain_state);
@@ -129,7 +134,12 @@ pub(crate) fn build_same_epoch_certificate_asset_data(
     certificate_verifying_key: &NonRecursiveCircuitVerifyingKey,
     recursive_chain_state: &State,
     random_generator: &mut (impl RngCore + CryptoRng),
-) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
+) -> (
+    CertificateProofBytes,
+    Accumulator<RecursiveEmulation>,
+    State,
+    Witness,
+) {
     let merkle_tree_commitment = recursive_chain_state.merkle_tree_commitment.as_field();
     let (message, message_preimage) =
         same_epoch_message_and_preimage_for_step(setup, recursive_chain_state);
@@ -158,12 +168,17 @@ fn build_certificate_asset_data_inner(
     certificate_commitment_parameters: &ParamsKZG<Bls12>,
     certificate_relation: &StmCertificateCircuit,
     certificate_verifying_key: &NonRecursiveCircuitVerifyingKey,
-    merkle_tree_commitment: F,
-    message: F,
+    merkle_tree_commitment: NativeField,
+    message: NativeField,
     message_preimage: Vec<u8>,
     next_state: State,
     random_generator: &mut (impl RngCore + CryptoRng),
-) -> (CertificateProofBytes, Accumulator<S>, State, Witness) {
+) -> (
+    CertificateProofBytes,
+    Accumulator<RecursiveEmulation>,
+    State,
+    Witness,
+) {
     let certificate_proving_key = zk_lib::setup_pk(
         certificate_relation,
         certificate_verifying_key.midnight_vk(),
@@ -228,7 +243,7 @@ fn build_certificate_asset_data_inner(
         certificate_public_inputs(merkle_tree_commitment, next_state.message.as_field());
 
     let certificate_proof = CertificateProofBytes::from_certificate_circuit_proof_bytes(
-        zk_lib::prove::<StmCertificateCircuit, PoseidonState<F>>(
+        zk_lib::prove::<StmCertificateCircuit, PoseidonState<NativeField>>(
             certificate_commitment_parameters,
             &certificate_proving_key,
             certificate_relation,
@@ -252,7 +267,7 @@ fn build_certificate_asset_data_inner(
             .clone()
             .check(&certificate_commitment_parameters.verifier_params())
     );
-    let mut certificate_accumulator: Accumulator<S> = certificate_dual_msm.into();
+    let mut certificate_accumulator: Accumulator<RecursiveEmulation> = certificate_dual_msm.into();
     certificate_accumulator.extract_fixed_bases(&certificate_fixed_bases);
     certificate_accumulator.collapse();
 
@@ -272,7 +287,10 @@ fn build_certificate_asset_data_inner(
 }
 
 /// Formats a `(merkle_tree_commitment, message)` pair as certificate public inputs.
-pub(super) fn certificate_public_inputs(merkle_tree_commitment: F, message: F) -> Vec<F> {
+pub(super) fn certificate_public_inputs(
+    merkle_tree_commitment: NativeField,
+    message: NativeField,
+) -> Vec<NativeField> {
     StmCertificateCircuit::format_instance(&(
         CircuitBaseField::from(merkle_tree_commitment),
         CircuitBaseField::from(message),
@@ -284,7 +302,7 @@ pub(super) fn certificate_public_inputs(merkle_tree_commitment: F, message: F) -
 pub(crate) fn certificate_public_inputs_for_step(
     previous_state: &State,
     next_state: &State,
-) -> Vec<F> {
+) -> Vec<NativeField> {
     certificate_public_inputs(
         previous_state.next_merkle_tree_commitment.as_field(),
         next_state.message.as_field(),
@@ -296,7 +314,7 @@ pub(crate) fn certificate_public_inputs_for_step(
 pub(crate) fn next_message_and_preimage_for_step(
     setup: &AssetGenerationSetup,
     previous_state: &State,
-) -> (F, Vec<u8>) {
+) -> (NativeField, Vec<u8>) {
     let current_epoch = current_epoch_from_state(previous_state);
     let step = step_index_from_state(previous_state);
 
@@ -327,7 +345,7 @@ pub(crate) fn next_message_and_preimage_for_step(
 pub(crate) fn same_epoch_message_and_preimage_for_step(
     setup: &AssetGenerationSetup,
     previous_state: &State,
-) -> (F, Vec<u8>) {
+) -> (NativeField, Vec<u8>) {
     let current_epoch = current_epoch_from_state(previous_state);
     let step = step_index_from_state(previous_state);
 
@@ -355,7 +373,7 @@ pub(crate) fn same_epoch_message_and_preimage_for_step(
 
 /// Returns the recursive next state for a non-genesis step once the next
 /// certificate message has been fixed.
-pub(crate) fn next_state_for_step(previous_state: &State, message: F) -> State {
+pub(crate) fn next_state_for_step(previous_state: &State, message: NativeField) -> State {
     let current_epoch = current_epoch_from_state(previous_state);
     let step = step_index_from_state(previous_state);
 
@@ -371,7 +389,10 @@ pub(crate) fn next_state_for_step(previous_state: &State, message: F) -> State {
 }
 
 /// Returns the recursive next state for a same-epoch step.
-pub(crate) fn same_epoch_next_state_for_step(previous_state: &State, message: F) -> State {
+pub(crate) fn same_epoch_next_state_for_step(
+    previous_state: &State,
+    message: NativeField,
+) -> State {
     let current_epoch = current_epoch_from_state(previous_state);
     let step = step_index_from_state(previous_state);
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
@@ -11,7 +11,8 @@ use midnight_proofs::{
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::{
-    Accumulator, AssignedAccumulator, C, E, F, RECURSIVE_CIRCUIT_DEGREE, S,
+    Accumulator, AssignedAccumulator, EmulatedCurve, NativeField, PairingEngine,
+    RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation,
     circuit::IvcCircuitData,
     state::{Global, State, Witness, trivial_acc},
     types::{CertificateProofBytes, IvcProofBytes},
@@ -43,7 +44,7 @@ pub(crate) struct MockProverSetup {
     /// Recursive verifying key loaded from the committed asset.
     pub(crate) recursive_verifying_key: RecursiveCircuitVerifyingKey,
     /// Trivial accumulator derived from the loaded VKs.
-    pub(crate) trivial_accumulator: Accumulator<S>,
+    pub(crate) trivial_accumulator: Accumulator<RecursiveEmulation>,
 }
 
 /// Builds the lightweight MockProver setup by loading VKs from the committed asset.
@@ -82,15 +83,15 @@ pub(crate) struct RecursiveMockProverSetup {
     /// Shared recursive global inputs.
     pub(crate) global: Global,
     /// Fixed bases extracted from the certificate verifying key.
-    pub(crate) certificate_fixed_bases: BTreeMap<String, C>,
+    pub(crate) certificate_fixed_bases: BTreeMap<String, EmulatedCurve>,
     /// Fixed bases extracted from the recursive verifying key.
-    pub(crate) recursive_fixed_bases: BTreeMap<String, C>,
+    pub(crate) recursive_fixed_bases: BTreeMap<String, EmulatedCurve>,
     /// Union of certificate and recursive fixed bases.
-    pub(crate) combined_fixed_bases: BTreeMap<String, C>,
+    pub(crate) combined_fixed_bases: BTreeMap<String, EmulatedCurve>,
     /// Verifier-side view of the shared universal KZG parameters.
-    pub(crate) universal_verifier_params: ParamsVerifierKZG<E>,
+    pub(crate) universal_verifier_params: ParamsVerifierKZG<PairingEngine>,
     /// The verifier-side `s_g2` element used for accumulator checks.
-    pub(crate) verifier_tau_in_g2: <E as Engine>::G2Affine,
+    pub(crate) verifier_tau_in_g2: <PairingEngine as Engine>::G2Affine,
 }
 
 /// Builds the shared recursive circuit context needed by MockProver-based golden tests.
@@ -131,7 +132,7 @@ pub(crate) fn build_recursive_mock_prover_setup(
 /// Runs `MockProver` on the recursive circuit and asserts that at least one constraint fails.
 pub(crate) fn assert_recursive_mock_prover_rejects(
     ivc_circuit_data: IvcCircuitData,
-    public_inputs: Vec<F>,
+    public_inputs: Vec<NativeField>,
 ) {
     let prover = MockProver::run(
         RECURSIVE_CIRCUIT_DEGREE,
@@ -148,7 +149,7 @@ pub(crate) fn assert_recursive_mock_prover_rejects(
 /// the failing case is identifiable when multiple scenarios share one `#[test]` function.
 pub(crate) fn assert_recursive_mock_prover_accepts_with_label(
     ivc_circuit_data: IvcCircuitData,
-    public_inputs: Vec<F>,
+    public_inputs: Vec<NativeField>,
     label: &str,
 ) {
     let prover = MockProver::run(
@@ -169,7 +170,7 @@ pub(crate) fn assert_recursive_mock_prover_accepts_with_label(
 /// so the scenario that unexpectedly passed is identifiable when multiple scenarios share one `#[test]` function.
 pub(crate) fn assert_recursive_mock_prover_rejects_with_label(
     ivc_circuit_data: IvcCircuitData,
-    public_inputs: Vec<F>,
+    public_inputs: Vec<NativeField>,
     label: &str,
 ) {
     let prover = MockProver::run(
@@ -193,7 +194,7 @@ pub(crate) fn assert_recursive_mock_prover_rejects_with_label(
 pub(crate) fn prepare_previous_recursive_proof_accumulator(
     setup: &RecursiveMockProverSetup,
     recursive_chain_state: &RecursiveChainStateAsset,
-) -> Accumulator<S> {
+) -> Accumulator<RecursiveEmulation> {
     let previous_public_inputs = [
         setup.global.as_public_input(),
         recursive_chain_state.state.as_public_input(),
@@ -211,7 +212,7 @@ pub(crate) fn prepare_previous_recursive_proof_accumulator(
         "stored previous recursive proof should verify before the normal step check"
     );
 
-    let mut previous_proof_accumulator: Accumulator<S> = previous_dual_msm.into();
+    let mut previous_proof_accumulator: Accumulator<RecursiveEmulation> = previous_dual_msm.into();
     previous_proof_accumulator.extract_fixed_bases(&setup.recursive_fixed_bases);
     previous_proof_accumulator.collapse();
     previous_proof_accumulator
@@ -225,8 +226,8 @@ pub(crate) fn prepare_previous_recursive_proof_accumulator(
 pub(crate) fn compute_expected_next_accumulator(
     setup: &RecursiveMockProverSetup,
     recursive_chain_state: &RecursiveChainStateAsset,
-    certificate_accumulator: Accumulator<S>,
-) -> Accumulator<S> {
+    certificate_accumulator: Accumulator<RecursiveEmulation>,
+) -> Accumulator<RecursiveEmulation> {
     let previous_proof_accumulator =
         prepare_previous_recursive_proof_accumulator(setup, recursive_chain_state);
 
@@ -254,7 +255,7 @@ pub(crate) fn prepare_stored_step_certificate_accumulator(
     recursive_chain_state: &RecursiveChainStateAsset,
     expected_next_state: &State,
     certificate_proof: &[u8],
-) -> Accumulator<S> {
+) -> Accumulator<RecursiveEmulation> {
     let certificate_public_inputs =
         certificate_public_inputs_for_step(&recursive_chain_state.state, expected_next_state);
 
@@ -270,7 +271,7 @@ pub(crate) fn prepare_stored_step_certificate_accumulator(
         "stored step certificate proof should verify before the chained-flow check"
     );
 
-    let mut certificate_accumulator: Accumulator<S> = certificate_dual_msm.into();
+    let mut certificate_accumulator: Accumulator<RecursiveEmulation> = certificate_dual_msm.into();
     certificate_accumulator.extract_fixed_bases(&setup.certificate_fixed_bases);
     certificate_accumulator.collapse();
     certificate_accumulator
@@ -303,7 +304,7 @@ pub(crate) fn build_trivial_mock_prover_circuit(
 pub(crate) fn build_mock_prover_public_inputs(
     setup: &MockProverSetup,
     next_state: &State,
-) -> Vec<F> {
+) -> Vec<NativeField> {
     [
         setup.global.as_public_input(),
         next_state.as_public_input(),
@@ -318,8 +319,11 @@ pub(crate) fn build_mock_prover_public_inputs(
 /// Uses the next-epoch step assets: the certificate proof lives in
 /// `recursive_step_output` and its public inputs are derived from
 /// `(recursive_chain_state.state, recursive_step_output.next_state)`.
-pub(crate) fn build_unextracted_certificate_accumulator_from_assets()
--> (Accumulator<S>, BTreeMap<String, C>, <E as Engine>::G2Affine) {
+pub(crate) fn build_unextracted_certificate_accumulator_from_assets() -> (
+    Accumulator<RecursiveEmulation>,
+    BTreeMap<String, EmulatedCurve>,
+    <PairingEngine as Engine>::G2Affine,
+) {
     let verification_context =
         load_embedded_verification_context_asset().expect("verification context asset should load");
     let recursive_chain_state = load_embedded_recursive_chain_state_asset()
@@ -337,7 +341,7 @@ pub(crate) fn build_unextracted_certificate_accumulator_from_assets()
         &recursive_step_output.next_state,
     );
 
-    let accumulator: Accumulator<S> = verify_prepare_poseidon_recursive_proof(
+    let accumulator: Accumulator<RecursiveEmulation> = verify_prepare_poseidon_recursive_proof(
         verification_context.certificate_verifying_key.as_ref(),
         recursive_step_output.certificate_proof.as_bytes(),
         &certificate_public_inputs,
@@ -356,8 +360,10 @@ pub(crate) fn build_unextracted_certificate_accumulator_from_assets()
 ///
 /// The chain-state proof is a Poseidon recursive proof; its public inputs are
 /// `[global | state | accumulator]` as stored in the committed assets.
-pub(crate) fn build_unextracted_recursive_proof_accumulator_from_assets()
--> (Accumulator<S>, BTreeMap<String, C>) {
+pub(crate) fn build_unextracted_recursive_proof_accumulator_from_assets() -> (
+    Accumulator<RecursiveEmulation>,
+    BTreeMap<String, EmulatedCurve>,
+) {
     let verification_context =
         load_embedded_verification_context_asset().expect("verification context asset should load");
     let recursive_chain_state = load_embedded_recursive_chain_state_asset()
@@ -375,7 +381,7 @@ pub(crate) fn build_unextracted_recursive_proof_accumulator_from_assets()
     ]
     .concat();
 
-    let accumulator: Accumulator<S> = verify_prepare_poseidon_recursive_proof(
+    let accumulator: Accumulator<RecursiveEmulation> = verify_prepare_poseidon_recursive_proof(
         verification_context.recursive_verifying_key.as_ref(),
         recursive_chain_state.ivc_proof.as_bytes(),
         &public_inputs,
@@ -391,7 +397,7 @@ pub(crate) fn compute_exact_next_accumulator_from_assets(
     recursive_chain_state: &RecursiveChainStateAsset,
     expected_next_state: &State,
     certificate_proof: &[u8],
-) -> Accumulator<S> {
+) -> Accumulator<RecursiveEmulation> {
     let certificate_accumulator = prepare_stored_step_certificate_accumulator(
         setup,
         recursive_chain_state,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/negative.rs
@@ -5,7 +5,7 @@ use ff::Field;
 use midnight_circuits::types::Instantiable;
 
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, F, PREIMAGE_CURRENT_EPOCH_BYTES,
+    AssignedAccumulator, NativeField, PREIMAGE_CURRENT_EPOCH_BYTES,
     PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
     protocol_message::{DynamicProtocolMessagePartKey, ProtocolMessage},
     state::State,
@@ -106,7 +106,7 @@ fn next_merkle_tree_commitment_tampered_public_input_is_rejected() {
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
+    tampered_state.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),
@@ -138,7 +138,7 @@ fn next_protocol_parameters_tampered_public_input_is_rejected() {
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
+    tampered_state.next_protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),
@@ -170,7 +170,7 @@ fn current_epoch_tampered_public_input_is_rejected() {
         .expect("recursive step output asset should load");
 
     let mut tampered_state = recursive_step_output.next_state.clone();
-    tampered_state.current_epoch = EpochNumber::from_field(F::ONE);
+    tampered_state.current_epoch = EpochNumber::from_field(NativeField::ONE);
 
     let public_inputs = [
         verification_context.global_field_elements.clone(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/encoding/positive.rs
@@ -6,9 +6,9 @@ use midnight_proofs::utils::SerdeFormat;
 use sha2::{Digest as Sha2Digest, Sha256};
 
 use crate::circuits::halo2_ivc::{
-    Accumulator, E, F, KZGCommitmentScheme, PREIMAGE_CURRENT_EPOCH_BYTES,
+    Accumulator, KZGCommitmentScheme, NativeField, PREIMAGE_CURRENT_EPOCH_BYTES,
     PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
-    PREIMAGE_SIZE, S, VerifyingKey,
+    PREIMAGE_SIZE, PairingEngine, RecursiveEmulation, VerifyingKey,
     circuit::IvcCircuitData,
     io::{Read as IvcRead, Write as IvcWrite},
     protocol_message::{DynamicProtocolMessagePartKey, ProtocolMessage},
@@ -95,13 +95,13 @@ fn state_public_input_has_7_elements_in_correct_order() {
     // Off-circuit check that State::as_public_input() returns exactly 7 field
     // elements in the order the circuit expects: step_counter, message, merkle_tree_commitment,
     // next_merkle_tree_commitment, protocol_parameters, next_protocol_parameters, current_epoch.
-    let step_counter = F::from(1u64);
-    let message = F::from(2u64);
-    let merkle_tree_commitment = F::from(3u64);
-    let next_merkle_tree_commitment = F::from(4u64);
-    let protocol_parameters = F::from(5u64);
-    let next_protocol_parameters = F::from(6u64);
-    let current_epoch = F::from(7u64);
+    let step_counter = NativeField::from(1u64);
+    let message = NativeField::from(2u64);
+    let merkle_tree_commitment = NativeField::from(3u64);
+    let next_merkle_tree_commitment = NativeField::from(4u64);
+    let protocol_parameters = NativeField::from(5u64);
+    let next_protocol_parameters = NativeField::from(6u64);
+    let current_epoch = NativeField::from(7u64);
 
     let state = State::new(
         StepCounter::from_field(step_counter),
@@ -152,9 +152,11 @@ fn accumulator_serialization_round_trip() {
         .write(&mut first_bytes, SerdeFormat::RawBytesUnchecked)
         .expect("accumulator serialization should succeed");
 
-    let deserialized =
-        Accumulator::<S>::read(&mut first_bytes.as_slice(), SerdeFormat::RawBytesUnchecked)
-            .expect("accumulator deserialization should succeed");
+    let deserialized = Accumulator::<RecursiveEmulation>::read(
+        &mut first_bytes.as_slice(),
+        SerdeFormat::RawBytesUnchecked,
+    )
+    .expect("accumulator deserialization should succeed");
 
     let mut second_bytes = Vec::new();
     deserialized
@@ -191,11 +193,10 @@ fn vk_serialization_round_trip() {
         .write(&mut bytes, SerdeFormat::RawBytesUnchecked)
         .expect("verifying key serialization should succeed");
 
-    let deserialized = VerifyingKey::<F, KZGCommitmentScheme<E>>::read::<_, IvcCircuitData>(
-        &mut bytes.as_slice(),
-        SerdeFormat::RawBytesUnchecked,
-        (),
-    )
+    let deserialized = VerifyingKey::<NativeField, KZGCommitmentScheme<PairingEngine>>::read::<
+        _,
+        IvcCircuitData,
+    >(&mut bytes.as_slice(), SerdeFormat::RawBytesUnchecked, ())
     .expect("verifying key deserialization should succeed");
 
     assert_eq!(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/accumulator.rs
@@ -9,7 +9,7 @@ use midnight_circuits::types::Instantiable;
 
 use crate::StmResult;
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, F,
+    AssignedAccumulator, NativeField,
     tests::common::{
         asset_readers::{
             StepOutputAsset, load_embedded_following_certificate_in_epoch_asset,
@@ -20,7 +20,7 @@ use crate::circuits::halo2_ivc::{
     },
 };
 
-/// Loads a step output via `load_step_output`, replaces `acc[0]` with `F::ONE`
+/// Loads a step output via `load_step_output`, replaces `acc[0]` with `NativeField::ONE`
 /// in the public inputs, then asserts the verifier rejects the resulting proof.
 fn assert_step_output_rejects_tampered_next_accumulator<T: StepOutputAsset>(
     load_step_output: impl FnOnce() -> StmResult<T>,
@@ -37,7 +37,7 @@ fn assert_step_output_rejects_tampered_next_accumulator<T: StepOutputAsset>(
     let mut accumulator_encoding =
         AssignedAccumulator::as_public_input(step_output.next_accumulator());
 
-    accumulator_encoding[0] = F::ONE;
+    accumulator_encoding[0] = NativeField::ONE;
 
     let public_inputs = [global, state, accumulator_encoding].concat();
 
@@ -91,7 +91,7 @@ mod slow {
     use midnight_circuits::types::Instantiable;
 
     use crate::circuits::halo2_ivc::{
-        AssignedAccumulator, F,
+        AssignedAccumulator, NativeField,
         circuit::IvcCircuitData,
         tests::common::{
             asset_readers::load_embedded_recursive_chain_state_asset,
@@ -143,7 +143,7 @@ mod slow {
         .expect("valid IvcCircuitData construction");
 
         let mut accumulator_encoding = AssignedAccumulator::as_public_input(&next_accumulator);
-        accumulator_encoding[0] = F::ONE;
+        accumulator_encoding[0] = NativeField::ONE;
 
         let public_inputs = [
             mock_prover_setup.global.as_public_input(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/public_inputs.rs
@@ -5,7 +5,7 @@ use ff::Field;
 use midnight_circuits::types::Instantiable;
 
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, F,
+    AssignedAccumulator, NativeField,
     state::State,
     tests::common::{
         asset_readers::{
@@ -28,7 +28,7 @@ use crate::circuits::halo2_ivc::{
 /// `global` layout: `[genesis_message, genesis_verification_key.x, genesis_verification_key.y,
 /// certificate_circuit_verification_key_representation, ivc_circuit_verification_key_representation]`.
 fn assert_genesis_step_output_rejects_tampered_public_inputs(
-    tamper: impl FnOnce(&mut Vec<F>, &mut Vec<F>, &mut Vec<F>),
+    tamper: impl FnOnce(&mut Vec<NativeField>, &mut Vec<NativeField>, &mut Vec<NativeField>),
     rejection_message: &str,
 ) {
     let verification_context =
@@ -62,7 +62,7 @@ fn genesis_message_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when genesis_message
     // is replaced in the global public inputs, confirming it is committed at index 0.
     assert_genesis_step_output_rejects_tampered_public_inputs(
-        |global, _, _| global[0] = F::ONE,
+        |global, _, _| global[0] = NativeField::ONE,
         "proof with tampered genesis_message should be rejected by the verifier",
     );
 }
@@ -72,7 +72,7 @@ fn genesis_verification_key_x_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when the x coordinate of
     // genesis_verification_key is replaced in the global public inputs, confirming index 1 is committed.
     assert_genesis_step_output_rejects_tampered_public_inputs(
-        |global, _, _| global[1] = F::ONE,
+        |global, _, _| global[1] = NativeField::ONE,
         "proof with tampered genesis_verification_key x coordinate should be rejected by the verifier",
     );
 }
@@ -82,7 +82,7 @@ fn genesis_verification_key_y_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when the y coordinate of
     // genesis_verification_key is replaced in the global public inputs, confirming index 2 is committed.
     assert_genesis_step_output_rejects_tampered_public_inputs(
-        |global, _, _| global[2] = F::ONE,
+        |global, _, _| global[2] = NativeField::ONE,
         "proof with tampered genesis_verification_key y coordinate should be rejected by the verifier",
     );
 }
@@ -93,7 +93,7 @@ fn certificate_circuit_verification_key_representation_tampered_public_input_is_
     // certificate_circuit_verification_key_representation is replaced in the global public inputs,
     // confirming it is committed at index 3.
     assert_genesis_step_output_rejects_tampered_public_inputs(
-        |global, _, _| global[3] = F::ONE,
+        |global, _, _| global[3] = NativeField::ONE,
         "proof with tampered certificate_circuit_verification_key_representation should be rejected by the verifier",
     );
 }
@@ -104,7 +104,7 @@ fn ivc_circuit_verification_key_representation_tampered_public_input_is_rejected
     // ivc_circuit_verification_key_representation is replaced in the global public inputs,
     // confirming it is committed at index 4.
     assert_genesis_step_output_rejects_tampered_public_inputs(
-        |global, _, _| global[4] = F::ONE,
+        |global, _, _| global[4] = NativeField::ONE,
         "proof with tampered ivc_circuit_verification_key_representation should be rejected by the verifier",
     );
 }
@@ -114,7 +114,7 @@ fn next_accumulator_tampered_public_input_is_rejected() {
     // Asset-based check that the verifier rejects a stored proof when next_accumulator
     // is replaced in the public inputs, confirming the accumulator output is committed.
     assert_genesis_step_output_rejects_tampered_public_inputs(
-        |_, _, accumulator_encoding| accumulator_encoding[0] = F::ONE,
+        |_, _, accumulator_encoding| accumulator_encoding[0] = NativeField::ONE,
         "proof with tampered next_accumulator should be rejected by the verifier",
     );
 }
@@ -136,7 +136,7 @@ mod slow {
         let state = next_state.as_public_input();
         let accumulator_encoding =
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator);
-        global[0] = F::ONE;
+        global[0] = NativeField::ONE;
         assert_recursive_mock_prover_rejects_with_label(
             ivc_circuit_data,
             [global, state, accumulator_encoding].concat(),
@@ -158,7 +158,7 @@ mod slow {
         let state = next_state.as_public_input();
         let accumulator_encoding =
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator);
-        global[3] = F::ONE;
+        global[3] = NativeField::ONE;
         assert_recursive_mock_prover_rejects_with_label(
             ivc_circuit_data,
             [global, state, accumulator_encoding].concat(),
@@ -180,7 +180,7 @@ mod slow {
         let state = next_state.as_public_input();
         let accumulator_encoding =
             AssignedAccumulator::as_public_input(&mock_prover_setup.trivial_accumulator);
-        global[4] = F::ONE;
+        global[4] = NativeField::ONE;
         assert_recursive_mock_prover_rejects_with_label(
             ivc_circuit_data,
             [global, state, accumulator_encoding].concat(),

--- a/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/in_circuit/state_transition.rs
@@ -15,7 +15,7 @@ mod slow {
     use ff::Field;
 
     use crate::circuits::halo2_ivc::{
-        F,
+        NativeField,
         state::Witness,
         tests::common::{
             asset_readers::load_embedded_recursive_chain_state_asset,
@@ -55,7 +55,8 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
+        tampered_state.next_merkle_tree_commitment =
+            MerkleTreeCommitment::from_field(NativeField::ONE);
         let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
@@ -87,7 +88,8 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
+        tampered_state.next_protocol_parameters =
+            ProtocolParametersHash::from_field(NativeField::ONE);
         let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(
@@ -120,7 +122,7 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, same_epoch_message);
-        tampered_state.message = MessageHash::from_field(F::ONE);
+        tampered_state.message = MessageHash::from_field(NativeField::ONE);
         let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         assert_recursive_mock_prover_rejects_with_label(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_collapse.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_collapse.rs
@@ -9,15 +9,18 @@ use std::collections::BTreeMap;
 use midnight_curves::pairing::Engine;
 
 use crate::circuits::halo2_ivc::{
-    Accumulator, C, E, S,
+    Accumulator, EmulatedCurve, PairingEngine, RecursiveEmulation,
     tests::common::helpers::build_unextracted_certificate_accumulator_from_assets,
 };
 
 /// Verifies the stored certificate proof and returns the accumulator after
 /// `extract_fixed_bases` but before `collapse`, together with the certificate
 /// fixed-base map and `tau_in_g2` needed to call `accumulator.check`.
-fn build_extracted_certificate_accumulator()
--> (Accumulator<S>, BTreeMap<String, C>, <E as Engine>::G2Affine) {
+fn build_extracted_certificate_accumulator() -> (
+    Accumulator<RecursiveEmulation>,
+    BTreeMap<String, EmulatedCurve>,
+    <PairingEngine as Engine>::G2Affine,
+) {
     let (mut accumulator, certificate_fixed_bases, tau_in_g2) =
         build_unextracted_certificate_accumulator_from_assets();
     accumulator.extract_fixed_bases(&certificate_fixed_bases);

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_update.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_update.rs
@@ -18,7 +18,7 @@ use ff::Field;
 use midnight_curves::pairing::Engine;
 
 use crate::circuits::halo2_ivc::{
-    Accumulator, C, E, Msm, S,
+    Accumulator, EmulatedCurve, Msm, PairingEngine, RecursiveEmulation,
     tests::common::{
         asset_readers::load_embedded_recursive_chain_state_asset,
         helpers::{
@@ -40,10 +40,10 @@ use crate::circuits::halo2_ivc::{
 /// KZG verifier parameters and are covered by
 /// `golden/positive.rs::replay_integrity_matches_stored_next_step_output`.
 fn build_proof_accumulators_from_stored_step_assets() -> (
-    Accumulator<S>,
-    Accumulator<S>,
-    BTreeMap<String, C>,
-    <E as Engine>::G2Affine,
+    Accumulator<RecursiveEmulation>,
+    Accumulator<RecursiveEmulation>,
+    BTreeMap<String, EmulatedCurve>,
+    <PairingEngine as Engine>::G2Affine,
 ) {
     let (mut certificate_accumulator, certificate_fixed_bases, tau_in_g2) =
         build_unextracted_certificate_accumulator_from_assets();
@@ -55,7 +55,7 @@ fn build_proof_accumulators_from_stored_step_assets() -> (
     previous_proof_accumulator.extract_fixed_bases(&recursive_fixed_bases);
     previous_proof_accumulator.collapse();
 
-    let combined_fixed_bases: BTreeMap<String, C> = certificate_fixed_bases
+    let combined_fixed_bases: BTreeMap<String, EmulatedCurve> = certificate_fixed_bases
         .into_iter()
         .chain(recursive_fixed_bases)
         .collect();
@@ -70,8 +70,11 @@ fn build_proof_accumulators_from_stored_step_assets() -> (
 
 /// Runs the full off-circuit accumulation pipeline on stored step assets and returns
 /// `(next_accumulator, combined_fixed_bases, tau_in_g2)`.
-fn build_next_accumulator_from_stored_step_assets()
--> (Accumulator<S>, BTreeMap<String, C>, <E as Engine>::G2Affine) {
+fn build_next_accumulator_from_stored_step_assets() -> (
+    Accumulator<RecursiveEmulation>,
+    BTreeMap<String, EmulatedCurve>,
+    <PairingEngine as Engine>::G2Affine,
+) {
     let recursive_chain_state = load_embedded_recursive_chain_state_asset()
         .expect("recursive chain state asset should load");
     let (certificate_accumulator, previous_proof_accumulator, combined_fixed_bases, tau_in_g2) =
@@ -124,7 +127,7 @@ fn pipeline_with_invalid_previous_accumulator_fails_accumulator_check() {
             !scalar.is_zero_vartime()
                 && combined_fixed_bases
                     .get(*key)
-                    .map(|base| *base != C::default())
+                    .map(|base| *base != EmulatedCurve::default())
                     .unwrap_or(false)
         })
         .map(|(key, _)| key.clone())
@@ -132,12 +135,12 @@ fn pipeline_with_invalid_previous_accumulator_fails_accumulator_check() {
     tampered_fixed_base_scalars
         .entry(key_to_negate)
         .and_modify(|scalar| *scalar = scalar.neg());
-    let tampered_right_hand_side = Msm::<S>::new(
+    let tampered_right_hand_side = Msm::<RecursiveEmulation>::new(
         &right_hand_side.bases(),
         &right_hand_side.scalars(),
         &tampered_fixed_base_scalars,
     );
-    let tampered_chain_accumulator = Accumulator::<S>::new(
+    let tampered_chain_accumulator = Accumulator::<RecursiveEmulation>::new(
         recursive_chain_state.accumulator.lhs(),
         tampered_right_hand_side,
     );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_verification.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_verification.rs
@@ -11,7 +11,7 @@ use std::ops::Neg;
 use ff::Field;
 
 use crate::circuits::halo2_ivc::{
-    Accumulator, C, Msm, S,
+    Accumulator, EmulatedCurve, Msm, RecursiveEmulation,
     tests::common::asset_readers::{
         load_embedded_following_certificate_in_epoch_asset,
         load_embedded_next_epoch_step_output_asset, load_embedded_recursive_chain_state_asset,
@@ -103,7 +103,7 @@ fn tampered_accumulator_fails_check() {
                 && verification_context
                     .combined_fixed_bases
                     .get(*key)
-                    .map(|base| *base != C::default())
+                    .map(|base| *base != EmulatedCurve::default())
                     .unwrap_or(false)
         })
         .map(|(key, _)| key.clone())
@@ -112,13 +112,15 @@ fn tampered_accumulator_fails_check() {
         .entry(key_to_negate)
         .and_modify(|scalar| *scalar = scalar.neg());
 
-    let tampered_right_hand_side = Msm::<S>::new(
+    let tampered_right_hand_side = Msm::<RecursiveEmulation>::new(
         &right_hand_side.bases(),
         &right_hand_side.scalars(),
         &tampered_fixed_base_scalars,
     );
-    let tampered_accumulator =
-        Accumulator::<S>::new(original_accumulator.lhs(), tampered_right_hand_side);
+    let tampered_accumulator = Accumulator::<RecursiveEmulation>::new(
+        original_accumulator.lhs(),
+        tampered_right_hand_side,
+    );
 
     assert!(
         !tampered_accumulator.check(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/fixed_base_extraction.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/fixed_base_extraction.rs
@@ -14,7 +14,7 @@ use ff::Field;
 use midnight_circuits::{types::Instantiable, verifier::AssignedMsm};
 
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, S, state::trivial_acc,
+    AssignedAccumulator, RecursiveEmulation, state::trivial_acc,
     tests::common::helpers::build_unextracted_recursive_proof_accumulator_from_assets,
 };
 
@@ -78,9 +78,11 @@ fn extract_fixed_bases_does_not_affect_lhs() {
     let (mut accumulator, recursive_fixed_bases) =
         build_unextracted_recursive_proof_accumulator_from_assets();
 
-    let lhs_encoding_before_extraction = AssignedMsm::<S>::as_public_input(&accumulator.lhs());
+    let lhs_encoding_before_extraction =
+        AssignedMsm::<RecursiveEmulation>::as_public_input(&accumulator.lhs());
     accumulator.extract_fixed_bases(&recursive_fixed_bases);
-    let lhs_encoding_after_extraction = AssignedMsm::<S>::as_public_input(&accumulator.lhs());
+    let lhs_encoding_after_extraction =
+        AssignedMsm::<RecursiveEmulation>::as_public_input(&accumulator.lhs());
 
     assert_eq!(
         lhs_encoding_before_extraction, lhs_encoding_after_extraction,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/genesis.rs
@@ -22,7 +22,7 @@ fn merkle_tree_commitment_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE),
         "proof with tampered merkle_tree_commitment should be rejected by the verifier",
     );
 }
@@ -33,7 +33,7 @@ fn protocol_parameters_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        |s| s.protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE),
         "proof with tampered protocol_parameters should be rejected by the verifier",
     );
 }
@@ -44,7 +44,7 @@ fn next_merkle_tree_commitment_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE),
         "proof with tampered next_merkle_tree_commitment should be rejected by the verifier",
     );
 }
@@ -55,7 +55,7 @@ fn next_protocol_parameters_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE),
         "proof with tampered next_protocol_parameters should be rejected by the verifier",
     );
 }
@@ -77,7 +77,7 @@ fn current_epoch_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.current_epoch = EpochNumber::from_field(F::ONE),
+        |s| s.current_epoch = EpochNumber::from_field(NativeField::ONE),
         "proof with tampered current_epoch should be rejected by the verifier",
     );
 }
@@ -88,7 +88,7 @@ fn msg_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_genesis_step_output_asset,
         "genesis step output",
-        |s| s.message = MessageHash::from_field(F::ONE),
+        |s| s.message = MessageHash::from_field(NativeField::ONE),
         "proof with tampered message should be rejected by the verifier",
     );
 }
@@ -121,7 +121,7 @@ mod slow {
         // MockProver check that the in-circuit Blake2b hash constraint between
         // message_preimage bytes and the resulting message field is wired correctly.
         assert_genesis_circuit_rejects_tampered_next_state(|s| {
-            s.message = MessageHash::from_field(F::ONE)
+            s.message = MessageHash::from_field(NativeField::ONE)
         });
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/mod.rs
@@ -6,7 +6,7 @@ use midnight_circuits::types::Instantiable;
 
 use crate::StmResult;
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, F,
+    AssignedAccumulator, NativeField,
     state::State,
     tests::common::{
         asset_readers::{StepOutputAsset, load_embedded_verification_context_asset},

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/next_epoch.rs
@@ -26,7 +26,7 @@ fn merkle_tree_commitment_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_next_epoch_step_output_asset,
         "recursive step output",
-        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE),
         "proof with tampered merkle_tree_commitment should be rejected by the verifier",
     );
 }
@@ -37,7 +37,7 @@ fn protocol_parameters_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_next_epoch_step_output_asset,
         "recursive step output",
-        |s| s.protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        |s| s.protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE),
         "proof with tampered protocol_parameters should be rejected by the verifier",
     );
 }
@@ -48,7 +48,7 @@ fn next_merkle_tree_commitment_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_next_epoch_step_output_asset,
         "recursive step output",
-        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE),
         "proof with tampered next_merkle_tree_commitment should be rejected by the verifier",
     );
 }
@@ -59,7 +59,7 @@ fn next_protocol_parameters_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_next_epoch_step_output_asset,
         "recursive step output",
-        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE),
         "proof with tampered next_protocol_parameters should be rejected by the verifier",
     );
 }
@@ -70,7 +70,7 @@ fn counter_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_next_epoch_step_output_asset,
         "recursive step output",
-        |s| s.step_counter = StepCounter::from_field(F::ONE),
+        |s| s.step_counter = StepCounter::from_field(NativeField::ONE),
         "proof with tampered step_counter should be rejected by the verifier",
     );
 }
@@ -92,7 +92,7 @@ fn msg_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_next_epoch_step_output_asset,
         "recursive step output",
-        |s| s.message = MessageHash::from_field(F::ONE),
+        |s| s.message = MessageHash::from_field(NativeField::ONE),
         "proof with tampered message should be rejected by the verifier",
     );
 }
@@ -121,7 +121,7 @@ mod slow {
             ),
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
-        tampered_state.protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
+        tampered_state.protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE);
         let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
@@ -153,7 +153,7 @@ mod slow {
             ),
         );
         let mut tampered_state = next_state_for_step(&prev_state, message);
-        tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
+        tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE);
         let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);

--- a/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/transitions/negative/same_epoch.rs
@@ -28,7 +28,7 @@ fn merkle_tree_commitment_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_following_certificate_in_epoch_asset,
         "same-epoch step output",
-        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        |s| s.merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE),
         "proof with tampered merkle_tree_commitment should be rejected by the verifier",
     );
 }
@@ -39,7 +39,7 @@ fn next_merkle_tree_commitment_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_following_certificate_in_epoch_asset,
         "same-epoch step output",
-        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE),
+        |s| s.next_merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE),
         "proof with tampered next_merkle_tree_commitment should be rejected by the verifier",
     );
 }
@@ -50,7 +50,7 @@ fn protocol_parameters_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_following_certificate_in_epoch_asset,
         "same-epoch step output",
-        |s| s.protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        |s| s.protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE),
         "proof with tampered protocol_parameters should be rejected by the verifier",
     );
 }
@@ -61,7 +61,7 @@ fn next_protocol_parameters_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_following_certificate_in_epoch_asset,
         "same-epoch step output",
-        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(F::ONE),
+        |s| s.next_protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE),
         "proof with tampered next_protocol_parameters should be rejected by the verifier",
     );
 }
@@ -72,7 +72,7 @@ fn current_epoch_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_following_certificate_in_epoch_asset,
         "same-epoch step output",
-        |s| s.current_epoch = EpochNumber::from_field(F::ONE),
+        |s| s.current_epoch = EpochNumber::from_field(NativeField::ONE),
         "proof with tampered current_epoch should be rejected by the verifier",
     );
 }
@@ -83,7 +83,7 @@ fn counter_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_following_certificate_in_epoch_asset,
         "same-epoch step output",
-        |s| s.step_counter = StepCounter::from_field(F::ONE),
+        |s| s.step_counter = StepCounter::from_field(NativeField::ONE),
         "proof with tampered step_counter should be rejected by the verifier",
     );
 }
@@ -94,7 +94,7 @@ fn msg_tampered_is_rejected() {
     assert_step_output_rejects_tampered_state(
         load_embedded_following_certificate_in_epoch_asset,
         "same-epoch step output",
-        |s| s.message = MessageHash::from_field(F::ONE),
+        |s| s.message = MessageHash::from_field(NativeField::ONE),
         "proof with tampered message should be rejected by the verifier",
     );
 }
@@ -124,7 +124,7 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
-        tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(F::ONE);
+        tampered_state.merkle_tree_commitment = MerkleTreeCommitment::from_field(NativeField::ONE);
         let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);
@@ -157,7 +157,7 @@ mod slow {
             ),
         );
         let mut tampered_state = same_epoch_next_state_for_step(&prev_state, message);
-        tampered_state.protocol_parameters = ProtocolParametersHash::from_field(F::ONE);
+        tampered_state.protocol_parameters = ProtocolParametersHash::from_field(NativeField::ONE);
         let ivc_circuit_data =
             build_trivial_mock_prover_circuit(&mock_prover_setup, prev_state, witness);
         let public_inputs = build_mock_prover_public_inputs(&mock_prover_setup, &tampered_state);

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -7,7 +7,7 @@ use ff::Field;
 use serde::{Deserialize, Serialize};
 
 use super::{
-    F, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+    NativeField, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE,
 };
 use crate::BaseFieldElement;
@@ -15,30 +15,30 @@ use crate::BaseFieldElement;
 macro_rules! field_wrapper {
     ($name:ident, zero) => {
         #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
-        pub(crate) struct $name(F);
+        pub(crate) struct $name(NativeField);
 
         impl $name {
-            pub(crate) const ZERO: Self = Self(F::ZERO);
+            pub(crate) const ZERO: Self = Self(NativeField::ZERO);
 
-            pub(crate) fn from_field(value: F) -> Self {
+            pub(crate) fn from_field(value: NativeField) -> Self {
                 Self(value)
             }
 
-            pub(crate) fn as_field(self) -> F {
+            pub(crate) fn as_field(self) -> NativeField {
                 self.0
             }
         }
     };
     ($name:ident) => {
         #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-        pub(crate) struct $name(F);
+        pub(crate) struct $name(NativeField);
 
         impl $name {
-            pub(crate) fn from_field(value: F) -> Self {
+            pub(crate) fn from_field(value: NativeField) -> Self {
                 Self(value)
             }
 
-            pub(crate) fn as_field(self) -> F {
+            pub(crate) fn as_field(self) -> NativeField {
                 self.0
             }
         }
@@ -67,12 +67,12 @@ macro_rules! u64_wrapper {
                 self.0
             }
 
-            pub(crate) fn as_field(self) -> F {
-                F::from(self.0)
+            pub(crate) fn as_field(self) -> NativeField {
+                NativeField::from(self.0)
             }
 
             #[cfg(test)]
-            pub(crate) fn from_field(value: F) -> Self {
+            pub(crate) fn from_field(value: NativeField) -> Self {
                 let bytes = value.to_bytes_le();
                 let low_bytes = bytes[0..8]
                     .try_into()


### PR DESCRIPTION
## Content

This is the first of two PRs for issue #3129 . It renames the recursive (IVC) circuit's Midnight backend type aliases to meaningful, self-documenting names, across the whole `halo2_ivc` module (and its tests) and the one external consumer in `halo2/`.

### Changes

- **Backend aliases renamed** (`halo2_ivc/mod.rs`): `S` → `RecursiveEmulation`, `F` → `NativeField`, `C` → `EmulatedCurve`, `E` → `PairingEngine`, `CBase` → `EmulatedCurveBaseField`.
- **Gadget alias renamed**: `NG` → `IvcNativeGadget`.
- **External consumer updated** (`halo2/keys.rs`): the non-recursive certificate verifying key refers to the renamed `NativeField` / `PairingEngine` when spelling the raw recursive verifying-key type.
- **VK regeneration helpers**: the two recursive verifying-key generators now use the `NativeField` / `PairingEngine` aliases instead of re-deriving `<BlstrsEmulation as SelfEmulation>::F` / `::Engine`.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Relates to https://github.com/input-output-hk/mithril/issues/3129