### PR TITLE
chore: update infrastructure and documentation for DMQ node `0.7.0.0`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,8 @@ jobs:
           cardano_network: ${{ matrix.cardano_network }}
           cardano_node_version: ${{ vars.CARDANO_NODE_VERSION }}
           cardano_node_docker_registry: ${{ vars.CARDANO_NODE_DOCKER_REGISTRY }}
+          dmq_node_version: ${{ vars.DMQ_NODE_VERSION }}
+          dmq_node_docker_registry: ${{ vars.DMQ_NODE_DOCKER_REGISTRY }}
           google_region: ${{ matrix.google_region }}
           google_zone: ${{ matrix.google_zone }}
           google_machine_type: ${{ matrix.google_machine_type }}

--- a/docs/website/blog/2026-08-03-distribution-2630.md
+++ b/docs/website/blog/2026-08-03-distribution-2630.md
@@ -7,10 +7,11 @@ tags: [release, distribution, 2630]
 
 ### Distribution `2630` is now available
 
-The [`2630.0`](https://github.com/input-output-hk/mithril/releases/tag/2630.0) distribution has been released, introducing the following changes:
+The [`2630.0`](https://github.com/IntersectMBO/mithril/releases/tag/2630.0) distribution has been released, introducing the following changes:
 
-- **Breaking Changes**: Removed support for the `CardanoImmutableFilesFull` certificate type in the Mithril signer and aggregator. Use `CardanoDatabase` (also known as Cardano database v2) instead.
-- **Cardano Blocks and Transactions**: Activation of the testing phase on the `pre-release-preview` and `release-preprod` networks.
+- **Breaking Changes**: Removed support for the `CardanoImmutableFilesFull` certificate type in the Mithril signer and aggregator. Use `CardanoDatabase` (also known as Cardano database v2) instead
+- **DMQ network**: Promoted the DMQ node as stable (beta) on `release-mainnet` and `release-preprod` networks
+- **Cardano Blocks and Transactions**: Activation of the testing phase on the `pre-release-preview` and `release-preprod` networks
 - **Maintenance**: Bug fixes and performance improvements.
 
 This new distribution has been deployed to the **Mithril aggregator** on the `release-mainnet`, `release-preprod` and `pre-release-preview` networks.
@@ -24,7 +25,7 @@ For those running a **Mithril signer**:
 You can update the Mithril signer using the one-line command below. By default, it downloads to the current directory, but you can specify a custom folder with the -p option:
 
 ```bash
-curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/input-output-hk/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2630.0 -p "$(pwd)"
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/IntersectMBO/mithril/refs/heads/main/mithril-install.sh | sh -s -- -c mithril-signer -d 2630.0 -p "$(pwd)"
 ```
 
 For any inquiries or assistance, contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).

--- a/docs/website/blog/2026-08-04-dmq-beta-release.md
+++ b/docs/website/blog/2026-08-04-dmq-beta-release.md
@@ -1,0 +1,46 @@
+---
+title: DMQ node beta on the release networks
+authors:
+  - name: Mithril Team
+tags: [DMQ, decentralization, beta, release, distribution, 2630]
+---
+
+### DMQ node beta on the release networks
+
+We are happy to announce that the **Decentralized Message Queue (DMQ)** node is now officially supported in **beta** on the `release-mainnet` and `release-preprod` networks. This milestone follows the [DMQ testing program with SPOs](https://mithril.network/doc/dev-blog/2026/01/06/dmq-testing-program) conducted on the `pre-release-preview` network, and would not have been possible without the feedback of the participating stake pool operators (SPOs).
+
+With the [`2630.0`](https://github.com/IntersectMBO/mithril/releases/tag/2630.0) distribution, the DMQ node version `0.7.0.0` has been promoted as **stable (beta)**, and the DMQ network is activated on both release networks.
+
+#### All SPOs should now run a DMQ node
+
+Running a DMQ node next to the Mithril signer is the new standard setup for SPOs:
+
+- Follow the [setup guide](https://mithril.network/doc/manual/operate/run-signer-node#set-up-the-dmq-node-beta) to install and operate the DMQ node version `0.7.0.0` in your infrastructure
+- Use the [network configurations](https://mithril.network/doc/manual/getting-started/network-configurations) page to retrieve the DMQ parameters of your network.
+
+:::info
+
+During the ramp-up phase, the fallback to the legacy signature registration mechanism remains active, so signer operations are not disrupted while the DMQ network adoption grows. This fallback will be deactivated in a future distribution.
+
+:::
+
+#### Why this matters
+
+The DMQ protocol, specified in [CIP-0137](https://cips.cardano.org/cip/CIP-0137), decentralizes the diffusion of the individual signatures produced by the Mithril signers. It is the foundation on which **multiple aggregators** can operate simultaneously on the same Mithril network.
+
+:::tip
+
+Running the DMQ network with all SPOs is what will activate multiple aggregators on the Mithril networks. The more SPOs run a DMQ node, the sooner this major decentralization step can be unlocked.
+
+:::
+
+A healthy DMQ network operated by a large majority of the stake is mandatory before follower aggregators can reliably produce valid certificates. Every SPO running a DMQ node directly contributes to the decentralization and the resilience of the Mithril network.
+
+#### References
+
+- [CIP-0137](https://cips.cardano.org/cip/CIP-0137): specification of the DMQ protocol
+- [DMQ node repository](https://github.com/IntersectMBO/dmq-node): implementation of the DMQ node
+- [DMQ node setup guide](https://mithril.network/doc/manual/operate/run-signer-node#set-up-the-dmq-node-beta): instructions for SPOs
+- [Network configurations](https://mithril.network/doc/manual/getting-started/network-configurations): DMQ parameters per network.
+
+For any inquiries or assistance, contact the team on the [Discord channel](https://discord.gg/5kaErDKDRq).


### PR DESCRIPTION
## Content

This PR includes the **infrastructure and documentation updates for the DMQ node `0.7.0.0` beta release on the `release-mainnet` and `release-preprod` networks**:

- Add the missing `dmq_node_version` and `dmq_node_docker_registry` inputs in the release workflow terraform deployment
- Update the distribution `2630` blog post with the promotion of the DMQ node as stable (beta) on the release networks
- Add a dev blog post announcing the DMQ node beta support on the release networks, with the setup instructions for SPOs and the impact on multiple aggregators activation.

## Pre-submit checklist

- Branch
  - [x] Commit sequence broadly makes sense
  - [x] Key commits have useful messages
- PR
  - [x] All check jobs of the CI have succeeded
  - [x] Self-reviewed the diff
  - [x] Useful pull request description
  - [x] Reviewer requested

## Issue(s)
Relates to #3361 
