### PR TITLE
fix(ci): prevent GitHub Pages deploy failure on workflow re-runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -980,6 +980,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     permissions:
+      actions: write
       contents: read
       pages: write
       id-token: write
@@ -1024,6 +1025,19 @@ jobs:
 
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v6
+
+      - name: Delete stale GitHub Pages artifacts from previous run attempts
+        if: github.run_attempt != '1'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          IDS=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+            --jq '.artifacts[] | select(.name == "github-pages") | .id')
+
+          for ID in $IDS; do
+            gh api --silent -X DELETE "repos/${{ github.repository }}/actions/artifacts/${ID}"
+          done
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1032,7 +1032,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          IDS=$(gh api "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" \
+          IDS=$(gh api --paginate "repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100" \
             --jq '.artifacts[] | select(.name == "github-pages") | .id')
 
           for ID in $IDS; do


### PR DESCRIPTION
## Content

This PR includes a **fix for the `publish-docs` job that fails with `Multiple artifacts named "github-pages" were unexpectedly found` when a workflow run is re-run** (see this [run](https://github.com/input-output-hk/mithril/actions/runs/28785806267/job/85376851231#step:9:22)):
- Adds a step that deletes stale `github-pages` artifacts from previous run attempts before uploading the fresh one, so `actions/deploy-pages` finds exactly one artifact to deploy
- Runs the cleanup only on re-runs (`github.run_attempt != '1'`) using the official `gh` CLI already available in the job, avoiding any third-party action
- Grants the `actions: write` permission required to delete artifacts via the GitHub API

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
