### PR TITLE
refactor(mithril-stm): enhance halo2_ivc modularity with gadgets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4715,7 +4715,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.10.48"
+version = "0.10.49"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.10.48", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.10.49", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.10.49 (07-10-2026)
+
+### Changed
+
+- Refactored the recursive (IVC) circuit for modularity: extracted reusable gadgets (genesis Schnorr, byte-combination) into a new `gadgets` module, moved the witness/public-input assignment and off-circuit accumulator helpers into dedicated modules, and decomposed the state transition into named helpers
+- Renamed the circuit's `IvcGadget` to `IvcConstraintBuilder`
+- Documented the recursive circuit's constraint builder, gadgets, and instance columns
+
 ## 0.10.47 (07-08-2026)
 
 ### Changed

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.10.48"
+version = "0.10.49"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
@@ -1,0 +1,50 @@
+//! Off-circuit accumulator and verification-key fixed-base helpers for the recursive IVC circuit.
+
+use std::collections::BTreeMap;
+
+use ff::Field;
+use group::Group;
+
+use super::{
+    Accumulator, ConstraintSystem, EmulatedCurve, KZGCommitmentScheme, Msm, NativeField,
+    PairingEngine, RecursiveEmulation, VerifyingKey, verifier,
+};
+
+pub(crate) fn trivial_accumulator(fixed_base_names: &[String]) -> Accumulator<RecursiveEmulation> {
+    Accumulator::<RecursiveEmulation>::new(
+        Msm::new(
+            &[EmulatedCurve::default()],
+            &[NativeField::ONE],
+            &BTreeMap::new(),
+        ),
+        Msm::new(
+            &[EmulatedCurve::default()],
+            &[NativeField::ONE],
+            &fixed_base_names
+                .iter()
+                .map(|name| (name.clone(), NativeField::ZERO))
+                .collect(),
+        ),
+    )
+}
+
+pub(crate) fn fixed_bases_and_names(
+    vk_name: &str,
+    vk: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
+) -> (BTreeMap<String, EmulatedCurve>, Vec<String>) {
+    let mut fixed_bases = BTreeMap::new();
+    fixed_bases.insert(String::from("com_instance"), EmulatedCurve::identity());
+    fixed_bases.extend(verifier::fixed_bases::<RecursiveEmulation>(vk_name, vk));
+    let fixed_base_names = fixed_bases.keys().cloned().collect::<Vec<_>>();
+    (fixed_bases, fixed_base_names)
+}
+
+pub(crate) fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<NativeField>) -> Vec<String> {
+    let mut fixed_base_names = vec![String::from("com_instance")];
+    fixed_base_names.extend(verifier::fixed_base_names::<RecursiveEmulation>(
+        vk_name,
+        cs.num_fixed_columns() + cs.num_selectors(),
+        cs.permutation().columns.len(),
+    ));
+    fixed_base_names
+}

--- a/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
@@ -10,6 +10,8 @@ use super::{
     PairingEngine, RecursiveEmulation, VerifyingKey, verifier,
 };
 
+/// Builds the trivial accumulator (the default that satisfies the accumulation invariant) for the
+/// given fixed-base names.
 pub(crate) fn trivial_accumulator(fixed_base_names: &[String]) -> Accumulator<RecursiveEmulation> {
     Accumulator::<RecursiveEmulation>::new(
         Msm::new(
@@ -28,6 +30,8 @@ pub(crate) fn trivial_accumulator(fixed_base_names: &[String]) -> Accumulator<Re
     )
 }
 
+/// Returns the fixed bases of a verifying key (including the `com_instance` entry) together with
+/// their names.
 pub(crate) fn fixed_bases_and_names(
     vk_name: &str,
     vk: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
@@ -39,6 +43,7 @@ pub(crate) fn fixed_bases_and_names(
     (fixed_bases, fixed_base_names)
 }
 
+/// Returns the fixed-base names of a verifying key, derived from its constraint system.
 pub(crate) fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<NativeField>) -> Vec<String> {
     let mut fixed_base_names = vec![String::from("com_instance")];
     fixed_base_names.extend(verifier::fixed_base_names::<RecursiveEmulation>(

--- a/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/accumulator.rs
@@ -32,7 +32,7 @@ pub(crate) fn trivial_accumulator(fixed_base_names: &[String]) -> Accumulator<Re
 
 /// Returns the fixed bases of a verifying key (including the `com_instance` entry) together with
 /// their names.
-pub(crate) fn fixed_bases_and_names(
+pub(crate) fn fixed_bases_and_names_from_verifying_key(
     vk_name: &str,
     vk: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
 ) -> (BTreeMap<String, EmulatedCurve>, Vec<String>) {
@@ -44,7 +44,10 @@ pub(crate) fn fixed_bases_and_names(
 }
 
 /// Returns the fixed-base names of a verifying key, derived from its constraint system.
-pub(crate) fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<NativeField>) -> Vec<String> {
+pub(crate) fn fixed_base_names_from_constraint_system(
+    vk_name: &str,
+    cs: &ConstraintSystem<NativeField>,
+) -> Vec<String> {
     let mut fixed_base_names = vec![String::from("com_instance")];
     fixed_base_names.extend(verifier::fixed_base_names::<RecursiveEmulation>(
         vk_name,

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -15,6 +15,7 @@ use super::{
     nb_foreign_ecc_chip_columns,
     state::{Global, State, Witness},
     types::{CertificateProofBytes, IvcProofBytes},
+    witness_assignments,
 };
 
 /// Data required to run one step of the IVC (Incrementally Verifiable Computation) circuit.
@@ -201,16 +202,18 @@ impl Circuit<NativeField> for IvcCircuitData {
         let ivc_gadget = IvcGadget::new(&config);
 
         // Assign global and constraint it as public input
-        let global = ivc_gadget.assign_global_as_public_input(
+        let global = witness_assignments::assign_global_as_public_input(
+            &ivc_gadget,
             &mut layouter,
             &self.global,
             &self.certificate_circuit_domain_and_constraint_system,
             &self.ivc_circuit_domain_and_constraint_system,
         )?;
         // Assign previous state
-        let state = ivc_gadget.assign_state(&mut layouter, &self.state)?;
+        let state = witness_assignments::assign_state(&ivc_gadget, &mut layouter, &self.state)?;
         // Assign witness for the new certificate to be aggregated
-        let witness = ivc_gadget.assign_witness(&mut layouter, &self.witness)?;
+        let witness =
+            witness_assignments::assign_witness(&ivc_gadget, &mut layouter, &self.witness)?;
 
         // If state.step_counter = 0, we are aggregating the genesis certificate
         let is_genesis = ivc_gadget.is_genesis(&mut layouter, &state)?;
@@ -229,7 +232,11 @@ impl Circuit<NativeField> for IvcCircuitData {
             &witness,
         )?;
         // Constrain the next state as public input
-        ivc_gadget.constrain_state_as_public_input(&mut layouter, &next_state)?;
+        witness_assignments::constrain_state_as_public_input(
+            &ivc_gadget,
+            &mut layouter,
+            &next_state,
+        )?;
 
         // Verify (prepare) certificate_proof and previous ivc_proof and update accumulator
         let next_acc = ivc_gadget.verify_prepare(

--- a/mithril-stm/src/circuits/halo2_ivc/circuit.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/circuit.rs
@@ -10,8 +10,8 @@ use super::{
     NB_SHA256_ADVICE_COLS, NB_SHA256_FIXED_COLS, NativeField, PublicInputInstructions,
     RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, SimpleFloorPlanner,
     config::{IvcConfig, configure_ivc_circuit, ivc_column_pool_sizes},
+    constraint_builder::IvcConstraintBuilder,
     errors::IvcCircuitError,
-    gadget::IvcGadget,
     nb_foreign_ecc_chip_columns,
     state::{Global, State, Witness},
     types::{CertificateProofBytes, IvcProofBytes},
@@ -199,31 +199,30 @@ impl Circuit<NativeField> for IvcCircuitData {
         config: Self::Config,
         mut layouter: impl Layouter<NativeField>,
     ) -> Result<(), Error> {
-        let ivc_gadget = IvcGadget::new(&config);
+        let builder = IvcConstraintBuilder::new(&config);
 
         // Assign global and constraint it as public input
         let global = witness_assignments::assign_global_as_public_input(
-            &ivc_gadget,
+            &builder,
             &mut layouter,
             &self.global,
             &self.certificate_circuit_domain_and_constraint_system,
             &self.ivc_circuit_domain_and_constraint_system,
         )?;
         // Assign previous state
-        let state = witness_assignments::assign_state(&ivc_gadget, &mut layouter, &self.state)?;
+        let state = witness_assignments::assign_state(&builder, &mut layouter, &self.state)?;
         // Assign witness for the new certificate to be aggregated
-        let witness =
-            witness_assignments::assign_witness(&ivc_gadget, &mut layouter, &self.witness)?;
+        let witness = witness_assignments::assign_witness(&builder, &mut layouter, &self.witness)?;
 
         // If state.step_counter = 0, we are aggregating the genesis certificate
-        let is_genesis = ivc_gadget.is_genesis(&mut layouter, &state)?;
-        let is_not_genesis = ivc_gadget.native_gadget.not(&mut layouter, &is_genesis)?;
+        let is_genesis = builder.is_genesis(&mut layouter, &state)?;
+        let is_not_genesis = builder.native_gadget.not(&mut layouter, &is_genesis)?;
 
         // Verify genesis certificate
-        ivc_gadget.assert_genesis(&mut layouter, &is_not_genesis, &global, &witness)?;
+        builder.assert_genesis(&mut layouter, &is_not_genesis, &global, &witness)?;
 
         // Verify certificate chain link between the last aggregated certificate and the new certificate to obtain the next state
-        let next_state = ivc_gadget.transition(
+        let next_state = builder.transition(
             &mut layouter,
             &is_genesis,
             &is_not_genesis,
@@ -232,14 +231,10 @@ impl Circuit<NativeField> for IvcCircuitData {
             &witness,
         )?;
         // Constrain the next state as public input
-        witness_assignments::constrain_state_as_public_input(
-            &ivc_gadget,
-            &mut layouter,
-            &next_state,
-        )?;
+        witness_assignments::constrain_state_as_public_input(&builder, &mut layouter, &next_state)?;
 
         // Verify (prepare) certificate_proof and previous ivc_proof and update accumulator
-        let next_acc = ivc_gadget.verify_prepare(
+        let next_acc = builder.verify_prepare(
             &mut layouter,
             &global,
             &is_not_genesis,
@@ -250,12 +245,12 @@ impl Circuit<NativeField> for IvcCircuitData {
             &self.acc,
         )?;
         // Constrain the next accumulator as public input
-        ivc_gadget
+        builder
             .verifier_gadget
             .constrain_as_public_input(&mut layouter, &next_acc)?;
 
-        ivc_gadget.core_decomp_chip.load(&mut layouter)?;
-        ivc_gadget.sha2_256_chip.load(&mut layouter)
+        builder.core_decomp_chip.load(&mut layouter)?;
+        builder.sha2_256_chip.load(&mut layouter)
     }
 }
 

--- a/mithril-stm/src/circuits/halo2_ivc/config.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/config.rs
@@ -49,7 +49,10 @@ pub fn configure_ivc_circuit(meta: &mut ConstraintSystem<NativeField>) -> IvcCon
 
     let advice_columns: Vec<_> = (0..nb_advice_cols).map(|_| meta.advice_column()).collect();
     let fixed_columns: Vec<_> = (0..nb_fixed_cols).map(|_| meta.fixed_column()).collect();
+    // Committed-instance column: reserved for committed public inputs; this circuit leaves it empty
+    // and places its entire public statement in the plaintext instance column below.
     let committed_instance_column = meta.instance_column();
+    // Instance column: carries this circuit's public statement (global, state, accumulator).
     let instance_column = meta.instance_column();
 
     let native_config = NativeChip::configure(

--- a/mithril-stm/src/circuits/halo2_ivc/constraint_builder.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/constraint_builder.rs
@@ -1,3 +1,9 @@
+//! In-circuit constraint builder for one recursive IVC step.
+//!
+//! `IvcConstraintBuilder` owns the chips the recursive circuit needs and exposes the constraint
+//! logic driven by `IvcCircuitData::synthesize`: genesis-signature gating, the state transition, and
+//! accumulator/proof verification. Reusable sub-gadgets live in the `gadgets` module.
+
 use ff::Field;
 use group::Group;
 use midnight_circuits::hash::sha256::Sha256Chip;
@@ -24,6 +30,10 @@ type DecodedProtocolMessageFields = (
     AssignedNative<NativeField>,
 );
 
+/// Owns the chips for the recursive IVC circuit and builds its in-circuit constraints.
+///
+/// Constructed once per synthesis from an [`IvcConfig`]; its methods emit the constraints for a
+/// single IVC step.
 #[derive(Debug, Clone)]
 pub struct IvcConstraintBuilder {
     pub(crate) core_decomp_chip: P2RDecompositionChip<NativeField>,
@@ -37,6 +47,7 @@ pub struct IvcConstraintBuilder {
 }
 
 impl IvcConstraintBuilder {
+    /// Builds the circuit's chips from the circuit configuration.
     pub fn new(config: &IvcConfig) -> Self {
         let native_chip = <NativeChip<NativeField> as ComposableChip<NativeField>>::new(
             &config.native_config,
@@ -66,6 +77,7 @@ impl IvcConstraintBuilder {
         }
     }
 
+    /// Returns a bit that is true when the state is the genesis state (step counter zero).
     pub fn is_genesis(
         &self,
         layouter: &mut impl Layouter<NativeField>,
@@ -95,6 +107,7 @@ impl IvcConstraintBuilder {
         )
     }
 
+    /// Enforces a valid genesis Schnorr signature, skipping the check on non-genesis steps.
     pub fn assert_genesis(
         &self,
         layouter: &mut impl Layouter<NativeField>,
@@ -115,6 +128,7 @@ impl IvcConstraintBuilder {
             .assert_equal_to_fixed(layouter, &check_genesis, true)
     }
 
+    /// Flattens the assigned global root-of-trust into its public-input field elements.
     pub fn global_as_public_input(
         &self,
         layouter: &mut impl Layouter<NativeField>,
@@ -135,6 +149,8 @@ impl IvcConstraintBuilder {
         Ok(pi)
     }
 
+    /// Verifies the certificate-chain link between the last aggregated certificate and the new one,
+    /// and returns the next state.
     pub fn transition(
         &self,
         layouter: &mut impl Layouter<NativeField>,
@@ -422,6 +438,8 @@ impl IvcConstraintBuilder {
         self.native_gadget.assert_equal_to_fixed(layouter, &is_valid, true)
     }
 
+    /// Verifies the certificate proof and the previous IVC proof in-circuit and folds them into the
+    /// next accumulator.
     #[allow(clippy::too_many_arguments)]
     pub fn verify_prepare(
         &self,

--- a/mithril-stm/src/circuits/halo2_ivc/constraint_builder.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/constraint_builder.rs
@@ -268,8 +268,9 @@ impl IvcConstraintBuilder {
         witness: &AssignedWitness,
         bases: &[NativeField],
     ) -> Result<DecodedProtocolMessageFields, Error> {
-        // digest(6) | bytes(32) | next_aggregate_verification_key(31) | bytes(44) | next_protocol_parameters(24) | bytes(32) | current_epoch(13) | bytes(8)
-        // todo: check field keywords(?)
+        // The byte ranges index the rigid protocol-message preimage assembled by
+        // `mithril-common::ProtocolMessage::rigid_preimage` (label-prefixed value segments).
+        // The next Merkle-tree commitment is the first 32 bytes of the aggregate-verification-key value.
         let next_merkle_tree_commitment_bytes =
             witness.message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].to_vec();
         let next_protocol_parameters_bytes =

--- a/mithril-stm/src/circuits/halo2_ivc/constraint_builder.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/constraint_builder.rs
@@ -25,7 +25,7 @@ type DecodedProtocolMessageFields = (
 );
 
 #[derive(Debug, Clone)]
-pub struct IvcGadget {
+pub struct IvcConstraintBuilder {
     pub(crate) core_decomp_chip: P2RDecompositionChip<NativeField>,
     pub(crate) native_gadget: IvcNativeGadget,
     pub(crate) jubjub_chip: EccChip<CircuitCurve>,
@@ -36,7 +36,7 @@ pub struct IvcGadget {
     pub(crate) verifier_gadget: VerifierGadget<RecursiveEmulation>,
 }
 
-impl IvcGadget {
+impl IvcConstraintBuilder {
     pub fn new(config: &IvcConfig) -> Self {
         let native_chip = <NativeChip<NativeField> as ComposableChip<NativeField>>::new(
             &config.native_config,
@@ -55,7 +55,7 @@ impl IvcGadget {
         let verifier_gadget: VerifierGadget<RecursiveEmulation> =
             VerifierGadget::new(&bls12_381_chip, &native_gadget, &poseidon_chip);
 
-        IvcGadget {
+        IvcConstraintBuilder {
             core_decomp_chip,
             native_gadget,
             jubjub_chip,

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -18,6 +18,10 @@ pub enum IvcCircuitError {
     #[error("IvcGadget: expected {expected} assigned values, got {actual}")]
     AssignedValueCountMismatch { expected: usize, actual: usize },
 
+    /// `combine_bytes` received more bytes than base weights, which would silently truncate.
+    #[error("combine_bytes received {bytes} bytes but only {bases} base weights")]
+    ByteCountExceedsBaseCount { bytes: usize, bases: usize },
+
     /// Not enough advice columns were allocated to satisfy chip requirements.
     #[error(
         "IvcCircuitData::validate_column_counts failed: need {needed} advice columns, only {available} allocated"

--- a/mithril-stm/src/circuits/halo2_ivc/errors.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/errors.rs
@@ -15,7 +15,7 @@ pub enum IvcCircuitError {
     IvcVerificationKeyDegreeMismatch { expected: u32, actual: u32 },
 
     /// `assign_many` returned a different number of values than expected.
-    #[error("IvcGadget: expected {expected} assigned values, got {actual}")]
+    #[error("IvcConstraintBuilder: expected {expected} assigned values, got {actual}")]
     AssignedValueCountMismatch { expected: usize, actual: usize },
 
     /// `combine_bytes` received more bytes than base weights, which would silently truncate.

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -2,19 +2,17 @@ use ff::Field;
 use group::Group;
 use midnight_circuits::hash::sha256::Sha256Chip;
 
-use crate::signature_scheme::DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE;
-
 use super::{
     Accumulator, ArithInstructions, AssertionInstructions, AssignedAccumulator, AssignedBit,
-    AssignedForeignPoint, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignmentInstructions, BinaryInstructions, CircuitCurve, CircuitCurveTrait, CircuitValue,
-    ComposableChip, ControlFlowInstructions, ConversionInstructions, EccChip, EccInstructions,
-    EmulatedCurve, EqualityInstructions, Error, ForeignEccChip, HashInstructions, IvcNativeGadget,
-    Layouter, NativeChip, NativeField, NativeGadget, P2RDecompositionChip,
-    PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
-    PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions,
-    RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, VerifierGadget, ZeroInstructions,
+    AssignedForeignPoint, AssignedNative, AssignmentInstructions, BinaryInstructions, CircuitCurve,
+    CircuitValue, ComposableChip, ControlFlowInstructions, EccChip, EccInstructions, EmulatedCurve,
+    EqualityInstructions, Error, ForeignEccChip, HashInstructions, IvcNativeGadget, Layouter,
+    NativeChip, NativeField, NativeGadget, P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES,
+    PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES, PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES,
+    PoseidonChip, PublicInputInstructions, RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation,
+    VerifierGadget, ZeroInstructions,
     config::IvcConfig,
+    gadgets::{GenesisSchnorrSignatureInputs, verify_genesis_signature},
     state::{AssignedGlobal, AssignedState, AssignedWitness},
 };
 
@@ -68,54 +66,25 @@ impl IvcGadget {
         self.native_gadget.is_zero(layouter, &state.step_counter)
     }
 
-    /// Verifies the genesis Schnorr signature in-circuit.
-    ///
-    /// Reconstructs the challenge via Poseidon hash over the genesis verification key,
-    /// the reconstructed nonce commitment, and the genesis message, then checks
-    /// equality against the committed challenge scalar from `witness.genesis_signature`.
-    /// Returns an `AssignedBit` that is `true` when the signature is valid.
+    /// Verifies the genesis Schnorr signature in-circuit (delegates to the `schnorr_signature` gadget).
     pub fn is_genesis_signature_valid(
         &self,
         layouter: &mut impl Layouter<NativeField>,
         global: &AssignedGlobal,
         witness: &AssignedWitness,
     ) -> Result<AssignedBit<NativeField>, Error> {
-        let s = witness.genesis_signature.0.clone();
-        let c_native = witness.genesis_signature.1.clone();
-        let c: AssignedScalarOfNativeCurve<_> = self.jubjub_chip.convert(layouter, &c_native)?;
-
-        let dst_signature: AssignedNative<_> = self
-            .native_gadget
-            .assign_fixed(layouter, DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE.0)?;
-        let generator: AssignedNativePoint<_> = self.jubjub_chip.assign_fixed(
+        verify_genesis_signature(
+            &self.jubjub_chip,
+            &self.native_gadget,
+            &self.poseidon_chip,
             layouter,
-            <CircuitCurve as CircuitCurveTrait>::CryptographicGroup::generator(),
-        )?;
-
-        let cap_r = self.jubjub_chip.msm(
-            layouter,
-            &[s, c.clone()],
-            &[generator.clone(), global.genesis_verification_key.clone()],
-        )?;
-
-        let vk_x = self.jubjub_chip.x_coordinate(&global.genesis_verification_key);
-        let vk_y = self.jubjub_chip.y_coordinate(&global.genesis_verification_key);
-        let cap_r_x = self.jubjub_chip.x_coordinate(&cap_r);
-        let cap_r_y = self.jubjub_chip.y_coordinate(&cap_r);
-
-        let c_prime = self.poseidon_chip.hash(
-            layouter,
-            &[
-                dst_signature.clone(),
-                vk_x,
-                vk_y,
-                cap_r_x,
-                cap_r_y,
-                global.genesis_message.clone(),
-            ],
-        )?;
-
-        self.native_gadget.is_equal(layouter, &c_prime, &c_native)
+            GenesisSchnorrSignatureInputs {
+                verification_key: &global.genesis_verification_key,
+                message: &global.genesis_message,
+                response: &witness.genesis_signature.0,
+                challenge: &witness.genesis_signature.1,
+            },
+        )
     }
 
     pub fn assert_genesis(

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -16,6 +16,14 @@ use super::{
     state::{AssignedGlobal, AssignedState, AssignedWitness},
 };
 
+/// Protocol-message fields decoded during a transition:
+/// `(next_merkle_tree_commitment, next_protocol_parameters, current_epoch)`.
+type DecodedProtocolMessageFields = (
+    AssignedNative<NativeField>,
+    AssignedNative<NativeField>,
+    AssignedNative<NativeField>,
+);
+
 #[derive(Debug, Clone)]
 pub struct IvcGadget {
     pub(crate) core_decomp_chip: P2RDecompositionChip<NativeField>,
@@ -154,8 +162,6 @@ impl IvcGadget {
             &certificate_message,
         )?;
 
-        let hash = self.sha2_256_chip.hash(layouter, &witness.message_preimage)?;
-
         let factor = NativeField::from(256u64);
         let bases: Vec<_> = (0..32)
             .scan(NativeField::ONE, |s, _| {
@@ -165,11 +171,7 @@ impl IvcGadget {
             })
             .collect();
 
-        {
-            // Compare message and hash
-            let hash_native = combine_bytes(&self.native_gadget, layouter, &hash, &bases)?;
-            self.native_gadget.assert_equal(layouter, &message, &hash_native)?;
-        }
+        self.assert_message_matches_preimage(layouter, &message, witness, &bases)?;
 
         // If it is genesis, merkle_tree_commitment = 0; otherwise, merkle_tree_commitment = certificate_merkle_tree_commitment.
         let zero = self.native_gadget.assign_fixed(layouter, NativeField::ZERO)?;
@@ -180,146 +182,41 @@ impl IvcGadget {
             &certificate_merkle_tree_commitment,
         )?;
 
-        // Read the next Merkle-tree commitment, next protocol parameters, and current epoch from the protocol message preimage.
-        // digest(6) | bytes(32) | next_aggregate_verification_key(31) | bytes(44) | next_protocol_parameters(24) | bytes(32) | current_epoch(13) | bytes(8)
-        // todo: check field keywords(?)
-        let next_merkle_tree_commitment_bytes =
-            witness.message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].to_vec();
-        let next_protocol_parameters_bytes =
-            witness.message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].to_vec();
-        let current_epoch_bytes = witness.message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].to_vec();
+        let (next_merkle_tree_commitment, next_protocol_parameters, current_epoch) =
+            self.read_transition_fields_from_preimage(layouter, witness, &bases)?;
 
-        // Get the field elements by linearly combining the bytes
-        let (next_merkle_tree_commitment, next_protocol_parameters, current_epoch) = {
-            let next_merkle_tree_commitment = combine_bytes(
-                &self.native_gadget,
-                layouter,
-                next_merkle_tree_commitment_bytes,
-                &bases,
-            )?;
-            let next_protocol_parameters = combine_bytes(
-                &self.native_gadget,
-                layouter,
-                next_protocol_parameters_bytes,
-                &bases,
-            )?;
-            let current_epoch =
-                combine_bytes(&self.native_gadget, layouter, current_epoch_bytes, &bases)?;
-            (
-                next_merkle_tree_commitment,
-                next_protocol_parameters,
-                current_epoch,
-            )
-        };
+        let (is_same_epoch, is_next_epoch) =
+            self.classify_epoch(layouter, &current_epoch, state)?;
 
-        let (is_same_epoch, is_next_epoch) = {
-            // current_epoch == state.current_epoch
-            let is_same_epoch =
-                self.native_gadget
-                    .is_equal(layouter, &current_epoch, &state.current_epoch)?;
+        self.assert_first_step_is_next_epoch(layouter, state, &is_next_epoch)?;
 
-            //  current_epoch == state.current_epoch + 1
-            let next = self.native_gadget.add_constant(
-                layouter,
-                &state.current_epoch,
-                NativeField::ONE,
-            )?;
-            let is_next_epoch = self.native_gadget.is_equal(layouter, &current_epoch, &next)?;
+        self.assert_merkle_tree_commitment_link(
+            layouter,
+            is_genesis,
+            &merkle_tree_commitment,
+            state,
+            &is_same_epoch,
+            &is_next_epoch,
+        )?;
 
-            (is_same_epoch, is_next_epoch)
-        };
+        let protocol_parameters = self.select_protocol_parameters(
+            layouter,
+            is_genesis,
+            is_not_genesis,
+            &is_same_epoch,
+            state,
+            &zero,
+        )?;
 
-        {
-            // If state.step_counter == 1, the previous certificate is a genesis certificate and
-            // the current certificate is the first certificate after the genesis and
-            // its epoch number must be the next epoch number.
-            // Assert true: is_not_first or is_next_epoch
-            let is_first = self.native_gadget.is_equal_to_fixed(
-                layouter,
-                &state.step_counter,
-                NativeField::ONE,
-            )?;
-            let is_not_first = self.native_gadget.not(layouter, &is_first)?;
-
-            let is_valid = self
-                .native_gadget
-                .or(layouter, &[is_not_first, is_next_epoch.clone()])?;
-            self.native_gadget.assert_equal_to_fixed(layouter, &is_valid, true)?;
-        }
-
-        {
-            // Check the current Merkle-tree commitment link; if it is genesis, skip the check.
-            // Assert true: is_genesis or (is_same_epoch && merkle_tree_commitment == state.merkle_tree_commitment) or (is_next_epoch && merkle_tree_commitment == state.next_merkle_tree_commitment)
-            let mut is_equal_current = self.native_gadget.is_equal(
-                layouter,
-                &merkle_tree_commitment,
-                &state.merkle_tree_commitment,
-            )?;
-            is_equal_current = self
-                .native_gadget
-                .and(layouter, &[is_equal_current, is_same_epoch.clone()])?;
-
-            let mut is_equal_next = self.native_gadget.is_equal(
-                layouter,
-                &merkle_tree_commitment,
-                &state.next_merkle_tree_commitment,
-            )?;
-            is_equal_next = self
-                .native_gadget
-                .and(layouter, &[is_equal_next, is_next_epoch.clone()])?;
-
-            let is_link_valid = self.native_gadget.or(
-                layouter,
-                &[is_genesis.clone(), is_equal_current, is_equal_next],
-            )?;
-            self.native_gadget
-                .assert_equal_to_fixed(layouter, &is_link_valid, true)?;
-        }
-
-        let protocol_parameters = {
-            // If genesis: protocol_parameters = 0
-            // Else:
-            //     if same_epoch: protocol_parameters = state.protocol_parameters;
-            //     else: protocol_parameters = state.next_protocol_parameters
-            let mut protocol_parameters = self.native_gadget.select(
-                layouter,
-                is_genesis,
-                &zero,
-                &state.next_protocol_parameters,
-            )?;
-            let is_same_epoch_not_genesis = self
-                .native_gadget
-                .and(layouter, &[is_same_epoch.clone(), is_not_genesis.clone()])?;
-            protocol_parameters = self.native_gadget.select(
-                layouter,
-                &is_same_epoch_not_genesis,
-                &state.protocol_parameters,
-                &protocol_parameters,
-            )?;
-            protocol_parameters
-        };
-
-        {
-            // Check the consistency on next_merkle_tree_commitment and next_protocol_parameters for certificates of the same epoch
-            // Assert true: is_genesis or (is_same_epoch && next_merkle_tree_commitment == state.next_merkle_tree_commitment && next_protocol_parameters == state.next_protocol_parameters) or is_next_epoch
-            let is_equal_mt = self.native_gadget.is_equal(
-                layouter,
-                &next_merkle_tree_commitment,
-                &state.next_merkle_tree_commitment,
-            )?;
-            let is_equal_pp = self.native_gadget.is_equal(
-                layouter,
-                &next_protocol_parameters,
-                &state.next_protocol_parameters,
-            )?;
-            let mut is_valid = self
-                .native_gadget
-                .and(layouter, &[is_same_epoch, is_equal_mt, is_equal_pp])?;
-            is_valid = self
-                .native_gadget
-                .or(layouter, &[is_genesis.clone(), is_valid, is_next_epoch])?;
-            self.native_gadget.assert_equal_to_fixed(layouter, &is_valid, true)?;
-        };
+        self.assert_next_values_consistency(
+            layouter,
+            is_genesis,
+            &is_same_epoch,
+            &is_next_epoch,
+            &next_merkle_tree_commitment,
+            &next_protocol_parameters,
+            state,
+        )?;
 
         // Return the next state
         Ok(AssignedState {
@@ -331,6 +228,198 @@ impl IvcGadget {
             next_protocol_parameters,
             current_epoch,
         })
+    }
+
+    /// Asserts the selected `message` equals the SHA-256 hash of the protocol-message preimage.
+    fn assert_message_matches_preimage(
+        &self,
+        layouter: &mut impl Layouter<NativeField>,
+        message: &AssignedNative<NativeField>,
+        witness: &AssignedWitness,
+        bases: &[NativeField],
+    ) -> Result<(), Error> {
+        let hash = self.sha2_256_chip.hash(layouter, &witness.message_preimage)?;
+        // Compare message and hash
+        let hash_native = combine_bytes(&self.native_gadget, layouter, &hash, bases)?;
+        self.native_gadget.assert_equal(layouter, message, &hash_native)
+    }
+
+    /// Reads the next Merkle-tree commitment, next protocol parameters, and current epoch from the
+    /// protocol message preimage.
+    fn read_transition_fields_from_preimage(
+        &self,
+        layouter: &mut impl Layouter<NativeField>,
+        witness: &AssignedWitness,
+        bases: &[NativeField],
+    ) -> Result<DecodedProtocolMessageFields, Error> {
+        // digest(6) | bytes(32) | next_aggregate_verification_key(31) | bytes(44) | next_protocol_parameters(24) | bytes(32) | current_epoch(13) | bytes(8)
+        // todo: check field keywords(?)
+        let next_merkle_tree_commitment_bytes =
+            witness.message_preimage[PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES].to_vec();
+        let next_protocol_parameters_bytes =
+            witness.message_preimage[PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES].to_vec();
+        let current_epoch_bytes = witness.message_preimage[PREIMAGE_CURRENT_EPOCH_BYTES].to_vec();
+
+        // Get the field elements by linearly combining the bytes
+        let next_merkle_tree_commitment = combine_bytes(
+            &self.native_gadget,
+            layouter,
+            next_merkle_tree_commitment_bytes,
+            bases,
+        )?;
+        let next_protocol_parameters = combine_bytes(
+            &self.native_gadget,
+            layouter,
+            next_protocol_parameters_bytes,
+            bases,
+        )?;
+        let current_epoch =
+            combine_bytes(&self.native_gadget, layouter, current_epoch_bytes, bases)?;
+        Ok((
+            next_merkle_tree_commitment,
+            next_protocol_parameters,
+            current_epoch,
+        ))
+    }
+
+    /// Classifies the incoming epoch relative to the current state: `(is_same_epoch, is_next_epoch)`.
+    fn classify_epoch(
+        &self,
+        layouter: &mut impl Layouter<NativeField>,
+        current_epoch: &AssignedNative<NativeField>,
+        state: &AssignedState,
+    ) -> Result<(AssignedBit<NativeField>, AssignedBit<NativeField>), Error> {
+        // current_epoch == state.current_epoch
+        let is_same_epoch =
+            self.native_gadget
+                .is_equal(layouter, current_epoch, &state.current_epoch)?;
+
+        //  current_epoch == state.current_epoch + 1
+        let next =
+            self.native_gadget
+                .add_constant(layouter, &state.current_epoch, NativeField::ONE)?;
+        let is_next_epoch = self.native_gadget.is_equal(layouter, current_epoch, &next)?;
+
+        Ok((is_same_epoch, is_next_epoch))
+    }
+
+    /// If `state.step_counter == 1` (first certificate after genesis), its epoch must be the next epoch.
+    fn assert_first_step_is_next_epoch(
+        &self,
+        layouter: &mut impl Layouter<NativeField>,
+        state: &AssignedState,
+        is_next_epoch: &AssignedBit<NativeField>,
+    ) -> Result<(), Error> {
+        // Assert true: is_not_first or is_next_epoch
+        let is_first = self.native_gadget.is_equal_to_fixed(
+            layouter,
+            &state.step_counter,
+            NativeField::ONE,
+        )?;
+        let is_not_first = self.native_gadget.not(layouter, &is_first)?;
+
+        let is_valid = self
+            .native_gadget
+            .or(layouter, &[is_not_first, is_next_epoch.clone()])?;
+        self.native_gadget.assert_equal_to_fixed(layouter, &is_valid, true)
+    }
+
+    /// Checks the current Merkle-tree commitment link; if it is genesis, the check is skipped.
+    fn assert_merkle_tree_commitment_link(
+        &self,
+        layouter: &mut impl Layouter<NativeField>,
+        is_genesis: &AssignedBit<NativeField>,
+        merkle_tree_commitment: &AssignedNative<NativeField>,
+        state: &AssignedState,
+        is_same_epoch: &AssignedBit<NativeField>,
+        is_next_epoch: &AssignedBit<NativeField>,
+    ) -> Result<(), Error> {
+        // Assert true: is_genesis or (is_same_epoch && merkle_tree_commitment == state.merkle_tree_commitment) or (is_next_epoch && merkle_tree_commitment == state.next_merkle_tree_commitment)
+        let mut is_equal_current = self.native_gadget.is_equal(
+            layouter,
+            merkle_tree_commitment,
+            &state.merkle_tree_commitment,
+        )?;
+        is_equal_current = self
+            .native_gadget
+            .and(layouter, &[is_equal_current, is_same_epoch.clone()])?;
+
+        let mut is_equal_next = self.native_gadget.is_equal(
+            layouter,
+            merkle_tree_commitment,
+            &state.next_merkle_tree_commitment,
+        )?;
+        is_equal_next = self
+            .native_gadget
+            .and(layouter, &[is_equal_next, is_next_epoch.clone()])?;
+
+        let is_link_valid = self.native_gadget.or(
+            layouter,
+            &[is_genesis.clone(), is_equal_current, is_equal_next],
+        )?;
+        self.native_gadget
+            .assert_equal_to_fixed(layouter, &is_link_valid, true)
+    }
+
+    /// Selects the next protocol parameters: genesis → 0, same-epoch → current, next-epoch → next.
+    fn select_protocol_parameters(
+        &self,
+        layouter: &mut impl Layouter<NativeField>,
+        is_genesis: &AssignedBit<NativeField>,
+        is_not_genesis: &AssignedBit<NativeField>,
+        is_same_epoch: &AssignedBit<NativeField>,
+        state: &AssignedState,
+        zero: &AssignedNative<NativeField>,
+    ) -> Result<AssignedNative<NativeField>, Error> {
+        let mut protocol_parameters = self.native_gadget.select(
+            layouter,
+            is_genesis,
+            zero,
+            &state.next_protocol_parameters,
+        )?;
+        let is_same_epoch_not_genesis = self
+            .native_gadget
+            .and(layouter, &[is_same_epoch.clone(), is_not_genesis.clone()])?;
+        protocol_parameters = self.native_gadget.select(
+            layouter,
+            &is_same_epoch_not_genesis,
+            &state.protocol_parameters,
+            &protocol_parameters,
+        )?;
+        Ok(protocol_parameters)
+    }
+
+    /// Checks that the same-epoch next Merkle-tree commitment and next protocol parameters are consistent.
+    #[allow(clippy::too_many_arguments)]
+    fn assert_next_values_consistency(
+        &self,
+        layouter: &mut impl Layouter<NativeField>,
+        is_genesis: &AssignedBit<NativeField>,
+        is_same_epoch: &AssignedBit<NativeField>,
+        is_next_epoch: &AssignedBit<NativeField>,
+        next_merkle_tree_commitment: &AssignedNative<NativeField>,
+        next_protocol_parameters: &AssignedNative<NativeField>,
+        state: &AssignedState,
+    ) -> Result<(), Error> {
+        // Assert true: is_genesis or (is_same_epoch && next_merkle_tree_commitment == state.next_merkle_tree_commitment && next_protocol_parameters == state.next_protocol_parameters) or is_next_epoch
+        let is_equal_mt = self.native_gadget.is_equal(
+            layouter,
+            next_merkle_tree_commitment,
+            &state.next_merkle_tree_commitment,
+        )?;
+        let is_equal_pp = self.native_gadget.is_equal(
+            layouter,
+            next_protocol_parameters,
+            &state.next_protocol_parameters,
+        )?;
+        let mut is_valid = self
+            .native_gadget
+            .and(layouter, &[is_same_epoch.clone(), is_equal_mt, is_equal_pp])?;
+        is_valid = self.native_gadget.or(
+            layouter,
+            &[is_genesis.clone(), is_valid, is_next_epoch.clone()],
+        )?;
+        self.native_gadget.assert_equal_to_fixed(layouter, &is_valid, true)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -17,11 +17,10 @@ use super::{
     P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions,
     RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, VerifierGadget, ZeroInstructions,
+    accumulator::fixed_base_names,
     config::IvcConfig,
     errors::{IvcCircuitError, to_synthesis_error},
-    state::{
-        AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness, fixed_base_names,
-    },
+    state::{AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness},
 };
 
 #[derive(Debug, Clone)]

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -12,7 +12,7 @@ use super::{
     PoseidonChip, PublicInputInstructions, RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation,
     VerifierGadget, ZeroInstructions,
     config::IvcConfig,
-    gadgets::{GenesisSchnorrSignatureInputs, verify_genesis_signature},
+    gadgets::{GenesisSchnorrSignatureInputs, combine_bytes, verify_genesis_signature},
     state::{AssignedGlobal, AssignedState, AssignedWitness},
 };
 
@@ -127,22 +127,6 @@ impl IvcGadget {
         Ok(pi)
     }
 
-    fn combine_bytes(
-        &self,
-        layouter: &mut impl Layouter<NativeField>,
-        bytes: impl IntoIterator<Item = impl Into<AssignedNative<NativeField>>>,
-        bases: &[NativeField],
-    ) -> Result<AssignedNative<NativeField>, Error> {
-        let items: Vec<_> = bytes
-            .into_iter()
-            .zip(bases.iter())
-            .map(|(v, base)| (*base, v.into()))
-            .collect();
-
-        self.native_gadget
-            .linear_combination(layouter, &items, NativeField::ZERO)
-    }
-
     pub fn transition(
         &self,
         layouter: &mut impl Layouter<NativeField>,
@@ -183,7 +167,7 @@ impl IvcGadget {
 
         {
             // Compare message and hash
-            let hash_native = self.combine_bytes(layouter, &hash, &bases)?;
+            let hash_native = combine_bytes(&self.native_gadget, layouter, &hash, &bases)?;
             self.native_gadget.assert_equal(layouter, &message, &hash_native)?;
         }
 
@@ -207,11 +191,20 @@ impl IvcGadget {
 
         // Get the field elements by linearly combining the bytes
         let (next_merkle_tree_commitment, next_protocol_parameters, current_epoch) = {
-            let next_merkle_tree_commitment =
-                self.combine_bytes(layouter, next_merkle_tree_commitment_bytes, &bases)?;
-            let next_protocol_parameters =
-                self.combine_bytes(layouter, next_protocol_parameters_bytes, &bases)?;
-            let current_epoch = self.combine_bytes(layouter, current_epoch_bytes, &bases)?;
+            let next_merkle_tree_commitment = combine_bytes(
+                &self.native_gadget,
+                layouter,
+                next_merkle_tree_commitment_bytes,
+                &bases,
+            )?;
+            let next_protocol_parameters = combine_bytes(
+                &self.native_gadget,
+                layouter,
+                next_protocol_parameters_bytes,
+                &bases,
+            )?;
+            let current_epoch =
+                combine_bytes(&self.native_gadget, layouter, current_epoch_bytes, &bases)?;
             (
                 next_merkle_tree_commitment,
                 next_protocol_parameters,

--- a/mithril-stm/src/circuits/halo2_ivc/gadget.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadget.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use ff::Field;
 use group::Group;
 use midnight_circuits::hash::sha256::Sha256Chip;
@@ -9,18 +7,15 @@ use crate::signature_scheme::DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE;
 use super::{
     Accumulator, ArithInstructions, AssertionInstructions, AssignedAccumulator, AssignedBit,
     AssignedForeignPoint, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignedVk, AssignmentInstructions, BinaryInstructions, CERTIFICATE_VERIFICATION_KEY_NAME,
-    CircuitCurve, CircuitCurveTrait, CircuitValue, ComposableChip, ConstraintSystem,
-    ControlFlowInstructions, ConversionInstructions, EccChip, EccInstructions, EmulatedCurve,
-    EqualityInstructions, Error, EvaluationDomain, ForeignEccChip, HashInstructions,
-    IVC_VERIFICATION_KEY_NAME, IvcNativeGadget, Layouter, NativeChip, NativeField, NativeGadget,
-    P2RDecompositionChip, PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
+    AssignmentInstructions, BinaryInstructions, CircuitCurve, CircuitCurveTrait, CircuitValue,
+    ComposableChip, ControlFlowInstructions, ConversionInstructions, EccChip, EccInstructions,
+    EmulatedCurve, EqualityInstructions, Error, ForeignEccChip, HashInstructions, IvcNativeGadget,
+    Layouter, NativeChip, NativeField, NativeGadget, P2RDecompositionChip,
+    PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
     PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PoseidonChip, PublicInputInstructions,
     RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation, VerifierGadget, ZeroInstructions,
-    accumulator::fixed_base_names,
     config::IvcConfig,
-    errors::{IvcCircuitError, to_synthesis_error},
-    state::{AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness},
+    state::{AssignedGlobal, AssignedState, AssignedWitness},
 };
 
 #[derive(Debug, Clone)]
@@ -63,208 +58,6 @@ impl IvcGadget {
             bls12_381_chip,
             verifier_gadget,
         }
-    }
-
-    pub fn assign_global_as_public_input(
-        &self,
-        layouter: &mut impl Layouter<NativeField>,
-        global: &CircuitValue<Global>,
-        certificate_circuit_domain_and_constraint_system: &(
-            EvaluationDomain<NativeField>,
-            ConstraintSystem<NativeField>,
-        ),
-        ivc_circuit_domain_and_constraint_system: &(
-            EvaluationDomain<NativeField>,
-            ConstraintSystem<NativeField>,
-        ),
-    ) -> Result<AssignedGlobal, Error> {
-        let genesis_message: AssignedNative<_> = self.native_gadget.assign_as_public_input(
-            layouter,
-            global.clone().map(|gl| gl.genesis_message.as_field()),
-        )?;
-        let genesis_verification_key: AssignedNativePoint<_> =
-            self.jubjub_chip.assign_as_public_input(
-                layouter,
-                global
-                    .clone()
-                    .map(|gl| *gl.genesis_verification_key.as_jubjub_subgroup()),
-            )?;
-
-        let (certificate_circuit_domain, certificate_circuit_constraint_system) =
-            &certificate_circuit_domain_and_constraint_system;
-        let certificate_verification_key: AssignedVk<RecursiveEmulation> =
-            self.verifier_gadget.assign_vk_as_public_input(
-                layouter,
-                CERTIFICATE_VERIFICATION_KEY_NAME,
-                certificate_circuit_domain,
-                certificate_circuit_constraint_system,
-                global
-                    .clone()
-                    .map(|gl| gl.certificate_circuit_verification_key_representation.as_field()),
-            )?;
-
-        // Assign for IVC proof verification
-        let (ivc_circuit_domain, ivc_circuit_constraint_system) =
-            &ivc_circuit_domain_and_constraint_system;
-        let ivc_verification_key: AssignedVk<RecursiveEmulation> =
-            self.verifier_gadget.assign_vk_as_public_input(
-                layouter,
-                IVC_VERIFICATION_KEY_NAME,
-                ivc_circuit_domain,
-                ivc_circuit_constraint_system,
-                global
-                    .clone()
-                    .map(|gl| gl.ivc_circuit_verification_key_representation.as_field()),
-            )?;
-
-        let fixed_base_names = {
-            let mut names = fixed_base_names(
-                CERTIFICATE_VERIFICATION_KEY_NAME,
-                certificate_circuit_constraint_system,
-            );
-            names.extend(fixed_base_names(
-                IVC_VERIFICATION_KEY_NAME,
-                ivc_circuit_constraint_system,
-            ));
-            // Remove repeated names for committed_instance and the generator
-            let mut seen = HashSet::new();
-            names.retain(|x| seen.insert(x.clone()));
-            names
-        };
-
-        Ok(AssignedGlobal {
-            genesis_message,
-            genesis_verification_key,
-            certificate_verification_key,
-            ivc_verification_key,
-            fixed_base_names,
-        })
-    }
-
-    pub fn assign_state(
-        &self,
-        layouter: &mut impl Layouter<NativeField>,
-        state: &CircuitValue<State>,
-    ) -> Result<AssignedState, Error> {
-        let values = state
-            .clone()
-            .map(|s| {
-                vec![
-                    s.step_counter.as_field(),
-                    s.message.as_field(),
-                    s.merkle_tree_commitment.as_field(),
-                    s.next_merkle_tree_commitment.as_field(),
-                    s.protocol_parameters.as_field(),
-                    s.next_protocol_parameters.as_field(),
-                    s.current_epoch.as_field(),
-                ]
-            })
-            .transpose_vec(7);
-
-        let [
-            step_counter,
-            message,
-            merkle_tree_commitment,
-            next_merkle_tree_commitment,
-            protocol_parameters,
-            next_protocol_parameters,
-            current_epoch,
-        ]: [AssignedNative<_>; 7] = {
-            self.native_gadget
-                .assign_many(layouter, &values)?
-                .try_into()
-                .map_err(|v: Vec<_>| {
-                    to_synthesis_error(IvcCircuitError::AssignedValueCountMismatch {
-                        expected: 7,
-                        actual: v.len(),
-                    })
-                })?
-        };
-
-        Ok(AssignedState {
-            step_counter,
-            message,
-            merkle_tree_commitment,
-            next_merkle_tree_commitment,
-            protocol_parameters,
-            next_protocol_parameters,
-            current_epoch,
-        })
-    }
-
-    pub fn constrain_state_as_public_input(
-        &self,
-        layouter: &mut impl Layouter<NativeField>,
-        state: &AssignedState,
-    ) -> Result<(), Error> {
-        for value in [
-            &state.step_counter,
-            &state.message,
-            &state.merkle_tree_commitment,
-            &state.next_merkle_tree_commitment,
-            &state.protocol_parameters,
-            &state.next_protocol_parameters,
-            &state.current_epoch,
-        ] {
-            self.native_gadget.constrain_as_public_input(layouter, value)?;
-        }
-
-        Ok(())
-    }
-
-    pub fn assign_witness(
-        &self,
-        layouter: &mut impl Layouter<NativeField>,
-        witness: &CircuitValue<Witness>,
-    ) -> Result<AssignedWitness, Error> {
-        let genesis_signature = {
-            let s: AssignedScalarOfNativeCurve<_> = self.jubjub_chip.assign(
-                layouter,
-                witness.clone().map(|w| w.genesis_signature.response.0),
-            )?;
-            let c: AssignedNative<_> = self.native_gadget.assign(
-                layouter,
-                witness.clone().map(|w| w.genesis_signature.challenge.0),
-            )?;
-            (s, c)
-        };
-
-        let [certificate_message, certificate_merkle_tree_commitment]: [AssignedNative<NativeField>;
-            2] = {
-            let values = witness
-                .clone()
-                .map(|w| {
-                    vec![
-                        w.certificate_message.as_field(),
-                        w.certificate_merkle_tree_commitment.as_field(),
-                    ]
-                })
-                .transpose_vec(2);
-            self.native_gadget
-                .assign_many(layouter, &values)?
-                .try_into()
-                .map_err(|v: Vec<_>| {
-                    to_synthesis_error(IvcCircuitError::AssignedValueCountMismatch {
-                        expected: 2,
-                        actual: v.len(),
-                    })
-                })?
-        };
-
-        let message_preimage = {
-            let preimage = witness
-                .clone()
-                .map(|w| w.message_preimage.into_inner())
-                .transpose_array();
-            self.native_gadget.assign_many(layouter, &preimage)?
-        };
-
-        Ok(AssignedWitness {
-            genesis_signature,
-            certificate_message,
-            certificate_merkle_tree_commitment,
-            message_preimage,
-        })
     }
 
     pub fn is_genesis(

--- a/mithril-stm/src/circuits/halo2_ivc/gadgets/byte_combination.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadgets/byte_combination.rs
@@ -1,0 +1,63 @@
+//! Combines assigned bytes into a single field element via a base-weighted linear combination.
+
+use ff::Field;
+
+use crate::circuits::halo2_ivc::{
+    ArithInstructions, AssignedNative, Error, IvcNativeGadget, Layouter, NativeField,
+    errors::{IvcCircuitError, to_synthesis_error},
+};
+
+/// Rejects more bytes than base weights, which would silently truncate the combination.
+///
+/// Fewer bytes than bases is allowed (e.g. an 8-byte epoch against 32 base weights).
+fn check_byte_count(byte_count: usize, base_count: usize) -> Result<(), IvcCircuitError> {
+    if byte_count > base_count {
+        return Err(IvcCircuitError::ByteCountExceedsBaseCount {
+            bytes: byte_count,
+            bases: base_count,
+        });
+    }
+    Ok(())
+}
+
+/// Combines `bytes` into a field element as `sum(bytes[i] * bases[i])`.
+pub(crate) fn combine_bytes(
+    native_gadget: &IvcNativeGadget,
+    layouter: &mut impl Layouter<NativeField>,
+    bytes: impl IntoIterator<Item = impl Into<AssignedNative<NativeField>>>,
+    bases: &[NativeField],
+) -> Result<AssignedNative<NativeField>, Error> {
+    let bytes: Vec<AssignedNative<NativeField>> = bytes.into_iter().map(Into::into).collect();
+    check_byte_count(bytes.len(), bases.len()).map_err(to_synthesis_error)?;
+
+    let items: Vec<_> = bytes
+        .into_iter()
+        .zip(bases.iter())
+        .map(|(v, base)| (*base, v))
+        .collect();
+
+    native_gadget.linear_combination(layouter, &items, NativeField::ZERO)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IvcCircuitError, check_byte_count};
+
+    #[test]
+    fn check_byte_count_accepts_equal_or_fewer_bytes() {
+        assert!(check_byte_count(32, 32).is_ok());
+        assert!(check_byte_count(8, 32).is_ok());
+        assert!(check_byte_count(0, 0).is_ok());
+    }
+
+    #[test]
+    fn check_byte_count_rejects_more_bytes_than_bases() {
+        assert_eq!(
+            check_byte_count(33, 32),
+            Err(IvcCircuitError::ByteCountExceedsBaseCount {
+                bytes: 33,
+                bases: 32,
+            })
+        );
+    }
+}

--- a/mithril-stm/src/circuits/halo2_ivc/gadgets/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadgets/mod.rs
@@ -1,5 +1,7 @@
 //! Constraint gadgets used by the recursive IVC circuit.
 
+mod byte_combination;
 mod schnorr_signature;
 
+pub(crate) use byte_combination::combine_bytes;
 pub(crate) use schnorr_signature::{GenesisSchnorrSignatureInputs, verify_genesis_signature};

--- a/mithril-stm/src/circuits/halo2_ivc/gadgets/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadgets/mod.rs
@@ -1,0 +1,5 @@
+//! Constraint gadgets used by the recursive IVC circuit.
+
+mod schnorr_signature;
+
+pub(crate) use schnorr_signature::{GenesisSchnorrSignatureInputs, verify_genesis_signature};

--- a/mithril-stm/src/circuits/halo2_ivc/gadgets/schnorr_signature.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/gadgets/schnorr_signature.rs
@@ -1,0 +1,73 @@
+//! In-circuit verification of the genesis standard-Schnorr signature (the IVC trust anchor).
+
+use group::Group;
+
+use crate::circuits::halo2_ivc::{
+    AssignedBit, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
+    AssignmentInstructions, CircuitCurve, CircuitCurveTrait, ConversionInstructions, EccChip,
+    EccInstructions, EqualityInstructions, Error, HashInstructions, IvcNativeGadget, Layouter,
+    NativeField, PoseidonChip,
+};
+use crate::signature_scheme::DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE;
+
+/// Assigned inputs required to verify the genesis Schnorr signature in-circuit.
+pub(crate) struct GenesisSchnorrSignatureInputs<'a> {
+    /// Assigned genesis verification key.
+    pub(crate) verification_key: &'a AssignedNativePoint<CircuitCurve>,
+    /// Assigned genesis message.
+    pub(crate) message: &'a AssignedNative<NativeField>,
+    /// Assigned response scalar from the genesis signature.
+    pub(crate) response: &'a AssignedScalarOfNativeCurve<CircuitCurve>,
+    /// Assigned challenge from the genesis signature, in the native field.
+    pub(crate) challenge: &'a AssignedNative<NativeField>,
+}
+
+/// Verifies the genesis Schnorr signature in-circuit.
+///
+/// Reconstructs the challenge via Poseidon hash over the genesis verification key,
+/// the reconstructed nonce commitment, and the genesis message, then checks
+/// equality against the committed challenge scalar. Returns an `AssignedBit` that
+/// is `true` when the signature is valid.
+pub(crate) fn verify_genesis_signature(
+    jubjub_chip: &EccChip<CircuitCurve>,
+    native_gadget: &IvcNativeGadget,
+    poseidon_chip: &PoseidonChip<NativeField>,
+    layouter: &mut impl Layouter<NativeField>,
+    inputs: GenesisSchnorrSignatureInputs<'_>,
+) -> Result<AssignedBit<NativeField>, Error> {
+    let response = inputs.response.clone();
+    let challenge_as_scalar: AssignedScalarOfNativeCurve<_> =
+        jubjub_chip.convert(layouter, inputs.challenge)?;
+
+    let dst_signature: AssignedNative<_> =
+        native_gadget.assign_fixed(layouter, DOMAIN_SEPARATION_TAG_STANDARD_SIGNATURE.0)?;
+    let generator: AssignedNativePoint<_> = jubjub_chip.assign_fixed(
+        layouter,
+        <CircuitCurve as CircuitCurveTrait>::CryptographicGroup::generator(),
+    )?;
+
+    let cap_r = jubjub_chip.msm(
+        layouter,
+        &[response, challenge_as_scalar.clone()],
+        &[generator.clone(), inputs.verification_key.clone()],
+    )?;
+
+    let verification_key_x = jubjub_chip.x_coordinate(inputs.verification_key);
+    let verification_key_y = jubjub_chip.y_coordinate(inputs.verification_key);
+    let cap_r_x = jubjub_chip.x_coordinate(&cap_r);
+    let cap_r_y = jubjub_chip.y_coordinate(&cap_r);
+
+    let recomputed_challenge = poseidon_chip.hash(
+        layouter,
+        &[
+            dst_signature.clone(),
+            verification_key_x,
+            verification_key_y,
+            cap_r_x,
+            cap_r_y,
+            inputs.message.clone(),
+        ],
+    )?;
+
+    native_gadget.is_equal(layouter, &recomputed_challenge, inputs.challenge)
+}

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -63,6 +63,7 @@ pub(crate) mod keys;
 pub(crate) mod protocol_message;
 pub(crate) mod state;
 pub(crate) mod types;
+pub(crate) mod witness_assignments;
 
 #[cfg(test)]
 pub(crate) mod tests;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -54,6 +54,7 @@ pub(crate) mod circuit;
 pub(crate) mod config;
 pub(crate) mod errors;
 pub(crate) mod gadget;
+pub(crate) mod gadgets;
 pub(crate) mod io;
 #[cfg_attr(not(test), allow(dead_code))]
 pub(crate) mod key_serialization;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -48,6 +48,7 @@ pub(crate) use midnight_proofs::{
     poly::{EvaluationDomain, kzg::KZGCommitmentScheme},
 };
 
+pub(crate) mod accumulator;
 pub(crate) mod certificate_proof;
 pub(crate) mod circuit;
 pub(crate) mod config;

--- a/mithril-stm/src/circuits/halo2_ivc/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/mod.rs
@@ -52,8 +52,8 @@ pub(crate) mod accumulator;
 pub(crate) mod certificate_proof;
 pub(crate) mod circuit;
 pub(crate) mod config;
+pub(crate) mod constraint_builder;
 pub(crate) mod errors;
-pub(crate) mod gadget;
 pub(crate) mod gadgets;
 pub(crate) mod io;
 #[cfg_attr(not(test), allow(dead_code))]

--- a/mithril-stm/src/circuits/halo2_ivc/state.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/state.rs
@@ -1,7 +1,3 @@
-use std::collections::BTreeMap;
-
-use ff::Field;
-use group::Group;
 use serde::{Deserialize, Serialize};
 
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
@@ -9,15 +5,13 @@ use crate::circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey;
 use crate::signature_scheme::{SchnorrVerificationKey, StandardSchnorrSignature};
 
 use super::{
-    Accumulator, AssignedByte, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve,
-    AssignedVk, CircuitCurve, ConstraintSystem, EmulatedCurve, Instantiable, KZGCommitmentScheme,
-    Msm, NativeField, PairingEngine, RecursiveEmulation, VerifyingKey,
+    AssignedByte, AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve, AssignedVk,
+    CircuitCurve, Instantiable, NativeField, RecursiveEmulation,
     types::{
         CertificateCircuitVerificationKeyRepresentation, EpochNumber,
         IvcCircuitVerificationKeyRepresentation, MerkleTreeCommitment, MessageHash,
         ProtocolMessagePreimage, ProtocolParametersHash, StepCounter,
     },
-    verifier,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -204,43 +198,4 @@ pub(crate) struct AssignedWitness {
     pub(crate) certificate_merkle_tree_commitment: AssignedNative<NativeField>,
     // Protocol message preimage bytes
     pub(crate) message_preimage: Vec<AssignedByte<NativeField>>,
-}
-
-pub(crate) fn trivial_acc(fixed_base_names: &[String]) -> Accumulator<RecursiveEmulation> {
-    Accumulator::<RecursiveEmulation>::new(
-        Msm::new(
-            &[EmulatedCurve::default()],
-            &[NativeField::ONE],
-            &BTreeMap::new(),
-        ),
-        Msm::new(
-            &[EmulatedCurve::default()],
-            &[NativeField::ONE],
-            &fixed_base_names
-                .iter()
-                .map(|name| (name.clone(), NativeField::ZERO))
-                .collect(),
-        ),
-    )
-}
-
-pub(crate) fn fixed_bases_and_names(
-    vk_name: &str,
-    vk: &VerifyingKey<NativeField, KZGCommitmentScheme<PairingEngine>>,
-) -> (BTreeMap<String, EmulatedCurve>, Vec<String>) {
-    let mut fixed_bases = BTreeMap::new();
-    fixed_bases.insert(String::from("com_instance"), EmulatedCurve::identity());
-    fixed_bases.extend(verifier::fixed_bases::<RecursiveEmulation>(vk_name, vk));
-    let fixed_base_names = fixed_bases.keys().cloned().collect::<Vec<_>>();
-    (fixed_bases, fixed_base_names)
-}
-
-pub(crate) fn fixed_base_names(vk_name: &str, cs: &ConstraintSystem<NativeField>) -> Vec<String> {
-    let mut fixed_base_names = vec![String::from("com_instance")];
-    fixed_base_names.extend(verifier::fixed_base_names::<RecursiveEmulation>(
-        vk_name,
-        cs.num_fixed_columns() + cs.num_selectors(),
-        cs.permutation().columns.len(),
-    ));
-    fixed_base_names
 }

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/asset_generation.rs
@@ -26,9 +26,10 @@ use crate::circuits::halo2_ivc::tests::common::asset_readers::{
 };
 use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, EmulatedCurve, PREIMAGE_SIZE, RecursiveEmulation,
+    accumulator::trivial_accumulator,
     circuit::IvcCircuitData,
     keys::RecursiveCircuitProvingKey,
-    state::{Global, State, trivial_acc},
+    state::{Global, State},
     types::{CertificateProofBytes, IvcProofBytes},
 };
 
@@ -58,7 +59,7 @@ fn build_certificate_chain_artifacts(
     recursive_fixed_base_names: &[String],
 ) -> CertificateChainArtifacts {
     let mut certificate_proofs = vec![CertificateProofBytes::empty()];
-    let mut certificate_accumulators = vec![trivial_acc(recursive_fixed_base_names)];
+    let mut certificate_accumulators = vec![trivial_accumulator(recursive_fixed_base_names)];
     let mut recursive_next_states = vec![build_genesis_base_case_next_state(setup, GENESIS_EPOCH)];
     let mut recursive_witnesses = vec![build_genesis_base_case_witness(setup)];
     let mut certificate_random_generator = OsRng;
@@ -114,7 +115,7 @@ fn build_recursive_chain_snapshot(
     let combined_fixed_base_names = combined_fixed_bases.keys().cloned().collect::<Vec<_>>();
     let mut current_state = State::genesis();
     let mut recursive_proof = IvcProofBytes::empty();
-    let mut current_accumulator = trivial_acc(&combined_fixed_base_names);
+    let mut current_accumulator = trivial_accumulator(&combined_fixed_base_names);
     let mut next_accumulator = current_accumulator.clone();
     let mut recursive_random_generator = OsRng;
 
@@ -532,7 +533,7 @@ pub(crate) fn generate_genesis_step_output_asset(setup: &AssetGenerationSetup, p
 
     let genesis_witness = build_genesis_base_case_witness(setup);
     let genesis_next_state = build_genesis_base_case_next_state(setup, GENESIS_EPOCH);
-    let current_accumulator = trivial_acc(&combined_fixed_base_names);
+    let current_accumulator = trivial_accumulator(&combined_fixed_base_names);
     let next_accumulator = current_accumulator.clone();
 
     let ivc_circuit_data = IvcCircuitData::try_new(

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -15,7 +15,7 @@ use crate::AggregateVerificationKeyForSnark;
 use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::RECURSIVE_CIRCUIT_DEGREE;
-use crate::circuits::halo2_ivc::accumulator::fixed_bases_and_names;
+use crate::circuits::halo2_ivc::accumulator::fixed_bases_and_names_from_verifying_key;
 use crate::circuits::halo2_ivc::keys::{RecursiveCircuitProvingKey, RecursiveCircuitVerifyingKey};
 use crate::circuits::halo2_ivc::types::MessageHash;
 use crate::circuits::halo2_ivc::{
@@ -251,12 +251,14 @@ pub(crate) fn build_recursive_fixed_bases(
     BTreeMap<String, EmulatedCurve>,
     BTreeMap<String, EmulatedCurve>,
 ) {
-    let (certificate_fixed_bases, _) = fixed_bases_and_names(
+    let (certificate_fixed_bases, _) = fixed_bases_and_names_from_verifying_key(
         CERTIFICATE_VERIFICATION_KEY_NAME,
         certificate_verifying_key.as_ref(),
     );
-    let (recursive_fixed_bases, _) =
-        fixed_bases_and_names(IVC_VERIFICATION_KEY_NAME, recursive_verifying_key.as_ref());
+    let (recursive_fixed_bases, _) = fixed_bases_and_names_from_verifying_key(
+        IVC_VERIFICATION_KEY_NAME,
+        recursive_verifying_key.as_ref(),
+    );
     let mut combined_fixed_bases = certificate_fixed_bases.clone();
     combined_fixed_bases.extend(recursive_fixed_bases.clone());
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/setup.rs
@@ -15,8 +15,8 @@ use crate::AggregateVerificationKeyForSnark;
 use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::RECURSIVE_CIRCUIT_DEGREE;
+use crate::circuits::halo2_ivc::accumulator::fixed_bases_and_names;
 use crate::circuits::halo2_ivc::keys::{RecursiveCircuitProvingKey, RecursiveCircuitVerifyingKey};
-use crate::circuits::halo2_ivc::state::fixed_bases_and_names;
 use crate::circuits::halo2_ivc::types::MessageHash;
 use crate::circuits::halo2_ivc::{
     CERTIFICATE_VERIFICATION_KEY_NAME, EmulatedCurve, IVC_VERIFICATION_KEY_NAME, NativeField,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -11,7 +11,7 @@ use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
 use crate::circuits::halo2::types::CircuitBaseField;
 use crate::circuits::halo2::witness::{CircuitMerkleTreeLeaf, CircuitWitnessEntry};
-use crate::circuits::halo2_ivc::accumulator::fixed_bases_and_names;
+use crate::circuits::halo2_ivc::accumulator::fixed_bases_and_names_from_verifying_key;
 use crate::circuits::halo2_ivc::protocol_message::{
     DynamicProtocolMessagePartKey, ProtocolMessage,
 };
@@ -184,7 +184,7 @@ fn build_certificate_asset_data_inner(
         certificate_relation,
         certificate_verifying_key.midnight_vk(),
     );
-    let (certificate_fixed_bases, _) = fixed_bases_and_names(
+    let (certificate_fixed_bases, _) = fixed_bases_and_names_from_verifying_key(
         CERTIFICATE_VERIFICATION_KEY_NAME,
         certificate_verifying_key.as_ref(),
     );

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/generators/transitions.rs
@@ -11,10 +11,11 @@ use crate::circuits::halo2::circuit::StmCertificateCircuit;
 use crate::circuits::halo2::keys::NonRecursiveCircuitVerifyingKey;
 use crate::circuits::halo2::types::CircuitBaseField;
 use crate::circuits::halo2::witness::{CircuitMerkleTreeLeaf, CircuitWitnessEntry};
+use crate::circuits::halo2_ivc::accumulator::fixed_bases_and_names;
 use crate::circuits::halo2_ivc::protocol_message::{
     DynamicProtocolMessagePartKey, ProtocolMessage,
 };
-use crate::circuits::halo2_ivc::state::{State, Witness, fixed_bases_and_names};
+use crate::circuits::halo2_ivc::state::{State, Witness};
 use crate::circuits::halo2_ivc::types::{
     CertificateProofBytes, EpochNumber, MerkleTreeCommitment, MessageHash, ProtocolMessagePreimage,
     ProtocolParametersHash, StepCounter,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/common/helpers.rs
@@ -13,8 +13,9 @@ use crate::circuits::halo2_ivc::keys::RecursiveCircuitVerifyingKey;
 use crate::circuits::halo2_ivc::{
     Accumulator, AssignedAccumulator, EmulatedCurve, NativeField, PairingEngine,
     RECURSIVE_CIRCUIT_DEGREE, RecursiveEmulation,
+    accumulator::trivial_accumulator,
     circuit::IvcCircuitData,
-    state::{Global, State, Witness, trivial_acc},
+    state::{Global, State, Witness},
     types::{CertificateProofBytes, IvcProofBytes},
 };
 
@@ -68,7 +69,7 @@ pub(crate) fn build_mock_prover_setup_from_assets(setup: &AssetGenerationSetup) 
         global,
         certificate_verifying_key: context.certificate_verifying_key,
         recursive_verifying_key: context.recursive_verifying_key,
-        trivial_accumulator: trivial_acc(&fixed_base_names),
+        trivial_accumulator: trivial_accumulator(&fixed_base_names),
     }
 }
 

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_construction.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_construction.rs
@@ -1,11 +1,11 @@
-//! Tests that `trivial_acc` has the expected structure, verifiable through
+//! Tests that `trivial_accumulator` has the expected structure, verifiable through
 //! its public-input encoding.
 
 use midnight_circuits::types::Instantiable;
 
 use crate::circuits::halo2_ivc::{
     AssignedAccumulator,
-    state::trivial_acc,
+    accumulator::trivial_accumulator,
     tests::common::asset_readers::{
         load_embedded_genesis_step_output_asset, load_embedded_verification_context_asset,
     },
@@ -13,8 +13,8 @@ use crate::circuits::halo2_ivc::{
 
 #[test]
 fn trivial_acc_public_inputs_match_stored_genesis_accumulator() {
-    // The genesis asset stores a trivial_acc clone as next_accumulator.
-    // Rebuilding trivial_acc from the same fixed-base name set must produce
+    // The genesis asset stores a trivial_accumulator clone as next_accumulator.
+    // Rebuilding trivial_accumulator from the same fixed-base name set must produce
     // an identical public-input encoding.
     let verification_context =
         load_embedded_verification_context_asset().expect("verification context asset should load");
@@ -24,12 +24,12 @@ fn trivial_acc_public_inputs_match_stored_genesis_accumulator() {
     let combined_fixed_base_names: Vec<String> =
         verification_context.combined_fixed_bases.keys().cloned().collect();
 
-    let accumulator = trivial_acc(&combined_fixed_base_names);
+    let accumulator = trivial_accumulator(&combined_fixed_base_names);
 
     assert_eq!(
         AssignedAccumulator::as_public_input(&accumulator),
         AssignedAccumulator::as_public_input(&genesis_step_output.next_accumulator),
-        "trivial_acc public inputs should match the stored genesis next_accumulator"
+        "trivial_accumulator public inputs should match the stored genesis next_accumulator"
     );
 }
 
@@ -39,12 +39,12 @@ fn trivial_acc_public_input_length_scales_with_fixed_base_name_count() {
     // fixed_base_scalars map, which contributes one field element to the
     // public-input encoding.
     let empty_accumulator_encoding_length =
-        AssignedAccumulator::as_public_input(&trivial_acc(&[])).len();
+        AssignedAccumulator::as_public_input(&trivial_accumulator(&[])).len();
 
     let three_fixed_base_names: Vec<String> =
         ["a", "b", "c"].iter().map(|name| name.to_string()).collect();
     let encoding_length_with_three_names =
-        AssignedAccumulator::as_public_input(&trivial_acc(&three_fixed_base_names)).len();
+        AssignedAccumulator::as_public_input(&trivial_accumulator(&three_fixed_base_names)).len();
 
     assert_eq!(
         encoding_length_with_three_names,

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_verification.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/accumulator_verification.rs
@@ -1,7 +1,7 @@
 //! Tests that `accumulator.check` accepts valid stored folded accumulators and
 //! rejects tampered ones.
 //!
-//! The genesis `next_accumulator` is a `trivial_acc` clone (never folded) and is
+//! The genesis `next_accumulator` is a `trivial_accumulator` clone (never folded) and is
 //! excluded here — its structure is covered by C2.1 `accumulator_construction`.
 //! All accumulators tested here were produced by the full off-circuit folding
 //! pipeline and stored in binary assets.

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/fixed_base_extraction.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/fixed_base_extraction.rs
@@ -14,7 +14,7 @@ use ff::Field;
 use midnight_circuits::{types::Instantiable, verifier::AssignedMsm};
 
 use crate::circuits::halo2_ivc::{
-    AssignedAccumulator, RecursiveEmulation, state::trivial_acc,
+    AssignedAccumulator, RecursiveEmulation, accumulator::trivial_accumulator,
     tests::common::helpers::build_unextracted_recursive_proof_accumulator_from_assets,
 };
 
@@ -24,15 +24,15 @@ fn extract_fixed_bases_reduces_public_input_length_by_n_times_field_elements_per
     // and one scalar from the variable-base part, then adds back only one scalar
     // as a fixed-base entry. Net reduction = field_elements_per_base_point per base.
     //
-    // field_elements_per_base_point is derived from trivial_acc, which has exactly one base
+    // field_elements_per_base_point is derived from trivial_accumulator, which has exactly one base
     // and one scalar per side (left-hand side and right-hand side) with no fixed-base entries:
-    //   trivial_acc(&[]).len() == 2 * (field_elements_per_base_point + 1)
+    //   trivial_accumulator(&[]).len() == 2 * (field_elements_per_base_point + 1)
     let (mut accumulator, recursive_fixed_bases) =
         build_unextracted_recursive_proof_accumulator_from_assets();
 
     let fixed_base_count = recursive_fixed_bases.len();
     let trivial_accumulator_encoding_length =
-        AssignedAccumulator::as_public_input(&trivial_acc(&[])).len();
+        AssignedAccumulator::as_public_input(&trivial_accumulator(&[])).len();
     let field_elements_per_base_point = trivial_accumulator_encoding_length / 2 - 1;
 
     let encoding_length_before_extraction =

--- a/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/mod.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/off_circuit/mod.rs
@@ -7,7 +7,7 @@
 //! covered by Layer C1.
 //!
 //! `accumulator_collapse`        — `collapse` preserves the `accumulator.check` invariant.
-//! `accumulator_construction`    — `trivial_acc` structure and public-input encoding.
+//! `accumulator_construction`    — `trivial_accumulator` structure and public-input encoding.
 //! `accumulator_update`          — full folding pipeline on stored assets; soundness under wrong previous accumulator.
 //! `accumulator_verification`    — `accumulator.check` accepts valid stored accumulators and rejects tampered ones.
 //! `certificate_proof_rejection` — `verify_and_prepare_accumulator` rejects garbage bytes and wrong public inputs.

--- a/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
@@ -1,6 +1,6 @@
 //! Assignment helpers that turn IVC circuit witness values into assigned layouter values.
 //!
-//! These free functions prepare assigned inputs for the circuit; `IvcGadget` owns the constraint logic.
+//! These free functions prepare assigned inputs for the circuit; `IvcConstraintBuilder` owns the constraint logic.
 
 use std::collections::HashSet;
 
@@ -10,13 +10,13 @@ use super::{
     Error, EvaluationDomain, IVC_VERIFICATION_KEY_NAME, Layouter, NativeField,
     PublicInputInstructions, RecursiveEmulation,
     accumulator::fixed_base_names,
+    constraint_builder::IvcConstraintBuilder,
     errors::{IvcCircuitError, to_synthesis_error},
-    gadget::IvcGadget,
     state::{AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness},
 };
 
 pub(crate) fn assign_global_as_public_input(
-    gadget: &IvcGadget,
+    builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,
     global: &CircuitValue<Global>,
     certificate_circuit_domain_and_constraint_system: &(
@@ -28,12 +28,12 @@ pub(crate) fn assign_global_as_public_input(
         ConstraintSystem<NativeField>,
     ),
 ) -> Result<AssignedGlobal, Error> {
-    let genesis_message: AssignedNative<_> = gadget.native_gadget.assign_as_public_input(
+    let genesis_message: AssignedNative<_> = builder.native_gadget.assign_as_public_input(
         layouter,
         global.clone().map(|gl| gl.genesis_message.as_field()),
     )?;
     let genesis_verification_key: AssignedNativePoint<_> =
-        gadget.jubjub_chip.assign_as_public_input(
+        builder.jubjub_chip.assign_as_public_input(
             layouter,
             global
                 .clone()
@@ -43,7 +43,7 @@ pub(crate) fn assign_global_as_public_input(
     let (certificate_circuit_domain, certificate_circuit_constraint_system) =
         &certificate_circuit_domain_and_constraint_system;
     let certificate_verification_key: AssignedVk<RecursiveEmulation> =
-        gadget.verifier_gadget.assign_vk_as_public_input(
+        builder.verifier_gadget.assign_vk_as_public_input(
             layouter,
             CERTIFICATE_VERIFICATION_KEY_NAME,
             certificate_circuit_domain,
@@ -57,7 +57,7 @@ pub(crate) fn assign_global_as_public_input(
     let (ivc_circuit_domain, ivc_circuit_constraint_system) =
         &ivc_circuit_domain_and_constraint_system;
     let ivc_verification_key: AssignedVk<RecursiveEmulation> =
-        gadget.verifier_gadget.assign_vk_as_public_input(
+        builder.verifier_gadget.assign_vk_as_public_input(
             layouter,
             IVC_VERIFICATION_KEY_NAME,
             ivc_circuit_domain,
@@ -92,7 +92,7 @@ pub(crate) fn assign_global_as_public_input(
 }
 
 pub(crate) fn assign_state(
-    gadget: &IvcGadget,
+    builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,
     state: &CircuitValue<State>,
 ) -> Result<AssignedState, Error> {
@@ -120,7 +120,7 @@ pub(crate) fn assign_state(
         next_protocol_parameters,
         current_epoch,
     ]: [AssignedNative<_>; 7] = {
-        gadget
+        builder
             .native_gadget
             .assign_many(layouter, &values)?
             .try_into()
@@ -144,7 +144,7 @@ pub(crate) fn assign_state(
 }
 
 pub(crate) fn constrain_state_as_public_input(
-    gadget: &IvcGadget,
+    builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,
     state: &AssignedState,
 ) -> Result<(), Error> {
@@ -157,23 +157,23 @@ pub(crate) fn constrain_state_as_public_input(
         &state.next_protocol_parameters,
         &state.current_epoch,
     ] {
-        gadget.native_gadget.constrain_as_public_input(layouter, value)?;
+        builder.native_gadget.constrain_as_public_input(layouter, value)?;
     }
 
     Ok(())
 }
 
 pub(crate) fn assign_witness(
-    gadget: &IvcGadget,
+    builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,
     witness: &CircuitValue<Witness>,
 ) -> Result<AssignedWitness, Error> {
     let genesis_signature = {
-        let s: AssignedScalarOfNativeCurve<_> = gadget.jubjub_chip.assign(
+        let s: AssignedScalarOfNativeCurve<_> = builder.jubjub_chip.assign(
             layouter,
             witness.clone().map(|w| w.genesis_signature.response.0),
         )?;
-        let c: AssignedNative<_> = gadget.native_gadget.assign(
+        let c: AssignedNative<_> = builder.native_gadget.assign(
             layouter,
             witness.clone().map(|w| w.genesis_signature.challenge.0),
         )?;
@@ -191,7 +191,7 @@ pub(crate) fn assign_witness(
                 ]
             })
             .transpose_vec(2);
-        gadget
+        builder
             .native_gadget
             .assign_many(layouter, &values)?
             .try_into()
@@ -208,7 +208,7 @@ pub(crate) fn assign_witness(
             .clone()
             .map(|w| w.message_preimage.into_inner())
             .transpose_array();
-        gadget.native_gadget.assign_many(layouter, &preimage)?
+        builder.native_gadget.assign_many(layouter, &preimage)?
     };
 
     Ok(AssignedWitness {

--- a/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
@@ -9,7 +9,7 @@ use super::{
     AssignmentInstructions, CERTIFICATE_VERIFICATION_KEY_NAME, CircuitValue, ConstraintSystem,
     Error, EvaluationDomain, IVC_VERIFICATION_KEY_NAME, Layouter, NativeField,
     PublicInputInstructions, RecursiveEmulation,
-    accumulator::fixed_base_names,
+    accumulator::fixed_base_names_from_constraint_system,
     constraint_builder::IvcConstraintBuilder,
     errors::{IvcCircuitError, to_synthesis_error},
     state::{AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness},
@@ -69,11 +69,11 @@ pub(crate) fn assign_global_as_public_input(
         )?;
 
     let fixed_base_names = {
-        let mut names = fixed_base_names(
+        let mut names = fixed_base_names_from_constraint_system(
             CERTIFICATE_VERIFICATION_KEY_NAME,
             certificate_circuit_constraint_system,
         );
-        names.extend(fixed_base_names(
+        names.extend(fixed_base_names_from_constraint_system(
             IVC_VERIFICATION_KEY_NAME,
             ivc_circuit_constraint_system,
         ));

--- a/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
@@ -15,6 +15,7 @@ use super::{
     state::{AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness},
 };
 
+/// Assigns the global root-of-trust as public input and returns its in-circuit form.
 pub(crate) fn assign_global_as_public_input(
     builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,
@@ -91,6 +92,7 @@ pub(crate) fn assign_global_as_public_input(
     })
 }
 
+/// Assigns the circuit state values into the layouter.
 pub(crate) fn assign_state(
     builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,
@@ -143,6 +145,7 @@ pub(crate) fn assign_state(
     })
 }
 
+/// Constrains the assigned next state as public input.
 pub(crate) fn constrain_state_as_public_input(
     builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,
@@ -163,6 +166,8 @@ pub(crate) fn constrain_state_as_public_input(
     Ok(())
 }
 
+/// Assigns the step witness (genesis signature, certificate fields, and message preimage) into the
+/// layouter.
 pub(crate) fn assign_witness(
     builder: &IvcConstraintBuilder,
     layouter: &mut impl Layouter<NativeField>,

--- a/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
+++ b/mithril-stm/src/circuits/halo2_ivc/witness_assignments.rs
@@ -1,0 +1,220 @@
+//! Assignment helpers that turn IVC circuit witness values into assigned layouter values.
+//!
+//! These free functions prepare assigned inputs for the circuit; `IvcGadget` owns the constraint logic.
+
+use std::collections::HashSet;
+
+use super::{
+    AssignedNative, AssignedNativePoint, AssignedScalarOfNativeCurve, AssignedVk,
+    AssignmentInstructions, CERTIFICATE_VERIFICATION_KEY_NAME, CircuitValue, ConstraintSystem,
+    Error, EvaluationDomain, IVC_VERIFICATION_KEY_NAME, Layouter, NativeField,
+    PublicInputInstructions, RecursiveEmulation,
+    accumulator::fixed_base_names,
+    errors::{IvcCircuitError, to_synthesis_error},
+    gadget::IvcGadget,
+    state::{AssignedGlobal, AssignedState, AssignedWitness, Global, State, Witness},
+};
+
+pub(crate) fn assign_global_as_public_input(
+    gadget: &IvcGadget,
+    layouter: &mut impl Layouter<NativeField>,
+    global: &CircuitValue<Global>,
+    certificate_circuit_domain_and_constraint_system: &(
+        EvaluationDomain<NativeField>,
+        ConstraintSystem<NativeField>,
+    ),
+    ivc_circuit_domain_and_constraint_system: &(
+        EvaluationDomain<NativeField>,
+        ConstraintSystem<NativeField>,
+    ),
+) -> Result<AssignedGlobal, Error> {
+    let genesis_message: AssignedNative<_> = gadget.native_gadget.assign_as_public_input(
+        layouter,
+        global.clone().map(|gl| gl.genesis_message.as_field()),
+    )?;
+    let genesis_verification_key: AssignedNativePoint<_> =
+        gadget.jubjub_chip.assign_as_public_input(
+            layouter,
+            global
+                .clone()
+                .map(|gl| *gl.genesis_verification_key.as_jubjub_subgroup()),
+        )?;
+
+    let (certificate_circuit_domain, certificate_circuit_constraint_system) =
+        &certificate_circuit_domain_and_constraint_system;
+    let certificate_verification_key: AssignedVk<RecursiveEmulation> =
+        gadget.verifier_gadget.assign_vk_as_public_input(
+            layouter,
+            CERTIFICATE_VERIFICATION_KEY_NAME,
+            certificate_circuit_domain,
+            certificate_circuit_constraint_system,
+            global
+                .clone()
+                .map(|gl| gl.certificate_circuit_verification_key_representation.as_field()),
+        )?;
+
+    // Assign for IVC proof verification
+    let (ivc_circuit_domain, ivc_circuit_constraint_system) =
+        &ivc_circuit_domain_and_constraint_system;
+    let ivc_verification_key: AssignedVk<RecursiveEmulation> =
+        gadget.verifier_gadget.assign_vk_as_public_input(
+            layouter,
+            IVC_VERIFICATION_KEY_NAME,
+            ivc_circuit_domain,
+            ivc_circuit_constraint_system,
+            global
+                .clone()
+                .map(|gl| gl.ivc_circuit_verification_key_representation.as_field()),
+        )?;
+
+    let fixed_base_names = {
+        let mut names = fixed_base_names(
+            CERTIFICATE_VERIFICATION_KEY_NAME,
+            certificate_circuit_constraint_system,
+        );
+        names.extend(fixed_base_names(
+            IVC_VERIFICATION_KEY_NAME,
+            ivc_circuit_constraint_system,
+        ));
+        // Remove repeated names for committed_instance and the generator
+        let mut seen = HashSet::new();
+        names.retain(|x| seen.insert(x.clone()));
+        names
+    };
+
+    Ok(AssignedGlobal {
+        genesis_message,
+        genesis_verification_key,
+        certificate_verification_key,
+        ivc_verification_key,
+        fixed_base_names,
+    })
+}
+
+pub(crate) fn assign_state(
+    gadget: &IvcGadget,
+    layouter: &mut impl Layouter<NativeField>,
+    state: &CircuitValue<State>,
+) -> Result<AssignedState, Error> {
+    let values = state
+        .clone()
+        .map(|s| {
+            vec![
+                s.step_counter.as_field(),
+                s.message.as_field(),
+                s.merkle_tree_commitment.as_field(),
+                s.next_merkle_tree_commitment.as_field(),
+                s.protocol_parameters.as_field(),
+                s.next_protocol_parameters.as_field(),
+                s.current_epoch.as_field(),
+            ]
+        })
+        .transpose_vec(7);
+
+    let [
+        step_counter,
+        message,
+        merkle_tree_commitment,
+        next_merkle_tree_commitment,
+        protocol_parameters,
+        next_protocol_parameters,
+        current_epoch,
+    ]: [AssignedNative<_>; 7] = {
+        gadget
+            .native_gadget
+            .assign_many(layouter, &values)?
+            .try_into()
+            .map_err(|v: Vec<_>| {
+                to_synthesis_error(IvcCircuitError::AssignedValueCountMismatch {
+                    expected: 7,
+                    actual: v.len(),
+                })
+            })?
+    };
+
+    Ok(AssignedState {
+        step_counter,
+        message,
+        merkle_tree_commitment,
+        next_merkle_tree_commitment,
+        protocol_parameters,
+        next_protocol_parameters,
+        current_epoch,
+    })
+}
+
+pub(crate) fn constrain_state_as_public_input(
+    gadget: &IvcGadget,
+    layouter: &mut impl Layouter<NativeField>,
+    state: &AssignedState,
+) -> Result<(), Error> {
+    for value in [
+        &state.step_counter,
+        &state.message,
+        &state.merkle_tree_commitment,
+        &state.next_merkle_tree_commitment,
+        &state.protocol_parameters,
+        &state.next_protocol_parameters,
+        &state.current_epoch,
+    ] {
+        gadget.native_gadget.constrain_as_public_input(layouter, value)?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn assign_witness(
+    gadget: &IvcGadget,
+    layouter: &mut impl Layouter<NativeField>,
+    witness: &CircuitValue<Witness>,
+) -> Result<AssignedWitness, Error> {
+    let genesis_signature = {
+        let s: AssignedScalarOfNativeCurve<_> = gadget.jubjub_chip.assign(
+            layouter,
+            witness.clone().map(|w| w.genesis_signature.response.0),
+        )?;
+        let c: AssignedNative<_> = gadget.native_gadget.assign(
+            layouter,
+            witness.clone().map(|w| w.genesis_signature.challenge.0),
+        )?;
+        (s, c)
+    };
+
+    let [certificate_message, certificate_merkle_tree_commitment]: [AssignedNative<NativeField>;
+        2] = {
+        let values = witness
+            .clone()
+            .map(|w| {
+                vec![
+                    w.certificate_message.as_field(),
+                    w.certificate_merkle_tree_commitment.as_field(),
+                ]
+            })
+            .transpose_vec(2);
+        gadget
+            .native_gadget
+            .assign_many(layouter, &values)?
+            .try_into()
+            .map_err(|v: Vec<_>| {
+                to_synthesis_error(IvcCircuitError::AssignedValueCountMismatch {
+                    expected: 2,
+                    actual: v.len(),
+                })
+            })?
+    };
+
+    let message_preimage = {
+        let preimage = witness
+            .clone()
+            .map(|w| w.message_preimage.into_inner())
+            .transpose_array();
+        gadget.native_gadget.assign_many(layouter, &preimage)?
+    };
+
+    Ok(AssignedWitness {
+        genesis_signature,
+        certificate_message,
+        certificate_merkle_tree_commitment,
+        message_preimage,
+    })
+}

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input_helpers.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_input_helpers.rs
@@ -178,7 +178,7 @@ pub(crate) mod tests {
         circuits::halo2_ivc::{
             PREIMAGE_CURRENT_EPOCH_BYTES, PREIMAGE_NEXT_MERKLE_TREE_COMMITMENT_BYTES,
             PREIMAGE_NEXT_PROTOCOL_PARAMETERS_BYTES, PREIMAGE_SIZE,
-            state::trivial_acc,
+            accumulator::trivial_accumulator,
             types::{EpochNumber, IvcProofBytes, ProtocolParametersHash, StepCounter},
         },
         signature_scheme::{BaseFieldElement, SchnorrSigningKey, StandardSchnorrSignature},
@@ -212,7 +212,7 @@ pub(crate) mod tests {
                 current_epoch,
             ),
             IvcProofBytes::empty(),
-            trivial_acc(&[]),
+            trivial_accumulator(&[]),
             build_signature(),
         )
     }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -21,7 +21,7 @@ use crate::{
         halo2::{keys::NonRecursiveCircuitVerifyingKey, types::CircuitBase},
         halo2_ivc::{
             CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME, RECURSIVE_CIRCUIT_DEGREE,
-            accumulator::fixed_bases_and_names,
+            accumulator::fixed_bases_and_names_from_verifying_key,
             certificate_proof::verify_and_prepare_accumulator,
             keys::{
                 RecursiveCircuitKeyGenerator, RecursiveCircuitProvingKey,
@@ -84,12 +84,14 @@ impl IvcSnarkProverSetup {
             recursive_key_provider.generator().certificate_verifying_key(&srs)?;
         let (ivc_verifying_key, ivc_proving_key) = recursive_key_provider.key_pair(&srs)?;
 
-        let (certificate_fixed_bases, _) = fixed_bases_and_names(
+        let (certificate_fixed_bases, _) = fixed_bases_and_names_from_verifying_key(
             CERTIFICATE_VERIFICATION_KEY_NAME,
             certificate_verifying_key.as_ref(),
         );
-        let (ivc_fixed_bases, _) =
-            fixed_bases_and_names(IVC_VERIFICATION_KEY_NAME, ivc_verifying_key.as_ref());
+        let (ivc_fixed_bases, _) = fixed_bases_and_names_from_verifying_key(
+            IVC_VERIFICATION_KEY_NAME,
+            ivc_verifying_key.as_ref(),
+        );
         let mut combined_fixed_bases = certificate_fixed_bases.clone();
         combined_fixed_bases.extend(ivc_fixed_bases.clone());
 

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/prover_setup.rs
@@ -21,12 +21,12 @@ use crate::{
         halo2::{keys::NonRecursiveCircuitVerifyingKey, types::CircuitBase},
         halo2_ivc::{
             CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME, RECURSIVE_CIRCUIT_DEGREE,
+            accumulator::fixed_bases_and_names,
             certificate_proof::verify_and_prepare_accumulator,
             keys::{
                 RecursiveCircuitKeyGenerator, RecursiveCircuitProvingKey,
                 RecursiveCircuitVerifyingKey,
             },
-            state::fixed_bases_and_names,
         },
         key_provider::KeyProvider,
         trusted_setup::TrustedSetupProvider,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/rolling_state.rs
@@ -14,8 +14,9 @@ use crate::{
         halo2::types::CircuitBase,
         halo2_ivc::{
             AssignedAccumulator, ProtocolMessagePreimage,
+            accumulator::trivial_accumulator,
             errors::{EpochTransitionErrorKind, IvcCircuitError},
-            state::{Global, State, trivial_acc},
+            state::{Global, State},
             types::{IvcProofBytes, StepCounter},
         },
     },
@@ -69,7 +70,7 @@ impl IvcRollingState {
         Self {
             state: State::genesis(),
             ivc_proof: IvcProofBytes::empty(),
-            accumulator: trivial_acc(fixed_base_names),
+            accumulator: trivial_accumulator(fixed_base_names),
             genesis_signature,
         }
     }

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -17,7 +17,8 @@ use crate::{
         halo2::keys::NonRecursiveCircuitVerifyingKey,
         halo2_ivc::{
             CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME,
-            keys::RecursiveCircuitVerifyingKey, state::fixed_bases_and_names, types::MessageHash,
+            accumulator::fixed_bases_and_names, keys::RecursiveCircuitVerifyingKey,
+            types::MessageHash,
         },
     },
     codec,

--- a/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
+++ b/mithril-stm/src/proof_system/ivc_halo2_snark/verifier_setup.rs
@@ -17,8 +17,8 @@ use crate::{
         halo2::keys::NonRecursiveCircuitVerifyingKey,
         halo2_ivc::{
             CERTIFICATE_VERIFICATION_KEY_NAME, IVC_VERIFICATION_KEY_NAME,
-            accumulator::fixed_bases_and_names, keys::RecursiveCircuitVerifyingKey,
-            types::MessageHash,
+            accumulator::fixed_bases_and_names_from_verifying_key,
+            keys::RecursiveCircuitVerifyingKey, types::MessageHash,
         },
     },
     codec,
@@ -65,12 +65,14 @@ impl IvcVerifierSetup {
     ) -> StmResult<Self> {
         let (verifier_params, tau_g2) = Self::read_embedded_params()?;
 
-        let (certificate_fixed_bases, _) = fixed_bases_and_names(
+        let (certificate_fixed_bases, _) = fixed_bases_and_names_from_verifying_key(
             CERTIFICATE_VERIFICATION_KEY_NAME,
             certificate_verifying_key.as_ref(),
         );
-        let (ivc_fixed_bases, _) =
-            fixed_bases_and_names(IVC_VERIFICATION_KEY_NAME, ivc_verifying_key.as_ref());
+        let (ivc_fixed_bases, _) = fixed_bases_and_names_from_verifying_key(
+            IVC_VERIFICATION_KEY_NAME,
+            ivc_verifying_key.as_ref(),
+        );
         let mut combined_fixed_bases = certificate_fixed_bases;
         combined_fixed_bases.extend(ivc_fixed_bases);
 


### PR DESCRIPTION
## Content

This refactors the recursive IVC circuit (`halo2_ivc`) for better modularity, following the structure of the certificate circuit (`halo2`). It extracts reusable gadgets and misplaced helpers out of the monolithic `gadget.rs`, splits the large `transition` function into named helpers, and documents the touched code. The change is purely structural: the circuit constraint count and the recursive verifying key are unchanged, and no committed asset changes.

### Changes
- **New `gadgets/` module**: extracted the genesis Schnorr verification (`schnorr_signature.rs`) and the byte-to-field combination (`byte_combination.rs`) into reusable functions. `combine_bytes` now returns an error instead of silently truncating when it gets more bytes than base weights.
- **`witness_assignments.rs`**: moved the witness and public-input assignment functions out of the circuit builder, leaving it responsible for constraint logic only.
- **`accumulator.rs`**: moved the off-circuit accumulator and fixed-base helpers out of `state.rs`.
- **`transition` decomposition**: split the ~190-line `transition` function into named private helpers (message/preimage check, epoch classification, Merkle-commitment link, protocol-parameter selection, consistency check).
- **Renames for clarity**: `IvcGadget` → `IvcConstraintBuilder` (file `constraint_builder.rs`), to avoid confusion with the new `gadgets/` module; `trivial_acc` → `trivial_accumulator`.
- **Documentation**: documented the constraint builder, the moved helpers, the new gadgets, and the two instance columns in `config.rs`.

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)
Closes https://github.com/input-output-hk/mithril/issues/3131
