### PR TITLE
fix(stm): stop forcing `rustls` in the `future_snark` feature

### DIFF
--- a/.github/workflows/test-rust.yml
+++ b/.github/workflows/test-rust.yml
@@ -19,7 +19,7 @@ jobs:
             test-args: --features full,unstable --workspace
             cargo-profile: ci-tests
           - os: ubuntu-24.04
-            test-args: --features future_snark -p mithril-stm -p mithril-common -p mithril-aggregator -p mithril-signer -p mithril-relay
+            test-args: --features future_snark,rustls -p mithril-stm -p mithril-common -p mithril-aggregator -p mithril-signer -p mithril-relay
             artifact-suffix: -future-snark
             # Default to the fast profile; the `prepare` step upgrades to `slow-cargo-profile`
             # only when the slow SNARK tests are actually in scope for this run (so we don't pay

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-aggregator"
-version = "0.9.18"
+version = "0.9.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.14.17"
+version = "0.14.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4518,7 +4518,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.7.14"
+version = "0.7.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-relay"
-version = "0.2.7"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-signer"
-version = "1.1.6"
+version = "1.1.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "blake2 0.10.6",

--- a/demo/protocol-demo/Cargo.toml
+++ b/demo/protocol-demo/Cargo.toml
@@ -9,8 +9,11 @@ license = { workspace = true }
 repository = { workspace = true }
 
 [features]
+default = ["rustls"]
 # Enable experimental SNARK support in mithril-stm and mithril-common.
 future_snark = ["mithril-stm/future_snark", "mithril-common/future_snark"]
+# Enable the TLS features of mithril-stm.
+rustls = ["mithril-stm/rustls"]
 
 [dependencies]
 clap = { workspace = true }

--- a/docs/runbook/update-circuit-keys/README.md
+++ b/docs/runbook/update-circuit-keys/README.md
@@ -29,13 +29,13 @@ Reviewers:
 Commands to run the integrity tests:
 
 ```bash
-cargo test -p mithril-stm --features future_snark --release integrity_test_for_non_recursive_production_key -- --ignored
+cargo test -p mithril-stm --features future_snark,rustls --release integrity_test_for_non_recursive_production_key -- --ignored
 ```
 
 and
 
 ```bash
-cargo test -p mithril-stm --features future_snark --release integrity_test_for_recursive_production_key -- --ignored
+cargo test -p mithril-stm --features future_snark,rustls --release integrity_test_for_recursive_production_key -- --ignored
 ```
 
 Release manager:
@@ -52,13 +52,13 @@ The author needs to update the golden value of the verification keys in the gold
 To update the production circuit verification keys, one needs to run the following commands:
 
 ```bash
-cargo test -p mithril-stm --features future_snark --release write_non_recursive_circuit_verification_key_for_production_to_file -- --ignored
+cargo test -p mithril-stm --features future_snark,rustls --release write_non_recursive_circuit_verification_key_for_production_to_file -- --ignored
 ```
 
 and
 
 ```bash
-cargo test -p mithril-stm --features future_snark --release write_recursive_circuit_verification_key_for_production_to_file -- --ignored
+cargo test -p mithril-stm --features future_snark,rustls --release write_recursive_circuit_verification_key_for_production_to_file -- --ignored
 ```
 
 that will update the files holding the values of the production keys, `mithril-stm/src/circuits/halo2/non_recursive_circuit_verification_key_for_production.bin` and `mithril-stm/src/circuits/halo2_ivc/recursive_circuit_verification_key_for_production.bin`.

--- a/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
+++ b/internal/cardano-node/mithril-cardano-node-internal-database/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 digest = { workspace = true }
 hex = { workspace = true }
-mithril-common = { path = "../../../mithril-common", version = "0.7.14" }
+mithril-common = { path = "../../../mithril-common", version = "0.7.15" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = "0.10.9"

--- a/internal/mithril-aggregator-client/Cargo.toml
+++ b/internal/mithril-aggregator-client/Cargo.toml
@@ -13,7 +13,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
-mithril-common = { path = "../../mithril-common", version = "0.7.14" }
+mithril-common = { path = "../../mithril-common", version = "0.7.15" }
 reqwest = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }

--- a/internal/mithril-aggregator-discovery/Cargo.toml
+++ b/internal/mithril-aggregator-discovery/Cargo.toml
@@ -14,7 +14,7 @@ include = ["**/*.rs", "Cargo.toml", "README.md", ".gitignore"]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 mithril-aggregator-client = { path = "../mithril-aggregator-client", version = "0.2.4" }
-mithril-common = { path = "../../mithril-common", version = "0.7.14" }
+mithril-common = { path = "../../mithril-common", version = "0.7.15" }
 rand = { version = "0.10.2" }
 reqwest = { workspace = true }
 serde = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-aggregator"
-version = "0.9.18"
+version = "0.9.19"
 description = "A Mithril Aggregator server"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-aggregator/Cargo.toml
+++ b/mithril-aggregator/Cargo.toml
@@ -11,7 +11,7 @@ repository = { workspace = true }
 
 [features]
 default = ["rustls"]
-rustls = ["reqwest/rustls"]
+rustls = ["mithril-common/rustls", "reqwest/rustls"]
 
 future_snark = ["mithril-common/future_snark", "dep:ciborium"]
 

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-client"
-version = "0.14.17"
+version = "0.14.18"
 description = "Mithril client library"
 authors = { workspace = true }
 edition = { workspace = true }
@@ -64,7 +64,7 @@ flate2 = { version = "1.1.9", optional = true }
 flume = { version = "0.12.0", optional = true }
 futures = "0.3.32"
 mithril-aggregator-client = { path = "../internal/mithril-aggregator-client", version = "0.2.4" }
-mithril-common = { path = "../mithril-common", version = "0.7.14", default-features = false }
+mithril-common = { path = "../mithril-common", version = "0.7.15", default-features = false }
 reqwest = { workspace = true, default-features = false, features = ["charset", "http2", "stream", "system-proxy"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mithril-client/Cargo.toml
+++ b/mithril-client/Cargo.toml
@@ -30,13 +30,13 @@ unstable = []
 
 # These features are for support of dependent crates only.
 # They do not change the operation of the main crate.
-native-tls = ["reqwest/native-tls"]
-native-tls-no-alpn = ["reqwest/native-tls-no-alpn"]
-native-tls-vendored = ["reqwest/native-tls-vendored"]
-native-tls-vendored-no-alpn = ["reqwest/native-tls-vendored-no-alpn"]
+native-tls = ["mithril-common/native-tls", "reqwest/native-tls"]
+native-tls-no-alpn = ["mithril-common/native-tls", "reqwest/native-tls-no-alpn"]
+native-tls-vendored = ["mithril-common/native-tls", "reqwest/native-tls-vendored"]
+native-tls-vendored-no-alpn = ["mithril-common/native-tls", "reqwest/native-tls-vendored-no-alpn"]
 
-rustls = ["reqwest/rustls"]
-rustls-no-provider = ["reqwest/rustls-no-provider"]
+rustls = ["mithril-common/rustls", "reqwest/rustls"]
+rustls-no-provider = ["mithril-common/rustls", "reqwest/rustls-no-provider"]
 
 # Support compressed traffic with `reqwest`
 enable-http-compression = ["reqwest/gzip", "reqwest/zstd", "reqwest/deflate", "reqwest/brotli"]

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -32,6 +32,11 @@ allow_skip_signer_certification = []
 # Enables the future SNARK implementation for the `mithril-stm` dependency
 future_snark = ["mithril-stm/future_snark"]
 
+# Enables the TLS features for the `mithril-stm` dependency
+# Exactly one of these must be enabled together with `future_snark`
+native-tls = ["mithril-stm/native-tls"]
+rustls = ["mithril-stm/rustls"]
+
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }

--- a/mithril-common/Cargo.toml
+++ b/mithril-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-common"
-version = "0.7.14"
+version = "0.7.15"
 description = "Common types, interfaces, and utilities for Mithril nodes."
 authors = { workspace = true }
 edition = { workspace = true }
@@ -51,7 +51,7 @@ fixed = "1.31.0"
 hex = { workspace = true }
 kes-summed-ed25519 = { version = "0.2.1", features = ["serde_enabled", "sk_clone_enabled"] }
 mithril-merkle-tree = { path = "../internal/mithril-merkle-tree", version = "0.1.4" }
-mithril-stm = { path = "../mithril-stm", version = "0.12.0", default-features = false }
+mithril-stm = { path = "../mithril-stm", version = "0.12.1", default-features = false }
 nom = "8.0.0"
 rand_chacha = { workspace = true }
 rand_core = { workspace = true }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-relay"
-version = "0.2.7"
+version = "0.2.8"
 description = "A Mithril relay"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-relay/Cargo.toml
+++ b/mithril-relay/Cargo.toml
@@ -13,7 +13,7 @@ repository = { workspace = true }
 default = ["rustls"]
 # For activating snark features
 future_snark = ["mithril-common/future_snark"]
-rustls = ["reqwest/rustls"]
+rustls = ["mithril-common/rustls", "reqwest/rustls"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-signer"
-version = "1.1.6"
+version = "1.1.7"
 description = "A Mithril Signer"
 authors = { workspace = true }
 edition = { workspace = true }

--- a/mithril-signer/Cargo.toml
+++ b/mithril-signer/Cargo.toml
@@ -16,7 +16,7 @@ ignored = ["reqwest"]
 [features]
 default = ["rustls"]
 future_snark = ["mithril-common/future_snark"]
-rustls = ["reqwest/rustls"]
+rustls = ["mithril-common/rustls", "reqwest/rustls"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/mithril-stm/CHANGELOG.md
+++ b/mithril-stm/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.1 (08-03-2026)
+
+### Changed
+
+- The `future_snark` feature no longer enables the `rustls` feature: the TLS backend of the SRS download is now selected by the caller, which makes the `native-tls` feature usable.
+
 ## 0.12.0 (07-29-2026)
 
 ### Added

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-stm"
-version = "0.12.0"
+version = "0.12.1"
 edition = { workspace = true }
 authors = { workspace = true }
 homepage = { workspace = true }

--- a/mithril-stm/Cargo.toml
+++ b/mithril-stm/Cargo.toml
@@ -31,8 +31,6 @@ future_snark = [
     "dep:sha2",
     "dep:rand_chacha",
     "dep:reqwest",
-    # Temporarily activate rustls before it is activated in the caller
-    "rustls",
 ]
 # TLS backend for the SRS download client (used by `future_snark`).
 # Exactly one of these must be enabled together with `future_snark`.

--- a/mithril-stm/README.md
+++ b/mithril-stm/README.md
@@ -43,6 +43,14 @@ cd mithril-stm
 cargo build --release
 ```
 
+## TLS backend
+
+The `future_snark` feature downloads the SRS of the trusted setup over HTTPS and lets the caller pick the TLS backend. Enable exactly one of the `rustls` or `native-tls` features along with it:
+
+```shell
+cargo build --release --features future_snark,rustls
+```
+
 ## Running the tests
 
 For running rust tests, simply run (to run the tests faster, the use of `--release` flag is recommended):
@@ -246,15 +254,15 @@ Three metrics are measured per tier: VK/PK setup time, proof generation time, an
 Small and medium tiers use Criterion (10 samples, flat sampling — one iteration per sample):
 
 ```bash
-cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/small
-cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/medium
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/small
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/medium
 ```
 
 Large and production tiers run a single timed measurement (Criterion's 10-sample minimum is impractical at this scale):
 
 ```bash
-cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/large
-cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/production
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/large
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/production
 ```
 
 ## CI Parameter Benchmarks
@@ -293,5 +301,5 @@ All tiers complete in under 15 minutes on any developer machine with at least 4 
 ### Running the benchmarks
 
 ```bash
-cargo bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_prover_modes
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_prover_modes
 ```

--- a/mithril-stm/benches/README.md
+++ b/mithril-stm/benches/README.md
@@ -18,8 +18,7 @@ front-ends.
 
 ## Prerequisites
 
-- **Toolchain:** the crate's dev-dependencies require `rustc ≥ 1.88`. The commands below pin `+1.88.0`; use
-  any installed toolchain `≥ 1.88`, or set it as the default and drop the `+1.88.0`.
+- **Toolchain:** the crate's dev-dependencies require the latest stable Rust toolchain.
 - **Features:** all circuit benches require `--features future_snark,rustls,benchmark-internals`. `future_snark`
   downloads the SRS over HTTPS and needs a TLS backend: pick either `rustls` or `native-tls`.
 - **Resources:** the recursive circuit runs at degree 19 (GB-scale RAM, minutes per proof); the non-recursive
@@ -28,7 +27,7 @@ front-ends.
 General invocation:
 
 ```bash
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench <name> -- <args>
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench <name> -- <args>
 ```
 
 Everything after `--` is passed to the benchmark binary.
@@ -65,24 +64,24 @@ never silently trigger a multi-minute key generation). Arguments go after `--`:
 
 ```bash
 # List every benchmark id — no benchmark setup or key generation (Cargo may still compile the target):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- --list
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- --list
 
 # Show usage:
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- --help
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- --help
 
 # Run everything (tens of minutes; performs TWO recursive key generations — the shared per-path
 # environment and the cold setup/keys measurement — then all proofs):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark
 
 # Run a subset: pass ONE literal id or prefix (substring match against the ids from --list).
 # One transition path (prove + verify + fold):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/same_epoch
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/same_epoch
 # One path's verification only:
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/genesis/verify
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/genesis/verify
 # SRS cold vs warm (no key generation):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/srs
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/srs
 # Keys cold vs warm (cold performs a full recursive key generation):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/keys
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/keys
 ```
 
 The filter is a **literal** substring, not a regex. The parser rejects (rather than silently ignores):
@@ -120,10 +119,10 @@ Criterion's list/filter modes do **not** gate the manually-timed `large`/`produc
 positional `certificate/<tier>` filter does.
 
 ```bash
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/small
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/medium
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/large
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/production
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/small
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/medium
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/large
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/production
 ```
 
 | Tier         | Quorum | `k` | Measurement           |
@@ -142,5 +141,5 @@ Takes no arguments — it sweeps a range of `k` tiers and prints, for each, the 
 timings projected onto a standard e2e run (~80 certificates):
 
 ```bash
-cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_prover_modes
+cargo bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_prover_modes
 ```

--- a/mithril-stm/benches/README.md
+++ b/mithril-stm/benches/README.md
@@ -20,14 +20,15 @@ front-ends.
 
 - **Toolchain:** the crate's dev-dependencies require `rustc ≥ 1.88`. The commands below pin `+1.88.0`; use
   any installed toolchain `≥ 1.88`, or set it as the default and drop the `+1.88.0`.
-- **Features:** all circuit benches require `--features future_snark,benchmark-internals`.
+- **Features:** all circuit benches require `--features future_snark,rustls,benchmark-internals`. `future_snark`
+  downloads the SRS over HTTPS and needs a TLS backend: pick either `rustls` or `native-tls`.
 - **Resources:** the recursive circuit runs at degree 19 (GB-scale RAM, minutes per proof); the non-recursive
   `production` tier needs ≥ 70 GB RAM (server-class). Scope your run accordingly.
 
 General invocation:
 
 ```bash
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench <name> -- <args>
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench <name> -- <args>
 ```
 
 Everything after `--` is passed to the benchmark binary.
@@ -64,24 +65,24 @@ never silently trigger a multi-minute key generation). Arguments go after `--`:
 
 ```bash
 # List every benchmark id — no benchmark setup or key generation (Cargo may still compile the target):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench ivc_halo2_snark -- --list
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- --list
 
 # Show usage:
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench ivc_halo2_snark -- --help
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- --help
 
 # Run everything (tens of minutes; performs TWO recursive key generations — the shared per-path
 # environment and the cold setup/keys measurement — then all proofs):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench ivc_halo2_snark
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark
 
 # Run a subset: pass ONE literal id or prefix (substring match against the ids from --list).
 # One transition path (prove + verify + fold):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench ivc_halo2_snark -- ivc/same_epoch
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/same_epoch
 # One path's verification only:
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench ivc_halo2_snark -- ivc/genesis/verify
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/genesis/verify
 # SRS cold vs warm (no key generation):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/srs
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/srs
 # Keys cold vs warm (cold performs a full recursive key generation):
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/keys
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench ivc_halo2_snark -- ivc/setup/keys
 ```
 
 The filter is a **literal** substring, not a regex. The parser rejects (rather than silently ignores):
@@ -119,10 +120,10 @@ Criterion's list/filter modes do **not** gate the manually-timed `large`/`produc
 positional `certificate/<tier>` filter does.
 
 ```bash
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/small
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/medium
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/large
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_snark -- certificate/production
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/small
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/medium
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/large
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_snark -- certificate/production
 ```
 
 | Tier         | Quorum | `k` | Measurement           |
@@ -141,5 +142,5 @@ Takes no arguments — it sweeps a range of `k` tiers and prints, for each, the 
 timings projected onto a standard e2e run (~80 certificates):
 
 ```bash
-cargo +1.88.0 bench -p mithril-stm --features future_snark,benchmark-internals --bench halo2_prover_modes
+cargo +1.88.0 bench -p mithril-stm --features future_snark,rustls,benchmark-internals --bench halo2_prover_modes
 ```

--- a/mithril-stm/src/circuits/halo2_ivc/tests/assets/README.md
+++ b/mithril-stm/src/circuits/halo2_ivc/tests/assets/README.md
@@ -69,15 +69,15 @@ assets are not expected to be byte-identical across regenerations.
 Run these commands from the repository root in order:
 
 ```bash
-cargo test -p mithril-stm --features future_snark --release generate_golden_recursive_circuit_verification_key_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_verification_context_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_genesis_step_output_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_recursive_chain_state_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_same_epoch_step_output_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_recursive_step_output_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_first_step_cert_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_recursive_step_output_accumulator_bytes_only -- --ignored --nocapture
-cargo test -p mithril-stm --features future_snark --release generate_recursive_proof_accumulator_bytes_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_golden_recursive_circuit_verification_key_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_verification_context_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_genesis_step_output_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_recursive_chain_state_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_same_epoch_step_output_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_recursive_step_output_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_first_step_cert_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_recursive_step_output_accumulator_bytes_only -- --ignored --nocapture
+cargo test -p mithril-stm --features future_snark,rustls --release generate_recursive_proof_accumulator_bytes_only -- --ignored --nocapture
 ```
 
 These commands intentionally use `--release` because asset generation is a

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -18,7 +18,7 @@ bench = false
 default = ["rustls"]
 allow_skip_signer_certification = []
 future_snark = ["mithril-common/future_snark"]
-rustls = ["reqwest/rustls"]
+rustls = ["mithril-common/rustls", "reqwest/rustls"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.7"
+version = "0.5.8"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }


### PR DESCRIPTION
## Content

This PR includes the **removal of the forced `rustls` activation in the `future_snark` feature of `mithril-stm`, so the TLS backend of the SRS download is selected by the callers**:

- Removed `rustls` from the `future_snark` feature list of `mithril-stm`, which makes its `native-tls` feature usable and activates the existing compile time guard that fails the build when no TLS backend is selected.
- Added the `native-tls` and `rustls` features to `mithril-common`, forwarding to the matching features of `mithril-stm`.
- Forwarded the TLS features of `mithril-client` to `mithril-common`, each `native-tls` variant to `native-tls` and `rustls-no-provider` to `rustls`.
- Selected the TLS backend in the `rustls` feature of the `mithril-signer`, `mithril-aggregator`, `mithril-relay` and `mithril-end-to-end` crates.
- Added a `rustls` default feature to the protocol demo, which depends on `mithril-stm` directly and had no TLS feature.
- Updated the documented `mithril-stm` commands of the READMEs, of the circuit keys runbook and of the `future_snark` CI test job to select a TLS backend explicitly.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] CHANGELOG file is updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #3423 
