### PR TITLE
chore(ci): deactivate DMQ node in release networks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,10 +107,10 @@ jobs:
           - environment: release-preprod
             environment_prefix: release
             cardano_network: preprod
-            mithril_use_p2p_network: true
-            mithril_p2p_use_dmq_protocol: true
-            mithril_p2p_use_real_dmq_node: true
-            mithril_p2p_dmq_use_ledger_peers: true
+            mithril_use_p2p_network: false
+            mithril_p2p_use_dmq_protocol: false
+            mithril_p2p_use_real_dmq_node: false
+            mithril_p2p_dmq_use_ledger_peers: false
             mithril_api_domain: api.mithril.network
             mithril_protocol_parameters: |
               {
@@ -136,10 +136,10 @@ jobs:
           - environment: release-mainnet
             environment_prefix: release
             cardano_network: mainnet
-            mithril_use_p2p_network: true
-            mithril_p2p_use_dmq_protocol: true
-            mithril_p2p_use_real_dmq_node: true
-            mithril_p2p_dmq_use_ledger_peers: true
+            mithril_use_p2p_network: false
+            mithril_p2p_use_dmq_protocol: false
+            mithril_p2p_use_real_dmq_node: false
+            mithril_p2p_dmq_use_ledger_peers: false
             mithril_api_domain: api.mithril.network
             mithril_protocol_parameters: |
               {

--- a/networks.json
+++ b/networks.json
@@ -4,7 +4,6 @@
       "mithril-signer": "10.6.2",
       "mithril-aggregator": "10.6.2"
     },
-    "dmq-minimum-version": "0.6.0.0",
     "mithril-networks": [
       {
         "release-mainnet": {
@@ -41,7 +40,6 @@
       "mithril-signer": "10.6.2",
       "mithril-aggregator": "10.6.2"
     },
-    "dmq-minimum-version": "0.6.0.0",
     "mithril-networks": [
       {
         "release-preprod": {


### PR DESCRIPTION
## Content

This PR includes the deactivation of the DMQ node in the release networks until a stable `0.7.X` is released:
- This will unlock the delivery of the next distribution
- Once the `0.7.0` version is released, the activation of the DMQ network can be done by merging the PR https://github.com/IntersectMBO/mithril/pull/3361 and following upgrade instructions in it.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3271 
