### PR TITLE
Remove docker-build

### DIFF
--- a/docs/website/root/manual/develop/nodes/mithril-aggregator.md
+++ b/docs/website/root/manual/develop/nodes/mithril-aggregator.md
@@ -451,20 +451,6 @@ If you wish to delve deeper and access several levels of logs from the Mithril a
 
 <CompiledBinaries  node="mithril-aggregator"/>
 
-## Build and run the Docker container
-
-Build a local Docker image:
-
-```bash
-make docker-build
-```
-
-Run a local Docker container:
-
-```bash
-make docker-run
-```
-
 ## Subcommands
 
 Here are the available subcommands:

--- a/docs/website/root/manual/develop/nodes/mithril-client.md
+++ b/docs/website/root/manual/develop/nodes/mithril-client.md
@@ -468,38 +468,6 @@ mithril_client cardano-stake-distribution list
 mithril_client cardano-stake-distribution download $UNIQUE_IDENTIFIER
 ```
 
-### Local image
-
-Build a local Docker image:
-
-<Tabs groupId="system" queryString>
-  <TabItem value="linux-mac" label="Linux / Mac">
-  ```bash
-  make docker-build
-  ```
-  </TabItem>
-  <TabItem value="windows" label="Windows">
-  ```powershell
-  pushd ..\; docker build -t mithril/mithril-client -f mithril-client-cli\Dockerfile . ; popd
-  ```
-  </TabItem>
-</Tabs>
-
-Run a local Docker container:
-
-<Tabs groupId="system" queryString>
-  <TabItem value="linux-mac" label="Linux / Mac">
-  ```bash
-  make docker-run
-  ```
-  </TabItem>
-  <TabItem value="windows" label="Windows">
-  ```powershell
-  docker run --rm --name='mithril-client' mithril/mithril-client
-  ```
-  </TabItem>
-</Tabs>
-
 ## Subcommands
 
 Here are the subcommands available:

--- a/docs/website/root/manual/develop/nodes/mithril-signer.md
+++ b/docs/website/root/manual/develop/nodes/mithril-signer.md
@@ -208,20 +208,6 @@ If you wish to delve deeper and access several levels of logs from the Mithril s
 
 <CompiledBinaries  node="mithril-signer"/>
 
-## Build and run a Docker container
-
-Build a local Docker image:
-
-```bash
-make docker-build
-```
-
-Run a local Docker container:
-
-```bash
-make docker-run
-```
-
 ## Configuration parameters
 
 The configuration parameters can be set in either of the following ways:

--- a/mithril-aggregator/Makefile
+++ b/mithril-aggregator/Makefile
@@ -29,9 +29,6 @@ help:
 doc:
 	${CARGO} doc --no-deps --open
 
-docker-build:
-	cd ../ && docker build -t mithril/mithril-aggregator -f mithril-aggregator/Dockerfile .
-
 docker-build-ci: build
 	# Check that we are on Linux, then build
 	if [ "$$(uname -s)" != "Linux" ]; then \

--- a/mithril-client-cli/Makefile
+++ b/mithril-client-cli/Makefile
@@ -37,9 +37,6 @@ help:
 doc:
 	${CARGO} doc --no-deps --open
 
-docker-build:
-	cd ../ && docker build -t mithril/mithril-client -f mithril-client-cli/Dockerfile .
-
 docker-build-ci: build
 	# Check that we are on Linux, then build
 	if [ "$$(uname -s)" != "Linux" ]; then \

--- a/mithril-relay/Makefile
+++ b/mithril-relay/Makefile
@@ -22,9 +22,6 @@ help:
 doc:
 	${CARGO} doc --no-deps --open
 
-docker-build:
-	cd ../ && docker build -t mithril/mithril-relay -f mithril-relay/Dockerfile .
-
 docker-build-ci: build
 	# Check that we are on Linux, then build
 	if [ "$$(uname -s)" != "Linux" ]; then \

--- a/mithril-relay/README.md
+++ b/mithril-relay/README.md
@@ -174,20 +174,6 @@ mithril_relay signer
 mithril_relay passive
 ```
 
-### Local image
-
-Build a local Docker image:
-
-```bash
-make docker-build
-```
-
-Run a local Docker container:
-
-```bash
-make docker-run
-```
-
 ## Subcommands
 
 Here are the subcommands available:

--- a/mithril-signer/Makefile
+++ b/mithril-signer/Makefile
@@ -29,9 +29,6 @@ help:
 doc:
 	${CARGO} doc --no-deps --open
 
-docker-build:
-	cd ../ && docker build -t mithril/mithril-signer -f mithril-signer/Dockerfile .
-
 docker-build-ci: build
 	# Check that we are on Linux, then build
 	if [ "$$(uname -s)" != "Linux" ]; then \


### PR DESCRIPTION
## Content

Remove docker-build command from Makefile and website since Dockerfile has been removed in the past in ticket #3295 ([PR](https://github.com/input-output-hk/mithril/pull/3311))

## Pre-submit checklist

- Branch
  - [ ] Tests are provided (if possible)
  - [ ] Crates versions are updated (if relevant)
  - [ ] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [ ] Update README file (if relevant)
  - [ ] Update documentation website (if relevant)
  - [ ] Add dev blog post (if relevant)
  - [ ] Add ADR blog post or Dev ADR entry (if relevant)
  - [x] No new TODOs introduced

this PR closes #3406 
