### PR TITLE
refactor(stm): update PoP, protocol parameters and decoding functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.11.4"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -46,7 +46,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.11.4", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.12.0", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-common/src/protocol/signer_builder.rs
+++ b/mithril-common/src/protocol/signer_builder.rs
@@ -230,7 +230,7 @@ mod test {
         );
 
         match error.downcast_ref::<RegisterError>() {
-            Some(RegisterError::EntryAlreadyRegistered { .. }) => (),
+            Some(RegisterError::EntryAlreadyRegistered) => (),
             _ => panic!("Expected an CoreRegister error, got: {error:?}"),
         }
     }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0 (07-29-2026)
+
+### Added
+
+- Added a `ProtocolError` enum with a `PhiFValueOutOfRange` variant for invalid `phi_f` values
+
+### Changed
+
+- Updated the `from_bytes_legacy` functions for `MerkleTreeBatchCommitment`, `MerkleTree`, `ConcatenationProof` and `SingleSignature`
+- Updated the validation of the `phi_f` value in the lottery/eligibility computations
+- Updated the visibility of `ClosedKeyRegistration`, `RegistrationEntry` and `ClosedRegistrationEntry` to ensure proper verification of the proof of possession
+- Updated `RegisterError::EntryAlreadyRegistered` to no longer carry the conflicting `RegistrationEntry`, since the type is now crate-private
+- Updated `ClosedKeyRegistration::number_of_registered_parties` to be available only when the `future_snark` feature is enabled
+- Updated `ConcatenationProofSigner::check_lottery` to return `StmResult<Vec<u64>>` instead of `Vec<u64>`
+
+### Removed
+
+- Removed the unused `to_bytes` and `from_bytes` methods from `MerkleTree`
+
 ## 0.11.4 (07-27-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.11.4"
+version = "0.12.0"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -69,7 +69,7 @@ use rayon::prelude::*;
 
 use mithril_stm::{
     AggregateSignatureType, AggregationError, AncillaryGenesisData, AncillaryProofInput, Clerk,
-    Initializer, KeyRegistration, Parameters, RegistrationEntry, Signer, SingleSignature,
+    Initializer, KeyRegistration, Parameters, Signer, SingleSignature,
     MithrilMembershipDigest, AggregateVerificationKey,
 };
 
@@ -100,13 +100,12 @@ let mut key_reg = KeyRegistration::initialize();
 let mut ps: Vec<Initializer> = Vec::with_capacity(nparties as usize);
 for stake in parties {
     let p = Initializer::new(params, stake, &mut rng);
-    let entry = RegistrationEntry::new(
-        p.get_verification_key_proof_of_possession_for_concatenation(),
+    key_reg.register(
         p.stake,
+        &p.get_verification_key_proof_of_possession_for_concatenation(),
         #[cfg(feature = "future_snark")] p.schnorr_verification_key,
     )
     .unwrap();
-    key_reg.register_by_entry(&entry).unwrap();
     ps.push(p);
 }
 

--- a/mithril-stm/benches/size_benches.rs
+++ b/mithril-stm/benches/size_benches.rs
@@ -32,7 +32,14 @@ where
     let mut key_reg = KeyRegistration::initialize();
     for stake in parties {
         let p = Initializer::new(params, stake, &mut rng);
-        key_reg.register_by_entry(&p.clone().try_into().unwrap()).unwrap();
+        key_reg
+            .register(
+                stake,
+                &p.get_verification_key_proof_of_possession_for_concatenation(),
+                #[cfg(feature = "future_snark")]
+                p.schnorr_verification_key,
+            )
+            .unwrap();
         ps.push(p);
     }
 

--- a/mithril-stm/benches/stm.rs
+++ b/mithril-stm/benches/stm.rs
@@ -44,7 +44,14 @@ fn stm_benches<D: MembershipDigest>(
             // We need to initialise the key_reg at each iteration
             key_reg = KeyRegistration::initialize();
             for p in initializers.iter() {
-                key_reg.register_by_entry(&p.clone().try_into().unwrap()).unwrap();
+                key_reg
+                    .register(
+                        p.stake,
+                        &p.get_verification_key_proof_of_possession_for_concatenation(),
+                        #[cfg(feature = "future_snark")]
+                        p.schnorr_verification_key,
+                    )
+                    .unwrap();
             }
         })
     });
@@ -136,7 +143,14 @@ fn batch_benches<D>(
             }
             let mut key_reg = KeyRegistration::initialize();
             for p in initializers.iter() {
-                key_reg.register_by_entry(&p.clone().try_into().unwrap()).unwrap();
+                key_reg
+                    .register(
+                        p.stake,
+                        &p.get_verification_key_proof_of_possession_for_concatenation(),
+                        #[cfg(feature = "future_snark")]
+                        p.schnorr_verification_key,
+                    )
+                    .unwrap();
             }
 
             let closed_reg = key_reg.close_registration(&params).unwrap();

--- a/mithril-stm/examples/key_registration.rs
+++ b/mithril-stm/examples/key_registration.rs
@@ -7,7 +7,7 @@ use rand_core::{RngCore, SeedableRng};
 use mithril_stm::{
     AggregateSignature, AggregateSignatureType, AncillaryGenesisData, AncillaryProofInput, Clerk,
     ClosedKeyRegistration, Initializer, KeyRegistration, MithrilMembershipDigest, Parameters,
-    RegistrationEntry, Stake, VerificationKeyProofOfPossessionForConcatenation,
+    Stake, VerificationKeyProofOfPossessionForConcatenation,
 };
 
 type D = MithrilMembershipDigest;
@@ -236,14 +236,14 @@ fn local_reg(
     };
     // data, such as the public key, stake and id.
     for (pk, _) in pks.iter().zip(ids.iter()) {
-        let entry = RegistrationEntry::new(
-            *pk,
-            1,
-            #[cfg(feature = "future_snark")]
-            None,
-        )
-        .unwrap();
-        local_keyreg.register_by_entry(&entry).unwrap();
+        local_keyreg
+            .register(
+                1,
+                pk,
+                #[cfg(feature = "future_snark")]
+                None,
+            )
+            .unwrap();
     }
     local_keyreg.close_registration(&params).unwrap()
 }

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! use mithril_stm::{
 //!    AggregateSignatureType, AggregationError, AncillaryGenesisData, AncillaryProofInput, Clerk,
-//!    Initializer, KeyRegistration, Parameters, RegistrationEntry, Signer, SingleSignature,
+//!    Initializer, KeyRegistration, Parameters, Signer, SingleSignature,
 //!    MithrilMembershipDigest,
 //! };
 //!
@@ -59,13 +59,12 @@
 //!     // Create keys for this party
 //!     let p = Initializer::new(params, stake, &mut rng);
 //!     // Register keys with the KeyRegistration service
-//!     let entry = RegistrationEntry::new(
-//!         p.get_verification_key_proof_of_possession_for_concatenation(),
+//!     key_reg.register(
 //!         p.stake,
+//!         &p.get_verification_key_proof_of_possession_for_concatenation(),
 //!        #[cfg(feature = "future_snark")] p.schnorr_verification_key,
 //!     )
 //!     .unwrap();
-//!     key_reg.register_by_entry(&entry).unwrap();
 //!     ps.push(p);
 //! }
 //!

--- a/mithril-stm/src/lib.rs
+++ b/mithril-stm/src/lib.rs
@@ -147,14 +147,15 @@ mod protocol;
 mod signature_scheme;
 
 pub use proof_system::AggregateVerificationKeyForConcatenation;
+pub(crate) use protocol::RegistrationEntry;
 pub use protocol::{
     AggregateSignature, AggregateSignatureError, AggregateSignatureType, AggregateVerificationKey,
     AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProofOutput,
     AncillaryProverData, AncillaryVerifierData, Clerk, ClosedKeyRegistration,
     ClosedRegistrationEntry, GenesisVerificationKeyBundle, Initializer, KeyRegistration,
-    Parameters, RegisterError, RegistrationEntry, RegistrationEntryForConcatenation,
-    SignatureError, Signer, SingleSignature, SingleSignatureWithRegisteredParty,
-    VerificationKeyForConcatenation, VerificationKeyProofOfPossessionForConcatenation,
+    Parameters, RegisterError, RegistrationEntryForConcatenation, SignatureError, Signer,
+    SingleSignature, SingleSignatureWithRegisteredParty, VerificationKeyForConcatenation,
+    VerificationKeyProofOfPossessionForConcatenation,
 };
 pub use signature_scheme::BlsSignatureError;
 

--- a/mithril-stm/src/membership_commitment/merkle_tree/commitment.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/commitment.rs
@@ -176,12 +176,23 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTreeBatchCommitment<D, L>
             )));
         }
 
-        let nr_nodes = self.nr_leaves + self.nr_leaves.next_power_of_two() - 1;
+        let nr_nodes = self
+            .nr_leaves
+            .checked_next_power_of_two()
+            .and_then(|nr_nodes| nr_nodes.checked_add(self.nr_leaves))
+            .and_then(|nr_nodes| nr_nodes.checked_sub(1))
+            .ok_or(MerkleTreeError::SerializationError)?;
 
         ordered_indices = ordered_indices
             .into_iter()
-            .map(|i| i + self.nr_leaves.next_power_of_two() - 1)
-            .collect();
+            .map(|i| {
+                self.nr_leaves
+                    .checked_next_power_of_two()
+                    .and_then(|idx| idx.checked_add(i))
+                    .and_then(|idx| idx.checked_sub(1))
+                    .ok_or(MerkleTreeError::SerializationError)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let mut idx = ordered_indices[0];
         // First we need to hash the leave values

--- a/mithril-stm/src/membership_commitment/merkle_tree/commitment.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/commitment.rs
@@ -183,12 +183,15 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTreeBatchCommitment<D, L>
             .and_then(|nr_nodes| nr_nodes.checked_sub(1))
             .ok_or(MerkleTreeError::SerializationError)?;
 
+        let nr_leaves_next_pow_2 = self
+            .nr_leaves
+            .checked_next_power_of_two()
+            .ok_or(MerkleTreeError::SerializationError)?;
         ordered_indices = ordered_indices
             .into_iter()
             .map(|i| {
-                self.nr_leaves
-                    .checked_next_power_of_two()
-                    .and_then(|idx| idx.checked_add(i))
+                nr_leaves_next_pow_2
+                    .checked_add(i)
                     .and_then(|idx| idx.checked_sub(1))
                     .ok_or(MerkleTreeError::SerializationError)
             })

--- a/mithril-stm/src/membership_commitment/merkle_tree/commitment.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/commitment.rs
@@ -176,17 +176,16 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTreeBatchCommitment<D, L>
             )));
         }
 
-        let nr_nodes = self
-            .nr_leaves
-            .checked_next_power_of_two()
-            .and_then(|nr_nodes| nr_nodes.checked_add(self.nr_leaves))
-            .and_then(|nr_nodes| nr_nodes.checked_sub(1))
-            .ok_or(MerkleTreeError::SerializationError)?;
-
         let nr_leaves_next_pow_2 = self
             .nr_leaves
             .checked_next_power_of_two()
             .ok_or(MerkleTreeError::SerializationError)?;
+
+        let nr_nodes = nr_leaves_next_pow_2
+            .checked_add(self.nr_leaves)
+            .and_then(|nr_nodes| nr_nodes.checked_sub(1))
+            .ok_or(MerkleTreeError::SerializationError)?;
+
         ordered_indices = ordered_indices
             .into_iter()
             .map(|i| {
@@ -197,7 +196,11 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTreeBatchCommitment<D, L>
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let mut idx = ordered_indices[0];
+        let mut idx = ordered_indices
+            .first()
+            .copied()
+            .ok_or(MerkleTreeError::SerializationError)
+            .with_context(|| "The ordered indices list is empty.")?;
         // First we need to hash the leave values
         let mut leaves: Vec<Vec<u8>> = batch_val
             .iter()

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -167,22 +167,32 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
         u64_bytes.copy_from_slice(bytes.get(..8).ok_or(MerkleTreeError::SerializationError)?);
         let n = usize::try_from(u64::from_be_bytes(u64_bytes))
             .map_err(|_| MerkleTreeError::SerializationError)?;
-        let num_nodes = n + n.next_power_of_two() - 1;
-        let mut nodes = Vec::with_capacity(num_nodes);
+        let num_nodes = n
+            .checked_next_power_of_two()
+            .and_then(|num_nodes| num_nodes.checked_add(n))
+            .and_then(|num_nodes| num_nodes.checked_sub(1))
+            .ok_or(MerkleTreeError::SerializationError)?;
+        let mut nodes = Vec::new();
         for i in 0..num_nodes {
+            let range_low = i
+                .checked_mul(<D as Digest>::output_size())
+                .and_then(|rl| rl.checked_add(16))
+                .ok_or(MerkleTreeError::SerializationError)?;
+            let range_high = i
+                .checked_add(1)
+                .and_then(|rh| rh.checked_mul(<D as Digest>::output_size()))
+                .and_then(|rh| rh.checked_add(16))
+                .ok_or(MerkleTreeError::SerializationError)?;
             nodes.push(
                 bytes
-                    .get(
-                        8 + i * <D as Digest>::output_size()
-                            ..8 + (i + 1) * <D as Digest>::output_size(),
-                    )
+                    .get(range_low..range_high)
                     .ok_or(MerkleTreeError::SerializationError)?
                     .to_vec(),
             );
         }
         Ok(Self {
             nodes,
-            leaf_off: num_nodes - n,
+            leaf_off: num_nodes.checked_sub(n).ok_or(MerkleTreeError::SerializationError)?,
             n,
             hasher: PhantomData,
             leaves: PhantomData,

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -3,9 +3,6 @@ use std::marker::PhantomData;
 use digest::{Digest, FixedOutput};
 use serde::{Deserialize, Serialize};
 
-use crate::{StmResult, codec};
-
-use super::MerkleTreeError;
 use super::{
     MerkleBatchPath, MerkleTreeBatchCommitment, MerkleTreeLeaf, left_child, parent, right_child,
     sibling,
@@ -144,62 +141,6 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
         MerkleBatchPath::new(proof, indices)
     }
 
-    /// Convert a `MerkleTree` into a byte string.
-    #[allow(dead_code)]
-    pub fn to_bytes(&self) -> StmResult<Vec<u8>> {
-        codec::to_cbor_bytes(self)
-    }
-
-    /// Try to convert a byte string into a `MerkleTree`.
-    /// # Error
-    /// It returns error if conversion fails.
-    #[allow(dead_code)]
-    pub fn from_bytes(bytes: &[u8]) -> StmResult<Self> {
-        codec::from_versioned_bytes(bytes, Self::from_bytes_legacy)
-    }
-
-    /// Try to convert a byte string into a `MerkleTree` using the legacy format.
-    /// # Layout
-    /// * Number of leaves committed in the Merkle Tree (as u64)
-    /// * All nodes of the merkle tree (starting with the root)
-    #[allow(dead_code)]
-    fn from_bytes_legacy(bytes: &[u8]) -> StmResult<Self> {
-        let mut u64_bytes = [0u8; 8];
-        u64_bytes.copy_from_slice(bytes.get(..8).ok_or(MerkleTreeError::SerializationError)?);
-        let n = usize::try_from(u64::from_be_bytes(u64_bytes))
-            .map_err(|_| MerkleTreeError::SerializationError)?;
-        let num_nodes = n
-            .checked_next_power_of_two()
-            .and_then(|num_nodes| num_nodes.checked_add(n))
-            .and_then(|num_nodes| num_nodes.checked_sub(1))
-            .ok_or(MerkleTreeError::SerializationError)?;
-        let mut nodes = Vec::new();
-        for i in 0..num_nodes {
-            let range_low = i
-                .checked_mul(<D as Digest>::output_size())
-                .and_then(|rl| rl.checked_add(8))
-                .ok_or(MerkleTreeError::SerializationError)?;
-            let range_high = i
-                .checked_add(1)
-                .and_then(|rh| rh.checked_mul(<D as Digest>::output_size()))
-                .and_then(|rh| rh.checked_add(8))
-                .ok_or(MerkleTreeError::SerializationError)?;
-            nodes.push(
-                bytes
-                    .get(range_low..range_high)
-                    .ok_or(MerkleTreeError::SerializationError)?
-                    .to_vec(),
-            );
-        }
-        Ok(Self {
-            nodes,
-            leaf_off: num_nodes.checked_sub(n).ok_or(MerkleTreeError::SerializationError)?,
-            n,
-            hasher: PhantomData,
-            leaves: PhantomData,
-        })
-    }
-
     #[cfg(feature = "future_snark")]
     /// Convert merkle tree to a commitment. This function simply returns the root.
     pub(crate) fn to_merkle_tree_commitment(&self) -> MerkleTreeCommitment<D, L> {
@@ -318,14 +259,6 @@ mod tests {
 
                 let tree_commitment = MerkleTree::<ConcatenationHash, MerkleTreeConcatenationLeaf>::new(&values).to_merkle_tree_commitment();
                 assert_eq!(tree_commitment.root, decoded.root);
-            }
-
-            #[test]
-            fn test_bytes_tree((t, values) in arb_tree(5)) {
-                let bytes = t.to_bytes().expect("MerkleTree serialization should not fail");
-                let deserialised = MerkleTree::<ConcatenationHash, MerkleTreeConcatenationLeaf>::from_bytes(&bytes).unwrap();
-                let tree = MerkleTree::<ConcatenationHash, MerkleTreeConcatenationLeaf>::new(&values);
-                assert_eq!(tree.nodes, deserialised.nodes);
             }
 
             #[cfg(feature = "future_snark")]
@@ -514,70 +447,6 @@ mod tests {
                 assert_eq!(golden_serialized, serialized);
             }
         }
-
-        mod golden_cbor {
-            use super::*;
-
-            fn golden_value() -> MerkleTree<ConcatenationHash, MerkleTreeConcatenationLeaf> {
-                let number_of_leaves = 4;
-                let pks = vec![VerificationKeyForConcatenation::default(); number_of_leaves];
-                let stakes: Vec<u64> = (0..number_of_leaves).map(|i| i as u64).collect();
-                let leaves = pks
-                    .into_iter()
-                    .zip(stakes)
-                    .map(|(key, stake)| MerkleTreeConcatenationLeaf(key, stake))
-                    .collect::<Vec<MerkleTreeConcatenationLeaf>>();
-
-                MerkleTree::<ConcatenationHash, MerkleTreeConcatenationLeaf>::new(&leaves)
-            }
-
-            const GOLDEN_CBOR_BYTES: &[u8; 485] = &[
-                1, 165, 101, 110, 111, 100, 101, 115, 135, 152, 32, 24, 178, 24, 30, 24, 231, 24,
-                127, 24, 65, 24, 247, 24, 162, 24, 149, 24, 33, 24, 29, 24, 147, 24, 148, 24, 224,
-                24, 156, 24, 96, 24, 113, 24, 140, 24, 42, 24, 98, 24, 166, 24, 137, 14, 24, 69,
-                24, 29, 24, 28, 24, 244, 24, 161, 24, 145, 24, 207, 24, 146, 24, 236, 24, 249, 152,
-                32, 24, 135, 24, 51, 24, 101, 24, 36, 24, 82, 24, 28, 24, 47, 24, 190, 24, 104, 24,
-                152, 24, 106, 24, 167, 24, 128, 24, 167, 22, 24, 36, 24, 125, 24, 91, 24, 137, 24,
-                208, 24, 224, 14, 24, 82, 24, 41, 24, 130, 24, 214, 24, 108, 24, 254, 24, 77, 24,
-                44, 24, 160, 24, 117, 152, 32, 24, 75, 24, 152, 24, 193, 24, 39, 24, 81, 24, 31,
-                24, 79, 24, 34, 24, 232, 24, 192, 24, 38, 24, 94, 24, 109, 24, 160, 24, 171, 24,
-                148, 24, 173, 24, 203, 24, 85, 24, 33, 24, 116, 20, 24, 62, 24, 51, 1, 24, 112, 24,
-                227, 4, 24, 226, 24, 56, 24, 30, 24, 27, 152, 32, 24, 133, 24, 163, 24, 160, 24,
-                181, 24, 171, 24, 82, 24, 229, 24, 168, 24, 80, 24, 193, 24, 182, 24, 163, 24, 172,
-                24, 80, 24, 114, 21, 24, 169, 24, 159, 24, 100, 24, 68, 24, 217, 24, 39, 24, 34,
-                24, 37, 24, 155, 24, 218, 24, 120, 24, 101, 24, 51, 24, 25, 24, 43, 24, 84, 152,
-                32, 24, 57, 20, 24, 139, 24, 83, 24, 194, 24, 218, 24, 202, 24, 66, 24, 139, 24,
-                49, 24, 144, 24, 148, 24, 132, 6, 2, 24, 97, 24, 112, 24, 38, 24, 29, 24, 60, 24,
-                139, 24, 233, 24, 189, 24, 95, 24, 168, 24, 204, 24, 84, 24, 33, 24, 201, 24, 140,
-                23, 22, 152, 32, 24, 102, 24, 192, 24, 198, 24, 230, 0, 24, 203, 24, 217, 24, 240,
-                24, 214, 24, 244, 24, 135, 24, 236, 24, 49, 24, 219, 24, 229, 14, 24, 209, 24, 46,
-                24, 61, 24, 237, 24, 28, 24, 195, 24, 231, 24, 61, 24, 214, 24, 51, 24, 59, 24, 39,
-                24, 186, 24, 114, 24, 64, 24, 107, 152, 32, 24, 128, 24, 78, 24, 52, 24, 132, 24,
-                35, 24, 118, 24, 64, 24, 83, 24, 60, 24, 38, 24, 181, 24, 197, 24, 144, 24, 188,
-                24, 235, 24, 225, 2, 24, 223, 24, 135, 24, 104, 24, 193, 24, 226, 24, 148, 24, 170,
-                24, 114, 24, 26, 24, 173, 24, 161, 24, 34, 24, 70, 24, 241, 24, 90, 104, 108, 101,
-                97, 102, 95, 111, 102, 102, 3, 97, 110, 4, 102, 104, 97, 115, 104, 101, 114, 246,
-                102, 108, 101, 97, 118, 101, 115, 246,
-            ];
-
-            #[test]
-            fn cbor_golden_bytes_can_be_decoded() {
-                let decoded =
-                    MerkleTree::<ConcatenationHash, MerkleTreeConcatenationLeaf>::from_bytes(
-                        GOLDEN_CBOR_BYTES,
-                    )
-                    .expect("CBOR golden bytes deserialization should not fail");
-                assert_eq!(golden_value().nodes, decoded.nodes);
-                assert_eq!(golden_value().n, decoded.n);
-                assert_eq!(golden_value().leaf_off, decoded.leaf_off);
-            }
-
-            #[test]
-            fn cbor_encoding_is_stable() {
-                let bytes = golden_value().to_bytes().expect("CBOR serialization should not fail");
-                assert_eq!(GOLDEN_CBOR_BYTES.as_slice(), bytes.as_slice());
-            }
-        }
     }
 
     #[cfg(feature = "future_snark")]
@@ -689,15 +558,6 @@ mod tests {
 
                 let tree_commitment = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&values).to_merkle_tree_commitment();
                 assert_eq!(tree_commitment.root, decoded.root);
-            }
-
-            #[cfg(feature = "future_snark")]
-            #[test]
-            fn test_bytes_tree((t, values) in arb_tree_poseidon(5)) {
-                let bytes = t.to_bytes().expect("MerkleTree serialization should not fail");
-                let deserialised = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::from_bytes(&bytes).unwrap();
-                let tree = MerkleTree::<SnarkHash, MerkleTreeSnarkLeaf>::new(&values);
-                assert_eq!(tree.nodes, deserialised.nodes);
             }
         }
 

--- a/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
+++ b/mithril-stm/src/membership_commitment/merkle_tree/tree.rs
@@ -3,16 +3,14 @@ use std::marker::PhantomData;
 use digest::{Digest, FixedOutput};
 use serde::{Deserialize, Serialize};
 
-use crate::StmResult;
-use crate::codec;
+use crate::{StmResult, codec};
 
+use super::MerkleTreeError;
 use super::{
-    MerkleBatchPath, MerkleTreeBatchCommitment, MerkleTreeError, MerkleTreeLeaf, left_child,
-    parent, right_child, sibling,
+    MerkleBatchPath, MerkleTreeBatchCommitment, MerkleTreeLeaf, left_child, parent, right_child,
+    sibling,
 };
 #[cfg(feature = "future_snark")]
-// TODO: remove this allow dead_code directive when function is called or future_snark is activated
-#[allow(dead_code)]
 use super::{MerklePath, MerkleTreeCommitment};
 
 /// Tree of hashes, providing a commitment of data and its ordering.
@@ -147,6 +145,7 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
     }
 
     /// Convert a `MerkleTree` into a byte string.
+    #[allow(dead_code)]
     pub fn to_bytes(&self) -> StmResult<Vec<u8>> {
         codec::to_cbor_bytes(self)
     }
@@ -154,6 +153,7 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
     /// Try to convert a byte string into a `MerkleTree`.
     /// # Error
     /// It returns error if conversion fails.
+    #[allow(dead_code)]
     pub fn from_bytes(bytes: &[u8]) -> StmResult<Self> {
         codec::from_versioned_bytes(bytes, Self::from_bytes_legacy)
     }
@@ -162,6 +162,7 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
     /// # Layout
     /// * Number of leaves committed in the Merkle Tree (as u64)
     /// * All nodes of the merkle tree (starting with the root)
+    #[allow(dead_code)]
     fn from_bytes_legacy(bytes: &[u8]) -> StmResult<Self> {
         let mut u64_bytes = [0u8; 8];
         u64_bytes.copy_from_slice(bytes.get(..8).ok_or(MerkleTreeError::SerializationError)?);
@@ -176,12 +177,12 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
         for i in 0..num_nodes {
             let range_low = i
                 .checked_mul(<D as Digest>::output_size())
-                .and_then(|rl| rl.checked_add(16))
+                .and_then(|rl| rl.checked_add(8))
                 .ok_or(MerkleTreeError::SerializationError)?;
             let range_high = i
                 .checked_add(1)
                 .and_then(|rh| rh.checked_mul(<D as Digest>::output_size()))
-                .and_then(|rh| rh.checked_add(16))
+                .and_then(|rh| rh.checked_add(8))
                 .ok_or(MerkleTreeError::SerializationError)?;
             nodes.push(
                 bytes
@@ -200,16 +201,12 @@ impl<D: Digest + FixedOutput, L: MerkleTreeLeaf> MerkleTree<D, L> {
     }
 
     #[cfg(feature = "future_snark")]
-    // TODO: remove this allow dead_code directive when function is called or future_snark is activated
-    #[allow(dead_code)]
     /// Convert merkle tree to a commitment. This function simply returns the root.
     pub(crate) fn to_merkle_tree_commitment(&self) -> MerkleTreeCommitment<D, L> {
         MerkleTreeCommitment::new(self.nodes[0].clone()) // Use private constructor
     }
 
     #[cfg(feature = "future_snark")]
-    // TODO: remove this allow dead_code directive when function is called or future_snark is activated
-    #[allow(dead_code)]
     /// Get a path (hashes of siblings of the path to the root node)
     /// for the `i`th value stored in the tree.
     /// Requires `i < self.n`

--- a/mithril-stm/src/proof_system/concatenation/aggregate_key.rs
+++ b/mithril-stm/src/proof_system/concatenation/aggregate_key.rs
@@ -77,7 +77,7 @@ impl<D: MembershipDigest> From<&ClosedKeyRegistration>
             mt_commitment: reg
                 .to_merkle_tree::<D::ConcatenationHash, RegistrationEntryForConcatenation>()
                 .to_merkle_tree_batch_commitment(),
-            total_stake: reg.total_stake,
+            total_stake: reg.get_total_stake(),
         }
     }
 }

--- a/mithril-stm/src/proof_system/concatenation/eligibility.rs
+++ b/mithril-stm/src/proof_system/concatenation/eligibility.rs
@@ -1,4 +1,4 @@
-use crate::{PhiFValue, Stake, StmResult, protocol::ProtocolError};
+use crate::{PhiFValue, RegisterError, Stake, StmResult, protocol::ProtocolError};
 
 cfg_num_integer! {
     use num_bigint::{BigInt, Sign};
@@ -31,6 +31,10 @@ cfg_num_integer! {
     /// Used to determine winning lottery tickets.
     #[allow(clippy::unnecessary_lazy_evaluations)]
     pub(crate) fn is_lottery_won(phi_f: PhiFValue, ev: [u8; 64], stake: Stake, total_stake: Stake) -> StmResult<bool> {
+        if total_stake == 0 {
+            return Err(RegisterError::ZeroTotalStake.into());
+        }
+
         // If phi_f = 1, then we automatically break with true
         if (phi_f - 1.0).abs() < PhiFValue::EPSILON {
             return Ok(true);
@@ -40,6 +44,9 @@ cfg_num_integer! {
 
         let ev_max = BigInt::from(2u8).pow(512);
         let ev = BigInt::from_bytes_le(Sign::Plus, &ev);
+        if ev == ev_max {
+            return Ok(false);
+        }
         let q = Ratio::new_raw(ev_max.clone(), ev_max - ev);
 
         let c =
@@ -96,6 +103,10 @@ cfg_rug! {
     /// decimal digits (in order to represent the 4.5e16 ada without any rounding errors, we need
     /// double that precision).
     pub(crate) fn is_lottery_won(phi_f: PhiFValue, ev: [u8; 64], stake: Stake, total_stake: Stake) -> StmResult<bool> {
+        if total_stake == 0 {
+            return Err(RegisterError::ZeroTotalStake.into());
+        }
+
         // If phi_f = 1, then we automatically break with true
         if (phi_f - 1.0).abs() < PhiFValue::EPSILON {
             return Ok(true);
@@ -182,5 +193,35 @@ mod tests {
                 "Unexpected error: {result:?}"
             );
         }
+    }
+
+    #[test]
+    fn is_lottery_won_rejects_zero_total_stake() {
+        let ev = [0u8; 64];
+        let stake = 100;
+        let total_stake = 0;
+        let phi_f = 0.8f64;
+
+        let result = is_lottery_won(phi_f, ev, stake, total_stake)
+            .expect_err("The lottery check should fail.");
+        assert!(
+            matches!(
+                result.downcast_ref::<RegisterError>(),
+                Some(RegisterError::ZeroTotalStake)
+            ),
+            "Unexpected error: {result:?}"
+        );
+    }
+
+    #[test]
+    fn is_lottery_won_rejects_max_ev_value() {
+        let ev = [255u8; 64];
+        let stake = 100;
+        let total_stake = 1000;
+        let phi_f = 0.8f64;
+
+        let result = is_lottery_won(phi_f, ev, stake, total_stake).unwrap();
+
+        assert!(!result);
     }
 }

--- a/mithril-stm/src/proof_system/concatenation/eligibility.rs
+++ b/mithril-stm/src/proof_system/concatenation/eligibility.rs
@@ -1,6 +1,4 @@
-use anyhow::anyhow;
-
-use crate::{PhiFValue, Stake, StmResult};
+use crate::{PhiFValue, Stake, StmResult, protocol::ProtocolError};
 
 cfg_num_integer! {
     use num_bigint::{BigInt, Sign};
@@ -36,7 +34,7 @@ cfg_num_integer! {
         if (phi_f - 1.0).abs() < PhiFValue::EPSILON {
             return Ok(true);
         } else if !(phi_f > 0.0 && phi_f <= 1.0) {
-            return Err(anyhow!("phi_f must be in the range (0, 1], got {phi_f}"));
+            return Err(ProtocolError::PhiFValueOutOfRange(phi_f).into());
         }
 
         let ev_max = BigInt::from(2u8).pow(512);
@@ -44,7 +42,7 @@ cfg_num_integer! {
         let q = Ratio::new_raw(ev_max.clone(), ev_max - ev);
 
         let c =
-            Ratio::from_float((1.0 - phi_f).ln()).ok_or_else(|| anyhow!("phi_f must not be infinite or NaN, got {phi_f}"))?;
+            Ratio::from_float((1.0 - phi_f).ln()).ok_or_else(|| ProtocolError::PhiFValueOutOfRange(phi_f))?;
         let w = Ratio::new_raw(BigInt::from(stake), BigInt::from(total_stake));
         let x = (w * c).neg();
 
@@ -101,7 +99,7 @@ cfg_rug! {
         if (phi_f - 1.0).abs() < PhiFValue::EPSILON {
             return Ok(true);
         } else if !(phi_f > 0.0 && phi_f <= 1.0) {
-            return Err(anyhow!("phi_f must be in the range (0, 1], got {phi_f}"));
+            return Err(ProtocolError::PhiFValueOutOfRange(phi_f).into());
         }
         let ev = rug::Integer::from_digits(&ev, Order::LsfLe);
         let ev_max: Float = Float::with_val(117, 2).pow(512);
@@ -173,9 +171,14 @@ mod tests {
         let total_stake = 1000;
 
         for invalid_phi_f in [-0.5, 0.0, 1.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let result = is_lottery_won(invalid_phi_f, ev, stake, total_stake)
+                .expect_err("The lottery check should fail.");
             assert!(
-                is_lottery_won(invalid_phi_f, ev, stake, total_stake).is_err(),
-                "phi_f = {invalid_phi_f} should be rejected"
+                matches!(
+                    result.downcast_ref::<ProtocolError>(),
+                    Some(ProtocolError::PhiFValueOutOfRange(..))
+                ),
+                "Unexpected error: {result:?}"
             );
         }
     }

--- a/mithril-stm/src/proof_system/concatenation/eligibility.rs
+++ b/mithril-stm/src/proof_system/concatenation/eligibility.rs
@@ -29,6 +29,7 @@ cfg_num_integer! {
     ///                 1 - p    1 - (ev / evMax)    (evMax - ev)
     ///
     /// Used to determine winning lottery tickets.
+    #[allow(clippy::unnecessary_lazy_evaluations)]
     pub(crate) fn is_lottery_won(phi_f: PhiFValue, ev: [u8; 64], stake: Stake, total_stake: Stake) -> StmResult<bool> {
         // If phi_f = 1, then we automatically break with true
         if (phi_f - 1.0).abs() < PhiFValue::EPSILON {

--- a/mithril-stm/src/proof_system/concatenation/eligibility.rs
+++ b/mithril-stm/src/proof_system/concatenation/eligibility.rs
@@ -1,4 +1,6 @@
-use crate::{PhiFValue, Stake};
+use anyhow::anyhow;
+
+use crate::{PhiFValue, Stake, StmResult};
 
 cfg_num_integer! {
     use num_bigint::{BigInt, Sign};
@@ -29,10 +31,12 @@ cfg_num_integer! {
     ///                 1 - p    1 - (ev / evMax)    (evMax - ev)
     ///
     /// Used to determine winning lottery tickets.
-    pub(crate) fn is_lottery_won(phi_f: PhiFValue, ev: [u8; 64], stake: Stake, total_stake: Stake) -> bool {
+    pub(crate) fn is_lottery_won(phi_f: PhiFValue, ev: [u8; 64], stake: Stake, total_stake: Stake) -> StmResult<bool> {
         // If phi_f = 1, then we automatically break with true
         if (phi_f - 1.0).abs() < PhiFValue::EPSILON {
-            return true;
+            return Ok(true);
+        } else if !(phi_f > 0.0 && phi_f <= 1.0) {
+            return Err(anyhow!("phi_f must be in the range (0, 1], got {phi_f}"));
         }
 
         let ev_max = BigInt::from(2u8).pow(512);
@@ -40,12 +44,12 @@ cfg_num_integer! {
         let q = Ratio::new_raw(ev_max.clone(), ev_max - ev);
 
         let c =
-            Ratio::from_float((1.0 - phi_f).ln()).expect("Only fails if the float is infinite or NaN.");
+            Ratio::from_float((1.0 - phi_f).ln()).ok_or_else(|| anyhow!("phi_f must not be infinite or NaN, got {phi_f}"))?;
         let w = Ratio::new_raw(BigInt::from(stake), BigInt::from(total_stake));
         let x = (w * c).neg();
 
         // Now we compute a taylor function that breaks when the result is known.
-        taylor_comparison(1000, q, x)
+        Ok(taylor_comparison(1000, q, x))
     }
 
     /// Checks if cmp < exp(x). Uses error approximation for an early stop. Whenever the value being
@@ -92,10 +96,12 @@ cfg_rug! {
     /// order to keep the error in the 1e-17 range, we need to carry out the computations with 34
     /// decimal digits (in order to represent the 4.5e16 ada without any rounding errors, we need
     /// double that precision).
-    pub(crate) fn is_lottery_won(phi_f: PhiFValue, ev: [u8; 64], stake: Stake, total_stake: Stake) -> bool {
+    pub(crate) fn is_lottery_won(phi_f: PhiFValue, ev: [u8; 64], stake: Stake, total_stake: Stake) -> StmResult<bool> {
         // If phi_f = 1, then we automatically break with true
         if (phi_f - 1.0).abs() < PhiFValue::EPSILON {
-            return true;
+            return Ok(true);
+        } else if !(phi_f > 0.0 && phi_f <= 1.0) {
+            return Err(anyhow!("phi_f must be in the range (0, 1], got {phi_f}"));
         }
         let ev = rug::Integer::from_digits(&ev, Order::LsfLe);
         let ev_max: Float = Float::with_val(117, 2).pow(512);
@@ -104,7 +110,7 @@ cfg_rug! {
         let w = Float::with_val(117, stake) / Float::with_val(117, total_stake);
         let phi = Float::with_val(117, 1.0) - Float::with_val(117, 1.0 - phi_f).pow(w);
 
-        q < phi
+        Ok(q < phi)
     }
 }
 
@@ -142,7 +148,7 @@ mod tests {
             ev.copy_from_slice(&[&ev_1[..], &ev_2[..]].concat());
 
             let quick_result = trivial_is_lottery_won(phi_f, ev, stake, total_stake);
-            let result = is_lottery_won(phi_f, ev, stake, total_stake);
+            let result = is_lottery_won(phi_f, ev, stake, total_stake).unwrap();
             assert_eq!(quick_result, result);
         }
 
@@ -157,6 +163,20 @@ mod tests {
             let cmp_p = Ratio::from_float(exponential + 2e-10_f64).unwrap();
             assert!(taylor_comparison(1000, cmp_n, Ratio::from_float(x).unwrap()));
             assert!(!taylor_comparison(1000, cmp_p, Ratio::from_float(x).unwrap()));
+        }
+    }
+
+    #[test]
+    fn is_lottery_won_rejects_out_of_range_phi_f() {
+        let ev = [0u8; 64];
+        let stake = 100;
+        let total_stake = 1000;
+
+        for invalid_phi_f in [-0.5, 0.0, 1.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                is_lottery_won(invalid_phi_f, ev, stake, total_stake).is_err(),
+                "phi_f = {invalid_phi_f} should be rejected"
+            );
         }
     }
 }

--- a/mithril-stm/src/proof_system/concatenation/proof.rs
+++ b/mithril-stm/src/proof_system/concatenation/proof.rs
@@ -282,21 +282,27 @@ impl<D: MembershipDigest> ConcatenationProof<D> {
             .map_err(|_| AggregateSignatureError::SerializationError)?;
         bytes_index += 8;
 
-        let mut sig_reg_list = Vec::with_capacity(total_sigs);
+        let mut sig_reg_list = Vec::new();
         for _ in 0..total_sigs {
+            let size_field_end = bytes_index
+                .checked_add(8)
+                .ok_or(AggregateSignatureError::SerializationError)?;
             u64_bytes.copy_from_slice(
                 bytes
-                    .get(bytes_index..bytes_index + 8)
+                    .get(bytes_index..size_field_end)
                     .ok_or(AggregateSignatureError::SerializationError)?,
             );
             let sig_reg_size = usize::try_from(u64::from_be_bytes(u64_bytes))
                 .map_err(|_| AggregateSignatureError::SerializationError)?;
+            let sig_reg_end = size_field_end
+                .checked_add(sig_reg_size)
+                .ok_or(AggregateSignatureError::SerializationError)?;
             let sig_reg = SingleSignatureWithRegisteredParty::from_bytes::<D>(
                 bytes
-                    .get(bytes_index + 8..bytes_index + 8 + sig_reg_size)
+                    .get(size_field_end..sig_reg_end)
                     .ok_or(AggregateSignatureError::SerializationError)?,
             )?;
-            bytes_index += 8 + sig_reg_size;
+            bytes_index = sig_reg_end;
             sig_reg_list.push(sig_reg);
         }
 

--- a/mithril-stm/src/proof_system/concatenation/signer.rs
+++ b/mithril-stm/src/proof_system/concatenation/signer.rs
@@ -60,7 +60,7 @@ impl<D: MembershipDigest> ConcatenationProofSigner<D> {
             self.key_registration_commitment.concatenate_with_message(message);
 
         let sigma = self.signing_key.sign(&message_with_commitment);
-        let indices = self.check_lottery(&message_with_commitment, &sigma);
+        let indices = self.check_lottery(&message_with_commitment, &sigma)?;
 
         if indices.is_empty() {
             Err(anyhow!(SignatureError::LotteryLost))
@@ -71,7 +71,11 @@ impl<D: MembershipDigest> ConcatenationProofSigner<D> {
 
     /// Checks the lottery for given `message_with_commitment` and the `sigma`.
     /// Returns a vector of winning indices.
-    pub fn check_lottery(&self, message_with_commitment: &[u8], sigma: &BlsSignature) -> Vec<u64> {
+    pub fn check_lottery(
+        &self,
+        message_with_commitment: &[u8],
+        sigma: &BlsSignature,
+    ) -> StmResult<Vec<u64>> {
         let mut indices = Vec::new();
         for index in 0..self.parameters.m {
             if is_lottery_won(
@@ -79,11 +83,11 @@ impl<D: MembershipDigest> ConcatenationProofSigner<D> {
                 sigma.evaluate_dense_mapping(message_with_commitment, index),
                 self.stake,
                 self.total_stake,
-            ) {
+            )? {
                 indices.push(index);
             }
         }
-        indices
+        Ok(indices)
     }
 
     pub fn get_verification_key(&self) -> VerificationKeyForConcatenation {

--- a/mithril-stm/src/proof_system/concatenation/signer.rs
+++ b/mithril-stm/src/proof_system/concatenation/signer.rs
@@ -71,6 +71,8 @@ impl<D: MembershipDigest> ConcatenationProofSigner<D> {
 
     /// Checks the lottery for given `message_with_commitment` and the `sigma`.
     /// Returns a vector of winning indices.
+    /// # Error
+    /// Returns an error if protocol parameters are invalid (e.g. `phi_f` outside `(0, 1]`).
     pub fn check_lottery(
         &self,
         message_with_commitment: &[u8],

--- a/mithril-stm/src/proof_system/concatenation/single_signature.rs
+++ b/mithril-stm/src/proof_system/concatenation/single_signature.rs
@@ -67,7 +67,7 @@ impl SingleSignatureForConcatenation {
 
             let ev = self.sigma.evaluate_dense_mapping(msg, index);
 
-            if !is_lottery_won(params.phi_f, ev, *stake, *total_stake) {
+            if !is_lottery_won(params.phi_f, ev, *stake, *total_stake)? {
                 return Err(anyhow!(SignatureError::LotteryLost));
             }
         }

--- a/mithril-stm/src/proof_system/halo2_snark/aggregate_key.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/aggregate_key.rs
@@ -123,7 +123,7 @@ impl<D: MembershipDigest> From<&ClosedKeyRegistration> for AggregateVerification
             merkle_tree_commitment: registration
                 .to_merkle_tree::<D::SnarkHash, RegistrationEntryForSnark>()
                 .to_merkle_tree_commitment(),
-            total_stake: registration.total_stake,
+            total_stake: registration.get_total_stake(),
         }
     }
 }

--- a/mithril-stm/src/proof_system/halo2_snark/eligibility.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/eligibility.rs
@@ -36,9 +36,12 @@ cfg_num_integer! {
     /// 1. Rejects `total_stake == 0` with `RegisterError::ZeroTotalStake`.
     /// 2. Short-circuits `phi_f ≈ 1.0` to `p - 1` (all indices win), matching the concatenation
     ///    proof system and avoiding `ln(0)`.
-    /// 3. Approximates `phi_f` as an exact `Ratio<i64>`, promotes to `Ratio<BigInt>`.
-    /// 4. Computes `ln(1 - phi_f)` via Taylor expansion (`ln_1p_taylor_expansion`).
-    /// 5. Delegates to `compute_target_value_for_snark_lottery_given_ln_approximation` for the final field-element computation.
+    /// 3. Rejects `phi_f` outside `(0, 1]`, since `Ratio::approximate_float` only rejects
+    ///    infinite/NaN values and the Taylor expansion below silently diverges (or converges to a
+    ///    value for a semantically invalid negative `phi_f`) otherwise.
+    /// 4. Approximates `phi_f` as an exact `Ratio<i64>`, promotes to `Ratio<BigInt>`.
+    /// 5. Computes `ln(1 - phi_f)` via Taylor expansion (`ln_1p_taylor_expansion`).
+    /// 6. Delegates to `compute_target_value_for_snark_lottery_given_ln_approximation` for the final field-element computation.
     #[cfg(feature = "future_snark")]
     pub fn compute_target_value_for_snark_lottery(phi_f: PhiFValue, stake: Stake, total_stake: Stake) -> StmResult<LotteryTargetValue> {
         if total_stake == 0 {
@@ -49,6 +52,10 @@ cfg_num_integer! {
             // This returns the maximal target possible Jubjub modulus - 1
             // to ensure every participant wins the lottery
             return Ok(&LotteryTargetValue::default() - &LotteryTargetValue::get_one());
+        }
+
+        if !(phi_f > 0.0 && phi_f <= 1.0) {
+            return Err(anyhow!("phi_f must be in the range (0, 1], got {phi_f}"));
         }
 
         let phi_f_ratio_int: Ratio<i64> =
@@ -331,6 +338,19 @@ mod tests {
             target.unwrap(),
             &BaseFieldElement::default() - &BaseFieldElement::get_one()
         );
+    }
+
+    #[test]
+    fn compute_target_value_for_snark_lottery_rejects_out_of_range_phi_f() {
+        let total_stake = 10_000;
+        let stake = 5_000;
+
+        for invalid_phi_f in [-0.5, 0.0, 1.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            assert!(
+                compute_target_value_for_snark_lottery(invalid_phi_f, stake, total_stake).is_err(),
+                "phi_f = {invalid_phi_f} should be rejected"
+            );
+        }
     }
 
     mod lottery_computations {

--- a/mithril-stm/src/proof_system/halo2_snark/eligibility.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/eligibility.rs
@@ -1,6 +1,6 @@
 use anyhow::anyhow;
 
-use crate::{PhiFValue, RegisterError};
+use crate::{PhiFValue, RegisterError, protocol::ProtocolError};
 
 #[cfg(feature = "future_snark")]
 use crate::{
@@ -55,7 +55,7 @@ cfg_num_integer! {
         }
 
         if !(phi_f > 0.0 && phi_f <= 1.0) {
-            return Err(anyhow!("phi_f must be in the range (0, 1], got {phi_f}"));
+            return Err(ProtocolError::PhiFValueOutOfRange(phi_f).into());
         }
 
         let phi_f_ratio_int: Ratio<i64> =
@@ -281,7 +281,10 @@ mod tests {
     use proptest::prelude::*;
     use rand_core::OsRng;
 
-    use crate::{LotteryTargetValue, SchnorrSigningKey, signature_scheme::BaseFieldElement};
+    use crate::{
+        LotteryTargetValue, SchnorrSigningKey, protocol::ProtocolError,
+        signature_scheme::BaseFieldElement,
+    };
 
     use super::{
         TAYLOR_EXPANSION_ITERATIONS, check_lottery_for_index, compute_exponential_taylor_expansion,
@@ -346,9 +349,14 @@ mod tests {
         let stake = 5_000;
 
         for invalid_phi_f in [-0.5, 0.0, 1.5, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let result = compute_target_value_for_snark_lottery(invalid_phi_f, stake, total_stake)
+                .expect_err("The lottery check should fail.");
             assert!(
-                compute_target_value_for_snark_lottery(invalid_phi_f, stake, total_stake).is_err(),
-                "phi_f = {invalid_phi_f} should be rejected"
+                matches!(
+                    result.downcast_ref::<ProtocolError>(),
+                    Some(ProtocolError::PhiFValueOutOfRange(..))
+                ),
+                "Unexpected error: {result:?}"
             );
         }
     }

--- a/mithril-stm/src/proof_system/halo2_snark/eligibility.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/eligibility.rs
@@ -59,7 +59,7 @@ cfg_num_integer! {
         }
 
         let phi_f_ratio_int: Ratio<i64> =
-            Ratio::approximate_float(phi_f).ok_or(anyhow!("Approximation of float as a Ratio failed because it is infinite or NaN."))?;
+            Ratio::approximate_float(phi_f).ok_or_else(|| anyhow!("Approximation of float as a Ratio failed because it is infinite or NaN."))?;
         let phi_f_ratio = Ratio::new_raw(
             BigInt::from(*phi_f_ratio_int.numer()),
             BigInt::from(*phi_f_ratio_int.denom()),

--- a/mithril-stm/src/proof_system/halo2_snark/mod.rs
+++ b/mithril-stm/src/proof_system/halo2_snark/mod.rs
@@ -113,7 +113,7 @@ mod tests {
             )
             .to_merkle_tree_commitment();
         let lottery_target_value =
-            ClosedRegistrationEntry::try_from((entry, closed_reg.total_stake, params.phi_f))
+            ClosedRegistrationEntry::try_from((entry, closed_reg.get_total_stake(), params.phi_f))
                 .unwrap()
                 .get_lottery_target_value()
                 .unwrap();

--- a/mithril-stm/src/protocol/error.rs
+++ b/mithril-stm/src/protocol/error.rs
@@ -7,6 +7,7 @@ use crate::VerificationKeyForSnark;
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum RegisterError {
     /// This key has already been registered by a participant
+    #[allow(private_interfaces)]
     #[error("This key has already been registered.")]
     EntryAlreadyRegistered(Box<RegistrationEntry>),
 

--- a/mithril-stm/src/protocol/error.rs
+++ b/mithril-stm/src/protocol/error.rs
@@ -1,4 +1,4 @@
-use crate::{RegistrationEntry, VerificationKeyForConcatenation};
+use crate::VerificationKeyForConcatenation;
 
 #[cfg(feature = "future_snark")]
 use crate::VerificationKeyForSnark;
@@ -7,9 +7,8 @@ use crate::VerificationKeyForSnark;
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 pub enum RegisterError {
     /// This key has already been registered by a participant
-    #[allow(private_interfaces)]
     #[error("This key has already been registered.")]
-    EntryAlreadyRegistered(Box<RegistrationEntry>),
+    EntryAlreadyRegistered,
 
     /// Cannot register if the registration is closed.
     #[error("Cannot register if the registration is closed.")]

--- a/mithril-stm/src/protocol/error.rs
+++ b/mithril-stm/src/protocol/error.rs
@@ -53,3 +53,11 @@ pub enum RegisterError {
     #[error("Cannot run the protocol if total stake is zero.")]
     ZeroTotalStake,
 }
+
+/// Errors which are due to an error in the protocol.
+#[derive(Debug, Clone, thiserror::Error, PartialEq)]
+pub enum ProtocolError {
+    /// Value of phi_f is out of the (0,1] range
+    #[error("phi_f must be in the range (0, 1], got {0}")]
+    PhiFValueOutOfRange(f64),
+}

--- a/mithril-stm/src/protocol/key_registration/closed_registration_entry.rs
+++ b/mithril-stm/src/protocol/key_registration/closed_registration_entry.rs
@@ -45,7 +45,13 @@ pub struct ClosedRegistrationEntry {
 
 impl ClosedRegistrationEntry {
     /// Creates a new closed registration entry.
-    pub fn new(
+    ///
+    /// This is private rather than `pub`: it performs no verification of any kind (unlike
+    /// `RegistrationEntry::new`, which verifies proof of possession), so it must only be used
+    /// where the caller has already established the verification key is trustworthy — currently
+    /// only via `TryFrom<(RegistrationEntry, Stake, PhiFValue)>`, which derives from an
+    /// already-verified `RegistrationEntry`.
+    fn new(
         verification_key_for_concatenation: VerificationKeyForConcatenation,
         stake: Stake,
         #[cfg(feature = "future_snark")] verification_key_for_snark: Option<

--- a/mithril-stm/src/protocol/key_registration/mod.rs
+++ b/mithril-stm/src/protocol/key_registration/mod.rs
@@ -9,6 +9,6 @@ mod snark_registration_entry;
 pub use closed_registration_entry::ClosedRegistrationEntry;
 pub use concatenation_registration_entry::RegistrationEntryForConcatenation;
 pub use register::{ClosedKeyRegistration, KeyRegistration};
-pub use registration_entry::RegistrationEntry;
+pub(crate) use registration_entry::RegistrationEntry;
 #[cfg(feature = "future_snark")]
 pub use snark_registration_entry::RegistrationEntryForSnark;

--- a/mithril-stm/src/protocol/key_registration/register.rs
+++ b/mithril-stm/src/protocol/key_registration/register.rs
@@ -121,7 +121,9 @@ impl KeyRegistration {
 /// Closed Key Registration
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct ClosedKeyRegistration {
+    /// The closed key registration entries
     closed_registration_entries: BTreeSet<ClosedRegistrationEntry>,
+    /// The total stake registered
     total_stake: Stake,
 }
 

--- a/mithril-stm/src/protocol/key_registration/register.rs
+++ b/mithril-stm/src/protocol/key_registration/register.rs
@@ -57,7 +57,7 @@ impl KeyRegistration {
                 .is_some_and(|vk_snark| self.registered_keys_for_snark.contains(&vk_snark));
 
         if is_already_registered {
-            return Err(RegisterError::EntryAlreadyRegistered(Box::new(*entry)).into());
+            return Err(RegisterError::EntryAlreadyRegistered.into());
         }
 
         self.registered_keys_for_concatenation.insert(vk_concatenation);
@@ -385,7 +385,7 @@ mod tests {
 
         assert!(matches!(
             result.unwrap_err().downcast_ref::<RegisterError>(),
-            Some(RegisterError::EntryAlreadyRegistered(_))
+            Some(RegisterError::EntryAlreadyRegistered)
         ));
     }
 
@@ -412,7 +412,7 @@ mod tests {
 
         assert!(matches!(
             result.unwrap_err().downcast_ref::<RegisterError>(),
-            Some(RegisterError::EntryAlreadyRegistered(_))
+            Some(RegisterError::EntryAlreadyRegistered)
         ));
     }
 
@@ -468,8 +468,7 @@ mod tests {
                                 assert!(registered_entries.insert(entry));
                             },
                             Err(error) => match error.downcast_ref::<RegisterError>(){
-                                Some(RegisterError::EntryAlreadyRegistered(e1)) => {
-                                    assert!(e1.as_ref() == &entry);
+                                Some(RegisterError::EntryAlreadyRegistered) => {
                                     assert!(keys.contains(&vk));
                                 },
                                 _ => {panic!("Unexpected error: {error}")}

--- a/mithril-stm/src/protocol/key_registration/register.rs
+++ b/mithril-stm/src/protocol/key_registration/register.rs
@@ -36,9 +36,16 @@ impl KeyRegistration {
 
     /// Check whether the given `RegistrationEntry` is already registered.
     /// Insert the new entry if all checks pass.
+    ///
+    /// This is `pub(crate)` rather than `pub`: it trusts that `entry` was produced through a
+    /// path that already verified proof of possession (`RegistrationEntry::new`), which every
+    /// internal caller does. Exposing it publicly would let external callers register an entry
+    /// obtained without that verification (e.g. via deserialization), so external registration
+    /// must go through [`KeyRegistration::register`] instead, which always constructs the entry
+    /// itself via `RegistrationEntry::new`.
     /// # Error
     /// The function fails when the entry is already registered.
-    pub fn register_by_entry(&mut self, entry: &RegistrationEntry) -> StmResult<()> {
+    pub(crate) fn register_by_entry(&mut self, entry: &RegistrationEntry) -> StmResult<()> {
         let vk_concatenation = entry.get_verification_key_for_concatenation();
         let is_already_registered =
             self.registered_keys_for_concatenation.contains(&vk_concatenation);
@@ -104,24 +111,46 @@ impl KeyRegistration {
             .map(|entry| ClosedRegistrationEntry::try_from((*entry, total_stake, params.phi_f)))
             .collect();
 
-        Ok(ClosedKeyRegistration {
-            closed_registration_entries: closed_registration_entries?,
-            total_stake,
-        })
+        Ok(ClosedKeyRegistration::new(closed_registration_entries?, total_stake))
     }
 }
 
 /// Closed Key Registration
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct ClosedKeyRegistration {
-    /// The closed key registration entries
-    pub closed_registration_entries: BTreeSet<ClosedRegistrationEntry>,
-
-    /// The total stake registered
-    pub total_stake: Stake,
+    closed_registration_entries: BTreeSet<ClosedRegistrationEntry>,
+    total_stake: Stake,
 }
 
 impl ClosedKeyRegistration {
+    /// Creates a new `ClosedKeyRegistration`.
+    ///
+    /// This is `pub(crate)` rather than `pub`: `closed_registration_entries` carries
+    /// verification keys with no guarantee of proof of possession unless it was built from a
+    /// [`KeyRegistration`], which only ever admits verified entries. Exposing this publicly
+    /// would let external callers assemble a forged registration (e.g. with a rogue key) and
+    /// feed it directly into the aggregation/verification pipeline, bypassing `KeyRegistration`
+    /// entirely.
+    pub(crate) fn new(
+        closed_registration_entries: BTreeSet<ClosedRegistrationEntry>,
+        total_stake: Stake,
+    ) -> Self {
+        Self {
+            closed_registration_entries,
+            total_stake,
+        }
+    }
+
+    /// Gets the closed registration entries.
+    pub fn get_closed_registration_entries(&self) -> &BTreeSet<ClosedRegistrationEntry> {
+        &self.closed_registration_entries
+    }
+
+    /// Gets the total stake registered.
+    pub fn get_total_stake(&self) -> Stake {
+        self.total_stake
+    }
+
     /// Creates a Merkle tree from the closed registration entries
     pub fn to_merkle_tree<D: Digest + FixedOutput, L: MerkleTreeLeaf>(&self) -> MerkleTree<D, L>
     where

--- a/mithril-stm/src/protocol/key_registration/register.rs
+++ b/mithril-stm/src/protocol/key_registration/register.rs
@@ -111,7 +111,10 @@ impl KeyRegistration {
             .map(|entry| ClosedRegistrationEntry::try_from((*entry, total_stake, params.phi_f)))
             .collect();
 
-        Ok(ClosedKeyRegistration::new(closed_registration_entries?, total_stake))
+        Ok(ClosedKeyRegistration::new(
+            closed_registration_entries?,
+            total_stake,
+        ))
     }
 }
 
@@ -123,14 +126,6 @@ pub struct ClosedKeyRegistration {
 }
 
 impl ClosedKeyRegistration {
-    /// Creates a new `ClosedKeyRegistration`.
-    ///
-    /// This is `pub(crate)` rather than `pub`: `closed_registration_entries` carries
-    /// verification keys with no guarantee of proof of possession unless it was built from a
-    /// [`KeyRegistration`], which only ever admits verified entries. Exposing this publicly
-    /// would let external callers assemble a forged registration (e.g. with a rogue key) and
-    /// feed it directly into the aggregation/verification pipeline, bypassing `KeyRegistration`
-    /// entirely.
     pub(crate) fn new(
         closed_registration_entries: BTreeSet<ClosedRegistrationEntry>,
         total_stake: Stake,
@@ -141,18 +136,15 @@ impl ClosedKeyRegistration {
         }
     }
 
-    /// Gets the closed registration entries.
-    pub fn get_closed_registration_entries(&self) -> &BTreeSet<ClosedRegistrationEntry> {
-        &self.closed_registration_entries
-    }
-
     /// Gets the total stake registered.
-    pub fn get_total_stake(&self) -> Stake {
+    pub(crate) fn get_total_stake(&self) -> Stake {
         self.total_stake
     }
 
     /// Creates a Merkle tree from the closed registration entries
-    pub fn to_merkle_tree<D: Digest + FixedOutput, L: MerkleTreeLeaf>(&self) -> MerkleTree<D, L>
+    pub(crate) fn to_merkle_tree<D: Digest + FixedOutput, L: MerkleTreeLeaf>(
+        &self,
+    ) -> MerkleTree<D, L>
     where
         Option<L>: From<ClosedRegistrationEntry>,
     {
@@ -166,7 +158,7 @@ impl ClosedKeyRegistration {
     }
 
     /// Gets the index of given closed registration entry.
-    pub fn get_signer_index_for_registration(
+    pub(crate) fn get_signer_index_for_registration(
         &self,
         entry: &ClosedRegistrationEntry,
     ) -> Option<SignerIndex> {
@@ -178,14 +170,15 @@ impl ClosedKeyRegistration {
 
     /// Check if any registration entry has a SNARK verification key.
     #[cfg(feature = "future_snark")]
-    pub fn has_snark_verification_keys(&self) -> bool {
+    pub(crate) fn has_snark_verification_keys(&self) -> bool {
         self.closed_registration_entries
             .iter()
             .any(|entry| entry.get_verification_key_for_snark().is_some())
     }
 
     /// Return the number of registered parties.
-    pub fn number_of_registered_parties(&self) -> usize {
+    #[cfg(feature = "future_snark")]
+    pub(crate) fn number_of_registered_parties(&self) -> usize {
         self.closed_registration_entries.len()
     }
 

--- a/mithril-stm/src/protocol/key_registration/registration_entry.rs
+++ b/mithril-stm/src/protocol/key_registration/registration_entry.rs
@@ -12,7 +12,7 @@ use super::ClosedRegistrationEntry;
 
 /// Represents a signer registration entry
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
-pub struct RegistrationEntry(
+pub(crate) struct RegistrationEntry(
     VerificationKeyForConcatenation,
     Stake,
     #[cfg(feature = "future_snark")] Option<VerificationKeyForSnark>,
@@ -21,7 +21,7 @@ pub struct RegistrationEntry(
 impl RegistrationEntry {
     /// Creates a new registration entry. Verifies the proof of possession of verification key for
     /// concatenation and validates the schnorr verification key before creating the entry.
-    pub fn new(
+    pub(crate) fn new(
         bls_verification_key_proof_of_possession: VerificationKeyProofOfPossessionForConcatenation,
         stake: Stake,
         #[cfg(feature = "future_snark")] schnorr_verification_key: Option<VerificationKeyForSnark>,
@@ -52,18 +52,18 @@ impl RegistrationEntry {
     }
 
     /// Gets the verification key for concatenation.
-    pub fn get_verification_key_for_concatenation(&self) -> VerificationKeyForConcatenation {
+    pub(crate) fn get_verification_key_for_concatenation(&self) -> VerificationKeyForConcatenation {
         self.0
     }
 
     #[cfg(feature = "future_snark")]
     /// Gets the verification key for snark.
-    pub fn get_verification_key_for_snark(&self) -> Option<VerificationKeyForSnark> {
+    pub(crate) fn get_verification_key_for_snark(&self) -> Option<VerificationKeyForSnark> {
         self.2
     }
 
     /// Gets the stake associated with the registration entry.
-    pub fn get_stake(&self) -> Stake {
+    pub(crate) fn get_stake(&self) -> Stake {
         self.1
     }
 }

--- a/mithril-stm/src/protocol/key_registration/registration_entry.rs
+++ b/mithril-stm/src/protocol/key_registration/registration_entry.rs
@@ -1,8 +1,6 @@
 use std::cmp::Ordering;
 use std::hash::Hash;
 
-use serde::{Deserialize, Serialize};
-
 #[cfg(feature = "future_snark")]
 use crate::VerificationKeyForSnark;
 use crate::{
@@ -13,13 +11,11 @@ use crate::{
 use super::ClosedRegistrationEntry;
 
 /// Represents a signer registration entry
-#[derive(PartialEq, Eq, Clone, Debug, Copy, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Debug, Copy)]
 pub struct RegistrationEntry(
     VerificationKeyForConcatenation,
     Stake,
-    #[cfg(feature = "future_snark")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    Option<VerificationKeyForSnark>,
+    #[cfg(feature = "future_snark")] Option<VerificationKeyForSnark>,
 );
 
 impl RegistrationEntry {

--- a/mithril-stm/src/protocol/mod.rs
+++ b/mithril-stm/src/protocol/mod.rs
@@ -10,7 +10,7 @@ pub use aggregate_signature::{
     AggregationError, AncillaryGenesisData, AncillaryProofInput, AncillaryProofOutput,
     AncillaryProverData, AncillaryVerifierData, Clerk, GenesisVerificationKeyBundle,
 };
-pub use error::RegisterError;
+pub use error::{ProtocolError, RegisterError};
 pub(crate) use key_registration::RegistrationEntry;
 #[cfg(feature = "future_snark")]
 pub use key_registration::RegistrationEntryForSnark;

--- a/mithril-stm/src/protocol/mod.rs
+++ b/mithril-stm/src/protocol/mod.rs
@@ -11,10 +11,11 @@ pub use aggregate_signature::{
     AncillaryProverData, AncillaryVerifierData, Clerk, GenesisVerificationKeyBundle,
 };
 pub use error::RegisterError;
+pub(crate) use key_registration::RegistrationEntry;
 #[cfg(feature = "future_snark")]
 pub use key_registration::RegistrationEntryForSnark;
 pub use key_registration::{
-    ClosedKeyRegistration, ClosedRegistrationEntry, KeyRegistration, RegistrationEntry,
+    ClosedKeyRegistration, ClosedRegistrationEntry, KeyRegistration,
     RegistrationEntryForConcatenation,
 };
 pub use parameters::Parameters;

--- a/mithril-stm/src/protocol/participant/initializer.rs
+++ b/mithril-stm/src/protocol/participant/initializer.rs
@@ -95,7 +95,7 @@ impl Initializer {
             .get_signer_index_for_registration(
                 &(
                     registration_entry,
-                    closed_key_registration.total_stake,
+                    closed_key_registration.get_total_stake(),
                     self.parameters.phi_f,
                 )
                     .try_into()?,
@@ -107,7 +107,7 @@ impl Initializer {
             .to_merkle_tree_batch_commitment();
         let concatenation_proof_signer = ConcatenationProofSigner::new(
             registration_entry.get_stake(),
-            closed_key_registration.total_stake,
+            closed_key_registration.get_total_stake(),
             self.parameters,
             self.bls_signing_key,
             self.bls_verification_key_proof_of_possession.vk,
@@ -123,7 +123,7 @@ impl Initializer {
                         .to_merkle_tree_commitment();
                     let lottery_target_value = ClosedRegistrationEntry::try_from((
                         registration_entry,
-                        closed_key_registration.total_stake,
+                        closed_key_registration.get_total_stake(),
                         self.parameters.phi_f,
                     ))?
                     .get_lottery_target_value()

--- a/mithril-stm/src/protocol/single_signature/signature.rs
+++ b/mithril-stm/src/protocol/single_signature/signature.rs
@@ -337,7 +337,7 @@ mod tests {
                 ).to_merkle_tree_commitment();
                 let closed_registration_entry = ClosedRegistrationEntry::try_from((
                     entry1,
-                    closed_key_registration.total_stake,
+                    closed_key_registration.get_total_stake(),
                     params.phi_f,
                 ))
                 .unwrap();
@@ -550,7 +550,7 @@ mod tests {
                 ).to_merkle_tree_commitment();
                 let closed_registration_entry = ClosedRegistrationEntry::try_from((
                     entry1,
-                    closed_key_registration.total_stake,
+                    closed_key_registration.get_total_stake(),
                     params.phi_f,
                 ))
                 .unwrap();

--- a/mithril-stm/src/protocol/single_signature/signature.rs
+++ b/mithril-stm/src/protocol/single_signature/signature.rs
@@ -96,55 +96,70 @@ impl SingleSignature {
         let nr_indexes = u64::from_be_bytes(u64_bytes) as usize;
 
         let mut indexes = Vec::new();
-        for i in 0..nr_indexes {
+        let mut offset = 8usize;
+        for _ in 0..nr_indexes {
+            let index_end =
+                offset.checked_add(8).ok_or(SignatureError::SerializationError)?;
             u64_bytes.copy_from_slice(
                 bytes
-                    .get(8 + i * 8..16 + i * 8)
+                    .get(offset..index_end)
                     .ok_or(SignatureError::SerializationError)?,
             );
             indexes.push(u64::from_be_bytes(u64_bytes));
+            offset = index_end;
         }
 
-        let offset = 8 + nr_indexes * 8;
+        let sigma_end = offset.checked_add(48).ok_or(SignatureError::SerializationError)?;
         let sigma = BlsSignature::from_bytes(
             bytes
-                .get(offset..offset + 48)
+                .get(offset..sigma_end)
                 .ok_or(SignatureError::SerializationError)?,
         )?;
 
+        let signer_index_end =
+            sigma_end.checked_add(8).ok_or(SignatureError::SerializationError)?;
         u64_bytes.copy_from_slice(
             bytes
-                .get(offset + 48..offset + 56)
+                .get(sigma_end..signer_index_end)
                 .ok_or(SignatureError::SerializationError)?,
         );
         let signer_index = u64::from_be_bytes(u64_bytes);
 
         #[cfg(feature = "future_snark")]
         let snark_signature = {
-            let snark_offset = offset + 56;
+            let snark_offset = signer_index_end;
             if snark_offset < bytes.len() {
+                let schnorr_signature_end = snark_offset
+                    .checked_add(96)
+                    .ok_or(SignatureError::SerializationError)?;
                 let schnorr_signature = crate::UniqueSchnorrSignature::from_bytes(
                     bytes
-                        .get(snark_offset..snark_offset + 96)
+                        .get(snark_offset..schnorr_signature_end)
                         .ok_or(SignatureError::SerializationError)?,
                 )?;
-                let mut snark_idx_offset = snark_offset + 96;
+                let nr_snark_indices_end = schnorr_signature_end
+                    .checked_add(8)
+                    .ok_or(SignatureError::SerializationError)?;
                 u64_bytes.copy_from_slice(
                     bytes
-                        .get(snark_idx_offset..snark_idx_offset + 8)
+                        .get(schnorr_signature_end..nr_snark_indices_end)
                         .ok_or(SignatureError::SerializationError)?,
                 );
                 let nr_snark_indices = u64::from_be_bytes(u64_bytes) as usize;
-                snark_idx_offset += 8;
 
-                let mut snark_indices = Vec::with_capacity(nr_snark_indices);
-                for i in 0..nr_snark_indices {
+                let mut snark_indices = Vec::new();
+                let mut snark_idx_offset = nr_snark_indices_end;
+                for _ in 0..nr_snark_indices {
+                    let snark_index_end = snark_idx_offset
+                        .checked_add(8)
+                        .ok_or(SignatureError::SerializationError)?;
                     u64_bytes.copy_from_slice(
                         bytes
-                            .get(snark_idx_offset + i * 8..snark_idx_offset + (i + 1) * 8)
+                            .get(snark_idx_offset..snark_index_end)
                             .ok_or(SignatureError::SerializationError)?,
                     );
                     snark_indices.push(u64::from_be_bytes(u64_bytes));
+                    snark_idx_offset = snark_index_end;
                 }
 
                 Some(SingleSignatureForSnark::new(

--- a/mithril-stm/src/protocol/single_signature/signature.rs
+++ b/mithril-stm/src/protocol/single_signature/signature.rs
@@ -98,8 +98,7 @@ impl SingleSignature {
         let mut indexes = Vec::new();
         let mut offset = 8usize;
         for _ in 0..nr_indexes {
-            let index_end =
-                offset.checked_add(8).ok_or(SignatureError::SerializationError)?;
+            let index_end = offset.checked_add(8).ok_or(SignatureError::SerializationError)?;
             u64_bytes.copy_from_slice(
                 bytes
                     .get(offset..index_end)

--- a/mithril-stm/src/protocol/single_signature/signature_registered_party.rs
+++ b/mithril-stm/src/protocol/single_signature/signature_registered_party.rs
@@ -251,7 +251,7 @@ mod tests {
             key_reg.register_by_entry(&entry2).unwrap();
             let closed_key_reg: ClosedKeyRegistration =
                 key_reg.close_registration(&params).unwrap();
-            let total_stake = closed_key_reg.total_stake;
+            let total_stake = closed_key_reg.get_total_stake();
 
             let concatenation_proof_signer: ConcatenationProofSigner<D> =
                 ConcatenationProofSigner::new(
@@ -272,7 +272,7 @@ mod tests {
                 ).to_merkle_tree_commitment();
                 let closed_registration_entry = ClosedRegistrationEntry::try_from((
                     entry1,
-                    closed_key_reg.total_stake,
+                    closed_key_reg.get_total_stake(),
                     params.phi_f,
                 ))
                 .unwrap();

--- a/mithril-stm/src/protocol/single_signature/signature_registered_party.rs
+++ b/mithril-stm/src/protocol/single_signature/signature_registered_party.rs
@@ -22,7 +22,7 @@ pub struct SingleSignatureWithRegisteredParty {
     /// Stm signature
     pub sig: SingleSignature,
     /// Registered party
-    pub reg_party: ClosedRegistrationEntry,
+    pub(crate) reg_party: ClosedRegistrationEntry,
 }
 
 impl SingleSignatureWithRegisteredParty {

--- a/mithril-stm/tests/test_extensions/protocol_phase.rs
+++ b/mithril-stm/tests/test_extensions/protocol_phase.rs
@@ -41,11 +41,16 @@ pub fn initialization_phase(
 
     for stake in parties {
         let p = Initializer::new(params, stake, &mut rng);
-        key_reg.register_by_entry(&p.clone().try_into().unwrap()).unwrap();
-        reg_parties.push((
-            p.get_verification_key_proof_of_possession_for_concatenation().vk,
-            stake,
-        ));
+        let vk_pop = p.get_verification_key_proof_of_possession_for_concatenation();
+        key_reg
+            .register(
+                stake,
+                &vk_pop,
+                #[cfg(feature = "future_snark")]
+                p.schnorr_verification_key,
+            )
+            .unwrap();
+        reg_parties.push((vk_pop.vk, stake));
         initializers.push(p);
     }
 


### PR DESCRIPTION
## Content

<!-- Explain the reason for this change, if a feature is added, a bug is fixed, ... -->

This PR includes an update to the handling of the proof of possession of BLS keys, a modification of the checks done on the protocol parameters and a modification to the decoding function of the merkle tree path and concatenation proof.

## Changes

- Add checked arithmetic to legacy byte decoders (Merkle tree, batch commitment, ConcatenationProof, SingleSignature)
- Validate `phi_f` is within (0, 1] before use in lottery/eligibility computations
- Restrict `KeyRegistration::register_by_entry` to `pub(crate)` so external registration must go through `register()`, which always verifies proof of possession
- Make `ClosedKeyRegistration` fields private with a `pub(crate)` constructor
- Narrow `RegistrationEntry`/`ClosedRegistrationEntry` (types, constructors, methods) to `pub(crate)` and dropped RegistrationEntry's unused Serialize/Deserialize
- Fix resulting lint warnings: #[allow(private_interfaces)] where a public error intentionally carries a now-private type, #[allow(dead_code)] on Merkle tree byte (de)serialization helpers that are test-only for now

## Pre-submit checklist

- Branch
  - [x] Tests are provided (if possible)
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [ ] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested


## Comments

<!-- Some optional comments about the PR, such as how to run a command, or warnings about usage, .... -->

## Issue(s)

<!-- The issue(s) this PR relates to or closes -->
