### PR TITLE
fix: anticipate Rust `1.97` clippy warnings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,7 +4114,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.15"
+version = "0.9.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4200,7 +4200,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator-discovery"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4291,7 +4291,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-cardano-node-internal-database"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client-cli"
-version = "0.13.18"
+version = "0.13.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4418,7 +4418,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.12"
+version = "0.7.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4484,7 +4484,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-doc"
-version = "0.1.28"
+version = "0.1.29"
 dependencies = [
  "clap",
  "config",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-era"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4544,7 +4544,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-merkle-tree"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "bincode",
@@ -4574,7 +4574,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-persistence"
-version = "0.2.74"
+version = "0.2.75"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4669,7 +4669,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "1.1.4"
+version = "1.1.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.47"
+version = "0.10.48"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-cardano-node-internal-database"
-version = "0.2.3"
+version = "0.2.4"
 description = "Mechanisms that allow Mithril nodes to read the files of a Cardano node internal database and compute digests from them"
 authors.workspace = true
 documentation.workspace = true
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.12" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.13" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/cardano-node/mithril-cardano-node-internal-database/src/signable_builder/cardano_database.rs
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/src/signable_builder/cardano_database.rs
@@ -45,7 +45,7 @@ impl SignableBuilder<CardanoDbBeacon> for CardanoDatabaseSignableBuilder {
             .with_context(|| {
                 format!(
                     "Cardano Database Signable Builder can not compute merkle tree of '{}'",
-                    &self.dirpath.display()
+                    self.dirpath.display()
                 )
             })?;
 

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.12" }
+mithril-common = { path = "../../mithril-common", version = "0.7.13" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mithril-aggregator-discovery"
 description = "Mechanisms to discover aggregators available in a Mithril network."
-version = "0.1.10"
+version = "0.1.11"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.4" }
-mithril-common = { path = "../../mithril-common", version = "0.7.12" }
+mithril-common = { path = "../../mithril-common", version = "0.7.13" }
 rand = { version = "0.10.2" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/src/http_config_discoverer.rs
+++ b/internal/mithril-aggregator-discovery/src/http_config_discoverer.rs
@@ -80,7 +80,7 @@ impl AggregatorDiscoverer<AggregatorEndpoint> for HttpConfigAggregatorDiscoverer
             .with_context(|| {
                 format!(
                     "AggregatorDiscovererHttpConfig failed retrieving configuration file from {}",
-                    &self.configuration_file_url
+                    self.configuration_file_url
                 )
             })?
             .json::<NetworksConfigMessage>()
@@ -88,7 +88,7 @@ impl AggregatorDiscoverer<AggregatorEndpoint> for HttpConfigAggregatorDiscoverer
             .with_context(|| {
                 format!(
                     "AggregatorDiscovererHttpConfig failed parsing configuration file from {}",
-                    &self.configuration_file_url
+                    self.configuration_file_url
                 )
             })?;
         let aggregator_endpoints = networks_configuration_response

--- a/internal/mithril-doc/Cargo.toml
+++ b/internal/mithril-doc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-doc"
-version = "0.1.28"
+version = "0.1.29"
 description = "An internal crate to generate documentation."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-doc/src/lib.rs
+++ b/internal/mithril-doc/src/lib.rs
@@ -165,7 +165,7 @@ impl GenerateDocCommands {
                 if write!(buffer, "\n{doc}").is_err() {
                     return Err(format!("Error writing in {output}"));
                 }
-                println!("Documentation generated in file `{}`", &output);
+                println!("Documentation generated in file `{}`", output);
             }
             _ => return Err(format!("Could not create {output}")),
         };

--- a/internal/mithril-era/Cargo.toml
+++ b/internal/mithril-era/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-era"
-version = "0.1.10"
+version = "0.1.11"
 authors.workspace = true
 documentation.workspace = true
 edition.workspace = true

--- a/internal/mithril-era/src/era_reader.rs
+++ b/internal/mithril-era/src/era_reader.rs
@@ -58,7 +58,7 @@ impl EraEpochToken {
     /// software.
     pub fn get_current_supported_era(&self) -> StdResult<SupportedEra> {
         SupportedEra::from_str(&self.current_era.name)
-            .with_context(|| format!("Unsupported era '{}'.", &self.current_era.name))
+            .with_context(|| format!("Unsupported era '{}'.", self.current_era.name))
     }
 
     /// Return the [EraMarker] of the current Era.
@@ -79,7 +79,7 @@ impl EraEpochToken {
         match self.next_era.as_ref() {
             Some(marker) => Ok(Some(
                 SupportedEra::from_str(&marker.name)
-                    .with_context(|| format!("Unsupported era '{}'.", &marker.name))?,
+                    .with_context(|| format!("Unsupported era '{}'.", marker.name))?,
             )),
             None => Ok(None),
         }
@@ -142,7 +142,7 @@ impl EraReader {
             .read()
             .await
             .map_err(|e| EraReaderError::AdapterFailure {
-                message: format!("Reading from EraReader adapter raised an error: '{}'.", &e),
+                message: format!("Reading from EraReader adapter raised an error: '{e}'."),
                 error: e,
             })?;
 

--- a/internal/mithril-merkle-tree/Cargo.toml
+++ b/internal/mithril-merkle-tree/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-merkle-tree"
-version = "0.1.3"
+version = "0.1.4"
 description = "Merkle tree and merkelized map primitives used by Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-merkle-tree/src/merkle_map.rs
+++ b/internal/mithril-merkle-tree/src/merkle_map.rs
@@ -329,7 +329,7 @@ impl<K: MKMapKey> MKMapProof<K> {
     /// Check if the merkelized map proof contains a leaf
     pub fn contains(&self, leaf: &MKTreeNode) -> StdResult<()> {
         let contains_leaf = {
-            self.master_proof.contains(&[leaf.to_owned()]).is_ok()
+            self.master_proof.contains(std::slice::from_ref(leaf)).is_ok()
                 || self.sub_proofs.iter().any(|(_k, p)| p.contains(leaf).is_ok())
         };
 

--- a/internal/mithril-persistence/Cargo.toml
+++ b/internal/mithril-persistence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-persistence"
-version = "0.2.74"
+version = "0.2.75"
 description = "Common types, interfaces, and utilities to persist data for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }

--- a/internal/mithril-persistence/src/sqlite/connection_extensions.rs
+++ b/internal/mithril-persistence/src/sqlite/connection_extensions.rs
@@ -72,7 +72,7 @@ fn prepare_statement<'conn>(
     sqlite_connection.prepare(sql).with_context(|| {
         format!(
             "Prepare query error: SQL=`{}`",
-            &sql.replace('\n', " ").trim()
+            sql.replace('\n', " ").trim()
         )
     })
 }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.15"
+version = "0.9.16"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/src/file_uploaders/local_uploader.rs
+++ b/mithril-aggregator/src/file_uploaders/local_uploader.rs
@@ -124,7 +124,7 @@ mod tests {
         let archive = create_fake_archive(&source_dir, archive_name);
         let expected_location = format!(
             "http://test.com:8080/base-root/{}",
-            &archive.file_name().unwrap().to_string_lossy()
+            archive.file_name().unwrap().to_string_lossy()
         );
 
         let url_prefix =
@@ -219,7 +219,7 @@ mod tests {
 
         let expected_location = format!(
             "http://test.com:8080/base-root/{}",
-            &archive.file_name().unwrap().to_string_lossy()
+            archive.file_name().unwrap().to_string_lossy()
         );
         assert_eq!(FileUri(expected_location), location);
     }

--- a/mithril-aggregator/src/runtime/runner.rs
+++ b/mithril-aggregator/src/runtime/runner.rs
@@ -211,7 +211,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
         for signed_entity_type in signed_entity_types {
             let current_open_message = self.get_current_open_message_for_signed_entity_type(&signed_entity_type)
                 .await
-                .with_context(|| format!("AggregatorRunner can not get current open message for signed entity type: '{}'", &signed_entity_type))?;
+                .with_context(|| format!("AggregatorRunner can not get current open message for signed entity type: '{}'", signed_entity_type))?;
             match current_open_message {
                 None => {
                     let protocol_message = self.compute_protocol_message(&signed_entity_type).await.with_context(|| format!("AggregatorRunner can not compute protocol message for signed_entity_type: '{signed_entity_type}'"))?;
@@ -468,7 +468,7 @@ impl AggregatorRunnerTrait for AggregatorRunner {
                 &open_message_signed_entity_type,
             )
             .await
-            .with_context(|| format!("AggregatorRuntime can not get the current open message for signed entity type: '{}'", &open_message_signed_entity_type))?;
+            .with_context(|| format!("AggregatorRuntime can not get the current open message for signed entity type: '{}'", open_message_signed_entity_type))?;
         let is_expired_open_message =
             current_open_message.as_ref().map(|om| om.is_expired).unwrap_or(false);
 

--- a/mithril-aggregator/src/tools/certificates_hash_migrator.rs
+++ b/mithril-aggregator/src/tools/certificates_hash_migrator.rs
@@ -77,7 +77,7 @@ impl CertificatesHashMigrator {
                     .get(&certificate.previous_hash)
                     .with_context(|| format!(
                         "Could not migrate certificate previous_hash: The hash '{}' doesn't exist in the certificate table",
-                        &certificate.previous_hash
+                        certificate.previous_hash
                     ))?.clone_into(&mut certificate.previous_hash);
 
                 old_previous_hash

--- a/mithril-client-cli/Cargo.toml
+++ b/mithril-client-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client-cli"
-version = "0.13.18"
+version = "0.13.19"
 description = "A Mithril Client"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-client-cli/src/commands/cardano_block/snapshot_show.rs
+++ b/mithril-client-cli/src/commands/cardano_block/snapshot_show.rs
@@ -67,14 +67,14 @@ impl CardanoBlocksSnapshotShowCommand {
             println!("{}", serde_json::to_string(&snapshot)?);
         } else {
             let snapshot_sets_table = vec![
-                vec!["Epoch".cell(), format!("{}", &snapshot.epoch).cell()],
+                vec!["Epoch".cell(), format!("{}", snapshot.epoch).cell()],
                 vec![
                     "Block Number Signed".cell(),
-                    format!("{}", &snapshot.block_number_signed).cell(),
+                    format!("{}", snapshot.block_number_signed).cell(),
                 ],
                 vec![
                     "Block Number Tip".cell(),
-                    format!("{}", &snapshot.block_number_tip).cell(),
+                    format!("{}", snapshot.block_number_tip).cell(),
                 ],
                 vec!["Merkle Root".cell(), snapshot.merkle_root.to_string().cell()],
                 vec![

--- a/mithril-client-cli/src/commands/cardano_db/show.rs
+++ b/mithril-client-cli/src/commands/cardano_db/show.rs
@@ -69,10 +69,10 @@ impl CardanoDbShowCommand {
             println!("{}", serde_json::to_string(&cardano_db_message)?);
         } else {
             let mut cardano_db_table = vec![
-                vec!["Epoch".cell(), format!("{}", &cardano_db_message.beacon.epoch).cell()],
+                vec!["Epoch".cell(), format!("{}", cardano_db_message.beacon.epoch).cell()],
                 vec![
                     "Immutable File Number".cell(),
-                    format!("{}", &cardano_db_message.beacon.immutable_file_number).cell(),
+                    format!("{}", cardano_db_message.beacon.immutable_file_number).cell(),
                 ],
                 vec!["Hash".cell(), cardano_db_message.hash.cell()],
                 vec!["Merkle root".cell(), cardano_db_message.merkle_root.cell()],

--- a/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/cardano_stake_distribution/download.rs
@@ -73,7 +73,7 @@ impl CardanoStakeDistributionDownloadCommand {
             .with_context(|| {
                 format!(
                     "Can not fetch Cardano stake distribution from unique identifier: '{}'",
-                    &self.unique_identifier
+                    self.unique_identifier
                 )
             })?;
 
@@ -88,7 +88,7 @@ impl CardanoStakeDistributionDownloadCommand {
             .with_context(|| {
                 format!(
                     "Can not verify the certificate chain from certificate_hash: '{}'",
-                    &cardano_stake_distribution.certificate_hash
+                    cardano_stake_distribution.certificate_hash
                 )
             })?;
 

--- a/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
+++ b/mithril-client-cli/src/commands/cardano_transaction/snapshot_show.rs
@@ -104,8 +104,8 @@ impl CardanoTransactionsSnapshotShowCommand {
             println!("{}", serde_json::to_string(&snapshot)?);
         } else {
             let transaction_sets_table = vec![
-                vec!["Epoch".cell(), format!("{}", &snapshot.epoch).cell()],
-                vec!["Block Number".cell(), format!("{}", &snapshot.block_number).cell()],
+                vec!["Epoch".cell(), format!("{}", snapshot.epoch).cell()],
+                vec!["Block Number".cell(), format!("{}", snapshot.block_number).cell()],
                 vec!["Merkle Root".cell(), snapshot.merkle_root.to_string().cell()],
                 vec![
                     "Certificate Hash".cell(),
@@ -161,14 +161,14 @@ impl CardanoTransactionsSnapshotShowCommand {
             println!("{}", serde_json::to_string(&snapshot)?);
         } else {
             let transaction_sets_table = vec![
-                vec!["Epoch".cell(), format!("{}", &snapshot.epoch).cell()],
+                vec!["Epoch".cell(), format!("{}", snapshot.epoch).cell()],
                 vec![
                     "Block Number Signed".cell(),
-                    format!("{}", &snapshot.block_number_signed).cell(),
+                    format!("{}", snapshot.block_number_signed).cell(),
                 ],
                 vec![
                     "Block Number Tip".cell(),
-                    format!("{}", &snapshot.block_number_tip).cell(),
+                    format!("{}", snapshot.block_number_tip).cell(),
                 ],
                 vec!["Merkle Root".cell(), snapshot.merkle_root.to_string().cell()],
                 vec![

--- a/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
+++ b/mithril-client-cli/src/commands/mithril_stake_distribution/download.rs
@@ -103,7 +103,7 @@ impl MithrilStakeDistributionDownloadCommand {
             .with_context(|| {
                 format!(
                     "Can not verify the certificate chain from certificate_hash: '{}'",
-                    &mithril_stake_distribution.certificate_hash
+                    mithril_stake_distribution.certificate_hash
                 )
             })?;
 

--- a/mithril-client-cli/src/utils/multi_download_progress_reporter.rs
+++ b/mithril-client-cli/src/utils/multi_download_progress_reporter.rs
@@ -111,7 +111,7 @@ impl MultiDownloadProgressReporter {
     /// Finish all child bars and the main progress bar and prints a message.
     pub async fn finish_all(&self, message: &str) {
         let mut reporters = self.dl_reporters.write().await;
-        for (_name, reporter) in reporters.iter() {
+        for reporter in reporters.values() {
             reporter.finish_and_clear();
             self.parent_container.remove(reporter.inner_progress_bar());
         }

--- a/mithril-client-cli/src/utils/progress_reporter.rs
+++ b/mithril-client-cli/src/utils/progress_reporter.rs
@@ -444,8 +444,8 @@ mod tests {
             seconds_elapsed * 3.0 - delta < seconds_left
                 && seconds_left < seconds_elapsed * 3.0 + delta,
             "seconds_left should be close to 3*{} but it's {}.",
-            &seconds_elapsed,
-            &seconds_left
+            seconds_elapsed,
+            seconds_left
         );
 
         let duration_left = Duration::from_secs_f64(seconds_left);

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -64,7 +64,7 @@ flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.4" }
-mithril-common = { path = "../mithril-common", version = "0.7.12", default-features = false }
+mithril-common = { path = "../mithril-common", version = "0.7.13", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -77,8 +77,8 @@ uuid = { version = "1.23.4", features = ["v4"] }
 zstd = { version = "0.13.3", optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-mithril-aggregator-discovery = { path = "../internal/mithril-aggregator-discovery", version = "0.1.10" }
-mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.2.3" }
+mithril-aggregator-discovery = { path = "../internal/mithril-aggregator-discovery", version = "0.1.11" }
+mithril-cardano-node-internal-database = { path = "../internal/cardano-node/mithril-cardano-node-internal-database", version = "0.2.4" }
 rand = { version = "0.10.2" }
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.12"
+version = "0.7.13"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -45,8 +45,8 @@ ed25519-dalek = { version = "2.2.0", features = ["rand_core", "serde"] }
 fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
-mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.3" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.47", default-features = false }
+mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
+mithril-stm = { path = "../mithril-stm", version = "0.10.48", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/crypto_helper/cardano/kes/kes_evolutions.rs
+++ b/mithril-common/src/crypto_helper/cardano/kes/kes_evolutions.rs
@@ -73,7 +73,7 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", KesEvolutions(72)), "72");
-        assert_eq!(format!("{}", &KesEvolutions(13224)), "13224");
+        assert_eq!(format!("{}", KesEvolutions(13224)), "13224");
     }
 
     #[test]

--- a/mithril-common/src/crypto_helper/cardano/kes/kes_period.rs
+++ b/mithril-common/src/crypto_helper/cardano/kes/kes_period.rs
@@ -86,7 +86,7 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", KesPeriod(72)), "72");
-        assert_eq!(format!("{}", &KesPeriod(13224)), "13224");
+        assert_eq!(format!("{}", KesPeriod(13224)), "13224");
     }
 
     #[test]

--- a/mithril-common/src/entities/block_number.rs
+++ b/mithril-common/src/entities/block_number.rs
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", BlockNumber(72)), "72");
-        assert_eq!(format!("{}", &BlockNumber(13224)), "13224");
+        assert_eq!(format!("{}", BlockNumber(13224)), "13224");
     }
 
     #[test]

--- a/mithril-common/src/entities/block_number_offset.rs
+++ b/mithril-common/src/entities/block_number_offset.rs
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", BlockNumberOffset(72)), "72");
-        assert_eq!(format!("{}", &BlockNumberOffset(13224)), "13224");
+        assert_eq!(format!("{}", BlockNumberOffset(13224)), "13224");
     }
 
     #[test]

--- a/mithril-common/src/entities/epoch.rs
+++ b/mithril-common/src/entities/epoch.rs
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", Epoch(72)), "72");
-        assert_eq!(format!("{}", &Epoch(13224)), "13224");
+        assert_eq!(format!("{}", Epoch(13224)), "13224");
     }
 
     #[test]

--- a/mithril-common/src/entities/slot_number.rs
+++ b/mithril-common/src/entities/slot_number.rs
@@ -56,7 +56,7 @@ mod tests {
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", SlotNumber(72)), "72");
-        assert_eq!(format!("{}", &SlotNumber(13224)), "13224");
+        assert_eq!(format!("{}", SlotNumber(13224)), "13224");
     }
 
     #[test]

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "1.1.4"
+version = "1.1.5"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/configuration.rs
+++ b/mithril-signer/src/configuration.rs
@@ -211,7 +211,7 @@ impl Configuration {
         CardanoNetwork::from_code(self.network.clone(), self.network_magic).with_context(|| {
             format!(
                 "Could not read Network '{}' from configuration.",
-                &self.network
+                self.network
             )
         })
     }
@@ -221,7 +221,7 @@ impl Configuration {
         DmqNetwork::from_code(self.network.clone(), self.dmq_network_magic).with_context(|| {
             format!(
                 "Could not read DMQ Network '{}' from configuration.",
-                &self.network
+                self.network
             )
         })
     }
@@ -256,7 +256,7 @@ impl Configuration {
         .with_context(|| {
             format!(
                 "Configuration: can not create era reader for adapter '{}'.",
-                &self.era_reader_adapter_type
+                self.era_reader_adapter_type
             )
         })
     }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.47"
+version = "0.10.48"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/proof_system/concatenation/clerk.rs
+++ b/mithril-stm/src/proof_system/concatenation/clerk.rs
@@ -118,7 +118,7 @@ impl ConcatenationClerk {
         let mut dedup_sigs: HashSet<SingleSignatureWithRegisteredParty> = HashSet::new();
         let mut count: u64 = 0;
 
-        for (_, &sig_reg) in sig_by_index.iter() {
+        for &sig_reg in sig_by_index.values() {
             if dedup_sigs.contains(sig_reg) {
                 continue;
             }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.5"
+version = "0.5.6"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -297,7 +297,7 @@ async fn main_exec() -> StdResult<()> {
         std::path::absolute(&dir).with_context(|| {
             format!(
                 "Failed to resolve absolute work directory path: {}",
-                &dir.display()
+                dir.display()
             )
         })?
     };

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/aggregator.rs
@@ -241,7 +241,7 @@ impl Aggregator {
     }
 
     pub fn endpoint(&self) -> String {
-        format!("http://localhost:{}/aggregator", &self.server_port)
+        format!("http://localhost:{}/aggregator", self.server_port)
     }
 
     pub fn db_directory(&self) -> &Path {

--- a/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/mithril/relay_signer.rs
@@ -101,7 +101,7 @@ impl RelaySigner {
     }
 
     pub fn endpoint(&self) -> String {
-        format!("http://localhost:{}", &self.server_port)
+        format!("http://localhost:{}", self.server_port)
     }
 
     /// Get the version of the mithril-relay binary.


### PR DESCRIPTION
## Content

This PR fix preemptively clippy lints added or updated with `rust 1.97`.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
  - [x] No new TODOs introduced

## Issue(s)

Closes #3387
