### PR TITLE
refactor(mithril-stm): decouple halo2_ivc from Midnight types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.46"
+version = "0.10.47"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.46", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.47", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.47 (07-08-2026)
+
+### Changed
+
+- Decoupled the recursive (IVC) circuit from Midnight proving-library types: single-sourced the backend aliases into a dedicated module, adopted the shared `CircuitCurve`, and isolated `Value<T>` behind a local `CircuitValue<T>` alias
+- Single-sourced the non-recursive verifying-key serde through its byte codec
+- Documented the recursive circuit module, its intentional Midnight couplings, and the serialized accumulator/MSM wire format
+
 ## 0.10.46 (07-07-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.46"
+version = "0.10.47"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2/keys.rs
+++ b/mithril-stm/src/circuits/halo2/keys.rs
@@ -51,30 +51,27 @@ impl AsRef<VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>>
     }
 }
 
-/// Serde for the wrapped Midnight verifying key: the raw-bytes encoding, matching the embedded
-/// SNARK-proof wire format.
+/// Serde for the wrapped Midnight verifying key: delegates to the key's [`TryToBytes`] /
+/// [`TryFromBytes`] impl so the raw-bytes encoding is defined in one place.
 mod midnight_verifying_key_serde {
-    use midnight_proofs::utils::SerdeFormat;
     use midnight_zk_stdlib::MidnightVK;
     use serde::{Deserializer, Serializer};
+
+    use crate::codec::{TryFromBytes, TryToBytes};
 
     pub(super) fn serialize<S: Serializer>(
         verifying_key: &MidnightVK,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        let mut buffer = Vec::new();
-        verifying_key
-            .write(&mut buffer, SerdeFormat::RawBytes)
-            .map_err(serde::ser::Error::custom)?;
-        serializer.serialize_bytes(&buffer)
+        let bytes = verifying_key.to_bytes_vec().map_err(serde::ser::Error::custom)?;
+        serializer.serialize_bytes(&bytes)
     }
 
     pub(super) fn deserialize<'de, D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<MidnightVK, D::Error> {
         let bytes: Vec<u8> = serde::Deserialize::deserialize(deserializer)?;
-        MidnightVK::read(&mut bytes.as_slice(), SerdeFormat::RawBytes)
-            .map_err(serde::de::Error::custom)
+        MidnightVK::try_from_bytes(&bytes).map_err(serde::de::Error::custom)
     }
 }
 
@@ -157,9 +154,31 @@ mod tests {
 
     use super::{NonRecursiveCircuitProvingKey, NonRecursiveCircuitVerifyingKey};
     use crate::Parameters;
+    use crate::circuits::halo2::NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION;
     use crate::circuits::halo2::circuit::StmCertificateCircuit;
     use crate::circuits::key_generator::KeyGenerator;
     use crate::codec::{TryFromBytes, TryToBytes};
+
+    #[test]
+    fn verifying_key_serde_round_trips_via_the_byte_codec() {
+        // Uses the embedded production verifying key so no keygen is needed (fast).
+        let verifying_key = NonRecursiveCircuitVerifyingKey::try_from_bytes(
+            NON_RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
+        )
+        .expect("production verifying key bytes should deserialize");
+
+        // Exercises the `#[serde(with = "midnight_verifying_key_serde")]` serialize + deserialize path.
+        let json = serde_json::to_vec(&verifying_key).expect("serde serialize should succeed");
+        let restored: NonRecursiveCircuitVerifyingKey =
+            serde_json::from_slice(&json).expect("serde deserialize should succeed");
+
+        // The serde path must agree with the byte codec it now delegates to.
+        assert_eq!(
+            verifying_key.to_bytes_vec().unwrap(),
+            restored.to_bytes_vec().unwrap(),
+            "serde round trip must preserve the verifying key bytes"
+        );
+    }
 
     #[test]
     fn generate_key_pair_downsizes_a_clone_and_round_trips() {

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -4,11 +4,11 @@ use crate::circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey;
 use anyhow::anyhow;
 
 use super::{
-    Accumulator, BinaryInstructions, Circuit, ComposableChip, ConstraintSystem, EmulatedCurve,
-    Error, EvaluationDomain, IvcNativeGadget, Layouter, NB_ARITH_COLS, NB_ARITH_FIXED_COLS,
-    NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS, NB_SHA256_ADVICE_COLS,
-    NB_SHA256_FIXED_COLS, NativeField, PublicInputInstructions, RECURSIVE_CIRCUIT_DEGREE,
-    RecursiveEmulation, SimpleFloorPlanner, Value,
+    Accumulator, BinaryInstructions, Circuit, CircuitValue, ComposableChip, ConstraintSystem,
+    EmulatedCurve, Error, EvaluationDomain, IvcNativeGadget, Layouter, NB_ARITH_COLS,
+    NB_ARITH_FIXED_COLS, NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS,
+    NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS, NativeField, PublicInputInstructions,
+    RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, SimpleFloorPlanner,
     config::{IvcConfig, configure_ivc_circuit, ivc_column_pool_sizes},
     errors::IvcCircuitError,
     gadget::IvcGadget,
@@ -25,17 +25,17 @@ use super::{
 #[derive(Clone, Debug)]
 pub struct IvcCircuitData {
     // Persistent values throughout an ivc stream. This is the root of trust for an ivc stream.
-    global: Value<Global>,
+    global: CircuitValue<Global>,
     // State values from the last aggregated certificate
-    state: Value<State>,
+    state: CircuitValue<State>,
     // Witness (mainly the next certificate to be aggregated) for deriving the next state
-    witness: Value<Witness>,
+    witness: CircuitValue<Witness>,
     // Snark proof of the next certificate
-    certificate_proof: Value<Vec<u8>>,
+    certificate_proof: CircuitValue<Vec<u8>>,
     // Latest IVC proof
-    ivc_proof: Value<Vec<u8>>,
+    ivc_proof: CircuitValue<Vec<u8>>,
     // Latest Accumulator
-    acc: Value<Accumulator<RecursiveEmulation>>,
+    acc: CircuitValue<Accumulator<RecursiveEmulation>>,
     // Domain and ConstraintSystem associated with certificate circuit VerifyingKey
     certificate_circuit_domain_and_constraint_system:
         (EvaluationDomain<NativeField>, ConstraintSystem<NativeField>),
@@ -119,12 +119,12 @@ impl IvcCircuitData {
         Self::validate_ivc_verification_key_degree(ivc_verification_key)?;
         Self::validate_column_counts()?;
         Ok(IvcCircuitData {
-            global: Value::known(global),
-            state: Value::known(state),
-            witness: Value::known(witness),
-            certificate_proof: Value::known(certificate_proof.into_vec()),
-            ivc_proof: Value::known(ivc_proof.into_vec()),
-            acc: Value::known(acc),
+            global: CircuitValue::known(global),
+            state: CircuitValue::known(state),
+            witness: CircuitValue::known(witness),
+            certificate_proof: CircuitValue::known(certificate_proof.into_vec()),
+            ivc_proof: CircuitValue::known(ivc_proof.into_vec()),
+            acc: CircuitValue::known(acc),
             certificate_circuit_domain_and_constraint_system: (
                 certificate_verification_key.as_ref().get_domain().clone(),
                 certificate_verification_key.as_ref().cs().clone(),
@@ -149,12 +149,12 @@ impl IvcCircuitData {
         );
 
         Ok(IvcCircuitData {
-            global: Value::unknown(),
-            state: Value::unknown(),
-            witness: Value::unknown(),
-            certificate_proof: Value::unknown(),
-            ivc_proof: Value::unknown(),
-            acc: Value::unknown(),
+            global: CircuitValue::unknown(),
+            state: CircuitValue::unknown(),
+            witness: CircuitValue::unknown(),
+            certificate_proof: CircuitValue::unknown(),
+            ivc_proof: CircuitValue::unknown(),
+            acc: CircuitValue::unknown(),
             certificate_circuit_domain_and_constraint_system: (
                 certificate_verification_key.as_ref().get_domain().clone(),
                 certificate_verification_key.as_ref().cs().clone(),
@@ -174,12 +174,12 @@ impl Circuit<NativeField> for IvcCircuitData {
 
     fn without_witnesses(&self) -> Self {
         IvcCircuitData {
-            global: Value::unknown(),
-            state: Value::unknown(),
-            witness: Value::unknown(),
-            certificate_proof: Value::unknown(),
-            ivc_proof: Value::unknown(),
-            acc: Value::unknown(),
+            global: CircuitValue::unknown(),
+            state: CircuitValue::unknown(),
+            witness: CircuitValue::unknown(),
+            certificate_proof: CircuitValue::unknown(),
+            ivc_proof: CircuitValue::unknown(),
+            acc: CircuitValue::unknown(),
             certificate_circuit_domain_and_constraint_system: self
                 .certificate_circuit_domain_and_constraint_system
                 .clone(),

--- a/mithril-stm/src/circuits/halo2_ivc/config.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/config.rs
@@ -1,9 +1,10 @@
 use super::{
-    ComposableChip, ConstraintSystem, EccChip, EccConfig, EmulatedCurve, EmulatedCurveBaseField,
-    FieldChip, ForeignEccChip, ForeignEccConfig, IvcNativeGadget, Jubjub, NB_ARITH_COLS,
-    NB_ARITH_FIXED_COLS, NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS, NB_POSEIDON_FIXED_COLS,
-    NativeChip, NativeConfig, NativeField, P2RDecompositionChip, P2RDecompositionConfig,
-    PoseidonChip, PoseidonConfig, Pow2RangeChip, nb_foreign_ecc_chip_columns,
+    CircuitCurve, ComposableChip, ConstraintSystem, EccChip, EccConfig, EmulatedCurve,
+    EmulatedCurveBaseField, FieldChip, ForeignEccChip, ForeignEccConfig, IvcNativeGadget,
+    NB_ARITH_COLS, NB_ARITH_FIXED_COLS, NB_EDWARDS_COLS, NB_POSEIDON_ADVICE_COLS,
+    NB_POSEIDON_FIXED_COLS, NativeChip, NativeConfig, NativeField, P2RDecompositionChip,
+    P2RDecompositionConfig, PoseidonChip, PoseidonConfig, Pow2RangeChip,
+    nb_foreign_ecc_chip_columns,
 };
 use midnight_circuits::hash::sha256::{
     NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS, Sha256Chip, Sha256Config,
@@ -68,7 +69,7 @@ pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<NativeField>) -> IvcCon
         P2RDecompositionChip::configure(meta, &(native_config.clone(), pow2_config))
     };
 
-    let jubjub_config = EccChip::<Jubjub>::configure(
+    let jubjub_config = EccChip::<CircuitCurve>::configure(
         meta,
         &advice_columns[..NB_EDWARDS_COLS]
             .try_into()

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -10,10 +10,10 @@ use super::{
     Accumulator, ArithInstructions, AssertionInstructions, AssignedAccumulator, AssignedBit,
     AssignedForeignPoint, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
     AssignedVk, AssignmentInstructions, BinaryInstructions, CERTIFICATE_VERIFICATION_KEY_NAME,
-    CircuitCurve, ComposableChip, ConstraintSystem, ControlFlowInstructions,
+    CircuitCurve, CircuitCurveTrait, ComposableChip, ConstraintSystem, ControlFlowInstructions,
     ConversionInstructions, EccChip, EccInstructions, EmulatedCurve, EqualityInstructions, Error,
     EvaluationDomain, ForeignEccChip, HashInstructions, IVC_VERIFICATION_KEY_NAME, IvcNativeGadget,
-    Jubjub, Layouter, NativeChip, NativeField, NativeGadget, P2RDecompositionChip,
+    Layouter, NativeChip, NativeField, NativeGadget, P2RDecompositionChip,
     PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions,
     RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, Value, VerifierGadget, ZeroInstructions,
@@ -28,7 +28,7 @@ use super::{
 pub struct IvcGadget {
     pub(crate) core_decomp_chip: P2RDecompositionChip<NativeField>,
     pub(crate) native_gadget: IvcNativeGadget,
-    pub(crate) jubjub_chip: EccChip<Jubjub>,
+    pub(crate) jubjub_chip: EccChip<CircuitCurve>,
     pub(crate) poseidon_chip: PoseidonChip<NativeField>,
     pub(crate) sha2_256_chip: Sha256Chip<NativeField>,
     pub(crate) bls12_381_chip:
@@ -47,7 +47,7 @@ impl IvcGadget {
             &(RECURSIVE_CIRCUIT_DEGREE as usize - 1),
         );
         let native_gadget = NativeGadget::new(core_decomp_chip.clone(), native_chip.clone());
-        let jubjub_chip = EccChip::<Jubjub>::new(&config.jubjub_config, &native_gadget);
+        let jubjub_chip = EccChip::<CircuitCurve>::new(&config.jubjub_config, &native_gadget);
         let bls12_381_chip: ForeignEccChip<_, EmulatedCurve, EmulatedCurve, _, _> =
             { ForeignEccChip::new(&config.bls12_381_config, &native_gadget, &native_gadget) };
         let poseidon_chip = PoseidonChip::new(&config.poseidon_config, &native_chip);
@@ -297,7 +297,7 @@ impl IvcGadget {
             .assign_fixed(layouter, DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE.0)?;
         let generator: AssignedNativePoint<_> = self.jubjub_chip.assign_fixed(
             layouter,
-            <Jubjub as CircuitCurve>::CryptographicGroup::generator(),
+            <CircuitCurve as CircuitCurveTrait>::CryptographicGroup::generator(),
         )?;
 
         let cap_r = self.jubjub_chip.msm(

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -10,13 +10,13 @@ use super::{
     Accumulator, ArithInstructions, AssertionInstructions, AssignedAccumulator, AssignedBit,
     AssignedForeignPoint, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
     AssignedVk, AssignmentInstructions, BinaryInstructions, CERTIFICATE_VERIFICATION_KEY_NAME,
-    CircuitCurve, CircuitCurveTrait, ComposableChip, ConstraintSystem, ControlFlowInstructions,
-    ConversionInstructions, EccChip, EccInstructions, EmulatedCurve, EqualityInstructions, Error,
-    EvaluationDomain, ForeignEccChip, HashInstructions, IVC_VERIFICATION_KEY_NAME, IvcNativeGadget,
-    Layouter, NativeChip, NativeField, NativeGadget, P2RDecompositionChip,
-    PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+    CircuitCurve, CircuitCurveTrait, CircuitValue, ComposableChip, ConstraintSystem,
+    ControlFlowInstructions, ConversionInstructions, EccChip, EccInstructions, EmulatedCurve,
+    EqualityInstructions, Error, EvaluationDomain, ForeignEccChip, HashInstructions,
+    IVC_VERIFICATION_KEY_NAME, IvcNativeGadget, Layouter, NativeChip, NativeField, NativeGadget,
+    P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions,
-    RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, Value, VerifierGadget, ZeroInstructions,
+    RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, VerifierGadget, ZeroInstructions,
     config::IvcConfig,
     errors::{IvcCircuitError, to_synthesis_error},
     state::{
@@ -69,7 +69,7 @@ impl IvcGadget {
     pub fn assign_global_as_public_input(
         &self,
         layouter: &mut impl Layouter<NativeField>,
-        global: &Value<Global>,
+        global: &CircuitValue<Global>,
         certificate_circuit_domain_and_constraint_system: &(
             EvaluationDomain<NativeField>,
             ConstraintSystem<NativeField>,
@@ -145,7 +145,7 @@ impl IvcGadget {
     pub fn assign_state(
         &self,
         layouter: &mut impl Layouter<NativeField>,
-        state: &Value<State>,
+        state: &CircuitValue<State>,
     ) -> Result<AssignedState, Error> {
         let values = state
             .clone()
@@ -216,7 +216,7 @@ impl IvcGadget {
     pub fn assign_witness(
         &self,
         layouter: &mut impl Layouter<NativeField>,
-        witness: &Value<Witness>,
+        witness: &CircuitValue<Witness>,
     ) -> Result<AssignedWitness, Error> {
         let genesis_signature = {
             let s: AssignedScalarOfNativeCurve<_> = self.jubjub_chip.assign(
@@ -587,9 +587,9 @@ impl IvcGadget {
         is_not_genesis: &AssignedBit<NativeField>,
         state: &AssignedState,
         witness: &AssignedWitness,
-        certificate_proof: &Value<Vec<u8>>,
-        ivc_proof: &Value<Vec<u8>>,
-        acc_value: &Value<Accumulator<RecursiveEmulation>>,
+        certificate_proof: &CircuitValue<Vec<u8>>,
+        ivc_proof: &CircuitValue<Vec<u8>>,
+        acc_value: &CircuitValue<Accumulator<RecursiveEmulation>>,
     ) -> Result<AssignedAccumulator<RecursiveEmulation>, Error> {
         let id_point: AssignedForeignPoint<_, _, _> = self
             .bls12_381_chip

--- a/mithril-stm/src/circuits/halo2_ivc/io.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/io.rs
@@ -1,6 +1,7 @@
+use super::types::SerdeFormat;
 use super::{Accumulator, EmulatedCurve, Msm, NativeField, RecursiveEmulation};
 use midnight_curves::serde::SerdeObject;
-use midnight_proofs::utils::{SerdeFormat, helpers::ProcessedSerdeObject};
+use midnight_proofs::utils::helpers::ProcessedSerdeObject;
 use std::{collections::BTreeMap, io};
 
 pub trait Write {

--- a/mithril-stm/src/circuits/halo2_ivc/io.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/io.rs
@@ -8,10 +8,9 @@
 //!   order, so the encoding is deterministic.
 //! - `Accumulator`: its `lhs` `Msm` followed by its `rhs` `Msm`.
 
-use super::types::SerdeFormat;
 use super::{Accumulator, EmulatedCurve, Msm, NativeField, RecursiveEmulation};
 use midnight_curves::serde::SerdeObject;
-use midnight_proofs::utils::helpers::ProcessedSerdeObject;
+use midnight_proofs::utils::{SerdeFormat, helpers::ProcessedSerdeObject};
 use std::{collections::BTreeMap, io};
 
 pub trait Write {

--- a/mithril-stm/src/circuits/halo2_ivc/io.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/io.rs
@@ -1,3 +1,13 @@
+//! Byte serialization of the recursive circuit's rolling accumulator and its MSMs.
+//!
+//! The `Write` / `Read` traits define the on-the-wire layout. All length prefixes are little-endian `u32`.
+//!
+//! - `Msm`: `bases.len()` then each base via the format-aware `write` (honours `SerdeFormat`);
+//!   `scalars.len()` then each scalar via raw `write_raw`; `fixed_base_scalars.len()` then, per entry,
+//!   `key.len()` + the UTF-8 key bytes + the value via raw `write_raw`. Entries follow `BTreeMap` key
+//!   order, so the encoding is deterministic.
+//! - `Accumulator`: its `lhs` `Msm` followed by its `rhs` `Msm`.
+
 use super::types::SerdeFormat;
 use super::{Accumulator, EmulatedCurve, Msm, NativeField, RecursiveEmulation};
 use midnight_curves::serde::SerdeObject;

--- a/mithril-stm/src/circuits/halo2_ivc/midnight_backend.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/midnight_backend.rs
@@ -1,0 +1,27 @@
+//! Single coupling point to the Midnight proving backend for the recursive (IVC) circuit.
+//!
+//! Every field, curve, and engine type the recursive circuit builds on derives from Midnight's
+//! `BlstrsEmulation` — its self-emulation of BLS12-381 proof verification. Isolating them here
+//! keeps the dependency on the Midnight backend in one place.
+
+use midnight_circuits::ecc::curves::CircuitCurve as CircuitCurveTrait;
+use midnight_circuits::verifier::{BlstrsEmulation, SelfEmulation};
+
+/// Midnight self-emulation backend the recursive circuit is built on: BLS12-381 verification
+/// emulated over its own scalar field. Parameterises the verifier gadget, accumulator, and MSM.
+pub(crate) type RecursiveEmulation = BlstrsEmulation;
+
+/// Native field the recursive circuit is defined over — the BLS12-381 scalar field. Every
+/// in-circuit value lives here; it is the same field the certificate circuit calls `CircuitBase`.
+pub(crate) type NativeField = <RecursiveEmulation as SelfEmulation>::F;
+
+/// Curve verified in-circuit during recursive proof verification: BLS12-381 G1, on which the
+/// recursive proof's commitments live. Its coordinates are emulated in [`EmulatedCurveBaseField`].
+pub(crate) type EmulatedCurve = <RecursiveEmulation as SelfEmulation>::C;
+
+/// Pairing engine backing the recursive circuit's KZG commitments (BLS12-381).
+pub(crate) type PairingEngine = <RecursiveEmulation as SelfEmulation>::Engine;
+
+/// Coordinate field of [`EmulatedCurve`] — the foreign field emulated in-circuit for BLS12-381 G1
+/// arithmetic. Larger than and distinct from [`NativeField`]; not the certificate circuit's `CircuitBase`.
+pub(crate) type EmulatedCurveBaseField = <EmulatedCurve as CircuitCurveTrait>::Base;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -6,11 +6,11 @@
 //! The code in this module is moved from the standalone recursive prototype and
 //! is kept locally here until the recursive circuit is wired into STM.
 
-pub(crate) use midnight_curves::JubjubExtended as Jubjub;
+pub(crate) use crate::circuits::CircuitCurve;
 
 pub(crate) use midnight_circuits::{
     ecc::{
-        curves::CircuitCurve,
+        curves::CircuitCurve as CircuitCurveTrait,
         foreign::{ForeignEccChip, ForeignEccConfig, nb_foreign_ecc_chip_columns},
         native::{EccChip, EccConfig, NB_EDWARDS_COLS},
     },
@@ -73,7 +73,7 @@ pub(crate) type NativeField = <RecursiveEmulation as SelfEmulation>::F;
 type EmulatedCurve = <RecursiveEmulation as SelfEmulation>::C;
 
 pub(crate) type PairingEngine = <RecursiveEmulation as SelfEmulation>::Engine;
-type EmulatedCurveBaseField = <EmulatedCurve as CircuitCurve>::Base;
+type EmulatedCurveBaseField = <EmulatedCurve as CircuitCurveTrait>::Base;
 
 type IvcNativeGadget =
     NativeGadget<NativeField, P2RDecompositionChip<NativeField>, NativeChip<NativeField>>;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -1,10 +1,13 @@
-//! Halo2 IVC circuit prototype integration (feature-gated by `future_snark`).
+//! Recursive (IVC) SNARK circuit for STM certificate-chain aggregation (feature-gated by `future_snark`).
 //!
-//! This module is the landing zone for the recursive SNARK / IVC prototype
-//! while it is being moved into `mithril-stm`.
+//! At each step the circuit verifies, in-circuit, the previous IVC proof and the current certificate proof
+//! (the certificate being aggregated at that step), folding their KZG openings into a running accumulator so
+//! one recursive proof attests to the whole certificate chain. The Midnight proving-backend aliases
+//! (field/curve/engine) are isolated in the `midnight_backend` submodule; the circuit-boundary types
+//! (`CircuitValue`, `SerdeFormat`, and the field-element wrappers) live in `types`.
 //!
-//! The code in this module is moved from the standalone recursive prototype and
-//! is kept locally here until the recursive circuit is wired into STM.
+//! Internally, `Accumulator`, raw `VerifyingKey`, and `ConstraintSystem` are used directly where the verifier
+//! gadget and PLONK APIs require them.
 
 pub(crate) use crate::circuits::CircuitCurve;
 

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -36,10 +36,7 @@ pub(crate) use midnight_circuits::{
         AssignedBit, AssignedByte, AssignedForeignPoint, AssignedNative, AssignedNativePoint,
         AssignedScalarOfNativeCurve, ComposableChip, Instantiable,
     },
-    verifier::{
-        self, Accumulator, AssignedAccumulator, AssignedVk, BlstrsEmulation, Msm, SelfEmulation,
-        VerifierGadget,
-    },
+    verifier::{self, Accumulator, AssignedAccumulator, AssignedVk, Msm, VerifierGadget},
 };
 
 pub(crate) use midnight_proofs::{
@@ -68,12 +65,10 @@ pub(crate) mod tests;
 
 pub(crate) use types::ProtocolMessagePreimage;
 
-type RecursiveEmulation = BlstrsEmulation;
-pub(crate) type NativeField = <RecursiveEmulation as SelfEmulation>::F;
-type EmulatedCurve = <RecursiveEmulation as SelfEmulation>::C;
+mod midnight_backend;
 
-pub(crate) type PairingEngine = <RecursiveEmulation as SelfEmulation>::Engine;
-type EmulatedCurveBaseField = <EmulatedCurve as CircuitCurveTrait>::Base;
+use midnight_backend::{EmulatedCurve, EmulatedCurveBaseField, RecursiveEmulation};
+pub(crate) use midnight_backend::{NativeField, PairingEngine};
 
 type IvcNativeGadget =
     NativeGadget<NativeField, P2RDecompositionChip<NativeField>, NativeChip<NativeField>>;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -63,7 +63,7 @@ pub(crate) mod types;
 #[cfg(test)]
 pub(crate) mod tests;
 
-pub(crate) use types::ProtocolMessagePreimage;
+pub(crate) use types::{CircuitValue, ProtocolMessagePreimage};
 
 mod midnight_backend;
 

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -10,8 +10,8 @@ use crate::signature_scheme::{SchnorrVerificationKey, StandardSchnorrSignature};
 
 use super::{
     Accumulator, AssignedByte, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignedVk, ConstraintSystem, EmulatedCurve, Instantiable, Jubjub, KZGCommitmentScheme, Msm,
-    NativeField, PairingEngine, RecursiveEmulation, VerifyingKey,
+    AssignedVk, CircuitCurve, ConstraintSystem, EmulatedCurve, Instantiable, KZGCommitmentScheme,
+    Msm, NativeField, PairingEngine, RecursiveEmulation, VerifyingKey,
     types::{
         CertificateCircuitVerificationKeyRepresentation, EpochNumber,
         IvcCircuitVerificationKeyRepresentation, MerkleTreeCommitment, MessageHash,
@@ -145,7 +145,7 @@ impl Global {
     pub(crate) fn as_public_input(&self) -> Vec<NativeField> {
         [
             vec![self.genesis_message.as_field()],
-            AssignedNativePoint::<Jubjub>::as_public_input(
+            AssignedNativePoint::<CircuitCurve>::as_public_input(
                 self.genesis_verification_key.as_jubjub_subgroup(),
             ),
             vec![
@@ -161,7 +161,7 @@ impl Global {
 pub(crate) struct AssignedGlobal {
     //Persistent values that do not change through an ivc stream
     pub(crate) genesis_message: AssignedNative<NativeField>,
-    pub(crate) genesis_verification_key: AssignedNativePoint<Jubjub>,
+    pub(crate) genesis_verification_key: AssignedNativePoint<CircuitCurve>,
     pub(crate) certificate_verification_key: AssignedVk<RecursiveEmulation>,
     pub(crate) ivc_verification_key: AssignedVk<RecursiveEmulation>,
     // Combined fixed base names for certificate and IVC verification keys.
@@ -197,7 +197,7 @@ impl Witness {
 #[derive(Clone, Debug)]
 pub(crate) struct AssignedWitness {
     pub(crate) genesis_signature: (
-        AssignedScalarOfNativeCurve<Jubjub>,
+        AssignedScalarOfNativeCurve<CircuitCurve>,
         AssignedNative<NativeField>,
     ),
     pub(crate) certificate_message: AssignedNative<NativeField>,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/verification_key.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use midnight_circuits::verifier::{BlstrsEmulation, SelfEmulation};
 use midnight_proofs::{
     plonk::{VerifyingKey, keygen_vk_with_k},
     poly::kzg::KZGCommitmentScheme,
@@ -13,7 +12,9 @@ use crate::{
     circuits::{
         halo2::circuit::StmCertificateCircuit,
         halo2::keys::NonRecursiveCircuitVerifyingKey,
-        halo2_ivc::{RECURSIVE_CIRCUIT_DEGREE, circuit::IvcCircuitData},
+        halo2_ivc::{
+            NativeField, PairingEngine, RECURSIVE_CIRCUIT_DEGREE, circuit::IvcCircuitData,
+        },
     },
 };
 
@@ -40,15 +41,13 @@ pub(crate) fn golden_recursive_circuit_verification_key_bytes() -> Vec<u8> {
 
     let default_ivc_circuit =
         IvcCircuitData::unknown(&circuit_verification_key).expect("valid IvcCircuitData unknown");
-    let recursive_verifying_key: VerifyingKey<
-        <BlstrsEmulation as SelfEmulation>::F,
-        KZGCommitmentScheme<<BlstrsEmulation as SelfEmulation>::Engine>,
-    > = keygen_vk_with_k(
-        &srs_for_recursive_circuit,
-        &default_ivc_circuit,
-        RECURSIVE_CIRCUIT_DEGREE,
-    )
-    .expect("recursive verifying key generation should not fail");
+    let recursive_verifying_key: VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> =
+        keygen_vk_with_k(
+            &srs_for_recursive_circuit,
+            &default_ivc_circuit,
+            RECURSIVE_CIRCUIT_DEGREE,
+        )
+        .expect("recursive verifying key generation should not fail");
 
     let mut buf_cvk = vec![];
     recursive_verifying_key

--- a/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/verification_key_computation.rs
@@ -1,5 +1,4 @@
 use anyhow::Context;
-use midnight_circuits::verifier::{BlstrsEmulation, SelfEmulation};
 use midnight_proofs::{
     plonk::{VerifyingKey, keygen_vk_with_k},
     poly::kzg::KZGCommitmentScheme,
@@ -15,8 +14,8 @@ use crate::{
             keys::NonRecursiveCircuitVerifyingKey,
         },
         halo2_ivc::{
-            RECURSIVE_CIRCUIT_DEGREE, RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION,
-            circuit::IvcCircuitData,
+            NativeField, PairingEngine, RECURSIVE_CIRCUIT_DEGREE,
+            RECURSIVE_CIRCUIT_VERIFICATION_KEY_FOR_PRODUCTION, circuit::IvcCircuitData,
         },
         trusted_setup::TrustedSetupProvider,
     },
@@ -40,14 +39,12 @@ fn compute_recursive_circuit_verification_key() -> StmResult<Vec<u8>> {
 
     let default_ivc_circuit =
         IvcCircuitData::unknown(&certificate_verifying_key).expect("valid IvcCircuitData unknown");
-    let recursive_verification_key: VerifyingKey<
-        <BlstrsEmulation as SelfEmulation>::F,
-        KZGCommitmentScheme<<BlstrsEmulation as SelfEmulation>::Engine>,
-    > = keygen_vk_with_k(
-        &recursive_commitment_parameters,
-        &default_ivc_circuit,
-        shared_srs_degree,
-    )?;
+    let recursive_verification_key: VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>> =
+        keygen_vk_with_k(
+            &recursive_commitment_parameters,
+            &default_ivc_circuit,
+            shared_srs_degree,
+        )?;
 
     let mut buffer_for_recursive_circuit_verification_key = vec![];
     recursive_verification_key

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -8,9 +8,16 @@ use serde::{Deserialize, Serialize};
 
 use super::{
     NativeField, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
-    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE,
+    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE, Value,
 };
 use crate::BaseFieldElement;
+
+/// Local re-export of Midnight proofs' `SerdeFormat`, isolating the Midnight serialization enum behind
+/// the IVC module boundary (used by the `io` serialization traits).
+pub(crate) use midnight_proofs::utils::SerdeFormat;
+
+/// Circuit-boundary alias for Midnight proofs' `Value<T>` witness wrapper.
+pub(crate) type CircuitValue<T> = Value<T>;
 
 macro_rules! field_wrapper {
     ($name:ident, zero) => {

--- a/mithril-stm/src/circuits/halo2_ivc/types.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/types.rs
@@ -12,10 +12,6 @@ use super::{
 };
 use crate::BaseFieldElement;
 
-/// Local re-export of Midnight proofs' `SerdeFormat`, isolating the Midnight serialization enum behind
-/// the IVC module boundary (used by the `io` serialization traits).
-pub(crate) use midnight_proofs::utils::SerdeFormat;
-
 /// Circuit-boundary alias for Midnight proofs' `Value<T>` witness wrapper.
 pub(crate) type CircuitValue<T> = Value<T>;
 

--- a/mithril-stm/src/circuits/mod.rs
+++ b/mithril-stm/src/circuits/mod.rs
@@ -15,6 +15,7 @@ pub mod trusted_setup;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+pub(crate) use halo2::types::CircuitCurve;
 pub(crate) use halo2::witness::{
     CircuitInstance, CircuitMerkleTreeLeaf, CircuitWitness, MerklePath,
 };


### PR DESCRIPTION
## Content

This is the second of two PRs for issue #3129. This PR completes the decoupling of `halo2_ivc` from Midnight proving-library types.

### Changes

- **Shared `CircuitCurve` path**: exported `CircuitCurve` from `circuits/mod.rs` so both circuits share one path, resolving the name clash by renaming the Midnight `CircuitCurve` trait import to `CircuitCurveTrait`. `halo2_ivc` now uses the shared `CircuitCurve` instead of its local `Jubjub` (`JubjubExtended`) alias at the circuit-curve sites (`config.rs`, `gadget.rs`, `state.rs`).
- **`midnight_backend` module**: the recursive circuit's Midnight backend aliases (`RecursiveEmulation`, `NativeField`, `EmulatedCurve`, `PairingEngine`, `EmulatedCurveBaseField`, all rooted in `BlstrsEmulation`) are single-sourced into a new documented `halo2_ivc/midnight_backend.rs`; `BlstrsEmulation` / `SelfEmulation` are now imported only there.
- **`CircuitValue<T>` + `SerdeFormat`**: added a `CircuitValue<T>` alias and a local `SerdeFormat` re-export in `halo2_ivc/types.rs`; applied `CircuitValue` in `circuit.rs` / `gadget.rs`, and routed `io.rs`'s `Write`/`Read` trait bounds through the local `SerdeFormat`.
- **Non-recursive VK serde single-source** (#3300 follow-up): the certificate verifying key's `#[serde(with = …)]` now delegates to its `TryToBytes` / `TryFromBytes` byte codec instead of re-implementing `write(RawBytes)`, so the `MidnightVK` ↔ RawBytes encoding is defined in one place (matching the recursive key's serde).
- **Documentation**: rewrote the stale "prototype" module doc in `halo2_ivc/mod.rs` (accurate IVC description + a note that `Accumulator`, raw `VerifyingKey`, and `ConstraintSystem` are used directly where the verifier gadget and PLONK APIs require them); documented the serialized `Accumulator` / `Msm` wire format in `io.rs`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Closes https://github.com/input-output-hk/mithril/issues/3129