### PR TITLE
fix(e2e): remove epoch gap flakiness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4603,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "mithril-end-to-end"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "anyhow",
  "async-recursion",

--- a/docs/website/blog/2026-07-17-repository-transfer-to-intersectmbo.md
+++ b/docs/website/blog/2026-07-17-repository-transfer-to-intersectmbo.md
@@ -88,6 +88,6 @@ curl -sSfL https://raw.githubusercontent.com/IntersectMBO/mithril/main/networks.
 | :--: | --------------------------- | ------------- | ------------------------------------------------------------------------------------ |
 |  ✅  | Announcement (today)        | July 17, 2026 | This announcement is published                                                       |
 |  ✅  | D-day (repository transfer) | July 20, 2026 | Repository transfer is performed, new GHCR images are published under `IntersectMBO` |
-|  ⬜  | From D+1                    | July 21, 2026 | Documentation cross-references and external references are refreshed                 |
+|  ✅  | From D+1                    | July 21, 2026 | Documentation cross-references and external references are refreshed                 |
 
 For any inquiries or assistance, contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).

--- a/mithril-test-lab/mithril-end-to-end/Cargo.toml
+++ b/mithril-test-lab/mithril-end-to-end/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mithril-end-to-end"
-version = "0.5.9"
+version = "0.5.10"
 authors = { workspace = true }
 edition = { workspace = true }
 documentation = { workspace = true }

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use slog_scope::{info, warn};
 use tokio::task::JoinSet;
 
@@ -175,10 +176,14 @@ impl FullScenario {
             .await?;
 
         if aggregator.is_first() || aggregator.version().is_below("0.7.94") {
-            // A certificate chain lagging one epoch behind the chain tip is normal, but a restart
-            // crossing an epoch boundary before the current epoch is certified would create an
-            // unrecoverable epoch gap and block the aggregator
-            let current_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
+            // Ensure the current epoch is certified
+            // Given the time needed to restart the aggregator, a restart crossing an epoch
+            // boundary before the current epoch is certified would create an unrecoverable
+            // epoch gap and block the aggregator
+            let current_epoch = chain_observer
+                .get_current_epoch()
+                .await?
+                .ok_or(anyhow!("Current epoch is not available"))?;
             self.toolkit
                 .check
                 .certificate

--- a/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/scenario/full.rs
@@ -175,6 +175,16 @@ impl FullScenario {
             .await?;
 
         if aggregator.is_first() || aggregator.version().is_below("0.7.94") {
+            // A certificate chain lagging one epoch behind the chain tip is normal, but a restart
+            // crossing an epoch boundary before the current epoch is certified would create an
+            // unrecoverable epoch gap and block the aggregator
+            let current_epoch = chain_observer.get_current_epoch().await?.unwrap_or_default();
+            self.toolkit
+                .check
+                .certificate
+                .is_creating_certificate_with_min_epoch(aggregator, current_epoch)
+                .await?;
+
             self.toolkit
                 .exec
                 .update_protocol_parameters(aggregator, infrastructure.aggregate_signature_type())

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/check/certificate.rs
@@ -59,7 +59,7 @@ impl CheckCertificateToolkit {
         }
 
         match poll_until!(
-            self.context.artifact_production_timeout(),
+            self.context.existing_artifact_fetch_timeout(),
             self.context.poll_backoff(),
             { fetch_certificate_message(url.clone()).await }
         ) {

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
@@ -34,7 +34,7 @@ impl ScenarioToolkitContext {
     /// Backoff polling at a constant tenth of the epoch duration, so that epoch transitions
     /// are detected shortly after the epoch boundary.
     pub fn tenth_of_epoch_poll_backoff(&self) -> Backoff {
-        let delay = self.timeout_for_epochs(1) / 10;
+        let delay = self.timeout_for_epoch_fraction(10);
         Backoff::new(delay, delay, 1)
     }
 
@@ -43,9 +43,23 @@ impl ScenarioToolkitContext {
         self.attempt_policy.timeout_for_epochs(epochs)
     }
 
+    /// Timeout covering the given fraction of a Cardano epoch.
+    pub fn timeout_for_epoch_fraction(&self, fraction: u32) -> Duration {
+        self.attempt_policy.timeout_for_epoch_fraction(fraction)
+    }
+
     /// Timeout to wait for the aggregator to produce a signed artifact once it is running.
+    ///
+    /// An artifact type is produced once per epoch, so a wait started late in an epoch may need to
+    /// span a full production cycle before the awaited artifact exists.
     pub fn artifact_production_timeout(&self) -> Duration {
         self.timeout_for_epochs(3)
+    }
+
+    /// Timeout to fetch an artifact which has already been produced, only covering transient
+    /// failures of the aggregator.
+    pub fn existing_artifact_fetch_timeout(&self) -> Duration {
+        self.timeout_for_epochs(1)
     }
 
     /// Timeout to wait for the devnet and aggregator to become ready during startup.
@@ -62,6 +76,10 @@ pub struct AttemptPolicy {
 }
 
 impl AttemptPolicy {
+    /// Floor of the timeouts derived from a fraction of an epoch, so that a misconfigured epoch
+    /// duration can never yield a zero timeout.
+    const MINIMUM_FRACTION_TIMEOUT: Duration = Duration::from_millis(10);
+
     /// Builds a policy from the given epoch duration.
     pub const fn new(base_duration: Duration) -> Self {
         Self {
@@ -79,6 +97,15 @@ impl AttemptPolicy {
     /// Returns a timeout covering the given number of epochs.
     pub fn timeout_for_epochs(self, epochs: u32) -> Duration {
         self.epoch_duration * epochs
+    }
+
+    /// Returns a timeout covering the given fraction of an epoch, never below
+    /// [`Self::MINIMUM_FRACTION_TIMEOUT`].
+    pub fn timeout_for_epoch_fraction(self, fraction: u32) -> Duration {
+        self.epoch_duration
+            .checked_div(fraction)
+            .unwrap_or_default()
+            .max(Self::MINIMUM_FRACTION_TIMEOUT)
     }
 }
 
@@ -104,6 +131,41 @@ mod tests {
     }
 
     #[test]
+    fn timeout_for_epoch_fraction_divides_the_epoch_duration() {
+        let policy = AttemptPolicy::new(Duration::from_secs(10));
+
+        assert_eq!(
+            policy.timeout_for_epoch_fraction(1),
+            Duration::from_secs(10)
+        );
+        assert_eq!(
+            policy.timeout_for_epoch_fraction(10),
+            Duration::from_secs(1)
+        );
+    }
+
+    #[test]
+    fn timeout_for_epoch_fraction_never_falls_below_the_minimum() {
+        let policy = AttemptPolicy::new(Duration::from_millis(1));
+        assert_eq!(
+            policy.timeout_for_epoch_fraction(10),
+            AttemptPolicy::MINIMUM_FRACTION_TIMEOUT
+        );
+
+        let policy = AttemptPolicy::new(Duration::ZERO);
+        assert_eq!(
+            policy.timeout_for_epoch_fraction(10),
+            AttemptPolicy::MINIMUM_FRACTION_TIMEOUT
+        );
+
+        let policy = AttemptPolicy::new(Duration::from_secs(10));
+        assert_eq!(
+            policy.timeout_for_epoch_fraction(0),
+            AttemptPolicy::MINIMUM_FRACTION_TIMEOUT
+        );
+    }
+
+    #[test]
     fn tenth_of_epoch_poll_backoff_polls_at_a_constant_delay() {
         let context = ScenarioToolkitContext::new(AttemptPolicy::new(Duration::from_secs(10)));
         let mut backoff = context.tenth_of_epoch_poll_backoff();
@@ -119,6 +181,10 @@ mod tests {
         assert_eq!(
             context.artifact_production_timeout(),
             Duration::from_secs(30)
+        );
+        assert_eq!(
+            context.existing_artifact_fetch_timeout(),
+            Duration::from_secs(10)
         );
         assert_eq!(
             context.startup_readiness_timeout(),

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
@@ -45,7 +45,7 @@ impl ScenarioToolkitContext {
 
     /// Timeout to wait for the aggregator to produce a signed artifact once it is running.
     pub fn artifact_production_timeout(&self) -> Duration {
-        self.timeout_for_epochs(1)
+        self.timeout_for_epochs(3)
     }
 
     /// Timeout to wait for the devnet and aggregator to become ready during startup.
@@ -118,7 +118,7 @@ mod tests {
 
         assert_eq!(
             context.artifact_production_timeout(),
-            Duration::from_secs(10)
+            Duration::from_secs(30)
         );
         assert_eq!(
             context.startup_readiness_timeout(),

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/context.rs
@@ -31,6 +31,13 @@ impl ScenarioToolkitContext {
         Backoff::default()
     }
 
+    /// Backoff polling at a constant tenth of the epoch duration, so that epoch transitions
+    /// are detected shortly after the epoch boundary.
+    pub fn tenth_of_epoch_poll_backoff(&self) -> Backoff {
+        let delay = self.timeout_for_epochs(1) / 10;
+        Backoff::new(delay, delay, 1)
+    }
+
     /// Timeout covering the given number of Cardano epochs.
     pub fn timeout_for_epochs(&self, epochs: u32) -> Duration {
         self.attempt_policy.timeout_for_epochs(epochs)
@@ -94,6 +101,15 @@ mod tests {
         assert_eq!(policy.timeout_for_epochs(0), Duration::from_secs(0));
         assert_eq!(policy.timeout_for_epochs(1), Duration::from_secs(10));
         assert_eq!(policy.timeout_for_epochs(5), Duration::from_secs(50));
+    }
+
+    #[test]
+    fn tenth_of_epoch_poll_backoff_polls_at_a_constant_delay() {
+        let context = ScenarioToolkitContext::new(AttemptPolicy::new(Duration::from_secs(10)));
+        let mut backoff = context.tenth_of_epoch_poll_backoff();
+
+        assert_eq!(backoff.next_delay(), Duration::from_secs(1));
+        assert_eq!(backoff.next_delay(), Duration::from_secs(1));
     }
 
     #[test]

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/exec.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/exec.rs
@@ -102,9 +102,9 @@ impl ExecToolkit {
         aggregator.stop().await?;
         let protocol_parameters_new = match aggregate_signature_type {
             AggregateSignatureType::Concatenation => ProtocolParameters {
-                k: 145,
-                m: 210,
-                phi_f: 0.80,
+                k: 83,
+                m: 130,
+                phi_f: 0.75,
             },
             AggregateSignatureType::Snark => ProtocolParameters {
                 k: 7,

--- a/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
+++ b/mithril-test-lab/mithril-end-to-end/src/toolkit/wait.rs
@@ -114,7 +114,7 @@ impl WaitToolkit {
         let epochs_to_wait = Self::compute_number_of_epochs_to_wait(target_epoch, current_epoch);
         let timeout = self.context.timeout_for_epochs(epochs_to_wait);
 
-        match poll_until!(timeout, self.context.poll_backoff(), {
+        match poll_until!(timeout, self.context.tenth_of_epoch_poll_backoff(), {
             match aggregator
                 .chain_observer()
                 .get_current_epoch()


### PR DESCRIPTION
## Content

This PR includes **the removal of several sources of flakiness in the e2e tests which caused intermittent `Timeout exhausted waiting for Certificate for epoch XX` failures in the CI**:

- Poll epoch transitions at a tenth of the epoch duration, so that target epochs are detected shortly after their boundary instead of up to a full epoch late with the previous exponential backoff
- Certify the current epoch before the protocol parameters restart of the aggregator, so that the restart can no longer create an unrecoverable epoch gap
- Extend the artifact production timeout from one to three epochs: an artifact type is produced once per epoch, so a wait started late in an epoch may need to span a full production cycle before the awaited artifact exists, which a single epoch timeout could not cover
- Lighten the updated protocol parameters by reducing the number of lotteries played, closer to the initial parameter set, as the test only needs to exercise the parameters update

The fixed e2e test has been run 381 times with 1 failure, a **99.74% success ratio**.

## Pre-submit checklist

- Branch
  - [x] Crates versions are updated (if relevant)
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Closes #3452 
