### PR TITLE
refactor(signer): simplify registration retriever

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "1.1.5"
+version = "1.1.6"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "1.1.5"
+version = "1.1.6"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -27,9 +27,7 @@ pub trait Runner: Send + Sync {
     ) -> StdResult<MithrilNetworkConfiguration>;
 
     /// Fetch the current epoch settings if any.
-    async fn get_signer_registrations_from_aggregator(
-        &self,
-    ) -> StdResult<Option<RegisteredSigners>>;
+    async fn get_signer_registrations_from_aggregator(&self) -> StdResult<RegisteredSigners>;
 
     /// Fetch the beacon to sign if any.
     async fn get_beacon_to_sign(&self, time_point: TimePoint) -> StdResult<Option<BeaconToSign>>;
@@ -129,16 +127,13 @@ impl Runner for SignerRunner {
             .await
     }
 
-    async fn get_signer_registrations_from_aggregator(
-        &self,
-    ) -> StdResult<Option<RegisteredSigners>> {
+    async fn get_signer_registrations_from_aggregator(&self) -> StdResult<RegisteredSigners> {
         debug!(self.logger, ">> get_epoch_settings");
 
         self.services
             .signers_registration_retriever
             .retrieve_all_signer_registrations()
             .await
-            .map(Some)
     }
 
     async fn get_beacon_to_sign(&self, time_point: TimePoint) -> StdResult<Option<BeaconToSign>> {

--- a/mithril-signer/src/runtime/runner.rs
+++ b/mithril-signer/src/runtime/runner.rs
@@ -138,6 +138,7 @@ impl Runner for SignerRunner {
             .signers_registration_retriever
             .retrieve_all_signer_registrations()
             .await
+            .map(Some)
     }
 
     async fn get_beacon_to_sign(&self, time_point: TimePoint) -> StdResult<Option<BeaconToSign>> {

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -43,6 +43,11 @@ pub enum SignerState {
     },
 }
 
+enum CycleOutcome {
+    TransitionTo(SignerState),
+    KeepState,
+}
+
 impl SignerState {
     /// Returns `true` if the state in `Init`
     pub fn is_init(&self) -> bool {
@@ -156,8 +161,8 @@ impl StateMachine {
             .get_runtime_cycle_total_since_startup_counter()
             .increment();
 
-        let next_state_or_skip = match current_state {
-            SignerState::Init => self.transition_from_init_to_unregistered().await.map(Some)?,
+        let outcome = match current_state {
+            SignerState::Init => self.cycle_init().await?,
             SignerState::Unregistered { epoch } => self.cycle_unregistered(epoch).await?,
             SignerState::RegisteredNotAbleToSign { epoch } => {
                 self.cycle_registered_not_able_to_sign(epoch).await?
@@ -165,8 +170,14 @@ impl StateMachine {
             SignerState::ReadyToSign { epoch } => self.cycle_ready_to_sign(epoch).await?,
         };
 
-        if let Some(next_state) = next_state_or_skip {
-            *self.state.lock().await = next_state;
+        match outcome {
+            CycleOutcome::TransitionTo(next_state) => {
+                info!(self.logger, "Transitioned to state: {next_state}");
+                *self.state.lock().await = next_state;
+            }
+            CycleOutcome::KeepState => {
+                info!(self.logger, "Keeping current state: {current_state}");
+            }
         }
 
         self.metrics_service
@@ -176,7 +187,16 @@ impl StateMachine {
         Ok(())
     }
 
-    async fn cycle_unregistered(&self, epoch: Epoch) -> Result<Option<SignerState>, RuntimeError> {
+    async fn cycle_init(&self) -> Result<CycleOutcome, RuntimeError> {
+        let current_epoch = self.get_current_time_point("init → unregistered").await?.epoch;
+        self.update_era_checker(current_epoch, "init → unregistered").await?;
+
+        Ok(CycleOutcome::TransitionTo(SignerState::Unregistered {
+            epoch: current_epoch,
+        }))
+    }
+
+    async fn cycle_unregistered(&self, epoch: Epoch) -> Result<CycleOutcome, RuntimeError> {
         if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(epoch).await? {
             info!(
                 self.logger,
@@ -185,7 +205,7 @@ impl StateMachine {
 
             self.transition_from_unregistered_to_unregistered(new_epoch)
                 .await
-                .map(Some)
+                .map(CycleOutcome::TransitionTo)
         } else {
             let signer_registrations = self
                 .runner
@@ -220,7 +240,7 @@ impl StateMachine {
                     signer_registrations.next_signers,
                 )
                 .await
-                .map(Some)
+                .map(CycleOutcome::TransitionTo)
             } else {
                 info!(
                     self.logger, " ⋅ Signer settings found, but its epoch is behind the known epoch, waiting…";
@@ -230,7 +250,7 @@ impl StateMachine {
                     "known_epoch" => ?epoch,
                 );
 
-                Ok(None)
+                Ok(CycleOutcome::KeepState)
             }
         }
     }
@@ -238,7 +258,7 @@ impl StateMachine {
     async fn cycle_registered_not_able_to_sign(
         &self,
         epoch: Epoch,
-    ) -> Result<Option<SignerState>, RuntimeError> {
+    ) -> Result<CycleOutcome, RuntimeError> {
         if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(epoch).await? {
             info!(
                 self.logger,
@@ -247,14 +267,14 @@ impl StateMachine {
 
             self.transition_from_registered_not_able_to_sign_to_unregistered(new_epoch)
                 .await
-                .map(Some)
+                .map(CycleOutcome::TransitionTo)
         } else {
             info!(self.logger, " ⋅ Epoch has NOT changed, waiting…");
-            Ok(None)
+            Ok(CycleOutcome::KeepState)
         }
     }
 
-    async fn cycle_ready_to_sign(&self, epoch: Epoch) -> Result<Option<SignerState>, RuntimeError> {
+    async fn cycle_ready_to_sign(&self, epoch: Epoch) -> Result<CycleOutcome, RuntimeError> {
         match self.has_epoch_changed(epoch).await? {
             EpochStatus::NewEpoch(new_epoch) => {
                 info!(
@@ -263,7 +283,7 @@ impl StateMachine {
                 );
                 self.transition_from_ready_to_sign_to_unregistered(new_epoch)
                     .await
-                    .map(Some)
+                    .map(CycleOutcome::TransitionTo)
             }
             EpochStatus::Unchanged(timepoint) => {
                 let beacon_to_sign =
@@ -282,11 +302,11 @@ impl StateMachine {
                         );
                         self.transition_from_ready_to_sign_to_ready_to_sign(epoch, beacon)
                             .await
-                            .map(Some)
+                            .map(CycleOutcome::TransitionTo)
                     }
                     None => {
                         info!(self.logger, " ⋅ No beacon to sign, waiting…");
-                        Ok(None)
+                        Ok(CycleOutcome::KeepState)
                     }
                 }
             }
@@ -313,15 +333,6 @@ impl StateMachine {
             .await?;
 
         Ok(SignerState::Unregistered { epoch: new_epoch })
-    }
-
-    async fn transition_from_init_to_unregistered(&self) -> Result<SignerState, RuntimeError> {
-        let current_epoch = self.get_current_time_point("init → unregistered").await?.epoch;
-        self.update_era_checker(current_epoch, "init → unregistered").await?;
-
-        Ok(SignerState::Unregistered {
-            epoch: current_epoch,
-        })
     }
 
     /// Launch the transition process from the `Unregistered` to `ReadyToSign` or `RegisteredNotAbleToSign` state.

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -180,7 +180,7 @@ impl StateMachine {
         if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(epoch).await? {
             info!(
                 self.logger,
-                "→ Epoch has changed, transiting to Unregistered"
+                "→ Epoch has changed, transitioning to Unregistered"
             );
 
             self.transition_from_unregistered_to_unregistered(new_epoch)
@@ -211,7 +211,7 @@ impl StateMachine {
 
             if signer_registrations.epoch >= epoch {
                 info!(self.logger, "New Epoch found");
-                info!(self.logger, " ⋅ Transiting to Registered");
+                info!(self.logger, " ⋅ Transitioning to Registered");
 
                 self.transition_from_unregistered_to_one_of_registered_states(
                     signer_registrations.epoch,
@@ -242,7 +242,7 @@ impl StateMachine {
         if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(epoch).await? {
             info!(
                 self.logger,
-                " → New Epoch detected, transiting to Unregistered"
+                " → New Epoch detected, transitioning to Unregistered"
             );
 
             self.transition_from_registered_not_able_to_sign_to_unregistered(new_epoch)
@@ -259,7 +259,7 @@ impl StateMachine {
             EpochStatus::NewEpoch(new_epoch) => {
                 info!(
                     self.logger,
-                    "→ Epoch has changed, transiting to Unregistered"
+                    "→ Epoch has changed, transitioning to Unregistered"
                 );
                 self.transition_from_ready_to_sign_to_unregistered(new_epoch)
                     .await
@@ -277,7 +277,7 @@ impl StateMachine {
                 match beacon_to_sign {
                     Some(beacon) => {
                         info!(
-                            self.logger, "→ Epoch has NOT changed we can sign this beacon, transiting to ReadyToSign";
+                            self.logger, "→ Epoch has NOT changed we can sign this beacon, transitioning to ReadyToSign";
                             "beacon_to_sign" => ?beacon,
                         );
                         self.transition_from_ready_to_sign_to_ready_to_sign(epoch, beacon)

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -166,16 +166,18 @@ impl StateMachine {
                         "→ Epoch has changed, transiting to Unregistered"
                     );
                     *state = self.transition_from_unregistered_to_unregistered(new_epoch).await?;
-                } else if let Some(signer_registrations) = self
-                    .runner
-                    .get_signer_registrations_from_aggregator()
-                    .await
-                    .map_err(|e| RuntimeError::KeepState {
-                        message: format!("could not retrieve epoch settings at epoch {epoch:?}"),
-                        nested_error: Some(e),
-                    })?
-                {
+                } else {
+                    let signer_registrations =
+                        self.runner.get_signer_registrations_from_aggregator().await.map_err(
+                            |e| RuntimeError::KeepState {
+                                message: format!(
+                                    "could not retrieve epoch settings at epoch {epoch:?}"
+                                ),
+                                nested_error: Some(e),
+                            },
+                        )?;
                     info!(self.logger, "→ Epoch Signer registrations found");
+
                     let network_configuration: MithrilNetworkConfiguration =
                         self.runner.get_mithril_network_configuration(*epoch).await.map_err(
                             |e| RuntimeError::KeepState {
@@ -207,8 +209,6 @@ impl StateMachine {
                             "known_epoch" => ?epoch,
                         );
                     }
-                } else {
-                    info!(self.logger, "→ No epoch settings found yet, waiting…");
                 }
             }
             SignerState::RegisteredNotAbleToSign { epoch } => {
@@ -515,12 +515,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unregistered_epoch_settings_not_found() {
+    async fn unregistered_epoch_settings_error() {
         let mut runner = MockSignerRunner::new();
         runner
             .expect_get_signer_registrations_from_aggregator()
             .once()
-            .returning(|| Ok(None));
+            .returning(|| Err(anyhow!("error")));
         runner
             .expect_get_current_time_point()
             .once()
@@ -534,7 +534,7 @@ mod tests {
         state_machine
             .cycle()
             .await
-            .expect("Cycling the state machine should not fail");
+            .expect_err("Cycling the state machine should fail");
 
         assert_eq!(
             SignerState::Unregistered {
@@ -556,7 +556,7 @@ mod tests {
         runner
             .expect_get_signer_registrations_from_aggregator()
             .once()
-            .returning(move || Ok(Some(epoch_settings.to_owned())));
+            .returning(move || Ok(epoch_settings.to_owned()));
         runner
             .expect_get_mithril_network_configuration()
             .once()
@@ -594,7 +594,7 @@ mod tests {
         runner
             .expect_get_signer_registrations_from_aggregator()
             .once()
-            .returning(|| Ok(Some(RegisteredSigners::dummy())));
+            .returning(|| Ok(RegisteredSigners::dummy()));
 
         runner
             .expect_get_mithril_network_configuration()
@@ -646,7 +646,7 @@ mod tests {
         runner
             .expect_get_signer_registrations_from_aggregator()
             .once()
-            .returning(|| Ok(Some(RegisteredSigners::dummy())));
+            .returning(|| Ok(RegisteredSigners::dummy()));
 
         runner
             .expect_get_mithril_network_configuration()
@@ -702,7 +702,7 @@ mod tests {
         runner
             .expect_get_signer_registrations_from_aggregator()
             .once()
-            .returning(|| Ok(Some(RegisteredSigners::dummy())));
+            .returning(|| Ok(RegisteredSigners::dummy()));
 
         runner
             .expect_get_mithril_network_configuration()

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -90,6 +90,11 @@ enum EpochStatus {
     Unchanged(TimePoint),
 }
 
+enum SignerRegistrationOutcome {
+    Registered,
+    RegistrationRoundNotYetOpened,
+}
+
 /// The state machine is responsible of the execution of the signer automate.
 pub struct StateMachine {
     state: Mutex<SignerState>,
@@ -366,49 +371,24 @@ impl StateMachine {
                 nested_error: Some(e),
             })?;
 
-        fn handle_registration_result(
-            register_result: Result<(), Error>,
-            epoch: Epoch,
-        ) -> Result<Option<SignerState>, RuntimeError> {
-            if let Err(e) = register_result {
-                if let Some(AggregatorHttpClientError::RegistrationRoundNotYetOpened(_)) =
-                    e.downcast_ref::<AggregatorHttpClientError>()
-                {
-                    Ok(Some(SignerState::Unregistered { epoch }))
-                } else if e.downcast_ref::<ProtocolInitializerError>().is_some() {
-                    Err(RuntimeError::Critical {
-                        message: format!(
-                            "Could not register to aggregator in 'unregistered → registered' phase for epoch {epoch:?}."
-                        ),
-                        nested_error: Some(e),
-                    })
-                } else {
-                    Err(RuntimeError::KeepState {
-                        message: format!(
-                            "Could not register to aggregator in 'unregistered → registered' phase for epoch {epoch:?}."
-                        ),
-                        nested_error: Some(e),
-                    })
-                }
-            } else {
-                Ok(None)
+        let register_result = self.runner.register_signer_to_aggregator().await;
+        match Self::handle_registration_result(register_result, epoch)? {
+            SignerRegistrationOutcome::Registered => {
+                self.metrics_service
+                    .get_signer_registration_success_since_startup_counter()
+                    .increment();
+
+                self.metrics_service
+                    .get_signer_registration_success_last_epoch_gauge()
+                    .record(epoch);
+            }
+            SignerRegistrationOutcome::RegistrationRoundNotYetOpened => {
+                self.metrics_service
+                    .get_signer_registration_success_since_startup_counter()
+                    .increment();
+                return Ok(SignerState::Unregistered { epoch });
             }
         }
-
-        let register_result = self.runner.register_signer_to_aggregator().await;
-        let next_state_found = handle_registration_result(register_result, epoch)?;
-
-        self.metrics_service
-            .get_signer_registration_success_since_startup_counter()
-            .increment();
-
-        if let Some(state) = next_state_found {
-            return Ok(state);
-        }
-
-        self.metrics_service
-            .get_signer_registration_success_last_epoch_gauge()
-            .record(epoch);
 
         self.runner.upkeep(epoch).await.map_err(|e| RuntimeError::KeepState {
             message: "Failed to upkeep signer in 'unregistered → registered' phase".to_string(),
@@ -522,6 +502,35 @@ impl StateMachine {
                 ),
                 nested_error: Some(e),
             })
+    }
+
+    fn handle_registration_result(
+        register_result: Result<(), Error>,
+        epoch: Epoch,
+    ) -> Result<SignerRegistrationOutcome, RuntimeError> {
+        if let Err(e) = register_result {
+            if let Some(AggregatorHttpClientError::RegistrationRoundNotYetOpened(_)) =
+                e.downcast_ref::<AggregatorHttpClientError>()
+            {
+                Ok(SignerRegistrationOutcome::RegistrationRoundNotYetOpened)
+            } else if e.downcast_ref::<ProtocolInitializerError>().is_some() {
+                Err(RuntimeError::Critical {
+                    message: format!(
+                        "Could not register to aggregator in 'unregistered → registered' phase for epoch {epoch:?}."
+                    ),
+                    nested_error: Some(e),
+                })
+            } else {
+                Err(RuntimeError::KeepState {
+                    message: format!(
+                        "Could not register to aggregator in 'unregistered → registered' phase for epoch {epoch:?}."
+                    ),
+                    nested_error: Some(e),
+                })
+            }
+        } else {
+            Ok(SignerRegistrationOutcome::Registered)
+        }
     }
 }
 
@@ -733,7 +742,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn unregistered_to_ready_to_sign_counter() {
+    async fn unregistered_keeps_state_when_registration_round_not_yet_opened_counter() {
         let mut runner = MockSignerRunner::new();
 
         runner

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -1,7 +1,8 @@
+use std::{fmt::Display, sync::Arc, time::Duration};
+
 use anyhow::Error;
 use chrono::Local;
 use slog::{Logger, debug, info};
-use std::{fmt::Display, ops::Deref, sync::Arc, time::Duration};
 use tokio::sync::Mutex;
 
 use mithril_common::{
@@ -144,127 +145,152 @@ impl StateMachine {
 
     /// Perform a cycle of the state machine.
     pub async fn cycle(&self) -> Result<(), RuntimeError> {
-        let mut state = self.state.lock().await;
+        let current_state = self.state.lock().await.clone();
         info!(
             self.logger,
             "================================================================================"
         );
-        info!(self.logger, "New cycle: {}", *state);
+        info!(self.logger, "New cycle: {current_state}");
 
         self.metrics_service
             .get_runtime_cycle_total_since_startup_counter()
             .increment();
 
-        match state.deref() {
-            SignerState::Init => {
-                *state = self.transition_from_init_to_unregistered().await?;
-            }
-            SignerState::Unregistered { epoch } => {
-                if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(*epoch).await? {
-                    info!(
-                        self.logger,
-                        "→ Epoch has changed, transiting to Unregistered"
-                    );
-                    *state = self.transition_from_unregistered_to_unregistered(new_epoch).await?;
-                } else {
-                    let signer_registrations =
-                        self.runner.get_signer_registrations_from_aggregator().await.map_err(
-                            |e| RuntimeError::KeepState {
-                                message: format!(
-                                    "could not retrieve epoch settings at epoch {epoch:?}"
-                                ),
-                                nested_error: Some(e),
-                            },
-                        )?;
-                    info!(self.logger, "→ Epoch Signer registrations found");
-
-                    let network_configuration: MithrilNetworkConfiguration =
-                        self.runner.get_mithril_network_configuration(*epoch).await.map_err(
-                            |e| RuntimeError::KeepState {
-                                message: format!(
-                                    "could not retrieve Mithril network configuration for epoch {epoch:?}"
-                                ),
-                                nested_error: Some(e),
-                            },
-                        )?;
-                    info!(self.logger, "→ Mithril network configuration found");
-
-                    if signer_registrations.epoch >= *epoch {
-                        info!(self.logger, "New Epoch found");
-                        info!(self.logger, " ⋅ Transiting to Registered");
-                        *state = self
-                            .transition_from_unregistered_to_one_of_registered_states(
-                                signer_registrations.epoch,
-                                network_configuration,
-                                signer_registrations.current_signers,
-                                signer_registrations.next_signers,
-                            )
-                            .await?;
-                    } else {
-                        info!(
-                            self.logger, " ⋅ Signer settings found, but its epoch is behind the known epoch, waiting…";
-                            "network_configuration" => ?network_configuration,
-                            "current_singer" => ?signer_registrations.current_signers,
-                            "next_signer" => ?signer_registrations.next_signers,
-                            "known_epoch" => ?epoch,
-                        );
-                    }
-                }
-            }
+        let next_state_or_skip = match current_state {
+            SignerState::Init => self.transition_from_init_to_unregistered().await.map(Some)?,
+            SignerState::Unregistered { epoch } => self.cycle_unregistered(epoch).await?,
             SignerState::RegisteredNotAbleToSign { epoch } => {
-                if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(*epoch).await? {
-                    info!(
-                        self.logger,
-                        " → New Epoch detected, transiting to Unregistered"
-                    );
-                    *state = self
-                        .transition_from_registered_not_able_to_sign_to_unregistered(new_epoch)
-                        .await?;
-                } else {
-                    info!(self.logger, " ⋅ Epoch has NOT changed, waiting…");
-                }
+                self.cycle_registered_not_able_to_sign(epoch).await?
             }
-
-            SignerState::ReadyToSign { epoch } => match self.has_epoch_changed(*epoch).await? {
-                EpochStatus::NewEpoch(new_epoch) => {
-                    info!(
-                        self.logger,
-                        "→ Epoch has changed, transiting to Unregistered"
-                    );
-                    *state = self.transition_from_ready_to_sign_to_unregistered(new_epoch).await?;
-                }
-                EpochStatus::Unchanged(timepoint) => {
-                    let beacon_to_sign =
-                        self.runner.get_beacon_to_sign(timepoint).await.map_err(|e| {
-                            RuntimeError::KeepState {
-                                message: "could not fetch the beacon to sign".to_string(),
-                                nested_error: Some(e),
-                            }
-                        })?;
-
-                    match beacon_to_sign {
-                        Some(beacon) => {
-                            info!(
-                                self.logger, "→ Epoch has NOT changed we can sign this beacon, transiting to ReadyToSign";
-                                "beacon_to_sign" => ?beacon,
-                            );
-                            *state = self
-                                .transition_from_ready_to_sign_to_ready_to_sign(*epoch, beacon)
-                                .await?;
-                        }
-                        None => {
-                            info!(self.logger, " ⋅ No beacon to sign, waiting…");
-                        }
-                    }
-                }
-            },
+            SignerState::ReadyToSign { epoch } => self.cycle_ready_to_sign(epoch).await?,
         };
+
+        if let Some(next_state) = next_state_or_skip {
+            *self.state.lock().await = next_state;
+        }
 
         self.metrics_service
             .get_runtime_cycle_success_since_startup_counter()
             .increment();
 
         Ok(())
+    }
+
+    async fn cycle_unregistered(&self, epoch: Epoch) -> Result<Option<SignerState>, RuntimeError> {
+        if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(epoch).await? {
+            info!(
+                self.logger,
+                "→ Epoch has changed, transiting to Unregistered"
+            );
+
+            self.transition_from_unregistered_to_unregistered(new_epoch)
+                .await
+                .map(Some)
+        } else {
+            let signer_registrations = self
+                .runner
+                .get_signer_registrations_from_aggregator()
+                .await
+                .map_err(|e| RuntimeError::KeepState {
+                    message: format!("could not retrieve epoch settings at epoch {epoch:?}"),
+                    nested_error: Some(e),
+                })?;
+            info!(self.logger, "→ Epoch Signer registrations found");
+
+            let network_configuration: MithrilNetworkConfiguration = self
+                .runner
+                .get_mithril_network_configuration(epoch)
+                .await
+                .map_err(|e| RuntimeError::KeepState {
+                    message: format!(
+                        "could not retrieve Mithril network configuration for epoch {epoch:?}"
+                    ),
+                    nested_error: Some(e),
+                })?;
+            info!(self.logger, "→ Mithril network configuration found");
+
+            if signer_registrations.epoch >= epoch {
+                info!(self.logger, "New Epoch found");
+                info!(self.logger, " ⋅ Transiting to Registered");
+
+                self.transition_from_unregistered_to_one_of_registered_states(
+                    signer_registrations.epoch,
+                    network_configuration,
+                    signer_registrations.current_signers,
+                    signer_registrations.next_signers,
+                )
+                .await
+                .map(Some)
+            } else {
+                info!(
+                    self.logger, " ⋅ Signer settings found, but its epoch is behind the known epoch, waiting…";
+                    "network_configuration" => ?network_configuration,
+                    "current_singer" => ?signer_registrations.current_signers,
+                    "next_signer" => ?signer_registrations.next_signers,
+                    "known_epoch" => ?epoch,
+                );
+
+                Ok(None)
+            }
+        }
+    }
+
+    async fn cycle_registered_not_able_to_sign(
+        &self,
+        epoch: Epoch,
+    ) -> Result<Option<SignerState>, RuntimeError> {
+        if let EpochStatus::NewEpoch(new_epoch) = self.has_epoch_changed(epoch).await? {
+            info!(
+                self.logger,
+                " → New Epoch detected, transiting to Unregistered"
+            );
+
+            self.transition_from_registered_not_able_to_sign_to_unregistered(new_epoch)
+                .await
+                .map(Some)
+        } else {
+            info!(self.logger, " ⋅ Epoch has NOT changed, waiting…");
+            Ok(None)
+        }
+    }
+
+    async fn cycle_ready_to_sign(&self, epoch: Epoch) -> Result<Option<SignerState>, RuntimeError> {
+        match self.has_epoch_changed(epoch).await? {
+            EpochStatus::NewEpoch(new_epoch) => {
+                info!(
+                    self.logger,
+                    "→ Epoch has changed, transiting to Unregistered"
+                );
+                self.transition_from_ready_to_sign_to_unregistered(new_epoch)
+                    .await
+                    .map(Some)
+            }
+            EpochStatus::Unchanged(timepoint) => {
+                let beacon_to_sign =
+                    self.runner.get_beacon_to_sign(timepoint).await.map_err(|e| {
+                        RuntimeError::KeepState {
+                            message: "could not fetch the beacon to sign".to_string(),
+                            nested_error: Some(e),
+                        }
+                    })?;
+
+                match beacon_to_sign {
+                    Some(beacon) => {
+                        info!(
+                            self.logger, "→ Epoch has NOT changed we can sign this beacon, transiting to ReadyToSign";
+                            "beacon_to_sign" => ?beacon,
+                        );
+                        self.transition_from_ready_to_sign_to_ready_to_sign(epoch, beacon)
+                            .await
+                            .map(Some)
+                    }
+                    None => {
+                        info!(self.logger, " ⋅ No beacon to sign, waiting…");
+                        Ok(None)
+                    }
+                }
+            }
+        }
     }
 
     /// Return the new epoch if the epoch is different than the given one, otherwise return the current time point.

--- a/mithril-signer/src/runtime/state_machine.rs
+++ b/mithril-signer/src/runtime/state_machine.rs
@@ -383,9 +383,6 @@ impl StateMachine {
                     .record(epoch);
             }
             SignerRegistrationOutcome::RegistrationRoundNotYetOpened => {
-                self.metrics_service
-                    .get_signer_registration_success_since_startup_counter()
-                    .increment();
                 return Ok(SignerState::Unregistered { epoch });
             }
         }
@@ -795,14 +792,14 @@ mod tests {
 
         let metrics_service = state_machine.metrics_service;
         assert_eq!(
-            1,
+            0,
             metrics_service
                 .get_signer_registration_success_since_startup_counter()
                 .get()
         );
 
         assert_eq!(
-            0 as f64,
+            0f64,
             metrics_service
                 .get_signer_registration_success_last_epoch_gauge()
                 .get()

--- a/mithril-signer/src/services/signer_registration/retriever/http.rs
+++ b/mithril-signer/src/services/signer_registration/retriever/http.rs
@@ -6,10 +6,10 @@ use crate::{FromEpochSettingsAdapter, RegisteredSigners};
 
 #[async_trait::async_trait]
 impl SignersRegistrationRetriever for AggregatorHttpClient {
-    async fn retrieve_all_signer_registrations(&self) -> StdResult<Option<RegisteredSigners>> {
+    async fn retrieve_all_signer_registrations(&self) -> StdResult<RegisteredSigners> {
         let message = self.send(GetEpochSettingsQuery::current()).await?;
         let epoch_settings = FromEpochSettingsAdapter::try_adapt(message)?;
 
-        Ok(Some(epoch_settings))
+        Ok(epoch_settings)
     }
 }

--- a/mithril-signer/src/services/signer_registration/retriever/interface.rs
+++ b/mithril-signer/src/services/signer_registration/retriever/interface.rs
@@ -7,5 +7,5 @@ use crate::RegisteredSigners;
 #[async_trait::async_trait]
 pub trait SignersRegistrationRetriever: Sync + Send {
     /// Retrieves signer's registration from the mithril network
-    async fn retrieve_all_signer_registrations(&self) -> StdResult<Option<RegisteredSigners>>;
+    async fn retrieve_all_signer_registrations(&self) -> StdResult<RegisteredSigners>;
 }

--- a/mithril-signer/src/test/double/signer_registration_retriever.rs
+++ b/mithril-signer/src/test/double/signer_registration_retriever.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use tokio::sync::RwLock;
 
 use mithril_common::StdResult;
@@ -21,9 +22,9 @@ impl Default for DumbSignersRegistrationRetriever {
 
 #[async_trait::async_trait]
 impl SignersRegistrationRetriever for DumbSignersRegistrationRetriever {
-    async fn retrieve_all_signer_registrations(&self) -> StdResult<Option<RegisteredSigners>> {
+    async fn retrieve_all_signer_registrations(&self) -> StdResult<RegisteredSigners> {
         let epoch_settings = self.epoch_settings.read().await.clone();
 
-        Ok(epoch_settings)
+        epoch_settings.with_context(|| "No epoch settings set")
     }
 }

--- a/mithril-signer/tests/test_extensions/fake_aggregator_http.rs
+++ b/mithril-signer/tests/test_extensions/fake_aggregator_http.rs
@@ -174,8 +174,7 @@ async fn epoch_settings(state: State<FakeAggregatorRoutesState>) -> Result<Respo
     slog::debug!(state.logger, "/epoch-settings");
 
     if state.store.read().await.withhold_epoch_settings {
-        // Note: aggregator doesn't return NotFound, it returns a 500
-        Ok(StatusCode::NOT_FOUND.into_response())
+        Ok(StatusCode::INTERNAL_SERVER_ERROR.into_response())
     } else {
         let time_point = state.get_time_point().await.map_err(internal_server_error)?;
         let current_signers = state.get_current_signers().await.map_err(internal_server_error)?;


### PR DESCRIPTION
## Content

This PR includes a slight refactor of the Mithril Signer `SignersRegistrationRetriever`, removing the `Option` from the returned type.

The rational is that no called sub-services returns an option (or something similar), even the called `/epoch-settings` route from the aggregator do not returns a `404` if it can't find an epoch setting for the given epoch.

Since this change also impact the state machine (which still had a logic to keep the current state if no signer registrations could be retrieved) I took the opportunity to sightly refactor the state machine, bringing it closer to the latest changes on the aggregator:
- extracted state handling code into dedicated methods instead of putting everyting in `cycle` (`cycle_idle`, `cycle_unregistered`, ...)
- added two domain enum types to make state handling and transition more understable and maintenable: `CycleOutcome` and `SignerRegistrationOutcome`
- slight adjustments to some log messages (`transiting` -> `transitioning`)
- fixed incorrect successful registration metrics increment when registration failed because the aggregator did not had a registration round opened yet

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested
- Documentation
  - [x] No new TODOs introduced

## Issue(s)

Closes #3410
