### PR TITLE
Capture e2e execution logs in artifacts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,6 +4507,7 @@ version = "0.5.6"
 dependencies = [
  "anyhow",
  "async-recursion",
+ "async-trait",
  "clap",
  "indicatif",
  "mithril-cardano-node-chain",

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -23,6 +23,7 @@ rustls = ["reqwest/rustls"]
 [dependencies]
 anyhow = { workspace = true }
 async-recursion = { workspace = true }
+async-trait = { workspace = true }
 clap = { workspace = true }
 indicatif = { version = "0.18.6", features = ["tokio"] }
 mithril-cardano-node-chain = { path = "../../internal/cardano-node/mithril-cardano-node-chain" }
@@ -41,4 +42,4 @@ slog-async = { workspace = true }
 slog-scope = "4.4.1"
 slog-term = { workspace = true }
 thiserror = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "signal"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "process", "signal", "time"] }

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -10,7 +10,7 @@ use tokio::process::Command;
 use mithril_common::StdResult;
 use mithril_common::entities::{BlockHash, PartyId, TransactionHash};
 
-use crate::utils::file_utils;
+use crate::utils::{ChildLoggerExt, file_utils};
 
 #[derive(Error, Debug, PartialEq, Eq)]
 #[error("Retryable devnet error: `{0}`")]
@@ -80,6 +80,16 @@ pub struct DevnetBootstrapArgs {
 }
 
 impl Devnet {
+    fn build_command(&self, script_path: &Path) -> StdResult<Command> {
+        let mut command = Command::new(script_path);
+        command
+            .current_dir(&self.artifacts_dir)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        Ok(command)
+    }
+
     pub async fn bootstrap(bootstrap_args: &DevnetBootstrapArgs) -> StdResult<Devnet> {
         let bootstrap_script = "devnet-mkfiles.sh";
         let bootstrap_script_path =
@@ -251,17 +261,16 @@ impl Devnet {
     }
 
     pub async fn run(&self) -> StdResult<()> {
-        let run_script = "start-cardano.sh";
-        let run_script_path = self.artifacts_dir.join(run_script);
-        let mut run_command = Command::new(&run_script_path);
-        run_command.current_dir(&self.artifacts_dir).kill_on_drop(true);
+        let script_name = "start-cardano.sh";
+        let run_script_path = self.artifacts_dir.join(script_name);
+        let mut run_command = self.build_command(&run_script_path)?;
 
         info!("Starting the Cardano devnet"; "script" => &run_script_path.display());
 
         let status = run_command
             .spawn()
             .with_context(|| "Failed to start the Cardano devnet")?
-            .wait()
+            .wait_forwarding_output_to_slog_scope(script_name)
             .await
             .with_context(|| "Error while starting the Cardano devnet")?;
         match status.code() {
@@ -276,15 +285,14 @@ impl Devnet {
     pub async fn run_dmq(&self) -> StdResult<()> {
         let run_script = "start-dmq.sh";
         let run_script_path = self.artifacts_dir.join(run_script);
-        let mut run_command = Command::new(&run_script_path);
-        run_command.current_dir(&self.artifacts_dir).kill_on_drop(true);
+        let mut run_command = self.build_command(&run_script_path)?;
 
         info!("Starting the DMQ devnet"; "script" => &run_script_path.display());
 
         let status = run_command
             .spawn()
             .with_context(|| "Failed to start the DMQ devnet")?
-            .wait()
+            .wait_forwarding_output_to_slog_scope(run_script)
             .await
             .with_context(|| "Error while starting the DMQ devnet")?;
         match status.code() {
@@ -299,15 +307,14 @@ impl Devnet {
     pub async fn stop(&self) -> StdResult<()> {
         let stop_script = "stop.sh";
         let stop_script_path = self.artifacts_dir.join(stop_script);
-        let mut stop_command = Command::new(&stop_script_path);
-        stop_command.current_dir(&self.artifacts_dir).kill_on_drop(true);
+        let mut stop_command = self.build_command(&stop_script_path)?;
 
         info!("Stopping the Devnet"; "script" => &stop_script_path.display());
 
         let exit_status = stop_command
             .spawn()
             .with_context(|| "Failed to stop the devnet")?
-            .wait()
+            .wait_forwarding_output_to_slog_scope(stop_script)
             .await
             .with_context(|| "Error while stopping the devnet")?;
         match exit_status.code() {
@@ -320,8 +327,7 @@ impl Devnet {
     pub async fn delegate_stakes(&self, delegation_round: u16) -> StdResult<()> {
         let run_script = "delegate.sh";
         let run_script_path = self.artifacts_dir.join(run_script);
-        let mut run_command = Command::new(&run_script_path);
-        run_command.current_dir(&self.artifacts_dir).kill_on_drop(true);
+        let mut run_command = self.build_command(&run_script_path)?;
         run_command.env("DELEGATION_ROUND", delegation_round.to_string());
 
         info!("Delegating stakes to the pools"; "script" => &run_script_path.display());
@@ -329,7 +335,7 @@ impl Devnet {
         let status = run_command
             .spawn()
             .with_context(|| "Failed to delegate stakes to the pools")?
-            .wait()
+            .wait_forwarding_output_to_slog_scope(run_script)
             .await
             .with_context(|| "Error while delegating stakes to the pools")?;
         match status.code() {
@@ -344,8 +350,7 @@ impl Devnet {
     pub async fn write_era_marker(&self, target_path: &Path) -> StdResult<()> {
         let run_script = "era-mithril.sh";
         let run_script_path = self.artifacts_dir.join(run_script);
-        let mut run_command = Command::new(&run_script_path);
-        run_command.current_dir(&self.artifacts_dir).kill_on_drop(true);
+        let mut run_command = self.build_command(&run_script_path)?;
         run_command.env("DATUM_FILE", target_path.to_str().unwrap());
 
         info!("Writing era marker on chain"; "script" => &run_script_path.display());
@@ -353,7 +358,7 @@ impl Devnet {
         let status = run_command
             .spawn()
             .with_context(|| "Failed to write era marker on chain")?
-            .wait()
+            .wait_forwarding_output_to_slog_scope(run_script)
             .await
             .with_context(|| "Error while writing era marker on chain")?;
         match status.code() {
@@ -368,8 +373,7 @@ impl Devnet {
     pub async fn transfer_funds(&self) -> StdResult<()> {
         let run_script = "payment-mithril.sh";
         let run_script_path = self.artifacts_dir.join(run_script);
-        let mut run_command = Command::new(&run_script_path);
-        run_command.current_dir(&self.artifacts_dir).kill_on_drop(true);
+        let mut run_command = self.build_command(&run_script_path)?;
         run_command.env("PAYMENT_ITERATIONS", "5");
 
         info!("Transferring some funds on chain"; "script" => &run_script_path.display());
@@ -377,7 +381,7 @@ impl Devnet {
         let status = run_command
             .spawn()
             .with_context(|| "Failed to transfer funds on chain")?
-            .wait()
+            .wait_forwarding_output_to_slog_scope(run_script)
             .await
             .with_context(|| "Error while to transferring funds on chain")?;
         match status.code() {

--- a/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/devnet/runner.rs
@@ -146,7 +146,8 @@ impl Devnet {
 
         bootstrap_command
             .current_dir(&bootstrap_args.devnet_scripts_dir)
-            .stdout(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
             .kill_on_drop(true);
 
         info!("Bootstrapping the Devnet"; "script" => &bootstrap_script_path.display());
@@ -154,7 +155,7 @@ impl Devnet {
         let exit_status = bootstrap_command
             .spawn()
             .with_context(|| format!("{bootstrap_script} failed to start"))?
-            .wait()
+            .wait_forwarding_output_to_slog_scope(bootstrap_script)
             .await
             .with_context(|| format!("{bootstrap_script} failed to run"))?;
         match exit_status.code() {

--- a/mithril-test-lab/mithril-end-to-end/src/lib.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/lib.rs
@@ -42,3 +42,8 @@ impl std::fmt::Display for AggregateSignatureType {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    mithril_common::define_test_logger!();
+}

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -5,7 +5,7 @@ use slog_scope::{error, info};
 use std::{
     collections::BTreeMap,
     fmt,
-    fs::{self, OpenOptions},
+    fs::{self, File},
     path::{Path, PathBuf},
     process::{ExitCode, Termination},
     sync::Arc,
@@ -276,6 +276,10 @@ fn main() -> AppResult {
 async fn main_exec() -> StdResult<()> {
     let args = Cli::parse();
 
+    if let Some(ScenarioArgs::GenerateDoc(cmd)) = &args.scenario {
+        return cmd.execute(&mut Cli::command()).map_err(|message| anyhow!(message));
+    }
+
     let work_dir = {
         let dir = match &args.work_directory {
             Some(path) => path.to_owned(),
@@ -300,10 +304,6 @@ async fn main_exec() -> StdResult<()> {
         &args,
         &work_dir.join("mithril-end-to-end.log"),
     ));
-
-    if let Some(ScenarioArgs::GenerateDoc(cmd)) = &args.scenario {
-        return cmd.execute(&mut Cli::command()).map_err(|message| anyhow!(message));
-    }
 
     info!("Starting Mithril End-to-End test suite"; "args" => #?args);
 
@@ -611,11 +611,7 @@ fn build_logger(args: &Cli, log_file: &Path) -> Logger {
     };
 
     let file_drain = {
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(log_file)
-            .expect("failed to open log file at {log_file}");
+        let file = File::create(log_file).expect("failed to open log file at {log_file}");
         let decorator = slog_term::PlainSyncDecorator::new(file);
         let drain = slog_term::FullFormat::new(decorator).build().fuse();
         let drain = slog::LevelFilter::new(drain, args.log_level()).fuse();

--- a/mithril-test-lab/mithril-end-to-end/src/main.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/main.rs
@@ -4,7 +4,8 @@ use slog::{Drain, Level, Logger};
 use slog_scope::{error, info};
 use std::{
     collections::BTreeMap,
-    fmt, fs,
+    fmt,
+    fs::{self, OpenOptions},
     path::{Path, PathBuf},
     process::{ExitCode, Termination},
     sync::Arc,
@@ -274,13 +275,6 @@ fn main() -> AppResult {
 
 async fn main_exec() -> StdResult<()> {
     let args = Cli::parse();
-    let _guard = slog_scope::set_global_logger(build_logger(&args));
-
-    if let Some(ScenarioArgs::GenerateDoc(cmd)) = &args.scenario {
-        return cmd.execute(&mut Cli::command()).map_err(|message| anyhow!(message));
-    }
-
-    info!("Starting Mithril End-to-End test suite"; "args" => #?args);
 
     let work_dir = {
         let dir = match &args.work_directory {
@@ -301,6 +295,18 @@ async fn main_exec() -> StdResult<()> {
             )
         })?
     };
+
+    let _guard = slog_scope::set_global_logger(build_logger(
+        &args,
+        &work_dir.join("mithril-end-to-end.log"),
+    ));
+
+    if let Some(ScenarioArgs::GenerateDoc(cmd)) = &args.scenario {
+        return cmd.execute(&mut Cli::command()).map_err(|message| anyhow!(message));
+    }
+
+    info!("Starting Mithril End-to-End test suite"; "args" => #?args);
+
     let artifacts_dir = {
         let path = work_dir.join("artifacts");
         fs::create_dir(&path).with_context(|| "Artifacts dir creation failure")?;
@@ -596,13 +602,29 @@ impl AppStopper {
     }
 }
 
-fn build_logger(args: &Cli) -> Logger {
-    let decorator = slog_term::TermDecorator::new().build();
-    let drain = slog_term::FullFormat::new(decorator).build().fuse();
-    let drain = slog::LevelFilter::new(drain, args.log_level()).fuse();
-    let drain = slog_async::Async::new(drain).build().fuse();
+fn build_logger(args: &Cli, log_file: &Path) -> Logger {
+    let terminal_drain = {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::FullFormat::new(decorator).build().fuse();
+        let drain = slog::LevelFilter::new(drain, args.log_level()).fuse();
+        slog_async::Async::new(drain).build().fuse()
+    };
 
-    Logger::root(Arc::new(drain), slog::o!())
+    let file_drain = {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(log_file)
+            .expect("failed to open log file at {log_file}");
+        let decorator = slog_term::PlainSyncDecorator::new(file);
+        let drain = slog_term::FullFormat::new(decorator).build().fuse();
+        let drain = slog::LevelFilter::new(drain, args.log_level()).fuse();
+        slog_async::Async::new(drain).build().fuse()
+    };
+
+    let slog_duplicate = slog::Duplicate::new(terminal_drain, file_drain).fuse();
+
+    Logger::root(slog_duplicate, slog::o!())
 }
 
 fn create_workdir_if_not_exist_clean_otherwise(work_dir: &Path) {

--- a/mithril-test-lab/mithril-end-to-end/src/utils/child_logger.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/child_logger.rs
@@ -1,8 +1,10 @@
+use std::pin::Pin;
 use std::process::ExitStatus;
+use std::task::Poll;
 use std::time::Duration;
 
 use slog::{Logger, info};
-use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::io::{AsyncRead, AsyncReadExt, ReadBuf};
 use tokio::process::Child;
 use tokio::time::timeout;
 
@@ -11,10 +13,12 @@ use mithril_common::StdResult;
 /// Timeout for joining the output forwarder thread, to avoid potential deadlocks.
 const OUTPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
 
+const OUTPUT_READ_BUFFER_SIZE: usize = 8 * 1024;
+
 /// Extension trait over a spawned [tokio Child][Child] to forward its output to a [slog Logger][Logger].
 #[async_trait::async_trait]
 pub trait ChildLoggerExt {
-    /// Run the child to completion, forwarding its stdout/stderr to `logger` line by line.
+    /// Run the child to completion, forwarding its stdout/stderr to `logger`.
     ///
     /// The child must have been spawned with `stdout(Stdio::piped())` and `stderr(Stdio::piped())`,
     /// otherwise the corresponding stream is simply ignored.
@@ -27,7 +31,7 @@ pub trait ChildLoggerExt {
         context: &str,
     ) -> StdResult<ExitStatus>;
 
-    /// Run the child to completion, forwarding its stdout/stderr to `slog_scope` global logger line by line.
+    /// Run the child to completion, forwarding its stdout/stderr to `slog_scope` global logger.
     ///
     /// The child must have been spawned with `stdout(Stdio::piped())` and `stderr(Stdio::piped())`,
     /// otherwise the corresponding stream is simply ignored.
@@ -48,10 +52,7 @@ impl ChildLoggerExt for Child {
             let logger = logger.clone();
             let context = context.to_owned();
             tokio::spawn(async move {
-                let mut lines = BufReader::new(stdout).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    info!(logger, "{line}"; "context" => &context, "stream" => "stdout");
-                }
+                forward_output_to_slog(stdout, &logger, &context, "stdout").await;
             })
         });
 
@@ -59,10 +60,7 @@ impl ChildLoggerExt for Child {
             let logger = logger.clone();
             let context = context.to_owned();
             tokio::spawn(async move {
-                let mut lines = BufReader::new(stderr).lines();
-                while let Ok(Some(line)) = lines.next_line().await {
-                    info!(logger, "{line}"; "context" => &context, "stream" => "stderr");
-                }
+                forward_output_to_slog(stderr, &logger, &context, "stderr").await;
             })
         });
 
@@ -84,6 +82,73 @@ impl ChildLoggerExt for Child {
     async fn wait_forwarding_output_to_slog_scope(self, context: &str) -> StdResult<ExitStatus> {
         self.wait_forwarding_output_to_slog(&slog_scope::logger(), context)
             .await
+    }
+}
+
+/// Forward an asynchronous output stream to a slog logger.
+///
+/// The stream is read in batches:
+/// - waits for at least one chunk of data;
+/// - immediately drains any additional data already available;
+/// - logs the collected batch with the given `context` and `stream_name`.
+///
+/// The function stops when the stream reaches EOF or when a read error occurs.
+/// Read errors are ignored and are not logged.
+async fn forward_output_to_slog<R>(
+    mut stream: R,
+    logger: &Logger,
+    context: &str,
+    stream_name: &'static str,
+) where
+    R: AsyncRead + Unpin,
+{
+    let mut pending_logs: Vec<u8> = Vec::with_capacity(OUTPUT_READ_BUFFER_SIZE);
+    let mut first_chunk_buffer = vec![0; OUTPUT_READ_BUFFER_SIZE];
+    let mut immediate_buffer = vec![0; OUTPUT_READ_BUFFER_SIZE];
+
+    loop {
+        pending_logs.clear();
+
+        // Wait for the first chunk of the next burst.
+        let bytes_read: usize = match stream.read(&mut first_chunk_buffer).await {
+            Ok(0) => break,
+            Ok(bytes_read) => bytes_read,
+            Err(_) => break,
+        };
+
+        pending_logs.extend_from_slice(&first_chunk_buffer[..bytes_read]);
+
+        // Drain whatever is immediately available
+        loop {
+            let read_result = std::future::poll_fn(|cx| {
+                let mut read_buf = ReadBuf::new(&mut immediate_buffer);
+
+                match Pin::new(&mut stream).poll_read(cx, &mut read_buf) {
+                    Poll::Ready(Ok(())) => Poll::Ready(Ok(read_buf.filled().len())),
+                    Poll::Ready(Err(error)) => Poll::Ready(Err(error)),
+                    // No more data immediately available meaning the end of the current batch
+                    Poll::Pending => Poll::Ready(Ok(0)),
+                }
+            })
+            .await;
+
+            match read_result {
+                Ok(0) => break,
+                Ok(bytes_read) => pending_logs.extend_from_slice(&immediate_buffer[..bytes_read]),
+                Err(_) => break,
+            }
+        }
+
+        log_output_batch(logger, context, stream_name, &pending_logs);
+    }
+}
+
+fn log_output_batch(logger: &Logger, context: &str, stream_name: &'static str, output: &[u8]) {
+    let output = String::from_utf8_lossy(output);
+    let output = output.trim_end_matches(['\r', '\n']);
+
+    if !output.is_empty() {
+        info!(logger, "{output}"; "context" => context, "stream" => stream_name);
     }
 }
 

--- a/mithril-test-lab/mithril-end-to-end/src/utils/child_logger.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/child_logger.rs
@@ -1,0 +1,165 @@
+use std::process::ExitStatus;
+use std::time::Duration;
+
+use slog::{Logger, info};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Child;
+use tokio::time::timeout;
+
+use mithril_common::StdResult;
+
+/// Timeout for joining the output forwarder thread, to avoid potential deadlocks.
+const OUTPUT_FORWARDER_JOIN_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Extension trait over a spawned [tokio Child][Child] to forward its output to a [slog Logger][Logger].
+#[async_trait::async_trait]
+pub trait ChildLoggerExt {
+    /// Run the child to completion, forwarding its stdout/stderr to `logger` line by line.
+    ///
+    /// The child must have been spawned with `stdout(Stdio::piped())` and `stderr(Stdio::piped())`,
+    /// otherwise the corresponding stream is simply ignored.
+    ///
+    /// This waits for the process to exit AND for all output to be forwarded to slog before
+    /// returning the process [ExitStatus](ExitStatus).
+    async fn wait_forwarding_output_to_slog(
+        self,
+        logger: &Logger,
+        context: &str,
+    ) -> StdResult<ExitStatus>;
+
+    /// Run the child to completion, forwarding its stdout/stderr to `slog_scope` global logger line by line.
+    ///
+    /// The child must have been spawned with `stdout(Stdio::piped())` and `stderr(Stdio::piped())`,
+    /// otherwise the corresponding stream is simply ignored.
+    ///
+    /// This waits for the process to exit AND for all output to be forwarded to slog before
+    /// returning the process [ExitStatus](ExitStatus).
+    async fn wait_forwarding_output_to_slog_scope(self, context: &str) -> StdResult<ExitStatus>;
+}
+
+#[async_trait::async_trait]
+impl ChildLoggerExt for Child {
+    async fn wait_forwarding_output_to_slog(
+        mut self,
+        logger: &Logger,
+        context: &str,
+    ) -> StdResult<ExitStatus> {
+        let stdout_handle = self.stdout.take().map(|stdout| {
+            let logger = logger.clone();
+            let context = context.to_owned();
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stdout).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    info!(logger, "{line}"; "context" => &context, "stream" => "stdout");
+                }
+            })
+        });
+
+        let stderr_handle = self.stderr.take().map(|stderr| {
+            let logger = logger.clone();
+            let context = context.to_owned();
+            tokio::spawn(async move {
+                let mut lines = BufReader::new(stderr).lines();
+                while let Ok(Some(line)) = lines.next_line().await {
+                    info!(logger, "{line}"; "context" => &context, "stream" => "stderr");
+                }
+            })
+        });
+
+        let status = self.wait().await?;
+
+        // The pipes reach EOF once the child exits, so these tasks finish on their own.
+        // We still join them here to guarantee every line is flushed to slog before returning,
+        // but only wait briefly to avoid blocking indefinitely.
+        if let Some(handle) = stdout_handle {
+            let _ = timeout(OUTPUT_FORWARDER_JOIN_TIMEOUT, handle).await;
+        }
+        if let Some(handle) = stderr_handle {
+            let _ = timeout(OUTPUT_FORWARDER_JOIN_TIMEOUT, handle).await;
+        }
+
+        Ok(status)
+    }
+
+    async fn wait_forwarding_output_to_slog_scope(self, context: &str) -> StdResult<ExitStatus> {
+        self.wait_forwarding_output_to_slog(&slog_scope::logger(), context)
+            .await
+    }
+}
+
+#[cfg(unix)]
+#[cfg(test)]
+mod tests {
+    use std::process::Stdio;
+
+    use tokio::process::Command;
+
+    use crate::test::TestLogger;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn forwards_stdout_and_stderr_to_slog_and_returns_exit_status() {
+        let (logger, log_inspector) = TestLogger::memory();
+
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("echo hello-standard-output; echo hello-standard-error 1>&2")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let status = command
+            .spawn()
+            .expect("failed to spawn test command")
+            .wait_forwarding_output_to_slog(&logger, "test-context")
+            .await
+            .expect("waiting for the child should not fail");
+
+        assert!(status.success());
+        assert!(log_inspector.contains_log("hello-standard-output"));
+        assert!(log_inspector.contains_log("hello-standard-error"));
+        assert!(log_inspector.contains_log("test-context"));
+        assert!(log_inspector.contains_log("stdout"));
+        assert!(log_inspector.contains_log("stderr"));
+    }
+
+    #[tokio::test]
+    async fn returns_non_zero_exit_status_and_still_forwards_output() {
+        let (logger, log_inspector) = TestLogger::memory();
+
+        let mut command = Command::new("sh");
+        command
+            .arg("-c")
+            .arg("echo before-exit; exit 3")
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let status = command
+            .spawn()
+            .expect("failed to spawn test command")
+            .wait_forwarding_output_to_slog(&logger, "test-context")
+            .await
+            .expect("waiting for the child should not fail");
+
+        assert_eq!(Some(3), status.code());
+        assert!(log_inspector.contains_log("before-exit"));
+    }
+
+    #[tokio::test]
+    async fn unpiped_stream_are_not_redirected() {
+        let (logger, log_inspector) = TestLogger::memory();
+        let mut command = Command::new("sh");
+        command.arg("-c").arg("echo hello-standard-output");
+
+        let status = command
+            .spawn()
+            .expect("failed to spawn test command")
+            .wait_forwarding_output_to_slog(&logger, "test-context")
+            .await
+            .expect("waiting for the child should not fail");
+
+        assert!(status.success());
+        assert!(log_inspector.to_string().is_empty());
+    }
+}

--- a/mithril-test-lab/mithril-end-to-end/src/utils/mod.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/utils/mod.rs
@@ -1,12 +1,14 @@
 mod mithril_command;
 #[macro_use]
 mod spec_utils;
+mod child_logger;
 mod compatibility_checker;
 pub(crate) mod file_utils;
 mod formatting;
 mod immutable_files_utils;
 mod version_req;
 
+pub use child_logger::*;
 pub use compatibility_checker::*;
 pub use formatting::*;
 pub use immutable_files_utils::*;


### PR DESCRIPTION
## Content

In order to facilitate the e2e debugging, this PR adds :
- a new file logger, witch is a duplicated logger from existing terminal
- a utility to redirect each command output and errors to log info!

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

this PR relates to or closes #3362 
