### PR TITLE
 feat(stm): add tests to circuit degrees are unchanged

### DIFF
--- a/docs/runbook/update-circuit-keys/README.md
+++ b/docs/runbook/update-circuit-keys/README.md
@@ -37,18 +37,6 @@ and
 cargo test -p mithril-stm --features future_snark --release integrity_test_for_recursive_production_key -- --ignored
 ```
 
-Commands to validate the degree of the circuits did not increase:
-
-```bash
-cargo test -p mithril-stm --features future_snark non_recursive_circuit_degree_correctness
-```
-
-and
-
-```bash
-cargo test -p mithril-stm --features future_snark ivc_constant_constraints_degree
-```
-
 Release manager:
 
 - Prepares the release of this update

--- a/docs/runbook/update-circuit-keys/README.md
+++ b/docs/runbook/update-circuit-keys/README.md
@@ -13,6 +13,7 @@ The author of the change:
 
 - Prepares the PR that includes the change
 - Needs to justify the change in the circuit
+- Checks that the changes did not increase the degree of the circuits
 - Updates the key values (golden and production)
 - Ensures the approval of the tech lead and all cryptographers before the merge
 
@@ -20,6 +21,7 @@ Reviewers:
 
 - Perform a thorough review of the change
 - Analyse the justification of the change to make sure it is valid and cannot be avoided
+- Make sure the degree of the circuits did not increase
 - Reviews the update of the key values (golden and production)
 - Run the tests for the integrity of the production keys
 
@@ -33,6 +35,18 @@ and
 
 ```bash
 cargo test -p mithril-stm --features future_snark --release integrity_test_for_recursive_production_key -- --ignored
+```
+
+Commands to validate the degree of the circuits did not increase:
+
+```bash
+cargo test -p mithril-stm --features future_snark non_recursive_circuit_degree_correctness
+```
+
+and
+
+```bash
+cargo test -p mithril-stm --features future_snark ivc_constant_constraints_degree
 ```
 
 Release manager:

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.46 (07-07-2026)
+
+### Added
+
+- Tests to verify that the degree of the circuits is unchanged
+
 ## 0.10.45 (07-07-2026)
 
 ### Changed

--- a/mithril-stm/src/circuits/halo2/circuit.rs
+++ b/mithril-stm/src/circuits/halo2/circuit.rs
@@ -469,7 +469,7 @@ mod non_recursive_circuit_degree_correctness {
     const NON_RECURSIVE_CIRCUIT_DEGREE: u32 = 22;
 
     #[test]
-    fn constant_certificate_circuit_constraint_degree_for_small_circuit() {
+    fn non_recursive_circuit_constraint_degree_stays_constant_for_small_circuit() {
         // Those parameters and merkle tree depth lead to a circuit
         // with constraints close to the next power of two
         let parameters = Parameters {
@@ -490,7 +490,7 @@ mod non_recursive_circuit_degree_correctness {
     }
 
     #[test]
-    fn constant_certificate_circuit_constraint_degree_for_production_circuit() {
+    fn non_recursive_circuit_constraint_degree_stays_constant_for_production_circuit() {
         let non_recursive_circuit_verifying_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
             NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
         )

--- a/mithril-stm/src/circuits/halo2/circuit.rs
+++ b/mithril-stm/src/circuits/halo2/circuit.rs
@@ -497,7 +497,7 @@ mod non_recursive_circuit_degree_correctness {
         .unwrap();
 
         assert_eq!(
-            non_recursive_circuit_verifying_key.midnight_vk().k() as u32,
+            non_recursive_circuit_verifying_key.circuit_degree() as u32,
             NON_RECURSIVE_CIRCUIT_DEGREE
         );
     }

--- a/mithril-stm/src/circuits/halo2/circuit.rs
+++ b/mithril-stm/src/circuits/halo2/circuit.rs
@@ -452,7 +452,7 @@ mod circuit_creation_tests {
 }
 
 #[cfg(test)]
-mod circuit_degree_correctness {
+mod non_recursive_circuit_degree_correctness {
     use midnight_zk_stdlib as zk;
 
     use crate::{
@@ -469,7 +469,7 @@ mod circuit_degree_correctness {
     const NON_RECURSIVE_CIRCUIT_DEGREE: u32 = 22;
 
     #[test]
-    fn certificate_circuit_constraint_degree_for_small_circuit() {
+    fn constant_certificate_circuit_constraint_degree_for_small_circuit() {
         // Those parameters and merkle tree depth lead to a circuit
         // with constraints close to the next power of two
         let parameters = Parameters {
@@ -490,7 +490,7 @@ mod circuit_degree_correctness {
     }
 
     #[test]
-    fn certificate_circuit_constraint_degree_for_production_circuit() {
+    fn constant_certificate_circuit_constraint_degree_for_production_circuit() {
         let non_recursive_circuit_verifying_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
             NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
         )

--- a/mithril-stm/src/circuits/halo2/circuit.rs
+++ b/mithril-stm/src/circuits/halo2/circuit.rs
@@ -450,3 +450,55 @@ mod circuit_creation_tests {
         circuit.expect_err("Creation should have failed with k too large.");
     }
 }
+
+#[cfg(test)]
+mod circuit_degree_correctness {
+    use midnight_zk_stdlib as zk;
+
+    use crate::{
+        Parameters,
+        circuits::halo2::{
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::StmCertificateCircuit,
+            keys::NonRecursiveCircuitVerifyingKey,
+        },
+        codec::TryFromBytes,
+    };
+
+    const SMALL_CERTIFICATE_CIRCUIT_DEGREE: u32 = 13;
+
+    const NON_RECURSIVE_CIRCUIT_DEGREE: u32 = 22;
+
+    #[test]
+    fn certificate_circuit_constraint_degree_for_small_circuit() {
+        // Those parameters and merkle tree depth lead to a circuit
+        // with constraints close to the next power of two
+        let parameters = Parameters {
+            k: 4,
+            m: 10,
+            phi_f: 0.2,
+        };
+        let merkle_tree_depth = 10;
+
+        let circuit = StmCertificateCircuit::try_new(&parameters, merkle_tree_depth).unwrap();
+        let circuit_cost = zk::cost_model(&circuit);
+
+        assert_eq!(circuit_cost.k, SMALL_CERTIFICATE_CIRCUIT_DEGREE);
+
+        let circuit = StmCertificateCircuit::try_new(&parameters, merkle_tree_depth + 1).unwrap();
+        let circuit_cost = zk::cost_model(&circuit);
+        assert_eq!(circuit_cost.k, SMALL_CERTIFICATE_CIRCUIT_DEGREE + 1);
+    }
+
+    #[test]
+    fn certificate_circuit_constraint_degree_for_production_circuit() {
+        let non_recursive_circuit_verifying_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        )
+        .unwrap();
+
+        assert_eq!(
+            non_recursive_circuit_verifying_key.midnight_vk().k() as u32,
+            NON_RECURSIVE_CIRCUIT_DEGREE
+        );
+    }
+}

--- a/mithril-stm/src/circuits/halo2/keys.rs
+++ b/mithril-stm/src/circuits/halo2/keys.rs
@@ -35,6 +35,12 @@ impl NonRecursiveCircuitVerifyingKey {
     pub(crate) fn midnight_vk(&self) -> &MidnightVK {
         &self.0
     }
+
+    #[cfg(test)]
+    /// Returns the circuit degree using the underlying `MidnightVK`
+    pub(crate) fn circuit_degree(&self) -> u8 {
+        self.midnight_vk().k()
+    }
 }
 
 impl AsRef<VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>>

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -254,6 +254,8 @@ impl Circuit<NativeField> for IvcCircuitData {
 
 #[cfg(test)]
 mod tests {
+    use midnight_proofs::dev::cost_model::circuit_model;
+
     use crate::{
         circuits::halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, codec::TryFromBytes,
     };
@@ -289,8 +291,8 @@ mod tests {
         .unwrap();
         let ivc_data = IvcCircuitData::unknown(&certificate_verification_key).unwrap();
 
-        let circuit_degree = ivc_data.ivc_circuit_domain_and_constraint_system.0.k();
+        let circuit_model = circuit_model::<_, 48, 32>(&ivc_data);
 
-        assert_eq!(circuit_degree, RECURSIVE_CIRCUIT_DEGREE);
+        assert_eq!(circuit_model.k, RECURSIVE_CIRCUIT_DEGREE);
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -311,7 +311,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            recursive_verifying_key.as_ref().get_domain().k(),
+            recursive_verifying_key.circuit_degree(),
             RECURSIVE_CIRCUIT_DEGREE,
         );
     }

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -254,6 +254,10 @@ impl Circuit<NativeField> for IvcCircuitData {
 
 #[cfg(test)]
 mod tests {
+    use crate::{
+        circuits::halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, codec::TryFromBytes,
+    };
+
     use super::*;
 
     #[test]
@@ -275,5 +279,18 @@ mod tests {
             7,
             "lookup argument count must not silently grow"
         );
+    }
+
+    #[test]
+    fn ivc_constraint_degree() {
+        let certificate_verification_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        )
+        .unwrap();
+        let ivc_data = IvcCircuitData::unknown(&certificate_verification_key).unwrap();
+
+        let circuit_degree = ivc_data.ivc_circuit_domain_and_constraint_system.0.k();
+
+        assert_eq!(circuit_degree, RECURSIVE_CIRCUIT_DEGREE);
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -282,7 +282,7 @@ mod tests {
     }
 
     #[test]
-    fn ivc_constraint_degree() {
+    fn ivc_constant_constraints_degree() {
         let certificate_verification_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
             NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
         )

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -257,7 +257,11 @@ mod tests {
     use midnight_proofs::dev::cost_model::circuit_model;
 
     use crate::{
-        circuits::halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, codec::TryFromBytes,
+        circuits::{
+            halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+            halo2_ivc::RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        },
+        codec::TryFromBytes,
     };
 
     use super::*;
@@ -284,15 +288,31 @@ mod tests {
     }
 
     #[test]
-    fn ivc_constant_constraints_degree() {
+    fn recursive_circuit_constraint_degree_stays_constant() {
         let certificate_verification_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
             NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
         )
         .unwrap();
         let ivc_data = IvcCircuitData::unknown(&certificate_verification_key).unwrap();
 
-        let circuit_model = circuit_model::<_, 48, 32>(&ivc_data);
+        const SIZE_BLS12_KZG_COMMITMENT: usize = 48;
+        const SIZE_SCALAR_FIELD_ELEMENT: usize = 32;
+        let circuit_model =
+            circuit_model::<_, SIZE_BLS12_KZG_COMMITMENT, SIZE_SCALAR_FIELD_ELEMENT>(&ivc_data);
 
         assert_eq!(circuit_model.k, RECURSIVE_CIRCUIT_DEGREE);
+    }
+
+    #[test]
+    fn production_recursive_circuit_verification_key_constraint_degree_stays_constant() {
+        let recursive_verifying_key = RecursiveCircuitVerifyingKey::try_from_bytes(
+            RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        )
+        .unwrap();
+
+        assert_eq!(
+            recursive_verifying_key.as_ref().get_domain().k(),
+            RECURSIVE_CIRCUIT_DEGREE,
+        );
     }
 }

--- a/mithril-stm/src/circuits/halo2_ivc/keys.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/keys.rs
@@ -46,6 +46,12 @@ impl RecursiveCircuitVerifyingKey {
     ) -> &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> {
         &self.0
     }
+
+    #[cfg(test)]
+    /// Returns the circuit degree using the domain of the underlying `VerifyingKey`
+    pub(crate) fn circuit_degree(&self) -> u32 {
+        self.as_ref().get_domain().k()
+    }
 }
 
 impl AsRef<VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>>


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes the addition of three tests that check that the degree of the circuits (recursive and non-recursive) are unchanged. The tests include:

- two tests checking the value of the degree inside the current production verification keys
- for the non recursive case, a test computing the number of constraints of a small circuit for which this number is close to the next power of two. This should allow for a quick detection of a circuit change that has the potential of increasing the power of two in which the constraints fit for production.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->

Closes #3330
